### PR TITLE
Rename `data` attribute to `body`

### DIFF
--- a/assets/js/src/newsletter_editor/components/content.js
+++ b/assets/js/src/newsletter_editor/components/content.js
@@ -11,7 +11,7 @@ define([
   // Does not hold newsletter content nor newsletter styles, those are
   // handled by other components.
   Module.NewsletterModel = SuperModel.extend({
-    stale: ['data'],
+    stale: ['body'],
     initialize: function(options) {
       this.on('change', function() {
           App.getChannel().trigger('autoSave');
@@ -45,7 +45,7 @@ define([
 
   Module.toJSON = function() {
     return _.extend({
-      data: {
+      body: {
         content: App._contentContainer.toJSON(),
         globalStyles: App.getGlobalStyles().toJSON(),
       },
@@ -64,12 +64,12 @@ define([
     App.toJSON = Module.toJSON;
     App.getNewsletter = Module.getNewsletter;
 
-    Module.newsletter = new Module.NewsletterModel(_.omit(_.clone(options.newsletter), ['data']));
+    Module.newsletter = new Module.NewsletterModel(_.omit(_.clone(options.newsletter), ['body']));
   });
 
   App.on('start', function(options) {
     // TODO: Other newsletter information will be needed as well.
-    App._contentContainer = new (this.getBlockTypeModel('container'))(options.newsletter.data.content, {parse: true});
+    App._contentContainer = new (this.getBlockTypeModel('container'))(options.newsletter.body.content, {parse: true});
     App._contentContainerView = new (this.getBlockTypeView('container'))({
       model: App._contentContainer,
       renderOptions: { depth: 0 },

--- a/assets/js/src/newsletter_editor/components/styles.js
+++ b/assets/js/src/newsletter_editor/components/styles.js
@@ -72,7 +72,7 @@ define([
 
     App.getAvailableStyles = Module.getAvailableStyles;
 
-    this.setGlobalStyles(options.newsletter.data.globalStyles);
+    this.setGlobalStyles(options.newsletter.body.globalStyles);
   });
 
   App.on('start', function(options) {

--- a/tests/javascript/newsletter_editor/components/content.spec.js
+++ b/tests/javascript/newsletter_editor/components/content.spec.js
@@ -9,7 +9,7 @@ define([
 
       beforeEach(function() {
         model = new (ContentComponent.NewsletterModel)({
-          data: {
+          body: {
             globalStyles: {
               style1: 'style1Value',
               style2: 'style2Value',
@@ -81,7 +81,7 @@ define([
         };
         var json = ContentComponent.toJSON();
         expect(json).to.deep.equal(_.extend({
-          data: {
+          body: {
             content: dataField,
             globalStyles: stylesField
           },

--- a/views/newsletter/editor.html
+++ b/views/newsletter/editor.html
@@ -245,7 +245,7 @@
 
   <script type="text/javascript">
     var newsletter = {
-      "data": {
+      "body": {
         "content": {
           "type": "container",
           "orientation": "vertical",


### PR DESCRIPTION
A continuation of #142.

Renames the `data` attribute to `body` as per @mrcasual's  suggestion.
