### PR TITLE
HelpScout integration fixes

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -31,3 +31,11 @@
   'mailpoet.js',
   'admin.js'
 )%>
+
+<script>
+  HS.beacon.config({
+    icon: 'message',
+    zIndex: 50000,
+    instructions: '<%= __('Want to give feedback to the MailPoet team? Write them right here with as much information as possible.') %>',
+  });
+</script>


### PR DESCRIPTION
- Change icon to `message`
- Increase `zIndex` to display HS modal above Form editor's controls
- Add an instructional message to HS modal
