### PR TITLE
Fix react-router dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "codemirror": "^5.8.0",
     "d3": "~3.5.5",
     "handlebars": "3.0.3",
-    "history": "^1.12.5",
+    "history": "1.13.1",
     "html2canvas": "0.5.0-alpha2",
     "interact.js": "latest",
     "moment": "^2.10.3",


### PR DESCRIPTION
Fixes react-router dependency issue of conflicting `history` versions in use.
Updates usable `history` version to `1.13.1`
