### PR TITLE
JSON encode newsletter body when sending it to server

### DIFF
--- a/assets/js/src/newsletter_editor/components/communication.js
+++ b/assets/js/src/newsletter_editor/components/communication.js
@@ -63,9 +63,10 @@ define([
   };
 
   Module.saveNewsletter = function(options) {
-    return Module._query({
+    return MailPoet.Ajax.post({
+      endpoint: 'newsletters',
       action: 'save',
-      options: options,
+      data: options || {},
     });
   };
 

--- a/assets/js/src/newsletters/templates.jsx
+++ b/assets/js/src/newsletters/templates.jsx
@@ -18,6 +18,12 @@ define(
 
     var ImportTemplate = React.createClass({
       saveTemplate: function(template) {
+
+        // Stringify to enable transmission of primitive non-string value types
+        if (!_.isUndefined(template.body)) {
+          template.body = JSON.stringify(template.body);
+        }
+
         MailPoet.Ajax.post({
           endpoint: 'newsletterTemplates',
           action: 'save',
@@ -111,12 +117,19 @@ define(
         }.bind(this));
       },
       handleSelectTemplate: function(template) {
+        var body = template.body;
+
+        // Stringify to enable transmission of primitive non-string value types
+        if (!_.isUndefined(body)) {
+          body = JSON.stringify(body);
+        }
+
         MailPoet.Ajax.post({
           endpoint: 'newsletters',
           action: 'save',
           data: {
             id: this.props.params.id,
-            body: template.body
+            body: body
           }
         }).done(function(response) {
           if(response.result === true) {

--- a/lib/Router/NewsletterTemplates.php
+++ b/lib/Router/NewsletterTemplates.php
@@ -30,10 +30,6 @@ class NewsletterTemplates {
   }
 
   function save($data = array()) {
-    if (isset($data['body'])) {
-      $data['body'] = json_encode($data['body']);
-    }
-
     $result = NewsletterTemplate::createOrUpdate($data);
     if($result !== true) {
       wp_send_json($result);

--- a/lib/Router/Newsletters.php
+++ b/lib/Router/Newsletters.php
@@ -59,10 +59,6 @@ class Newsletters {
       unset($data['options']);
     }
 
-    if (isset($data['body'])) {
-      $data['body'] = json_encode($data['body']);
-    }
-
     $errors = array();
     $result = false;
 


### PR DESCRIPTION
Before this PR, the `body` attribute of a newsletter JSON would be a regular Javascript object and not a string.
This causes an issue with non string values, because in order to transmit such object via HTTP POST to the server, all values would be turned into strings without the ability to detect what was a boolean, what was a string.
E.g.: this:
`{ name: 'Some Email', body: { type: 'image', width: 100, padded: true }}`
during HTTP transmission would turn into:
`name=Some%20Email&body[type]=image&body[width]=100&body[padded]=true`
and the server would interpret it as:
`{ name: 'Some Email', body: { type: 'image', width: '100', padded: 'true' }}`

The solution to this problem is to JSON encode the newsletter body whenever it is being sent from client to server.
Server to client transmission does not have such issue, thus remains unchanged for clarity.

This PR JSON encodes newsletter body whenever JSON object of a newsletter is being transmitted from client to server (save newsletter, save newsletter template, import newsletter template).
