### PR TITLE
Disables send method for all mailer tests

### DIFF
--- a/tests/unit/Mailer/Methods/AmazonSESCest.php
+++ b/tests/unit/Mailer/Methods/AmazonSESCest.php
@@ -6,9 +6,15 @@ class AmazonSESCest {
   function _before() {
     $this->settings = array(
       'method' => 'AmazonSES',
-      'access_key' => 'AKIAJDCYK7DHCRVF7LXA',
-      'secret_key' => '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',
-      'region' => 'us-west-2',
+      'access_key' => getenv('WP_TEST_MAILER_AMAZON_ACCESS') ?
+        getenv('WP_TEST_MAILER_AMAZON_ACCESS') :
+        '1234567890',
+      'secret_key' => getenv('WP_TEST_MAILER_AMAZON_SECRET') ?
+        getenv('WP_TEST_MAILER_AMAZON_SECRET') :
+        'abcdefghijk',
+      'region' => getenv('WP_TEST_MAILER_AMAZON_REGION') ?
+        getenv('WP_TEST_MAILER_AMAZON_REGION') :
+        'us-west-2',
     );
     $this->sender = array(
       'from_name' => 'Sender',
@@ -150,6 +156,7 @@ class AmazonSESCest {
   }
 
   function itCannotSendWithoutProperAccessKey() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->aws_access_key = 'somekey';
     $result = $this->mailer->send(
       $this->newsletter,
@@ -159,6 +166,7 @@ class AmazonSESCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber

--- a/tests/unit/Mailer/Methods/ElasticEmailCest.php
+++ b/tests/unit/Mailer/Methods/ElasticEmailCest.php
@@ -6,7 +6,9 @@ class ElasticEmailCest {
   function _before() {
     $this->settings = array(
       'method' => 'ElasticEmail',
-      'api_key' => '997f1f7f-41de-4d7f-a8cb-86c8481370fa'
+      'api_key' => getenv('WP_TEST_MAILER_ELASTICEMAIL_API') ?
+        getenv('WP_TEST_MAILER_ELASTICEMAIL_API') :
+        '1234567890'
     );
     $this->sender = array(
       'from_name' => 'Sender',
@@ -56,6 +58,7 @@ class ElasticEmailCest {
   }
 
   function itCannotSendWithoutProperApiKey() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->api_key = 'someapi';
     $result = $this->mailer->send(
       $this->newsletter,
@@ -65,6 +68,7 @@ class ElasticEmailCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber

--- a/tests/unit/Mailer/Methods/MailGunCest.php
+++ b/tests/unit/Mailer/Methods/MailGunCest.php
@@ -6,8 +6,12 @@ class MailGunCest {
   function _before() {
     $this->settings = array(
       'method' => 'MailGun',
-      'api_key' => 'key-6cf5g5qjzenk-7nodj44gdt8phe6vam2',
-      'domain' => 'mrcasual.com'
+      'api_key' => getenv('WP_TEST_MAILER_MAILGUN_API') ?
+        getenv('WP_TEST_MAILER_MAILGUN_API') :
+        '1234567890',
+      'domain' => getenv('WP_TEST_MAILER_MAILGUN_DOMAIN') ?
+        getenv('WP_TEST_MAILER_MAILGUN_DOMAIN') :
+        'example.com'
     );
     $this->sender = array(
       'from_name' => 'Sender',
@@ -64,6 +68,7 @@ class MailGunCest {
   }
 
   function itCannotSendWithoutProperApiKey() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->api_key = 'someapi';
     $result = $this->mailer->send(
       $this->newsletter,
@@ -73,6 +78,7 @@ class MailGunCest {
   }
 
   function itCannotSendWithoutProperDomain() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->url =
       str_replace($this->settings['domain'], 'somedomain', $this->mailer->url);
     $result = $this->mailer->send(
@@ -83,6 +89,7 @@ class MailGunCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber

--- a/tests/unit/Mailer/Methods/MailPoetCest.php
+++ b/tests/unit/Mailer/Methods/MailPoetCest.php
@@ -6,7 +6,9 @@ class MailPoetCest {
   function _before() {
     $this->settings = array(
       'method' => 'MailPoet',
-      'api_key' => 'dhNSqj1XHkVltIliyQDvMiKzQShOA5rs0m_DdRUVZHU'
+      'api_key' => getenv('WP_TEST_MAILER_MAILPOET_API') ?
+        getenv('WP_TEST_MAILER_MAILPOET_API') :
+        '1234567890'
     );
     $this->sender = array(
       'from_name' => 'Sender',
@@ -88,6 +90,7 @@ class MailPoetCest {
   }
 
   function itCannotSendWithoutProperApiKey() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->api_key = 'someapi';
     $result = $this->mailer->send(
       $this->newsletter,
@@ -97,6 +100,7 @@ class MailPoetCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber

--- a/tests/unit/Mailer/Methods/PHPMailCest.php
+++ b/tests/unit/Mailer/Methods/PHPMailCest.php
@@ -2,7 +2,7 @@
 
 use MailPoet\Mailer\Methods\PHPMail;
 
-class WPMailCest {
+class PHPMailCest {
   function _before() {
     $this->sender = array(
       'from_name' => 'Sender',
@@ -30,7 +30,8 @@ class WPMailCest {
 
   function itCanBuildMailer() {
     $mailer = $this->mailer->buildMailer();
-    expect($mailer->getTransport()->getHost())
+    expect($mailer->getTransport()
+             ->getHost())
       ->equals('localhost');
   }
 
@@ -60,6 +61,7 @@ class WPMailCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber

--- a/tests/unit/Mailer/Methods/SMTPCest.php
+++ b/tests/unit/Mailer/Methods/SMTPCest.php
@@ -6,10 +6,16 @@ class SMTPCest {
   function _before() {
     $this->settings = array(
       'method' => 'SMTP',
-      'host' => 'email-smtp.us-west-2.amazonaws.com',
+      'host' => getenv('WP_TEST_MAILER_SMTP_HOST') ?
+        getenv('WP_TEST_MAILER_SMTP_HOST') :
+        'example.com',
       'port' => 587,
-      'login' => 'AKIAIGPBLH6JWG5VCBQQ',
-      'password' => 'AudVHXHaYkvr54veCzqiqOxDiMMyfQW3/V6F1tYzGXY3',
+      'login' => getenv('WP_TEST_MAILER_SMTP_LOGIN') ?
+        getenv('WP_TEST_MAILER_SMTP_LOGIN') :
+        'example.com',
+      'password' => getenv('WP_TEST_MAILER_SMTP_PASSWORD') ?
+        getenv('WP_TEST_MAILER_SMTP_PASSWORD') :
+        'example.com',
       'authentication' => '1',
       'encryption' => 'tls'
     );
@@ -83,6 +89,7 @@ class SMTPCest {
   }
 
   function itCantSentWithoutProperAuthentication() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->login = 'someone';
     $this->mailer->mailer = $this->mailer->buildMailer();
     $result = $this->mailer->send(
@@ -93,6 +100,7 @@ class SMTPCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber

--- a/tests/unit/Mailer/Methods/SendGridCest.php
+++ b/tests/unit/Mailer/Methods/SendGridCest.php
@@ -6,7 +6,9 @@ class SendGridCest {
   function _before() {
     $this->settings = array(
       'method' => 'SendGrid',
-      'api_key' => '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'
+      'api_key' => getenv('WP_TEST_MAILER_SENDGRID_API') ?
+        getenv('WP_TEST_MAILER_SENDGRID_API') :
+        '1234567890'
     );
     $this->sender = array(
       'from_name' => 'Sender',
@@ -61,6 +63,7 @@ class SendGridCest {
   }
 
   function itCannotSendWithoutProperApiKey() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $this->mailer->api_key = 'someapi';
     $result = $this->mailer->send(
       $this->newsletter,
@@ -70,6 +73,7 @@ class SendGridCest {
   }
 
   function itCanSend() {
+    if(getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') return;
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber


### PR DESCRIPTION
Mailer test credentials have been moved to `.env` You can also specify whether to enable the `send()` method.

```
WP_TEST_MAILER_ENABLE_SENDING="true"
WP_TEST_MAILER_AMAZON_ACCESS="AKIAJDCYK7DHCRVF7LXA"
WP_TEST_MAILER_AMAZON_SECRET="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"
WP_TEST_MAILER_AMAZON_REGION="us-west-2"
WP_TEST_MAILER_ELASTICEMAIL_API="997f1f7f-41de-4d7f-a8cb-86c8481370fa"
WP_TEST_MAILER_MAILGUN_API="key-6cf5g5qjzenk-7nodj44gdt8phe6vam2"
WP_TEST_MAILER_MAILGUN_DOMAIN="mrcasual.com"
WP_TEST_MAILER_MAILPOET_API="dhNSqj1XHkVltIliyQDvMiKzQShOA5rs0m_DdRUVZHU"
WP_TEST_MAILER_SENDGRID_API="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"
WP_TEST_MAILER_SMTP_HOST="email-smtp.us-west-2.amazonaws.com"
WP_TEST_MAILER_SMTP_LOGIN="AKIAIGPBLH6JWG5VCBQQ"
WP_TEST_MAILER_SMTP_PASSWORD="AudVHXHaYkvr54veCzqiqOxDiMMyfQW3/V6F1tYzGXY3"
```
