### PR TITLE
Code coverage report

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -108,6 +108,16 @@ class RoboFile extends \Robo\Tasks {
     $this->_exec('vendor/bin/codecept run unit '.(($file) ? $file : ''));
   }
 
+  function testCoverage() {
+    $this->loadEnv();
+    $this->_exec('vendor/bin/codecept build');
+    $this->_exec(join(' ', array(
+      'vendor/bin/codecept run',
+      '--coverage',
+      '--coverage-html'
+    )));
+  }
+
   function testJavascript() {
     $this->compileJs();
 

--- a/codeception.yml
+++ b/codeception.yml
@@ -19,3 +19,12 @@ modules:
             user: ''
             password: ''
             dump: tests/_data/dump.sql
+coverage:
+    enabled: true
+    whitelist:
+        include:
+            - lib/*
+        exclude:
+    blacklist:
+        include:
+        exclude:


### PR DESCRIPTION
in order to run this command, you need XDebug enabled:
- `sudo apt-get install php5-xdebug`
- `sudo php5enmod xdebug`

Run the command using: `./do test:coverage` OR `./do t:c` 
The report will be generated in `tests/_output/coverage/`
