### PR TITLE
Editor bug fixes

### DIFF
--- a/assets/js/src/newsletter_editor/blocks/base.js
+++ b/assets/js/src/newsletter_editor/blocks/base.js
@@ -58,7 +58,6 @@ define([
       DraggableBehavior: {
         cloneOriginal: true,
         hideOriginal: true,
-        ignoreSelector: ".mailpoet_tool:not(.mailpoet_move_block)",
         onDrop: function(options) {
           // After a clone of model has been dropped, cleanup
           // and destroy self

--- a/assets/js/src/newsletter_editor/blocks/container.js
+++ b/assets/js/src/newsletter_editor/blocks/container.js
@@ -94,7 +94,6 @@ define([
       DraggableBehavior: {
         cloneOriginal: true,
         hideOriginal: true,
-        ignoreSelector: ".mailpoet_tool:not(.mailpoet_move_block)",
         onDrop: function(options) {
           // After a clone of model has been dropped, cleanup
           // and destroy self

--- a/assets/js/src/newsletter_editor/blocks/social.js
+++ b/assets/js/src/newsletter_editor/blocks/social.js
@@ -120,7 +120,6 @@ define([
       DraggableBehavior: {
         cloneOriginal: true,
         hideOriginal: true,
-        ignoreSelector: ".mailpoet_tool:not(.mailpoet_move_block)",
         onDrop: function(options) {
           // After a clone of model has been dropped, cleanup
           // and destroy self

--- a/views/newsletter/templates/blocks/base/toolsGeneric.hbs
+++ b/views/newsletter/templates/blocks/base/toolsGeneric.hbs
@@ -1,7 +1,7 @@
-{{#if tools.layerSelector}}<a href="javascript:;" class="mailpoet_tool mailpoet_newsletter_layer_selector" title="<%= __('Switch editing layer') %>">
+{{#if tools.layerSelector}}<a href="javascript:;" class="mailpoet_tool mailpoet_newsletter_layer_selector mailpoet_ignore_drag" title="<%= __('Switch editing layer') %>">
     <%= source('newsletter/templates/svg/block-tools/settings-column.svg') %>
-</a>{{/if}}{{#if tools.settings}}<a href="javascript:;" class="mailpoet_tool mailpoet_edit_block" title="<%= __('Edit settings') %>">
+</a>{{/if}}{{#if tools.settings}}<a href="javascript:;" class="mailpoet_tool mailpoet_edit_block mailpoet_ignore_drag" title="<%= __('Edit settings') %>">
 <%= source('newsletter/templates/svg/block-tools/settings.svg') %>
-</a>{{/if}}{{#if tools.delete}}<div class="mailpoet_delete_block"><a href="javascript:;" class="mailpoet_tool mailpoet_delete_block_activate" title="<%= __('Delete') %>"><%= source('newsletter/templates/svg/block-tools/trash.svg') %></a><a href="javascript:;" class="mailpoet_delete_block_confirm" title="<%= __('Confirm deletion') %>"><%= __('Delete') %></a><a href="javascript:;" class="mailpoet_delete_block_cancel" title="<%= __('Cancel deletion') %>"><%= __('Cancel') %></a></div>{{/if}}{{#if tools.move}}<a href="javascript:;" class="mailpoet_tool mailpoet_move_block" title="<%= __('Drag to move') %>">
+</a>{{/if}}{{#if tools.delete}}<div class="mailpoet_delete_block mailpoet_ignore_drag"><a href="javascript:;" class="mailpoet_tool mailpoet_delete_block_activate" title="<%= __('Delete') %>"><%= source('newsletter/templates/svg/block-tools/trash.svg') %></a><a href="javascript:;" class="mailpoet_delete_block_confirm" title="<%= __('Confirm deletion') %>"><%= __('Delete') %></a><a href="javascript:;" class="mailpoet_delete_block_cancel" title="<%= __('Cancel deletion') %>"><%= __('Cancel') %></a></div>{{/if}}{{#if tools.move}}<a href="javascript:;" class="mailpoet_tool mailpoet_move_block" title="<%= __('Drag to move') %>">
 <%= source('newsletter/templates/svg/block-tools/move.svg') %>
 </a>{{/if}}


### PR DESCRIPTION
- Changes Posts/ALC converter to use MailPoet specific newsletter image size;
- Allows content blocks to be only dragged by the "Move" tool or by block contents. "Settings" or "Trash" tools should not initiate block drag;
- Changed editor to not send `last_modified` field back to the server, as that prevented `Last modified` field from being auto updated and caused it to be static.
