### PR TITLE
Fixes detection of reply_to address

### DIFF
--- a/lib/Mailer/Mailer.php
+++ b/lib/Mailer/Mailer.php
@@ -122,7 +122,7 @@ class Mailer {
       }
     }
     if(!$reply_to['address']) {
-      $reply_to['reply_to_email'] = $this->sender['from_email'];
+      $reply_to['address'] = $this->sender['from_email'];
     }
     return array(
       'reply_to_name' => $reply_to['name'],


### PR DESCRIPTION
If no reply_to address was specified, mailer class assigns it a value of sender's address
