### PR TITLE
Subscribe in comments

### DIFF
--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -9,10 +9,17 @@ class Hooks {
   function init() {
     // Subscribe in comments
     if((bool)Setting::getValue('subscribe.on_comment.enabled')) {
-      add_action(
-        'comment_form_after_fields',
-        '\MailPoet\Subscription\Comment::extendForm'
-      );
+      if(is_user_logged_in()) {
+        add_action(
+          'comment_form_field_comment',
+          '\MailPoet\Subscription\Comment::extendLoggedInForm'
+        );
+      } else {
+        add_action(
+          'comment_form_after_fields',
+          '\MailPoet\Subscription\Comment::extendLoggedOutForm'
+        );
+      }
 
       add_action(
         'comment_post',

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -25,7 +25,7 @@ class Initializer {
     register_activation_hook(Env::$file, array($this, 'runMigrator'));
     register_activation_hook(Env::$file, array($this, 'runPopulator'));
 
-    add_action('init', array($this, 'setup'));
+    add_action('plugins_loaded', array($this, 'setup'));
     add_action('widgets_init', array($this, 'setupWidget'));
   }
 

--- a/lib/Config/Localizer.php
+++ b/lib/Config/Localizer.php
@@ -11,8 +11,7 @@ class Localizer {
   function init() {
     add_action(
       'init',
-      array($this, 'setup'),
-      0
+      array($this, 'setup')
     );
   }
 

--- a/lib/Subscription/Comment.php
+++ b/lib/Subscription/Comment.php
@@ -8,13 +8,22 @@ class Comment {
   const APPROVED = 1;
   const PENDING_APPROVAL = 0;
 
-  static function extendForm() {
+  static function extendLoggedInForm($field) {
+    $field .= self::getSubscriptionField();
+    return $field;
+  }
+
+  static function extendLoggedOutForm() {
+    echo self::getSubscriptionField();
+  }
+
+  static function getSubscriptionField() {
     $label = Setting::getValue(
       'subscribe.on_comment.label',
       __('Yes, add me to your mailing list.')
     );
 
-    print '<p class="comment-form-mailpoet">
+    return '<p class="comment-form-mailpoet">
       <label for="mailpoet_subscribe_on_comment">
         <input
           type="checkbox"


### PR DESCRIPTION
## Issue

The `comment_form_after_fields` hook is only available for "anonymous" users (logged out).
Therefore, logged in users could not subscribe via comment.
## Solution

if a user is logged in, it uses the `comment_form_field_comment` hook which is called when the "comment" field is rendered. I just "append" our checkbox to it. That's the only reliable way I found to have it displayed before the submit button.
