### PR TITLE
Manage subscriptions (part 1)

### DIFF
--- a/assets/css/src/admin.styl
+++ b/assets/css/src/admin.styl
@@ -17,3 +17,5 @@
 
 @require 'settings'
 @require 'progress_bar'
+
+@require 'subscribers'

--- a/assets/css/src/subscribers.styl
+++ b/assets/css/src/subscribers.styl
@@ -1,0 +1,3 @@
+#subscribers_container
+  .mailpoet_segments_unsubscribed
+    color: lighten(#555, 33)

--- a/assets/js/src/segments/list.jsx
+++ b/assets/js/src/segments/list.jsx
@@ -181,13 +181,13 @@ const SegmentList = React.createClass({
           <abbr>{ segment.description }</abbr>
         </td>
         <td className="column-date" data-colname="Subscribed">
-          <abbr>{ segment.subscribed || 0 }</abbr>
+          <abbr>{ segment.subscribers_count.subscribed || 0 }</abbr>
         </td>
         <td className="column-date" data-colname="Unconfirmed">
-          <abbr>{ segment.unconfirmed || 0 }</abbr>
+          <abbr>{ segment.subscribers_count.unconfirmed || 0 }</abbr>
         </td>
         <td className="column-date" data-colname="Unsubscribed">
-          <abbr>{ segment.unsubscribed || 0 }</abbr>
+          <abbr>{ segment.subscribers_count.unsubscribed || 0 }</abbr>
         </td>
         <td className="column-date" data-colname="Created on">
           <abbr>{ segment.created_at }</abbr>

--- a/assets/js/src/subscribers/list.jsx
+++ b/assets/js/src/subscribers/list.jsx
@@ -231,6 +231,15 @@ const item_actions = [
 ];
 
 const SubscriberList = React.createClass({
+  getSegmentFromId: function(segment_id) {
+    let result = false;
+    mailpoet_segments.map(function(segment) {
+      if (segment.id === segment_id) {
+        result = segment;
+      }
+    });
+    return result;
+  },
   renderItem: function(subscriber, actions) {
     let row_classes = classNames(
       'manage-column',
@@ -255,11 +264,41 @@ const SubscriberList = React.createClass({
       break;
     }
 
-    let segments = mailpoet_segments.filter(function(segment) {
-      return (jQuery.inArray(segment.id, subscriber.segments) !== -1);
-    }).map(function(segment) {
-      return segment.name;
-    }).join(', ');
+    let segments = false;
+
+    if (subscriber.subscriptions.length > 0) {
+      let subscribed_segments = [];
+      let unsubscribed_segments = [];
+
+      subscriber.subscriptions.map((subscription) => {
+        const segment = this.getSegmentFromId(subscription.segment_id);
+        if (subscription.status === 'subscribed') {
+          subscribed_segments.push(segment.name);
+        } else {
+          unsubscribed_segments.push(segment.name);
+        }
+      });
+
+      segments = (
+        <span>
+          <span className="mailpoet_segments_subscribed">
+            { subscribed_segments.join(', ') }
+            {
+              (
+                subscribed_segments.length > 0
+                && unsubscribed_segments.length > 0
+              ) ? ' / ' : ''
+            }
+          </span>
+          <span
+            className="mailpoet_segments_unsubscribed"
+            title="Lists to which the subscriber was subscribed."
+          >
+            { unsubscribed_segments.join(', ') }
+          </span>
+        </span>
+      );
+    }
 
     let avatar = false;
     if(subscriber.avatar_url) {

--- a/lib/Form/Util/Export.php
+++ b/lib/Form/Util/Export.php
@@ -22,19 +22,21 @@ class Export {
         ), site_url());
 
         // generate iframe
-        return '<iframe '.
-        'width="100%" '.
-        'scrolling="no" '.
-        'frameborder="0" '.
-        'src="'.$iframe_url.'" '.
-        'class="mailpoet_form_iframe" '.
-        'vspace="0" '.
-        'tabindex="0" '.
-        'onload="javascript:(this.style.height = this.contentWindow.document.body.scrollHeight + \'px\');"'.
-        'marginwidth="0" '.
-        'marginheight="0" '.
-        'hspace="0" '.
-        'allowtransparency="true"></iframe>';
+        return join(' ', array(
+          '<iframe',
+          'width="100%"',
+          'scrolling="no"',
+          'frameborder="0"',
+          'src="'.$iframe_url.'"',
+          'class="mailpoet_form_iframe"',
+          'vspace="0"',
+          'tabindex="0"',
+          'onload="javascript:(this.style.height = this.contentWindow.document.body.scrollHeight + \'px\');"',
+          'marginwidth="0"',
+          'marginheight="0"',
+          'hspace="0"',
+          'allowtransparency="true"></iframe>'
+        ));
       break;
 
       case 'php':

--- a/lib/Listing/Handler.php
+++ b/lib/Listing/Handler.php
@@ -89,7 +89,7 @@ class Handler {
     $items = $this->model
       ->offset($this->data['offset'])
       ->limit($this->data['limit'])
-      ->findArray();
+      ->findMany();
 
     return array(
       'count' => $count,

--- a/lib/Models/Newsletter.php
+++ b/lib/Models/Newsletter.php
@@ -52,6 +52,11 @@ class Newsletter extends Model {
     );
   }
 
+  function withSegments() {
+    $this->segments = $this->segments()->findArray();
+    return $this;
+  }
+
   function options() {
     return $this->has_many_through(
       __NAMESPACE__.'\NewsletterOptionField',
@@ -66,6 +71,12 @@ class Newsletter extends Model {
       ->orderByDesc('updated_at')
       ->findOne();
   }
+
+  function withSendingQueue() {
+    $this->queue = $this->getQueue();
+    return $this;
+  }
+
 
   static function search($orm, $search = '') {
     return $orm->where_like('subject', '%' . $search . '%');

--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -291,7 +291,7 @@ class Subscriber extends Model {
         }
       }
       if($segment_ids !== false) {
-        $subscriber->addToSegments($segment_ids);
+        SubscriberSegment::setSubscriptions($subscriber, $segment_ids);
       }
     }
     return $subscriber;
@@ -311,6 +311,17 @@ class Subscriber extends Model {
       $this->{'cf_'.$relation->custom_field_id} = $relation->value;
     }
 
+    return $this;
+  }
+
+  function withSegments() {
+    $this->segments = $this->segments()->findArray();
+    return $this;
+  }
+
+  function withSubscriptions() {
+    $this->subscriptions = SubscriberSegment::where('subscriber_id', $this->id())
+      ->findArray();
     return $this;
   }
 

--- a/lib/Router/Forms.php
+++ b/lib/Router/Forms.php
@@ -13,11 +13,10 @@ class Forms {
 
   function get($id = false) {
     $form = Form::findOne($id);
-    if($form === false) {
-      return false;
-    } else {
-      return $form->asArray();
+    if($form !== false) {
+      $form = $form->asArray();
     }
+    return $form;
   }
 
   function listing($data = array()) {
@@ -29,19 +28,14 @@ class Forms {
     $listing_data = $listing->get();
 
     // fetch segments relations for each returned item
-    foreach($listing_data['items'] as &$item) {
-      // form's segments
-      $form_settings = (
-        (is_serialized($item['settings']))
-        ? unserialize($item['settings'])
+    foreach($listing_data['items'] as $key => $form) {
+      $form = $form->asArray();
+      $form['segments'] = (
+        !empty($form['settings']['segments'])
+        ? $form['settings']['segments']
         : array()
       );
-
-      $item['segments'] = (
-        !empty($form_settings['segments'])
-        ? $form_settings['segments']
-        : array()
-      );
+      $listing_data['items'][$key] = $form;
     }
 
     return $listing_data;

--- a/lib/Router/Newsletters.php
+++ b/lib/Router/Newsletters.php
@@ -206,20 +206,11 @@ class Newsletters {
 
     $listing_data = $listing->get();
 
-    foreach($listing_data['items'] as &$item) {
-      // get segments
-      $segments = NewsletterSegment::select('segment_id')
-        ->where('newsletter_id', $item['id'])
-        ->findMany();
-      $item['segments'] = array_map(function($relation) {
-        return $relation->segment_id;
-      }, $segments);
-
-      // get queue
-      $queue = SendingQueue::where('newsletter_id', $item['id'])
-        ->orderByDesc('updated_at')
-        ->findOne();
-      $item['queue'] = ($queue !== false) ? $queue->asArray() : null;
+    foreach($listing_data['items'] as $key => $newsletter) {
+      $listing_data['items'][$key] = $newsletter
+        ->withSegments()
+        ->withSendingQueue()
+        ->asArray();
     }
 
     return $listing_data;

--- a/lib/Router/Segments.php
+++ b/lib/Router/Segments.php
@@ -30,36 +30,14 @@ class Segments {
     $listing_data = $listing->get();
 
     // fetch segments relations for each returned item
-    foreach($listing_data['items'] as &$item) {
-      $stats = SubscriberSegment::table_alias('relation')
-        ->where(
-          'relation.segment_id',
-          $item['id']
-        )
-        ->join(
-          MP_SUBSCRIBERS_TABLE,
-          'subscribers.id = relation.subscriber_id',
-          'subscribers'
-        )
-        ->select_expr(
-          'SUM(CASE subscribers.status WHEN "subscribed" THEN 1 ELSE 0 END)',
-          'subscribed'
-        )
-        ->select_expr(
-          'SUM(CASE subscribers.status WHEN "unsubscribed" THEN 1 ELSE 0 END)',
-          'unsubscribed'
-        )
-        ->select_expr(
-          'SUM(CASE subscribers.status WHEN "unconfirmed" THEN 1 ELSE 0 END)',
-          'unconfirmed'
-        )
-        ->findOne()->asArray();
-
-      $item = array_merge($item, $stats);
-
-      $item['subscribers_url'] = admin_url(
-        'admin.php?page=mailpoet-subscribers#/filter[segment='.$item['id'].']'
+    foreach($listing_data['items'] as $key => $segment) {
+      $segment->subscribers_url = admin_url(
+        'admin.php?page=mailpoet-subscribers#/filter[segment='.$segment->id.']'
       );
+
+      $listing_data['items'][$key] = $segment
+        ->withSubscribersCount()
+        ->asArray();
     }
 
     return $listing_data;

--- a/lib/Twig/i18n.php
+++ b/lib/Twig/i18n.php
@@ -18,7 +18,13 @@ class i18n extends \Twig_Extension {
     // twig custom functions
     $twig_functions = array();
     // list of WP functions to map
-    $functions = array('localize', '__', '_n');
+    $functions = array(
+      'localize',
+      '__',
+      '_n',
+      'date',
+      'date_format'
+    );
 
     foreach($functions as $function) {
       $twig_functions[] = new \Twig_SimpleFunction(
@@ -55,6 +61,23 @@ class i18n extends \Twig_Extension {
     $args = func_get_args();
 
     return call_user_func_array('_n', $this->setTextDomain($args));
+  }
+
+  function date() {
+    $args = func_get_args();
+    $date = (isset($args[0])) ? $args[0] : null;
+    $date_format = (isset($args[1])) ? $args[1] : get_option('date_format');
+
+    if(empty($date)) return;
+
+    // check if it's an int passed as a string
+    if((string)(int)$date === $date) {
+      $date = (int)$date;
+    } else if(!is_int($date)) {
+      $date = strtotime($date);
+    }
+
+    return get_date_from_gmt(date('Y-m-d H:i:s', $date), $date_format);
   }
 
   private function setTextDomain($args = array()) {

--- a/tests/unit/Router/NewslettersCest.php
+++ b/tests/unit/Router/NewslettersCest.php
@@ -160,13 +160,18 @@ class NewslettersCest {
 
     expect($response['items'][0]['subject'])->equals('My Standard Newsletter');
     expect($response['items'][1]['subject'])->equals('My Post Notification');
-    expect($response['items'][0]['segments'])->equals(array(
-      $segment_1->id(),
-      $segment_2->id()
-    ));
-    expect($response['items'][1]['segments'])->equals(array(
-      $segment_2->id()
-    ));
+
+    // 1st subscriber has 2 segments
+    expect($response['items'][0]['segments'])->count(2);
+    expect($response['items'][0]['segments'][0]['id'])
+      ->equals($segment_1->id);
+    expect($response['items'][0]['segments'][1]['id'])
+      ->equals($segment_2->id);
+
+    // 2nd subscriber has 1 segment
+    expect($response['items'][1]['segments'])->count(1);
+    expect($response['items'][1]['segments'][0]['id'])
+      ->equals($segment_2->id);
   }
 
   function itCanBulkDeleteNewsletters() {
@@ -193,6 +198,7 @@ class NewslettersCest {
 
   function _after() {
     Newsletter::deleteMany();
+    NewsletterSegment::deleteMany();
     Segment::deleteMany();
   }
 }

--- a/views/subscribers/subscribers.html
+++ b/views/subscribers/subscribers.html
@@ -20,5 +20,7 @@
     var mailpoet_segments = <%= json_encode(segments) %>;
     var mailpoet_custom_fields = <%= json_encode(custom_fields) %>;
     var mailpoet_month_names = <%= json_encode(month_names) %>;
+    var mailpoet_date_format = "<%= get_option('date_format') %>";
+    var mailpoet_date_offset = "<%= get_option('gmt_offset') %>";
   </script>
 <% endblock %>


### PR DESCRIPTION
- make use of the SubscriberSegment::status column to keep track of unsubscriptions
- unsubscribed segments now appear grayed out in the Subscribers listing
- added unsubscribed_at after segment names when editing a subscriber
- added date() method for Twig (uses WP's date format / date_offset)
- fixed typo in Form iframe export
- fixed unit test for Newsletters
- updated selection component (JSX) to allow more customization
