### PR TITLE
Updates the newsletter shortcode

### DIFF
--- a/lib/Newsletter/Links/Links.php
+++ b/lib/Newsletter/Links/Links.php
@@ -25,7 +25,7 @@ class Links {
       . ')\\1#';
     preg_match_all($regex, $text, $links);
     $shortcodes = new Shortcodes();;
-    $shortcodes = $shortcodes->extract($text);
+    $shortcodes = $shortcodes->extract($text, $limit = array('subscription'));
     return array_merge(
       array_unique($links[2]),
       $shortcodes

--- a/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -13,8 +13,13 @@ class Shortcodes {
     $this->subscriber = $subscriber;
   }
 
-  function extract($text) {
-    preg_match_all('/\[(?:\w+):.*?\]/ism', $text, $shortcodes);
+  function extract($text, $limit = false) {
+    $limit = (is_array($limit)) ? implode('|', $limit) : false;
+    $regex = sprintf(
+      '/\[%s:.*?\]/ism',
+      ($limit) ? '(?:' . $limit . ')' : '(?:\w+)'
+    );
+    preg_match_all($regex, $text, $shortcodes);
     return array_unique($shortcodes[0]);
   }
 

--- a/tests/unit/Newsletter/ShortcodesTest.php
+++ b/tests/unit/Newsletter/ShortcodesTest.php
@@ -18,8 +18,10 @@ class ShortcodesTest extends MailPoetTest {
     $this->newsletter = array(
       'subject' => 'some subject',
       'type' => 'notification',
-      'id' => 1
+      'id' => 2
     );
+    $post = get_post(1);
+    $this->latest_post_title = $post->post_title;
     $this->rendered_newsletter = '
       Hello [user:displayname | default:member].
       Your first name is [user:firstname | default:First Name].
@@ -32,7 +34,7 @@ class ShortcodesTest extends MailPoetTest {
 
       There are [newsletter:total] posts in this newsletter.
       You are reading [newsletter:subject].
-      The latest post on this blog is called [newsletter:post_title].
+      The latest post in this newsletter is called [newsletter:post_title].
       The issue number of this newsletter is [newsletter:number].
 
       Date: [date:d].
@@ -58,15 +60,11 @@ class ShortcodesTest extends MailPoetTest {
 
   function testItCanProcessShortcodes() {
     $wp_user = get_userdata($this->wp_user);
-    $wp_latest_post = wp_get_recent_posts(array('numberposts' => 1));
-    $wp_latest_post = (isset($wp_latest_post)) ?
-      $wp_latest_post[0]['post_title'] :
-      false;
 
     $queue = SendingQueue::create();
     $queue->newsletter_id = $this->newsletter['id'];
     $queue->save();
-    $issue_number = 2;
+    $issue_number = 1;
 
     $number_of_posts = 2;
 
@@ -92,7 +90,7 @@ class ShortcodesTest extends MailPoetTest {
 
       There are {$number_of_posts} posts in this newsletter.
       You are reading {$this->newsletter['subject']}.
-      The latest post on this blog is called {$wp_latest_post}.
+      The latest post in this newsletter is called {$this->latest_post_title}.
       The issue number of this newsletter is {$issue_number}.
 
       Date: {$date->format('d')}.


### PR DESCRIPTION
- Fixes incorrect newsletter issue number display
- Updates newsletter 'last post title' logic
- Updates shortcode extraction regex to allow limiting extraction of only specific categories; this way during link extraction, `newsletter:total` would not convert into a link
- Updates unit tests
- Closes #380
