### PR TITLE
Import udate

### DIFF
--- a/assets/js/src/subscribers/importExport/import.js
+++ b/assets/js/src/subscribers/importExport/import.js
@@ -1112,6 +1112,7 @@ define(
                   });
                 importData.step2 = importResults;
                 enableSegmentSelection(mailpoetSegments);
+                toggleNextStepButton('off');
                 router.navigate('step3', {trigger: true});
               }
             });

--- a/tests/unit/Subscribers/ImportExport/Import/ImportTest.php
+++ b/tests/unit/Subscribers/ImportExport/Import/ImportTest.php
@@ -77,13 +77,15 @@ class ImportTest extends MailPoetTest {
       array(
         'first_name' => 'Adam',
         'last_name' => 'Smith',
-        'email' => 'adam@smith.com'
+        'email' => 'adam@smith.com',
+        'wp_user_id' => 1
       ));
     $subscriber->save();
-    list($existing, $new) = $this->import->filterExistingAndNewSubscribers(
+    list($existing, $wp_users, $new) = $this->import->filterExistingAndNewSubscribers(
       $subscribers_data
     );
     expect($existing['email'][0])->equals($subscribers_data['email'][0]);
+    expect($wp_users[0])->equals($subscriber->wp_user_id);
     expect($new['email'][0])->equals($subscribers_data['email'][1]);
   }
 


### PR DESCRIPTION
- Prevents WP user's first/last name to be updated during import
- Resets "next step" button state when going to step 3 of import
  Closes #469
