### PR TITLE
Prevent user from manually editing Standard newsletter scheduling date

### DIFF
--- a/assets/js/src/newsletters/send/standard.jsx
+++ b/assets/js/src/newsletters/send/standard.jsx
@@ -159,7 +159,7 @@ define(
             size="10"
             name={this.getFieldName()}
             value={this.getDisplayDate(this.props.value)}
-            readOnly="readOnly"
+            readOnly={ true }
             onChange={this.onChange}
             ref="dateInput"
             {...this.props.validation} />


### PR DESCRIPTION
This PR fixes a bug in Date picker of standard newsletter scheduling section.

This PR sets "Date" field as "Read Only" to prevent the user from manually editing the date field, and allows the user to only select a date via the date picker.

Otherwise Date parser may fail to parse the date (e.g. in case of empty string) and it will get stuck on "Invalid Date" value.

![image](https://cloud.githubusercontent.com/assets/562769/15426305/54b8818e-1e96-11e6-904d-bf64d507d10e.png)
