### PR TITLE
Fix Twig cache regeneration

### DIFF
--- a/lib/Config/Renderer.php
+++ b/lib/Config/Renderer.php
@@ -14,7 +14,8 @@ class Renderer {
       $file_system,
       array(
         'cache' => $this->detectCache(),
-        'debug' => WP_DEBUG
+        'debug' => WP_DEBUG,
+        'auto_reload' => true
       )
     );
   }
@@ -26,6 +27,7 @@ class Renderer {
     $this->setupHandlebars();
     $this->setupGlobalVariables();
     $this->setupSyntax();
+
     return $this->renderer;
   }
 


### PR DESCRIPTION
Closes #534 

Fixes Twig cache regeneration by enabling the `auto_reload` flag in `Twig_Environment` options.
This enables Twig to compare last modification times of the cached and actual templates to determine if it needs to be recompiled.
