### PR TITLE
Do not reset plugin settings on plugin reactivation

### DIFF
--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -75,12 +75,12 @@ class Populator {
       'address' => $current_user->user_email
     );
 
-    if (!Setting::getValue('sender')) {
+    if(!Setting::getValue('sender')) {
       // default from name & address
       Setting::setValue('sender', $sender);
     }
 
-    if (!Setting::getValue('signup_confirmation')) {
+    if(!Setting::getValue('signup_confirmation')) {
       // enable signup confirmation by default
       Setting::setValue('signup_confirmation', array(
         'enabled' => true,


### PR DESCRIPTION
Closes #455 

Fixes Populator to not overwrite existing plugin settings during activation.
