### PR TITLE
Removes object keys with null values when doing an ajax request

### DIFF
--- a/assets/js/src/ajax.js
+++ b/assets/js/src/ajax.js
@@ -1,4 +1,4 @@
-define('ajax', ['mailpoet', 'jquery'], function(MailPoet, jQuery) {
+define('ajax', ['mailpoet', 'jquery', 'underscore'], function(MailPoet, jQuery, _) {
   'use strict';
   MailPoet.Ajax = {
       version: 0.5,
@@ -51,6 +51,13 @@ define('ajax', ['mailpoet', 'jquery'], function(MailPoet, jQuery) {
         // set request params
         var params = this.getParams();
         var jqXHR;
+
+        // remove null values from the data object
+        if (_.isObject(params.data)) {
+          params.data = _.pick(params.data, function(value) {
+            return (value !== null)
+          })
+        }
 
         // make ajax request depending on method
         if(method === 'get') {


### PR DESCRIPTION
Issue: `null` values are transferred via POST/GET request as empty values that trigger DB errors when used with columns that are nullable. 

![image](http://i.imgur.com/UrfDadW.png)
`["SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'parent_id' at row 1"]`
