### PR TITLE
Manage Subscriptions fixes

### DIFF
--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -56,9 +56,16 @@ class API {
 
   static function decodeRequestData($data) {
     $data = base64_decode($data);
-    return (is_serialized($data)) ?
-      unserialize($data) :
-      self::terminateRequest(self::RESPONSE_ERROR, __('Invalid API data format.'));
+
+    if(is_serialized($data)) {
+      $data = unserialize($data);
+    }
+
+    if(!is_array($data)) {
+      $data = array();
+    }
+
+    return $data;
   }
 
   static function encodeRequestData($data) {

--- a/lib/API/Endpoints/Subscription.php
+++ b/lib/API/Endpoints/Subscription.php
@@ -10,6 +10,7 @@ class Subscription {
 
   static function confirm($data) {
     $subscription = new UserSubscription\Pages('confirm', $data);
+    $subscription->confirm();
   }
 
   static function manage($data) {
@@ -18,5 +19,6 @@ class Subscription {
 
   static function unsubscribe($data) {
     $subscription = new UserSubscription\Pages('unsubscribe', $data);
+    $subscription->unsubscribe();
   }
 }


### PR DESCRIPTION
related to issue #419
## API
- fixed issue when data parameter is not a valid base64 string, it now ensures that the decoded data is an array and does not terminate the request so as to allow fallback handled by the endpoint.
## Subscription Pages
- return specific error title/content when not in preview mode and the subscriber cannot be found.
- removed `isMailPoetPage()` as the logic was flawed, fixes an unreported issue where only the selected page in settings would display the page even though the api parameters were correct. (see details below)
- actually confirms the unconfirmed subscribers (it had been broken after the API refactor)
- actually unsubscribe the subscriber (it had been broken after the API refactor)
### Steps to reproduce on current master:
- leave the standard "confirmation page" in the settings.
- subscribe via a form, the confirmation link you receive is "X"
- change the "confirmation page" in the settings and save
- if you try to access "X", you would see the [mailpoet_page] shortcode instead of the correct confirmation message.

This issue affected all actions (unsubscribe, subscribe, manage). Now, whether you use an "old url" or a new url. As long as the api related parameters are correct. It'll behave as expected - only the display will change.
