### PR TITLE
Newsletter Archives page

### DIFF
--- a/lib/Config/Shortcodes.php
+++ b/lib/Config/Shortcodes.php
@@ -67,17 +67,16 @@ class Shortcodes {
   }
 
   function getArchive($params) {
+    $segment_ids = array();
     if(!empty($params['segments'])) {
       $segment_ids = array_map(function($segment_id) {
         return (int)trim($segment_id);
       }, explode(',', $params['segments']));
     }
 
-    $newsletters = array();
     $html = '';
 
-    // TODO: needs more advanced newsletters in order to finish
-    $newsletters = Newsletter::limit(10)->orderByDesc('created_at')->findMany();
+    $newsletters = Newsletter::getArchives($segment_ids);
 
     if(empty($newsletters)) {
       return apply_filters(
@@ -109,7 +108,7 @@ class Shortcodes {
   function renderArchiveDate($newsletter) {
     return date_i18n(
       get_option('date_format'),
-      strtotime($newsletter->created_at)
+      strtotime($newsletter->processed_at)
     );
   }
 


### PR DESCRIPTION
- replaced created_at by processed_at as the issue date (it's the date at which the newsletter finished sending).
- added the `Newsletter::getArchives($segment_ids = array())` method in order to fetch newsletters as per issue #487 requirements.
