### PR TITLE
Cron update

### DIFF
--- a/lib/Cron/CronHelper.php
+++ b/lib/Cron/CronHelper.php
@@ -76,13 +76,14 @@ class CronHelper {
     // proxy where there could be different ports (e.g., host:8080 => guest:80)
     $site_url = ($site_url) ? $site_url : home_url();
     $parsed_url = parse_url($site_url);
-    // 1. if the site URL does not contain a port, return the URL
+    // 1. if site URL does not contain a port, return the URL
     if(empty($parsed_url['port'])) return $site_url;
-    // 2. connect to the URL with specified port
+    // 2. if site URL contains valid port, try connecting to it
     $fp = @fsockopen($parsed_url['host'], $parsed_url['port'], $errno, $errstr, 1);
     if($fp) return $site_url;
+    // 3. if connection fails, attempt to connect the standard port derived from URL
+    // schema
     $port = (strtolower($parsed_url['scheme']) === 'http') ? 80 : 443;
-    // 3. connect to the URL with default port
     $fp = @fsockopen($parsed_url['host'], $port, $errno, $errstr, 1);
     if($fp) return sprintf('%s://%s', $parsed_url['scheme'], $parsed_url['host']);
     // 4. throw an error if all connection attempts failed

--- a/tests/unit/Cron/CronHelperTest.php
+++ b/tests/unit/Cron/CronHelperTest.php
@@ -91,7 +91,7 @@ class CronHelperTest extends MailPoetTest {
     $site_url = 'http://example.com:80';
     expect(CronHelper::getSiteUrl($site_url))->equals($site_url);
     //3. when url contains invalid port, try connecting to it. when connection fails,
-    // another attempt will be made to connect to the standard port derived form URL schema
+    // another attempt will be made to connect to the standard port derived from URL schema
     $site_url = 'http://example.com:8080';
     expect(CronHelper::getSiteUrl($site_url))->equals('http://example.com');
     //4. when connection can't be established, exception should be thrown


### PR DESCRIPTION
Fixes an issue when cron won't execute on sites that are behind proxy or running inside a virtual machine where host and guest ports are different (e.g., host localhost:8080 -> guest localhost:80)
