### PR TITLE
Preparation for plugin repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ rm -rf $plugin_name/vendor/swiftmailer/swiftmailer/tests
 rm -rf $plugin_name/vendor/cerdic/css-tidy/testing
 
 # Copy release files.
-cp LICENSE $plugin_name
+cp license.txt $plugin_name
 cp index.php $plugin_name
 cp $plugin_name.php $plugin_name
 cp readme.txt $plugin_name

--- a/license.txt
+++ b/license.txt
@@ -1,3 +1,42 @@
+WordPress - Web publishing software
+
+Copyright 2011-2016 by the contributors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+This program incorporates work covered by the following copyright and
+permission notices:
+
+  b2 is (c) 2001, 2002 Michel Valdrighi - m@tidakada.com -
+  http://tidakada.com
+
+  Wherever third party code has been used, credit has been given in the code's
+  comments.
+
+  b2 is released under the GPL
+
+and
+
+  WordPress - Web publishing software
+
+  Copyright 2003-2010 by the contributors
+
+  WordPress is released under the GPL
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
@@ -337,3 +376,10 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+WRITTEN OFFER
+
+The source code for any program binaries or compressed scripts that are
+included with WordPress can be freely obtained at the following URL:
+
+	https://wordpress.org/download/source/

--- a/readme.txt
+++ b/readme.txt
@@ -1,41 +1,89 @@
-=== MailPoet ===
+=== MailPoet 3 - Beta Version ===
 Contributors: mailpoet
-Donate link: http://mailpoet.com
-Tags: wordpress, plugin
-Requires at least: 4.0
-Tested up to: 4.0
-Stable tag: 1.0
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-
-MailPoet newsletters.
+Tags: newsletter, email, welcome email, post notification, autoresponder, mailchimp, signup, smtp
+Requires at least: 4.6
+Tested up to: 4.6
+Stable tag: 3.0.0
+Create and send beautiful emails and newsletters from WordPress.
 
 == Description ==
 
-Long description.
+Try the new MailPoet! This is a beta version of our completely new email newsletter plugin.(https://wordpress.org/plugins/wysija-newsletters/).
+
+= What's new? =
+
+* New email designer
+* Responsive templates
+* Send with MailPoet's sending service
+* Fast user interface
+* Easier initial configuration
+
+[Try the demo.](http://demo3.mailpoet.com/launch/)
+
+= Check out this 2 minute video. =
+
+[vimeo https://vimeo.com/183339372]
+
+= Use at your own risk! =
+
+Use [the current stable MailPoet](https://wordpress.org/plugins/wysija-newsletters/) instead of this version if you are not a power user.
+
+* This beta version is for testing purposes only!
+* Not RTL compatible
+* We expect bug reports from you!
+* Multisite not supported
+* No migration script from MailPoet 2.X to this version
+* Weekly releases
+
+= Premium version =
+
+Not available yet. Limited stats in free version.
+
+= Translations in your language =
+
+We accept translations in the repository.
 
 == Installation ==
 
-Installation instructions.
+There are 3 ways to install this plugin:
 
-== Screenshots ==
+= 1. The super easy way =
+1. In your Admin, go to menu Plugins > Add
+1. Search for `mailpoet`
+1. Click to install
+1. Activate the plugin
+1. A new menu `mailpoet` will appear in your Admin
 
-Screenshots.
+= 2. The easy way =
+1. Download the plugin (.zip file) on the right column of this page
+1. In your Admin, go to menu Plugins > Add
+1. Select the tab "Upload"
+1. Upload the .zip file you just downloaded
+1. Activate the plugin
+1. A new menu `MailPoet` will appear in your Admin
+
+= 3. The old and reliable way (FTP) =
+1. Upload `mailpoet` folder to the `/wp-content/plugins/` directory
+1. Activate the plugin through the 'Plugins' menu in WordPress
+1. A new menu `MailPoet` will appear in your Admin
 
 == Frequently Asked Questions ==
 
-= Question? =
+= Need help? =
 
-Answer.
+Our [support site](https://docs.mailpoet.com/) has plenty of articles. You can write to us on the forums too.
+
+== Screenshots ==
+
+1. Sample newsletters.
+2. The drag & drop editor.
+3. Subscriber management.
+4. Sending method configuration in Settings.
+5. Importing subscribers with a CSV or from MailChimp.
 
 == Changelog ==
 
-= 1.0 =
-* 2020-01-01
-* Initial release
+= 3.0.0 - 2016-09 =
 
-== Upgrade Notice ==
+* Hello world.
 
-= 1.0 =
-* 2020-01-01
-* Initial release

--- a/views/update.html
+++ b/views/update.html
@@ -50,7 +50,7 @@
 
   <div clas="feature-section one-col">
     <br>
-    <p style="text-align: center"><a class="button button-primary" href="https://wordpress.org/plugins/wysija-newsletters/changelog/" target="_blank"><%= __("View all changes") %> &rarr;</a></p>
+    <p style="text-align: center"><a class="button button-primary" href="https://wordpress.org/plugins/mailpoet/changelog/" target="_blank"><%= __("View all changes") %> &rarr;</a></p>
   </div>
 
 </div>


### PR DESCRIPTION
Related to #606 
- Replaces `LICENSE` file with `license.txt` and updates its contents with the ones given in the original issue;
- Updates contents of `readme.txt` with new readme text;
- Updates `View All Changes` button on `Changelog` tab of the plugin update page to link to our final plugin page on MailPoet plugin repo: `https://wordpress.org/plugins/mailpoet/changelog/`.
