### PR TITLE
ALC block tool fixes [MAILPOET-676]

### DIFF
--- a/assets/css/src/newsletter_editor/contentBlocks/automatedLatestContent.styl
+++ b/assets/css/src/newsletter_editor/contentBlocks/automatedLatestContent.styl
@@ -9,12 +9,13 @@
   background: rgba(255, 255, 255, 0)
   transition: background .15s ease-out
 
-  &:hover
+  .mailpoet_automated_latest_content_block:hover &
     background: rgba(255, 255, 255, 0.7)
     cursor: pointer
 
 .mailpoet_automated_latest_content_block_posts
   overflow: auto
+  pointer-events: none
 
   & > .mailpoet_block
     width: 100%


### PR DESCRIPTION
- Fixes ALC newsletter content block to prevent block tools of inner blocks from showing up.

Previously block tools of inner ALC blocks would appear if you moved your mouse from outside content area, and placed it where block tools of an inner block would appear.
That would've displayed two layers of block tools: lower layer was from ALC, upper layer was from inner block. And user would be able to interact with both, though both tools would interfere.
We want only ALC block tools to be displayed, which this PR fixes.