### PR TITLE
Escape paths for regexes in ExportTest->testItCanConstruct() to make …

### DIFF
--- a/tests/unit/Subscribers/ImportExport/Export/ExportTest.php
+++ b/tests/unit/Subscribers/ImportExport/Export/ExportTest.php
@@ -134,14 +134,14 @@ class ExportTest extends MailPoetTest {
     expect(
       preg_match(
         '|' .
-        Env::$temp_path . '/MailPoet_export_[a-f0-9]{15}.' .
+        preg_quote(Env::$temp_path, '|') . '/MailPoet_export_[a-f0-9]{15}.' .
         $this->export->export_format_option .
         '|', $this->export->export_file)
     )->equals(1);
     expect(
       preg_match(
         '|' .
-        Env::$temp_url . '/' .
+        preg_quote(Env::$temp_url, '|') . '/' .
         basename($this->export->export_file) .
         '|'
         , $this->export->export_file_URL)


### PR DESCRIPTION
…it pass on Windows

Otherwise it treated Windows-style slashed paths a-la `C:\WWW\home` as containing special characters and failed.