### PR TITLE
Fix import step 2 list selection box tallying unconfirmed subscribers… [MAILPOET-709]

### DIFF
--- a/lib/Models/Segment.php
+++ b/lib/Models/Segment.php
@@ -174,31 +174,7 @@ class Segment extends Model {
   }
 
   static function getSegmentsForImport() {
-    $query = self::selectMany(array(self::$_table.'.id', self::$_table.'.name'))
-      ->selectExpr(
-        self::$_table.'.*, ' .
-        'COUNT(IF('.
-          MP_SUBSCRIBER_SEGMENT_TABLE.'.status="'.Subscriber::STATUS_SUBSCRIBED.'"'
-          .' AND '.
-          MP_SUBSCRIBERS_TABLE.'.deleted_at IS NULL'
-          .', 1, NULL)) `subscribers`'
-      )
-      ->leftOuterJoin(
-        MP_SUBSCRIBER_SEGMENT_TABLE,
-        array(self::$_table.'.id', '=', MP_SUBSCRIBER_SEGMENT_TABLE.'.segment_id'))
-      ->leftOuterJoin(
-        MP_SUBSCRIBERS_TABLE,
-        array(MP_SUBSCRIBER_SEGMENT_TABLE.'.subscriber_id', '=', MP_SUBSCRIBERS_TABLE.'.id'))
-      ->groupBy(self::$_table.'.id')
-      ->groupBy(self::$_table.'.name')
-      ->orderByAsc(self::$_table.'.name')
-      ->whereNull(self::$_table.'.deleted_at');
-
-    if(!empty($type)) {
-      $query->where(self::$_table.'.type', $type);
-    }
-
-    return $query->findArray();
+    return self::getSegmentsWithSubscriberCount($type = false);
   }
 
   static function getSegmentsForExport($withConfirmedSubscribers = false) {

--- a/tests/unit/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/tests/unit/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -22,7 +22,7 @@ class ImportExportFactoryTest extends MailPoetTest {
       'first_name' => 'Mike',
       'last_name' => 'Smith',
       'status' => Subscriber::STATUS_SUBSCRIBED,
-      'email' => 'mike@maipoet.com'
+      'email' => 'mike@mailpoet.com'
     ));
 
     $association = SubscriberSegment::create();
@@ -50,27 +50,27 @@ class ImportExportFactoryTest extends MailPoetTest {
     expect($segments[0]['name'])->equals('Confirmed Segment');
     expect($segments[0]['subscriberCount'])->equals(1);
     expect($segments[1]['name'])->equals('Unconfirmed Segment');
-    expect($segments[1]['subscriberCount'])->equals(1);
+    expect($segments[1]['subscriberCount'])->equals(0);
   }
 
   function testItCanGetPublicSegmentsForImport() {
     $segments = $this->importFactory->getSegments();
     expect($segments[0]['subscriberCount'])->equals(1);
-    expect($segments[1]['subscriberCount'])->equals(1);
+    expect($segments[1]['subscriberCount'])->equals(0);
 
     $subscriber = Subscriber::where(
-      'email', 'john@mailpoet.com'
+      'email', 'mike@mailpoet.com'
     )->findOne();
     expect($subscriber->deleted_at)->null();
     $subscriber->trash();
 
     $subscriber = Subscriber::where(
-      'email', 'john@mailpoet.com'
+      'email', 'mike@mailpoet.com'
     )->whereNull('deleted_at')->findOne();
     expect($subscriber)->false();
 
     $segments = $this->importFactory->getSegments();
-    expect($segments[0]['subscriberCount'])->equals(1);
+    expect($segments[0]['subscriberCount'])->equals(0);
     expect($segments[1]['subscriberCount'])->equals(0);
   }
 


### PR DESCRIPTION
… (item B from #476)

Segments::getSegmentsForImport() was aliased to Segments::getSegmentsWithSubscriberCount()