### PR TITLE
Stop sending when newsletter is trashed [MAILPOET-716]

### DIFF
--- a/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -21,7 +21,7 @@ class Newsletter {
   }
 
   function getAndPreProcess($queue) {
-    $newsletter = $queue->newsletter()->findOne();
+    $newsletter = $queue->newsletter()->whereNull('deleted_at')->findOne();
     if(!$newsletter) {
       return false;
     }


### PR DESCRIPTION
- Runs mailer and cron execution limit checks at the same and in 3 locations: before processing, after each send operations and after queue
  processing
- Fixes an issue with sending continuing when newsletter is trashed
- Updates unit tests