### PR TITLE
Fix displaying dividers in ALC blocks MAILPOET-721

### DIFF
--- a/lib/Newsletter/Editor/PostListTransformer.php
+++ b/lib/Newsletter/Editor/PostListTransformer.php
@@ -14,7 +14,7 @@ class PostListTransformer {
 
   function transform($posts) {
     $results = array();
-    $use_divider = $this->args['showDivider'] === 'true';
+    $use_divider = filter_var($this->args['showDivider'], FILTER_VALIDATE_BOOLEAN);
 
     foreach($posts as $index => $post) {
       if($use_divider && $index > 0) {

--- a/lib/Newsletter/Editor/PostTransformer.php
+++ b/lib/Newsletter/Editor/PostTransformer.php
@@ -29,7 +29,7 @@ class PostTransformer {
       $structure = $this->appendFeaturedImage(
         $post,
         $this->args['displayType'],
-        $this->args['imageFullWidth'] === 'true',
+        filter_var($this->args['imageFullWidth'], FILTER_VALIDATE_BOOLEAN),
         $structure
       );
     } else {
@@ -37,7 +37,7 @@ class PostTransformer {
         $structure = $this->appendFeaturedImage(
           $post,
           $this->args['displayType'],
-          $this->args['imageFullWidth'] === 'true',
+          filter_var($this->args['imageFullWidth'], FILTER_VALIDATE_BOOLEAN),
           $structure
         );
       }
@@ -155,7 +155,7 @@ class PostTransformer {
   private function getPostTitle($post) {
     $title = $post->post_title;
 
-    if($this->args['titleIsLink'] === 'true') {
+    if(filter_var($this->args['titleIsLink'], FILTER_VALIDATE_BOOLEAN)) {
       $title = '<a href="' . get_permalink($post->ID) . '">' . $title . '</a>';
     }
 


### PR DESCRIPTION
Fixes displaying dividers in ALC blocks, when newsletter is rendered for emails and previews.

The issue was that boolean `true` was being compared with string `'true'` (due to boolean transmission issue over HTTP POST)
This is a quick fix patching the problem, a proper fix should be submitted later in a separate PR.