### PR TITLE
Add cache breaker query string to plugin static asset URLs [MAILPOET-713]

### DIFF
--- a/lib/Config/Renderer.php
+++ b/lib/Config/Renderer.php
@@ -55,8 +55,8 @@ class Renderer {
 
   function setupGlobalVariables() {
     $this->renderer->addExtension(new Twig\Assets(array(
-      'assets_url' => Env::$assets_url,
-      'assets_path' => Env::$assets_path
+      'version' => Env::$version,
+      'assets_url' => Env::$assets_url
     )));
   }
 

--- a/lib/Twig/Assets.php
+++ b/lib/Twig/Assets.php
@@ -47,8 +47,13 @@ class Assets
     $output = array();
 
     foreach($stylesheets as $stylesheet) {
-      $output[] = '<link rel="stylesheet" type="text/css"'.
-                  ' href="'.$this->_globals['assets_url'].'/css/'.$stylesheet.'">';
+      $url = $this->appendVersionToUrl(
+        $this->_globals['assets_url'] . '/css/' . $stylesheet
+      );
+      $output[] = sprintf(
+        '<link rel="stylesheet" type="text/css" href="%s">',
+        $url
+      );
     }
 
     return join("\n", $output);
@@ -59,15 +64,25 @@ class Assets
     $output = array();
 
     foreach($scripts as $script) {
-      $output[] = '<script type="text/javascript"'.
-                  ' src="'.$this->_globals['assets_url'].'/js/'.$script.'">'.
-                  '</script>';
+      $url = $this->appendVersionToUrl(
+        $this->_globals['assets_url'] . '/js/' . $script
+      );
+      $output[] = sprintf(
+        '<script type="text/javascript" src="%s"></script>',
+        $url
+      );
     }
 
     return join("\n", $output);
   }
 
   public function generateImageUrl($path) {
-    return $this->_globals['assets_url'].'/img/'.$path;
+    return $this->appendVersionToUrl(
+      $this->_globals['assets_url'] . '/img/' . $path
+    );
+  }
+
+  public function appendVersionToUrl($url) {
+    return add_query_arg('mailpoet_version', $this->_globals['version'], $url);
   }
 }

--- a/tests/unit/Twig/AssetsTest.php
+++ b/tests/unit/Twig/AssetsTest.php
@@ -1,0 +1,54 @@
+<?php
+use \MailPoet\Twig\Assets;
+
+class AssetsTest extends MailPoetTest {
+  function _before() {
+    $this->assets_url = 'https://www.testing.com/wp-content/plugins/mailpoet/assets';
+    $this->version = '1.2.3';
+    $this->assetsExtension = new Assets(array(
+      'assets_url' => $this->assets_url,
+      'version' => $this->version
+    ));
+  }
+
+  function testItGeneratesJavascriptTags() {
+    expect($this->assetsExtension->generateJavascript('script1.js', 'script2.js'))->equals(
+      '<script type="text/javascript" src="' . $this->assets_url . '/js/script1.js?mailpoet_version=' . $this->version . '"></script>'
+      . "\n"
+      . '<script type="text/javascript" src="' . $this->assets_url . '/js/script2.js?mailpoet_version=' . $this->version . '"></script>'
+    );
+  }
+
+  function testItGeneratesStylesheetTags() {
+    expect($this->assetsExtension->generateStylesheet('style1.css', 'style2.css'))->equals(
+      '<link rel="stylesheet" type="text/css" href="' . $this->assets_url . '/css/style1.css?mailpoet_version=' . $this->version . '">'
+      . "\n"
+      . '<link rel="stylesheet" type="text/css" href="' . $this->assets_url . '/css/style2.css?mailpoet_version=' . $this->version . '">'
+    );
+  }
+
+  function testItGeneratesImageUrls() {
+    expect($this->assetsExtension->generateImageUrl('image1.png'))->equals(
+      $this->assets_url . '/img/image1.png?mailpoet_version=' . $this->version
+    );
+  }
+
+  function testItAppendsVersionToUrl() {
+    $without_file = 'http://url.com/';
+    expect($this->assetsExtension->appendVersionToUrl($without_file))->equals(
+      $without_file . '?mailpoet_version=' . $this->version
+    );
+    $with_file = 'http://url.com/file.php';
+    expect($this->assetsExtension->appendVersionToUrl($with_file))->equals(
+      $with_file . '?mailpoet_version=' . $this->version
+    );
+    $with_folder = 'http://url.com/folder/file.php';
+    expect($this->assetsExtension->appendVersionToUrl($with_folder))->equals(
+      $with_folder . '?mailpoet_version=' . $this->version
+    );
+    $with_query_string = 'http://url.com/folder/file.php?name=value';
+    expect($this->assetsExtension->appendVersionToUrl($with_query_string))->equals(
+      $with_query_string . '&mailpoet_version=' . $this->version
+    );
+  }
+}


### PR DESCRIPTION
Adds a version specific query string to URLs of our static assets (JS, CSS and image files) when they are being included in Twig views.
This query string will change in each MailPoet release, thus it will also force the browser to re-download new static assets, preventing it from using old ones.