### PR TITLE
Save newsletter before sending preview [MAILPOET-702]

### DIFF
--- a/assets/js/src/newsletter_editor/components/save.js
+++ b/assets/js/src/newsletter_editor/components/save.js
@@ -40,7 +40,7 @@ define([
     App.getChannel().trigger('beforeEditorSave', json);
 
     // save newsletter
-    CommunicationComponent.saveNewsletter(json).done(function(response) {
+    return CommunicationComponent.saveNewsletter(json).done(function(response) {
       if(response.success !== undefined && response.success === true) {
         // TODO: Handle translations
         //MailPoet.Notice.success("<?php _e('Newsletter has been saved.'); ?>");
@@ -64,6 +64,14 @@ define([
       // TODO: Handle saving errors
       App.getChannel().trigger('afterEditorSave', {}, response);
     });
+  };
+
+  // For getting a promise after triggering save event
+  Module.saveAndProvidePromise = function(saveResult) {
+    var promise = Module.save();
+    if (saveResult !== undefined) {
+      saveResult.promise = promise;
+    }
   };
 
   Module.getThumbnail = function(element, options) {
@@ -335,12 +343,12 @@ define([
   };
 
   App.on('before:start', function(options) {
-    App.save = Module.save;
+    App.save = Module.saveAndProvidePromise;
     App.getChannel().on('autoSave', Module.autoSave);
 
     window.onbeforeunload = Module.beforeExitWithUnsavedChanges;
 
-    App.getChannel().on('save', function() { App.save(); });
+    App.getChannel().on('save', function(saveResult) { App.save(saveResult); });
   });
 
   App.on('start', function(options) {

--- a/assets/js/src/newsletter_editor/components/sidebar.js
+++ b/assets/js/src/newsletter_editor/components/sidebar.js
@@ -301,19 +301,25 @@ define([
       // send test email
       MailPoet.Modal.loading(true);
 
-      CommunicationComponent.previewNewsletter(data).always(function() {
-        MailPoet.Modal.loading(false);
-      }).done(function(response) {
-        MailPoet.Notice.success(
-          MailPoet.I18n.t('newsletterPreviewSent'),
-          { scroll: true });
-      }).fail(function(response) {
-        if (response.errors.length > 0) {
-          MailPoet.Notice.error(
-            response.errors.map(function(error) { return error.message; }),
-            { scroll: true, static: true }
-          );
-        }
+      // save before sending
+      var saveResult = {promise: null};
+      App.getChannel().trigger('save', saveResult);
+
+      saveResult.promise.always(function() {
+        CommunicationComponent.previewNewsletter(data).always(function() {
+          MailPoet.Modal.loading(false);
+        }).done(function(response) {
+          MailPoet.Notice.success(
+            MailPoet.I18n.t('newsletterPreviewSent'),
+            { scroll: true });
+        }).fail(function(response) {
+          if (response.errors.length > 0) {
+            MailPoet.Notice.error(
+              response.errors.map(function(error) { return error.message; }),
+              { scroll: true, static: true }
+            );
+          }
+        });
       });
     },
   });

--- a/tests/javascript/newsletter_editor/components/save.spec.js
+++ b/tests/javascript/newsletter_editor/components/save.spec.js
@@ -90,6 +90,16 @@ define([
 
         mock.verify();
       });
+
+      it('provides a promise if a result container is passed to save event', function() {
+        var spy = sinon.spy(module, 'save'),
+          saveResult = {promise: null};
+        module.saveAndProvidePromise(saveResult);
+        spy.restore();
+        expect(spy.calledOnce).to.be.true;
+        expect(saveResult.promise).to.be.an('object');
+        expect(saveResult.promise.then).to.be.a('function');
+      });
     });
 
     describe('view', function() {


### PR DESCRIPTION
I've used an object argument trick to pry the promise out of triggered save event. The promise made it possible to send preview only after saving is done.