### PR TITLE
Fix hardcoded year in unit tests [MAILPOET-767]

### DIFF
--- a/tests/unit/Form/Block/DateTest.php
+++ b/tests/unit/Form/Block/DateTest.php
@@ -28,8 +28,9 @@ class DateTest extends MailPoetTest {
   }
 
   function testItCanConvertMonthToDatetime() {
+    $current_year = date('Y');
     expect(Date::convertDateToDatetime('05', 'MM'))
-      ->equals('2016-05-01 00:00:00');
+      ->equals(sprintf('%s-05-01 00:00:00', $current_year));
   }
 
   function testItCanConvertYearToDatetime() {


### PR DESCRIPTION
Previously running unit tests in year 2017 would throw this error:

```
1) DateTest: It can convert month to datetime
 Test  tests/unit/Form/Block/DateTest.php:testItCanConvertMonthToDatetime
Failed asserting that two strings are equal.
- Expected | + Actual
@@ @@
-'2016-05-01 00:00:00'
+'2017-05-01 00:00:00'
#1  /var/www/mailpoet/tests/unit/Form/Block/DateTest.php:32
#2  DateTest->testItCanConvertMonthToDatetime
```
For a date format `MM`, when year is not given, the code defaults to using the current year.

This PR changes the test to always use the current year in that particular test.