### PR TITLE
Update tests and risky files removal in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,11 +50,13 @@ rm -rf $plugin_name/vendor/soundasleep/html2text/tests
 rm -rf $plugin_name/vendor/mtdowling/cron-expression/tests
 rm -rf $plugin_name/vendor/swiftmailer/swiftmailer/tests
 rm -rf $plugin_name/vendor/cerdic/css-tidy/testing
+rm -rf $plugin_name/vendor/sabberworm/php-css-parser/tests
 
 # Remove risky files from 3rd party extensions
 echo '[BUILD] Removing risky and demo files from vendor libraries'
 rm -f $plugin_name/vendor/j4mie/idiorm/demo.php
 rm -f $plugin_name/vendor/cerdic/css-tidy/css_optimiser.php
+rm -f $plugin_name/assets/js/lib/tinymce/package.json
 
 # Copy release files.
 echo '[BUILD] Copying release files'


### PR DESCRIPTION
Remove `vendor/sabberworm/php-css-parser/tests/` - 3rd party unit tests
Remove `assets/js/lib/tinymce/package.json` - risky file (useless, leaks dev machine full path in `_args` key)