### PR TITLE
Fix 'Create a new form' link on widgets page having no feedback [MAILPOET-691]

### DIFF
--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -79,9 +79,9 @@ class Widget extends \WP_Widget {
           endpoint: 'forms',
           action: 'create'
         }).done(function(response) {
-          if(response.result && response.form_id) {
+          if(response.data && response.data.id) {
             window.location =
-              "<?php echo $form_edit_url; ?>" + response.form_id;
+              "<?php echo $form_edit_url; ?>" + response.data.id;
           }
         });
         return false;


### PR DESCRIPTION
I fixed it to redirect to a form editor as was intended in the code. Not perfect in terms of UI, but we don't want to duplicate a form editor in a modal box, right?