### PR TITLE
Fix categories not showing for posts in newsletter editor [MAILPOET-808]

### DIFF
--- a/lib/Newsletter/Editor/MetaInformationManager.php
+++ b/lib/Newsletter/Editor/MetaInformationManager.php
@@ -43,7 +43,7 @@ class MetaInformationManager {
     // Get categories
     $categories = wp_get_post_terms(
       $post_id,
-      get_object_taxonomies($post_type),
+      array('post_tag', 'category'),
       array('fields' => 'names')
     );
     if(!empty($categories)) {


### PR DESCRIPTION
The issue was introduced in WP 4.7 whose code of post terms retrieval was refactored and results started to pass through a filter (`_post_format_get_terms`) that strips out anything not being a post format if only names are retrieved and the requested taxonomies list happens to contain `post_format`, no matter the rest.

Presumably we don't need to retrieve any custom taxonomies besides `category` and `post_tag` for displaying categories in ALC, so I thought I can explicitly specify them in the query.