### PR TITLE
Fix notices on newsletter editor page to not be absorbed into contents [MAILPOET-811]

### DIFF
--- a/assets/css/src/newsletter_editor/libraryOverrides.styl
+++ b/assets/css/src/newsletter_editor/libraryOverrides.styl
@@ -131,6 +131,7 @@ body
   display: none
 
 .wrap > .mailpoet_notice,
+.notice
 .update-nag
   margin-left: 2px + 15px !important
 

--- a/views/newsletter/editor.html
+++ b/views/newsletter/editor.html
@@ -224,6 +224,9 @@
 <% endblock %>
 
 <% block content %>
+<!-- Hidden heading for notices to appear under -->
+<h1 style="display:none"><%= __('Newsletter Editor') %></h1>
+
 <div id="mailpoet_editor">
     <div id="mailpoet_editor_heading"></div>
     <div class="mailpoet_breadcrumbs">


### PR DESCRIPTION
This adds a hidden heading, as WP default scripts will move and insert notices just after the first h1 or h2 heading.