### PR TITLE
Reschedules sending queues when scheduling options change [MAILPOET-837]

### DIFF
--- a/lib/Newsletter/Scheduler/Scheduler.php
+++ b/lib/Newsletter/Scheduler/Scheduler.php
@@ -157,6 +157,7 @@ class Scheduler {
     }
     $relation->value = $schedule;
     $relation->save();
+    return $relation->value;
   }
 
   static function getNextRunDate($schedule) {


### PR DESCRIPTION
For changelog: 

_* Fixed: previously scheduled send tasks are rescheduled when post notifications' scheduling options change. Thanks, Karen and Eric!;_