### PR TITLE
Forces ampersand as query separator for mailers [MAILPOET-850]

### DIFF
--- a/lib/Mailer/Methods/AmazonSES.php
+++ b/lib/Mailer/Methods/AmazonSES.php
@@ -134,7 +134,7 @@ class AmazonSES {
         'Authorization' => $this->signRequest($body),
         'X-Amz-Date' => $this->date
       ),
-      'body' => urldecode(http_build_query($body))
+      'body' => urldecode(http_build_query($body, null, '&'))
     );
   }
 
@@ -175,7 +175,7 @@ class AmazonSES {
       'x-amz-date:' . $this->date,
       '',
       'host;x-amz-date',
-      hash($this->hash_algorithm, urldecode(http_build_query($body)))
+      hash($this->hash_algorithm, urldecode(http_build_query($body, null, '&')))
     ));
   }
 

--- a/lib/Mailer/Methods/SendGrid.php
+++ b/lib/Mailer/Methods/SendGrid.php
@@ -75,7 +75,7 @@ class SendGrid {
       'headers' => array(
         'Authorization' => $this->auth()
       ),
-      'body' => http_build_query($body)
+      'body' => http_build_query($body, null, '&')
     );
   }
 }


### PR DESCRIPTION
For changelog:

_* Fixed: Amazon SES sending method now works regardless of custom "arg_separator" set in PHP's configuration. Thanks Lukas!;_