### PR TITLE
Improve performance of a subscriber listing on MySQL 5.5 and lower [MAILPOET-867]

### DIFF
--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -787,20 +787,13 @@ class Subscriber extends Model {
 
   static function withoutSegments($orm) {
     return $orm->select(MP_SUBSCRIBERS_TABLE.'.*')
-      ->rawJoin(
-        'LEFT OUTER JOIN (
-          SELECT `subscriber_id`
-          FROM '.MP_SUBSCRIBER_SEGMENT_TABLE.'
-          WHERE `status` = "'.self::STATUS_SUBSCRIBED.'"
-        )',
-        array(
-          MP_SUBSCRIBERS_TABLE.'.id',
-          '=',
-          MP_SUBSCRIBER_SEGMENT_TABLE.'.subscriber_id'
-        ),
-        MP_SUBSCRIBER_SEGMENT_TABLE
-      )
-      ->whereNull(MP_SUBSCRIBER_SEGMENT_TABLE.'.subscriber_id');
+      ->whereRaw(
+        MP_SUBSCRIBERS_TABLE . '.id NOT IN (
+        SELECT `subscriber_id`
+        FROM '.MP_SUBSCRIBER_SEGMENT_TABLE.'
+        WHERE `status` = "'.self::STATUS_SUBSCRIBED.'"
+        )'
+      );
   }
 
   static function createMultiple($columns, $values) {


### PR DESCRIPTION
MySQL <=5.5 does not use indexes for derived tables. More info: http://mysqlserverteam.com/mysql-5-7-improved-performance-of-queries-with-derived-tables/

I replaced a derived table with a subquery.