### PR TITLE
Rename a 'method' field in a form widget so it doesn't break the WP interactive customizer [MAILPOET-851]

### DIFF
--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -64,9 +64,13 @@ class API {
     $this->_endpoint = isset($data['endpoint'])
       ? Helpers::underscoreToCamelCase(trim($data['endpoint']))
       : null;
-    $this->_method = isset($data['method'])
-      ? Helpers::underscoreToCamelCase(trim($data['method']))
+
+    // JS part of /wp-admin/customize.php does not like a 'method' field in a form widget
+    $method_param_name = isset($data['mailpoet_method']) ? 'mailpoet_method' : 'method';
+    $this->_method = isset($data[$method_param_name])
+      ? Helpers::underscoreToCamelCase(trim($data[$method_param_name]))
       : null;
+
     $this->_token = isset($data['token'])
       ? trim($data['token'])
       : null;
@@ -100,6 +104,7 @@ class API {
           'token',
           'endpoint',
           'method',
+          'mailpoet_method', // alias of 'method'
           'mailpoet_redirect'
         );
         $this->_data = array_diff_key(

--- a/views/form/widget.html
+++ b/views/form/widget.html
@@ -16,7 +16,7 @@
       <input type="hidden" name="form_id" value="<%= form.id %>" />
       <input type="hidden" name="token" value="<%= token %>" />
       <input type="hidden" name="endpoint" value="subscribers" />
-      <input type="hidden" name="method" value="subscribe" />
+      <input type="hidden" name="mailpoet_method" value="subscribe" />
 
       <%= html | raw %>
       <div class="mailpoet_message">


### PR DESCRIPTION
Please check that both WP's customizer and our subscription form widget work as expected.