### PR TITLE
Fix last <br/> removal cutting off text when rendering a text block [MAILPOET-856]

### DIFF
--- a/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/lib/Newsletter/Renderer/Blocks/Text.php
@@ -166,7 +166,7 @@ class Text {
   }
 
   static function removeLastLineBreak($html) {
-    return preg_replace('/(^)?(<br.*?\/?>)+$/i', '', $html);
+    return preg_replace('/(^)?(<br[^>]*?\/?>)+$/i', '', $html);
   }
 
   static function insertLineBreak($element) {

--- a/tests/unit/Newsletter/RendererTest.php
+++ b/tests/unit/Newsletter/RendererTest.php
@@ -235,6 +235,14 @@ class NewsletterRendererTest extends MailPoetTest {
     // headings should be styled
     expect($DOM('tr > td.mailpoet_text > h1', 0)->attr('style'))
       ->contains('padding:0;font-style:normal;font-weight:normal;');
+
+    // trailing line breaks should be cut off, but not inside an element
+    $template = $newsletter['content']['blocks'][0]['blocks'][0]['blocks'][8];
+    $DOM = $this->DOM_parser->parseStr(Text::render($template));
+    expect(count($DOM('tr > td > br', 0)))
+      ->equals(0);
+    expect($DOM('tr > td > h3', 0)->html())
+      ->contains('<a');
   }
 
   function testItRendersDivider() {

--- a/tests/unit/Newsletter/RendererTestData.json
+++ b/tests/unit/Newsletter/RendererTestData.json
@@ -207,6 +207,10 @@
                     "textAlign": "center"
                   }
                 }
+              },
+              {
+                "type": "text",
+                "text": "<p>Test trailing line breaks removal</p>\n<h3>Test line breaks <br/> in headings <a href=\"http://www.example.org\">haha</a></h3><br /><br><br/>"
               }
             ]
           }


### PR DESCRIPTION
The regex in the `Text::removeLastLineBreak()` method was flawed. Working on a last line of a HTML string, it was cutting off everything from the first `<br />` it encounters to the end of the string if the last symbol happened to be `>` (a tag closing symbol). This affected headings because they contain no newlines.