### PR TITLE
Wrap notices containing HTML in a paragraph, upgrade notice classes [MAILPOET-733]

### DIFF
--- a/assets/js/src/notice.js
+++ b/assets/js/src/notice.js
@@ -142,13 +142,13 @@ define('notice', ['mailpoet', 'jquery'], function(MailPoet, jQuery) {
       // set class name
       switch (this.options.type) {
         case 'success':
-          this.element.addClass('updated');
+          this.element.addClass('notice notice-success');
         break;
         case 'system':
-          this.element.addClass('update-nag');
+          this.element.addClass('notice notice-warning');
         break;
         case 'error':
-          this.element.addClass('error');
+          this.element.addClass('notice notice-error');
         break;
       }
 
@@ -188,7 +188,7 @@ define('notice', ['mailpoet', 'jquery'], function(MailPoet, jQuery) {
         // single id
         jQuery('[data-id="' + all + '"]').trigger('close');
       } else {
-        jQuery('.mailpoet_notice.updated:not([id]), .mailpoet_notice.error:not([id])')
+        jQuery('.mailpoet_notice.notice-success:not([id]), .mailpoet_notice.notice-error:not([id])')
           .trigger('close');
       }
     },


### PR DESCRIPTION
When a notice contained HTML it wasn't wrapped in a paragraph thus appearing thin and with a dislocated close button.

I've also upgraded notice classes as the ones we used before were deprecated. More info: 
https://digwp.com/2016/05/wordpress-admin-notices/
https://codex.wordpress.org/Plugin_API/Action_Reference/admin_notices