### PR TITLE
Wrap form widget title as configured by the sidebar [MAILPOET-910]

### DIFF
--- a/views/form/widget.html
+++ b/views/form/widget.html
@@ -2,7 +2,7 @@
   <%= before_widget | raw %>
 
   <% if(title) %>
-    <h2 class="widget-title"><%= title | raw %></h2>
+    <%= before_title | raw %><%= title | raw %><%= after_title | raw %>
   <% endif %>
 
   <div id="<%= form_id %>" class="mailpoet_form mailpoet_form_<%= form_type %>">


### PR DESCRIPTION
Previously the wrapping HTML used for Form Widget title was hardcoded to be `h2`.
Instead it should be wrapped in HTML that is defined by the sidebar itself, in the form of `before_widget`, `after_widget`, `before_title`, `after_title` values.

This PR fixes title wrapping to use `before_title` and `after_title` values.

This may be tested by selecting one of the default themes (e.g. `twentyseventeen`), looking up the `register_sidebar()` function calls in `functions.php` file of the theme and changing `before_title` and `after_title` values for the sidebar.
Refreshing the page should display updated form widgets, which should also conform with other widgets on the page.