### PR TITLE
Add indexes to stat tables to speed up counting unopened subscribers [PREMIUM-21]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -319,7 +319,8 @@ class Migrator {
       'updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (id),',
       'KEY newsletter_id (newsletter_id),',
-      'KEY queue_id (queue_id)',
+      'KEY queue_id (queue_id),',
+      'KEY subscriber_id (subscriber_id)',
     );
     return $this->sqlify(__FUNCTION__, $attributes);
   }
@@ -333,7 +334,8 @@ class Migrator {
       'created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (id),',
       'KEY newsletter_id (newsletter_id),',
-      'KEY queue_id (queue_id)',
+      'KEY queue_id (queue_id),',
+      'KEY subscriber_id (subscriber_id)',
     );
     return $this->sqlify(__FUNCTION__, $attributes);
   }
@@ -347,7 +349,8 @@ class Migrator {
       'created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (id),',
       'KEY newsletter_id (newsletter_id),',
-      'KEY queue_id (queue_id)',
+      'KEY queue_id (queue_id),',
+      'KEY subscriber_id (subscriber_id)',
     );
     return $this->sqlify(__FUNCTION__, $attributes);
   }


### PR DESCRIPTION
The performance problem was with the query that counts unopened subscribers, it joins tables by `subscriber_id` fields which had no indexes:
https://github.com/mailpoet/mailpoet-premium/blob/master/lib/Newsletter/Stats/SubscriberEngagement.php#L287