### PR TITLE
Fix inability to deactivate MSS [MAILPOET-1058]

### DIFF
--- a/views/settings/mta.html
+++ b/views/settings/mta.html
@@ -760,6 +760,8 @@
         saveSendingMethodConfiguration('mailpoet');
       });
       $('.mailpoet_mta_setup_save').on('click', function() {
+        $('#mailpoet_smtp_method').trigger("change");
+        $('#other_frequency_emails').trigger("change");
         // get selected method
         var group = $('.mailpoet_sending_method:visible').data('group');
         saveSendingMethodConfiguration(group);


### PR DESCRIPTION
It isn't so beautiful, just a quick fix as we have users on support complaining.

The MTA settings mess is getting more and more tangled. For example, I don't like the coupling of rendering and setting values to-be-sent-to-server in `renderHostsSelect` and similar functions. Not necessarily a React rewrite rom scratch, but introducing a bit of clarity and structure to existing code would be nice.