### PR TITLE
Fixes undefined JS error when vendor.js is loaded deferred [MAILPOET-1026]

### DIFF
--- a/lib/Config/Widget.php
+++ b/lib/Config/Widget.php
@@ -121,7 +121,7 @@ function initMailpoetTranslation() {
   if(typeof MailPoet !== 'undefined') {
     MailPoet.I18n.add('ajaxFailedErrorMessage', '%s')
   } else {
-    setTimeout(waitForElement, 250);
+    setTimeout(initMailpoetTranslation, 250);
   }
 }
 setTimeout(initMailpoetTranslation, 250);


### PR DESCRIPTION
To replicate: install https://en-ca.wordpress.org/plugins/async-javascript/ and configure it to load all JS deferred, then load the main site (not admin) and check browser console. 

To test the fix: replicate the issue first, then add a subscription widget to the main site, add an `exit()` statement to https://github.com/mailpoet/mailpoet/blob/mailpoet_undefined_fix/lib/API/JSON/v1/Subscribers.php#L61 and then try subscribing. 