### PR TITLE
Prevents WP subscribers' first/last name from being erased [MAILPOET-1062]

### DIFF
--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -488,7 +488,10 @@ class Subscriber extends Model {
       unset($data['segments']);
     }
 
-    $data = self::setRequiredFieldsDefaultValues($data);
+    // if new subscriber, make sure that required fields are set
+    if(!$subscriber) {
+      $data = self::setRequiredFieldsDefaultValues($data);
+    }
 
     // get custom fields
     list($data, $custom_fields) = self::extractCustomFieldsFromFromObject($data);

--- a/tests/unit/Models/SubscriberTest.php
+++ b/tests/unit/Models/SubscriberTest.php
@@ -1025,6 +1025,29 @@ class SubscriberTest extends \MailPoetTest {
     );
   }
 
+  function testItSetsDefaultValuesForNewSubscribers() {
+    $result = Subscriber::createOrUpdate(
+      array(
+        'email' => 'new.subscriber@example.com'
+      )
+    );
+    expect($result->getErrors())->false();
+    expect($result->first_name)->isEmpty();
+    expect($result->last_name)->isEmpty();
+  }
+
+  function testItDoesNotSetDefaultValuesForExistingSubscribers() {
+    $existing_subscriber_data = $this->data;
+    $result = Subscriber::createOrUpdate(
+      array(
+        'email' => $existing_subscriber_data['email']
+      )
+    );
+    expect($result->getErrors())->false();
+    expect($result->first_name)->equals($this->data['first_name']);
+    expect($result->last_name)->equals($this->data['last_name']);
+  }
+
   function testItExtractsCustomFieldsFromObject() {
     $data = array(
       'email' => 'test@example.com',


### PR DESCRIPTION
To replicate: send an email to a WP subscriber, click on "manage subscription" and update subscription. When the form reloads, first/last name are blank.