### PR TITLE
Fix makepot adding extra slashes to escaped characters in views [MAILPOET-1093]

### DIFF
--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/extract.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/extract.php
@@ -289,7 +289,7 @@ class StringExtractor {
         $arguments = array();
         foreach($arguments_matches[0] as $argument) {
           // Remove surrounding quotes of the same type from argument strings
-          $arguments[] = preg_replace("/^(('|\")+)(.*)\\1$/", "\\3", $argument);
+          $arguments[] = preg_replace("/^(('|\")+)(.*)\\1$/", "\\3", stripslashes($argument));
         }
 
         $call = array(


### PR DESCRIPTION
This fixes item #2 from [here](https://mailpoet.atlassian.net/browse/MAILPOET-1093?focusedCommentId=16028&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16028).

After fixing this we also need to log in to Transifex and manually remove excessive slashes from 4 strings in each language to be able to bundle fixed translations in the next release.