### PR TITLE
Fix the possibility of repeatedly submitting a form with an existing e-mail address [MAILPOET-1115]

### DIFF
--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -184,8 +184,8 @@ class Subscriber extends Model {
         'subscribed_ip',
         $subscriber_data['subscribed_ip']
       )->whereRaw(
-        'TIME_TO_SEC(TIMEDIFF(NOW(), created_at)) < ?',
-        self::SUBSCRIPTION_LIMIT_COOLDOWN
+        '(TIME_TO_SEC(TIMEDIFF(NOW(), created_at)) < ? OR TIME_TO_SEC(TIMEDIFF(NOW(), updated_at)) < ?)',
+        array(self::SUBSCRIPTION_LIMIT_COOLDOWN, self::SUBSCRIPTION_LIMIT_COOLDOWN)
       )->count();
 
     if($subscription_count > 0) {
@@ -205,6 +205,7 @@ class Subscriber extends Model {
     } else {
       // store subscriber data to be updated after confirmation
       $subscriber->setUnconfirmedData($subscriber_data);
+      $subscriber->setExpr('updated_at', 'NOW()');
     }
 
     // restore trashed subscriber


### PR DESCRIPTION
We needed to set and check the `updated_at` date to prevent this.