### PR TITLE
Move throttling out of the Subscriber model to the API subscribe method [MAILPOET-1115]

### DIFF
--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -14,7 +14,6 @@ class Subscriber extends Model {
   const STATUS_UNSUBSCRIBED = 'unsubscribed';
   const STATUS_UNCONFIRMED = 'unconfirmed';
   const STATUS_BOUNCED = 'bounced';
-  const SUBSCRIPTION_LIMIT_COOLDOWN = 60;
   const SUBSCRIBER_TOKEN_LENGTH = 6;
 
   function __construct() {
@@ -175,22 +174,7 @@ class Subscriber extends Model {
       'signup_confirmation.enabled'
     );
 
-    $subscriber_data['subscribed_ip'] = (isset($_SERVER['REMOTE_ADDR']))
-      ? $_SERVER['REMOTE_ADDR']
-      : null;
-
-    // make sure we don't allow too many subscriptions with the same ip address
-    $subscription_count = Subscriber::where(
-        'subscribed_ip',
-        $subscriber_data['subscribed_ip']
-      )->whereRaw(
-        '(TIME_TO_SEC(TIMEDIFF(NOW(), created_at)) < ? OR TIME_TO_SEC(TIMEDIFF(NOW(), updated_at)) < ?)',
-        array(self::SUBSCRIPTION_LIMIT_COOLDOWN, self::SUBSCRIPTION_LIMIT_COOLDOWN)
-      )->count();
-
-    if($subscription_count > 0) {
-      throw new \Exception(__('You need to wait before subscribing again.', 'mailpoet'));
-    }
+    $subscriber_data['subscribed_ip'] = Helpers::getIP();
 
     $subscriber = self::findOne($subscriber_data['email']);
 

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -64,7 +64,7 @@ class Pages {
     $subscriber_data = $this->subscriber->getUnconfirmedData();
 
     $this->subscriber->status = Subscriber::STATUS_SUBSCRIBED;
-    $this->subscriber->confirmed_ip = (!empty($_SERVER['REMOTE_ADDR'])) ? $_SERVER['REMOTE_ADDR'] : null;
+    $this->subscriber->confirmed_ip = Helpers::getIP();
     $this->subscriber->setExpr('confirmed_at', 'NOW()');
     $this->subscriber->unconfirmed_data = null;
     $this->subscriber->save();

--- a/lib/Util/Helpers.php
+++ b/lib/Util/Helpers.php
@@ -146,4 +146,9 @@ class Helpers {
     return explode(self::DIVIDER, $object);
   }
 
+  static function getIP() {
+    return (isset($_SERVER['REMOTE_ADDR']))
+      ? $_SERVER['REMOTE_ADDR']
+      : null;
+  }
 }


### PR DESCRIPTION
This is done to not throttle internal calls to `Subscriber::subscribe()`, e.g. in hooks for subscribing from comments or site registration.

As a bonus, this will be a cleaner base for implementing progressive throttling and more sophisticated IP retrieval routine a-la MP2.