### PR TITLE
Don't synchronize WP users without emails [MAILPOET-1158]

### DIFF
--- a/lib/Segments/WP.php
+++ b/lib/Segments/WP.php
@@ -180,7 +180,7 @@ class WP {
 
     $wp_segment->subscribers()
       ->leftOuterJoin($wpdb->users, array(MP_SUBSCRIBERS_TABLE . '.wp_user_id', '=', 'wu.id'), 'wu')
-      ->whereNull('wu.id')
+      ->whereRaw('(wu.id IS NULL OR ' . MP_SUBSCRIBERS_TABLE . '.email = "")')
       ->findResultSet()
       ->set('wp_user_id', null)
       ->delete();


### PR DESCRIPTION
There's removal of WP subscribers with empty emails introduced, please make sure it doesn't bring any harm.