### PR TITLE
plugin scripts should be loaded with a dependency on jquery [MAILPOET-1149]

### DIFF
--- a/lib/Config/Widget.php
+++ b/lib/Config/Widget.php
@@ -105,7 +105,7 @@ class Widget {
     wp_enqueue_script(
       'mailpoet_public',
       Env::$assets_url . '/js/' . $this->renderer->getJsAsset('public.js'),
-      array(),
+      array('jquery'),
       Env::$version,
       true
     );


### PR DESCRIPTION
To reproduce the issue, I added these lines to the `twentyseventeen_scripts` function into `functions.php` file (yes I am using the default twentyseventeen theme):

```
wp_deregister_script( 'jquery' );
wp_register_script( 'jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js', array(), '1.11.0', true );
wp_enqueue_script( 'jquery' );
```