### PR TITLE
Enable permissions for superadmin users [MAILPOET-1200]

### DIFF
--- a/lib/Config/AccessControl.php
+++ b/lib/Config/AccessControl.php
@@ -22,8 +22,6 @@ class AccessControl {
 
   function __construct() {
     $this->permissions = self::getDefaultPermissions();
-    $this->user_roles = $this->getUserRoles();
-    $this->user_capabilities = $this->getUserCapabilities();
   }
 
   static function getDefaultPermissions() {
@@ -80,30 +78,8 @@ class AccessControl {
     );
   }
 
-  function getUserRoles() {
-    $user = wp_get_current_user();
-    return $user->roles;
-  }
-
-  function getUserCapabilities() {
-    $user = wp_get_current_user();
-    return array_keys($user->allcaps);
-  }
-
-  function getUserFirstCapability() {
-    return (!empty($this->user_capabilities)) ?
-      $this->user_capabilities[0] :
-      null;
-  }
-
   function validatePermission($permission) {
     if($permission === self::NO_ACCESS_RESTRICTION) return true;
-    foreach($this->user_roles as $role) {
-      $role_object = get_role($role);
-      if($role_object && $role_object->has_cap($permission)) {
-        return true;
-      }
-    }
-    return false;
+    return current_user_can($permission);
   }
 }

--- a/tests/unit/Config/AccessControlTest.php
+++ b/tests/unit/Config/AccessControlTest.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Test\Config;
 
+use AspectMock\Test as Mock;
+use Codeception\Util\Stub;
+use Helper\WordPress as WPHelper;
 use Helper\WordPressHooks as WPHooksHelper;
 use MailPoet\Config\AccessControl;
 use MailPoet\WP\Hooks;
@@ -103,7 +106,18 @@ class AccessControlTest extends \MailPoetTest {
     expect(count($permissions))->equals(count($labels));
   }
 
+  function testItValidatesIfUserHasCapability() {
+    $capability = 'some_capability';
+    $access_control = new AccessControl();
+
+    $func = Mock::func('MailPoet\Config', 'current_user_can', true);
+
+    expect($access_control->validatePermission($capability))->true();
+    $func->verifyInvoked([$capability]);
+  }
+
   function _after() {
-    WPHooksHelper::releaseAllHooks();
+    Mock::clean();
+    WPHelper::releaseAllFunctions();
   }
 }

--- a/tests/unit/Router/RouterTest.php
+++ b/tests/unit/Router/RouterTest.php
@@ -95,23 +95,37 @@ class RouterTest extends \MailPoetTest {
   }
 
   function testItValidatesGlobalPermission() {
-    $access_control = new AccessControl();
     $router = $this->router;
 
     $permissions = array(
       'global' => AccessControl::PERMISSION_MANAGE_SETTINGS,
     );
-    $access_control->user_roles = array();
+    $access_control = Stub::make(
+      new AccessControl(),
+      array(
+        'validatePermission' => Stub::once(function($cap) {
+          expect($cap)->equals(AccessControl::PERMISSION_MANAGE_SETTINGS);
+          return false;
+        })
+      )
+    );
     $router->access_control = $access_control;
     expect($router->validatePermissions(null, $permissions))->false();
 
-    $access_control->user_roles = $access_control->permissions[AccessControl::PERMISSION_MANAGE_SETTINGS];
+    $access_control = Stub::make(
+      new AccessControl(),
+      array(
+        'validatePermission' => Stub::once(function($cap) {
+          expect($cap)->equals(AccessControl::PERMISSION_MANAGE_SETTINGS);
+          return true;
+        })
+      )
+    );
     $router->access_control = $access_control;
     expect($router->validatePermissions(null, $permissions))->true();
   }
 
   function testItValidatesEndpointActionPermission() {
-    $access_control = new AccessControl();
     $router = $this->router;
 
     $permissions = array(
@@ -121,11 +135,27 @@ class RouterTest extends \MailPoetTest {
       )
     );
 
-    $access_control->user_roles = array();
+    $access_control = Stub::make(
+      new AccessControl(),
+      array(
+        'validatePermission' => Stub::once(function($cap) {
+          expect($cap)->equals(AccessControl::PERMISSION_MANAGE_SETTINGS);
+          return false;
+        })
+      )
+    );
     $router->access_control = $access_control;
     expect($router->validatePermissions('test', $permissions))->false();
 
-    $access_control->user_roles = $access_control->permissions[AccessControl::PERMISSION_MANAGE_SETTINGS];
+    $access_control = Stub::make(
+      new AccessControl(),
+      array(
+        'validatePermission' => Stub::once(function($cap) {
+          expect($cap)->equals(AccessControl::PERMISSION_MANAGE_SETTINGS);
+          return true;
+        })
+      )
+    );
     $router->access_control = $access_control;
     expect($router->validatePermissions('test', $permissions))->true();
   }


### PR DESCRIPTION
This change is relevant only for multisites.
Thing is that "superadmin" is not an actual role a WP user can have. A superadmin may have all roles and capabilities disabled, but WP core has a special list for superadmin users, and being a superadmin grants all capabilities.
This granting of all capabilities is enforced in `$user->has_cap()` method within WP core and is not tied to any particular role.
Because of this, we have to switch from checking each user's role for granted capabilities, to checking if a user has a specific capability.
WP core will figure it out if any of the roles a user has grants the user that particular capability.

Because of the way it's built, we cannot stub out `is_multisite()` and `is_super_admin()` methods to write a test for this behavior, since it is checked in `$user->has_cap()` method and `is_super_admin()` global WP function, so without a multisite environment to run in I don't see much choice here.

So instead we switch to using `current_user_can()` to check for capabilities, without explicitly testing that it will work for a superadmin (and instead we implicitly trust that WP core will do the right thing).