### PR TITLE
Fix an 'Undefined index: SERVER_NAME' error in ConflictResolverTest [MAILPOET-1187]

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -50,6 +50,10 @@ $kernel->init(
   )
 );
 
+// This hook throws an 'Undefined index: SERVER_NAME' error in CLI mode,
+// the action is called in ConflictResolverTest
+remove_filter('admin_print_styles', 'wp_resource_hints', 1);
+
 abstract class MailPoetTest extends \Codeception\TestCase\Test {
   protected $backupGlobals = true;
   protected $backupGlobalsBlacklist = array(


### PR DESCRIPTION
The error was arising when our Migrator was triggered (e.g. when the plugin needed an update or on a second test run with empty tables).

How this happened:
1. Migrator class includes `upgrade.php` WP file: https://github.com/mailpoet/mailpoet/blob/3.1.0/lib/Config/Migrator.php#L10
2. The included file calls `admin.php` and then `admin-filters.php` which sets up a hook on `admin_print_styles` named `wp_resource_hints` (https://core.trac.wordpress.org/browser/tags/4.8.3/src/wp-admin/includes/admin-filters.php#L48) that handles DNS prefetching tags (they are useless in CLI) and causes the error.
3. That hooks is executed when ConflictResolver calls the `admin_print_styles` action.

Please ensure that second runs of `./do t:u` and `./do t:c` work normally.

P.S.: `remove_filter` didn't work in the test because of Codeception backing up globals.