### PR TITLE
Move key checks from constructor to init() in Menu class [MAILPOET-1204]

### DIFF
--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -37,13 +37,14 @@ class Menu {
     $this->renderer = $renderer;
     $this->assets_url = $assets_url;
     $this->access_control = $access_control;
+  }
+
+  function init() {
     $subscribers_feature = new SubscribersFeature();
     $this->subscribers_over_limit = $subscribers_feature->check();
     $this->checkMailPoetAPIKey();
     $this->checkPremiumKey();
-  }
 
-  function init() {
     add_action(
       'admin_menu',
       array(


### PR DESCRIPTION
Key checks that populate notices were run twice because the `Menu` class was instantiated once more in the Premium plugin. Now these check are only performed when calling the `init()` method.