### PR TITLE
Changes plugin language based on user's locale [MAILPOET-1211]

### DIFF
--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -232,6 +232,7 @@ class Initializer {
       $this->setupHooks();
       $this->setupJSONAPI();
       $this->setupRouter();
+      $this->setupUserLocale();
     } catch(\Exception $e) {
       $this->handleFailedInitialization($e);
     }
@@ -245,6 +246,13 @@ class Initializer {
   function setupRouter() {
     $router = new Router\Router($this->access_control);
     $router->init();
+  }
+
+  function setupUserLocale() {
+    if(get_user_locale() === get_locale()) return;
+    unload_textdomain(Env::$plugin_name);
+    $localizer = new Localizer();
+    $localizer->init();
   }
 
   function setupPages() {

--- a/lib/Config/Localizer.php
+++ b/lib/Config/Localizer.php
@@ -30,7 +30,7 @@ class Localizer {
   function locale() {
     $locale = apply_filters(
       'plugin_locale',
-      get_locale(),
+      get_user_locale(),
       Env::$plugin_name
     );
     return $locale;


### PR DESCRIPTION
1. `get_user_locale()` defaults to `get_locale()` when user is not logged in, so we can safely use it in Localizer

2. Localizer should still be loaded before the rest of the plugin so that installation/upgrades are done in using site language (user's locale is not available at that moment)

3. If site and user locales are different once the plugin has initialized, we reload language file using user's locale.