### PR TITLE
Fix a fatal error when creating a subscribers table in MySQL strict mode [MAILPOET-1268]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -161,8 +161,8 @@ class Migrator {
     $attributes = array(
       'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
       'wp_user_id bigint(20) NULL,',
-      'first_name tinytext NOT NULL DEFAULT "",',
-      'last_name tinytext NOT NULL DEFAULT "",',
+      'first_name varchar(255) NOT NULL DEFAULT "",',
+      'last_name varchar(255) NOT NULL DEFAULT "",',
       'email varchar(150) NOT NULL,',
       'status varchar(12) NOT NULL DEFAULT "' . Subscriber::STATUS_UNCONFIRMED . '",',
       'subscribed_ip varchar(45) NULL,',


### PR DESCRIPTION
To reproduce the original bug:

1. Enable `STRICT_TRANS_TABLES` mode in your MySQL configuration;
2. Add the following hook to `wp-config.php` before `wp-settings.php` inclusion as WP will try to unset the mode otherwise:

```
$wp_filter[ 'incompatible_sql_modes' ][ 10 ][ 'unique_id' ] = array(
  'function' => function () { return array(); },
  'accepted_args' => 1,
);
```

3. Deactivate MailPoet, drop the subscribers table and reactivate.