### PR TITLE
Allow select2 to be destroyed and re-rendered [PREMIUM-60]

### DIFF
--- a/assets/js/src/form/fields/selection.jsx
+++ b/assets/js/src/form/fields/selection.jsx
@@ -16,8 +16,11 @@ define([
     isSelect2Initialized: function () {
       return (jQuery(`#${this.refs.select.id}`).hasClass('select2-hidden-accessible') === true);
     },
+    isSelect2Component: function () {
+      return this.allowMultipleValues() || this.props.field.forceSelect2;
+    },
     componentDidMount: function () {
-      if (this.allowMultipleValues() || this.props.field.forceSelect2) {
+      if (this.isSelect2Component()) {
         this.setupSelect2();
       }
     },
@@ -38,7 +41,7 @@ define([
       }
     },
     componentWillUnmount: function () {
-      if (this.allowMultipleValues() || this.props.field.forceSelect2) {
+      if (this.isSelect2Component()) {
         this.destroySelect2();
       }
     },
@@ -74,6 +77,10 @@ define([
 
       let select2Options = {
         width: (this.props.width || ''),
+        placeholder: {
+          id: '', // the value of the option
+          text: this.props.field.placeholder,
+        },
         templateResult: function (item) {
           if (item.element && item.element.selected) {
             return null;


### PR DESCRIPTION
This is just a small update to `selection.jsx`. I had much more changes here but after I rebased Vlad's changes there is not much left.

The most important change here is the placeholder. Without this change, the placeholder didn't update when one select2 was destroyed and another one was created.