### PR TITLE
Make sure preselected value is active [PREMIUM-59]

### DIFF
--- a/assets/js/src/form/fields/selection.jsx
+++ b/assets/js/src/form/fields/selection.jsx
@@ -227,6 +227,7 @@ define([
     },
     render: function () {
       const items = this.getItems(this.props.field);
+      const selectedValues = this.getSelectedValues();
       const options = items.map((item, index) => {
         const label = this.getLabel(item);
         const searchLabel = this.getSearchLabel(item);
@@ -238,6 +239,7 @@ define([
             className="default"
             value={value}
             title={searchLabel}
+            selected={value === selectedValues}
           >
             { label }
           </option>
@@ -251,7 +253,7 @@ define([
           disabled={this.props.field.disabled}
           data-placeholder={this.props.field.placeholder}
           multiple={this.props.field.multiple}
-          defaultValue={this.getSelectedValues()}
+          defaultValue={selectedValues}
           {...this.props.field.validation}
         >
           { this.insertEmptyOption() }


### PR DESCRIPTION
I spent so much time on this. This is an existing bug but I had to make this change for [PREMIUM-59] . This happens when you edit a woo commerce dynamic segment. The product/category field is not populated. I couldn't figure out why is that. Nothing worked for me. The weirdest thing is email dynamic segments work. They are populated without any issue. This worked. But I still don't know why it didn't work before.