### PR TITLE
Do not save defaults for container blocks [MAILPOET-1339]

### DIFF
--- a/assets/js/src/newsletter_editor/blocks/container.js
+++ b/assets/js/src/newsletter_editor/blocks/container.js
@@ -48,6 +48,7 @@ define([
         blocks: new BlockCollection()
       }, App.getConfig().get('blockDefaults.container'));
     },
+    _updateDefaults: function updateDefaults() {},
     validate: function () {
       // Recursively propagate validation checks to blocks in the tree
       var invalidBlock = this.get('blocks').find(function (block) { return !block.isValid(); });

--- a/tests/javascript/newsletter_editor/blocks/container.spec.js
+++ b/tests/javascript/newsletter_editor/blocks/container.spec.js
@@ -50,6 +50,14 @@ define([
 
           expect(innerModel.get('styles.block.backgroundColor')).to.equal('#123456');
         });
+
+        it('do not update blockDefaults.container when changed', function () {
+          var sandbox = sinon.sandbox.create();
+          var stub = sandbox.stub(EditorApplication.getConfig(), 'set');
+          model.trigger('change');
+          expect(stub.callCount).to.equal(0);
+          sandbox.restore();
+        });
       });
 
       describe('when creating with children', function () {


### PR DESCRIPTION
Container blocks are used to create 1, 2 and 3 column layout blocks