### PR TITLE
Easier "What's new" skipping [MAILPOET-1344]

### DIFF
--- a/lib/Util/Url.php
+++ b/lib/Util/Url.php
@@ -3,7 +3,15 @@ namespace MailPoet\Util;
 
 class Url {
   static function getCurrentUrl() {
-    return home_url(add_query_arg(null, null));
+    $home_url = parse_url(home_url());
+    $query_args = add_query_arg(null, null);
+
+    // Remove home_url() path from add_query_arg
+    if(isset($home_url['path'])) {
+      $query_args = str_replace($home_url['path'], null, $query_args);
+    }
+
+    return home_url($query_args);
   }
 
   static function redirectTo($url = null) {

--- a/tests/unit/Util/UrlTest.php
+++ b/tests/unit/Util/UrlTest.php
@@ -4,8 +4,9 @@ namespace MailPoet\Test\Util;
 use MailPoet\Util\Url;
 
 class UrlTest extends \MailPoetTest {
-  function testItCanReturnCurrentUrl() {
+  function testCurrentUrlReturnsHomeUrlOnHome() {
     $current_url = Url::getCurrentUrl();
-    expect($current_url)->startsWith('http');
+    $home_url = home_url();
+    expect($current_url)->equals($home_url);
   }
 }

--- a/views/update.html
+++ b/views/update.html
@@ -8,6 +8,10 @@
   <p class="about-text"><%= __('The new MailPoet. Simply better. And with regular updates.') %></p>
   <div class="mailpoet-logo"><img src="<%= image_url('welcome_template/mailpoet-logo.png') %>" alt="MailPoet Logo" /></div>
 
+  <div class="feature-section one-col mailpoet_centered">
+    <a class="button button-primary go-to-plugin" href="<%= redirect_url %>"><%= __('I don\'t care about the update, back to work!') %> &rarr;</a>
+  </div>
+
   <h2 class="nav-tab-wrapper wp-clearfix">
     <a href="admin.php?page=mailpoet-welcome" class="nav-tab"><%= __('Welcome') %></a>
     <a href="admin.php?page=mailpoet-update" class="nav-tab nav-tab-active"><%= __("What's New") %></a>
@@ -70,7 +74,7 @@
   <hr>
 
   <div class="feature-section one-col mailpoet_centered">
-    <a class="button button-primary go-to-plugin" href="admin.php?page=mailpoet-newsletters"><%= __('Awesome! Now, take me to MailPoet') %> &rarr;</a>
+    <a class="button button-primary go-to-plugin" href="<%= redirect_url %>"><%= __('Thanks, now take me to where I was going.') %> &rarr;</a>
   </div>
 
 </div>


### PR DESCRIPTION
* URL test now check for home URL instead of just 'http'
* Fixed a bug where getCurrentlURL() returned a broken path
* Added "I don't care about the update" button
* Update skip buttons now return to the previous page