### PR TITLE
Fix: CPU usage and sending issue on slow host [MAILPOET-1371]

### DIFF
--- a/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -21,12 +21,11 @@ class AutomatedLatestContent extends APIEndpoint {
 
   function getPostTypes() {
     $post_types = array_map(function($post_type) {
-      if(!empty($post_type->exclude_from_search)) return;
       return array(
         'name' => $post_type->name,
         'label' => $post_type->label
       );
-    }, get_post_types(array(), 'objects'));
+    }, WPPosts::getTypes(array(), 'objects'));
     return $this->successResponse(
       array_filter($post_types)
     );

--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Config;
 
 use MailPoet\Models\Setting;
+use MailPoet\WP\Posts as WPPosts;
 
 class Hooks {
   function init() {
@@ -166,8 +167,7 @@ class Hooks {
   }
 
   function setupPostNotifications() {
-    $post_types = get_post_types();
-    foreach($post_types as $post_type) {
+    foreach(WPPosts::getTypes() as $post_type) {
       add_filter(
         'publish_' . $post_type,
         '\MailPoet\Newsletter\Scheduler\Scheduler::schedulePostNotification',

--- a/lib/Newsletter/Scheduler/Scheduler.php
+++ b/lib/Newsletter/Scheduler/Scheduler.php
@@ -108,6 +108,14 @@ class Scheduler {
   }
 
   static function createPostNotificationQueue($newsletter) {
+    $existing_notification_history = Newsletter::where('parent_id', $newsletter->id)
+      ->where('type', Newsletter::TYPE_NOTIFICATION_HISTORY)
+      ->where('status', Newsletter::STATUS_SENDING)
+      ->findOne();
+    if($existing_notification_history) {
+      return;
+    }
+
     $next_run_date = self::getNextRunDate($newsletter->schedule);
     if(!$next_run_date) return;
     // do not schedule duplicate queues for the same time

--- a/lib/Newsletter/Shortcodes/Categories/Newsletter.php
+++ b/lib/Newsletter/Shortcodes/Categories/Newsletter.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 
 use MailPoet\Models\Newsletter as NewsletterModel;
+use MailPoet\WP\Posts as WPPosts;
 
 if(!defined('ABSPATH')) exit;
 require_once(ABSPATH . "wp-includes/pluggable.php");
@@ -45,7 +46,7 @@ class Newsletter {
   private static function getLatestWPPost($post_ids) {
     $posts = new \WP_Query(
       array(
-        'post_type' => get_post_types(),
+        'post_type' => WPPosts::getTypes(),
         'post__in' => $post_ids,
         'posts_per_page' => 1,
         'ignore_sticky_posts' => true,

--- a/lib/WP/Posts.php
+++ b/lib/WP/Posts.php
@@ -15,4 +15,12 @@ class Posts {
     }
   }
 
+  static function getTypes($args = array(), $output = 'names', $operator = 'and') {
+    $defaults = array(
+      'exclude_from_search' => false
+    );
+    $args = array_merge($defaults, $args);
+    return get_post_types($args, $output, $operator);
+  }
+
 }

--- a/tests/unit/Config/HooksTest.php
+++ b/tests/unit/Config/HooksTest.php
@@ -2,13 +2,13 @@
 namespace MailPoet\Test\Config;
 
 use MailPoet\Config\Hooks;
+use MailPoet\WP\Posts as WPPosts;
 
 class HooksTest extends \MailPoetTest {
   function testItHooksSchedulerToMultiplePostTypes() {
     $hooks = new Hooks();
     $hooks->setupPostNotifications();
-    $post_types = get_post_types();
-    foreach($post_types as $post_type) {
+    foreach(WPPosts::getTypes() as $post_type) {
       expect(has_filter('publish_' . $post_type, '\MailPoet\Newsletter\Scheduler\Scheduler::schedulePostNotification'))->notEmpty();
     }
   }


### PR DESCRIPTION
On some slow host, the `newsletter` table get filled with
duplicated `notification_history` marked as `sending` that
never get sent.

To prevent this we've made the two following changes:
* We prevent firing `publish_*` hooks on post_type which
are excluded from search.
* We do not schedule a new post notification email if one
has an `notification_history` entry marked as `sending`.

[MAILPOET-1371]