### PR TITLE
Fix custom fields to allow values longer than 255 characters [MAILPOET-1381]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -200,7 +200,7 @@ class Migrator {
       'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
       'subscriber_id int(11) unsigned NOT NULL,',
       'custom_field_id int(11) unsigned NOT NULL,',
-      'value text,',
+      'value text NOT NULL,',
       'created_at TIMESTAMP NULL,',
       'updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (id),',

--- a/tests/unit/Models/SubscriberTest.php
+++ b/tests/unit/Models/SubscriberTest.php
@@ -827,6 +827,7 @@ class SubscriberTest extends \MailPoetTest {
       $subscriber_custom_field->subscriber_id = ($custom_field !== 5) ?
         $subscriber->id :
         100; // create one record with a nonexistent subscriber id
+      $subscriber_custom_field->value = 'somevalue';
       $subscriber_custom_field->save();
     }
     expect(SubscriberCustomField::findMany())->count(5);


### PR DESCRIPTION
Testing notes:

Testing this requires to run DB migrations.
An easy way to do so is:
a) MailPoet > Settings > Reinstall from scratch
b) change DB version to an older one in `wp_mailpoet_settings` table, refresh the page to trigger the update

To test the change, two ways:
a) Check that `wp_mailpoet_subscriber_custom_field` table's `value` field has a `TEXT` type. (`DESCRIBE  wp_mailpoet_subscriber_custom_field;`)
b) Create a new custom field (e.g. with type=textarea), edit a subscriber and add more than 255 characters to the custom field's value. Saving and refreshing the admin page should still show the full value.