### PR TITLE
Add index based on subscriber_id to scheduled_task_subscribers [MAILPOET-1382]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -131,7 +131,8 @@ class Migrator {
       'subscriber_id int(11) unsigned NOT NULL,',
       'processed int(1) NOT NULL,',
       'created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,',
-      'PRIMARY KEY  (task_id, subscriber_id)',
+      'PRIMARY KEY  (task_id, subscriber_id),',
+      'KEY subscriber_id (subscriber_id)'
     );
     return $this->sqlify(__FUNCTION__, $attributes);
   }


### PR DESCRIPTION
This is done to avoid full table scans when scheduling welcome emails
and checking whether or not an email has been sent.
There we have to query based on `subscriber_id`, but without having a
`task_id`, so MySQL cannot make use of the `(task_id, subscriber_id)`
primary key.

Doing so turns this query execution plan:
```
EXPLAIN SELECT * FROM `wp_mailpoet_sending_queues` `queues` JOIN `wp_mailpoet_scheduled_tasks` `tasks` ON tasks.id = queues.task_id JOIN `wp_mailpoet_scheduled_task_subscribers` `subscribers` ON tasks.id = subscribers.task_id WHERE `queues`.`newsletter_id` = '11' AND `subscribers`.`subscriber_id` = '9522' LIMIT 1

id select_type table type possible_keys key key_len ref rows Extra
1 SIMPLE tasks ALL PRIMARY NULL NULL NULL 19936 NULL
1 SIMPLE queues ref task_id_index,task_id task_id_index 4 pailala_wp_4_2.tasks.id 1 Using where
1 SIMPLE subscribers eq_ref PRIMARY PRIMARY 8 pailala_wp_4_2.tasks.id,const 1 NULL
```

into this one:
```
id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | subscribers | ref | PRIMARY,subscriber_id | subscriber_id | 4 | const | 17 | NULL
1 | SIMPLE | queues | ref | task_id_index,task_id | task_id_index | 4 | pailala_wp_4_2.subscribers.task_id | 1 | Using where
1 | SIMPLE | tasks | eq_ref | PRIMARY | PRIMARY | 4 | pailala_wp_4_2.subscribers.task_id | 1 | NULL
```

And query runtime drops down from 20-45 seconds down to 0.001 seconds, helping to avoid the full table scan.


Testing notes:

Behaviorally here nothing changes. I think it would be sufficient to ensure welcome emails can be scheduled and sent for new subscribers.