### PR TITLE
Fix sending task reschedule [MAILPOET-1378]

### DIFF
--- a/lib/Models/SendingQueue.php
+++ b/lib/Models/SendingQueue.php
@@ -141,6 +141,7 @@ class SendingQueue extends Model {
 
   static function getTasks() {
     return ScheduledTask::table_alias('tasks')
+    ->selectExpr('tasks.*')
     ->join(
       MP_SENDING_QUEUES_TABLE,
       'tasks.id = queues.task_id',


### PR DESCRIPTION
The query returned data from the sending queue table
So the next update updated the wrong row in the tasks table
