### PR TITLE
Force migration to set default value for template description column [MAILPOET-1398]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -249,7 +249,7 @@ class Migrator {
       'newsletter_id int NULL DEFAULT 0,',
       'name varchar(250) NOT NULL,',
       'categories varchar(250) NOT NULL DEFAULT "[]",',
-      'description varchar(250) NOT NULL DEFAULT "",',
+      'description varchar(255) NOT NULL DEFAULT "",',
       'body LONGTEXT,',
       'thumbnail LONGTEXT,',
       'readonly TINYINT(1) DEFAULT 0,',


### PR DESCRIPTION
To PHP this is true: `null == ''`
Which makes these equivalent for `dbDelta` (https://core.trac.wordpress.org/browser/tags/4.9/src/wp-admin/includes/upgrade.php#L2378):
```
description varchar(250) NOT NULL DEFAULT "",
```
```
description varchar(250) NOT NULL,
```
So it skips setting the default value.

We have to change the field type to make this default value change work.