### PR TITLE
Dont call flush_rewrite in init [MAILPOET-1392]

### DIFF
--- a/lib/Settings/Pages.php
+++ b/lib/Settings/Pages.php
@@ -37,7 +37,6 @@ class Pages {
       'post_title' => __('MailPoet Page', 'mailpoet'),
       'post_name' => 'subscriptions'
     ));
-    flush_rewrite_rules();
 
     return ((int)$id > 0) ? (int)$id : false;
   }


### PR DESCRIPTION
Following http://wpengineer.com/2044/custom-post-type-and-permalink/
and validating with Tautvidas we concluded there was not
reason not to use flush_rewrite_rules() as recommended which is,
upon activating and deactivating the plugin.