### PR TITLE
Always display colum block controls on mouse over [MAILPOET-1399]

### DIFF
--- a/assets/css/src/newsletter_editor/components/blockTools.styl
+++ b/assets/css/src/newsletter_editor/components/blockTools.styl
@@ -32,15 +32,18 @@ $master-column-tool-width = 24px
     vertical-align: top
 
   .mailpoet_container_horizontal + &
-    left: 100%
-    right: initial
     padding-left: 5px
+    width: 30px
+    transition: right 3s linear
 
     .mailpoet_tool_slider
       left: -100%
       right: initial
 
     &.mailpoet_display_tools
+      right: -38px
+      transition: none
+
       .mailpoet_tool_slider
         left: 0
 


### PR DESCRIPTION
the div.mailpoet_tools is now behind the newsletter editor and
move to the right on mouse over instead of simply hidden which,
caused all the invisible elements to overlap.