### PR TITLE
Fix side toolbar display problems properly [MAILPOET-1432]

### DIFF
--- a/assets/css/src/newsletter_editor/components/blockTools.styl
+++ b/assets/css/src/newsletter_editor/components/blockTools.styl
@@ -41,6 +41,8 @@ $master-column-tool-width = 24px
       right: initial
 
     &.mailpoet_display_tools
+      z-index: 21
+
       .mailpoet_tool_slider
         left: 0
 


### PR DESCRIPTION
Remember that bugfix I with complicated `mouseleave` `mouseenter` JS management that turns out to be a CSS problem? I ended up doing some random magical CSS work to fix it but it didn't cut it. I added a new issue.

Turn out the solution was adding +1 to the active block `z-index`. Simple as that...