### PR TITLE
Add queue_id index into newsletter_links table

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -310,7 +310,8 @@ class Migrator {
       'hash varchar(20) NOT NULL,',
       'created_at TIMESTAMP NULL,',
       'updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
-      'PRIMARY KEY  (id)',
+      'PRIMARY KEY  (id),',
+      'KEY queue_id (queue_id)',
     );
     return $this->sqlify(__FUNCTION__, $attributes);
   }


### PR DESCRIPTION
Missing index caused that it took to long when generating tracked unsubscribe URL.

[MAILPOET-1486]