### PR TITLE
Symfony DI Container Proof of Concept

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,6 +70,9 @@ rm -f $plugin_name/vendor/j4mie/idiorm/demo.php
 rm -f $plugin_name/vendor/cerdic/css-tidy/css_optimiser.php
 rm -f $plugin_name/assets/js/lib/tinymce/package.json
 
+# Remove 3rd party extensions which are copied in lib/Dependencies
+rm -rf $plugin_name/vendor/symfony/dependency-injection
+
 # Copy release files.
 echo '[BUILD] Copying release files'
 cp license.txt $plugin_name

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
     {
       "type": "vcs",
       "url": "https://github.com/mailpoet/swiftmailer"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/costasovo/mozart"
     }
   ],
   "require": {
@@ -41,7 +45,7 @@
     "kint-php/kint": "^2.2",
     "squizlabs/php_codesniffer": "^2.8.1",
     "wimg/php-compatibility": "^7.1.2",
-    "coenjacobs/mozart": "^0.2.2"
+    "coenjacobs/mozart": "dev-dependency-tree"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     "symfony/polyfill-php72": "^1.8",
     "symfony/polyfill-mbstring": "1.8.0",
     "sensiolabs/security-checker": "^4.1",
-    "monolog/monolog": "^1.23"
+    "monolog/monolog": "^1.23",
+    "symfony/dependency-injection": "3.3.18",
+    "psr/container": "^1.0"
   },
   "require-dev": {
     "codeception/aspect-mock": "2.0.1",
@@ -58,7 +60,8 @@
       "classmap_directory": "/classes/dependencies/",
       "classmap_prefix": "MP_",
       "packages": [
-        "monolog/monolog"
+        "monolog/monolog",
+        "symfony/dependency-injection"
       ]
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,8 @@
     }
   },
   "scripts": {
-    "post-update-cmd": "\"vendor/bin/mozart\" compose; rm -rf vendor/monolog; rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility",
-    "post-install-cmd": "\"vendor/bin/mozart\" compose; rm -rf vendor/monolog; rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility"
+    "post-update-cmd": "rm -rf vendor/symfony/dependency-injection/Tests;\"vendor/bin/mozart\" compose; rm -rf vendor/monolog; rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility",
+    "post-install-cmd": "rm -rf vendor/symfony/dependency-injection/Tests;\"vendor/bin/mozart\" compose; rm -rf vendor/monolog; rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility"
   },
   "extra": {
     "mozart": {
@@ -60,8 +60,8 @@
       "classmap_directory": "/classes/dependencies/",
       "classmap_prefix": "MP_",
       "packages": [
-        "monolog/monolog",
-        "symfony/dependency-injection"
+        "symfony/dependency-injection",
+        "monolog/monolog"
       ]
     }
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee3adaf81b26c53100664c4a94d13e9f",
+    "content-hash": "f89bc8ca9d3968210bb9597b7eabb22b",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -1653,16 +1653,16 @@
         },
         {
             "name": "coenjacobs/mozart",
-            "version": "0.2.2",
+            "version": "dev-dependency-tree",
             "source": {
                 "type": "git",
-                "url": "https://github.com/coenjacobs/mozart.git",
-                "reference": "f9218cc4643ba15d775bb8018a2c1b716a2951a6"
+                "url": "https://github.com/costasovo/mozart.git",
+                "reference": "35a82a50fee53d5270b2544c18d1ff7467e0407a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/coenjacobs/mozart/zipball/f9218cc4643ba15d775bb8018a2c1b716a2951a6",
-                "reference": "f9218cc4643ba15d775bb8018a2c1b716a2951a6",
+                "url": "https://api.github.com/repos/costasovo/mozart/zipball/35a82a50fee53d5270b2544c18d1ff7467e0407a",
+                "reference": "35a82a50fee53d5270b2544c18d1ff7467e0407a",
                 "shasum": ""
             },
             "require": {
@@ -1684,7 +1684,6 @@
                     "CoenJacobs\\Mozart\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1694,7 +1693,10 @@
                     "email": "coenjacobs@gmail.com"
                 }
             ],
-            "time": "2018-06-25T14:11:53+00:00"
+            "support": {
+                "source": "https://github.com/costasovo/mozart/tree/dependency-tree"
+            },
+            "time": "2018-09-28T12:41:41+00:00"
         },
         {
             "name": "composer/composer",
@@ -8573,7 +8575,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "swiftmailer/swiftmailer": 20,
-        "soundasleep/html2text": 20
+        "soundasleep/html2text": 20,
+        "coenjacobs/mozart": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11462ba92651491882f2405c4261a843",
+    "content-hash": "ee3adaf81b26c53100664c4a94d13e9f",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -404,6 +404,55 @@
             "time": "2018-08-07T08:39:47+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -776,6 +825,76 @@
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
             "time": "2018-07-26T11:19:56+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v3.3.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "54243abc4e1a1a15e274e391bd6f7090b44711f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/54243abc4e1a1a15e274e391bd6f7090b44711f1",
+                "reference": "54243abc4e1a1a15e274e391bd6f7090b44711f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.7",
+                "symfony/finder": "<3.3",
+                "symfony/yaml": "<3.3"
+            },
+            "provide": {
+                "psr/container-implementation": "1.0"
+            },
+            "require-dev": {
+                "symfony/config": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/yaml": "~3.3"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
+                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-29T09:02:23+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4586,55 +4705,6 @@
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -5635,76 +5705,6 @@
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
             "time": "2018-07-26T09:06:28+00:00"
-        },
-        {
-            "name": "symfony/dependency-injection",
-            "version": "v3.3.18",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "54243abc4e1a1a15e274e391bd6f7090b44711f1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/54243abc4e1a1a15e274e391bd6f7090b44711f1",
-                "reference": "54243abc4e1a1a15e274e391bd6f7090b44711f1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "symfony/config": "<3.3.7",
-                "symfony/finder": "<3.3",
-                "symfony/yaml": "<3.3"
-            },
-            "provide": {
-                "psr/container-implementation": "1.0"
-            },
-            "require-dev": {
-                "symfony/config": "~3.3",
-                "symfony/expression-language": "~2.8|~3.0",
-                "symfony/yaml": "~3.3"
-            },
-            "suggest": {
-                "symfony/config": "",
-                "symfony/expression-language": "For using expressions in service container configuration",
-                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
-                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
-                "symfony/yaml": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\DependencyInjection\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony DependencyInjection Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:02:23+00:00"
         },
         {
             "name": "symfony/dom-crawler",

--- a/lib/Config/Capabilities.php
+++ b/lib/Config/Capabilities.php
@@ -9,7 +9,7 @@ class Capabilities {
 
   private $renderer = null;
 
-  function __construct($renderer = null) {
+  function __construct(Renderer $renderer = null) {
     if($renderer !== null) {
       $this->renderer = $renderer;
     }

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -4,6 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\API;
 use MailPoet\Cron\CronTrigger;
+use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Container;
 use MailPoet\Models\Setting;
 use MailPoet\Router;
 use MailPoet\Util\ConflictResolver;
@@ -18,13 +19,16 @@ require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 class Initializer {
   private $access_control;
   private $renderer;
+  /** @var Container */
+  private $container;
 
   const INITIALIZED = 'MAILPOET_INITIALIZED';
 
-  function __construct($params = array(
+  function __construct(Container $container, $params = array(
     'file' => '',
     'version' => '1.0.0'
   )) {
+    $this->container = $container;
     Env::init($params['file'], $params['version']);
   }
 

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -40,7 +40,7 @@ class Menu {
   private $access_control;
   private $subscribers_over_limit;
 
-  function __construct($renderer, $assets_url, AccessControl $access_control) {
+  function __construct(Renderer $renderer, $assets_url, AccessControl $access_control) {
     $this->renderer = $renderer;
     $this->assets_url = $assets_url;
     $this->access_control = $access_control;

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -28,6 +28,7 @@ class ContainerFactory {
     // Services
     self::$container
       ->register('initializer', \MailPoet\Config\Initializer::class)
+      ->addArgument(self::$container)
       ->addArgument('%mailpoet.plugin_data%');
   }
 }

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MailPoet\DI;
+
+use MailPoet\Dependencies\Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ContainerFactory {
+
+  /** @var ContainerBuilder */
+  private static $container;
+
+  static function getContainer() {
+    if (!self::$container) {
+      self::createContainer();
+    }
+    return self::$container;
+  }
+
+  private static function createContainer() {
+    self::$container = new ContainerBuilder();
+  }
+}

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -2,7 +2,29 @@
 
 namespace MailPoet\DI;
 
+use MailPoet\API\JSON\API as JsonApi;
+use MailPoet\Config\AccessControl;
+use MailPoet\Config\Activator;
+use MailPoet\Config\Capabilities;
+use MailPoet\Config\Changelog;
+use MailPoet\Config\Database;
+use MailPoet\Config\DeactivationSurvey;
+use MailPoet\Config\Env;
+use MailPoet\Config\Hooks as ConfigHooks;
+use MailPoet\Config\Localizer;
+use MailPoet\Config\Menu;
+use MailPoet\Config\PersonalDataErasers;
+use MailPoet\Config\PersonalDataExporters;
+use MailPoet\Config\PHPVersionWarnings;
+use MailPoet\Config\PrivacyPolicy;
+use MailPoet\Config\Renderer;
+use MailPoet\Config\RequirementsChecker;
+use MailPoet\Config\Shortcodes;
+use MailPoet\Cron\CronTrigger;
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\ContainerBuilder;
+use MailPoet\Router\Router;
+use MailPoet\Settings\Pages;
+use MailPoet\Util\ConflictResolver;
 
 class ContainerFactory {
 
@@ -25,10 +47,40 @@ class ContainerFactory {
       'file' => ''
     ]);
 
+    self::$container->setParameter('mailpoet.assets_url', Env::$assets_url);
+    self::$container->setParameter('mailpoet.caching_enabled', !WP_DEBUG);
+    self::$container->setParameter('mailpoet.debugging_enabled', WP_DEBUG);
+
     // Services
     self::$container
       ->register('initializer', \MailPoet\Config\Initializer::class)
       ->addArgument(self::$container)
       ->addArgument('%mailpoet.plugin_data%');
+
+    self::$container
+      ->register(Renderer::class)
+      ->addArgument('%mailpoet.caching_enabled%')
+      ->addArgument('%mailpoet.debugging_enabled%');
+
+    self::$container->autowire(JsonApi::class);
+    self::$container->autowire(AccessControl::class);
+    self::$container->autowire(Capabilities::class);
+    self::$container->autowire(Localizer::class);
+    self::$container->autowire(RequirementsChecker::class);
+    self::$container->autowire(Activator::class);
+    self::$container->autowire(Database::class);
+    self::$container->autowire(Shortcodes::class);
+    self::$container->autowire(Router::class);
+    self::$container->autowire(Changelog::class);
+    self::$container->autowire(CronTrigger::class);
+    self::$container->autowire(ConflictResolver::class);
+    self::$container->autowire(DeactivationSurvey::class);
+    self::$container->autowire(Pages::class);
+    self::$container->autowire(ConfigHooks::class);
+    self::$container->autowire(PrivacyPolicy::class);
+    self::$container->autowire(PersonalDataExporters::class);
+    self::$container->autowire(PersonalDataErasers::class);
+    self::$container->autowire(PHPVersionWarnings::class);
+    self::$container->autowire(Menu::class)->setArgument('$assets_url', '%mailpoet.assets_url%');
   }
 }

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -10,7 +10,7 @@ class ContainerFactory {
   private static $container;
 
   static function getContainer() {
-    if (!self::$container) {
+    if(!self::$container) {
       self::createContainer();
     }
     return self::$container;
@@ -18,5 +18,16 @@ class ContainerFactory {
 
   private static function createContainer() {
     self::$container = new ContainerBuilder();
+
+    // Parameters
+    self::$container->setParameter('mailpoet.plugin_data', [
+      'version' => '1.0.0',
+      'file' => ''
+    ]);
+
+    // Services
+    self::$container
+      ->register('initializer', \MailPoet\Config\Initializer::class)
+      ->addArgument('%mailpoet.plugin_data%');
   }
 }

--- a/mailpoet_initializer.php
+++ b/mailpoet_initializer.php
@@ -1,6 +1,6 @@
 <?php
 
-use MailPoet\Config\Initializer;
+use MailPoet\DI\ContainerFactory;
 
 if(!defined('ABSPATH') || empty($mailpoet_plugin)) exit;
 
@@ -8,10 +8,11 @@ require_once($mailpoet_plugin['autoloader']);
 
 define('MAILPOET_VERSION', $mailpoet_plugin['version']);
 
-$initializer = new Initializer(
-  array(
-    'file' => $mailpoet_plugin['filename'],
-    'version' => $mailpoet_plugin['version']
-  )
-);
+$container = ContainerFactory::getContainer();
+$container->setParameter('mailpoet.plugin_data', [
+  'file' => $mailpoet_plugin['filename'],
+  'version' => $mailpoet_plugin['version']
+]);
+
+$initializer = $container->get('initializer');
 $initializer->init();

--- a/mailpoet_initializer.php
+++ b/mailpoet_initializer.php
@@ -13,6 +13,7 @@ $container->setParameter('mailpoet.plugin_data', [
   'file' => $mailpoet_plugin['filename'],
   'version' => $mailpoet_plugin['version']
 ]);
+$container->compile();
 
 $initializer = $container->get('initializer');
 $initializer->init();


### PR DESCRIPTION
I've added "symfony/dependency-injection": "3.3.18" and I've refactored Initializer as a proof of concept.

### Why symfony/dependency-injection
symfony/dependency-injection is a heavily used and it has only one dependency (https://github.com/php-fig/container) so it can be wrapped to a custom namespace by Mozart.
It has also a rich [documentation](https://symfony.com/doc/3.4/components/dependency_injection.html) and it has an [auto-wiring feature ](https://symfony.com/doc/3.3/service_container/autowiring.html) which is a real time saver.
 
### Limitations
- We can't use some features because they require additional packages which we can't wrap to a custom namespace by Mozart. We can't use config loaders, which means, that we have to define services using PHP in [some factory](https://github.com/mailpoet/mailpoet/compare/di-container?expand=1#diff-62a5f403697e6a4441a0c8768685d1ee). We can't use proxy services.
- We have to use version 3.3.18 since we have a dependency wp-cli/wp-cli which requires some older symfony packages.

### Working with container
 The easiest way to register service into the container is to add type hints to its constructor parameters and then use [autowire and specify parameters which can't be typehinted](https://github.com/mailpoet/mailpoet/pull/1503/files#diff-62a5f403697e6a4441a0c8768685d1eeR84).

I've created a factory so you can get the container [by calling a static method](https://github.com/mailpoet/mailpoet/pull/1503/files#diff-52fe181227eb6d2dd7160177c93a9964R11).

### Pros
- In most cases, we won't have to call the constructor and the service construction (definition) will be in one place. This is very useful since using DI pattern may lead to often changes in service constructors.
- Services in a container are held as singletons. We have to keep that in mind. For example, some services may hold state and we may want to reset this state for each run...
- In DI config we will be able to easily switch service for another. E.g. we can define a sending service and set it according to settings.

### Cons
- $container->get() it not type-hinted so e.g. PHPStorm will not know the type of the service. At the beginning there will be some $container->get() calls over our code but they number should reduce as we refactor services to use DI pattern
- services are singletons
- limitations I've mentioned above

### Next steps
- We should refactor/create classes to follow DI pattern and register those services into a container
- We need to figure out how to add services from premium plugin to DI


## UPDATE
I tried to test builded plugin and found out that it has a hidden dependency on `Symfony\Component\Config\Resource\ClassExistenceResource` so we have to add this plugin as well but this will be tricky with the namespace replacement. :(