### PR TITLE
Permit JS assets to be loaded from WP.com CDN on MP3 pages [MAILPOET-1584]

### DIFF
--- a/lib/Util/ConflictResolver.php
+++ b/lib/Util/ConflictResolver.php
@@ -15,7 +15,9 @@ class ConflictResolver {
       // WP default
       '^/wp-admin',
       '^/wp-includes',
+      // CDN
       'googleapis.com/ajax/libs',
+      'wp.com',
       // third-party
       'query-monitor',
       'wpt-tx-updater-network'


### PR DESCRIPTION
The CDN is provided by JetPack plugin in their "Asset CDN" beta feature.
The CDN may attempt to host default WP JS assets, which includes jQuery - something MP3 relies on.
However, due to this conflict resolution jQuery will then be prevented from loading, as its path is not from site's WP default JS asset locations, so it would be treated as a 3rd party script and thus prevented from loading on MP3 pages.

I'm not whitelisting wp.com for CSS assets, doing it only for JS assets, as at least from testing it on the test site having CSS location not whitelisted didn't have any visual impact - the WP interfaces looked normal.

Because it's whitelisting any asset loaded via wp.com, in the future this may cause problems with 3rd party plugin conflicts, as if assets of that plugin get loaded via wp.com on MP3 pages - they would be allowed by this PR.
I'm not sure how we could reliably prevent such cases.

If you need to, mailpoet-sg.com has Jetpack set up for this.