### PR TITLE
 Fix AspectMock to work when the Premium plugin is active [MAILPOET-1585]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -131,7 +131,7 @@ class Migrator {
       'task_id int(11) unsigned NOT NULL,',
       'subscriber_id int(11) unsigned NOT NULL,',
       'processed int(1) NOT NULL,',
-      'failed int(1) NOT NULL,',
+      'failed int(1) NOT NULL DEFAULT 0,',
       'error text NULL,',
       'created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (task_id, subscriber_id),',

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -53,11 +53,15 @@ if(is_dir(getenv('WP_TEST_CACHE_PATH'))) {
   $cacheDir = getenv('WP_TEST_CACHE_PATH');
 }
 
+$console->writeln('Clearing AspectMock cache...');
+exec('rm -rf ' . $cacheDir . '/_transformation.cache');
+
 $console->writeln('Initializing AspectMock library...');
 $kernel = \AspectMock\Kernel::getInstance();
 $kernel->init(
   array(
     'debug' => true,
+    'appDir' => __DIR__ . '/../',
     'cacheDir' => $cacheDir,
     'includePaths' => [__DIR__ . '/../lib']
   )

--- a/tests/unit/Models/CustomFieldTest.php
+++ b/tests/unit/Models/CustomFieldTest.php
@@ -112,6 +112,7 @@ class CustomFieldTest extends \MailPoetTest {
       $association = SubscriberCustomField::create();
       $association->subscriber_id = $subscriber->id;
       $association->custom_field_id = $this->custom_field->id;
+      $association->value = '';
       $association->save();
     }
     $custom_field = CustomField::findOne($this->custom_field->id);


### PR DESCRIPTION
We have two autoloaders, Free and Premium. Due to the way Composer works ([executes autoloaders from last to first](https://stackoverflow.com/questions/23647387/order-of-execution-of-multiple-composer-autoloaders#comment36320267_23647387)) the system-under-test autoloader gets overridden by the one that plugs into it later. So we essentially have a dep conflict between the two: Free uses Premium's AspectMock, Premium uses Free's library in turn. 

AspectMock by default uses an `appDir` relative to its own files so it tries to load classes from the wrong plugin's `lib` folder. I fixed that by hardcoding the correct directory in Free AM initialization, so even the wrongly located library could still look into the correct path.

Apart from that I added cache clearing as we had problems with caching on the recent AspectMock/GoAOP version 2.2.0. But if we decide to keep an older version due to [non-existent functions mocking problem](https://github.com/Codeception/AspectMock/issues/158), this might be unnecessary for now.

P.S.: I also fixed a couple of tests that failed in MySQL strict mode on my machine, all green now!

>  Test  tests/unit/Cron/Workers/BounceTest.php:testItProcessesTask
 > [Exception] SQLSTATE[HY000]: General error: 1364 Field 'failed' doesn't have a default value

>  Test  tests/unit/Models/CustomFieldTest.php:testItCanHaveManySubscribers
> Failed asserting that 0 matches expected 2. (Under the hood: Field 'value' doesn't have a default value)