### PR TITLE
Fix code coverage on PHPUnit 5.7 and PHP 7.2 [MAILPOET-1596]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,17 @@
     }
   },
   "scripts": {
-    "post-update-cmd": "\"vendor/bin/mozart\" compose; rm -rf vendor/monolog",
-    "post-install-cmd": "\"vendor/bin/mozart\" compose; rm -rf vendor/monolog"
+    "post-update-cmd": [
+      "\"vendor/bin/mozart\" compose",
+      "rm -rf vendor/monolog",
+      "@fixPHPUnit57CodeCoverageForPHP72"
+    ],
+    "post-install-cmd": [
+      "\"vendor/bin/mozart\" compose",
+      "rm -rf vendor/monolog",
+      "@fixPHPUnit57CodeCoverageForPHP72"
+    ],
+    "fixPHPUnit57CodeCoverageForPHP72": "sed -i -- 's/\\$numTests = count(\\$coverageData\\[\\$i\\]);/$numTests = (is_array($coverageData[$i]) ? count($coverageData[$i]) : 0);/g' vendor/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php"
   },
   "extra": {
     "mozart": {


### PR DESCRIPTION
The fix needs to be removed when we drop PHP 5.6 support and upgrade PHPUnit to 6.x+.