### PR TITLE
Add league dependency injection container

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,10 @@ test -d node_modules && rm -rf node_modules
 npm install
 ./do compile:all --env production
 
+# Mozart processed libraries
+echo '[BUILD] Running composer to process libaries by mozart'
+./composer.phar install
+
 # Production libraries.
 echo '[BUILD] Fetching production libraries'
 test -d vendor && rm -rf vendor

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,12 @@
     {
       "type": "vcs",
       "url": "https://github.com/mailpoet/swiftmailer"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/costasovo/mozart"
     }
+
   ],
   "require": {
     "php": ">=5.5",
@@ -39,7 +44,7 @@
     "kint-php/kint": "^3.0",
     "squizlabs/php_codesniffer": "^3.3",
     "phpcompatibility/php-compatibility": "^9.0",
-    "coenjacobs/mozart": "^0.2.2"
+    "coenjacobs/mozart": "dev-dependency-tree"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
     "post-update-cmd": [
       "\"vendor/bin/mozart\" compose",
       "rm -rf vendor/monolog",
+      "rm -rf vendor/league/container",
       "@fixPHPUnit57CodeCoverageForPHP72"
     ],
     "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "symfony/polyfill-php72": "^1.9",
     "symfony/polyfill-mbstring": "^1.9",
     "sensiolabs/security-checker": "^5.0",
-    "monolog/monolog": "^1.23"
+    "monolog/monolog": "^1.23",
+    "league/container": "2.4.1"
   },
   "require-dev": {
     "codeception/aspect-mock": "2.0.1",
@@ -72,7 +73,8 @@
       "classmap_directory": "/classes/dependencies/",
       "classmap_prefix": "MP_",
       "packages": [
-        "monolog/monolog"
+        "monolog/monolog",
+        "league/container"
       ]
     }
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "548dd0db75412e7939828d57012876ea",
+    "content-hash": "cc70fc563b5114482541645521f0a52b",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -496,16 +496,16 @@
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "df4625e39868ecf4e868355caf45352f566791db"
+                "reference": "9ea927417c949039a9cfb0d92af76fd1c538d9e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/df4625e39868ecf4e868355caf45352f566791db",
-                "reference": "df4625e39868ecf4e868355caf45352f566791db",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/9ea927417c949039a9cfb0d92af76fd1c538d9e9",
+                "reference": "9ea927417c949039a9cfb0d92af76fd1c538d9e9",
                 "shasum": ""
             },
             "require": {
@@ -538,7 +538,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2018-09-04T07:02:17+00:00"
+            "time": "2018-10-16T10:30:44+00:00"
         },
         {
             "name": "soundasleep/html2text",
@@ -1536,16 +1536,16 @@
         },
         {
             "name": "coenjacobs/mozart",
-            "version": "0.2.2",
+            "version": "dev-dependency-tree",
             "source": {
                 "type": "git",
-                "url": "https://github.com/coenjacobs/mozart.git",
-                "reference": "f9218cc4643ba15d775bb8018a2c1b716a2951a6"
+                "url": "https://github.com/costasovo/mozart.git",
+                "reference": "9f851cef387ae94b7b5c681e876cbcf7339caed1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/coenjacobs/mozart/zipball/f9218cc4643ba15d775bb8018a2c1b716a2951a6",
-                "reference": "f9218cc4643ba15d775bb8018a2c1b716a2951a6",
+                "url": "https://api.github.com/repos/costasovo/mozart/zipball/9f851cef387ae94b7b5c681e876cbcf7339caed1",
+                "reference": "9f851cef387ae94b7b5c681e876cbcf7339caed1",
                 "shasum": ""
             },
             "require": {
@@ -1567,7 +1567,6 @@
                     "CoenJacobs\\Mozart\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1577,7 +1576,10 @@
                     "email": "coenjacobs@gmail.com"
                 }
             ],
-            "time": "2018-06-25T14:11:53+00:00"
+            "support": {
+                "source": "https://github.com/costasovo/mozart/tree/dependency-tree"
+            },
+            "time": "2018-10-17T11:47:01+00:00"
         },
         {
             "name": "composer/composer",
@@ -1983,19 +1985,20 @@
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "3.2.1",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "d78ef59aea19d3e2e5a23f90a055155ee78a0ad5"
+                "reference": "853d2d462a191d44a25a5593d8fe2c4a1e59e382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/d78ef59aea19d3e2e5a23f90a055155ee78a0ad5",
-                "reference": "d78ef59aea19d3e2e5a23f90a055155ee78a0ad5",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/853d2d462a191d44a25a5593d8fe2c4a1e59e382",
+                "reference": "853d2d462a191d44a25a5593d8fe2c4a1e59e382",
                 "shasum": ""
             },
             "require": {
+                "dflydev/dot-access-data": "^1.1.0",
                 "php": ">=5.4.0",
                 "symfony/console": "^2.8|^3|^4",
                 "symfony/finder": "^2.5|^3|^4"
@@ -2034,7 +2037,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2018-05-25T18:02:34+00:00"
+            "time": "2018-10-16T01:14:51+00:00"
         },
         {
             "name": "consolidation/robo",
@@ -3535,16 +3538,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.47",
+            "version": "1.0.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "a11e4a75f256bdacf99d20780ce42d3b8272975c"
+                "reference": "a6ded5b2f6055e2db97b4b859fdfca2b952b78aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a11e4a75f256bdacf99d20780ce42d3b8272975c",
-                "reference": "a11e4a75f256bdacf99d20780ce42d3b8272975c",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a6ded5b2f6055e2db97b4b859fdfca2b952b78aa",
+                "reference": "a6ded5b2f6055e2db97b4b859fdfca2b952b78aa",
                 "shasum": ""
             },
             "require": {
@@ -3615,7 +3618,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-09-14T15:30:29+00:00"
+            "time": "2018-10-15T13:53:10+00:00"
         },
         {
             "name": "lucatume/codeception-setup-local",
@@ -8642,7 +8645,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "swiftmailer/swiftmailer": 20,
-        "soundasleep/html2text": 20
+        "soundasleep/html2text": 20,
+        "coenjacobs/mozart": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc70fc563b5114482541645521f0a52b",
+    "content-hash": "458cf5f5b66cbc5fe5b99d1fd3aa16d0",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -100,6 +100,37 @@
                 "tls"
             ],
             "time": "2018-08-08T08:57:40+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "j4mie/idiorm",
@@ -225,6 +256,71 @@
                 "paris"
             ],
             "time": "2017-03-21T02:13:30+00:00"
+        },
+        {
+            "name": "league/container",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/43f35abd03a12977a60ffd7095efd6a7808488c0",
+                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "php": "^5.4.0 || ^7.0"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "philipobenito@gmail.com",
+                    "homepage": "http://www.philipobenito.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "time": "2017-05-10T09:20:27+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -402,6 +498,55 @@
                 "time"
             ],
             "time": "2018-09-20T19:36:25+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -1540,12 +1685,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/costasovo/mozart.git",
-                "reference": "9f851cef387ae94b7b5c681e876cbcf7339caed1"
+                "reference": "e7f04ffc136f8175dec82615dcee43e234f001ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/costasovo/mozart/zipball/9f851cef387ae94b7b5c681e876cbcf7339caed1",
-                "reference": "9f851cef387ae94b7b5c681e876cbcf7339caed1",
+                "url": "https://api.github.com/repos/costasovo/mozart/zipball/e7f04ffc136f8175dec82615dcee43e234f001ae",
+                "reference": "e7f04ffc136f8175dec82615dcee43e234f001ae",
                 "shasum": ""
             },
             "require": {
@@ -1579,7 +1724,7 @@
             "support": {
                 "source": "https://github.com/costasovo/mozart/tree/dependency-tree"
             },
-            "time": "2018-10-17T11:47:01+00:00"
+            "time": "2018-10-23T18:15:03+00:00"
         },
         {
             "name": "composer/composer",
@@ -2169,37 +2314,6 @@
             ],
             "description": "Provides a self:update command for Symfony Console applications.",
             "time": "2018-08-24T17:01:46+00:00"
-        },
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3472,71 +3586,6 @@
             "time": "2018-09-30T08:05:18+00:00"
         },
         {
-            "name": "league/container",
-            "version": "2.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/container.git",
-                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/43f35abd03a12977a60ffd7095efd6a7808488c0",
-                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.2",
-                "php": "^5.4.0 || ^7.0"
-            },
-            "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "orno/di": "~2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Container\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Phil Bennett",
-                    "email": "philipobenito@gmail.com",
-                    "homepage": "http://www.philipobenito.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A fast and intuitive dependency injection container.",
-            "homepage": "https://github.com/thephpleague/container",
-            "keywords": [
-                "container",
-                "dependency",
-                "di",
-                "injection",
-                "league",
-                "provider",
-                "service"
-            ],
-            "time": "2017-05-10T09:20:27+00:00"
-        },
-        {
             "name": "league/flysystem",
             "version": "1.0.48",
             "source": {
@@ -4722,55 +4771,6 @@
                 "xunit"
             ],
             "time": "2017-06-30T09:13:00+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -4,6 +4,8 @@ namespace MailPoet\Config;
 
 use MailPoet\API;
 use MailPoet\Cron\CronTrigger;
+use MailPoet\Dependencies\League\Container\Container;
+use MailPoet\DI\ContainerFactory;
 use MailPoet\Models\Setting;
 use MailPoet\Router;
 use MailPoet\Util\ConflictResolver;
@@ -18,6 +20,8 @@ require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 class Initializer {
   private $access_control;
   private $renderer;
+  /** @var Container */
+  private $container;
 
   const INITIALIZED = 'MAILPOET_INITIALIZED';
 
@@ -26,6 +30,7 @@ class Initializer {
     'version' => '1.0.0'
   )) {
     Env::init($params['file'], $params['version']);
+    $this->container = ContainerFactory::getContainer();
   }
 
   function init() {
@@ -170,7 +175,7 @@ class Initializer {
   }
 
   function setupAccessControl() {
-    $this->access_control = new AccessControl();
+    $this->access_control = $this->container->get(AccessControl::class);
   }
 
   function setupInstaller() {

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -95,6 +95,11 @@ class Initializer {
     ));
   }
 
+  function compileContainer() {
+    $this->container = ContainerFactory::getContainer();
+    $this->container->compile();
+  }
+
   function checkRequirements() {
     $requirements = new RequirementsChecker();
     return $requirements->checkAllRequirements();
@@ -259,7 +264,7 @@ class Initializer {
   }
 
   function setupRouter() {
-    $router = new Router\Router($this->access_control);
+    $router = new Router\Router($this->access_control, $this->container);
     $router->init();
   }
 

--- a/lib/Cron/DaemonHttpRunner.php
+++ b/lib/Cron/DaemonHttpRunner.php
@@ -6,7 +6,6 @@ require_once(ABSPATH . 'wp-includes/pluggable.php');
 
 class DaemonHttpRunner {
   public $settings_daemon_data;
-  public $request_data;
   public $timer;
   public $token;
 
@@ -15,15 +14,11 @@ class DaemonHttpRunner {
 
   const PING_SUCCESS_RESPONSE = 'pong';
 
-  function __construct($request_data = false, $daemon = null) {
-    $this->request_data = $request_data;
+  function __construct(Daemon $daemon = null) {
     $this->settings_daemon_data = CronHelper::getDaemon();
     $this->token = CronHelper::createToken();
     $this->timer = microtime(true);
     $this->daemon = $daemon;
-    if(!$daemon) {
-      $this->daemon = new Daemon($this->settings_daemon_data);
-    }
   }
 
   function ping() {
@@ -31,20 +26,20 @@ class DaemonHttpRunner {
     $this->terminateRequest(self::PING_SUCCESS_RESPONSE);
   }
 
-  function run() {
+  function run($request_data) {
     ignore_user_abort(true);
     if(strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
       set_time_limit(0);
     }
     $this->addCacheHeaders();
-    if(!$this->request_data) {
+    if(!$request_data) {
       $error = __('Invalid or missing request data.', 'mailpoet');
     } else {
       if(!$this->settings_daemon_data) {
         $error = __('Daemon does not exist.', 'mailpoet');
       } else {
-        if(!isset($this->request_data['token']) ||
-          $this->request_data['token'] !== $this->settings_daemon_data['token']
+        if(!isset($request_data['token']) ||
+          $request_data['token'] !== $this->settings_daemon_data['token']
         ) {
           $error = 'Invalid or missing token.';
         }

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -1,0 +1,27 @@
+<?php
+namespace MailPoet\DI;
+
+use MailPoet\Dependencies\League\Container\Container;
+use MailPoet\Dependencies\League\Container\ReflectionContainer;
+
+class ContainerFactory {
+  /** @var Container */
+  private static $container;
+
+  static function getContainer() {
+    if(!self::$container) {
+      self::$container = self::createContainer();
+    }
+    return self::$container;
+  }
+
+  private static function createContainer() {
+    $container = new Container();
+
+    // register the reflection container as a delegate to enable auto wiring
+    $container->delegate(
+      new ReflectionContainer()
+    );
+    return $container;
+  }
+}

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -15,7 +15,7 @@ class ContainerFactory {
     return self::$container;
   }
 
-  private static function createContainer() {
+  static function createContainer() {
     $container = new Container();
 
     // register the reflection container as a delegate to enable auto wiring

--- a/lib/Router/Endpoints/CronDaemon.php
+++ b/lib/Router/Endpoints/CronDaemon.php
@@ -23,13 +23,15 @@ class CronDaemon {
     'global' => AccessControl::NO_ACCESS_RESTRICTION
   );
 
-  function __construct($data) {
-    $this->data = $data;
+  /** @var DaemonHttpRunner */
+  private $daemon_runner;
+
+  function __construct(DaemonHttpRunner $daemon_runner) {
+    $this->daemon_runner = $daemon_runner;
   }
 
-  function run() {
-    $queue = new DaemonHttpRunner($this->data);
-    $queue->run();
+  function run($data) {
+    $this->daemon_runner->run($data);
   }
 
   function ping() {
@@ -37,7 +39,6 @@ class CronDaemon {
   }
 
   function pingResponse() {
-    $queue = new DaemonHttpRunner();
-    $queue->ping();
+    $this->daemon_runner->ping();
   }
 }

--- a/lib/Router/Endpoints/Subscription.php
+++ b/lib/Router/Endpoints/Subscription.php
@@ -17,30 +17,25 @@ class Subscription {
     self::ACTION_MANAGE,
     self::ACTION_UNSUBSCRIBE
   );
-  public $data;
   public $permissions = array(
     'global' => AccessControl::NO_ACCESS_RESTRICTION
   );
 
-  function __construct($data) {
-    $this->data = $data;
-  }
-
-  function confirm() {
-    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM);
+  function confirm($data) {
+    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM, $data);
     $subscription->confirm();
   }
 
-  function manage() {
-    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_MANAGE);
+  function manage($data) {
+    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_MANAGE, $data);
   }
 
-  function unsubscribe() {
-    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE);
+  function unsubscribe($data) {
+    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
     $subscription->unsubscribe();
   }
 
-  private function initSubscriptionPage($action) {
-    return new UserSubscription\Pages($action, $this->data, true, true);
+  private function initSubscriptionPage($action, $data) {
+    return new UserSubscription\Pages($action, $data, true, true);
   }
 }

--- a/lib/Router/Endpoints/Track.php
+++ b/lib/Router/Endpoints/Track.php
@@ -22,23 +22,18 @@ class Track {
     self::ACTION_CLICK,
     self::ACTION_OPEN
   );
-  public $data;
   public $permissions = array(
     'global' => AccessControl::NO_ACCESS_RESTRICTION
   );
 
-  function __construct($data) {
-    $this->data = $this->_processTrackData($data);
-  }
-
-  function click() {
+  function click($data) {
     $click_event = new Clicks();
-    return $click_event->track($this->data);
+    return $click_event->track($this->_processTrackData($data));
   }
 
-  function open() {
+  function open($data) {
     $open_event = new Opens();
-    return $open_event->track($this->data);
+    return $open_event->track($this->_processTrackData($data));
   }
 
   function _processTrackData($data) {
@@ -82,7 +77,7 @@ class Track {
       false;
   }
 
-  private function terminate($code) {
+  function terminate($code) {
     status_header($code);
     get_template_part((string)$code);
     exit;

--- a/lib/Router/Endpoints/ViewInBrowser.php
+++ b/lib/Router/Endpoints/ViewInBrowser.php
@@ -17,19 +17,18 @@ class ViewInBrowser {
   const ENDPOINT = 'view_in_browser';
   const ACTION_VIEW = 'view';
   public $allowed_actions = array(self::ACTION_VIEW);
-  public $data;
   public $permissions = array(
     'global' => AccessControl::NO_ACCESS_RESTRICTION
   );
 
-  function __construct($data, AccessControl $access_control) {
+  function __construct(AccessControl $access_control) {
     $this->access_control = $access_control;
-    $this->data = $this->_processBrowserPreviewData($data);
   }
 
-  function view() {
+  function view($data) {
+    $data = $this->_processBrowserPreviewData($data);
     $view_in_browser = new NewsletterViewInBrowser();
-    return $this->_displayNewsletter($view_in_browser->view($this->data));
+    return $this->_displayNewsletter($view_in_browser->view($data));
   }
 
   function _processBrowserPreviewData($data) {

--- a/lib/Router/Router.php
+++ b/lib/Router/Router.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Router;
 
 use MailPoet\Config\AccessControl;
+use MailPoet\Dependencies\League\Container\Container;
 use MailPoet\Util\Helpers;
 
 if(!defined('ABSPATH')) exit;
@@ -12,11 +13,13 @@ class Router {
   public $endpoint;
   public $action;
   public $data;
+  /** @var Container */
+  private $container;
   const NAME = 'mailpoet_router';
   const RESPONSE_ERROR = 404;
   const RESPONE_FORBIDDEN = 403;
 
-  function __construct(AccessControl $access_control, $api_data = false) {
+  function __construct(AccessControl $access_control, Container $container, $api_data = false) {
     $api_data = ($api_data) ? $api_data : $_GET;
     $this->api_request = isset($api_data[self::NAME]);
     $this->endpoint = isset($api_data['endpoint']) ?
@@ -29,15 +32,19 @@ class Router {
       self::decodeRequestData($api_data['data']) :
       array();
     $this->access_control = $access_control;
+    $this->container = $container;
   }
 
   function init() {
-    $endpoint_class = __NAMESPACE__ . "\\Endpoints\\" . ucfirst($this->endpoint);
     if(!$this->api_request) return;
+    $endpoint_class = __NAMESPACE__ . "\\Endpoints\\" . ucfirst($this->endpoint);
+
     if(!$this->endpoint || !class_exists($endpoint_class)) {
       return $this->terminateRequest(self::RESPONSE_ERROR, __('Invalid router endpoint', 'mailpoet'));
     }
-    $endpoint = new $endpoint_class($this->data, $this->access_control);
+
+    $endpoint = $this->container->get($endpoint_class);
+
     if(!method_exists($endpoint, $this->endpoint_action) || !in_array($this->endpoint_action, $endpoint->allowed_actions)) {
       return $this->terminateRequest(self::RESPONSE_ERROR, __('Invalid router endpoint action', 'mailpoet'));
     }
@@ -46,10 +53,11 @@ class Router {
     }
     do_action('mailpoet_conflict_resolver_router_url_query_parameters');
     return call_user_func(
-      array(
+      [
         $endpoint,
-        $this->endpoint_action
-      )
+        $this->endpoint_action,
+      ],
+      $this->data
     );
   }
 

--- a/tests/unit/Cron/DaemonHttpRunnerTest.php
+++ b/tests/unit/Cron/DaemonHttpRunnerTest.php
@@ -14,15 +14,14 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       CronHelper::DAEMON_SETTING,
       []
     );
-    $daemon = new DaemonHttpRunner($request_data = 'request data');
-    expect($daemon->request_data)->equals('request data');
+    $daemon = new DaemonHttpRunner();
     expect(strlen($daemon->timer))->greaterOrEquals(5);
     expect(strlen($daemon->token))->greaterOrEquals(5);
   }
 
   function testItDoesNotRunWithoutRequestData() {
     $daemon = Stub::construct(
-      new DaemonHttpRunner(),
+      new DaemonHttpRunner(new Daemon()),
       array(),
       array(
         'abortWithError' => function($message) {
@@ -30,13 +29,12 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
         }
       )
     );
-    $daemon->request_data = false;
-    expect($daemon->run())->equals('Invalid or missing request data.');
+    expect($daemon->run(false))->equals('Invalid or missing request data.');
   }
 
   function testItDoesNotRunWhenThereIsInvalidOrMissingToken() {
     $daemon = Stub::construct(
-      new DaemonHttpRunner(),
+      new DaemonHttpRunner(new Daemon()),
       array(),
       array(
         'abortWithError' => function($message) {
@@ -47,8 +45,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $daemon->settings_daemon_data = array(
       'token' => 123
     );
-    $daemon->request_data = array('token' => 456);
-    expect($daemon->run())->equals('Invalid or missing token.');
+    expect($daemon->run(['token' => 456]))->equals('Invalid or missing token.');
   }
 
   function testItStoresErrorMessageAndContinuesExecutionWhenWorkersThrowException() {
@@ -63,13 +60,13 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
         throw new \Exception();
       },
     ), $this);
-    $daemon_http_runner = Stub::make(new DaemonHttpRunner($data, $daemon), array(
+    $daemon_http_runner = Stub::make(new DaemonHttpRunner($daemon), array(
       'pauseExecution' => null,
       'callSelf' => null
     ), $this);
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon_http_runner->__construct($data, $daemon);
-    $daemon_http_runner->run();
+    $daemon_http_runner->__construct($daemon);
+    $daemon_http_runner->run($data);
     $updated_daemon = Setting::getValue(CronHelper::DAEMON_SETTING);
     expect($updated_daemon['last_error'])->greaterOrEquals('Message');
   }
@@ -79,7 +76,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'executeScheduleWorker' => null,
       'executeQueueWorker' => null,
     ), $this);
-    $daemon_http_runner = Stub::make(new DaemonHttpRunner(true, $daemon), array(
+    $daemon_http_runner = Stub::make(new DaemonHttpRunner($daemon), array(
       'pauseExecution' => Expected::exactly(1, function($pause_delay) {
         expect($pause_delay)->lessThan(CronHelper::DAEMON_EXECUTION_LIMIT);
         expect($pause_delay)->greaterThan(CronHelper::DAEMON_EXECUTION_LIMIT - 1);
@@ -90,13 +87,13 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'token' => 123
     );
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon_http_runner->__construct($data, $daemon);
-    $daemon_http_runner->run();
+    $daemon_http_runner->__construct($daemon);
+    $daemon_http_runner->run($data);
   }
 
 
   function testItTerminatesExecutionWhenDaemonIsDeleted() {
-    $daemon = Stub::make(new DaemonHttpRunner(true), array(
+    $daemon = Stub::make(new DaemonHttpRunner(new Daemon()), array(
       'executeScheduleWorker' => function() {
         Setting::deleteValue(CronHelper::DAEMON_SETTING);
       },
@@ -108,12 +105,12 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'token' => 123
     );
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon->__construct($data);
-    $daemon->run();
+    $daemon->__construct(new Daemon());
+    $daemon->run($data);
   }
 
   function testItTerminatesExecutionWhenDaemonTokenChangesAndKeepsChangedToken() {
-    $daemon = Stub::make(new DaemonHttpRunner(true), array(
+    $daemon = Stub::make(new DaemonHttpRunner(new Daemon()), array(
       'executeScheduleWorker' => function() {
         Setting::setValue(
           CronHelper::DAEMON_SETTING,
@@ -128,14 +125,14 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'token' => 123
     );
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon->__construct($data);
-    $daemon->run();
+    $daemon->__construct(new Daemon());
+    $daemon->run($data);
     $data_after_run = Setting::getValue(CronHelper::DAEMON_SETTING);
     expect($data_after_run['token'], 567);
   }
 
   function testItTerminatesExecutionWhenDaemonIsDeactivated() {
-    $daemon = Stub::make(new DaemonHttpRunner(true), [
+    $daemon = Stub::make(new DaemonHttpRunner(new Daemon()), [
       'executeScheduleWorker' => null,
       'executeQueueWorker' => null,
       'pauseExecution' => null,
@@ -146,12 +143,12 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'status' => CronHelper::DAEMON_STATUS_INACTIVE,
     ];
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon->__construct($data);
-    $daemon->run();
+    $daemon->__construct(new Daemon());
+    $daemon->run($data);
   }
 
   function testItUpdatesDaemonTokenDuringExecution() {
-    $daemon_http_runner = Stub::make(new DaemonHttpRunner(true), array(
+    $daemon_http_runner = Stub::make(new DaemonHttpRunner(new Daemon()), array(
       'executeScheduleWorker' => null,
       'executeQueueWorker' => null,
       'pauseExecution' => null,
@@ -161,8 +158,8 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'token' => 123
     );
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon_http_runner->__construct($data);
-    $daemon_http_runner->run();
+    $daemon_http_runner->__construct(new Daemon());
+    $daemon_http_runner->run($data);
     $updated_daemon = Setting::getValue(CronHelper::DAEMON_SETTING);
     expect($updated_daemon['token'])->equals($daemon_http_runner->token);
   }
@@ -174,7 +171,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       },
       'executeQueueWorker' => null,
     ), $this);
-    $daemon_http_runner = Stub::make(new DaemonHttpRunner(true, $daemon), array(
+    $daemon_http_runner = Stub::make(new DaemonHttpRunner($daemon), array(
       'pauseExecution' => null,
       'callSelf' => null
     ), $this);
@@ -183,8 +180,8 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     );
     $now = time();
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon_http_runner->__construct($data, $daemon);
-    $daemon_http_runner->run();
+    $daemon_http_runner->__construct($daemon);
+    $daemon_http_runner->run($data);
     $updated_daemon = Setting::getValue(CronHelper::DAEMON_SETTING);
     expect($updated_daemon['run_started_at'])->greaterOrEquals($now);
     expect($updated_daemon['run_started_at'])->lessThan($now + 2);
@@ -195,7 +192,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
   function testItCanRun() {
     ignore_user_abort(0);
     expect(ignore_user_abort())->equals(0);
-    $daemon = Stub::make(new DaemonHttpRunner(true), array(
+    $daemon = Stub::make(new DaemonHttpRunner(new Daemon()), array(
       'pauseExecution' => null,
       // workers should be executed
       'executeScheduleWorker' => Expected::exactly(1),
@@ -207,13 +204,13 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'token' => 123
     );
     Setting::setValue(CronHelper::DAEMON_SETTING, $data);
-    $daemon->__construct($data);
-    $daemon->run();
+    $daemon->__construct(new Daemon());
+    $daemon->run($data);
     expect(ignore_user_abort())->equals(1);
   }
 
   function testItRespondsToPingRequest() {
-    $daemon = Stub::make(new DaemonHttpRunner(true), array(
+    $daemon = Stub::make(new DaemonHttpRunner(new Daemon()), array(
       'terminateRequest' => Expected::exactly(1, function($message) {
         expect($message)->equals('pong');
       })

--- a/tests/unit/Router/Endpoints/TrackTest.php
+++ b/tests/unit/Router/Endpoints/TrackTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace MailPoet\Test\Router\Endpoints;
 
-use AspectMock\Test as Mock;
+use Codeception\Stub;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterLink;
 use MailPoet\Models\ScheduledTask;
@@ -74,9 +74,10 @@ class TrackTest extends \MailPoetTest {
       )
     );
     $data->subscriber->email = 'random@email.com';
-    $track = Mock::double($this->track, array('terminate' => null));
+    $track = Stub::make(new Track(), ['terminate' => function($code) {
+      expect($code)->equals(403);
+    }]);
     $track->_validateTrackData($data);
-    $track->verifyInvokedOnce('terminate', array(403));
   }
 
   function testItFailsWhenSubscriberIsNotOnProcessedList() {

--- a/tests/unit/Router/Endpoints/ViewInBrowserTest.php
+++ b/tests/unit/Router/Endpoints/ViewInBrowserTest.php
@@ -39,7 +39,7 @@ class ViewInBrowserTest extends \MailPoetTest {
       'preview' => false
     );
     // instantiate class
-    $this->view_in_browser = new ViewInBrowser($this->browser_preview_data, new AccessControl());
+    $this->view_in_browser = new ViewInBrowser(new AccessControl());
   }
 
   function testItAbortsWhenBrowserPreviewDataIsMissing() {
@@ -203,8 +203,7 @@ class ViewInBrowserTest extends \MailPoetTest {
     $view_in_browser = Stub::make($this->view_in_browser, array(
       '_displayNewsletter' => Expected::exactly(1)
     ), $this);
-    $view_in_browser->data = $view_in_browser->_processBrowserPreviewData($this->browser_preview_data);
-    $view_in_browser->view();
+    $view_in_browser->view($this->browser_preview_data);
   }
 
   function _after() {

--- a/tests/unit/Router/RouterTest.php
+++ b/tests/unit/Router/RouterTest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Router;
 use Codeception\Stub;
 use Codeception\Stub\Expected;
 use MailPoet\Config\AccessControl;
+use MailPoet\Dependencies\League\Container\Container;
+use MailPoet\DI\ContainerFactory;
+use MailPoet\Router\Endpoints\RouterTestMockEndpoint;
 use MailPoet\Router\Router;
 
 require_once('RouterTestMockEndpoint.php');
@@ -12,6 +15,8 @@ require_once('RouterTestMockEndpoint.php');
 class RouterTest extends \MailPoetTest {
   public $access_control;
   public $router_data;
+  /** @var Container */
+  private $container;
 
   function _before() {
     $this->router_data = array(
@@ -21,7 +26,9 @@ class RouterTest extends \MailPoetTest {
       'data' => base64_encode(json_encode(array('data' => 'dummy data')))
     );
     $this->access_control = new AccessControl();
-    $this->router = new Router($this->access_control, $this->router_data);
+    $this->container = ContainerFactory::createContainer();
+    $this->container->add(RouterTestMockEndpoint::class);
+    $this->router = new Router($this->access_control, $this->container, $this->router_data);
   }
 
   function testItCanGetAPIDataFromGetRequest() {
@@ -29,7 +36,7 @@ class RouterTest extends \MailPoetTest {
     $url = 'http://example.com/?' . Router::NAME . '&endpoint=view_in_browser&action=view&data='
       . base64_encode(json_encode($data));
     parse_str(parse_url($url, PHP_URL_QUERY), $_GET);
-    $router = new Router($this->access_control);
+    $router = new Router($this->access_control, $this->container);
     expect($router->api_request)->equals(true);
     expect($router->endpoint)->equals('viewInBrowser');
     expect($router->endpoint_action)->equals('view');
@@ -41,7 +48,7 @@ class RouterTest extends \MailPoetTest {
     unset($router_data[Router::NAME]);
     $router = Stub::construct(
       '\MailPoet\Router\Router',
-      array($this->access_control, $router_data)
+      array($this->access_control, $this->container, $router_data)
     );
     $result = $router->init();
     expect($result)->null();
@@ -52,7 +59,7 @@ class RouterTest extends \MailPoetTest {
     $router_data['endpoint'] = 'invalid_endpoint';
     $router = Stub::construct(
       '\MailPoet\Router\Router',
-      array($this->access_control, $router_data),
+      array($this->access_control, $this->container, $router_data),
       array(
         'terminateRequest' => function($code, $error) {
           return array(
@@ -76,7 +83,7 @@ class RouterTest extends \MailPoetTest {
     $router_data['action'] = 'invalid_action';
     $router = Stub::construct(
       '\MailPoet\Router\Router',
-      array($this->access_control, $router_data),
+      array($this->access_control, $this->container, $router_data),
       array(
         'terminateRequest' => function($code, $error) {
           return array(
@@ -164,7 +171,7 @@ class RouterTest extends \MailPoetTest {
   function testItValidatesPermissionBeforeProcessingEndpointAction() {
     $router = Stub::construct(
       '\MailPoet\Router\Router',
-      array($this->access_control, $this->router_data),
+      array($this->access_control, $this->container, $this->router_data),
       array(
         'validatePermissions' => function($action, $permissions) {
           expect($action)->equals($this->router_data['action']);
@@ -186,7 +193,7 @@ class RouterTest extends \MailPoetTest {
   function testItReturnsForbiddenResponseWhenPermissionFailsValidation() {
     $router = Stub::construct(
       '\MailPoet\Router\Router',
-      array($this->access_control, $this->router_data),
+      array($this->access_control, $this->container, $this->router_data),
       array(
         'validatePermissions' => false,
         'terminateRequest' => function($code, $error) {

--- a/tests/unit/Router/RouterTestMockEndpoint.php
+++ b/tests/unit/Router/RouterTestMockEndpoint.php
@@ -14,11 +14,7 @@ class RouterTestMockEndpoint {
     'global' => AccessControl::NO_ACCESS_RESTRICTION
   );
 
-  function __construct($data) {
-    $this->data = $data;
-  }
-
-  function test() {
-    return $this->data;
+  function test($data) {
+    return $data;
   }
 }


### PR DESCRIPTION
# League/container
- services are by default re-created on every get call

## Pros
- quite known solution (over 2.7M downloads, 2 active contributors)
- small library (mailpoet.zip 8.5M)
- autowiring
- easy setup
- compatible with PSR-11 https://github.com/php-fig/container 
- [decent documentation](https://container.thephpleague.com/2.x/)

## Cons
- less popular compared to symfony
- we have to use version 2 because of php version (version 3 is a bit different)