### PR TITLE
Permit CSS assets to be loaded from WP.com CDN on MP3 pages [MAILPOET-1584]

### DIFF
--- a/lib/Util/ConflictResolver.php
+++ b/lib/Util/ConflictResolver.php
@@ -7,6 +7,9 @@ class ConflictResolver {
       // WP default
       '^/wp-admin',
       '^/wp-includes',
+      // CDN
+      'googleapis.com/ajax/libs',
+      'wp.com',
       // third-party
       'query-monitor',
       'wpt-tx-updater-network'


### PR DESCRIPTION
This is for the media library to work in the newsletter editor when Jetpack's "Asset CDN" is active.