### PR TITLE
Fix flaky segments test [MAILPOET-1578]

### DIFF
--- a/tests/integration/API/JSON/v1/SegmentsTest.php
+++ b/tests/integration/API/JSON/v1/SegmentsTest.php
@@ -124,7 +124,7 @@ class SegmentsTest extends \MailPoetTest {
   }
 
   function testItCanBulkDeleteSegments() {
-    $subscriber_segment = SubscriberSegment::create(array(
+    $subscriber_segment = SubscriberSegment::createOrUpdate(array(
       'subscriber_id' => 1,
       'segment_id' => $this->segment_1->id,
       'status' => Subscriber::STATUS_SUBSCRIBED


### PR DESCRIPTION
This is hard to debug, but the id was NULL in the previous implementation
and that sometimes returned an object instead of expected
Now the id is always a number and that will hopefully fix the flakiness.

