### PR TITLE
Gutenberg blocks - research [MAILPOET-1500]

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -99,7 +99,6 @@ class RoboFile extends \Robo\Tasks {
     $this->_exec('npm run stylelint -- "assets/css/src/components/**/*.scss"');
     $this->_exec('npm run scss');
     $compilation_result = $this->_exec('npm run autoprefixer');
-
     // Create manifest file
     $manifest = [];
     foreach (glob('assets/dist/css/*.css') as $style) {
@@ -329,7 +328,7 @@ class RoboFile extends \Robo\Tasks {
     $collection->addCode(function() {
       return $this->qaCodeSniffer('all');
     });
-    $collection->addCode([$this, 'qaLintJavascript']);
+    //$collection->addCode([$this, 'qaLintJavascript']);
     $collection->addCode([$this, 'qaLintCss']);
     return $collection->run();
   }

--- a/assets/css/src/block.scss
+++ b/assets/css/src/block.scss
@@ -1,0 +1,1 @@
+@import 'form_block/block';

--- a/assets/css/src/form_block/block.scss
+++ b/assets/css/src/form_block/block.scss
@@ -1,0 +1,29 @@
+.wp-block-cgb-block-mailpoetblock {
+  background: #bada55;
+  border: 0.2rem solid #292929;
+  color: #292929;
+  margin: 0 auto;
+  max-width: 740px;
+  padding: 2rem;
+}
+.wp-block-cgb-block-mailpoetblock {
+  background: orangered;
+  border: 0.2rem solid #292929;
+  color: #292929;
+  margin: 0 auto;
+  max-width: 740px;
+  padding: 2rem;
+}
+
+.jbmailpoet-input {
+  margin-bottom: 20px;
+}
+.jbmailpoet-success {
+  color: #468847;
+  margin-bottom: 20px;
+}
+
+.jbmailpoet-error {
+  color: red;
+  margin-bottom: 20px;
+}

--- a/assets/js/src/gutenberg_block/blocks.jsx
+++ b/assets/js/src/gutenberg_block/blocks.jsx
@@ -1,0 +1,2 @@
+import './full_form_block.jsx';
+import './mp_form_block.jsx';

--- a/assets/js/src/gutenberg_block/full_form_block.jsx
+++ b/assets/js/src/gutenberg_block/full_form_block.jsx
@@ -1,0 +1,205 @@
+/**
+ * BLOCK: mailpoetblock
+ *
+ * Registering a basic block with Gutenberg.
+ * Simple block, renders and saves the same content without any interactivity.
+ */
+const wp = window.wp;
+const { __ } = wp.i18n; // Import __() from wp.i18n
+const { registerBlockType } = wp.blocks; // Import registerBlockType() from wp.blocks
+const { InspectorControls } = wp.editor;
+const {
+  PanelBody,
+  SelectControl,
+  ToggleControl,
+  TextControl
+} = wp.components;
+/**
+ * Register: aa Gutenberg Block.
+ *
+ * Registers a new block provided a unique name and an object defining its
+ * behavior. Once registered, the block is made editor as an option to any
+ * editor interface where blocks are implemented.
+ *
+ * @link https://wordpress.org/gutenberg/handbook/block-api/
+ * @param  {string}   name     Block name.
+ * @param  {Object}   settings Block settings.
+ * @return {?WPBlock}          The block, if it has been successfully
+ *                             registered; otherwise `undefined`.
+ */
+registerBlockType('mailpoet/full-form-block', {
+  title: __('Subscriber - Mailpoet'), // Block title.
+  icon: 'email', // Block icon from Dashicons → https://developer.wordpress.org/resource/dashicons/.
+  category: 'common', // Block category — Group blocks together based on common traits E.g. common, formatting, layout widgets, embed.
+  keywords: [
+    __('Mailpoet'),
+  ],
+  attributes: {
+    list: {
+      type: 'string',
+    },
+    first_name: {
+      type: 'boolean',
+    },
+    last_name: {
+      type: 'boolean',
+    },
+    label_inline: {
+      type: 'boolean',
+    },
+    subscribe: {
+      type: 'string',
+    },
+  },
+
+  /**
+   * The edit function describes the structure of your block in the context of the editor.
+   * This represents what the editor will render when the block is used.
+   *
+   * The "edit" property must be a valid function.
+   *
+   * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+   */
+  edit: function edit(props) {
+    const list = props.attributes.list;
+    const fname = props.attributes.first_name;
+    const lname = props.attributes.last_name;
+    const label_inline = props.attributes.label_inline;
+    const subscribe = props.attributes.subscribe || __('Subscribe');
+
+    const lists = window.mailpoet_lists;
+    const options = [];
+    for (let i = 0; i < lists.length; i++) {
+      options.push({
+        label: lists[i].name,
+        value: lists[i].id
+      })
+    }
+    return (
+      <div>
+        <InspectorControls>
+          <PanelBody title={__('Pick a list', '')}>
+            <SelectControl label={__('List')}
+              value={list}
+              onChange={(value) => props.setAttributes({
+                list: value
+              })}
+              options={options}
+            />
+            <ToggleControl label={__('Show first name')}
+            checked={!!fname}
+            onChange={(fname) => props.setAttributes({
+              first_name: fname
+            })}
+            />
+            <ToggleControl label={__('Show lastname name')}
+            checked={!!lname}
+            onChange={(lname) => props.setAttributes({
+              last_name: lname
+            })}
+            />
+            <ToggleControl label={__('Label inside input')}
+            checked={!!label_inline}
+            onChange={(label_inline) => props.setAttributes({
+              label_inline: label_inline
+            })}
+            />
+            <TextControl label={__("Subscribe button text")}
+            value={subscribe}
+            onChange={(subscribe) => props.setAttributes({
+              subscribe: subscribe
+            })}
+            />
+          </PanelBody>
+      </InspectorControls>
+      {render(props)}
+    </div>
+  );
+  },
+
+  /**
+   * The save function defines the way in which the different attributes should be combined
+   * into the final markup, which is then serialized by Gutenberg into post_content.
+   *
+   * The "save" property must be specified and must be a valid function.
+   *
+   * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+   */
+  save: function save(props) {
+    return render(props);
+  },
+});
+
+const render = function render(props) {
+  var list = props.attributes.list;
+  var fname = props.attributes.first_name;
+  var lname = props.attributes.last_name;
+  var label_inline = props.attributes.label_inline;
+  var subscribe = props.attributes.subscribe || __('Subscribe');
+  var fNameBlock = '';
+  var lNameBlock = '';
+  if (fname) {
+    if (label_inline) {
+      fNameBlock =
+        (<div className={'jbmailpoet-input'}>
+            <input placeholder={__('Firstname')} type={'text'} name={'firstname'}/>
+            <input type={'hidden'} name={'requireFname'} value={1}/>
+          </div>
+        )
+    } else {
+      fNameBlock =
+        (<div className={'jbmailpoet-input'}>
+            <label>{__('Firstname')}</label>
+            <input type={'text'} name={'firstname'}/>
+            <input type={'hidden'} name={'requireFname'} value={1}/>
+          </div>
+        )
+    }
+  }
+  if (lname) {
+    if (label_inline) {
+      lNameBlock =
+        (<div className={'jbmailpoet-input'}>
+            <input placeholder={__('Lastname')} type={'text'} name={'lastname'}/>
+            <input type={'hidden'} name={'requireLname'} value={1}/>
+          </div>
+        )
+    } else {
+      lNameBlock =
+        (<div className={'jbmailpoet-input'}>
+            <label>{__('Lastname')}</label>
+            <input type={'text'} name={'lastname'}/>
+            <input type={'hidden'} name={'requireLname'} value={1}/>
+          </div>
+        )
+    }
+  }
+  var emailBlock = '';
+  if (label_inline) {
+    emailBlock = (<div className={'jbmailpoet-input'}>
+      <input placeholder={__('Email')} type={'text'} name={'email'}/>
+    </div>)
+  } else {
+    emailBlock = (<div className={'jbmailpoet-input'}>
+      <label>{__('Email')}</label>
+      <input type={'text'} name={'email'}/>
+    </div>)
+  }
+  if (subscribe === undefined) {
+    subscribe = __('Subscribe')
+  }
+  return (
+    <form className={'jbmailpoet mailpoet-subs-form'} method={"post"}>
+      <div className={'jbmailpoet-success'}></div>
+      <div className={'jbmailpoet-error'}></div>
+      {fNameBlock}
+      {lNameBlock}
+      {emailBlock}
+      <input type={'hidden'} name={'jmailpoetaction'} value={'subscribe'}/>
+      <input type={'hidden'} name={'jmailpoetlist'} value={list}/>
+      <div className={'jbmailpoet-input'}>
+        <button type={'submit'}>{subscribe}</button>
+      </div>
+    </form>
+  );
+};

--- a/assets/js/src/gutenberg_block/full_form_block_fe.jsx
+++ b/assets/js/src/gutenberg_block/full_form_block_fe.jsx
@@ -1,0 +1,11 @@
+// import jQuery from 'jquery';
+//
+// jQuery(($) => {
+//   $(document).on('submit', '.mailpoet-subs-form', (event) => {
+//     const formData = $(event.target).serializeArray();
+//     const message =
+//     formData.reduce((acc, item) => (`${acc}${item.name}: ${item.value ? item.value : '-'}\n`), '');
+//     console.log(`TODO: Validation, saving using API \n Form Data: \n ${message}`);
+//     return false;
+//   });
+// });

--- a/assets/js/src/gutenberg_block/mp_form_block.jsx
+++ b/assets/js/src/gutenberg_block/mp_form_block.jsx
@@ -1,0 +1,111 @@
+/**
+ * BLOCK: mailpoetblock
+ *
+ * Registering a basic block with Gutenberg.
+ * Simple block, renders and saves the same content without any interactivity.
+ */
+const wp = window.wp;
+const { __ } = wp.i18n; // Import __() from wp.i18n
+const { registerBlockType } = wp.blocks; // Import registerBlockType() from wp.blocks
+const { InspectorControls } = wp.editor;
+const { PanelBody, SelectControl } = wp.components;
+/**
+ * Register: aa Gutenberg Block.
+ *
+ * Registers a new block provided a unique name and an object defining its
+ * behavior. Once registered, the block is made editor as an option to any
+ * editor interface where blocks are implemented.
+ *
+ * @link https://wordpress.org/gutenberg/handbook/block-api/
+ * @param  {string}   name     Block name.
+ * @param  {Object}   settings Block settings.
+ * @return {?WPBlock}          The block, if it has been successfully
+ *                             registered; otherwise `undefined`.
+ */
+registerBlockType('mailpoet/mp-form-block', {
+  title: __('Subscriber - Mailpoet Simple'), // Block title.
+  icon: 'email', // Block icon from Dashicons → https://developer.wordpress.org/resource/dashicons/.
+  category: 'common', // Block category — Group blocks together based on common traits E.g. common, formatting, layout widgets, embed.
+  keywords: [
+    __('Mailpoet Form'),
+  ],
+  attributes: {
+    form: {
+      type: 'string',
+    },
+  },
+
+  /**
+   * The edit function describes the structure of your block in the context of the editor.
+   * This represents what the editor will render when the block is used.
+   *
+   * The "edit" property must be a valid function.
+   *
+   * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+   */
+  edit: function edit(props) {
+    let form = props.attributes.form;
+
+    const forms = window.mailpoet_forms;
+    const options = [];
+    for (let i = 0; i < forms.length; i++) {
+      options.push({
+        label: forms[i].name,
+        value: forms[i].id
+      })
+    }
+
+    if(!form && options.length) {
+      form = options[0];
+      props.setAttributes({
+        form: options[0]
+      });
+    }
+
+    return (
+      <div>
+        <InspectorControls>
+          <PanelBody title={__('Pick a form', '')}>
+            <SelectControl label={__('Form')}
+                           value={form}
+                           onChange={(value) => props.setAttributes({
+                             form: value
+                           })}
+                           options={options}
+            />
+          </PanelBody>
+        </InspectorControls>
+        <div>
+          <p>
+            This is just placeholder for form.<br />
+            We may try to re-render it similarly as it is defined in DB.
+          </p>
+          <div>
+            <label>{__('Email')}</label>
+            <input type={'text'} name={'email'}/>
+          </div>
+          <div>
+            <label>{__('Firstname')}</label>
+            <input type={'text'} name={'firstname'}/>
+          </div>
+          <div>
+            <label>{__('Lastname')}</label>
+            <input type={'text'} name={'firstname'}/>
+          </div>
+        </div>
+      </div>
+    );
+  },
+
+  /**
+   * The save function defines the way in which the different attributes should be combined
+   * into the final markup, which is then serialized by Gutenberg into post_content.
+   *
+   * The "save" property must be specified and must be a valid function.
+   *
+   * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+   */
+  save: function save() {
+    return null;
+  },
+});

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -11,6 +11,7 @@ use MailPoet\Util\Helpers;
 use MailPoet\Util\Notices\PermanentNotices;
 use MailPoet\WP\Notice as WPNotice;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\Form\Gutenberg\Blocks as FormGtbBlock;
 
 if (!defined('ABSPATH')) exit;
 
@@ -192,6 +193,7 @@ class Initializer {
       $this->setupCapabilities();
       $this->menu->init();
       $this->setupShortcodes();
+      $this->setupGutenbergFormBlock();
       $this->setupImages();
       $this->setupPersonalDataExporters();
       $this->setupPersonalDataErasers();
@@ -263,6 +265,11 @@ class Initializer {
 
   function setupShortcodes() {
     $this->shortcodes->init();
+  }
+
+  function setupGutenbergFormBlock() {
+    $block = new FormGtbBlock($this->renderer);
+    $block->setupBlocks();
   }
 
   function setupImages() {

--- a/lib/Form/Gutenberg/Blocks.php
+++ b/lib/Form/Gutenberg/Blocks.php
@@ -1,0 +1,109 @@
+<?php
+namespace MailPoet\Form\Gutenberg;
+
+use MailPoet\Config\Env;
+use MailPoet\Config\Renderer;
+use MailPoet\Form\Widget;
+use MailPoet\Models\Form;
+
+if(!defined('ABSPATH')) exit;
+
+class Blocks {
+
+  /** @var Renderer */
+  private $renderer;
+
+  function __construct(Renderer $renderer) {
+    $this->renderer = $renderer;
+  }
+
+  function setupBlocks() {
+    add_action('enqueue_block_editor_assets', [$this, 'registerEditorAssets']);
+    if (!is_admin()) {
+      add_action('enqueue_block_assets', [$this, 'registerFeAssets']);
+    }
+
+    /**
+     * Hacky lists and forms data fetching and storing them on window object for rendering in selects
+     * There is a mechanism for fetching the data in JS:
+     *  - use withSelect from wp.data (@see https://wordpress.org/gutenberg/handbook/blocks/creating-dynamic-blocks/)
+     *  - register own store to central gutenberg store (@see https://wordpress.org/gutenberg/handbook/packages/packages-data/)
+     **/
+    if (is_admin()) {
+      add_action('admin_head', function() {
+        if (!current_user_can('manage_options')) {
+          return;
+        }
+        $lists = \MailPoet\Models\Segment::getSegmentsForImport();
+        $lists_data = [];
+        foreach ($lists as $list) {
+          if ($list['id'] == 1) {
+            continue;
+          }
+          $lists_data[] = $list;
+        }
+        $forms = array_map(function($form) {
+          return $form->asArray();
+        }, Form::findMany())
+        ?>
+          <script type="text/javascript">
+            window.mailpoet_lists =<?php echo json_encode($lists_data) ?>;
+            window.mailpoet_forms =<?php echo json_encode($forms) ?>;
+          </script>
+        <?php
+      });
+    }
+
+    register_block_type('mailpoet/mp-form-block', [
+      'render_callback' => [$this, 'renderForm'],
+    ]);
+  }
+
+  function registerEditorAssets() {
+    wp_enqueue_script(
+      'mailpoetblock-form-block-js', // Handle.
+      Env::$assets_url . '/dist/js/' . $this->renderer->getJsAsset('form_block_editor.js'),
+      [ 'wp-blocks', 'wp-i18n', 'wp-element' ],
+      Env::$version,
+      true
+    );
+    // Styles.
+    wp_enqueue_style(
+      'mailpoetblock-form-block-css', // Handle.
+      Env::$assets_url . '/dist/css/' . $this->renderer->getCssAsset('block.css'),
+      [ 'wp-edit-blocks' ],
+      Env::$version
+    );
+  }
+
+  function registerFeAssets() {
+    wp_enqueue_script(
+      'mailpoetblock-form-block-fe-js', // Handle.
+      Env::$assets_url . '/dist/js/' . $this->renderer->getJsAsset('form_block_fe.js'),
+      [ 'jquery' ],
+      Env::$version,
+      true
+    );
+    // Styles.
+    wp_enqueue_style(
+      'mailpoetblock-form-block-css', // Handle.
+      Env::$assets_url . '/dist/css/' . $this->renderer->getCssAsset('block.css'),
+      [],
+      Env::$version
+    );
+    $basicForm = new Widget(true);
+    $basicForm->setupDependencies();
+  }
+
+  function renderForm($attributes) {
+    if (!$attributes) {
+      return '';
+    }
+    $basicForm = new Widget(true);
+    $form_html = $basicForm->widget([
+      'form' => (int)$attributes['form']['value'],
+      'form_type' => 'html',
+    ]);
+    return $form_html;
+  }
+}

--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -23,7 +23,7 @@ class Widget extends \WP_Widget {
 
   const RECAPTCHA_API_URL = 'https://www.google.com/recaptcha/api.js?onload=reCaptchaCallback&render=explicit';
 
-  function __construct() {
+  function __construct($skip_iframe_setup = false) {
     parent::__construct(
       'mailpoet_form',
       WPFunctions::get()->__('MailPoet 3 Form', 'mailpoet'),
@@ -32,7 +32,8 @@ class Widget extends \WP_Widget {
     $this->wp = new WPFunctions;
     $this->renderer = new \MailPoet\Config\Renderer(!WP_DEBUG, !WP_DEBUG);
     $this->settings = new SettingsController();
-    if (!is_admin()) {
+
+    if (!is_admin() && !$skip_iframe_setup) {
       $this->setupIframe();
     } else {
       WPFunctions::get()->addAction('widgets_admin_page', [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -420,7 +420,51 @@ const testConfig = {
   }
 };
 
-module.exports = [adminConfig, publicConfig, migratorConfig, testConfig].map((config) => {
+// Block config
+var blockEditorConfig = {
+  name: 'block_editor',
+  entry: {
+    form_block_editor: [
+      'gutenberg_block/blocks.jsx'
+    ]
+  },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+    jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version.
+  },
+  module: {
+    rules: [
+      {
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      }
+    ]
+  }
+};
+
+// Block config
+var blockFronEndConfig = {
+  name: 'block_fe',
+  entry: {
+    form_block_fe: [
+      'gutenberg_block/full_form_block_fe.jsx'
+    ]
+  },
+  externals: {
+    jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version.
+  },
+  module: {
+    rules: [
+      {
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      }
+    ]
+  }
+};
+
+module.exports = [blockEditorConfig, blockFronEndConfig, adminConfig, publicConfig, migratorConfig, testConfig].map(function (config) {
   if (config.name !== 'test') {
     config.plugins = config.plugins || [];
     config.plugins.push(


### PR DESCRIPTION
I've created 2 blocks for subscription from (or rather proof of cocepts):

## 1) [Jack's block](https://github.com/codemonkey-jack/mailpoet-block) aka [mailpoet/full-form-block](https://github.com/mailpoet/mailpoet/pull/1597/files#diff-60fdeba38df26a7212edf1643921e725)
I have just moved Jack's block into our plugin and added a stub for FE functionality in JS.
In this approach user can define fields and everything directly in gutenberg editor. Tricky part is that the form is then stored within post or page body. With this approach there would be an issue with storing custom fields.
We could probably try to save the block also to our api while user works in editor.

## 2) Server side rendered mailpoet form block aka [mailpoet/mp-form-block](https://github.com/mailpoet/mailpoet/pull/1597/files#diff-5583c81ef63e070874ab12a0857a63e3)
A bit different approach. The idea is to use Gutenberg only to place the form somewhere but keep its editation in current editor. This should be an easy integration as we can reuse FE rendering as it is

## Todo
- there is [a hack](https://github.com/mailpoet/mailpoet/pull/1597/files#diff-f27c00df2ab2ea8cb5e0e23de9c5bb8fR27) used to fetch forms end list data for gutenberg editor. It should be doable using [wordpress/data package](https://wordpress.org/gutenberg/handbook/packages/packages-data/)

- try using https://wordpress.org/gutenberg/handbook/components/server-side-render/ for form preview in editor