### PR TITLE
Make all services registered in DI public [MAILPOET-1621]

### DIFF
--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -46,13 +46,13 @@ class ContainerFactory {
 
   function createContainer() {
     $container = new ContainerBuilder();
-    $container->autowire(\MailPoet\Config\AccessControl::class);
-    $container->autowire(\MailPoet\Cron\Daemon::class);
-    $container->autowire(\MailPoet\Cron\DaemonHttpRunner::class);
-    $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class);
-    $container->autowire(\MailPoet\Router\Endpoints\Subscription::class);
-    $container->autowire(\MailPoet\Router\Endpoints\Track::class);
-    $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class);
+    $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Daemon::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\DaemonHttpRunner::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
     return $container;
   }
 


### PR DESCRIPTION
In ideal application one needs only one public service (some bootstrap) and that is why all services are private as default. Our code is not ideal yet so we have to declare services as public.

See https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default

We don't use XML or Yaml (because of package size) so we have to define services as public one by one.