### PR TITLE
Add space between save and next buttons [MAILPOET-1630]

### DIFF
--- a/assets/css/src/newsletter_editor/components/save.styl
+++ b/assets/css/src/newsletter_editor/components/save.styl
@@ -7,6 +7,9 @@
   margin-right: 20px
   margin-bottom: 10px
 
+  .mailpoet_save_next
+    margin-left: 5px
+
 .mailpoet_save_options
   border-radius(3px)
 
@@ -43,6 +46,8 @@
 
 .mailpoet_save_show_options_icon
   vertical-align: middle
+  height: 14px;
+  margin-top: -6px;
 
 .mailpoet_save_as_template_container,
 .mailpoet_export_template_container
@@ -64,9 +69,6 @@
   
 .mailpoet_save_next, .mailpoet_save_button_group
   float: right
-
-.mailpoet_save_next
-  margin-left: 10px !important
 
 .mailpoet_editor_messages
   position: absolute

--- a/assets/css/src/newsletter_editor/components/save.styl
+++ b/assets/css/src/newsletter_editor/components/save.styl
@@ -65,6 +65,9 @@
 .mailpoet_save_next, .mailpoet_save_button_group
   float: right
 
+.mailpoet_save_next
+  margin-left: 10px !important
+
 .mailpoet_editor_messages
   position: absolute
   right: 0


### PR DESCRIPTION
[MAILPOET-1630 Save and Next buttons in editor lack proper spacing](https://mailpoet.atlassian.net/browse/MAILPOET-1630)