### PR TITLE
Introduce DI to plugin API [MAILPOET-1637]

### DIFF
--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\API;
 
-use MailPoet\Config\AccessControl;
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Container;
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
@@ -17,8 +16,9 @@ class API {
     self::$container = $container;
   }
 
-  static function JSON(AccessControl $access_control) {
-    return new \MailPoet\API\JSON\API($access_control);
+  static function JSON() {
+    self::checkContainer();
+    return self::$container->get(JSON\API::class);
   }
 
   static function MP($version) {

--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -4,6 +4,7 @@ namespace MailPoet\API;
 
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Container;
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use MailPoet\DI\ContainerFactory;
 
 if(!defined('ABSPATH')) exit;
 
@@ -17,12 +18,11 @@ class API {
   }
 
   static function JSON() {
-    self::checkContainer();
     return self::$container->get(JSON\API::class);
   }
 
   static function MP($version) {
-    self::checkContainer();
+    self::ensureContainerIsLoaded();
     $api_class = sprintf('%s\MP\%s\API', __NAMESPACE__, $version);
     try {
       return self::$container->get($api_class);
@@ -31,9 +31,14 @@ class API {
     }
   }
 
-  private static function checkContainer() {
+  /**
+   * MP API is used by third party plugins so we have to ensure that container is loaded
+   * @see https://kb.mailpoet.com/article/195-add-subscribers-through-your-own-form-or-plugin
+   */
+  private static function ensureContainerIsLoaded() {
     if(!self::$container) {
-      throw new \Exception(__('Api was not initialized properly. Is MailPoet plugin active?.', 'mailpoet'));
+      $factory = new ContainerFactory();
+      self::$container = $factory->getContainer();
     }
   }
 }

--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -3,19 +3,37 @@
 namespace MailPoet\API;
 
 use MailPoet\Config\AccessControl;
+use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Container;
+use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 if(!defined('ABSPATH')) exit;
 
 class API {
+
+  /** @var Container */
+  private static $container;
+
+  static function injectContainer(Container $container) {
+    self::$container = $container;
+  }
+
   static function JSON(AccessControl $access_control) {
     return new \MailPoet\API\JSON\API($access_control);
   }
 
   static function MP($version) {
+    self::checkContainer();
     $api_class = sprintf('%s\MP\%s\API', __NAMESPACE__, $version);
-    if(class_exists($api_class)) {
-      return new $api_class();
+    try {
+      return self::$container->get($api_class);
+    } catch (ServiceNotFoundException $e) {
+      throw new \Exception(__('Invalid API version.', 'mailpoet'));
     }
-    throw new \Exception(__('Invalid API version.', 'mailpoet'));
+  }
+
+  private static function checkContainer() {
+    if(!self::$container) {
+      throw new \Exception(__('Api was not initialized properly. Is MailPoet plugin active?.', 'mailpoet'));
+    }
   }
 }

--- a/lib/API/JSON/API.php
+++ b/lib/API/JSON/API.php
@@ -2,6 +2,7 @@
 namespace MailPoet\API\JSON;
 
 use MailPoet\Config\AccessControl;
+use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Container;
 use MailPoet\Models\Setting;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Security;
@@ -20,10 +21,16 @@ class API {
   private $_available_api_versions = array(
       'v1'
   );
+  /** @var Container */
+  private $container;
+
+  /** @var AccessControl */
   private $access_control;
+
   const CURRENT_VERSION = 'v1';
 
-  function __construct(AccessControl $access_control) {
+  function __construct(Container $container, AccessControl $access_control) {
+    $this->container = $container;
     $this->access_control = $access_control;
     foreach($this->_available_api_versions as $available_api_version) {
       $this->addEndpointNamespace(
@@ -135,7 +142,7 @@ class API {
         throw new \Exception(__('Invalid API endpoint.', 'mailpoet'));
       }
 
-      $endpoint = new $this->_request_endpoint_class();
+      $endpoint = $this->container->get($this->_request_endpoint_class);
 
       if(!method_exists($endpoint, $this->_request_method)) {
         throw new \Exception(__('Invalid API endpoint method.', 'mailpoet'));

--- a/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -10,13 +10,14 @@ use MailPoet\WP\Posts as WPPosts;
 if(!defined('ABSPATH')) exit;
 
 class AutomatedLatestContent extends APIEndpoint {
+  /** @var \MailPoet\Newsletter\AutomatedLatestContent  */
   public $ALC;
   public $permissions = array(
     'global' => AccessControl::PERMISSION_MANAGE_EMAILS
   );
 
-  function __construct() {
-    $this->ALC = new \MailPoet\Newsletter\AutomatedLatestContent();
+  function __construct(\MailPoet\Newsletter\AutomatedLatestContent $alc) {
+    $this->ALC = $alc;
   }
 
   function getPostTypes() {
@@ -74,14 +75,12 @@ class AutomatedLatestContent extends APIEndpoint {
   }
 
   function getBulkTransformedPosts($data = array()) {
-    $alc = new \MailPoet\Newsletter\AutomatedLatestContent();
-
     $used_posts = array();
     $rendered_posts = array();
 
     foreach($data['blocks'] as $block) {
-      $posts = $alc->getPosts($block, $used_posts);
-      $rendered_posts[] = $alc->transformPosts($block, $posts);
+      $posts = $this->ALC->getPosts($block, $used_posts);
+      $rendered_posts[] = $this->ALC->transformPosts($block, $posts);
 
       foreach($posts as $post) {
         $used_posts[] = $post->ID;

--- a/lib/API/MP/v1/API.php
+++ b/lib/API/MP/v1/API.php
@@ -15,6 +15,26 @@ use MailPoet\Tasks\Sending;
 if(!defined('ABSPATH')) exit;
 
 class API {
+
+  /** @var NewSubscriberNotificationMailer */
+  private $new_subscribe_notification_mailer;
+
+  /** @var ConfirmationEmailMailer */
+  private $confirmation_email_mailer;
+
+  /** @var RequiredCustomFieldValidator */
+  private $required_custom_field_validator;
+
+  public function __construct(
+    NewSubscriberNotificationMailer $new_subscribe_notification_mailer,
+    ConfirmationEmailMailer $confirmation_email_mailer,
+    RequiredCustomFieldValidator $required_custom_field_validator
+  ) {
+    $this->new_subscribe_notification_mailer = $new_subscribe_notification_mailer;
+    $this->confirmation_email_mailer = $confirmation_email_mailer;
+    $this->required_custom_field_validator = $required_custom_field_validator;
+  }
+
   function getSubscriberFields() {
     $data = array(
       array(
@@ -168,8 +188,7 @@ class API {
     // if some required default fields are missing, set their values
     $default_fields = Subscriber::setRequiredFieldsDefaultValues($default_fields);
 
-    $validator = new RequiredCustomFieldValidator();
-    $validator->validate($custom_fields);
+    $this->required_custom_field_validator->validate($custom_fields);
 
     // add subscriber
     $new_subscriber = Subscriber::create();
@@ -255,8 +274,7 @@ class API {
   }
 
   protected function _sendConfirmationEmail(Subscriber $subscriber) {
-    $sender = new ConfirmationEmailMailer();
-    return $sender->sendConfirmationEmail($subscriber);
+    return $this->confirmation_email_mailer->sendConfirmationEmail($subscriber);
   }
 
   protected function _scheduleWelcomeNotification(Subscriber $subscriber, array $segments) {
@@ -274,7 +292,6 @@ class API {
   }
 
   private function sendSubscriberNotification(Subscriber $subscriber, array $segment_ids) {
-    $sender = new NewSubscriberNotificationMailer();
-    $sender->send($subscriber, Segment::whereIn('id', $segment_ids)->findMany());
+    $this->new_subscribe_notification_mailer->send($subscriber, Segment::whereIn('id', $segment_ids)->findMany());
   }
 }

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -261,7 +261,7 @@ class Initializer {
   }
 
   function setupJSONAPI() {
-    $json_api = API\API::JSON($this->access_control);
+    $json_api = API\API::JSON();
     $json_api->init();
   }
 

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -99,6 +99,7 @@ class Initializer {
   function loadContainer() {
     $container_factory = new ContainerFactory(WP_DEBUG);
     $this->container = $container_factory->getContainer();
+    API\API::injectContainer($this->container);
   }
 
   function checkRequirements() {

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -53,6 +53,10 @@ class ContainerFactory {
     $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\MP\v1\API::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
     return $container;
   }
 

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -47,18 +47,8 @@ class ContainerFactory {
 
   function createContainer() {
     $container = new ContainerBuilder();
-    $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
-    $container->autowire(\MailPoet\Cron\Daemon::class)->setPublic(true);
-    $container->autowire(\MailPoet\Cron\DaemonHttpRunner::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
+    // API
     $container->autowire(\MailPoet\API\MP\v1\API::class)->setPublic(true);
-    $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
-    $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
-    $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
-    // JSON API
     $container->register(\MailPoet\API\JSON\API::class)
       ->addArgument(new Reference('service_container'))
       ->setAutowired(true)
@@ -77,6 +67,20 @@ class ContainerFactory {
     $container->autowire(\MailPoet\API\JSON\v1\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Setup::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
+    // Config
+    $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
+    // Cron
+    $container->autowire(\MailPoet\Cron\Daemon::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\DaemonHttpRunner::class)->setPublic(true);
+    // Router
+    $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
+    // Subscribers
+    $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
     return $container;
   }
 

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -4,6 +4,7 @@ namespace MailPoet\DI;
 
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\ContainerBuilder;
 use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use MailPoet\Dependencies\Symfony\Component\DependencyInjection\Reference;
 
 class ContainerFactory {
 
@@ -57,6 +58,25 @@ class ContainerFactory {
     $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
+    // JSON API
+    $container->register(\MailPoet\API\JSON\API::class)
+      ->addArgument(new Reference('service_container'))
+      ->setAutowired(true)
+      ->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\AutomatedLatestContent::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\CustomFields::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Forms::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\ImportExport::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Mailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\MP2Migrator::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Newsletters::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\NewsletterTemplates::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Segments::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\SendingQueue::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Services::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Settings::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Setup::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
     return $container;
   }
 

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -81,6 +81,8 @@ class ContainerFactory {
     $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
+    // Newsletter
+    $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
     return $container;
   }
 

--- a/lib/Subscription/Form.php
+++ b/lib/Subscription/Form.php
@@ -4,13 +4,12 @@ namespace MailPoet\Subscription;
 
 use MailPoet\API\API as API;
 use MailPoet\API\JSON\Response as APIResponse;
-use MailPoet\Config\AccessControl;
 use MailPoet\Util\Url as UrlHelper;
 
 class Form {
   static function onSubmit($request_data = false) {
     $request_data = ($request_data) ? $request_data : $_REQUEST;
-    $api = API::JSON(new AccessControl());
+    $api = API::JSON();
     $api->setRequestData($request_data);
     $form_id = (!empty($request_data['data']['form_id'])) ? (int)$request_data['data']['form_id'] : false;
     $response = $api->processRoute();

--- a/tests/integration/API/APITest.php
+++ b/tests/integration/API/APITest.php
@@ -6,7 +6,7 @@ use MailPoet\Config\AccessControl;
 
 class APITest extends \MailPoetTest {
   function testItCallsJSONAPI() {
-    expect(API::JSON(new AccessControl()))->isInstanceOf('MailPoet\API\JSON\API');
+    expect(API::JSON())->isInstanceOf('MailPoet\API\JSON\API');
   }
 
   function testItCallsMPAPI() {

--- a/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
+++ b/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
@@ -6,8 +6,8 @@ use MailPoet\API\JSON\v1\AutomatedLatestContent;
 
 class AutomatedLatestContentTest extends \MailPoetTest {
   function testItGetsPostTypes() {
-    $router = new AutomatedLatestContent();
-    $response = $router->getPostTypes();
+    $endpoint = new AutomatedLatestContent(new \MailPoet\Newsletter\AutomatedLatestContent());
+    $response = $endpoint->getPostTypes();
     expect($response->data)->notEmpty();
     foreach($response->data as $post_type) {
       expect($post_type)->count(2);
@@ -17,8 +17,8 @@ class AutomatedLatestContentTest extends \MailPoetTest {
   }
 
   function testItDoesNotGetPostTypesExludedFromSearch() {
-    $router = new AutomatedLatestContent();
-    $response = $router->getPostTypes();
+    $endpoint = new AutomatedLatestContent(new \MailPoet\Newsletter\AutomatedLatestContent());
+    $response = $endpoint ->getPostTypes();
     // WP's default post type 'revision' is excluded from search
     // https://codex.wordpress.org/Post_Types
     $revision_post_type = get_post_type_object('revision');


### PR DESCRIPTION
I've just configured DI for MP API and JSON API and refactored MP API so that services which were instantiated inside are now passed via constructor.

There are still dependencies in form of static calls which we will have to address in the future (wrapping them or maybe Doctrine for models?).

For JSON API I've managed to refactor only one of its endpoints.