### PR TITLE
Phpstan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,26 @@ jobs:
           root: /home/circleci/mailpoet
           paths:
             - .
+  static_analysis:
+    working_directory: /home/circleci/mailpoet
+    docker:
+    - image: mailpoet/wordpress:7.1_20181009.1
+    - image: circleci/mysql:5.7
+    environment:
+      TZ: /usr/share/zoneinfo/Etc/UTC
+    steps:
+    - attach_workspace:
+        at: /home/circleci/mailpoet
+    - run:
+        name: "Set up environment"
+        command: |
+          ./composer.phar install --no-dev --no-scripts
+          source ./.circleci/setup.bash && setup php7
+          wget https://github.com/phpstan/phpstan/releases/download/0.10.5/phpstan.phar
+    - run:
+        name: "Static analysis"
+        command: |
+          WP_ROOT="/home/circleci/mailpoet/wordpress" php -d memory_limit=2G phpstan.phar analyse -c tasks/phpstan/phpstan.neon -l 0 lib/
   php5_unit:
     working_directory: /home/circleci/mailpoet
     docker:
@@ -257,6 +277,9 @@ workflows:
   build_and_test:
     jobs:
       - build_and_code_qa
+      - static_analysis:
+          requires:
+            - build_and_code_qa
       - php5_unit:
           requires:
             - build_and_code_qa

--- a/lib/Config/Changelog.php
+++ b/lib/Config/Changelog.php
@@ -4,7 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\Models\Setting;
 use MailPoet\Util\Url;
-use MailPoet\Wp\Hooks as WPHooks;
+use MailPoet\WP\Hooks as WPHooks;
 
 class Changelog {
   function init() {

--- a/lib/Config/MP2Migrator.php
+++ b/lib/Config/MP2Migrator.php
@@ -103,7 +103,7 @@ class MP2Migrator {
       $sql = "SHOW TABLES LIKE '{$table}'";
       $result = $wpdb->query($sql);
       return !empty($result);
-    } catch (Exception $e) {
+    } catch (\Exception $e) {
       // Do nothing
     }
 

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -325,7 +325,7 @@ class Menu {
   }
 
   function migration() {
-    $mp2_migrator = new MP2Migrator($this->access_control);
+    $mp2_migrator = new MP2Migrator();
     $mp2_migrator->init();
     $data = array(
       'log_file_url' => $mp2_migrator->log_file_url,

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -318,7 +318,7 @@ class Populator {
   private function rowExists($table, $columns) {
     global $wpdb;
 
-    $conditions = array_map(function($key) use ($columns) {
+    $conditions = array_map(function($key) {
       return $key . '=%s';
     }, array_keys($columns));
 

--- a/lib/Cron/Workers/SimpleWorker.php
+++ b/lib/Cron/Workers/SimpleWorker.php
@@ -12,10 +12,11 @@ if(!defined('ABSPATH')) exit;
 abstract class SimpleWorker {
   public $timer;
 
+  const TASK_TYPE = null;
   const TASK_BATCH_SIZE = 5;
 
   function __construct($timer = false) {
-    if(!defined('static::TASK_TYPE')) {
+    if(static::TASK_TYPE === null) {
       throw new \Exception('Constant TASK_TYPE is not defined on subclass ' . get_class($this));
     }
     $this->timer = ($timer) ? $timer : microtime(true);
@@ -27,14 +28,15 @@ abstract class SimpleWorker {
     return true;
   }
 
+  function init() {
+  }
+
   function process() {
     if(!$this->checkProcessingRequirements()) {
       return false;
     }
 
-    if(is_callable(array($this, 'init'))) {
-      $this->init();
-    }
+    $this->init();
 
     $scheduled_tasks = self::getScheduledTasks();
     $running_tasks = self::getRunningTasks();

--- a/lib/Newsletter/Renderer/Blocks/Renderer.php
+++ b/lib/Newsletter/Renderer/Blocks/Renderer.php
@@ -11,7 +11,7 @@ class Renderer {
   public $posts;
   public $ALC;
 
-  function __construct(array $newsletter, $preview) {
+  function __construct(array $newsletter) {
     $this->newsletter = $newsletter;
     $this->posts = array();
     $newer_than_timestamp = false;

--- a/lib/Newsletter/Renderer/Renderer.php
+++ b/lib/Newsletter/Renderer/Renderer.php
@@ -21,7 +21,7 @@ class Renderer {
   function __construct($newsletter, $preview = false) {
     $this->newsletter = (is_object($newsletter)) ? $newsletter->asArray() : $newsletter;
     $this->preview = $preview;
-    $this->blocks_renderer = new Blocks\Renderer($this->newsletter, $this->preview);
+    $this->blocks_renderer = new Blocks\Renderer($this->newsletter);
     $this->columns_renderer = new Columns\Renderer();
     $this->DOM_parser = new pQuery();
     $this->CSS_inliner = new \MailPoet\Util\CSS();

--- a/lib/Subscribers/ImportExport/Import/MailChimp.php
+++ b/lib/Subscribers/ImportExport/Import/MailChimp.php
@@ -10,7 +10,7 @@ class MailChimp {
   public $export_url;
   const API_KEY_REGEX = '/[a-zA-Z0-9]{32}-[a-zA-Z0-9]{2,4}$/';
 
-  function __construct($api_key, $lists = false) {
+  function __construct($api_key) {
     $this->api_key = $this->getAPIKey($api_key);
     $this->max_post_size = Helpers::getMaxPostSize('bytes');
     $this->data_center = $this->getDataCenter($this->api_key);

--- a/lib/Util/Sudzy/Engine.php
+++ b/lib/Util/Sudzy/Engine.php
@@ -46,7 +46,7 @@ class Engine
     */
     public function addValidator($label, $function)
     {
-        if (isset($this->_checks[$label])) throw \Exception();
+        if (isset($this->_checks[$label])) throw new \Exception();
         $this->setValidator($label, $function);
     }
 

--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -1,7 +1,7 @@
 <?php
 namespace MailPoet\WP;
 
-use Mailpoet\Config\Env;
+use MailPoet\Config\Env;
 
 class Functions {
   static function wpRemotePost() {

--- a/tasks/phpstan/bootstrap.php
+++ b/tasks/phpstan/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+define('ABSPATH', getenv('WP_ROOT') . '/');
+
+require_once ABSPATH . 'wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/admin.php';

--- a/tasks/phpstan/phpstan.neon
+++ b/tasks/phpstan/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+	tmpDir: temp/phpstan
+	bootstrap: tasks/phpstan/bootstrap.php
+	ignoreErrors:
+		- '#Access to an undefined property#' # current code suffers from this, it should be fixed & this line removed
+		- '#Static call to instance method MailPoet\\Models\\Model::#'
+		- '#Access to an undefined static property MailPoet\\Models\\Model::#'
+		- '#Function members_register_.+ not found#'
+	excludes_analyse:
+		- lib/Dependencies
+		- lib/DI/CachedContainer.php


### PR DESCRIPTION
A few notes (since running PHPStan with WordPress is a bit tricky):
- PHPStan still uses reflection (in future might be replaced by static reflection library that parses files only as tokens without loading them).
- The loading is done automatically using `autoload.php` from composer but there can be also a custom setting of directories or files to load.
- All the above means that including code which does not only define classes and functions but also executes something is tricky - that's WordPress and that's why we need also DB and all the stuff.
- It also means it's better to run it with `--no-dev` to load less libs. At the moment it's even necessary due to conflict between PHPStan and `goaop`.
- The above point means it cannot be very easily added as a `./do` script. That's why this first MVP version is run in CircleCI using `phpstan.phar` command directly.
- For MVP it's reusing the CircleCI workspace from QA job so it's run after it.

Most of the issues can be addressed in future hackings:
- If PHPStan won't add static reflection soon we can add WP method stubs (https://packagist.org/packages/giacocorsiglia/wordpress-stubs) to avoid loading WordPress.
- The `./do` logic can use custom Docker environment for PHPStan (for instance).
- We can improve CircleCI workflow to let fail PHPStan sooner.