### PR TITLE
Pause sending of spammer users [MAILPOET-1649]

### DIFF
--- a/assets/js/src/newsletters/listings/mixins.jsx
+++ b/assets/js/src/newsletters/listings/mixins.jsx
@@ -410,9 +410,11 @@ const MailerMixin = {
       mailerErrorNotice += ` ${MailPoet.I18n.t('mailerErrorCode')
         .replace('%$1s', state.meta.mta_log.error.error_code)}`;
     }
+    // eslint-disable-next-line react/no-danger
+    mailerErrorNotice = <p dangerouslySetInnerHTML={{ __html: mailerErrorNotice }} />;
     return (
       <div>
-        <p>{ mailerErrorNotice }</p>
+        { mailerErrorNotice }
         <p>{ mailerCheckSettingsNotice }</p>
         <p>
           <a

--- a/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -5,6 +5,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\SubscriberError;
 use MailPoet\Services\Bridge\API;
 use InvalidArgumentException;
+use MailPoet\Util\Helpers;
 
 if(!defined('ABSPATH')) exit;
 
@@ -48,6 +49,13 @@ class MailPoetMapper {
       case API::RESPONSE_CODE_TEMPORARY_UNAVAILABLE:
         $message = __('Email service is temporarily not available, please try again in a few minutes.', 'mailpoet');
         $retry_interval = self::TEMPORARY_UNAVAILABLE_RETRY_INTERVAL;
+        break;
+      case API::RESPONSE_CODE_BANNED_ACCOUNT:
+        $message = Helpers::replaceLinkTags(
+          __('You currently are not permitted to send any emails with MailPoet Sending Service, which may have happened due to poor deliverability. Please [link]contact our support team[/link] to resolve the issue.', 'mailpoet'),
+          'https://www.mailpoet.com/support/',
+          array('target' => '_blank')
+        );
         break;
       case API::RESPONSE_CODE_KEY_INVALID:
       case API::RESPONSE_CODE_PAYLOAD_TOO_BIG:

--- a/lib/Services/Bridge/API.php
+++ b/lib/Services/Bridge/API.php
@@ -20,6 +20,7 @@ class API {
   const RESPONSE_CODE_NOT_ARRAY = 422;
   const RESPONSE_CODE_PAYLOAD_TOO_BIG = 413;
   const RESPONSE_CODE_PAYLOAD_ERROR = 400;
+  const RESPONSE_CODE_BANNED_ACCOUNT = 403;
 
   private $api_key;
 
@@ -85,6 +86,7 @@ class API {
         'message' => $result->get_error_message()
       );
     }
+
     $response_code = WPFunctions::wpRemoteRetrieveResponseCode($result);
     if($response_code !== 201) {
       $response = (WPFunctions::wpRemoteRetrieveBody($result)) ?


### PR DESCRIPTION
[MAILPOET-1649 Pause sending of spammer users](https://mailpoet.atlassian.net/browse/MAILPOET-1649)

# How to test that?

In order to test this change on local, on way is to mock the response of the MSS bridge by changing the `Services\Bridge\API::sendMessages` method to return a hard coded response:

https://github.com/mailpoet/mailpoet/blob/master/lib/Services/Bridge/API.php#L77

```php
  function sendMessages($message_body) {
    // add the following return statement
    return [
      'status' => self::SENDING_STATUS_SEND_ERROR,
      'message' => '...',
      'code' => 403
    ];

    $result = $this->request(
      $this->url_messages,
      $message_body
    );
    // ...
  }
```