### PR TITLE
Premium Plugin DI [PREMIUM-99]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ echo '[BUILD] Fetching prefixed production libraries'
 echo '[BUILD] Copying release folders'
 cp -Rf lang $plugin_name
 cp -RfL assets $plugin_name
+cp -Rf generated $plugin_name
 cp -Rf lib $plugin_name
 cp -Rf vendor $plugin_name
 cp -Rf vendor-prefixed $plugin_name

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,9 @@
     ],
     "psr-4": {
       "MailPoet\\": "lib/",
-      "Sudzy\\": "lib/Util/Sudzy"
+      "MailPoetVendor\\": "vendor-prefixed/",
+      "Sudzy\\": "lib/Util/Sudzy",
+      "MailPoetGenerated\\": "generated/"
     }
   },
   "scripts": {

--- a/generated/.gitignore
+++ b/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\API;
 
-use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
+use MailPoetVendor\Psr\Container\ContainerInterface;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use MailPoet\DI\ContainerFactory;
 
@@ -10,10 +10,10 @@ if(!defined('ABSPATH')) exit;
 
 class API {
 
-  /** @var Container */
+  /** @var ContainerInterface */
   private static $container;
 
-  static function injectContainer(Container $container) {
+  static function injectContainer(ContainerInterface $container) {
     self::$container = $container;
   }
 

--- a/lib/API/API.php
+++ b/lib/API/API.php
@@ -2,9 +2,9 @@
 
 namespace MailPoet\API;
 
+use MailPoet\DI\ContainerWrapper;
 use MailPoetVendor\Psr\Container\ContainerInterface;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
-use MailPoet\DI\ContainerFactory;
 
 if(!defined('ABSPATH')) exit;
 
@@ -37,8 +37,7 @@ class API {
    */
   private static function ensureContainerIsLoaded() {
     if(!self::$container) {
-      $factory = new ContainerFactory();
-      self::$container = $factory->getContainer();
+      self::$container = ContainerWrapper::getInstance();
     }
   }
 }

--- a/lib/API/JSON/API.php
+++ b/lib/API/JSON/API.php
@@ -2,7 +2,7 @@
 namespace MailPoet\API\JSON;
 
 use MailPoet\Config\AccessControl;
-use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
+use MailPoetVendor\Psr\Container\ContainerInterface;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use MailPoet\Models\Setting;
 use MailPoet\Util\Helpers;
@@ -22,7 +22,7 @@ class API {
   private $_available_api_versions = array(
       'v1'
   );
-  /** @var Container */
+  /** @var ContainerInterface */
   private $container;
 
   /** @var AccessControl */
@@ -30,7 +30,7 @@ class API {
 
   const CURRENT_VERSION = 'v1';
 
-  function __construct(Container $container, AccessControl $access_control) {
+  function __construct(ContainerInterface $container, AccessControl $access_control) {
     $this->container = $container;
     $this->access_control = $access_control;
     foreach($this->_available_api_versions as $available_api_version) {

--- a/lib/API/JSON/API.php
+++ b/lib/API/JSON/API.php
@@ -108,7 +108,7 @@ class API {
           $namespace,
           ucfirst($this->_request_endpoint)
         );
-        if(class_exists($endpoint_class)) {
+        if($this->container->has($endpoint_class)) {
           $this->_request_endpoint_class = $endpoint_class;
           break;
         }
@@ -138,7 +138,9 @@ class API {
 
   function processRoute() {
     try {
-      if(empty($this->_request_endpoint_class)) {
+      if(empty($this->_request_endpoint_class) ||
+        !$this->container->has($this->_request_endpoint_class)
+      ) {
         throw new \Exception(__('Invalid API endpoint.', 'mailpoet'));
       }
 

--- a/lib/API/JSON/API.php
+++ b/lib/API/JSON/API.php
@@ -3,7 +3,6 @@ namespace MailPoet\API\JSON;
 
 use MailPoet\Config\AccessControl;
 use MailPoetVendor\Psr\Container\ContainerInterface;
-use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use MailPoet\Models\Setting;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Security;
@@ -143,13 +142,7 @@ class API {
         throw new \Exception(__('Invalid API endpoint.', 'mailpoet'));
       }
 
-      try {
-        $endpoint = $this->container->get($this->_request_endpoint_class);
-      } catch (ServiceNotFoundException $e) {
-        // Hotfix for Premium plugin which adds endpoints which are not registered in DI container
-        $endpoint = new $this->_request_endpoint_class();
-      }
-
+      $endpoint = $this->container->get($this->_request_endpoint_class);
       if(!method_exists($endpoint, $this->_request_method)) {
         throw new \Exception(__('Invalid API endpoint method.', 'mailpoet'));
       }

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -4,7 +4,6 @@ namespace MailPoet\Config;
 
 use MailPoet\API;
 use MailPoet\Cron\CronTrigger;
-use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
 use MailPoet\DI\ContainerFactory;
 use MailPoet\Models\Setting;
 use MailPoet\Router;
@@ -12,6 +11,7 @@ use MailPoet\Util\ConflictResolver;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Notices\PermanentNotices;
 use MailPoet\WP\Notice as WPNotice;
+use MailPoetVendor\Psr\Container\ContainerInterface;
 
 if(!defined('ABSPATH')) exit;
 
@@ -20,7 +20,7 @@ require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 class Initializer {
   private $access_control;
   private $renderer;
-  /** @var Container */
+  /** @var ContainerInterface */
   private $container;
 
   const INITIALIZED = 'MAILPOET_INITIALIZED';

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -4,7 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\API;
 use MailPoet\Cron\CronTrigger;
-use MailPoet\DI\ContainerFactory;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Models\Setting;
 use MailPoet\Router;
 use MailPoet\Util\ConflictResolver;
@@ -97,8 +97,7 @@ class Initializer {
   }
 
   function loadContainer() {
-    $container_factory = new ContainerFactory(WP_DEBUG);
-    $this->container = $container_factory->getContainer();
+    $this->container = ContainerWrapper::getInstance(WP_DEBUG);
     API\API::injectContainer($this->container);
   }
 

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MailPoet\DI;
+
+use MailPoetVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+use MailPoetVendor\Symfony\Component\DependencyInjection\Reference;
+use MailPoetVendor\Psr\Container\ContainerInterface;
+
+class ContainerConfigurator implements IContainerConfigurator {
+
+  function getDumpNamespace() {
+    return 'MailPoetGenerated';
+  }
+
+  function getDumpClassname() {
+    return 'FreeCachedContainer';
+  }
+
+  function configure(ContainerBuilder $container) {
+    // Premium plugin services factory
+    $container->register(IContainerConfigurator::PREMIUM_CONTAINER_SERVICE_SLUG)
+      ->setSynthetic(true)
+      ->setPublic(true);
+    // Container wrapper service
+    $container->register(ContainerWrapper::class)
+      ->setPublic(true)
+      ->setFactory([
+      ContainerWrapper::class,
+      'getInstance'
+      ]);
+    // API
+    $container->autowire(\MailPoet\API\JSON\API::class)
+      ->addArgument(new Reference(ContainerWrapper::class))
+      ->setAutowired(true)
+      ->setPublic(true);
+    $container->autowire(\MailPoet\API\MP\v1\API::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\AutomatedLatestContent::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\CustomFields::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Forms::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\ImportExport::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Mailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\MP2Migrator::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Newsletters::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\NewsletterTemplates::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Segments::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\SendingQueue::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Services::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Settings::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Setup::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
+    // Config
+    $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
+    // Cron
+    $container->autowire(\MailPoet\Cron\Daemon::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\DaemonHttpRunner::class)->setPublic(true);
+    // Router
+    $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
+    // Subscribers
+    $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
+    // Newsletter
+    $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
+    return $container;
+  }
+}

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -66,4 +66,22 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
     return $container;
   }
+
+  private function registerPremiumService(ContainerBuilder $container, $id) {
+    $container->register($id)
+      ->setPublic(true)
+      ->addArgument($id)
+      ->addArgument(new Reference('service_container'))
+      ->setFactory([
+        self::class,
+        'getPremiumService',
+      ]);
+  }
+
+  static function getPremiumService($id, ContainerInterface $container = null) {
+    if(!$container->has(IContainerConfigurator::PREMIUM_CONTAINER_SERVICE_SLUG)) {
+      return null;
+    }
+    return $container->get(IContainerConfigurator::PREMIUM_CONTAINER_SERVICE_SLUG)->get($id);
+  }
 }

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -4,18 +4,11 @@ namespace MailPoet\DI;
 
 use MailPoetVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Dumper\PhpDumper;
-use MailPoetVendor\Symfony\Component\DependencyInjection\Reference;
 
 class ContainerFactory {
 
-  /** @var ContainerBuilder */
-  private $container;
-
-  /** @var string */
-  private $dump_file = 'CachedContainer.php';
-
-  /** @var string */
-  private $dump_class = 'CachedContainer';
+  /** @var IContainerConfigurator */
+  private $configurator;
 
   /** @var bool */
   private $debug;
@@ -24,66 +17,24 @@ class ContainerFactory {
    * ContainerFactory constructor.
    * @param bool $debug
    */
-  public function __construct($debug = false) {
+  public function __construct(IContainerConfigurator $configurator, $debug = false) {
     $this->debug = $debug;
+    $this->configurator = $configurator;
   }
 
   function getContainer() {
-    if($this->container) {
-      return $this->container;
-    }
-
-    $dump_file = __DIR__ . '/' . $this->dump_file;
-    if(!$this->debug && file_exists($dump_file)) {
-      require_once $dump_file;
-      $this->container = new $this->dump_class();
+    $dump_class = '\\'. $this->configurator->getDumpNamespace() . '\\' . $this->configurator->getDumpClassname();
+    if(!$this->debug && class_exists($dump_class)) {
+      $container = new $dump_class();
     } else {
-      $this->container = $this->createContainer();
-      $this->container->compile();
+      $container = $this->getConfiguredContainer();
+      $container->compile();
     }
-
-    return $this->container;
+    return $container;
   }
 
-  function createContainer() {
-    $container = new ContainerBuilder();
-    // API
-    $container->autowire(\MailPoet\API\MP\v1\API::class)->setPublic(true);
-    $container->register(\MailPoet\API\JSON\API::class)
-      ->addArgument(new Reference('service_container'))
-      ->setAutowired(true)
-      ->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\AutomatedLatestContent::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\CustomFields::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Forms::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\ImportExport::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Mailer::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\MP2Migrator::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Newsletters::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\NewsletterTemplates::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Segments::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\SendingQueue::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Services::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Settings::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Setup::class)->setPublic(true);
-    $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
-    // Config
-    $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
-    // Cron
-    $container->autowire(\MailPoet\Cron\Daemon::class)->setPublic(true);
-    $container->autowire(\MailPoet\Cron\DaemonHttpRunner::class)->setPublic(true);
-    // Router
-    $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
-    $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
-    // Subscribers
-    $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
-    $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
-    $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
-    // Newsletter
-    $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
-    return $container;
+  function getConfiguredContainer() {
+    return $this->configurator->configure(new ContainerBuilder());
   }
 
   function dumpContainer() {

--- a/lib/DI/ContainerFactory.php
+++ b/lib/DI/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace MailPoet\DI;
 
 use MailPoetVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
-use MailPoetVendor\Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 
 class ContainerFactory {
 
@@ -35,17 +34,5 @@ class ContainerFactory {
 
   function getConfiguredContainer() {
     return $this->configurator->configure(new ContainerBuilder());
-  }
-
-  function dumpContainer() {
-    $container = $this->createContainer();
-    $container->compile();
-    $dumper = new PhpDumper($container);
-    file_put_contents(
-      __DIR__ . '/' . $this->dump_file,
-      $dumper->dump([
-        'class' => $this->dump_class
-      ])
-    );
   }
 }

--- a/lib/DI/ContainerWrapper.php
+++ b/lib/DI/ContainerWrapper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace MailPoet\DI;
+
+use MailPoetVendor\Psr\Container\ContainerInterface;
+use MailPoetVendor\Psr\Container\NotFoundExceptionInterface;
+
+class ContainerWrapper implements ContainerInterface {
+
+  /** @var ContainerInterface */
+  private $free_container;
+
+  /** @var ContainerInterface|null */
+  private $premium_container;
+
+  /** @var ContainerWrapper */
+  private static $instance;
+
+  public function __construct(ContainerInterface $free_container, ContainerInterface $premium_container = null) {
+    $this->free_container = $free_container;
+    $this->premium_container = $premium_container;
+  }
+
+  function get($id) {
+    try {
+      return $this->free_container->get($id);
+    } catch (NotFoundExceptionInterface $e) {
+      if(!$this->premium_container) {
+        throw $e;
+      }
+      return $this->premium_container->get($id);
+    }
+  }
+
+  function has($id) {
+    return $this->free_container->has($id) || ($this->premium_container && $this->premium_container->has($id));
+  }
+
+  /**
+   * @return ContainerInterface|null
+   */
+  function getPremiumContainer() {
+    return $this->premium_container;
+  }
+
+  static function getInstance($debug = false) {
+    if(self::$instance) {
+      return self::$instance;
+    }
+    $free_container_factory = new ContainerFactory(new ContainerConfigurator(), $debug);
+    $free_container = $free_container_factory->getContainer();
+    $premium_container = null;
+    if(class_exists(\MailPoet\Premium\DI\ContainerConfigurator::class)) {
+      $premium_container_factory =  new ContainerFactory(new \MailPoet\Premium\DI\ContainerConfigurator($free_container), $debug);
+      $premium_container = $premium_container_factory->getContainer();
+      $premium_container->set(IContainerConfigurator::FREE_CONTAINER_SERVICE_SLUG, $free_container);
+      $free_container->set(IContainerConfigurator::PREMIUM_CONTAINER_SERVICE_SLUG, $premium_container);
+    }
+    self::$instance = new ContainerWrapper($free_container, $premium_container);
+    return self::$instance;
+  }
+}

--- a/lib/DI/IContainerConfigurator.php
+++ b/lib/DI/IContainerConfigurator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MailPoet\DI;
+
+use MailPoetVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+
+interface IContainerConfigurator {
+  const FREE_CONTAINER_SERVICE_SLUG = 'free_container';
+  const PREMIUM_CONTAINER_SERVICE_SLUG = 'premium_container';
+
+  function configure(ContainerBuilder $container);
+  function getDumpNamespace();
+  function getDumpClassname();
+}

--- a/lib/Router/Router.php
+++ b/lib/Router/Router.php
@@ -3,7 +3,7 @@
 namespace MailPoet\Router;
 
 use MailPoet\Config\AccessControl;
-use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
+use MailPoetVendor\Psr\Container\ContainerInterface;
 use MailPoet\Util\Helpers;
 
 if(!defined('ABSPATH')) exit;
@@ -13,13 +13,13 @@ class Router {
   public $endpoint;
   public $action;
   public $data;
-  /** @var Container */
+  /** @var ContainerInterface */
   private $container;
   const NAME = 'mailpoet_router';
   const RESPONSE_ERROR = 404;
   const RESPONE_FORBIDDEN = 403;
 
-  function __construct(AccessControl $access_control, Container $container, $api_data = false) {
+  function __construct(AccessControl $access_control, ContainerInterface $container, $api_data = false) {
     $api_data = ($api_data) ? $api_data : $_GET;
     $this->api_request = isset($api_data[self::NAME]);
     $this->endpoint = isset($api_data['endpoint']) ?

--- a/tasks/phpstan/phpstan.neon
+++ b/tasks/phpstan/phpstan.neon
@@ -6,5 +6,4 @@ parameters:
 		- '#Static call to instance method MailPoet\\Models\\Model::#'
 		- '#Access to an undefined static property MailPoet\\Models\\Model::#'
 		- '#Function members_register_.+ not found#'
-	excludes_analyse:
-		- */lib/DI/CachedContainer.php
+		- '#MailPoet\\Premium\\DI\\ContainerConfigurator not found#' # this class is not available when premium is not active

--- a/tests/integration/API/JSON/APITest.php
+++ b/tests/integration/API/JSON/APITest.php
@@ -12,6 +12,7 @@ use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\API\JSON\v1\APITestNamespacedEndpointStubV1;
 use MailPoet\API\JSON\v2\APITestNamespacedEndpointStubV2;
 use MailPoet\Config\AccessControl;
+use MailPoet\DI\ContainerConfigurator;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
 use MailPoet\DI\ContainerFactory;
 use MailPoet\WP\Hooks;
@@ -35,12 +36,12 @@ class APITest extends \MailPoetTest {
     } else {
       $this->wp_user_id = $wp_user_id;
     }
-    $container_factory = new ContainerFactory();
-    $this->container = $container_factory->createContainer();
+    $container_factory = new ContainerFactory(new ContainerConfigurator());
+    $this->container = $container_factory->getConfiguredContainer();
     $this->container->autowire(APITestNamespacedEndpointStubV1::class)->setPublic(true);
     $this->container->autowire(APITestNamespacedEndpointStubV2::class)->setPublic(true);
     $this->container->compile();
-    $this->api = $this->container->get(\MailPoet\API\JSON\API::class);
+    $this->api = new \MailPoet\API\JSON\API($this->container, $this->container->get(AccessControl::class));
   }
 
   function testItCallsAPISetupAction() {

--- a/tests/integration/Router/RouterTest.php
+++ b/tests/integration/Router/RouterTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Router;
 use Codeception\Stub;
 use Codeception\Stub\Expected;
 use MailPoet\Config\AccessControl;
+use MailPoet\DI\ContainerConfigurator;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
 use MailPoet\DI\ContainerFactory;
 use MailPoet\Router\Endpoints\RouterTestMockEndpoint;
@@ -26,8 +27,8 @@ class RouterTest extends \MailPoetTest {
       'data' => base64_encode(json_encode(array('data' => 'dummy data')))
     );
     $this->access_control = new AccessControl();
-    $container_factory = new ContainerFactory(true);
-    $this->container = $container_factory->createContainer();
+    $container_factory = new ContainerFactory(new ContainerConfigurator());
+    $this->container = $container_factory->getConfiguredContainer();
     $this->container->register(RouterTestMockEndpoint::class)->setPublic(true);
     $this->container->compile();
     $this->router = new Router($this->access_control, $this->container, $this->router_data);

--- a/tests/unit/DI/ContainerWrapperTest.php
+++ b/tests/unit/DI/ContainerWrapperTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace MailPoet\Test\DI;
+
+use Codeception\Stub;
+use MailPoet\DI\ContainerWrapper;
+use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
+use MailPoetVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+use MailPoetVendor\Psr\Container\ContainerInterface;
+use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+class ContainerWrapperTest extends \MailPoetUnitTest {
+  function testItCanConstruct() {
+    $instance = new ContainerWrapper(new ContainerBuilder());
+    expect($instance)->isInstanceOf(ContainerWrapper::class);
+    expect($instance)->isInstanceOf(ContainerInterface::class);
+
+    $instance = new ContainerWrapper(new ContainerBuilder(), new ContainerBuilder());
+    expect($instance)->isInstanceOf(ContainerWrapper::class);
+    expect($instance)->isInstanceOf(ContainerInterface::class);
+  }
+
+  function testItProvidesPremiumContainerIfAvailable() {
+    $instance = new ContainerWrapper(new ContainerBuilder());
+    expect($instance->getPremiumContainer())->null();
+
+    $instance = new ContainerWrapper(new ContainerBuilder(), new ContainerBuilder());
+    expect($instance->getPremiumContainer())->isInstanceOf(ContainerBuilder::class);
+  }
+
+  function testItProvidesFreePluginServices() {
+    $free_container_stub = Stub::make(Container::class, [
+      'get' => function () {
+          return 'service';
+      }
+    ]);
+    $instance = new ContainerWrapper($free_container_stub);
+    $service = $instance->get('service_id');
+    expect($service)->equals('service');
+  }
+
+  function testItThrowsFreePluginServices() {
+    $free_container_stub = Stub::make(Container::class, [
+      'get' => function ($id) {
+        throw new ServiceNotFoundException($id);
+      }
+    ]);
+    $instance = new ContainerWrapper($free_container_stub);
+    $exception = null;
+    try {
+      $instance->get('service');
+    } catch (ServiceNotFoundException $e) {
+      $exception = $e;
+    }
+    expect($exception)->isInstanceOf(ServiceNotFoundException::class);
+  }
+
+  function testItReturnServiceFromPremium() {
+    $free_container_stub = Stub::make(Container::class, [
+      'get' => function ($id) {
+        throw new ServiceNotFoundException($id);
+      }
+    ]);
+    $premium_container_stub = Stub::make(Container::class, [
+      'get' => function () {
+        return 'service_1';
+      }
+    ]);
+    $instance = new ContainerWrapper($free_container_stub, $premium_container_stub);
+    expect($instance->get('service'))->equals('service_1');
+  }
+
+  function testItThrowsIfServiceNotFoundInBothContainers() {
+    $container_stub = Stub::make(Container::class, [
+      'get' => function ($id) {
+        throw new ServiceNotFoundException($id);
+      }
+    ]);
+    $instance = new ContainerWrapper($container_stub, $container_stub);
+    $exception = null;
+    try {
+      $instance->get('service');
+    } catch (ServiceNotFoundException $e) {
+      $exception = $e;
+    }
+    expect($exception)->isInstanceOf(ServiceNotFoundException::class);
+  }
+}


### PR DESCRIPTION
## DI for Premium plugin
In order to add DI for premium, I had to make some changes also in a free plugin.

### Container configuration
I've split ContainerFactory into ContainerFactory (responsible for building container either from dump file or using a Configurator) and [ContainerConfigurator](https://github.com/mailpoet/mailpoet/blob/premium-di/lib/DI/ContainerConfigurator.php) (responsible for a configuration of services). So that in Premium (or any other future plugin) we just create a ContainerConfigurator. ContainerConfigurator is also used for container dumps (cached containers). There is a one ContainerConfigurator for the free plugin and one for the premium plugin.

### [ContainerWrapper](https://github.com/mailpoet/mailpoet/blob/premium-di/lib/DI/ContainerWrapper.php)

I've added a class which holds both free and also premium containers (if the premium is activated). The ContainerWrapper implements `Psr\Container\ContainerInterface` and internally it checks whether the service can be retrieved from the free container and tries also premium container as a fallback. ContainerWrapper is the main container for the free plugin. This is the first (and preferred) way how to retrieve a premium service within free plugin code. This enables the free plugin to use premium plugin service (e.g. API endpoint) without registering it into a free container config so it can be added just by premium plugin update.

ContainerWrapper also contains [a static factory method](https://github.com/mailpoet/mailpoet/blob/7e4038b432df0df06151b570592502411613ac57/lib/DI/ContainerWrapper.php#L46) which is kind of a starting point for DI and is used also by the premium plugin to retrieve its container.

### DI in Premium plugin
PremiumPlugin doesn't use ContainerWrapper. It uses only its own PremiumContainer which means that every free plugin service we want to use in Premium plugin has to be registered in premium ContainerConfigurator.

#### Using free service in Premium Plugin
Premium container contains a free plugin container (a synthetic service which is injected during startup) and there is [a shortcut method in premium ContainerConfigurator](https://github.com/mailpoet/mailpoet-premium/blob/bd71a78f77534e0fb9af2ef9b20860ea3c39fe61/lib/DI/ContainerConfigurator.php#L26) which helps to register a factory for free container service. With this approach, the free plugin service remains still a singleton service within the free container.

### Using premium service as a dependency of free plugin service
For the use case when we need to use a premium plugin service in a free plugin service I've created [a shortcut method in free container configurator](https://github.com/mailpoet/mailpoet/blob/7e4038b432df0df06151b570592502411613ac57/lib/DI/ContainerConfigurator.php#L70). It works the same way as in premium with the only difference that when the premium container is not available it returns null.

e.g.

```
class Foo {
    
    /** @var PremiumService|null */
    private $premium_service;

    function __construct(PremiumService $premium_service = null) {
          // When premium is active this will be instance of PremiumService otherwise it will be null
         $this->premium_service = $premium_service;
    }
}
```

## Build Changes

- I've moved the code for generating container dumps from application code to the Robofile because it is needed only for build
- The dumped container file is now in a new `generated` folder so that we don't have to
- **The premium build now requires access to free plugin files in order to create a container dump :( The dump is not dependent on any changes within the premium just the free plugin classes which are extended by premium classes Symfony DI files are needed. I've added a new env variable to premium: MAILPOET_FREE_PATH. Please set fill it with a path to mailpoet dir with installed PHP deps.** 