### PR TITLE
Fix routes after React Router upgrade [MAILPOET-1675]

### DIFF
--- a/assets/js/src/newsletters/newsletters.jsx
+++ b/assets/js/src/newsletters/newsletters.jsx
@@ -47,19 +47,19 @@ if (container) {
   let routes = [
     /* Listings */
     {
-      path: '/standard(/)**',
+      path: '/standard/(.*)?',
       component: NewsletterListStandard,
     },
     {
-      path: '/welcome(/)**',
+      path: '/welcome/(.*)?',
       component: NewsletterListWelcome,
     },
     {
-      path: '/notification/history/:parent_id(/)**',
+      path: '/notification/history/:parent_id/(.*)?',
       component: NewsletterListNotificationHistory,
     },
     {
-      path: '/notification(/)**',
+      path: '/notification/(.*)?',
       component: NewsletterListNotification,
     },
     /* New newsletter: types */


### PR DESCRIPTION
Please check that all URL hash-modifying actions in affected routes work as expected: post notification history viewing, tab switching, sorting and filtering in email listings etc.