### PR TITLE
Fix a warning when selecting bulk actions in the subscribers listing [MAILPOET-1669]

### DIFF
--- a/assets/js/src/subscribers/list.jsx
+++ b/assets/js/src/subscribers/list.jsx
@@ -108,7 +108,7 @@ const bulkActions = [
     onSelect: function onSelect() {
       const field = {
         id: 'move_to_segment',
-        api_version: window.mailpoet_api_version,
+        name: 'move_to_segment',
         endpoint: 'segments',
         filter: function filter(segment) {
           return !!(
@@ -140,7 +140,7 @@ const bulkActions = [
     onSelect: function onSelect() {
       const field = {
         id: 'add_to_segment',
-        api_version: window.mailpoet_api_version,
+        name: 'add_to_segment',
         endpoint: 'segments',
         filter: function filter(segment) {
           return !!(
@@ -172,7 +172,7 @@ const bulkActions = [
     onSelect: function onSelect() {
       const field = {
         id: 'remove_from_segment',
-        api_version: window.mailpoet_api_version,
+        name: 'remove_from_segment',
         endpoint: 'segments',
         filter: function filter(segment) {
           return !!(


### PR DESCRIPTION
I could not reproduce the problem in the ticket and only fixed the console warning when choosing segment-related bulk actions. I've also removed the `api_version` parameter as it's unused.