### PR TITLE
Encapsulating WP calls

### DIFF
--- a/lib/API/JSON/v1/Newsletters.php
+++ b/lib/API/JSON/v1/Newsletters.php
@@ -29,6 +29,11 @@ class Newsletters extends APIEndpoint {
   public $permissions = array(
     'global' => AccessControl::PERMISSION_MANAGE_EMAILS
   );
+  private $wp;
+
+  function __construct() {
+    $this->wp = new WPFunctions;
+  }
 
   function get($data = array()) {
     $id = (isset($data['id']) ? (int)$data['id'] : false);
@@ -183,7 +188,7 @@ class Newsletters extends APIEndpoint {
       $queue = $newsletter->queue()->findOne();
       if($queue) {
         $queue->task()
-          ->whereLte('scheduled_at', Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp')))
+          ->whereLte('scheduled_at', Carbon::createFromTimestamp($this->wp->currentTime('timestamp')))
           ->where('status', SendingQueue::STATUS_SCHEDULED)
           ->findResultSet()
           ->set('scheduled_at', $next_run_date)
@@ -432,7 +437,7 @@ class Newsletters extends APIEndpoint {
       'mta_log' => Setting::getValue('mta_log'),
       'mta_method' => Setting::getValue('mta.method'),
       'cron_accessible' => CronHelper::isDaemonAccessible(),
-      'current_time' => WPFunctions::currentTime('mysql')
+      'current_time' => $this->wp->currentTime('mysql')
     ));
   }
 

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -38,10 +38,12 @@ class Menu {
   public $renderer;
   private $access_control;
   private $subscribers_over_limit;
+  private $wp;
 
   function __construct($renderer, AccessControl $access_control) {
     $this->renderer = $renderer;
     $this->access_control = $access_control;
+    $this->wp = new WPFunctions;
   }
 
   function init() {
@@ -372,7 +374,7 @@ class Menu {
     $data['is_old_user'] = false;
     if(!empty($data['settings']['installed_at'])) {
       $installed_at = Carbon::createFromTimestamp(strtotime($data['settings']['installed_at']));
-      $current_time = Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp'));
+      $current_time = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
       $data['is_new_user'] = $current_time->diffInDays($installed_at) <= 30;
       $data['is_old_user'] = $current_time->diffInMonths($installed_at) >= 6;
       $data['stop_call_for_rating'] = isset($data['settings']['stop_call_for_rating']) ? $data['settings']['stop_call_for_rating'] : false;
@@ -816,7 +818,7 @@ class Menu {
       return true;
     }
     $installed_at = Carbon::createFromTimestamp(strtotime($installed_at));
-    $current_time = Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp'));
+    $current_time = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
     return $current_time->diffInDays($installed_at) <= 30;
   }
 }

--- a/lib/Cron/CronHelper.php
+++ b/lib/Cron/CronHelper.php
@@ -82,7 +82,8 @@ class CronHelper {
     );
     $result = self::queryCronUrl($url);
     if(is_wp_error($result)) return $result->get_error_message();
-    $response = WPFunctions::wpRemoteRetrieveBody($result);
+    $wp = new WPFunctions();
+    $response = $wp->wpRemoteRetrieveBody($result);
     $response = substr(trim($response), -strlen(DaemonHttpRunner::PING_SUCCESS_RESPONSE)) === DaemonHttpRunner::PING_SUCCESS_RESPONSE ?
       DaemonHttpRunner::PING_SUCCESS_RESPONSE :
       $response;
@@ -104,7 +105,8 @@ class CronHelper {
     $daemon['run_accessed_at'] = time();
     self::saveDaemon($daemon);
     $result = self::queryCronUrl($url);
-    return WPFunctions::wpRemoteRetrieveBody($result);
+    $wp = new WPFunctions();
+    return $wp->wpRemoteRetrieveBody($result);
   }
 
   /**
@@ -127,7 +129,7 @@ class CronHelper {
     return null;
   }
 
-  static function queryCronUrl($url) {
+  static function queryCronUrl($url, $wp = null) {
     $args = WPHooks::applyFilters(
       'mailpoet_cron_request_args',
       array(
@@ -137,7 +139,10 @@ class CronHelper {
         'user-agent' => 'MailPoet Cron'
       )
     );
-    return WPFunctions::wpRemotePost($url, $args);
+    if(is_null($wp)) {
+      $wp = new WPFunctions();
+    }
+    return $wp->wpRemotePost($url, $args);
   }
 
   static function getCronUrl($action, $data = false) {

--- a/lib/Cron/Workers/Scheduler.php
+++ b/lib/Cron/Workers/Scheduler.php
@@ -19,6 +19,7 @@ if(!defined('ABSPATH')) exit;
 
 class Scheduler {
   public $timer;
+  private $wp;
   const UNCONFIRMED_SUBSCRIBER_RESCHEDULE_TIMEOUT = 5;
   const TASK_BATCH_SIZE = 5;
 
@@ -26,6 +27,7 @@ class Scheduler {
     $this->timer = ($timer) ? $timer : microtime(true);
     // abort if execution limit is reached
     CronHelper::enforceExecutionLimit($this->timer);
+    $this->wp = new WPFunctions();
   }
 
   function process() {
@@ -172,7 +174,7 @@ class Scheduler {
     // check if subscriber is confirmed (subscribed)
     if($subscriber->status !== Subscriber::STATUS_SUBSCRIBED) {
       // reschedule delivery in 5 minutes
-      $scheduled_at = Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp'));
+      $scheduled_at = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
       $queue->scheduled_at = $scheduled_at->addMinutes(
         self::UNCONFIRMED_SUBSCRIBER_RESCHEDULE_TIMEOUT
       );

--- a/lib/Cron/Workers/SendingQueue/Migration.php
+++ b/lib/Cron/Workers/SendingQueue/Migration.php
@@ -241,8 +241,11 @@ class Migration extends SimpleWorker {
     return true;
   }
 
-  static function getNextRunDate() {
+  static function getNextRunDate($wp = null) {
+    if(is_null($wp)) {
+      $wp = new WPFunctions();
+    }
     // run migration immediately
-    return Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp'));
+    return Carbon::createFromTimestamp($wp->currentTime('timestamp'));
   }
 }

--- a/lib/Mailer/Methods/AmazonSES.php
+++ b/lib/Mailer/Methods/AmazonSES.php
@@ -32,6 +32,8 @@ class AmazonSES {
   /** @var AmazonSESMapper */
   private $error_mapper;
 
+  private $wp;
+
   function __construct(
     $region,
     $access_key,
@@ -61,11 +63,12 @@ class AmazonSES {
     $this->date = gmdate('Ymd\THis\Z');
     $this->date_without_time = gmdate('Ymd');
     $this->error_mapper = $error_mapper;
+    $this->wp = new WPFunctions();
   }
 
   function send($newsletter, $subscriber, $extra_params = array()) {
     try {
-      $result = WPFunctions::wpRemotePost(
+      $result = $this->wp->wpRemotePost(
         $this->url,
         $this->request($newsletter, $subscriber, $extra_params)
       );
@@ -77,8 +80,8 @@ class AmazonSES {
       $error = $this->error_mapper->getConnectionError($result->get_error_message());
       return Mailer::formatMailerErrorResult($error);
     }
-    if(WPFunctions::wpRemoteRetrieveResponseCode($result) !== 200) {
-      $response = simplexml_load_string(WPFunctions::wpRemoteRetrieveBody($result));
+    if($this->wp->wpRemoteRetrieveResponseCode($result) !== 200) {
+      $response = simplexml_load_string($this->wp->wpRemoteRetrieveBody($result));
       $error = $this->error_mapper->getErrorFromResponse($response, $subscriber);
       return Mailer::formatMailerErrorResult($error);
     }

--- a/lib/Mailer/Methods/SendGrid.php
+++ b/lib/Mailer/Methods/SendGrid.php
@@ -17,15 +17,18 @@ class SendGrid {
   /** @var SendGridMapper */
   private $error_mapper;
 
+  private $wp;
+
   function __construct($api_key, $sender, $reply_to, SendGridMapper $error_mapper) {
     $this->api_key = $api_key;
     $this->sender = $sender;
     $this->reply_to = $reply_to;
     $this->error_mapper = $error_mapper;
+    $this->wp = new WPFunctions();
   }
 
   function send($newsletter, $subscriber, $extra_params = array()) {
-    $result = WPFunctions::wpRemotePost(
+    $result = $this->wp->wpRemotePost(
       $this->url,
       $this->request($newsletter, $subscriber, $extra_params)
     );
@@ -33,7 +36,7 @@ class SendGrid {
       $error = $this->error_mapper->getConnectionError($result->get_error_message());
       return Mailer::formatMailerErrorResult($error);
     }
-    if(WPFunctions::wpRemoteRetrieveResponseCode($result) !== 200) {
+    if($this->wp->wpRemoteRetrieveResponseCode($result) !== 200) {
       $response = json_decode($result['body'], true);
       $error = $this->error_mapper->getErrorFromResponse($response, $subscriber);
       return Mailer::formatMailerErrorResult($error);

--- a/lib/Models/ScheduledTask.php
+++ b/lib/Models/ScheduledTask.php
@@ -16,6 +16,13 @@ class ScheduledTask extends Model {
   const PRIORITY_MEDIUM = 5;
   const PRIORITY_LOW = 10;
 
+  private $wp;
+
+  function __construct() {
+    parent::__construct();
+    $this->wp = new WPFunctions();
+  }
+
   function subscribers() {
     return $this->hasManyThrough(
       __NAMESPACE__.'\Subscriber',
@@ -61,7 +68,7 @@ class ScheduledTask extends Model {
   }
 
   function complete() {
-    $this->processed_at = WPFunctions::currentTime('mysql');
+    $this->processed_at = $this->wp->currentTime('mysql');
     $this->set('status', self::STATUS_COMPLETED);
     $this->save();
     return ($this->getErrors() === false && $this->id() > 0);

--- a/lib/Newsletter/Editor/PostTransformer.php
+++ b/lib/Newsletter/Editor/PostTransformer.php
@@ -14,11 +14,13 @@ class PostTransformer {
   private $args;
   private $with_layout;
   private $image_position;
+  private $wp;
 
   function __construct($args) {
     $this->args = $args;
     $this->with_layout = isset($args['withLayout']) ? (bool)filter_var($args['withLayout'], FILTER_VALIDATE_BOOLEAN) : false;
     $this->image_position = 'left';
+    $this->wp = new WPFunctions();
   }
 
   function getDivider() {
@@ -150,7 +152,7 @@ class PostTransformer {
     }
 
     $thumbnail_id = get_post_thumbnail_id($post_id);
-    $image_info = WPFunctions::getImageInfo($thumbnail_id);
+    $image_info = $this->wp->getImageInfo($thumbnail_id);
 
     // get alt text
     $alt_text = trim(strip_tags(get_post_meta(

--- a/lib/Newsletter/Scheduler/Scheduler.php
+++ b/lib/Newsletter/Scheduler/Scheduler.php
@@ -226,7 +226,8 @@ class Scheduler {
   }
 
   static function getNextRunDate($schedule, $from_timestamp = false) {
-    $from_timestamp = ($from_timestamp) ? $from_timestamp : WPFunctions::currentTime('timestamp');
+    $wp = new WPFunctions();
+    $from_timestamp = ($from_timestamp) ? $from_timestamp : $wp->currentTime('timestamp');
     try {
       $schedule = \Cron\CronExpression::factory($schedule);
       $next_run_date = $schedule->getNextRunDate(Carbon::createFromTimestamp($from_timestamp))
@@ -238,7 +239,8 @@ class Scheduler {
   }
 
   static function getPreviousRunDate($schedule, $from_timestamp = false) {
-    $from_timestamp = ($from_timestamp) ? $from_timestamp : WPFunctions::currentTime('timestamp');
+    $wp = new WPFunctions();
+    $from_timestamp = ($from_timestamp) ? $from_timestamp : $wp->currentTime('timestamp');
     try {
       $schedule = \Cron\CronExpression::factory($schedule);
       $previous_run_date = $schedule->getPreviousRunDate(Carbon::createFromTimestamp($from_timestamp))
@@ -250,7 +252,8 @@ class Scheduler {
   }
 
   static function getScheduledTimeWithDelay($after_time_type, $after_time_number) {
-    $current_time = Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp'));
+    $wp = new WPFunctions();
+    $current_time = Carbon::createFromTimestamp($wp->currentTime('timestamp'));
     switch($after_time_type) {
       case 'hours':
         return $current_time->addHours($after_time_number);

--- a/lib/Newsletter/Shortcodes/Categories/Date.php
+++ b/lib/Newsletter/Shortcodes/Categories/Date.php
@@ -16,11 +16,12 @@ class Date {
       'mtext' => 'F',
       'y' => 'Y'
     );
+    $wp = new WPFunctions();
     if(!empty($action_mapping[$shortcode_details['action']])) {
-      return date_i18n($action_mapping[$shortcode_details['action']], WPFunctions::currentTime('timestamp'));
+      return date_i18n($action_mapping[$shortcode_details['action']], $wp->currentTime('timestamp'));
     }
     return ($shortcode_details['action'] === 'custom' && $shortcode_details['action_argument'] === 'format') ?
-      date_i18n($shortcode_details['action_argument_value'], WPFunctions::currentTime('timestamp')) :
+      date_i18n($shortcode_details['action_argument_value'], $wp->currentTime('timestamp')) :
       false;
   }
 }

--- a/lib/Services/Bridge.php
+++ b/lib/Services/Bridge.php
@@ -56,8 +56,9 @@ class Bridge {
       'blocking' => true,
       'timeout' => 10
     );
-    $result = WPFunctions::wpRemoteGet(self::BRIDGE_URL, $params);
-    return WPFunctions::wpRemoteRetrieveResponseCode($result) === 200;
+    $wp = new WPFunctions();
+    $result = $wp->wpRemoteGet(self::BRIDGE_URL, $params);
+    return $wp->wpRemoteRetrieveResponseCode($result) === 200;
   }
 
   function initApi($api_key) {

--- a/lib/Services/Bridge/API.php
+++ b/lib/Services/Bridge/API.php
@@ -23,6 +23,7 @@ class API {
   const RESPONSE_CODE_BANNED_ACCOUNT = 403;
 
   private $api_key;
+  private $wp;
 
   public $url_me = 'https://bridge.mailpoet.com/api/v0/me';
   public $url_premium = 'https://bridge.mailpoet.com/api/v0/premium';
@@ -30,8 +31,13 @@ class API {
   public $url_bounces = 'https://bridge.mailpoet.com/api/v0/bounces/search';
   public $url_stats = 'https://bridge.mailpoet.com/api/v0/stats';
 
-  function __construct($api_key) {
+  function __construct($api_key, $wp = null) {
     $this->setKey($api_key);
+    if(is_null($wp)) {
+      $this->wp = new WPFunctions();
+    } else {
+      $this->wp = $wp;
+    }
   }
 
   function checkMSSKey() {
@@ -40,10 +46,10 @@ class API {
       array('site' => home_url())
     );
 
-    $code = WPFunctions::wpRemoteRetrieveResponseCode($result);
+    $code = $this->wp->wpRemoteRetrieveResponseCode($result);
     switch($code) {
       case 200:
-        $body = json_decode(WPFunctions::wpRemoteRetrieveBody($result), true);
+        $body = json_decode($this->wp->wpRemoteRetrieveBody($result), true);
         break;
       default:
         $body = null;
@@ -59,10 +65,10 @@ class API {
       array('site' => home_url())
     );
 
-    $code = WPFunctions::wpRemoteRetrieveResponseCode($result);
+    $code = $this->wp->wpRemoteRetrieveResponseCode($result);
     switch($code) {
       case 200:
-        if($body = WPFunctions::wpRemoteRetrieveBody($result)) {
+        if($body = $this->wp->wpRemoteRetrieveBody($result)) {
           $body = json_decode($body, true);
         }
         break;
@@ -87,11 +93,11 @@ class API {
       );
     }
 
-    $response_code = WPFunctions::wpRemoteRetrieveResponseCode($result);
+    $response_code = $this->wp->wpRemoteRetrieveResponseCode($result);
     if($response_code !== 201) {
-      $response = (WPFunctions::wpRemoteRetrieveBody($result)) ?
-        WPFunctions::wpRemoteRetrieveBody($result) :
-        WPFunctions::wpRemoteRetrieveResponseMessage($result);
+      $response = ($this->wp->wpRemoteRetrieveBody($result)) ?
+        $this->wp->wpRemoteRetrieveBody($result) :
+        $this->wp->wpRemoteRetrieveResponseMessage($result);
       return array(
         'status' => self::SENDING_STATUS_SEND_ERROR,
         'message' => $response,
@@ -106,8 +112,8 @@ class API {
       $this->url_bounces,
       $emails
     );
-    if(WPFunctions::wpRemoteRetrieveResponseCode($result) === 200) {
-      return json_decode(WPFunctions::wpRemoteRetrieveBody($result), true);
+    if($this->wp->wpRemoteRetrieveResponseCode($result) === 200) {
+      return json_decode($this->wp->wpRemoteRetrieveBody($result), true);
     }
     return false;
   }
@@ -118,7 +124,7 @@ class API {
       array('subscriber_count' => (int)$count),
       'PUT'
     );
-    return WPFunctions::wpRemoteRetrieveResponseCode($result) === self::RESPONSE_CODE_STATS_SAVED;
+    return $this->wp->wpRemoteRetrieveResponseCode($result) === self::RESPONSE_CODE_STATS_SAVED;
   }
 
   function setKey($api_key) {
@@ -144,6 +150,6 @@ class API {
       ),
       'body' => json_encode($body)
     );
-    return WPFunctions::wpRemotePost($url, $params);
+    return $this->wp->wpRemotePost($url, $params);
   }
 }

--- a/lib/Services/Release/API.php
+++ b/lib/Services/Release/API.php
@@ -8,11 +8,12 @@ if(!defined('ABSPATH')) exit;
 
 class API {
   private $api_key;
-
+  private $wp;
   public $url_products = 'https://release.mailpoet.com/products/';
 
   function __construct($api_key) {
     $this->setKey($api_key);
+    $this->wp = new WPFunctions();
   }
 
   function getPluginInformation($plugin_name) {
@@ -20,10 +21,10 @@ class API {
       $this->url_products . $plugin_name
     );
 
-    $code = WPFunctions::wpRemoteRetrieveResponseCode($result);
+    $code = $this->wp->wpRemoteRetrieveResponseCode($result);
     switch($code) {
       case 200:
-        if($body = WPFunctions::wpRemoteRetrieveBody($result)) {
+        if($body = $this->wp->wpRemoteRetrieveBody($result)) {
           $body = json_decode($body);
         }
         break;
@@ -50,6 +51,6 @@ class API {
       'timeout' => 10,
       'httpversion' => '1.0'
     );
-    return WPFunctions::wpRemoteGet($url, $args);
+    return $this->wp->wpRemoteGet($url, $args);
   }
 }

--- a/lib/Tasks/Sending.php
+++ b/lib/Tasks/Sending.php
@@ -229,12 +229,13 @@ class Sending {
   }
 
   static function getScheduledQueues($amount = self::RESULT_BATCH_SIZE) {
+    $wp = new WPFunctions();
     $tasks = ScheduledTask::table_alias('tasks')
       ->select('tasks.*')
       ->join(SendingQueue::$_table, 'tasks.id = queues.task_id', 'queues')
       ->whereNull('tasks.deleted_at')
       ->where('tasks.status', ScheduledTask::STATUS_SCHEDULED)
-      ->whereLte('tasks.scheduled_at', Carbon::createFromTimestamp(WPFunctions::currentTime('timestamp')))
+      ->whereLte('tasks.scheduled_at', Carbon::createFromTimestamp($wp->currentTime('timestamp')))
       ->where('tasks.type', 'sending')
       ->whereNotEqual('tasks.status', ScheduledTask::STATUS_PAUSED)
       ->orderByAsc('tasks.updated_at')

--- a/lib/WP/DateTime.php
+++ b/lib/WP/DateTime.php
@@ -10,7 +10,10 @@ class DateTime {
   const DEFAULT_TIME_FORMAT = 'H:i:s';
   const DEFAULT_DATE_TIME_FORMAT = 'Y-m-d H:i:s';
 
+  private $wp;
+
   function __construct() {
+    $this->wp = new WPFunctions();
   }
 
   function getTimeFormat() {
@@ -27,7 +30,7 @@ class DateTime {
 
   function getCurrentTime($format=false) {
     if (empty($format)) $format = $this->getTimeFormat();
-    return WPFunctions::currentTime($format);
+    return $this->wp->currentTime($format);
   }
 
   function getCurrentDate($format=false) {

--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -4,39 +4,31 @@ namespace MailPoet\WP;
 use MailPoet\Config\Env;
 
 class Functions {
-  static function wpRemotePost() {
-    return self::callWithFallback('wp_remote_post', func_get_args());
+  function wpRemotePost() {
+    return call_user_func_array('wp_remote_post', func_get_args());
   }
 
-  static function wpRemoteGet() {
-    return self::callWithFallback('wp_remote_get', func_get_args());
+  function wpRemoteGet() {
+    return call_user_func_array('wp_remote_get', func_get_args());
   }
 
-  static function wpRemoteRetrieveBody() {
-    return self::callWithFallback('wp_remote_retrieve_body', func_get_args());
+  function wpRemoteRetrieveBody() {
+    return call_user_func_array('wp_remote_retrieve_body', func_get_args());
   }
 
-  static function wpRemoteRetrieveResponseCode() {
-    return self::callWithFallback('wp_remote_retrieve_response_code', func_get_args());
+  function wpRemoteRetrieveResponseCode() {
+    return call_user_func_array('wp_remote_retrieve_response_code', func_get_args());
   }
 
-  static function wpRemoteRetrieveResponseMessage() {
-    return self::callWithFallback('wp_remote_retrieve_response_message', func_get_args());
+  function wpRemoteRetrieveResponseMessage() {
+    return call_user_func_array('wp_remote_retrieve_response_message', func_get_args());
   }
 
-  static function currentTime() {
-    return self::callWithFallback('current_time', func_get_args());
+  function currentTime() {
+    return call_user_func_array('current_time', func_get_args());
   }
 
-  private static function callWithFallback($func, $args) {
-    $local_func = __NAMESPACE__ . '\\' . $func;
-    if(function_exists($local_func)) {
-      return call_user_func_array($local_func, $args);
-    }
-    return call_user_func_array($func, $args);
-  }
-
-  static function getImageInfo($id) {
+  function getImageInfo($id) {
     /*
      * In some cases wp_get_attachment_image_src ignore the second parameter
      * and use global variable $content_width value instead.

--- a/tests/integration/Cron/Workers/SendingQueue/MigrationTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/MigrationTest.php
@@ -1,8 +1,9 @@
 <?php
 namespace MailPoet\Test\Cron\Workers;
 
+
 use Carbon\Carbon;
-use Helper\WordPress as WordPressHelper;
+use Codeception\Stub;
 use MailPoet\Cron\Workers\SendingQueue\Migration;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\ScheduledTask;
@@ -11,6 +12,7 @@ use MailPoet\Models\SendingQueue;
 use MailPoet\Models\Setting;
 use MailPoet\Models\Subscriber;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\WP\Functions as WPFunctions;
 
 class MigrationTest extends \MailPoetTest {
   function _before() {
@@ -111,14 +113,15 @@ class MigrationTest extends \MailPoetTest {
   function testItUsesWPTimeToReturnNextRunDate() {
     $timestamp = 1514801410;
 
-    WordPressHelper::interceptFunction('current_time', function($time) use($timestamp) {
-      // "timestamp" string is passed as an argument
-      expect($time)->equals('timestamp');
+    $wp = Stub::make(new WPFunctions, [
+      'currentTime' => function($time) use($timestamp) {
+        // "timestamp" string is passed as an argument
+        expect($time)->equals('timestamp');
+        return $timestamp;
+      }
+    ]);
 
-      return $timestamp;
-    });
-
-    $next_run_date = Migration::getNextRunDate();
+    $next_run_date = Migration::getNextRunDate($wp);
     expect($next_run_date->timestamp)->equals($timestamp);
   }
 
@@ -200,7 +203,5 @@ class MigrationTest extends \MailPoetTest {
       $this->restoreTable();
       $this->altered = false;
     }
-
-    WordPressHelper::releaseAllFunctions();
   }
 }

--- a/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -231,8 +231,9 @@ class NewsletterTest extends \MailPoetTest {
     $queue = $this->queue;
     $newsletter = $this->newsletter_task->preProcessNewsletter($newsletter, $queue);
     $queue = SendingTask::getByNewsletterId($newsletter->id);
+    $wp = new Functions();
     expect($queue->newsletter_rendered_subject)
-      ->contains(date_i18n('dS', Functions::currentTime('timestamp')));
+      ->contains(date_i18n('dS', $wp->currentTime('timestamp')));
   }
 
 

--- a/tests/integration/WP/FunctionsTest.php
+++ b/tests/integration/WP/FunctionsTest.php
@@ -50,7 +50,8 @@ class FunctionsTest extends \MailPoetTest {
     $id = $this->makeAttachment($upload);
     expect($id)->notEmpty();
 
-    $image = WPFunctions::getImageInfo($id);
+    $wp = new WPFunctions();
+    $image = $wp->getImageInfo($id);
     expect($image[1])->equals(Env::NEWSLETTER_CONTENT_WIDTH);
 
     wp_delete_attachment($id, $force_delete = true);


### PR DESCRIPTION
- The functions on `WP\Functions` are now instance methods.
- For all classes which were calling `WPFunctions::someMethod` from an instance method, I added a property `$wp` and instanciated it on the constructor (this should be injected by DI container later).
- For all classes which were calling `WPFunctions::someMethod` from a static method, I created an instance of `WPFunctions` inside each method and called the method on it. This made it difficult to mock these instances for while testing, so I ended up adding an optional parameter to some static methods to be able to pass the WPFunctions mock instance. The bottom line is that we should start getting ride of all static methods, they make testing and DI difficult!