### PR TITLE
Remove outdated vendor prefixes and mixins - hacking day [MAILPOET-1695]

### DIFF
--- a/assets/css/src/form_editor.styl
+++ b/assets/css/src/form_editor.styl
@@ -28,9 +28,7 @@ handle_icon = '../img/handle.png'
   bottom: 12px
   background: transparent
   -webkit-transform: skew(-5deg) rotate(-5deg)
-  -moz-transform: skew(-5deg) rotate(-5deg)
   -ms-transform: skew(-5deg) rotate(-5deg)
-  -o-transform: skew(-5deg) rotate(-5deg)
   transform: skew(-5deg) rotate(-5deg)
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3)
   z-index: -1
@@ -39,9 +37,7 @@ handle_icon = '../img/handle.png'
   left: auto
   right: 12px
   -webkit-transform: skew(5deg) rotate(5deg)
-  -moz-transform: skew(5deg) rotate(5deg)
   -ms-transform: skew(5deg) rotate(5deg)
-  -o-transform: skew(5deg) rotate(5deg)
   transform: skew(5deg) rotate(5deg)
 
 /* Warnings in blocks*/

--- a/assets/css/src/form_editor.styl
+++ b/assets/css/src/form_editor.styl
@@ -16,7 +16,7 @@ handle_icon = '../img/handle.png'
   border: 1px solid #ccc
   position: relative
   background-color: #fff
-  box-shadow(0 0 5px rgba(0, 0, 0, 0.2), inset 0 0 20px rgba(0, 0, 0, 0.1));
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2), inset 0 0 20px rgba(0, 0, 0, 0.1)
 
 #mailpoet_form_editor:before,
 #mailpoet_form_editor:after
@@ -32,9 +32,7 @@ handle_icon = '../img/handle.png'
   -ms-transform: skew(-5deg) rotate(-5deg)
   -o-transform: skew(-5deg) rotate(-5deg)
   transform: skew(-5deg) rotate(-5deg)
-  -webkit-box-shadow(0 6px 12px rgba(0, 0, 0, 0.3))
-  -moz-box-shadow(0 6px 12px rgba(0, 0, 0, 0.3))
-  box-shadow(0 6px 12px rgba(0, 0, 0, 0.3))
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3)
   z-index: -1
 
 #mailpoet_form_editor:after
@@ -163,7 +161,7 @@ handle_icon = '../img/handle.png'
   background linear-gradient(center top, #F9F9F9, #F5F5F5)
   border: 1px solid #DFDFDF
   border-radius: 3px 3px 0 0
-  box-shadow(0 1px 0 #FFFFFF inset)
+  box-shadow: 0 1px 0 #FFFFFF inset
   padding: 0 7px
 
 #mailpoet_form_toolbar .mailpoet_form_toolbar_tabs a:hover
@@ -202,7 +200,7 @@ handle_icon = '../img/handle.png'
   margin-bottom: 0
   background: none repeat scroll 0 0 #fff
   border: 1px solid #e5e5e5
-  box-shadow(0 1px 1px rgba(0, 0, 0, 0.04))
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04)
   min-width: 255px
   position: relative
   cursor: pointer
@@ -232,7 +230,7 @@ handle_icon = '../img/handle.png'
 
 .mailpoet_toolbar_section .mailpoet_toggle:focus
   outline: 0 none !important
-  box-shadow(none !important)
+  box-shadow: none !important
 
 .mailpoet_toolbar_section .mailpoet_toggle:before
   right: 12px
@@ -265,7 +263,7 @@ handle_icon = '../img/handle.png'
   background linear-gradient(center top, #F9F9F9, #ececec)
   border: 1px solid #DFDFDF
   border-radius: 3px
-  box-shadow(0 1px 0 #FFFFFF inset)
+  box-shadow: 0 1px 0 #FFFFFF inset
   display: block
   font-size: 12px
   font-weight: bold
@@ -491,7 +489,7 @@ handle_icon = '../img/handle.png'
   background linear-gradient(center top, #F9F9F9, #ececec)
   border: 1px solid #DFDFDF
   border-radius: 3px
-  box-shadow(0 1px 0 #FFFFFF inset)
+  box-shadow: 0 1px 0 #FFFFFF inset
   font-size: 12px
   font-weight: normal
   cursor: pointer

--- a/assets/css/src/form_editor.styl
+++ b/assets/css/src/form_editor.styl
@@ -162,7 +162,7 @@ handle_icon = '../img/handle.png'
   background-color: #F5F5F5
   background linear-gradient(center top, #F9F9F9, #F5F5F5)
   border: 1px solid #DFDFDF
-  border-radius(3px 3px 0 0)
+  border-radius: 3px 3px 0 0
   box-shadow(0 1px 0 #FFFFFF inset)
   padding: 0 7px
 
@@ -264,7 +264,7 @@ handle_icon = '../img/handle.png'
   background-color: #F5F5F5
   background linear-gradient(center top, #F9F9F9, #ececec)
   border: 1px solid #DFDFDF
-  border-radius(3px)
+  border-radius: 3px
   box-shadow(0 1px 0 #FFFFFF inset)
   display: block
   font-size: 12px
@@ -337,7 +337,7 @@ handle_icon = '../img/handle.png'
 .mailpoet_form_block .wysija_controls
   background-color: #dfdfdf
   background linear-gradient(center top, #eee, #bbb)
-  border-radius(2px)
+  border-radius: 2px
   border: 1px solid #ccc
   position: absolute
   margin: 0
@@ -490,7 +490,7 @@ handle_icon = '../img/handle.png'
   background-color: #F5F5F5
   background linear-gradient(center top, #F9F9F9, #ececec)
   border: 1px solid #DFDFDF
-  border-radius(3px)
+  border-radius: 3px
   box-shadow(0 1px 0 #FFFFFF inset)
   font-size: 12px
   font-weight: normal

--- a/assets/css/src/in_app_announcements.styl
+++ b/assets/css/src/in_app_announcements.styl
@@ -10,21 +10,18 @@
 
 @-webkit-keyframes mailpoet_in_app_dot_pulse
   0%
-    -webkit-box-shadow: 0 0 0 0 rgba(255, 83, 1, 0.4)
+    box-shadow: 0 0 0 0 rgba(255, 83, 1, 0.4)
   70%
-    -webkit-box-shadow: 0 0 0 10px rgba(255, 83, 1, 0)
+    box-shadow: 0 0 0 10px rgba(255, 83, 1, 0)
   100%
-    -webkit-box-shadow: 0 0 0 0 rgba(255, 83, 1, 0)
+    box-shadow: 0 0 0 0 rgba(255, 83, 1, 0)
 
 @keyframes mailpoet_in_app_dot_pulse
   0%
-    -moz-box-shadow: 0 0 0 0 rgba(255, 83, 1, 0.4)
     box-shadow: 0 0 0 0 rgba(255, 83, 1, 0.4)
   70%
-    -moz-box-shadow: 0 0 0 10px rgba(255, 83, 1, 0)
     box-shadow: 0 0 0 10px rgba(255, 83, 1, 0)
   100%
-    -moz-box-shadow: 0 0 0 0 rgba(255, 83, 1, 0)
     box-shadow: 0 0 0 0 rgba(255, 83, 1, 0)
 
 .mailpoet_in_app_announcement_free_welcome_emails

--- a/assets/css/src/modal.styl
+++ b/assets/css/src/modal.styl
@@ -183,7 +183,7 @@ body.mailpoet_modal_opened
   animation-duration(1.9500000000000002s)
   animation-iteration-count(infinite)
   animation-name(bounce_mailpoet_modal_loading)
-  border-radius(21px)
+  border-radius: 21px
   background-color: #E01D4E
   height: 32px
   margin-left: 17px

--- a/assets/css/src/modal.styl
+++ b/assets/css/src/modal.styl
@@ -28,7 +28,7 @@ body.mailpoet_modal_opened
   background-color: modal_highlight_background_color
   position: relative
   z-index: 100001 !important
-  box-shadow(0px 0px 20px 2px alpha(#fff, 75%))
+  box-shadow: 0px 0px 20px 2px alpha(#fff, 75%)
 
 // overlay: state
 .mailpoet_modal_overlay.mailpoet_overlay_hidden

--- a/assets/css/src/newsletter_editor/common.styl
+++ b/assets/css/src/newsletter_editor/common.styl
@@ -40,7 +40,7 @@ select.mailpoet_font-size
 
 .mailpoet_input, .mailpoet_select
   border-radius: 1px
-  box-shadow(none !important)
+  box-shadow: none !important
   appearance: none
 
   padding: $form-control-padding = 3px

--- a/assets/css/src/newsletter_editor/common.styl
+++ b/assets/css/src/newsletter_editor/common.styl
@@ -39,7 +39,7 @@ select.mailpoet_font-size
   width: 5em
 
 .mailpoet_input, .mailpoet_select
-  border-radius(1px)
+  border-radius: 1px
   box-shadow(none !important)
   appearance: none
 
@@ -74,13 +74,13 @@ select.mailpoet_font-size
     cursor: pointer
     animate: 0.2s
     background: $range-track-background-color
-    border-radius($range-border-radius)
+    border-radius: $range-border-radius
     border: 1px solid $range-track-border-color
   &::-webkit-slider-thumb
     border: 1px solid $range-thumb-border-color
     height: $range-thumb-height
     width: $range-thumb-width
-    border-radius($range-border-radius)
+    border-radius: $range-border-radius
     background: $range-thumb-background-color
     cursor: pointer
     -webkit-appearance: none
@@ -93,13 +93,13 @@ select.mailpoet_font-size
     cursor: pointer
     animate: 0.2s
     background: $range-track-background-color
-    border-radius($range-border-radius)
+    border-radius: $range-border-radius
     border: 1px solid $range-track-border-color
   &::-moz-range-thumb
     border: 1px solid $range-thumb-border-color
     height: $range-thumb-height
     width: $range-thumb-width
-    border-radius($range-border-radius)
+    border-radius: $range-border-radius
     background: $range-thumb-background-color
     cursor: pointer
   &:hover::-moz-range-thumb
@@ -123,7 +123,7 @@ select.mailpoet_font-size
     border: 1px solid $range-thumb-border-color
     height: $range-thumb-height
     width: $range-thumb-width
-    border-radius($range-border-radius)
+    border-radius: $range-border-radius
     background: $range-thumb-background-color
     cursor: pointer
   &:hover::-ms-thumb
@@ -171,7 +171,7 @@ select.mailpoet_font-size
   background-color: $button-default-background-color
   padding: 6px 20px
   color: $button-default-text-color
-  border-radius(3px)
+  border-radius: 3px
   line-height: normal
   vertical-align: top
 

--- a/assets/css/src/newsletter_editor/components/blockTools.styl
+++ b/assets/css/src/newsletter_editor/components/blockTools.styl
@@ -146,7 +146,7 @@ $master-column-tool-width = 24px
 .mailpoet_delete_block_activated
   height: auto
   width: auto
-  border-radius(3px)
+  border-radius: 3px
   background-color: $warning-background-color
   padding: 3px 5px
 

--- a/assets/css/src/newsletter_editor/components/dragAndDrop.styl
+++ b/assets/css/src/newsletter_editor/components/dragAndDrop.styl
@@ -12,7 +12,7 @@ $draggable-widget-z-index = 2
   min-height: $marker-width
   z-index: $marker-z-index
 
-  box-shadow(0px 0px 1px 0px $primary-active-color)
+  box-shadow: 0px 0px 1px 0px $primary-active-color
 
   &::before, &::after
     position: absolute
@@ -60,7 +60,7 @@ $draggable-widget-z-index = 2
 
 .mailpoet_drop_active > .mailpoet_container > div > .mailpoet_container_empty
   background-color: $primary-active-color
-  box-shadow(inset 1px 2px 1px $primary-inset-shadow-color)
+  box-shadow: inset 1px 2px 1px $primary-inset-shadow-color
   color: $white-color
 
 .mailpoet_droppable_block

--- a/assets/css/src/newsletter_editor/components/resize.styl
+++ b/assets/css/src/newsletter_editor/components/resize.styl
@@ -16,7 +16,7 @@ $resize-handle-z-index = 2
   position: relative
   top: 5px
   background: $resize-handle-background-color
-  border-radius(3px)
+  border-radius: 3px
   display: inline-block
   width: $resize-handle-width
   cursor: ns-resize
@@ -60,7 +60,7 @@ $resize-handle-z-index = 2
 .mailpoet_image_resize_handle
   position: relative
   background: $resize-handle-background-color
-  border-radius(3px)
+  border-radius: 3px
   display: inline-block
   width: 20px
   height: 20px

--- a/assets/css/src/newsletter_editor/components/save.styl
+++ b/assets/css/src/newsletter_editor/components/save.styl
@@ -11,7 +11,7 @@
     margin-left: 5px
 
 .mailpoet_save_options
-  border-radius(3px)
+  border-radius: 3px
 
   position: absolute
   right: 0
@@ -51,7 +51,7 @@
 
 .mailpoet_save_as_template_container,
 .mailpoet_export_template_container
-  border-radius(3px)
+  border-radius: 3px
   display: inline-block
   position: absolute
   right: 0
@@ -66,7 +66,7 @@
 .mailpoet_save_as_template_title,
 .mailpoet_export_template_title
   font-size: 1.1em
-  
+
 .mailpoet_save_next, .mailpoet_save_button_group
   float: right
 

--- a/assets/css/src/newsletter_editor/components/sidebar.styl
+++ b/assets/css/src/newsletter_editor/components/sidebar.styl
@@ -94,7 +94,7 @@ $widget-icon-width = 30px
     height: $widget-width
     background-color: $widget-background-color
     border-radius: 3px
-    box-shadow(1px 2px $widget-shadow-color)
+    box-shadow: 1px 2px $widget-shadow-color
     color: $widget-icon-color
     fill: $widget-icon-color
     text-align: center
@@ -122,7 +122,7 @@ $widget-icon-width = 30px
       border: 1px solid $widget-icon-hover-color
       color: $widget-icon-hover-color
       fill: $widget-icon-hover-color
-      box-shadow(none)
+      box-shadow: none
 
     .mailpoet_widget_title
       display: none

--- a/assets/css/src/newsletter_editor/components/sidebar.styl
+++ b/assets/css/src/newsletter_editor/components/sidebar.styl
@@ -93,7 +93,7 @@ $widget-icon-width = 30px
     width: $widget-width
     height: $widget-width
     background-color: $widget-background-color
-    border-radius(3px)
+    border-radius: 3px
     box-shadow(1px 2px $widget-shadow-color)
     color: $widget-icon-color
     fill: $widget-icon-color

--- a/assets/css/src/newsletter_editor/contentBlocks/base.styl
+++ b/assets/css/src/newsletter_editor/contentBlocks/base.styl
@@ -21,12 +21,11 @@ $block-text-line-height = $text-line-height
     left: 0
     pointer-events: none
     border: 1px solid $transparent-color
-    -webkit-transition: 0.3s;
     transition: 0.3s;
 
   &:hover > .mailpoet_block_highlight
     border: 1px dashed $block-hover-highlight-color
-    
+
   &.mailpoet_highlight > .mailpoet_block_highlight
     border: 1px dashed $block-hover-highlight-color !important
 

--- a/assets/css/src/newsletter_editor/contentBlocks/container.styl
+++ b/assets/css/src/newsletter_editor/contentBlocks/container.styl
@@ -83,5 +83,5 @@ $two-column-wider-column-width = (($newsletter-width / 3) - $column-margin) * 2
   padding: 15px
   box-shadow(inset 1px 2px 1px $primary-inactive-color)
   color: #656565
-  border-radius(3px)
+  border-radius: 3px
   animation-background-color()

--- a/assets/css/src/newsletter_editor/contentBlocks/container.styl
+++ b/assets/css/src/newsletter_editor/contentBlocks/container.styl
@@ -81,7 +81,7 @@ $two-column-wider-column-width = (($newsletter-width / 3) - $column-margin) * 2
   background-color: #f2f2f2
   margin: 20px
   padding: 15px
-  box-shadow(inset 1px 2px 1px $primary-inactive-color)
+  box-shadow: inset 1px 2px 1px $primary-inactive-color
   color: #656565
   border-radius: 3px
   animation-background-color()

--- a/assets/css/src/newsletter_editor/contentBlocks/posts.styl
+++ b/assets/css/src/newsletter_editor/contentBlocks/posts.styl
@@ -35,7 +35,7 @@
   max-height: 400px
 
 .mailpoet_settings_posts_single_post
-  border-radius(1px)
+  border-radius: 1px
   width: 100%
   margin-top: 5px
   margin-bottom: 5px

--- a/assets/css/src/newsletter_editor/libraryOverrides.styl
+++ b/assets/css/src/newsletter_editor/libraryOverrides.styl
@@ -25,7 +25,7 @@ div.mce-toolbar-grp.mce-container
   position: absolute
 
 .mce-tinymce.mce-tinymce-inline
-  border-radius(3px)
+  border-radius: 3px
   background-color: $primary-background-color
   border: 1px solid $content-border-color
   box-shadow(0px 0px 3px 1px rgba(0, 0, 0, 0.05))
@@ -104,7 +104,7 @@ body
 
 /* Alter Spectrum color picker to leave only the color preview, without arrows */
 .sp-replacer
-  border-radius(3px)
+  border-radius: 3px
   padding: 0
   border: 0
   box-shadow(1px 2px darken($primary-background-color, 13%))

--- a/assets/css/src/newsletter_editor/libraryOverrides.styl
+++ b/assets/css/src/newsletter_editor/libraryOverrides.styl
@@ -28,7 +28,7 @@ div.mce-toolbar-grp.mce-container
   border-radius: 3px
   background-color: $primary-background-color
   border: 1px solid $content-border-color
-  box-shadow(0px 0px 3px 1px rgba(0, 0, 0, 0.05))
+  box-shadow: 0px 0px 3px 1px rgba(0, 0, 0, 0.05)
 
 .mce-window
   /* Fix TinyMCE mailpoet_shortcodes window lack of hiding overflow */
@@ -107,7 +107,7 @@ body
   border-radius: 3px
   padding: 0
   border: 0
-  box-shadow(1px 2px darken($primary-background-color, 13%))
+  box-shadow: 1px 2px darken($primary-background-color, 13%)
 
 .sp-preview
   border-width: 0

--- a/assets/css/src/newsletter_editor/libraryOverrides.styl
+++ b/assets/css/src/newsletter_editor/libraryOverrides.styl
@@ -37,7 +37,6 @@ div.mce-toolbar-grp.mce-container
 
   /* Fix TinyMCE popup window's close button to not be covered by draggable section */
   .mce-window-head div.mce-dragh
-    width: -webkit-calc( 100% - 36px )
     width: calc( 100% - 36px )
 
 /* TinyMCE mailpoet_shortcodes toolbar icon */

--- a/assets/css/src/newsletter_editor/mixins/border-radius.styl
+++ b/assets/css/src/newsletter_editor/mixins/border-radius.styl
@@ -1,4 +1,0 @@
-border-radius()
-  -webkit-border-radius: arguments
-  -moz-border-radius: arguments
-  border-radius: arguments

--- a/assets/css/src/newsletter_editor/mixins/box-shadow.styl
+++ b/assets/css/src/newsletter_editor/mixins/box-shadow.styl
@@ -1,4 +1,0 @@
-box-shadow()
-  -webkit-box-shadow: arguments
-  -moz-box-shadow: arguments
-  box-shadow: arguments

--- a/assets/css/src/newsletter_editor/newsletter_editor.styl
+++ b/assets/css/src/newsletter_editor/newsletter_editor.styl
@@ -3,7 +3,6 @@
 @require 'spectrum-colorpicker/spectrum.css'
 
 // Bootstrapping
-@require 'mixins/box-shadow'
 @require 'mixins/filter-shadow'
 @require 'mixins/transitions'
 

--- a/assets/css/src/newsletter_editor/newsletter_editor.styl
+++ b/assets/css/src/newsletter_editor/newsletter_editor.styl
@@ -3,7 +3,6 @@
 @require 'spectrum-colorpicker/spectrum.css'
 
 // Bootstrapping
-@require 'mixins/border-radius'
 @require 'mixins/box-shadow'
 @require 'mixins/filter-shadow'
 @require 'mixins/transitions'

--- a/assets/css/src/parsley.styl
+++ b/assets/css/src/parsley.styl
@@ -21,8 +21,5 @@ textarea.parsley-error
   color #B94A48
   opacity 0
   transition all .3s ease-in
-  -o-transition all .3s ease-in
-  -moz-transition all .3s ease-in
-  -webkit-transition all .3s ease-in
   &.filled
     opacity 1


### PR DESCRIPTION
Some of these prefixes will still be present in compiled CSS due to `nib` which wasn't updated for a long time. A solution may be to turn off `nib`'s vendor prefixes and use `autoprefixer` instead, but that's a bigger task for another hacking day maybe.