### PR TITLE
Add WooCommerce customers list [MAILPOET-1721]

### DIFF
--- a/assets/js/src/segments/list.jsx
+++ b/assets/js/src/segments/list.jsx
@@ -108,7 +108,7 @@ const itemActions = [
       );
     },
     display: function display(segment) {
-      return isWPUsersSegment(segment);
+      return !isSpecialSegment(segment);
     },
   },
   {

--- a/assets/js/src/segments/list.jsx
+++ b/assets/js/src/segments/list.jsx
@@ -6,6 +6,10 @@ import PropTypes from 'prop-types';
 
 import Listing from 'listing/listing.jsx';
 
+const isWPUsersSegment = segment => segment.type === 'wp_users';
+const isWooCommerceCustomersSegment = segment => segment.type === 'woocommerce_users';
+const isSpecialSegment = segmt => isWPUsersSegment(segmt) || isWooCommerceCustomersSegment(segmt);
+
 const columns = [
   {
     name: 'name',
@@ -104,7 +108,7 @@ const itemActions = [
       );
     },
     display: function display(segment) {
-      return (segment.type !== 'wp_users');
+      return isWPUsersSegment(segment);
     },
   },
   {
@@ -129,7 +133,7 @@ const itemActions = [
       );
     }),
     display: function display(segment) {
-      return (segment.type !== 'wp_users');
+      return !isSpecialSegment(segment);
     },
   },
   {
@@ -144,7 +148,7 @@ const itemActions = [
       );
     },
     display: function display(segment) {
-      return (segment.type === 'wp_users');
+      return isWPUsersSegment(segment);
     },
   },
   {
@@ -173,7 +177,7 @@ const itemActions = [
       });
     },
     display: function display(segment) {
-      return (segment.type === 'wp_users');
+      return isWPUsersSegment(segment);
     },
   },
   {
@@ -187,7 +191,7 @@ const itemActions = [
   {
     name: 'trash',
     display: function display(segment) {
-      return (segment.type !== 'wp_users');
+      return !isSpecialSegment(segment);
     },
   },
 ];
@@ -207,8 +211,9 @@ class SegmentList extends React.Component {
 
     let segmentName;
 
-    if (segment.type === 'wp_users') {
-      // the WP users segment is not editable so just display its name
+    if (isSpecialSegment(segment)) {
+      // the WP users and WooCommerce customers segments
+      // are not editable so just display their names
       segmentName = (
         <span className="row-title">{ segment.name }</span>
       );

--- a/assets/js/src/subscribers/form.jsx
+++ b/assets/js/src/subscribers/form.jsx
@@ -11,7 +11,7 @@ const fields = [
     label: MailPoet.I18n.t('email'),
     type: 'text',
     disabled: function disabled(subscriber) {
-      return Number(subscriber.wp_user_id > 0);
+      return Number(subscriber.wp_user_id > 0) || Number(subscriber.is_woocommerce_user) === 1;
     },
   },
   {
@@ -19,7 +19,7 @@ const fields = [
     label: MailPoet.I18n.t('firstname'),
     type: 'text',
     disabled: function disabled(subscriber) {
-      return Number(subscriber.wp_user_id > 0);
+      return Number(subscriber.wp_user_id > 0) || Number(subscriber.is_woocommerce_user) === 1;
     },
   },
   {
@@ -27,7 +27,7 @@ const fields = [
     label: MailPoet.I18n.t('lastname'),
     type: 'text',
     disabled: function disabled(subscriber) {
-      return Number(subscriber.wp_user_id > 0);
+      return Number(subscriber.wp_user_id > 0) || Number(subscriber.is_woocommerce_user) === 1;
     },
   },
   {
@@ -41,7 +41,7 @@ const fields = [
       bounced: MailPoet.I18n.t('bounced'),
     },
     filter: function filter(subscriber, value) {
-      if (Number(subscriber.wp_user_id) > 0 && value === 'unconfirmed') {
+      if ((Number(subscriber.wp_user_id) > 0 || Number(subscriber.is_woocommerce_user) === 1) && value === 'unconfirmed') {
         return false;
       }
       return true;

--- a/assets/js/src/subscribers/list.jsx
+++ b/assets/js/src/subscribers/list.jsx
@@ -238,7 +238,7 @@ const itemActions = [
   {
     name: 'trash',
     display: function display(subscriber) {
-      return Number(subscriber.wp_user_id) === 0;
+      return Number(subscriber.wp_user_id) === 0 && Number(subscriber.is_woocommerce_user) === 0;
     },
   },
 ];

--- a/lib/API/MP/v1/API.php
+++ b/lib/API/MP/v1/API.php
@@ -144,10 +144,10 @@ class API {
     $found_segments_ids = array();
     foreach($found_segments as $segment) {
       if($segment->type === Segment::TYPE_WP_USERS) {
-        throw new \Exception(__(sprintf("Can't subscribe to a WordPress Users list with ID %d.", $segment->id), 'mailpoet'));
+        throw new \Exception(__(sprintf("Can't unsubscribe from a WordPress Users list with ID %d.", $segment->id), 'mailpoet'));
       }
       if($segment->type === Segment::TYPE_WC_USERS) {
-        throw new \Exception(__(sprintf("Can't subscribe to a WooCommerce Customers list with ID %d.", $segment->id), 'mailpoet'));
+        throw new \Exception(__(sprintf("Can't unsubscribe from a WooCommerce Customers list with ID %d.", $segment->id), 'mailpoet'));
       }
       $found_segments_ids[] = $segment->id;
     }
@@ -168,7 +168,7 @@ class API {
 
   function getLists() {
     return Segment::whereNotIn('type', [Segment::TYPE_WP_USERS, Segment::TYPE_WC_USERS])
-    ->findArray();
+      ->findArray();
   }
 
   function addSubscriber(array $subscriber, $segments = array(), $options = array()) {

--- a/lib/API/MP/v1/API.php
+++ b/lib/API/MP/v1/API.php
@@ -86,11 +86,14 @@ class API {
       throw new \Exception($exception);
     }
 
-    // throw exception when trying to subscribe to a WP Users segment
+    // throw exception when trying to subscribe to WP Users or WooCommerce Customers segments
     $found_segments_ids = array();
     foreach($found_segments as $found_segment) {
       if($found_segment->type === Segment::TYPE_WP_USERS) {
         throw new \Exception(__(sprintf("Can't subscribe to a WordPress Users list with ID %d.", $found_segment->id), 'mailpoet'));
+      }
+      if($found_segment->type === Segment::TYPE_WC_USERS) {
+        throw new \Exception(__(sprintf("Can't subscribe to a WooCommerce Customers list with ID %d.", $found_segment->id), 'mailpoet'));
       }
       $found_segments_ids[] = $found_segment->id;
     }
@@ -137,11 +140,14 @@ class API {
       throw new \Exception($exception);
     }
 
-    // throw exception when trying to subscribe to a WP Users segment
+    // throw exception when trying to subscribe to WP Users or WooCommerce Customers segments
     $found_segments_ids = array();
     foreach($found_segments as $segment) {
       if($segment->type === Segment::TYPE_WP_USERS) {
         throw new \Exception(__(sprintf("Can't subscribe to a WordPress Users list with ID %d.", $segment->id), 'mailpoet'));
+      }
+      if($segment->type === Segment::TYPE_WC_USERS) {
+        throw new \Exception(__(sprintf("Can't subscribe to a WooCommerce Customers list with ID %d.", $segment->id), 'mailpoet'));
       }
       $found_segments_ids[] = $segment->id;
     }
@@ -161,7 +167,8 @@ class API {
   }
 
   function getLists() {
-    return Segment::whereNotEqual('type', Segment::TYPE_WP_USERS)->findArray();
+    return Segment::whereNotIn('type', [Segment::TYPE_WP_USERS, Segment::TYPE_WC_USERS])
+    ->findArray();
   }
 
   function addSubscriber(array $subscriber, $segments = array(), $options = array()) {

--- a/lib/Config/MP2Migrator.php
+++ b/lib/Config/MP2Migrator.php
@@ -221,14 +221,14 @@ class MP2Migrator {
   }
 
   /**
-   * Delete the existing segments except the wp_users segment
+   * Delete the existing segments except the wp_users and woocommerce_users segments
    *
    */
   private function deleteSegments() {
     global $wpdb;
 
     $table = MP_SEGMENTS_TABLE;
-    $wpdb->query("DELETE FROM {$table} WHERE type != '" . Segment::TYPE_WP_USERS . "'");
+    $wpdb->query("DELETE FROM {$table} WHERE type != '" . Segment::TYPE_WP_USERS . "' AND type != '" . Segment::TYPE_WC_USERS ."'");
   }
 
   /**

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -166,6 +166,7 @@ class Migrator {
     $attributes = array(
       'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
       'wp_user_id bigint(20) NULL,',
+      'is_woocommerce_user int(1) NOT NULL DEFAULT 0,',
       'first_name varchar(255) NOT NULL DEFAULT "",',
       'last_name varchar(255) NOT NULL DEFAULT "",',
       'email varchar(150) NOT NULL,',

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -191,6 +191,8 @@ class Populator {
   private function createDefaultSegments() {
     // WP Users segment
     Segment::getWPSegment();
+    // WooCommerce customers segment
+    Segment::getWooCommerceSegment();
 
     // Synchronize WP Users
     WP::synchronizeUsers();
@@ -398,6 +400,12 @@ class Populator {
       ' SET `source` = "' . Source::WORDPRESS_USER . '"' .
       ' WHERE `source` = "' . Source::UNKNOWN . '"' .
       ' AND `wp_user_id` IS NOT NULL'
+    );
+    Subscriber::rawExecute(
+      'UPDATE LOW_PRIORITY `' . Subscriber::$_table . '`' .
+      ' SET `source` = "' . Source::WOOCOMMERCE_USER . '"' .
+      ' WHERE `source` = "' . Source::UNKNOWN . '"' .
+      ' AND `is_woocommerce_user` = 1'
     );
   }
 

--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -80,7 +80,7 @@ class Subscriber extends Model {
   }
 
   function isWooCommerceUser() {
-    return $this->is_woocommerce_user == true;
+    return (bool)$this->is_woocommerce_user;
   }
 
   static function getCurrentWPUser() {

--- a/lib/Segments/BulkAction.php
+++ b/lib/Segments/BulkAction.php
@@ -36,7 +36,9 @@ class BulkAction {
    * @throws \Exception
    */
   private function applySegment($segment) {
-    if(!$segment || $segment['type'] === Segment::TYPE_DEFAULT || $segment['type'] === Segment::TYPE_WP_USERS) {
+    if(!$segment
+      || in_array($segment['type'], [Segment::TYPE_DEFAULT, Segment::TYPE_WP_USERS, Segment::TYPE_WC_USERS], true)
+    ) {
       $bulk_action = new \MailPoet\Listing\BulkActionController(new Handler());
       return $bulk_action->apply('\MailPoet\Models\Subscriber', $this->data);
     } else {

--- a/lib/Segments/SubscribersFinder.php
+++ b/lib/Segments/SubscribersFinder.php
@@ -36,7 +36,7 @@ class SubscribersFinder {
   }
 
   private function isStaticSegment(Segment $segment) {
-    return $segment->type === Segment::TYPE_DEFAULT || $segment->type === Segment::TYPE_WP_USERS;
+    return in_array($segment->type, [Segment::TYPE_DEFAULT, Segment::TYPE_WP_USERS, Segment::TYPE_WC_USERS], true);
   }
 
   function addSubscribersToTaskFromSegments(ScheduledTask $task, array $segments) {

--- a/lib/Segments/SubscribersListings.php
+++ b/lib/Segments/SubscribersListings.php
@@ -25,8 +25,9 @@ class SubscribersListings {
   }
 
   private function getListings($data, Segment $segment = null) {
-    if(!$segment || $segment->type === Segment::TYPE_DEFAULT || $segment->type === Segment::TYPE_WP_USERS) {
-
+    if(!$segment
+      || in_array($segment->type, [Segment::TYPE_DEFAULT, Segment::TYPE_WP_USERS, Segment::TYPE_WC_USERS], true)
+    ) {
       return $listing_data = $this->handler->get('\MailPoet\Models\Subscriber', $data);
     }
     $handlers = Hooks::applyFilters('mailpoet_get_subscribers_listings_in_segment_handlers', array());

--- a/lib/Segments/WP.php
+++ b/lib/Segments/WP.php
@@ -170,7 +170,7 @@ class WP {
       SET %1$s.last_name = wpum.meta_value
         WHERE %1$s.last_name = ""
         AND %1$s.wp_user_id IS NOT NULL
-        AND wpum.meta_value IS NOT NULL        
+        AND wpum.meta_value IS NOT NULL
     ', $subscribers_table, $wpdb->usermeta));
   }
 

--- a/lib/Subscribers/Source.php
+++ b/lib/Subscribers/Source.php
@@ -11,6 +11,7 @@ class Source {
   const ADMINISTRATOR = 'administrator';
   const API = 'api';
   const WORDPRESS_USER = 'wordpress_user';
+  const WOOCOMMERCE_USER = 'woocommerce_user';
   const UNKNOWN = 'unknown';
 
   private static $allowed_sources = array(
@@ -19,6 +20,7 @@ class Source {
     Source::ADMINISTRATOR,
     Source::API,
     Source::WORDPRESS_USER,
+    Source::WOOCOMMERCE_USER,
     Source::UNKNOWN,
   );
 

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -294,7 +294,7 @@ class Pages {
         'params' => array(
           'label' => __('First name', 'mailpoet'),
           'value' => $subscriber->first_name,
-          'disabled' => ($subscriber->isWPUser())
+          'disabled' => ($subscriber->isWPUser() || $subscriber->isWooCommerceUser())
         )
       ),
       array(
@@ -303,7 +303,7 @@ class Pages {
         'params' => array(
           'label' => __('Last name', 'mailpoet'),
           'value' => $subscriber->last_name,
-          'disabled' => ($subscriber->isWPUser())
+          'disabled' => ($subscriber->isWPUser() || $subscriber->isWooCommerceUser())
         )
       ),
       array(
@@ -387,7 +387,7 @@ class Pages {
     $form_html .= '<label>Email *<br /><strong>'.$subscriber->email.'</strong></label>';
     $form_html .= '<br /><span style="font-size:85%;">';
     // special case for WP users as they cannot edit their subscriber's email
-    if($subscriber->isWPUser()) {
+    if($subscriber->isWPUser() || $subscriber->isWooCommerceUser()) {
       // check if subscriber's associated WP user is the currently logged in WP user
       $wp_current_user = wp_get_current_user();
       if($wp_current_user->user_email === $subscriber->email) {

--- a/tests/_data/acceptanceDump.sql
+++ b/tests/_data/acceptanceDump.sql
@@ -323,7 +323,8 @@ CREATE TABLE `mp_mailpoet_segments` (
 
 INSERT INTO `mp_mailpoet_segments` (`id`, `name`, `type`, `description`, `created_at`, `updated_at`, `deleted_at`) VALUES
 (1,	'WordPress Users',	'wp_users',	'This list contains all of your WordPress users.',	'2017-10-30 00:57:39',	'2017-10-30 00:57:39',	NULL),
-(2,	'My First List',	'default',	'This list is automatically created when you install MailPoet.',	'2017-10-30 00:57:39',	'2017-10-30 00:57:39',	NULL);
+(2,	'WooCommerce Customers',	'woocommerce_users',	'This list contains all of your WooCommerce customers.',	'2019-01-17 00:57:39',	'2019-01-17 00:57:39',	NULL),
+(3,	'My First List',	'default',	'This list is automatically created when you install MailPoet.',	'2017-10-30 00:57:39',	'2017-10-30 00:57:39',	NULL);
 
 DROP TABLE IF EXISTS `mp_mailpoet_sending_queues`;
 CREATE TABLE `mp_mailpoet_sending_queues` (

--- a/tests/acceptance/ListsListingCest.php
+++ b/tests/acceptance/ListsListingCest.php
@@ -11,7 +11,8 @@ class ListsListingCest {
     $I->amOnMailpoetPage('Lists');
 
     $I->waitForText('WordPress Users', 5, '[data-automation-id="listing_item_1"]');
-    $I->see('My First List', '[data-automation-id="listing_item_2"]');
+    $I->see('WooCommerce Customers', '[data-automation-id="listing_item_2"]');
+    $I->see('My First List', '[data-automation-id="listing_item_3"]');
     $I->seeNoJSErrors();
   }
 

--- a/tests/acceptance/ReinstallFromScratchCest.php
+++ b/tests/acceptance/ReinstallFromScratchCest.php
@@ -59,8 +59,9 @@ class ReinstallFromScratchCest {
     // Check lists
     $I->amOnMailpoetPage('Lists');
     $I->waitForText('WordPress Users', 30, '[data-automation-id="listing_item_1"]');
-    $I->see('My First List', '[data-automation-id="listing_item_2"]');
-    $I->seeNumberOfElements('[data-automation-id^=listing_item_]', 2);
+    $I->see('WooCommerce Customers', '[data-automation-id="listing_item_2"]');
+    $I->see('My First List', '[data-automation-id="listing_item_3"]');
+    $I->seeNumberOfElements('[data-automation-id^=listing_item_]', 3);
     // Check subscribers
     $I->amOnMailPoetPage('Subscribers');
     $I->waitForText('admin', 30, '[data-automation-id="listing_item_1"]');

--- a/tests/integration/API/MP/APITest.php
+++ b/tests/integration/API/MP/APITest.php
@@ -104,6 +104,24 @@ class APITest extends \MailPoetTest {
     }
   }
 
+  function testItDoesNotSubscribeSubscriberToWooCommerceCustomersList() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(Fixtures::get('subscriber_template'));
+    $subscriber->save();
+    $segment = Segment::createOrUpdate(
+      array(
+        'name' => 'Default',
+        'type' => Segment::TYPE_WC_USERS
+      )
+    );
+    try {
+      $this->getApi()->subscribeToLists($subscriber->id, array($segment->id));
+      $this->fail('WooCommerce Customers segment exception should have been thrown.');
+    } catch(\Exception $e) {
+      expect($e->getMessage())->equals("Can't subscribe to a WooCommerce Customers list with ID {$segment->id}.");
+    }
+  }
+
   function testItDoesNotSubscribeSubscriberToListsWhenOneOrMoreListsAreMissing() {
     $subscriber = Subscriber::create();
     $subscriber->hydrate(Fixtures::get('subscriber_template'));
@@ -261,7 +279,7 @@ class APITest extends \MailPoetTest {
     expect($result[0]['id'])->equals($segment->id);
   }
 
-  function testItExcludesWPUsersSegmentWhenGettingSegments() {
+  function testItExcludesWPUsersAndWooCommerceCustomersSegmentsWhenGettingSegments() {
     $default_segment = Segment::createOrUpdate(
       array(
         'name' => 'Default',
@@ -272,6 +290,12 @@ class APITest extends \MailPoetTest {
       array(
         'name' => 'Default',
         'type' => Segment::TYPE_WP_USERS
+      )
+    );
+    $wc_segment = Segment::createOrUpdate(
+      array(
+        'name' => 'Default',
+        'type' => Segment::TYPE_WC_USERS
       )
     );
     $result = $this->getApi()->getLists();
@@ -598,6 +622,24 @@ class APITest extends \MailPoetTest {
       $this->fail('WP Users segment exception should have been thrown.');
     } catch(\Exception $e) {
       expect($e->getMessage())->equals("Can't subscribe to a WordPress Users list with ID {$segment->id}.");
+    }
+  }
+
+  function testItDoesNotUnsubscribeSubscriberFromWooCommerceCustomersList() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(Fixtures::get('subscriber_template'));
+    $subscriber->save();
+    $segment = Segment::createOrUpdate(
+      array(
+        'name' => 'Default',
+        'type' => Segment::TYPE_WC_USERS
+      )
+    );
+    try {
+      $this->getApi()->unsubscribeFromLists($subscriber->id, array($segment->id));
+      $this->fail('WooCommerce Customers segment exception should have been thrown.');
+    } catch(\Exception $e) {
+      expect($e->getMessage())->equals("Can't subscribe to a WooCommerce Customers list with ID {$segment->id}.");
     }
   }
 

--- a/tests/integration/API/MP/APITest.php
+++ b/tests/integration/API/MP/APITest.php
@@ -621,7 +621,7 @@ class APITest extends \MailPoetTest {
       $this->getApi()->unsubscribeFromLists($subscriber->id, array($segment->id));
       $this->fail('WP Users segment exception should have been thrown.');
     } catch(\Exception $e) {
-      expect($e->getMessage())->equals("Can't subscribe to a WordPress Users list with ID {$segment->id}.");
+      expect($e->getMessage())->equals("Can't unsubscribe from a WordPress Users list with ID {$segment->id}.");
     }
   }
 
@@ -639,7 +639,7 @@ class APITest extends \MailPoetTest {
       $this->getApi()->unsubscribeFromLists($subscriber->id, array($segment->id));
       $this->fail('WooCommerce Customers segment exception should have been thrown.');
     } catch(\Exception $e) {
-      expect($e->getMessage())->equals("Can't subscribe to a WooCommerce Customers list with ID {$segment->id}.");
+      expect($e->getMessage())->equals("Can't unsubscribe from a WooCommerce Customers list with ID {$segment->id}.");
     }
   }
 

--- a/tests/integration/Config/MP2MigratorTest.php
+++ b/tests/integration/Config/MP2MigratorTest.php
@@ -121,7 +121,7 @@ class MP2MigratorTest extends \MailPoetTest {
     $this->initImport();
     $this->loadMP2Fixtures();
     $this->invokeMethod($this->MP2Migrator, 'importSegments');
-    expect(Segment::count())->equals(3);
+    expect(Segment::count())->equals(4); // two regular lists, WP users list, WooCommerce customers list (not imported)
 
     // Check a segment data
     $this->initImport();

--- a/tests/integration/Models/SubscriberTest.php
+++ b/tests/integration/Models/SubscriberTest.php
@@ -551,6 +551,7 @@ class SubscriberTest extends \MailPoetTest {
         // the fields below should NOT be taken into account
         'id' => 1337,
         'wp_user_id' => 7331,
+        'is_woocommerce_user' => 1,
         'status' => Subscriber::STATUS_SUBSCRIBED,
         'created_at' => '1984-03-09 00:00:01',
         'updated_at' => '1984-03-09 00:00:02',
@@ -567,6 +568,7 @@ class SubscriberTest extends \MailPoetTest {
     expect($subscriber->last_name)->equals('Trump');
 
     expect($subscriber->wp_user_id)->equals(null);
+    expect($subscriber->is_woocommerce_user)->equals(0);
     expect($subscriber->status)->equals(Subscriber::STATUS_UNCONFIRMED);
     expect($subscriber->created_at)->notEquals('1984-03-09 00:00:01');
     expect($subscriber->updated_at)->notEquals('1984-03-09 00:00:02');
@@ -815,6 +817,33 @@ class SubscriberTest extends \MailPoetTest {
       'first_name' => 'Some',
       'last_name' => 'WP User',
       'wp_user_id' => 1
+    ));
+    expect($wp_subscriber->delete())->equals(false);
+
+    $subscriber = Subscriber::findOne($wp_subscriber->id);
+    expect($subscriber)->notEquals(false);
+  }
+
+  function testItCannotTrashWooCommerceCustomer() {
+    $wp_subscriber = Subscriber::createOrUpdate(array(
+      'email' => 'some.woocommerce.customer@mailpoet.com',
+      'first_name' => 'Some',
+      'last_name' => 'WooCommerce Customer',
+      'is_woocommerce_user' => 1
+    ));
+    expect($wp_subscriber->trash())->equals(false);
+
+    $subscriber = Subscriber::findOne($wp_subscriber->id);
+    expect($subscriber)->notEquals(false);
+    expect($subscriber->deleted_at)->equals(null);
+  }
+
+  function testItCannotDeleteWooCommerceCustomer() {
+    $wp_subscriber = Subscriber::createOrUpdate(array(
+      'email' => 'some.woocommerce.customer@mailpoet.com',
+      'first_name' => 'Some',
+      'last_name' => 'WooCommerce Customer',
+      'is_woocommerce_user' => 1
     ));
     expect($wp_subscriber->delete())->equals(false);
 


### PR DESCRIPTION
The code is mostly done by analogy with the existing WP Users segment behavior, the only difference may be that WP Users list can be edited/imported and WooCommerce list can't (which may in fact be a bug of the former).

The `is_woocommerce_user` field is binary because we don't have separate customer IDs in WooCommerce.