### PR TITLE
Introduce default timeout to acceptance tests, remove custom timeouts [MAILPOET-1759]

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -256,19 +256,21 @@ class RoboFile extends \Robo\Tasks {
     return $this->testIntegration($opts);
   }
 
-  function testAcceptance($opts=['file' => null, 'skip-deps' => false]) {
+  function testAcceptance($opts=['file' => null, 'skip-deps' => false, 'timeout' => null]) {
     return $this->_exec(
       'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
       ($opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
+      ($opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
       'codeception --steps --debug -vvv ' .
       '-f ' . ($opts['file'] ? $opts['file'] : '')
     );
   }
 
-  function testAcceptanceMultisite($opts=['file' => null, 'skip-deps' => false]) {
+  function testAcceptanceMultisite($opts=['file' => null, 'skip-deps' => false, 'timeout' => null]) {
     return $this->_exec(
       'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
       ($opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
+      ($opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
       '-e MULTISITE=1 ' .
       'codeception --steps --debug -vvv' .
       '-f ' . ($opts['file'] ? $opts['file'] : '')

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -22,13 +22,13 @@ require_once __DIR__ . '/../DataFactories/Form.php';
 class AcceptanceTester extends \Codeception\Actor {
   use _generated\AcceptanceTesterActions {
     switchToNextTab as _switchToNextTab;
-    waitForElement            as _waitForElement;
-    waitForElementChange      as _waitForElementChange;
-    waitForElementClickable   as _waitForElementClickable;
-    waitForElementNotVisible  as _waitForElementNotVisible;
-    waitForElementVisible     as _waitForElementVisible;
-    waitForJS                 as _waitForJS;
-    waitForText               as _waitForText;
+    waitForElement as _waitForElement;
+    waitForElementChange as _waitForElementChange;
+    waitForElementClickable as _waitForElementClickable;
+    waitForElementNotVisible as _waitForElementNotVisible;
+    waitForElementVisible as _waitForElementVisible;
+    waitForJS as _waitForJS;
+    waitForText as _waitForText;
   }
 
   const WP_URL = 'http://wordpress';

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -34,8 +34,6 @@ class AcceptanceTester extends \Codeception\Actor {
   const WP_URL = 'http://wordpress';
   const MAIL_URL = 'http://mailhog:8025';
 
-  const DEFAULT_WAIT_TIMEOUT = null;
-
   /**
    * Define custom actions here
    */
@@ -191,9 +189,7 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   private function getDefaultTimeout($timeout) {
-    return (int)getenv('WAIT_TIMEOUT')
-      ?: self::DEFAULT_WAIT_TIMEOUT
-      ?: $timeout;
+    return (int)getenv('WAIT_TIMEOUT') ?: $timeout;
   }
 
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -22,10 +22,19 @@ require_once __DIR__ . '/../DataFactories/Form.php';
 class AcceptanceTester extends \Codeception\Actor {
   use _generated\AcceptanceTesterActions {
     switchToNextTab as _switchToNextTab;
+    waitForElement            as _waitForElement;
+    waitForElementChange      as _waitForElementChange;
+    waitForElementClickable   as _waitForElementClickable;
+    waitForElementNotVisible  as _waitForElementNotVisible;
+    waitForElementVisible     as _waitForElementVisible;
+    waitForJS                 as _waitForJS;
+    waitForText               as _waitForText;
   }
 
   const WP_URL = 'http://wordpress';
   const MAIL_URL = 'http://mailhog:8025';
+
+  const DEFAULT_WAIT_TIMEOUT = null;
 
   /**
    * Define custom actions here
@@ -149,4 +158,42 @@ class AcceptanceTester extends \Codeception\Actor {
     // workaround for frozen tabs when opened by clicking on links
     $this->wait(1);
   }
+
+  /**
+   * Override waitFor* methods to have a common default timeout
+   */
+  public function waitForElement($element, $timeout = 10) {
+    return $this->_waitForElement($element, $this->getDefaultTimeout($timeout));
+  }
+
+  public function waitForElementChange($element, \Closure $callback, $timeout = 30) {
+    return $this->_waitForElementChange($element, $callback, $this->getDefaultTimeout($timeout));
+  }
+
+  public function waitForElementClickable($element, $timeout = 10) {
+    return $this->_waitForElementClickable($element, $this->getDefaultTimeout($timeout));
+  }
+
+  public function waitForElementNotVisible($element, $timeout = 10) {
+    return $this->_waitForElementNotVisible($element, $this->getDefaultTimeout($timeout));
+  }
+
+  public function waitForElementVisible($element, $timeout = 10) {
+    return $this->_waitForElementVisible($element, $this->getDefaultTimeout($timeout));
+  }
+
+  public function waitForJS($script, $timeout = 5) {
+    return $this->_waitForJS($script, $this->getDefaultTimeout($timeout));
+  }
+
+  public function waitForText($text, $timeout = 10, $selector = null) {
+    return $this->_waitForText($text, $this->getDefaultTimeout($timeout), $selector);
+  }
+
+  private function getDefaultTimeout($timeout) {
+    return (int)getenv('WAIT_TIMEOUT')
+      ?: self::DEFAULT_WAIT_TIMEOUT
+      ?: $timeout;
+  }
+
 }

--- a/tests/acceptance/ConfirmNewsletterAutosaveCest.php
+++ b/tests/acceptance/ConfirmNewsletterAutosaveCest.php
@@ -26,10 +26,10 @@ class ConfirmNewsletterAutosaveCest {
 
     // step 3 - Add subject, wait for Autosave
     $title_element = '[data-automation-id="newsletter_title"]';
-    $I->waitForElement($title_element, 20);
+    $I->waitForElement($title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->fillField($title_element, $newsletter_title);
-    $I->waitForText('Autosaved', 20);
+    $I->waitForText('Autosaved');
     $I->seeNoJSErrors();
   }
 

--- a/tests/acceptance/ConfirmNotificationAutosaveCest.php
+++ b/tests/acceptance/ConfirmNotificationAutosaveCest.php
@@ -24,7 +24,7 @@ class ConfirmNotificationAutosaveCest {
     $I->waitForElement($title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->fillField($title_element, $newsletter_title);
-    $I->waitForText('Autosaved', 20);
+    $I->waitForText('Autosaved');
   }
 
 }

--- a/tests/acceptance/CreateWelcomeEmailCest.php
+++ b/tests/acceptance/CreateWelcomeEmailCest.php
@@ -11,27 +11,27 @@ class CreateWelcomeEmailCest {
     $I->click('[data-automation-id="new_email"]');
     $I->seeInCurrentUrl('#/new');
     $I->click('[data-automation-id="create_welcome"]');
-    $I->waitForText('Welcome Email', 20);
+    $I->waitForText('Welcome Email');
     $I->seeInCurrentUrl('mailpoet-newsletters#/new/welcome');
     $I->click('Next');
     $welcome_template = '[data-automation-id="select_template_0"]';
-    $I->waitForElement($welcome_template, 20);
+    $I->waitForElement($welcome_template);
     $I->see('Welcome Emails', ['css' => 'a.current']);
     $I->seeInCurrentUrl('#/template');
     $I->click($welcome_template);
     $title_element = '[data-automation-id="newsletter_title"]';
-    $I->waitForElement($title_element, 20);
+    $I->waitForElement($title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->fillField($title_element, $newsletter_title);
     $I->click('Next');
-    $I->waitForText('Send this Welcome Email when', 30);
+    $I->waitForText('Send this Welcome Email when');
     $I->click('Activate');
-    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]', 20);
+    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
     $I->seeInCurrentUrl('mailpoet-newsletters');
     $I->click('Welcome Emails');
     $I->seeInCurrentUrl('mailpoet-newsletters#/welcome');
     $I->searchFor($newsletter_title, 2);
-    $I->waitForText($newsletter_title, 10);
+    $I->waitForText($newsletter_title);
     $I->seeNoJSErrors();
   }
 }

--- a/tests/acceptance/DeleteNotificationCest.php
+++ b/tests/acceptance/DeleteNotificationCest.php
@@ -48,7 +48,7 @@ class DeleteNotificationCest {
     $I->clickItemRowActionByItemName($newsletter_name, 'Restore');
     $I->amOnMailpoetPage('Emails');
     $I->click('Post Notifications', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_name, 5);
+    $I->waitForText($newsletter_name);
   }
 
   function deleteNotificationPermanently(\AcceptanceTester $I) {

--- a/tests/acceptance/DuplicatePostNotificationCest.php
+++ b/tests/acceptance/DuplicatePostNotificationCest.php
@@ -24,7 +24,7 @@ class DuplicatePostNotificationCest {
     $I->click('Post Notifications', '[data-automation-id="newsletters_listing_tabs"]');
 
     // step 3 - Duplicate post notification
-    $I->waitForText($newsletter_title, 10);
+    $I->waitForText($newsletter_title);
     $I->clickItemRowActionByItemName($newsletter_title, 'Duplicate');
     $I->waitForText('Copy of ' . $newsletter_title);
     $I->waitForListingItemsToLoad();

--- a/tests/acceptance/ExportSubscribersCest.php
+++ b/tests/acceptance/ExportSubscribersCest.php
@@ -26,7 +26,7 @@ class ExportSubscribersCest {
     $I->selectOptionInSelect2($segment_name);
     //export
     $I->click('.button-primary.mailpoet_export_process');
-    $I->waitForText('3 subscribers were exported. Get the exported file here.', 20);
+    $I->waitForText('3 subscribers were exported. Get the exported file here.');
     $I->seeNoJSErrors();
   }
 }

--- a/tests/acceptance/ManageSubscriptionLinkCest.php
+++ b/tests/acceptance/ManageSubscriptionLinkCest.php
@@ -48,7 +48,7 @@ class ManageSubscriptionLinkCest {
     $I->seeInCurrentUrl('#/send');
     $I->selectOptionInSelect2('WordPress Users');
     $I->click('Send');
-    $I->waitForText('Sent to 1 of 1', 60);
+    $I->waitForText('Sent to 1 of 1');
   }
 
   function manageSubscriptionLink(\AcceptanceTester $I) {

--- a/tests/acceptance/ManageWelcomeEmailCest.php
+++ b/tests/acceptance/ManageWelcomeEmailCest.php
@@ -31,23 +31,23 @@ class ManageWelcomeEmailCest {
     $I->click('[data-automation-id="new_email"]');
     $I->seeInCurrentUrl('#/new');
     $I->click('[data-automation-id="create_welcome"]');
-    $I->waitForText('Welcome Email', 20);
+    $I->waitForText('Welcome Email');
     $I->seeInCurrentUrl('mailpoet-newsletters#/new/welcome');
     $I->click('Next');
-    $I->waitForElement($this->welcome_template, 20);
+    $I->waitForElement($this->welcome_template);
     $I->see('Welcome Emails', ['css' => 'a.current']);
     $I->seeInCurrentUrl('#/template');
     $I->click($this->welcome_template);
-    $I->waitForElement($this->title_element, 20);
+    $I->waitForElement($this->title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->fillField($this->title_element, $newsletter_title);
     $I->click('Next');
-    $I->waitForText('Reply-to', 20);
+    $I->waitForText('Reply-to');
     $I->click('Save as draft and close');
-    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]', 20);
+    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
     $I->seeInCurrentUrl('mailpoet-newsletters');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
   }
 
   function editWelcomeEmail(\AcceptanceTester $I) {
@@ -57,19 +57,19 @@ class ManageWelcomeEmailCest {
     $I->login();
     $I->amOnMailpoetPage('Emails');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
     $I->clickItemRowActionByItemName($newsletter_title, 'Edit');
-    $I->waitForElement($this->title_element, 10);
+    $I->waitForElement($this->title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->fillField($this->title_element, 'Edit Test Welcome Edited');
     $I->click('Next');
-    $I->waitForText('Reply-to', 20);
+    $I->waitForText('Reply-to');
     $I->click('Save as draft and close');
     $I->amOnMailpoetPage('Emails');
-    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]', 20);
+    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
     $I->seeInCurrentUrl('mailpoet-newsletters');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText('Edit Test Welcome Edited', 20);
+    $I->waitForText('Edit Test Welcome Edited');
   }
 
   function deleteWelcomeEmail(\AcceptanceTester $I) {
@@ -79,7 +79,7 @@ class ManageWelcomeEmailCest {
     $I->login();
     $I->amOnMailpoetPage('Emails');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
     $I->clickItemRowActionByItemName($newsletter_title, 'Move to trash');
     $I->waitForElement('[data-automation-id="filters_trash"]');
     $I->click('[data-automation-id="filters_trash"]');
@@ -87,7 +87,7 @@ class ManageWelcomeEmailCest {
     $I->clickItemRowActionByItemName($newsletter_title, 'Restore');
     $I->amOnMailpoetPage('Emails');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 15);
+    $I->waitForText($newsletter_title);
   }
 
   function duplicateWelcomeEmail (\AcceptanceTester $I) {
@@ -97,9 +97,9 @@ class ManageWelcomeEmailCest {
     $I->login();
     $I->amOnMailpoetPage('Emails');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
     $I->clickItemRowActionByItemName($newsletter_title, 'Duplicate');
-    $I->waitForText('Copy of ' . $newsletter_title, 10);
+    $I->waitForText('Copy of ' . $newsletter_title);
   }
 
   function searchForWelcomeEmail (\AcceptanceTester $I) {
@@ -110,12 +110,12 @@ class ManageWelcomeEmailCest {
     $I->login();
     $I->amOnMailpoetPage('Emails');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
     $I->searchFor($failure_condition_newsletter, 2);
     $I->wait(5);
-    $I->waitForElement('tr.no-items', 10);
+    $I->waitForElement('tr.no-items');
     $I->searchFor($newsletter_title);
-    $I->waitForText($newsletter_title, 10);
+    $I->waitForText($newsletter_title);
   }
 
   function saveWelcomeEmailAsTemplate (\AcceptanceTester $I) {
@@ -131,25 +131,25 @@ class ManageWelcomeEmailCest {
     $I->login();
     $I->amOnMailpoetPage('Emails');
     $I->click('Welcome Emails', '[data-automation-id="newsletters_listing_tabs"]');
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
     $I->clickItemRowActionByItemName($newsletter_title, 'Edit');
-    $I->waitForElement($this->title_element, 10);
+    $I->waitForElement($this->title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->click('[data-automation-id="newsletter_save_options_toggle"]');
-    $I->waitForElement($save_template_option, 10);
+    $I->waitForElement($save_template_option);
     $I->click($save_template_option);
-    $I->waitForElement($save_template_button, 10);
+    $I->waitForElement($save_template_button);
     $I->fillField('template_name', $template_title);
     $I->fillField('template_description', $template_descr);
     $I->click($save_template_button);
-    $I->waitForText('Template has been saved.', 20);
+    $I->waitForText('Template has been saved.');
     $I->amOnMailpoetPage('Emails');
     $I->click('[data-automation-id="new_email"]');
     $I->seeInCurrentUrl('#/new');
     $I->click('[data-automation-id="create_welcome"]');
     $I->seeInCurrentUrl('#/new/welcome');
     $I->click('Next');
-    $I->waitForElement($this->welcome_template, 20);
+    $I->waitForElement($this->welcome_template);
     $I->see('Welcome Emails', ['css' => 'a.current']);
     $I->seeInCurrentUrl('#/template');
     $I->see($template_title);

--- a/tests/acceptance/NewslettersListingCest.php
+++ b/tests/acceptance/NewslettersListingCest.php
@@ -33,7 +33,7 @@ class NewslettersListingCest {
     $I->click('[data-automation-id="settings-submit-button"]');
 
     $I->amOnMailpoetPage('Emails');
-    $I->waitForText('Subject', 5);
+    $I->waitForText('Subject');
     $I->dontSee('Opened, Clicked');
 
     // column is visible when tracking is enabled
@@ -43,7 +43,7 @@ class NewslettersListingCest {
     $I->click('[data-automation-id="settings-submit-button"]');
 
     $I->amOnMailpoetPage('Emails');
-    $I->waitForText('Subject', 5);
+    $I->waitForText('Subject');
     $I->see('Opened, Clicked');
     $I->seeNoJSErrors();
   }

--- a/tests/acceptance/ReceiveStandardEmailCest.php
+++ b/tests/acceptance/ReceiveStandardEmailCest.php
@@ -21,16 +21,16 @@ class ReceiveStandardEmailCest {
     $I->click('[data-automation-id=\'new_email\']');
     $I->seeInCurrentUrl('#/new');
     $I->click('[data-automation-id=\'create_standard\']');
-    $I->waitForElement($standard_template, 30);
+    $I->waitForElement($standard_template);
     $I->see('Newsletters', ['css' => 'a.current']);
     $I->seeInCurrentUrl('#/template');
     $I->click($standard_template);
-    $I->waitForElement($title_element, 30);
+    $I->waitForElement($title_element);
     $I->seeInCurrentUrl('mailpoet-newsletter-editor');
     $I->fillField($title_element, $newsletter_title);
     $I->click('Next');
     //Choose list and send
-    $I->waitForElement($send_form_element, 30);
+    $I->waitForElement($send_form_element);
     $I->seeInCurrentUrl('mailpoet-newsletters#/send/');
     $I->selectOptionInSelect2('WordPress Users');
     $I->click('Send');

--- a/tests/acceptance/ReinstallFromScratchCest.php
+++ b/tests/acceptance/ReinstallFromScratchCest.php
@@ -37,11 +37,11 @@ class ReinstallFromScratchCest {
 
     // Step 2 - reinstall from scratch
     $I->amOnPage('/wp-admin/admin.php?page=mailpoet-settings#advanced');
-    $I->waitForElement('#mailpoet_reinstall', 30);
+    $I->waitForElement('#mailpoet_reinstall');
     $I->click('Reinstall now...');
     $I->acceptPopup();
-    $I->waitForElement('#mailpoet_loading', 30);
-    $I->waitForElementNotVisible('#mailpoet_loading', 30);
+    $I->waitForElement('#mailpoet_loading');
+    $I->waitForElementNotVisible('#mailpoet_loading');
 
     // Step 3 - skip all tutorials, which could interfere with other tests
     $settings = new Settings();
@@ -50,7 +50,7 @@ class ReinstallFromScratchCest {
     // Step 4 - check if data are emptied and repopulated
     // Check emails
     $I->amOnMailpoetPage('Emails');
-    $I->waitForText('Nothing here yet!', 30);
+    $I->waitForText('Nothing here yet!');
     $I->seeNumberOfElements('[data-automation-id^=listing_item_]', 0);
     // Check forms
     $I->amOnMailpoetPage('Forms');

--- a/tests/acceptance/SaveNewsletterAsTemplateCest.php
+++ b/tests/acceptance/SaveNewsletterAsTemplateCest.php
@@ -29,7 +29,7 @@ class SaveNewsletterAsTemplateCest {
     $I->fillField(['name' => 'template_name'], $template_name);
     $I->fillField(['name' => 'template_description'], $template_description);
     $I->click('[data-automation-id="newsletter_save_as_template_button"]');
-    $I->waitForText('Template has been saved', 20);
+    $I->waitForText('Template has been saved');
 
     //step 4 - confirm template can be used
     $I->amOnMailpoetPage('Emails');

--- a/tests/acceptance/SaveNotificationAsDraftCest.php
+++ b/tests/acceptance/SaveNotificationAsDraftCest.php
@@ -26,7 +26,7 @@ class SaveNotificationAsDraftCest {
     $I->seeInCurrentUrl('mailpoet-newsletters#/send/');
     $I->selectOptionInSelect2('WordPress Users');
     $I->click('Save as draft and close');
-    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]', 10);
+    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
     $I->seeInCurrentUrl('/wp-admin/admin.php?page=mailpoet-newsletters#/notification');
     $I->waitForText('Draft Test Post Notification');
   }

--- a/tests/acceptance/SavePostNotificationEmailAsTemplateCest.php
+++ b/tests/acceptance/SavePostNotificationEmailAsTemplateCest.php
@@ -35,7 +35,7 @@ class SavePostNotificationEmailAsTemplateCest {
     $I->fillField('template_name', $template_title);
     $I->fillField('template_description', $template_descr);
     $I->click($save_template_button);
-    $I->waitForText('Template has been saved.', 20);
+    $I->waitForText('Template has been saved.');
 
     // step 4 - Use the new template
     $I->amOnMailpoetPage('Emails');

--- a/tests/acceptance/ScheduleNewsletterCest.php
+++ b/tests/acceptance/ScheduleNewsletterCest.php
@@ -29,7 +29,7 @@ class ScheduleNewsletterCest {
     $I->click('select[name=time]');
     $I->selectOption('form select[name=time]', '6:00');
     $I->click('Schedule');
-    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]', 20);
+    $I->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
     $I->seeInCurrentUrl('mailpoet-newsletters');
 
   }

--- a/tests/acceptance/SearchForNotificationCest.php
+++ b/tests/acceptance/SearchForNotificationCest.php
@@ -24,9 +24,9 @@ class SearchForNotificationCest {
     $I->waitForListingItemsToLoad();
     $I->searchFor($failure_condition_newsletter, 2);
     $I->wait(5);
-    $I->waitForElement('tr.no-items', 10);
+    $I->waitForElement('tr.no-items');
     $I->searchFor($newsletter_title);
-    $I->waitForText($newsletter_title, 10);
+    $I->waitForText($newsletter_title);
   }
 
 }

--- a/tests/acceptance/SearchForStandardNewsletterCest.php
+++ b/tests/acceptance/SearchForStandardNewsletterCest.php
@@ -26,7 +26,7 @@ class SearchForStandardNewsletterCest {
     $I->wait(5);
     $I->dontSee($newsletter_title);
     $I->searchFor($newsletter_title);
-    $I->waitForText($newsletter_title, 20);
+    $I->waitForText($newsletter_title);
   }
 
 }

--- a/tests/acceptance/SettingsPageBasicsCest.php
+++ b/tests/acceptance/SettingsPageBasicsCest.php
@@ -8,15 +8,15 @@ class SettingsPageBasicsCest {
     $I->login();
     $I->amOnMailPoetPage('Settings');
     //Basics Tab
-    $I->waitForText('Basics', 10);
+    $I->waitForText('Basics');
     $I->seeNoJSErrors();
     //Sign-up Confirmation Tab
     $I->click('[data-automation-id="signup_settings_tab"]');
-    $I->waitForText('Enable sign-up confirmation', 10);
+    $I->waitForText('Enable sign-up confirmation');
     $I->seeNoJSErrors();
     //Send With Tab
     $I->click('[data-automation-id="send_with_settings_tab"]');
-    $I->waitForText('MailPoet Sending Service', 10);
+    $I->waitForText('MailPoet Sending Service');
     $I->seeNoJSErrors();
     //Advanced Tab
     $I->click('[data-automation-id="settings-advanced-tab"]');
@@ -24,7 +24,7 @@ class SettingsPageBasicsCest {
     $I->seeNoJSErrors();
     //Activation Key Tab
     $I->click('[data-automation-id="activation_settings_tab"]');
-    $I->waitForText('Activation Key', 10);
+    $I->waitForText('Activation Key');
     $I->seeNoJSErrors();
   }
   function editDefaultSenderInformation(\AcceptanceTester $I) {
@@ -38,7 +38,7 @@ class SettingsPageBasicsCest {
     $I->fillField(['name' => 'reply_to[address]'], 'reply@fake.fake');
     //save settings
     $I->click('[data-automation-id="settings-submit-button"]');
-    $I->waitForText('Settings saved', 10);
+    $I->waitForText('Settings saved');
   }
   function allowSubscribeInComments(\AcceptanceTester $I) {
     $I->wantTo('Allow users to subscribe to lists in site comments');
@@ -51,9 +51,9 @@ class SettingsPageBasicsCest {
     //save settings
     $I->click('[data-automation-id="settings-submit-button"]');
     $I->amOnPage('/');
-    $I->waitForText($post_title, 10);
+    $I->waitForText($post_title);
     $I->click($post_title);
-    $I->waitForElement(['css'=>'.comment-form-mailpoet'], 10);
+    $I->waitForElement(['css'=>'.comment-form-mailpoet']);
     //clear checkbox to hide Select2 from next test
     $I->amOnMailPoetPage('Settings');
     $I->seeInCurrentUrl('page=mailpoet-settings');
@@ -62,7 +62,7 @@ class SettingsPageBasicsCest {
     $I->click('[data-automation-id="settings-submit-button"]');
     //check to make sure comment subscription form is gone
     $I->amOnPage('/');
-    $I->waitForText($post_title, 10);
+    $I->waitForText($post_title);
     $I->click($post_title);
     $I->dontSee("Yes, add me to your mailing list");    
   }

--- a/tests/acceptance/SettingsUnsubscribePageCest.php
+++ b/tests/acceptance/SettingsUnsubscribePageCest.php
@@ -9,7 +9,7 @@ class SettingsUnsubscribePageCest {
     $I->amOnMailPoetPage('Settings');
     $I->click('[data-automation-id="unsubscribe_page_preview_link"]');
     $I->switchToNextTab();
-    $I->waitForElement(['css'=>'.entry-title'], 20);
+    $I->waitForElement(['css'=>'.entry-title']);
     $I->seeInCurrentUrl('&action=unsubscribe');
   }
 

--- a/tests/acceptance/SubscribeToMultipleListsCest.php
+++ b/tests/acceptance/SubscribeToMultipleListsCest.php
@@ -46,9 +46,9 @@ class SubscribeToMultipleListsCest {
     $I->click('Click here to confirm your subscription');
     $I->switchToNextTab();
     $I->see('You have subscribed');
-    $I->waitForText($seg1, 10);
-    $I->waitForText($seg2, 10);
-    $I->waitForText($seg3, 10);
+    $I->waitForText($seg1);
+    $I->waitForText($seg2);
+    $I->waitForText($seg3);
     $I->seeNoJSErrors();
     //reset widget for other tests
     $I->cli('widget reset sidebar-1 --allow-root');

--- a/tests/acceptance/SubscriberManageImportExportCest.php
+++ b/tests/acceptance/SubscriberManageImportExportCest.php
@@ -11,7 +11,7 @@ class SubscriberManageImportExportCest {
     $I->amOnMailPoetPage ('Subscribers');
     //click import
     $I->click(['xpath'=>'//*[@id="subscribers_container"]/div/h1/a[2]']);
-    $I->waitForText('Back to Subscribers', 10);
+    $I->waitForText('Back to Subscribers');
     //select upload file as import method, import CSV
     $I->click(['css'=>'#select_method > label:nth-of-type(2)']);
     $I->attachFile(['css'=>'#file_local'], 'MailPoetImportList.csv');
@@ -22,28 +22,28 @@ class SubscriberManageImportExportCest {
     $I->click(['xpath'=>'//*[@id="select2-mailpoet_segments_select-results"]/li[2]']);
     //click next step
     $I->click(['xpath'=>'//*[@id="step2_process"]']);
-    $I->waitForText('Import again', 10);
+    $I->waitForText('Import again');
     //confirm subscribers from import list were added
     $I->amOnMailPoetPage ('Subscribers');
     $I->seeInCurrentUrl('mailpoet-subscribers#');
     $I->searchFor('aaa@example.com', 2);
-    $I->waitForText('aaa@example.com', 10);
+    $I->waitForText('aaa@example.com');
     $I->searchFor('bbb@example.com');
-    $I->waitForText('bbb@example.com', 10);
+    $I->waitForText('bbb@example.com');
     $I->searchFor('ccc@example.com');
-    $I->waitForText('ccc@example.com', 10);
+    $I->waitForText('ccc@example.com');
     $I->searchFor('ddd@example.com');
-    $I->waitForText('ddd@example.com', 10);
+    $I->waitForText('ddd@example.com');
     $I->searchFor('eee@example.com');
-    $I->waitForText('eee@example.com', 10);
+    $I->waitForText('eee@example.com');
     $I->searchFor('fff@example.com');
-    $I->waitForText('fff@example.com', 10);
+    $I->waitForText('fff@example.com');
     $I->searchFor('ggg@example.com');
-    $I->waitForText('ggg@example.com', 10);
+    $I->waitForText('ggg@example.com');
     $I->searchFor('hhh@example.com');
-    $I->waitForText('hhh@example.com', 10);
+    $I->waitForText('hhh@example.com');
     $I->searchFor('iii@example.com');
-    $I->waitForText('iii@example.com', 10);
+    $I->waitForText('iii@example.com');
     $I->seeNoJSErrors();
   }
 }

--- a/tests/acceptance/SubscriberManagementCest.php
+++ b/tests/acceptance/SubscriberManagementCest.php
@@ -46,7 +46,7 @@ class SubscriberManagementCest {
     $I->wantTo('View list of subscribers');
     $this->generateWPUsersList($I);
     $I->searchFor('Alec Saunders', 2);
-    $I->waitForText('Alec Saunders', 10);
+    $I->waitForText('Alec Saunders');
     $I->seeNoJSErrors();
   }
 
@@ -63,7 +63,7 @@ class SubscriberManagementCest {
     $I->click('[data-automation-id="subscriber_edit_form"] input[type="submit"]');
     $I->amOnMailPoetPage ('Subscribers');
     $I->searchFor('newglobaluser99@fakemail.fake', 2);
-    $I->waitForText('newglobaluser99@fakemail.fake', 10);
+    $I->waitForText('newglobaluser99@fakemail.fake');
     $I->seeNoJSErrors();
   }
 
@@ -93,7 +93,7 @@ class SubscriberManagementCest {
     $I->amOnMailPoetPage ('Subscribers');
     $I->waitForListingItemsToLoad();
     $I->clickItemRowActionByItemName($new_subscriber_email, 'Edit');
-    $I->waitForText('Subscriber', 30);
+    $I->waitForText('Subscriber');
     $I->seeInCurrentUrl('mailpoet-subscribers#/edit/');
     $I->waitForElementNotVisible('.mailpoet_form_loading');
     $I->selectOptionInSelect2('Cooking');
@@ -109,13 +109,13 @@ class SubscriberManagementCest {
     $I->amOnMailPoetPage ('Subscribers');
     $I->waitForListingItemsToLoad();
     $I->clickItemRowActionByItemName($new_subscriber_email, 'Edit');
-    $I->waitForText('Subscriber', 10);
+    $I->waitForText('Subscriber');
     $I->seeInCurrentUrl('mailpoet-subscribers#/edit/');
     $I->waitForElementNotVisible('.mailpoet_form_loading');
     $I->selectOptionInSelect2('Cooking');
     $I->click('.select2-selection__choice__remove');
     $I->click('[data-automation-id="subscriber_edit_form"] input[type="submit"]');
-    $I->waitForText('Subscriber was updated', 10);
+    $I->waitForText('Subscriber was updated');
   }
 
   function editSubscriber(\AcceptanceTester $I) {
@@ -126,7 +126,7 @@ class SubscriberManagementCest {
     $I->amOnMailPoetPage ('Subscribers');
     $I->waitForListingItemsToLoad();
     $I->clickItemRowActionByItemName($new_subscriber_email, 'Edit');
-    $I->waitForText('Subscriber', 10);
+    $I->waitForText('Subscriber');
     $I->seeInCurrentUrl('mailpoet-subscribers#/edit/');
   }
 

--- a/tests/acceptance/SubscribersListingCest.php
+++ b/tests/acceptance/SubscribersListingCest.php
@@ -10,7 +10,7 @@ class SubscribersListingCest {
     $I->login();
     $I->amOnMailpoetPage('Subscribers');
     $I->searchFor('wp@example.com', 2);
-    $I->waitForText('wp@example.com', 10);
+    $I->waitForText('wp@example.com');
   }
 
 }

--- a/tests/acceptance/SubscriptionFormEditCest.php
+++ b/tests/acceptance/SubscriptionFormEditCest.php
@@ -19,16 +19,16 @@ class SubscriptionFormEditCest {
     $I->wantTo('Edit a form');
     $I->login();
     $I->amOnMailpoetPage('Forms');
-    $I->waitForText($form_name, 10);
+    $I->waitForText($form_name);
     $I->clickItemRowActionByItemName($form_name, 'Edit');
     $title_element = '[data-automation-id="mailpoet_form_name_input"]';
-    $I->waitForElement($title_element, 10);
+    $I->waitForElement($title_element);
     $I->seeInCurrentUrl('mailpoet-form-editor');
     $I->fillField($title_element, $form_edited_name);
     $I->selectOptionInSelect2('My First List');
     $I->click('[data-automation-id="save_form"]');
     //Step three - assertions
-    $I->waitForText('Saved!', 10);
+    $I->waitForText('Saved!');
     $I->amOnMailpoetPage('Forms');
     $I->waitForText($form_edited_name);
   }


### PR DESCRIPTION
Now there are three ways to set default timeouts:
* `WAIT_TIMEOUT` environment variable;
* `DEFAULT_WAIT_TIMEOUT` constant (if we need to set it for all environments);
* Leave both empty to use default timeouts for every function as specified in Codeception docs.

With these improvements, there's hopefully no need to explicitly set timeouts for individual method calls.