### PR TITLE
Css specificity fixes in renderer [MAILPOET-1730]

### DIFF
--- a/lib/Newsletter/Renderer/Blocks/Footer.php
+++ b/lib/Newsletter/Renderer/Blocks/Footer.php
@@ -17,9 +17,10 @@ class Footer {
     if(isset($element['styles']['link'])) {
       $links = $DOM->query('a');
       if($links->count()) {
+        $css = new CSS();
         foreach($links as $link) {
           $element_link_styles = StylesHelper::getStyles($element['styles'], 'link');
-          $link->style = CSS::mergeInlineStyles($element_link_styles, $link->style);
+          $link->style = $css->mergeInlineStyles($element_link_styles, $link->style);
         }
       }
     }

--- a/lib/Newsletter/Renderer/Blocks/Header.php
+++ b/lib/Newsletter/Renderer/Blocks/Header.php
@@ -17,9 +17,10 @@ class Header {
     if(isset($element['styles']['link'])) {
       $links = $DOM->query('a');
       if($links->count()) {
+        $css = new CSS();
         foreach($links as $link) {
           $element_link_styles = StylesHelper::getStyles($element['styles'], 'link');
-          $link->style = CSS::mergeInlineStyles($element_link_styles, $link->style);
+          $link->style = $css->mergeInlineStyles($element_link_styles, $link->style);
         }
       }
     }

--- a/lib/Util/CSS.php
+++ b/lib/Util/CSS.php
@@ -28,9 +28,151 @@ use csstidy;
 */
 
 class CSS {
-  private $parsed_css = array();
+  /*
+  * The core of the algorithm, takes a URL and returns the HTML found there with the CSS inlined.
+  * If you pass $contents then the original HTML is not downloaded and $contents is used instead.
+  * $url is mandatory as it is used to resolve the links to the stylesheets found in the HTML.
+  */
+  function inlineCSS($url, $contents=null) {
+    $html = \pQuery::parseStr($contents);
 
-  public static function splitMediaQueries($css) {
+    if(!is_object($html)) {
+      return false;
+    }
+
+    $css_blocks = '';
+
+    // Find all <style> blocks and cut styles from them (leaving media queries)
+    foreach($html->query('style') as $style) {
+      list($_css_to_parse, $_css_to_keep) = $this->splitMediaQueries($style->getInnerText());
+      $css_blocks .= $_css_to_parse;
+      if(!empty($_css_to_keep)) {
+        $style->setInnerText($_css_to_keep);
+      } else {
+        $style->setOuterText('');
+      }
+    }
+
+    $raw_css = '';
+    if(!empty($css_blocks)) {
+      $raw_css .= $css_blocks;
+    }
+
+    // Get the CSS rules by decreasing specificity (the most specific rule first).
+    // This is an array with, amongst other things, the keys 'properties', which hold the CSS properties
+    // and the 'selector', which holds the CSS selector
+    $rules = $this->parseCSS($raw_css);
+
+    // We loop over each rule by increasing order of specificity, find the nodes matching the selector
+    // and apply the CSS properties
+    foreach ($rules as $rule) {
+      foreach($html->query($rule['selector']) as $node) {
+        // I'm leaving this for debug purposes, it has proved useful.
+        /*
+        if($node->already_styled === 'yes')
+        {
+          echo "<PRE>";
+          echo "Rule:\n";
+          print_r($rule);
+          echo "\n\nOld style:\n";
+          echo $node->style."\n";
+          print_r($this->styleToArray($node->style));
+          echo "\n\nNew style:\n";
+          print_r(array_merge($this->styleToArray($node->style), $rule['properties']));
+          echo "</PRE>";
+          die();
+        }//*/
+
+        // Unserialize the style array, merge the rule's CSS into it...
+        $nodeStyles = $this->styleToArray($node->style);
+        $style = array_merge($rule['properties'], $nodeStyles);
+
+        // And put the CSS back as a string!
+        $node->style = $this->arrayToStyle($style);
+
+        // I'm leaving this for debug purposes, it has proved useful.
+        /*
+        if($rule['selector'] === 'table.table-recap td')
+        {
+          $node->already_styled = 'yes';
+        }//*/
+      }
+    }
+
+    // Now a tricky part: do a second pass with only stuff marked !important
+    // because !important properties do not care about specificity, except when fighting
+    // against another !important property
+    // We need to start with a rule with lowest specificity
+    $rules = array_reverse($rules);
+    foreach ($rules as $rule) {
+      foreach($rule['properties'] as $key => $value) {
+        if(strpos($value, '!important') === false) {
+          continue;
+        }
+        foreach($html->query($rule['selector']) as $node) {
+          $style = $this->styleToArray($node->style);
+          $style[$key] = $value;
+          $node->style = $this->arrayToStyle($style);
+          // remove all !important tags (inlined styles take precedent over others anyway)
+          $node->style = str_replace("!important", "", $node->style);
+        }
+      }
+    }
+
+    // Let simple_html_dom give us back our HTML with inline CSS!
+    return (string)$html;
+  }
+
+  function parseCSS($text) {
+    $css  = new csstidy();
+    $css->settings['compress_colors'] = false;
+    $css->parse($text);
+
+    $rules    = array();
+    $position   = 0;
+
+    foreach($css->css as $declarations) {
+      foreach($declarations as $selectors => $properties) {
+        foreach(explode(",", $selectors) as $selector) {
+          $rules[] = array(
+            'position'    => $position,
+            'specificity'   => $this->calculateCSSSpecifity($selector),
+            'selector'    => $selector,
+            'properties'  => $properties
+          );
+        }
+
+        $position += 1;
+      }
+    }
+
+    usort($rules, function($a, $b) {
+      if($a['specificity'] > $b['specificity']) {
+        return -1;
+      } else if($a['specificity'] < $b['specificity']) {
+        return 1;
+      } else {
+        if($a['position'] > $b['position']) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+    });
+
+    return $rules;
+  }
+
+  /*
+  * Merges two CSS inline styles strings into one.
+  * If both styles defines same property the property from second styles will be used.
+  */
+  function mergeInlineStyles($styles_1, $styles_2) {
+    $merged_styles = array_merge($this->styleToArray($styles_1), $this->styleToArray($styles_2));
+    return $this->arrayToStyle($merged_styles);
+  }
+
+  private function splitMediaQueries($css) {
     $start = 0;
     $queries = '';
 
@@ -69,46 +211,6 @@ class CSS {
     return array($css, $queries);
   }
 
-  public function parseCSS($text) {
-    $css  = new csstidy();
-    $css->settings['compress_colors'] = false;
-    $css->parse($text);
-
-    $rules    = array();
-    $position   = 0;
-
-    foreach($css->css as $declarations) {
-      foreach($declarations as $selectors => $properties) {
-        foreach(explode(",", $selectors) as $selector) {
-          $rules[] = array(
-            'position'    => $position,
-            'specificity'   => self::calculateCSSSpecifity($selector),
-            'selector'    => $selector,
-            'properties'  => $properties
-          );
-        }
-
-        $position += 1;
-      }
-    }
-
-    usort($rules, function($a, $b) {
-      if($a['specificity'] > $b['specificity']) {
-        return -1;
-      } else if($a['specificity'] < $b['specificity']) {
-        return 1;
-      } else {
-        if($a['position'] > $b['position']) {
-          return -1;
-        } else {
-          return 1;
-        }
-      }
-    });
-
-    return $rules;
-  }
-
   /**
    * The following function fomes from CssToInlineStyles.php - here is the original licence FOR THIS FUNCTION
    *
@@ -120,7 +222,7 @@ class CSS {
    * @license   BSD License
    */
 
-  public static function calculateCSSSpecifity($selector) {
+  private function calculateCSSSpecifity($selector) {
       // cleanup selector
     $selector = str_replace(array('>', '+'), array(' > ', ' + '), $selector);
 
@@ -150,7 +252,7 @@ class CSS {
   * Turns a CSS style string (like: "border: 1px solid black; color:red")
   * into an array of properties (like: array("border" => "1px solid black", "color" => "red"))
   */
-  public static function styleToArray($str) {
+  private function styleToArray($str) {
     $array = array();
 
     if(trim($str) === '') return $array;
@@ -171,114 +273,11 @@ class CSS {
   * Reverses what styleToArray does, see above.
   * array("border" => "1px solid black", "color" => "red") yields "border: 1px solid black; color:red"
   */
-  public static function arrayToStyle($array) {
+  private function arrayToStyle($array) {
     $parts = array();
     foreach($array as $k => $v) {
       $parts[] = "$k:$v";
     }
     return implode(';', $parts);
-  }
-
-  /*
-   * Merges two CSS inline styles strings into one.
-   * If both styles defines same property the property from second styles will be used.
-   */
-  public static function mergeInlineStyles($styles_1, $styles_2) {
-    $merged_styles = array_merge(self::styleToArray($styles_1), self::styleToArray($styles_2));
-    return self::arrayToStyle($merged_styles);
-  }
-
-  /*
-  * The core of the algorithm, takes a URL and returns the HTML found there with the CSS inlined.
-  * If you pass $contents then the original HTML is not downloaded and $contents is used instead.
-  * $url is mandatory as it is used to resolve the links to the stylesheets found in the HTML.
-  */
-  function inlineCSS($url, $contents=null) {
-    $html = \pQuery::parseStr($contents);
-
-    if(!is_object($html)) {
-      return false;
-    }
-
-    $css_blocks = '';
-
-    // Find all <style> blocks and cut styles from them (leaving media queries)
-    foreach($html->query('style') as $style) {
-      list($_css_to_parse, $_css_to_keep) = self::splitMediaQueries($style->getInnerText());
-      $css_blocks .= $_css_to_parse;
-      if(!empty($_css_to_keep)) {
-        $style->setInnerText($_css_to_keep);
-      } else {
-        $style->setOuterText('');
-      }
-    }
-
-    $raw_css = '';
-    if(!empty($css_blocks)) {
-      $raw_css .= $css_blocks;
-    }
-
-    // Get the CSS rules by decreasing specificity (the most specific rule first).
-    // This is an array with, amongst other things, the keys 'properties', which hold the CSS properties
-    // and the 'selector', which holds the CSS selector
-    $rules = $this->parseCSS($raw_css);
-
-    // We loop over each rule by increasing order of specificity, find the nodes matching the selector
-    // and apply the CSS properties
-    foreach ($rules as $rule) {
-      foreach($html->query($rule['selector']) as $node) {
-        // I'm leaving this for debug purposes, it has proved useful.
-        /*
-        if($node->already_styled === 'yes')
-        {
-          echo "<PRE>";
-          echo "Rule:\n";
-          print_r($rule);
-          echo "\n\nOld style:\n";
-          echo $node->style."\n";
-          print_r(self::styleToArray($node->style));
-          echo "\n\nNew style:\n";
-          print_r(array_merge(self::styleToArray($node->style), $rule['properties']));
-          echo "</PRE>";
-          die();
-        }//*/
-
-        // Unserialize the style array, merge the rule's CSS into it...
-        $nodeStyles = self::styleToArray($node->style);
-        $style = array_merge($rule['properties'], $nodeStyles);
-
-        // And put the CSS back as a string!
-        $node->style = self::arrayToStyle($style);
-
-        // I'm leaving this for debug purposes, it has proved useful.
-        /*
-        if($rule['selector'] === 'table.table-recap td')
-        {
-          $node->already_styled = 'yes';
-        }//*/
-      }
-    }
-
-    // Now a tricky part: do a second pass with only stuff marked !important
-    // because !important properties do not care about specificity, except when fighting
-    // against another !important property
-    // We need to start with a rule with lowest specificity
-    $rules = array_reverse($rules);
-    foreach ($rules as $rule) {
-      foreach($rule['properties'] as $key => $value) {
-        if(strpos($value, '!important') !== false) {
-          foreach($html->query($rule['selector']) as $node) {
-            $style = self::styleToArray($node->style);
-            $style[$key] = $value;
-            $node->style = self::arrayToStyle($style);
-            // remove all !important tags (inlined styles take precedent over others anyway)
-            $node->style = str_replace("!important", "", $node->style);
-          }
-        }
-      }
-    }
-
-    // Let simple_html_dom give us back our HTML with inline CSS!
-    return (string)$html;
   }
 }

--- a/tests/unit/Util/CSSTest.php
+++ b/tests/unit/Util/CSSTest.php
@@ -70,13 +70,13 @@ class CSSTest extends \MailPoetUnitTest {
   }
 
   public function testItMergesInlineStylesCorrectly() {
-    $styles = CSS::mergeInlineStyles('color: red', 'margin: 10px');
+    $styles = $this->css->mergeInlineStyles('color: red', 'margin: 10px');
     $this->assertEquals('color:red;margin:10px', $styles);
-    $styles = CSS::mergeInlineStyles('color: red', 'margin: 10px; color: blue');
+    $styles = $this->css->mergeInlineStyles('color: red', 'margin: 10px; color: blue');
     $this->assertEquals('color:blue;margin:10px', $styles);
-    $styles = CSS::mergeInlineStyles('', 'margin: 10px; color: blue');
+    $styles = $this->css->mergeInlineStyles('', 'margin: 10px; color: blue');
     $this->assertEquals('margin:10px;color:blue', $styles);
-    $styles = CSS::mergeInlineStyles('margin:10px;color:blue', '');
+    $styles = $this->css->mergeInlineStyles('margin:10px;color:blue', '');
     $this->assertEquals('margin:10px;color:blue', $styles);
   }
 


### PR DESCRIPTION
I think It was a combination of more bugs.
- parseCss method returned rules in wrong order (should be most specific rule first)
- node styles were always overwritten by rule styles

After this changes we apply rules on node but we never overwrite styles which are already on node (inline styles or styles from previously applied more specific rule) and in the end we apply important css rules.

