### PR TITLE
Add WooCommerce customer synchronization [MAILPOET-1723]

### DIFF
--- a/lib/Analytics/Reporter.php
+++ b/lib/Analytics/Reporter.php
@@ -9,6 +9,7 @@ use MailPoet\Models\Subscriber;
 use MailPoet\Settings\Pages;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 
 class Reporter {
   /** @var SettingsController */
@@ -26,7 +27,8 @@ class Reporter {
     $checker = new ServicesChecker();
     $bounceAddress = $this->settings->get('bounce.address');
     $segments = Segment::getAnalytics();
-    $has_wc = class_exists('WooCommerce');
+    $woocommerce_helper = new WooCommerceHelper;
+    $has_wc = $woocommerce_helper->isWooCommerceActive();
     $wc_customers_count = 0;
     if($has_wc) {
       $wc_customers_count = (int)Newsletter::rawQuery(

--- a/lib/Analytics/Reporter.php
+++ b/lib/Analytics/Reporter.php
@@ -15,8 +15,12 @@ class Reporter {
   /** @var SettingsController */
   private $settings;
 
+  /** @var WooCommerceHelper */
+  private $woocommerce_helper;
+
   public function __construct(SettingsController $settings) {
     $this->settings = $settings;
+    $this->woocommerce_helper = new WooCommerceHelper;
   }
 
   function getData() {
@@ -27,8 +31,7 @@ class Reporter {
     $checker = new ServicesChecker();
     $bounceAddress = $this->settings->get('bounce.address');
     $segments = Segment::getAnalytics();
-    $woocommerce_helper = new WooCommerceHelper;
-    $has_wc = $woocommerce_helper->isWooCommerceActive();
+    $has_wc = $this->woocommerce_helper->isWooCommerceActive();
     $wc_customers_count = 0;
     if($has_wc) {
       $wc_customers_count = (int)Newsletter::rawQuery(

--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -52,25 +52,25 @@ class Hooks {
       (bool)$subscribe['on_comment']['enabled']
     ) {
       if($this->wp->isUserLoggedIn()) {
-        add_action(
+        $this->wp->addAction(
           'comment_form_field_comment',
           '\MailPoet\Subscription\Comment::extendLoggedInForm'
         );
       } else {
-        add_action(
+        $this->wp->addAction(
           'comment_form_after_fields',
           '\MailPoet\Subscription\Comment::extendLoggedOutForm'
         );
       }
 
-      add_action(
+      $this->wp->addAction(
         'comment_post',
         '\MailPoet\Subscription\Comment::onSubmit',
         60,
         2
       );
 
-      add_action(
+      $this->wp->addAction(
         'wp_set_comment_status',
         '\MailPoet\Subscription\Comment::onStatusUpdate',
         60,
@@ -85,22 +85,22 @@ class Hooks {
       (bool)$subscribe['on_register']['enabled']
     ) {
       if(is_multisite()) {
-        add_action(
+        $this->wp->addAction(
           'signup_extra_fields',
           '\MailPoet\Subscription\Registration::extendForm'
         );
-        add_action(
+        $this->wp->addAction(
           'wpmu_validate_user_signup',
           '\MailPoet\Subscription\Registration::onMultiSiteRegister',
           60,
           1
         );
       } else {
-        add_action(
+        $this->wp->addAction(
           'register_form',
           '\MailPoet\Subscription\Registration::extendForm'
         );
-        add_action(
+        $this->wp->addAction(
           'register_post',
           '\MailPoet\Subscription\Registration::onRegister',
           60,
@@ -110,21 +110,21 @@ class Hooks {
     }
 
     // Manage subscription
-    add_action(
+    $this->wp->addAction(
       'admin_post_mailpoet_subscription_update',
       '\MailPoet\Subscription\Manage::onSave'
     );
-    add_action(
+    $this->wp->addAction(
       'admin_post_nopriv_mailpoet_subscription_update',
       '\MailPoet\Subscription\Manage::onSave'
     );
 
     // Subscription form
-    add_action(
+    $this->wp->addAction(
       'admin_post_mailpoet_subscription_form',
       [$this->subscription_form, 'onSubmit']
     );
-    add_action(
+    $this->wp->addAction(
       'admin_post_nopriv_mailpoet_subscription_form',
       [$this->subscription_form, 'onSubmit']
     );
@@ -132,33 +132,33 @@ class Hooks {
 
   function setupWPUsers() {
     // WP Users synchronization
-    add_action(
+    $this->wp->addAction(
       'user_register',
       '\MailPoet\Segments\WP::synchronizeUser',
       6
     );
-    add_action(
+    $this->wp->addAction(
       'added_existing_user',
       '\MailPoet\Segments\WP::synchronizeUser',
       6
     );
-    add_action(
+    $this->wp->addAction(
       'profile_update',
       '\MailPoet\Segments\WP::synchronizeUser',
       6, 2
     );
-    add_action(
+    $this->wp->addAction(
       'delete_user',
       '\MailPoet\Segments\WP::synchronizeUser',
       1
     );
     // multisite
-    add_action(
+    $this->wp->addAction(
       'deleted_user',
       '\MailPoet\Segments\WP::synchronizeUser',
       1
     );
-    add_action(
+    $this->wp->addAction(
       'remove_user_from_blog',
       '\MailPoet\Segments\WP::synchronizeUser',
       1
@@ -167,27 +167,27 @@ class Hooks {
 
   function setupWooCommerceUsers() {
     // WooCommerce Customers synchronization
-    add_action(
+    $this->wp->addAction(
       'woocommerce_new_customer',
       [$this->woocommerce_segment, 'synchronizeRegisteredCustomer'],
       7
     );
-    add_action(
+    $this->wp->addAction(
       'woocommerce_update_customer',
       [$this->woocommerce_segment, 'synchronizeRegisteredCustomer'],
       7
     );
-    add_action(
+    $this->wp->addAction(
       'woocommerce_delete_customer',
       [$this->woocommerce_segment, 'synchronizeRegisteredCustomer'],
       7
     );
-    add_action(
+    $this->wp->addAction(
       'woocommerce_checkout_update_order_meta',
       [$this->woocommerce_segment, 'synchronizeGuestCustomer'],
       7
     );
-    add_action(
+    $this->wp->addAction(
       'woocommerce_process_shop_order_meta',
       [$this->woocommerce_segment, 'synchronizeGuestCustomer'],
       7
@@ -195,7 +195,7 @@ class Hooks {
   }
 
   function setupImageSize() {
-    add_filter(
+    $this->wp->addFilter(
       'image_size_names_choose',
       array($this, 'appendImageSize'),
       10, 1
@@ -209,7 +209,7 @@ class Hooks {
   }
 
   function setupListing() {
-    add_filter(
+    $this->wp->addFilter(
       'set-screen-option',
       array($this, 'setScreenOption'),
       10, 3
@@ -225,7 +225,7 @@ class Hooks {
   }
 
   function setupPostNotifications() {
-    add_action(
+    $this->wp->addAction(
       'transition_post_status',
       '\MailPoet\Newsletter\Scheduler\Scheduler::transitionHook',
       10, 3

--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -4,6 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscription\Form;
+use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Hooks {
@@ -17,18 +18,24 @@ class Hooks {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var WooCommerceSegment */
+  private $woocommerce_segment;
+
   function __construct(
     Form $subscription_form,
     SettingsController $settings,
-    WPFunctions $wp
+    WPFunctions $wp,
+    WooCommerceSegment $woocommerce_segment
   ) {
     $this->subscription_form = $subscription_form;
     $this->settings = $settings;
     $this->wp = $wp;
+    $this->woocommerce_segment = $woocommerce_segment;
   }
 
   function init() {
     $this->setupWPUsers();
+    $this->setupWooCommerceUsers();
     $this->setupImageSize();
     $this->setupListing();
     $this->setupSubscriptionEvents();
@@ -155,6 +162,35 @@ class Hooks {
       'remove_user_from_blog',
       '\MailPoet\Segments\WP::synchronizeUser',
       1
+    );
+  }
+
+  function setupWooCommerceUsers() {
+    // WooCommerce Customers synchronization
+    add_action(
+      'woocommerce_new_customer',
+      [$this->woocommerce_segment, 'synchronizeRegisteredCustomer'],
+      7
+    );
+    add_action(
+      'woocommerce_update_customer',
+      [$this->woocommerce_segment, 'synchronizeRegisteredCustomer'],
+      7
+    );
+    add_action(
+      'woocommerce_delete_customer',
+      [$this->woocommerce_segment, 'synchronizeRegisteredCustomer'],
+      7
+    );
+    add_action(
+      'woocommerce_checkout_update_order_meta',
+      [$this->woocommerce_segment, 'synchronizeGuestCustomer'],
+      7
+    );
+    add_action(
+      'woocommerce_process_shop_order_meta',
+      [$this->woocommerce_segment, 'synchronizeGuestCustomer'],
+      7
     );
   }
 

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -25,6 +25,7 @@ use MailPoet\Tasks\Sending;
 use MailPoet\Tasks\State;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\License\License;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\DateTime;
 use MailPoet\WP\Notice as WPNotice;
 use MailPoet\WP\Readme;
@@ -35,6 +36,9 @@ if(!defined('ABSPATH')) exit;
 class Menu {
   const MAIN_PAGE_SLUG = 'mailpoet-newsletters';
   const LAST_ANNOUNCEMENT_DATE = '2019-01-28 10:00:00';
+
+  /** @var WooCommerceHelper */
+  private $woocommerce_helper;
 
   /** @var Renderer */
   public $renderer;
@@ -54,12 +58,14 @@ class Menu {
     Renderer $renderer,
     AccessControl $access_control,
     SettingsController $settings,
-    WPFunctions $wp
+    WPFunctions $wp,
+    WooCommerceHelper $woocommerce_helper
   ) {
     $this->renderer = $renderer;
     $this->access_control = $access_control;
     $this->wp = $wp;
     $this->settings = $settings;
+    $this->woocommerce_helper = $woocommerce_helper;
   }
 
   function init() {
@@ -370,7 +376,7 @@ class Menu {
     if((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
     $data = [
       'is_mp2_migration_complete' => (bool)$this->settings->get('mailpoet_migration_complete'),
-      'is_woocommerce_active' => class_exists('WooCommerce'),
+      'is_woocommerce_active' => $this->woocommerce_helper->isWooCommerceActive(),
       'finish_wizard_url' => admin_url('admin.php?page=' . self::MAIN_PAGE_SLUG),
       'sender' => $this->settings->get('sender'),
       'reply_to' => $this->settings->get('reply_to'),
@@ -617,7 +623,7 @@ class Menu {
 
     $data['tracking_enabled'] = $this->settings->get('tracking.enabled');
     $data['premium_plugin_active'] = License::getLicense();
-    $data['is_woocommerce_active'] = class_exists('WooCommerce');
+    $data['is_woocommerce_active'] = $this->woocommerce_helper->isWooCommerceActive();
 
     $user_id = $data['current_wp_user']['ID'];
     $data['feature_announcement_has_news'] = empty($data['settings']['last_announcement_seen'][$user_id])

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -197,7 +197,7 @@ class Migrator {
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'deleted_at timestamp NULL,',
       'unconfirmed_data longtext,',
-      "source enum('form','imported','administrator','api','wordpress_user','unknown') DEFAULT 'unknown',",
+      "source enum('form','imported','administrator','api','wordpress_user','woocommerce_user','unknown') DEFAULT 'unknown',",
       'count_confirmations int(11) unsigned NOT NULL DEFAULT 0,',
       'PRIMARY KEY  (id),',
       'UNIQUE KEY email (email),',

--- a/lib/Cron/Daemon.php
+++ b/lib/Cron/Daemon.php
@@ -27,6 +27,7 @@ class Daemon {
       $this->executeSendingServiceKeyCheckWorker();
       $this->executePremiumKeyCheckWorker();
       $this->executeBounceWorker();
+      //$this->executeWooCommerceSyncWorker();
     } catch(\Exception $e) {
       CronHelper::saveDaemonLastError($e->getMessage());
     }
@@ -62,6 +63,11 @@ class Daemon {
   function executeBounceWorker() {
     $bounce = $this->workers_factory->createBounceWorker($this->timer);
     return $bounce->process();
+  }
+
+  function executeWooCommerceSyncWorker() {
+    $worker = $this->workers_factory->createWooCommerceSyncWorker($this->timer);
+    return $worker->process();
   }
 
   function executeMigrationWorker() {

--- a/lib/Cron/Daemon.php
+++ b/lib/Cron/Daemon.php
@@ -27,7 +27,7 @@ class Daemon {
       $this->executeSendingServiceKeyCheckWorker();
       $this->executePremiumKeyCheckWorker();
       $this->executeBounceWorker();
-      //$this->executeWooCommerceSyncWorker();
+      // TODO: execute WooCommerceSync worker
     } catch(\Exception $e) {
       CronHelper::saveDaemonLastError($e->getMessage());
     }

--- a/lib/Cron/Workers/WooCommerceSync.php
+++ b/lib/Cron/Workers/WooCommerceSync.php
@@ -1,0 +1,39 @@
+<?php
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Cron\CronHelper;
+use MailPoet\Models\ScheduledTask;
+use MailPoet\Segments\WooCommerce as WooCommerceSegment;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+
+if(!defined('ABSPATH')) exit;
+
+class WooCommerceSync extends SimpleWorker {
+  const TASK_TYPE = 'woocommerce_sync';
+
+  /** @var WooCommerceSegment */
+  private $woocommerce_segment;
+
+  /** @var WooCommerceHelper */
+  private $woocommerce_helper;
+
+  function __construct(WooCommerceSegment $woocommerce_segment, WooCommerceHelper $woocommerce_helper, $timer = false) {
+    $this->woocommerce_segment = $woocommerce_segment;
+    $this->woocommerce_helper = $woocommerce_helper;
+    parent::__construct($timer);
+  }
+
+  function checkProcessingRequirements() {
+    return $this->woocommerce_helper->isWooCommerceActive();
+  }
+
+  function processTaskStrategy(ScheduledTask $task) {
+
+    $this->woocommerce_segment->synchronizeCustomers();
+
+    // abort if execution limit is reached
+    CronHelper::enforceExecutionLimit($this->timer);
+
+    return true;
+  }
+}

--- a/lib/Cron/Workers/WorkersFactory.php
+++ b/lib/Cron/Workers/WorkersFactory.php
@@ -11,7 +11,9 @@ use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
 use MailPoet\Cron\Workers\Bounce as BounceWorker;
 use MailPoet\Cron\Workers\KeyCheck\PremiumKeyCheck as PremiumKeyCheckWorker;
 use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck as SendingServiceKeyCheckWorker;
+use MailPoet\Cron\Workers\WooCommerceSync as WooCommerceSyncWorker;
 use MailPoet\Cron\Workers\SendingQueue\SendingErrorHandler;
+use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Settings\SettingsController;
 
@@ -29,6 +31,9 @@ class WorkersFactory {
   /** @var SettingsController */
   private $settings;
 
+  /** @var WooCommerceSegment */
+  private $woocommerce_segment;
+
   /**
    * @var Renderer
    */
@@ -39,13 +44,15 @@ class WorkersFactory {
     StatsNotificationScheduler $scheduler,
     Mailer $mailer,
     Renderer $renderer,
-    SettingsController $settings
-   ) {
+    SettingsController $settings,
+    WooCommerceSegment $woocommerce_segment
+  ) {
     $this->sending_error_handler = $sending_error_handler;
     $this->scheduler = $scheduler;
     $this->mailer = $mailer;
     $this->renderer = $renderer;
     $this->settings = $settings;
+    $this->woocommerce_segment = $woocommerce_segment;
   }
 
   /** @return SchedulerWorker */
@@ -80,6 +87,11 @@ class WorkersFactory {
   /** @return MigrationWorker */
   function createMigrationWorker($timer) {
     return new MigrationWorker($timer);
+  }
+
+  /** @return WooCommerceSyncWorker */
+  function createWooCommerceSyncWorker($timer) {
+    return new WooCommerceSyncWorker($this->woocommerce_segment, $timer);
   }
 
 }

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -86,6 +86,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscription\Form::class)->setPublic(true);
     // Newsletter
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
+    // WooCommerce
+    $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
     // WordPress
     $container->autowire(\MailPoet\WP\Functions::class)->setPublic(true);
     return $container;

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -80,6 +80,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
     // Segments
     $container->autowire(\MailPoet\Segments\SubscribersListings::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\WooCommerce::class)->setPublic(true);
     // Settings
     $container->autowire(\MailPoet\Settings\SettingsController::class)->setPublic(true);
     // Subscription

--- a/lib/Segments/WooCommerce.php
+++ b/lib/Segments/WooCommerce.php
@@ -86,26 +86,19 @@ class WooCommerce {
 
     if($wc_order === false or $wc_segment === false) return;
 
-    $current_filter = $current_filter ?: $this->wp->currentFilter();
-    switch($current_filter) {
-      case 'woocommerce_checkout_update_order_meta':
-      case 'woocommerce_process_shop_order_meta':
-      default:
-        $inserted_emails = $this->insertSubscribersFromOrders($order_id);
-        if(empty($inserted_emails[0]['email'])) {
-          return false;
-        }
-        $subscriber = Subscriber::where('email', $inserted_emails[0]['email'])
-          ->findOne();
+    $inserted_emails = $this->insertSubscribersFromOrders($order_id);
+    if(empty($inserted_emails[0]['email'])) {
+      return false;
+    }
+    $subscriber = Subscriber::where('email', $inserted_emails[0]['email'])
+      ->findOne();
 
-        if($subscriber !== false) {
-          // add subscriber to the WooCommerce Customers segment
-          SubscriberSegment::subscribeToSegments(
-            $subscriber,
-            array($wc_segment->id)
-          );
-        }
-        break;
+    if($subscriber !== false) {
+      // add subscriber to the WooCommerce Customers segment
+      SubscriberSegment::subscribeToSegments(
+        $subscriber,
+        array($wc_segment->id)
+      );
     }
   }
 

--- a/lib/Segments/WooCommerce.php
+++ b/lib/Segments/WooCommerce.php
@@ -122,9 +122,9 @@ class WooCommerce {
       UPDATE %1$s mps
         JOIN %2$s wu ON mps.wp_user_id = wu.id
         JOIN %3$s wpum ON wu.id = wpum.user_id AND wpum.meta_key = "' . $wpdb->prefix . 'capabilities"
-      SET is_woocommerce_user = 1
+      SET is_woocommerce_user = 1, source = "%4$s"
         WHERE wpum.meta_value LIKE "%%\"customer\"%%"
-    ', $subscribers_table, $wpdb->users, $wpdb->usermeta));
+    ', $subscribers_table, $wpdb->users, $wpdb->usermeta, Source::WOOCOMMERCE_USER));
   }
 
   private function insertSubscribersFromOrders($order_id = null) {

--- a/lib/Segments/WooCommerce.php
+++ b/lib/Segments/WooCommerce.php
@@ -1,0 +1,263 @@
+<?php
+namespace MailPoet\Segments;
+
+use MailPoet\Models\ModelValidator;
+use MailPoet\Models\Subscriber;
+use MailPoet\Models\Segment;
+use MailPoet\Models\SubscriberSegment;
+use MailPoet\Newsletter\Scheduler\Scheduler;
+use MailPoet\Subscribers\Source;
+
+if(!defined('ABSPATH')) exit;
+
+class WooCommerce {
+  function synchronizeRegisteredCustomer($wp_user_id, $current_filter = null) {
+    $wc_segment = Segment::getWooCommerceSegment();
+
+    if($wc_segment === false) return;
+
+    $current_filter = $current_filter ?: current_filter();
+    switch($current_filter) {
+      case 'woocommerce_delete_customer':
+        // subscriber should be already deleted in WP users sync
+        $this->unsubscribeUsersFromSegment(); // remove leftover association
+        break;
+      case 'woocommerce_new_customer':
+        $new_customer = true;
+      case 'woocommerce_update_customer':
+      default:
+        $wp_user = \get_userdata($wp_user_id);
+        $subscriber = Subscriber::where('wp_user_id', $wp_user_id)
+          ->findOne();
+
+        if ($wp_user === false || $subscriber === false) {
+          // registered customers should exist as WP users and WP segment subscribers
+          return false;
+        }
+
+        $data = array(
+          'is_woocommerce_user' => 1,
+        );
+        if (!empty($new_customer)) {
+          $data['status'] = Subscriber::STATUS_SUBSCRIBED;
+          $data['source'] = Source::WOOCOMMERCE_USER;
+        }
+        $data['id'] = $subscriber->id();
+        $data['deleted_at'] = null; // remove the user from the trash
+
+        $subscriber = Subscriber::createOrUpdate($data);
+        if($subscriber->getErrors() === false && $subscriber->id > 0) {
+          // add subscriber to the WooCommerce Customers segment
+          SubscriberSegment::subscribeToSegments(
+            $subscriber,
+            array($wc_segment->id)
+          );
+        }
+        break;
+    }
+
+    return true;
+  }
+
+  function synchronizeGuestCustomer($order_id, $current_filter = null) {
+    $wc_order = \get_post($order_id);
+    $wc_segment = Segment::getWooCommerceSegment();
+
+    if($wc_order === false or $wc_segment === false) return;
+
+    $current_filter = $current_filter ?: current_filter();
+    switch($current_filter) {
+      case 'woocommerce_checkout_update_order_meta':
+      case 'woocommerce_process_shop_order_meta':
+      default:
+        $inserted_emails = $this->insertSubscribersFromOrders($order_id);
+        if (empty($inserted_emails[0]['email'])) {
+          return false;
+        }
+        $subscriber = Subscriber::where('email', $inserted_emails[0]['email'])
+          ->findOne();
+
+        if($subscriber !== false) {
+          // add subscriber to the WooCommerce Customers segment
+          SubscriberSegment::subscribeToSegments(
+            $subscriber,
+            array($wc_segment->id)
+          );
+        }
+        break;
+    }
+  }
+
+  function synchronizeCustomers() {
+
+    WP::synchronizeUsers(); // synchronize registered users
+
+    $this->markRegisteredCustomers();
+    $inserted_users_emails = $this->insertSubscribersFromOrders();
+    $this->removeUpdatedSubscribersWithInvalidEmail($inserted_users_emails);
+    $this->removeFromTrash();
+    $this->updateFirstNames();
+    $this->updateLastNames();
+    $this->insertUsersToSegment();
+    $this->unsubscribeUsersFromSegment();
+    $this->removeOrphanedSubscribers();
+
+    return true;
+  }
+
+  private function markRegisteredCustomers() {
+    // Mark WP users having a customer role as WooCommerce subscribers
+    global $wpdb;
+    $subscribers_table = Subscriber::$_table;
+    Subscriber::raw_execute(sprintf('
+      UPDATE %1$s mps
+        JOIN %2$s wu ON mps.wp_user_id = wu.id
+        JOIN %3$s wpum ON wu.id = wpum.user_id AND wpum.meta_key = "wpdev_capabilities"
+      SET is_woocommerce_user = 1
+        WHERE wpum.meta_value LIKE "%%\"customer\"%%"
+    ', $subscribers_table, $wpdb->users, $wpdb->usermeta));
+  }
+
+  private function insertSubscribersFromOrders($order_id = null) {
+    global $wpdb;
+    $subscribers_table = Subscriber::$_table;
+    $order_id = !is_null($order_id) ? (int)$order_id : null;
+
+    $inserted_users_emails = \ORM::for_table($wpdb->users)->raw_query(
+      'SELECT DISTINCT wppm.meta_value as email FROM `wpdev_postmeta` wppm
+        JOIN `wpdev_posts` p ON wppm.post_id = p.ID AND p.post_type = "shop_order"
+        WHERE wppm.meta_key = "_billing_email" AND wppm.meta_value != ""
+        ' . ($order_id ? ' AND p.ID = "' . $order_id . '"' : '') . '
+      ')->findArray();
+
+    Subscriber::raw_execute(sprintf('
+      INSERT IGNORE INTO %1$s (is_woocommerce_user, email, status, created_at, source)
+      SELECT 1, wppm.meta_value, "%2$s", CURRENT_TIMESTAMP(), "%3$s" FROM `wpdev_postmeta` wppm
+        JOIN `wpdev_posts` p ON wppm.post_id = p.ID AND p.post_type = "shop_order"
+        WHERE wppm.meta_key = "_billing_email" AND wppm.meta_value != ""
+        ' . ($order_id ? ' AND p.ID = "' . $order_id . '"' : '') . '
+      ON DUPLICATE KEY UPDATE is_woocommerce_user = 1
+    ', $subscribers_table, Subscriber::STATUS_SUBSCRIBED, Source::WOOCOMMERCE_USER));
+
+    return $inserted_users_emails;
+  }
+
+  private function removeUpdatedSubscribersWithInvalidEmail($updated_emails) {
+    $validator = new ModelValidator();
+    $invalid_is_woocommerce_users = array_map(function($item) {
+      return $item['email'];
+    },
+    array_filter($updated_emails, function($updated_email) use($validator) {
+      return !$validator->validateEmail($updated_email['email']);
+    }));
+    if(!$invalid_is_woocommerce_users) {
+      return;
+    }
+    \ORM::for_table(Subscriber::$_table)
+      ->whereNull('wp_user_id')
+      ->where('is_woocommerce_user', 1)
+      ->whereIn('email', $invalid_is_woocommerce_users)
+      ->delete_many();
+  }
+
+  private function updateFirstNames() {
+    global $wpdb;
+    $subscribers_table = Subscriber::$_table;
+    Subscriber::raw_execute(sprintf('
+      UPDATE %1$s mps
+        JOIN %2$s wppm ON mps.email = wppm.meta_value AND wppm.meta_key = "_billing_email"
+        JOIN %2$s wppm2 ON wppm2.post_id = wppm.post_id AND wppm2.meta_key = "_billing_first_name"
+        JOIN (SELECT MAX(post_id) AS max_id FROM %2$s WHERE meta_key = "_billing_email" GROUP BY meta_value) AS tmaxid ON tmaxid.max_id = wppm.post_id
+      SET mps.first_name = wppm2.meta_value
+        WHERE mps.first_name = ""
+        AND mps.is_woocommerce_user = 1
+        AND wppm2.meta_value IS NOT NULL
+    ', $subscribers_table, $wpdb->postmeta));
+  }
+
+  private function updateLastNames() {
+    global $wpdb;
+    $subscribers_table = Subscriber::$_table;
+    Subscriber::raw_execute(sprintf('
+      UPDATE %1$s mps
+        JOIN %2$s wppm ON mps.email = wppm.meta_value AND wppm.meta_key = "_billing_email"
+        JOIN %2$s wppm2 ON wppm2.post_id = wppm.post_id AND wppm2.meta_key = "_billing_last_name"
+        JOIN (SELECT MAX(post_id) AS max_id FROM %2$s WHERE meta_key = "_billing_email" GROUP BY meta_value) AS tmaxid ON tmaxid.max_id = wppm.post_id
+      SET mps.last_name = wppm2.meta_value
+        WHERE mps.last_name = ""
+        AND mps.is_woocommerce_user = 1
+        AND wppm2.meta_value IS NOT NULL
+    ', $subscribers_table, $wpdb->postmeta));
+  }
+
+  private function insertUsersToSegment() {
+    $wc_segment = Segment::getWooCommerceSegment();
+    $subscribers_table = Subscriber::$_table;
+    $wp_mailpoet_subscriber_segment_table = SubscriberSegment::$_table;
+    // Subscribe WC users to segment
+    Subscriber::raw_execute(sprintf('
+     INSERT IGNORE INTO %s (subscriber_id, segment_id, created_at)
+      SELECT mps.id, "%s", CURRENT_TIMESTAMP() FROM %s mps
+        WHERE mps.is_woocommerce_user = 1
+    ', $wp_mailpoet_subscriber_segment_table, $wc_segment->id, $subscribers_table));
+  }
+
+  private function unsubscribeUsersFromSegment() {
+    $wc_segment = Segment::getWooCommerceSegment();
+    $subscribers_table = Subscriber::$_table;
+    $wp_mailpoet_subscriber_segment_table = SubscriberSegment::$_table;
+    // Unsubscribe non-WC or invalid users from segment
+    Subscriber::raw_execute(sprintf('
+     DELETE mpss FROM %s mpss
+      LEFT JOIN %s mps ON mpss.subscriber_id = mps.id
+        WHERE mpss.segment_id = %s AND (mps.is_woocommerce_user = 0 OR mps.email = "" OR mps.email IS NULL)
+    ', $wp_mailpoet_subscriber_segment_table, $subscribers_table, $wc_segment->id));
+  }
+
+  private function removeFromTrash() {
+    $subscribers_table = Subscriber::$_table;
+    Subscriber::raw_execute(sprintf('
+      UPDATE %1$s
+      SET %1$s.deleted_at = NULL
+        WHERE %1$s.is_woocommerce_user = 1
+    ', $subscribers_table));
+  }
+
+  private function removeOrphanedSubscribers() {
+    // Remove orphaned WooCommerce segment subscribers (not having a matching WC customer email),
+    // e.g. if WC orders were deleted directly from the database
+    // or a customer role was revoked and a user has no orders
+    global $wpdb;
+
+    $wc_segment = Segment::getWooCommerceSegment();
+
+    // Unmark registered customers
+    $set = $wc_segment->subscribers()
+      ->leftOuterJoin(
+        $wpdb->postmeta,
+        'wppm.meta_key = "_billing_email" AND ' . MP_SUBSCRIBERS_TABLE . '.email = wppm.meta_value',
+        'wppm'
+      )
+      ->leftOuterJoin($wpdb->posts, 'wppm.post_id = wpp.ID AND wpp.post_type = "shop_order"', 'wpp')
+      ->join($wpdb->usermeta, 'wp_user_id = wpum.user_id AND wpum.meta_key = "wpdev_capabilities"', 'wpum')
+      ->whereRaw('(wppm.meta_value IS NULL AND wpum.meta_value NOT LIKE "%\"customer\"%")')
+      ->whereNotNull('wp_user_id')
+      ->findResultSet()
+      ->set('is_woocommerce_user', 0)
+      ->save();
+
+    // Remove guest customers
+    $wc_segment->subscribers()
+      ->leftOuterJoin(
+        $wpdb->postmeta,
+        'wppm.meta_key = "_billing_email" AND ' . MP_SUBSCRIBERS_TABLE . '.email = wppm.meta_value',
+        'wppm'
+      )
+      ->leftOuterJoin($wpdb->posts, 'wppm.post_id = wpp.ID AND wpp.post_type = "shop_order"', 'wpp')
+      ->whereRaw('(wppm.meta_value IS NULL OR wpp.ID IS NULL OR ' . MP_SUBSCRIBERS_TABLE . '.email = "")')
+      ->whereNull('wp_user_id')
+      ->findResultSet()
+      ->set('is_woocommerce_user', 0)
+      ->delete();
+  }
+}

--- a/lib/Segments/WooCommerce.php
+++ b/lib/Segments/WooCommerce.php
@@ -4,16 +4,23 @@ namespace MailPoet\Segments;
 use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\Segment;
-use MailPoet\Models\Setting;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Scheduler\Scheduler;
+use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\Source;
 
 if(!defined('ABSPATH')) exit;
 
 class WooCommerce {
+  /** @var SettingsController */
+  private $settings;
+
+  function __construct(SettingsController $settings) {
+    $this->settings = $settings;
+  }
+
   function synchronizeRegisteredCustomer($wp_user_id, $current_filter = null) {
-    if(!$current_filter && !Setting::getValue('enable_wc_hooks_testing')) {
+    if(!$current_filter && !$this->settings->get('enable_wc_hooks_testing')) {
       return false; // temporarily disable hooks (except for testing)
     }
 
@@ -65,7 +72,7 @@ class WooCommerce {
   }
 
   function synchronizeGuestCustomer($order_id, $current_filter = null) {
-    if(!$current_filter && !Setting::getValue('enable_wc_hooks_testing')) {
+    if(!$current_filter && !$this->settings->get('enable_wc_hooks_testing')) {
       return false; // temporarily disable hooks (except for testing)
     }
 

--- a/lib/Segments/WooCommerce.php
+++ b/lib/Segments/WooCommerce.php
@@ -4,6 +4,7 @@ namespace MailPoet\Segments;
 use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\Segment;
+use MailPoet\Models\Setting;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Subscribers\Source;
@@ -12,6 +13,10 @@ if(!defined('ABSPATH')) exit;
 
 class WooCommerce {
   function synchronizeRegisteredCustomer($wp_user_id, $current_filter = null) {
+    if(!$current_filter && !Setting::getValue('enable_wc_hooks_testing')) {
+      return false; // temporarily disable hooks (except for testing)
+    }
+
     $wc_segment = Segment::getWooCommerceSegment();
 
     if($wc_segment === false) return;
@@ -60,6 +65,10 @@ class WooCommerce {
   }
 
   function synchronizeGuestCustomer($order_id, $current_filter = null) {
+    if(!$current_filter && !Setting::getValue('enable_wc_hooks_testing')) {
+      return false; // temporarily disable hooks (except for testing)
+    }
+
     $wc_order = \get_post($order_id);
     $wc_segment = Segment::getWooCommerceSegment();
 

--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -52,6 +52,10 @@ class Functions {
     return call_user_func_array('remove_all_filters', func_get_args());
   }
 
+  function currentFilter() {
+    return call_user_func_array('current_filter', func_get_args());
+  }
+
   function currentTime() {
     return call_user_func_array('current_time', func_get_args());
   }
@@ -63,9 +67,17 @@ class Functions {
   function isUserLoggedIn() {
     return call_user_func_array('is_user_logged_in', func_get_args());
   }
-  
+
   function getOption() {
     return call_user_func_array('get_option', func_get_args());
+  }
+
+  function getUserdata() {
+    return call_user_func_array('get_userdata', func_get_args());
+  }
+
+  function getPost() {
+    return call_user_func_array('get_post', func_get_args());
   }
 
   function wpEncodeEmoji() {

--- a/lib/WooCommerce/Helper.php
+++ b/lib/WooCommerce/Helper.php
@@ -1,0 +1,8 @@
+<?php
+namespace MailPoet\WooCommerce;
+
+class Helper {
+  function isWooCommerceActive() {
+    return class_exists('WooCommerce');
+  }
+}

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -8,6 +8,7 @@ use MailPoet\Config\Menu;
 use MailPoet\Config\Renderer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Settings\SettingsController;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions;
 
 class MenuTest extends \MailPoetTest {
@@ -42,7 +43,7 @@ class MenuTest extends \MailPoetTest {
 
   function testItChecksMailpoetAPIKey() {
     $renderer = Stub::make(new Renderer());
-    $menu = new Menu($renderer, new AccessControl(), new SettingsController(), new Functions());
+    $menu = new Menu($renderer, new AccessControl(), new SettingsController(), new Functions(), new WooCommerceHelper);
 
     $_REQUEST['page'] = 'mailpoet-newsletters';
     $checker = Stub::make(
@@ -64,7 +65,7 @@ class MenuTest extends \MailPoetTest {
 
   function testItChecksPremiumKey() {
     $renderer = Stub::make(new Renderer());
-    $menu = new Menu($renderer, new AccessControl(), new SettingsController(), new Functions());
+    $menu = new Menu($renderer, new AccessControl(), new SettingsController(), new Functions(), new WooCommerceHelper);
 
     $_REQUEST['page'] = 'mailpoet-newsletters';
     $checker = Stub::make(

--- a/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace MailPoet\Test\Cron\Workers;
+
+use Codeception\Util\Stub;
+use MailPoet\Cron\Workers\WooCommerceSync;
+use MailPoet\Models\ScheduledTask;
+use MailPoet\Segments\WooCommerce as WooCommerceSegment;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+
+class WooCommerceSyncTest extends \MailPoetTest {
+  function _before() {
+    $this->woocommerce_segment = $this->createMock(WooCommerceSegment::class);
+    $this->woocommerce_helper = $this->createMock(WooCommerceHelper::class);
+    $this->worker = new WooCommerceSync($this->woocommerce_segment, $this->woocommerce_helper, microtime(true));
+  }
+
+  function testItWillNotRunIfWooCommerceIsDisabled() {
+    $this->woocommerce_helper->method('isWooCommerceActive')
+      ->willReturn(false);
+    expect($this->worker->checkProcessingRequirements())->false();
+  }
+
+  function testItWillRunIfWooCommerceIsEnabled() {
+    $this->woocommerce_helper->method('isWooCommerceActive')
+      ->willReturn(true);
+    expect($this->worker->checkProcessingRequirements())->true();
+  }
+
+  function testItCallsWooCommerceSync() {
+    $this->woocommerce_segment->expects($this->once())
+      ->method('synchronizeCustomers');
+    $task = Stub::make(ScheduledTask::class);
+    expect($this->worker->processTaskStrategy($task))->equals(true);
+  }
+}

--- a/tests/integration/Segments/WooCommerceTest.php
+++ b/tests/integration/Segments/WooCommerceTest.php
@@ -1,0 +1,537 @@
+<?php
+
+namespace MailPoet\Test\Segments;
+
+require_once(ABSPATH . 'wp-admin/includes/user.php');
+
+use Carbon\Carbon;
+use MailPoet\Models\Segment;
+use MailPoet\Models\Subscriber;
+use MailPoet\Models\SubscriberSegment;
+use MailPoet\Segments\WooCommerce as WooCommerceSegment;
+use MailPoet\Subscribers\Source;
+
+class WooCommerceTest extends \MailPoetTest  {
+
+  private $userEmails = array();
+
+  function _before() {
+    $this->woocommerce_segment = new WooCommerceSegment;
+    $this->cleanData();
+    $this->addCustomerRole();
+  }
+
+  function testItSynchronizesNewRegisteredCustomer() {
+    $user = $this->insertRegisteredCustomer();
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(array(
+      'first_name' => 'Mike',
+      'last_name' => 'Mike',
+      'email' => $user->user_email,
+      'wp_user_id' => $user->ID,
+    ));
+    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+    $subscriber->source = Source::WORDPRESS_USER;
+    $subscriber->save();
+    $subscriber->trash();
+    $hook = 'woocommerce_new_customer';
+    $this->woocommerce_segment->synchronizeRegisteredCustomer($user->ID, $hook);
+    $subscriber = Segment::getWooCommerceSegment()->subscribers()
+      ->where('wp_user_id', $user->ID)
+      ->findOne();
+    expect($subscriber)->notEmpty();
+    expect($subscriber->email)->equals($user->user_email);
+    expect($subscriber->is_woocommerce_user)->equals(1);
+    expect($subscriber->source)->equals(Source::WOOCOMMERCE_USER);
+    expect($subscriber->deleted_at)->equals(null);
+  }
+
+  function testItSynchronizesUpdatedRegisteredCustomer() {
+    $user = $this->insertRegisteredCustomer();
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(array(
+      'first_name' => 'Mike',
+      'last_name' => 'Mike',
+      'email' => $user->user_email,
+      'wp_user_id' => $user->ID,
+    ));
+    $subscriber->status = Subscriber::STATUS_UNSUBSCRIBED;
+    $subscriber->source = Source::WORDPRESS_USER;
+    $subscriber->save();
+    $hook = 'woocommerce_update_customer';
+    $this->woocommerce_segment->synchronizeRegisteredCustomer($user->ID, $hook);
+    $subscriber = Segment::getWooCommerceSegment()->subscribers()
+      ->where('wp_user_id', $user->ID)
+      ->findOne();
+    expect($subscriber)->notEmpty();
+    expect($subscriber->email)->equals($user->user_email);
+    expect($subscriber->is_woocommerce_user)->equals(1);
+    expect($subscriber->source)->equals(Source::WORDPRESS_USER); // no overriding
+    expect($subscriber->status)->equals(Subscriber::STATUS_UNSUBSCRIBED); // no overriding
+  }
+
+  function testItSynchronizesDeletedRegisteredCustomer() {
+    $wc_segment = Segment::getWooCommerceSegment();
+    $user = $this->insertRegisteredCustomer();
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(array(
+      'first_name' => 'Mike',
+      'last_name' => 'Mike',
+      'email' => $user->user_email,
+      'wp_user_id' => $user->ID,
+    ));
+    $subscriber->status = Subscriber::STATUS_UNSUBSCRIBED;
+    $subscriber->source = Source::WORDPRESS_USER;
+    $subscriber->save();
+    $association = SubscriberSegment::create();
+    $association->subscriber_id = $subscriber->id;
+    $association->segment_id = $wc_segment->id;
+    $association->save();
+    expect(SubscriberSegment::findOne($association->id))->notEmpty();
+    $hook = 'woocommerce_delete_customer';
+    $this->woocommerce_segment->synchronizeRegisteredCustomer($user->ID, $hook);
+    expect(SubscriberSegment::findOne($association->id))->isEmpty();
+  }
+
+  function testItSynchronizesNewGuestCustomer() {
+    $guest = $this->insertGuestCustomer();
+    $hook = 'woocommerce_checkout_update_order_meta';
+    $this->woocommerce_segment->synchronizeGuestCustomer($guest['order_id'], $hook);
+    $subscriber = Segment::getWooCommerceSegment()->subscribers()
+      ->where('email', $guest['email'])
+      ->findOne();
+    expect($subscriber)->notEmpty();
+    expect($subscriber->is_woocommerce_user)->equals(1);
+    expect($subscriber->source)->equals(Source::WOOCOMMERCE_USER);
+  }
+
+  function testItSynchronizesCustomers() {
+    $user = $this->insertRegisteredCustomer();
+    $guest = $this->insertGuestCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscribersCount = $this->getSubscribersCount();
+    expect($subscribersCount)->equals(2);
+    $subscriber = Subscriber::where('email', $user->user_email)->findOne();
+    expect($subscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
+    $subscriber = Subscriber::where('email', $guest['email'])->findOne();
+    expect($subscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
+  }
+
+  function testItSynchronizesNewCustomers() {
+    $this->insertRegisteredCustomer();
+    $this->insertGuestCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $this->insertRegisteredCustomer();
+    $this->insertGuestCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscribersCount = $this->getSubscribersCount();
+    expect($subscribersCount)->equals(4);
+  }
+
+  function testItSynchronizesPresubscribedRegisteredCustomers() {
+    $random_number = 12345;
+    $subscriber = Subscriber::createOrUpdate(array(
+      'email' => 'user-sync-test' . $random_number . '@example.com',
+      'status' => Subscriber::STATUS_SUBSCRIBED
+    ));
+    $user = $this->insertRegisteredCustomer($random_number);
+    $this->woocommerce_segment->synchronizeCustomers();
+    $wp_subscriber = Segment::getWooCommerceSegment()->subscribers()
+      ->where('is_woocommerce_user', 1)
+      ->where('wp_user_id', $user->ID)
+      ->findOne();
+    expect($wp_subscriber)->notEmpty();
+    expect($wp_subscriber->id)->equals($subscriber->id);
+  }
+
+  function testItSynchronizesPresubscribedGuestCustomers() {
+    $random_number = 12345;
+    $subscriber = Subscriber::createOrUpdate(array(
+      'email' => 'user-sync-test' . $random_number . '@example.com',
+      'status' => Subscriber::STATUS_SUBSCRIBED
+    ));
+    $guest = $this->insertGuestCustomer($random_number);
+    $this->woocommerce_segment->synchronizeCustomers();
+    $wp_subscriber = Segment::getWooCommerceSegment()->subscribers()
+      ->where('is_woocommerce_user', 1)
+      ->where('email', $guest['email'])
+      ->findOne();
+    expect($wp_subscriber)->notEmpty();
+    expect($wp_subscriber->email)->equals($subscriber->email);
+  }
+
+  function testItDoesNotSynchronizeEmptyEmailsForNewUsers() {
+    $guest = $this->insertGuestCustomer();
+    update_post_meta($guest['order_id'], '_billing_email', '');
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where('email', '')->findOne();
+    expect($subscriber)->isEmpty();
+    $this->deleteOrder($guest['order_id']);
+  }
+
+  function testItDoesNotSynchronizeInvalidEmailsForNewUsers() {
+    $guest = $this->insertGuestCustomer();
+    $invalid_email = 'ivalid.@email.com';
+    update_post_meta($guest['order_id'], '_billing_email', $invalid_email);
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where('email', $invalid_email)->findOne();
+    expect($subscriber)->isEmpty();
+    $this->deleteOrder($guest['order_id']);
+  }
+
+  function testItSynchronizesFirstNamesForRegisteredCustomers() {
+    $user = $this->insertRegisteredCustomerWithOrder(null, ['first_name' => '']);
+    $this->woocommerce_segment->synchronizeCustomers();
+    update_post_meta($user->order_id, '_billing_first_name', 'First name');
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where('wp_user_id', $user->ID)->findOne();
+    expect($subscriber->first_name)->equals('First name');
+  }
+
+  function testItSynchronizesLastNamesForRegisteredCustomers() {
+    $user = $this->insertRegisteredCustomerWithOrder(null, ['last_name' => '']);
+    $this->woocommerce_segment->synchronizeCustomers();
+    update_post_meta($user->order_id, '_billing_last_name', 'Last name');
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where('wp_user_id', $user->ID)->findOne();
+    expect($subscriber->last_name)->equals('Last name');
+  }
+
+  function testItSynchronizesFirstNamesForGuestCustomers() {
+    $guest = $this->insertGuestCustomer(null, ['first_name' => '']);
+    $this->woocommerce_segment->synchronizeCustomers();
+    update_post_meta($guest['order_id'], '_billing_first_name', 'First name');
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where('email', $guest['email'])->findOne();
+    expect($subscriber->first_name)->equals('First name');
+  }
+
+  function testItSynchronizesLastNamesForGuestCustomers() {
+    $guest = $this->insertGuestCustomer(null, ['last_name' => '']);
+    $this->woocommerce_segment->synchronizeCustomers();
+    update_post_meta($guest['order_id'], '_billing_last_name', 'Last name');
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where('email', $guest['email'])->findOne();
+    expect($subscriber->last_name)->equals('Last name');
+  }
+
+  function testItSynchronizesSegment() {
+    $this->insertRegisteredCustomer();
+    $this->insertRegisteredCustomer();
+    $this->insertGuestCustomer();
+    $this->insertGuestCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscribers = Segment::getWooCommerceSegment()->subscribers()
+      ->where('is_woocommerce_user', 1)
+      ->whereIn('email', $this->userEmails);
+    expect($subscribers->count())->equals(4);
+  }
+
+  function testItRemovesRegisteredCustomersFromTrash() {
+    $user = $this->insertRegisteredCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where("email", $user->user_email)
+      ->where('is_woocommerce_user', 1)
+      ->findOne();
+    $subscriber->deleted_at = Carbon::now();
+    $subscriber->save();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where("email", $user->user_email)
+      ->where('is_woocommerce_user', 1)
+      ->findOne();
+    expect($subscriber->deleted_at)->null();
+  }
+
+  function testItRemovesGuestCustomersFromTrash() {
+    $guest = $this->insertGuestCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where("email", $guest['email'])
+      ->where('is_woocommerce_user', 1)
+      ->findOne();
+    $subscriber->deleted_at = Carbon::now();
+    $subscriber->save();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscriber = Subscriber::where("email", $guest['email'])
+      ->where('is_woocommerce_user', 1)
+      ->findOne();
+    expect($subscriber->deleted_at)->null();
+  }
+
+  /* function testItSynchronizesDeletedWPUsersUsingHooks() {
+    $user = $this->insertRegisteredCustomer();
+    $this->insertRegisteredCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscribersCount = $this->getSubscribersCount();
+    expect($subscribersCount)->equals(2);
+    wp_delete_user($id);
+    $subscribersCount = $this->getSubscribersCount();
+    expect($subscribersCount)->equals(1);
+  } */
+
+  function testItRemovesOrphanedSubscribers() {
+    $this->insertRegisteredCustomer();
+    $this->insertGuestCustomer();
+    $user = $this->insertRegisteredCustomerWithOrder();
+    $guest = $this->insertGuestCustomer();
+    $this->woocommerce_segment->synchronizeCustomers();
+    $user->remove_role('customer');
+    $this->deleteOrder($user->order_id);
+    $this->deleteOrder($guest['order_id']);
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscribers = Segment::getWooCommerceSegment()->subscribers()
+      ->where('is_woocommerce_user', 1)
+      ->whereIn('email', $this->userEmails);
+    expect($subscribers->count())->equals(2);
+  }
+
+  function testItDoesntDeleteNonWCData() {
+    $this->insertRegisteredCustomer();
+    $this->insertGuestCustomer();
+    // WP user
+    $user = $this->insertRegisteredCustomer();
+    $user->remove_role('customer');
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(array(
+      'first_name' => 'John',
+      'last_name' => 'John',
+      'email' => $user->user_email,
+      'wp_user_id' => $user->ID,
+    ));
+    $subscriber->status = Subscriber::STATUS_UNCONFIRMED;
+    $subscriber->save();
+    // Regular subscriber
+    $subscriber2 = Subscriber::create();
+    $subscriber2->hydrate(array(
+      'first_name' => 'Mike',
+      'last_name' => 'Mike',
+      'email' => 'user-sync-test2' . rand() . '@example.com',
+    ));
+    $subscriber2->status = Subscriber::STATUS_SUBSCRIBED;
+    $subscriber2->save();
+    // email is empty
+    $subscriber3 = Subscriber::create();
+    $subscriber3->hydrate(array(
+      'first_name' => 'Dave',
+      'last_name' => 'Dave',
+      'email' => 'user-sync-test3' . rand() . '@example.com', // need to pass validation
+    ));
+    $subscriber3->status = Subscriber::STATUS_SUBSCRIBED;
+    $subscriber3->save();
+    $this->clearEmail($subscriber3);
+    $this->woocommerce_segment->synchronizeCustomers();
+    $subscribersCount = $this->getSubscribersCount();
+    expect($subscribersCount)->equals(4);
+    $db_subscriber = Subscriber::findOne($subscriber3->id);
+    expect($db_subscriber)->notEmpty();
+    $subscriber3->delete();
+  }
+
+  function testItUnsubscribesSubscribersWithoutWCFlagFromWCSegment() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(array(
+      'first_name' => 'Mike',
+      'last_name' => 'Mike',
+      'email' => 'user-sync-test' . rand() . '@example.com',
+      'is_woocommerce_user' => 0,
+    ));
+    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+    $subscriber->save();
+    $wc_segment = Segment::getWooCommerceSegment();
+    $association = SubscriberSegment::create();
+    $association->subscriber_id = $subscriber->id;
+    $association->segment_id = $wc_segment->id;
+    $association->save();
+    expect(SubscriberSegment::findOne($association->id))->notEmpty();
+    $this->woocommerce_segment->synchronizeCustomers();
+    expect(SubscriberSegment::findOne($association->id))->isEmpty();
+  }
+
+  function testItUnsubscribesSubscribersWithoutEmailFromWCSegment() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(array(
+      'first_name' => 'Mike',
+      'last_name' => 'Mike',
+      'email' => 'user-sync-test' . rand() . '@example.com', // need to pass validation
+      'is_woocommerce_user' => 1,
+    ));
+    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+    $subscriber->save();
+    $this->clearEmail($subscriber);
+    $wc_segment = Segment::getWooCommerceSegment();
+    $association = SubscriberSegment::create();
+    $association->subscriber_id = $subscriber->id;
+    $association->segment_id = $wc_segment->id;
+    $association->save();
+    expect(SubscriberSegment::findOne($association->id))->notEmpty();
+    $this->woocommerce_segment->synchronizeCustomers();
+    expect(SubscriberSegment::findOne($association->id))->isEmpty();
+  }
+
+  function _after() {
+    $this->cleanData();
+    $this->removeCustomerRole();
+  }
+
+  private function addCustomerRole() {
+    if (!get_role('customer')) {
+      add_role('customer', 'Customer');
+      $this->customerRoleAdded = true;
+    }
+  }
+
+  private function removeCustomerRole() {
+    if (!empty($this->customerRoleAdded)) {
+      remove_role('customer');
+    }
+  }
+
+  private function cleanData() {
+    \ORM::raw_execute('TRUNCATE ' . Segment::$_table);
+    \ORM::raw_execute('TRUNCATE ' . SubscriberSegment::$_table);
+    global $wpdb;
+    $db = \ORM::getDb();
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         subscriber_id IN (select id from %s WHERE email LIKE "user-sync-test%%")
+    ', SubscriberSegment::$_table, Subscriber::$_table));
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         user_id IN (select id from %s WHERE user_email LIKE "user-sync-test%%")
+    ', $wpdb->usermeta, $wpdb->users));
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         user_email LIKE "user-sync-test%%"
+         OR user_login LIKE "user-sync-test%%"
+    ', $wpdb->users));
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         email LIKE "user-sync-test%%"
+    ', Subscriber::$_table));
+    // delete orders
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         id IN (SELECT DISTINCT post_id FROM %s WHERE meta_value LIKE "user-sync-test%%")
+    ', $wpdb->posts, $wpdb->postmeta));
+    // delete order meta
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         post_id IN (
+          SELECT post_id FROM (
+            SELECT DISTINCT post_id FROM %s WHERE meta_value LIKE "user-sync-test%%"
+          ) AS t
+        )
+    ', $wpdb->postmeta, $wpdb->postmeta));
+  }
+
+  private function getSubscribersCount($a = null) {
+    return Subscriber::whereLike("email", "user-sync-test%")->count();
+  }
+
+  /**
+   * Insert a user without invoking wp hooks.
+   * Those tests are testing user synchronisation, so we need data in wp_users table which has not been synchronised to
+   * mailpoet database yet. We cannot use wp_insert_user functions because they would do the sync on insert.
+   *
+   * @return string
+   */
+  private function insertRegisteredCustomer($number = null) {
+    global $wpdb;
+    $db = \ORM::getDb();
+    $number_sql = !is_null($number) ? (int)$number : 'rand()';
+    // add user
+    $db->exec(sprintf('
+         INSERT INTO
+           %s (user_login, user_email, user_registered)
+           VALUES
+           (
+             CONCAT("user-sync-test", ' . $number_sql . '),
+             CONCAT("user-sync-test", ' . $number_sql . ', "@example.com"),
+             "2017-01-02 12:31:12"
+           )', $wpdb->users));
+    $id = $db->lastInsertId();
+    // add customer role
+    $user = new \WP_User($id);
+    $user->add_role('customer');
+    $this->userEmails[] = $user->user_email;
+    return $user;
+  }
+
+  /**
+   * A guest customer is whose data is only contained in an order
+   */
+  private function insertGuestCustomer($number = null, array $data = null) {
+    $number = !is_null($number) ? (int)$number : mt_rand();
+    // add order
+    $guest = array(
+      'email' => $data['email'] ?? 'user-sync-test' . $number . '@example.com',
+      'first_name' => $data['first_name'] ?? 'user-sync-test' . $number . ' first',
+      'last_name' => $data['last_name'] ?? 'user-sync-test' . $number . ' last',
+    );
+    $guest['order_id'] = $this->createOrder($guest);
+    $this->userEmails[] = $guest['email'];
+    return $guest;
+  }
+
+  private function insertRegisteredCustomerWithOrder($number = null, array $data = null) {
+    $number = !is_null($number) ? (int)$number : mt_rand();
+    $user = $this->insertRegisteredCustomer($number);
+    $data = is_array($data) ? $data : [];
+    $data['email'] = $user->user_email;
+    $data['user_id'] = $user->ID;
+    $user->order_id = $this->createOrder($data);
+    return $user;
+  }
+
+  private function createOrder($data) {
+    $order_data = array(
+      'post_type' => 'shop_order',
+      'meta_input' => array(
+        '_billing_email' => $data['email'] ?? '',
+        '_billing_first_name' => $data['first_name'] ?? '',
+        '_billing_last_name' => $data['last_name'] ?? '',
+      )
+    );
+    if (!empty($data['user_id'])) {
+      $order_data['meta_input']['_customer_user'] = (int)$data['user_id'];
+    }
+    $id = wp_insert_post($order_data);
+    return $id;
+  }
+
+  private function deleteOrder($id) {
+    global $wpdb;
+    $db = \ORM::getDb();
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         id = %s
+    ', $wpdb->posts, $id));
+    $db->exec(sprintf('
+       DELETE FROM
+         %s
+       WHERE
+         post_id = %s
+    ', $wpdb->postmeta, $id));
+  }
+
+  private function clearEmail($subscriber) {
+    \ORM::raw_execute('
+      UPDATE ' . MP_SUBSCRIBERS_TABLE . '
+      SET `email` = "" WHERE `id` = ' . $subscriber->id
+    );
+  }
+
+}

--- a/tests/integration/Segments/WooCommerceTest.php
+++ b/tests/integration/Segments/WooCommerceTest.php
@@ -257,17 +257,6 @@ class WooCommerceTest extends \MailPoetTest  {
     expect($subscriber->deleted_at)->null();
   }
 
-  /* function testItSynchronizesDeletedWPUsersUsingHooks() {
-    $user = $this->insertRegisteredCustomer();
-    $this->insertRegisteredCustomer();
-    $this->woocommerce_segment->synchronizeCustomers();
-    $subscribersCount = $this->getSubscribersCount();
-    expect($subscribersCount)->equals(2);
-    wp_delete_user($id);
-    $subscribersCount = $this->getSubscribersCount();
-    expect($subscribersCount)->equals(1);
-  } */
-
   function testItRemovesOrphanedSubscribers() {
     $this->insertRegisteredCustomer();
     $this->insertGuestCustomer();
@@ -373,14 +362,14 @@ class WooCommerceTest extends \MailPoetTest  {
   }
 
   private function addCustomerRole() {
-    if (!get_role('customer')) {
+    if(!get_role('customer')) {
       add_role('customer', 'Customer');
       $this->customerRoleAdded = true;
     }
   }
 
   private function removeCustomerRole() {
-    if (!empty($this->customerRoleAdded)) {
+    if(!empty($this->customerRoleAdded)) {
       remove_role('customer');
     }
   }
@@ -475,9 +464,9 @@ class WooCommerceTest extends \MailPoetTest  {
     $number = !is_null($number) ? (int)$number : mt_rand();
     // add order
     $guest = array(
-      'email' => $data['email'] ?? 'user-sync-test' . $number . '@example.com',
-      'first_name' => $data['first_name'] ?? 'user-sync-test' . $number . ' first',
-      'last_name' => $data['last_name'] ?? 'user-sync-test' . $number . ' last',
+      'email' => isset($data['email']) ? $data['email'] : 'user-sync-test' . $number . '@example.com',
+      'first_name' => isset($data['first_name']) ? $data['first_name'] : 'user-sync-test' . $number . ' first',
+      'last_name' => isset($data['last_name']) ? $data['last_name'] : 'user-sync-test' . $number . ' last',
     );
     $guest['order_id'] = $this->createOrder($guest);
     $this->userEmails[] = $guest['email'];
@@ -498,12 +487,12 @@ class WooCommerceTest extends \MailPoetTest  {
     $order_data = array(
       'post_type' => 'shop_order',
       'meta_input' => array(
-        '_billing_email' => $data['email'] ?? '',
-        '_billing_first_name' => $data['first_name'] ?? '',
-        '_billing_last_name' => $data['last_name'] ?? '',
+        '_billing_email' => isset($data['email']) ? $data['email'] : '',
+        '_billing_first_name' => isset($data['first_name']) ? $data['first_name'] : '',
+        '_billing_last_name' => isset($data['last_name']) ? $data['last_name'] : '',
       )
     );
-    if (!empty($data['user_id'])) {
+    if(!empty($data['user_id'])) {
       $order_data['meta_input']['_customer_user'] = (int)$data['user_id'];
     }
     $id = wp_insert_post($order_data);

--- a/tests/integration/Segments/WooCommerceTest.php
+++ b/tests/integration/Segments/WooCommerceTest.php
@@ -186,36 +186,40 @@ class WooCommerceTest extends \MailPoetTest  {
     $user = $this->insertRegisteredCustomerWithOrder(null, ['first_name' => '']);
     $this->woocommerce_segment->synchronizeCustomers();
     update_post_meta($user->order_id, '_billing_first_name', 'First name');
+    $this->createOrder(['email' => $user->user_email, 'first_name' => 'First name (newer)']);
     $this->woocommerce_segment->synchronizeCustomers();
     $subscriber = Subscriber::where('wp_user_id', $user->ID)->findOne();
-    expect($subscriber->first_name)->equals('First name');
+    expect($subscriber->first_name)->equals('First name (newer)');
   }
 
   function testItSynchronizesLastNamesForRegisteredCustomers() {
     $user = $this->insertRegisteredCustomerWithOrder(null, ['last_name' => '']);
     $this->woocommerce_segment->synchronizeCustomers();
     update_post_meta($user->order_id, '_billing_last_name', 'Last name');
+    $this->createOrder(['email' => $user->user_email, 'last_name' => 'Last name (newer)']);
     $this->woocommerce_segment->synchronizeCustomers();
     $subscriber = Subscriber::where('wp_user_id', $user->ID)->findOne();
-    expect($subscriber->last_name)->equals('Last name');
+    expect($subscriber->last_name)->equals('Last name (newer)');
   }
 
   function testItSynchronizesFirstNamesForGuestCustomers() {
     $guest = $this->insertGuestCustomer(null, ['first_name' => '']);
     $this->woocommerce_segment->synchronizeCustomers();
     update_post_meta($guest['order_id'], '_billing_first_name', 'First name');
+    $this->createOrder(['email' => $guest['email'], 'first_name' => 'First name (newer)']);
     $this->woocommerce_segment->synchronizeCustomers();
     $subscriber = Subscriber::where('email', $guest['email'])->findOne();
-    expect($subscriber->first_name)->equals('First name');
+    expect($subscriber->first_name)->equals('First name (newer)');
   }
 
   function testItSynchronizesLastNamesForGuestCustomers() {
     $guest = $this->insertGuestCustomer(null, ['last_name' => '']);
     $this->woocommerce_segment->synchronizeCustomers();
     update_post_meta($guest['order_id'], '_billing_last_name', 'Last name');
+    $this->createOrder(['email' => $guest['email'], 'last_name' => 'Last name (newer)']);
     $this->woocommerce_segment->synchronizeCustomers();
     $subscriber = Subscriber::where('email', $guest['email'])->findOne();
-    expect($subscriber->last_name)->equals('Last name');
+    expect($subscriber->last_name)->equals('Last name (newer)');
   }
 
   function testItSynchronizesSegment() {

--- a/tests/integration/Segments/WooCommerceTest.php
+++ b/tests/integration/Segments/WooCommerceTest.php
@@ -113,8 +113,10 @@ class WooCommerceTest extends \MailPoetTest  {
     expect($subscribersCount)->equals(2);
     $subscriber = Subscriber::where('email', $user->user_email)->findOne();
     expect($subscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
+    expect($subscriber->source)->equals(Source::WOOCOMMERCE_USER);
     $subscriber = Subscriber::where('email', $guest['email'])->findOne();
     expect($subscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
+    expect($subscriber->source)->equals(Source::WOOCOMMERCE_USER);
   }
 
   function testItSynchronizesNewCustomers() {

--- a/tests/integration/Segments/WooCommerceTest.php
+++ b/tests/integration/Segments/WooCommerceTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Segments;
 require_once(ABSPATH . 'wp-admin/includes/user.php');
 
 use Carbon\Carbon;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
@@ -16,7 +17,7 @@ class WooCommerceTest extends \MailPoetTest  {
   private $userEmails = array();
 
   function _before() {
-    $this->woocommerce_segment = new WooCommerceSegment;
+    $this->woocommerce_segment = ContainerWrapper::getInstance()->get(WooCommerceSegment::class);
     $this->cleanData();
     $this->addCustomerRole();
   }


### PR DESCRIPTION
WooCommerce has two types of customers: registered (WP users) and guest (only stored in order fields). Since we can't use IDs for all of them, we will use emails as identifiers.

The main idea is: to avoid conflicts, our existing WP users sync will take care of registered users and WC sync will mainly take care of guests while changing some properties for registered users too.

To trigger mass synchronization, make a PHP file in your WordPress web root, name it as you like:
```php
require_once( dirname( __FILE__ ) . '/wp-load.php' );

use MailPoet\Segments\WooCommerce as WooCommerceSegment;

$wc_segment = new WooCommerceSegment(new MailPoet\Settings\SettingsController);
$result = $wc_segment->synchronizeCustomers();
var_dump($result);

```

Run it, when you see `bool(true)`, the sync is done.

To test hooks for individual customer creation/updates/deletion, add a truthy `enable_wc_hooks_testing` setting to the settings table in the DB:
```php
Setting::setValue('enable_wc_hooks_testing', 1);
```

Then perform actions in WooCommerce.

Notes: 
* I'm not sure I've used all relevant WC hooks to trigger sync on;
* Scheduled task triggering is not fully implemented in this task, in line with the ticket;
* Welcome emails aren't scheduled for WC subscribers.