### PR TITLE
Chrome update [MAILPOET-1738]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
     volumes:
       - /dev/shm:/dev/shm
-    image: selenium/standalone-chrome-debug:3.14.0-helium
+    image: selenium/standalone-chrome-debug:3.141.59-fluorine
     ports:
       - 4444
       - 5900:5900

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -20,7 +20,9 @@ require_once __DIR__ . '/../DataFactories/Form.php';
  * @SuppressWarnings(PHPMD)
  */
 class AcceptanceTester extends \Codeception\Actor {
-  use _generated\AcceptanceTesterActions;
+  use _generated\AcceptanceTesterActions {
+    switchToNextTab as _switchToNextTab;
+  }
 
   const WP_URL = 'http://wordpress';
   const MAIL_URL = 'http://mailhog:8025';
@@ -141,4 +143,10 @@ class AcceptanceTester extends \Codeception\Actor {
     $I->click($button);
   }
 
+  public function switchToNextTab($offset = 1) {
+    $this->_switchToNextTab($offset);
+
+    // workaround for frozen tabs when opened by clicking on links
+    $this->wait(1);
+  }
 }


### PR DESCRIPTION
It's not so easy to get rid of tab switching since many links simply open in new tabs and there is no easy way to open them in the same one instead. This, however, seems to fix it. Build run 2 times on CircleCI, many times locally.