### PR TITLE
Set default day in post notification [MAILPOET-1781]

### DIFF
--- a/assets/js/src/newsletters/types/notification/scheduling.jsx
+++ b/assets/js/src/newsletters/types/notification/scheduling.jsx
@@ -52,7 +52,13 @@ class NotificationScheduling extends React.Component {
     });
   };
 
-  handleIntervalChange = event => this.handleValueChange('intervalType', event.target.value);
+  handleIntervalChange = (event) => {
+    const intervalType = event.target.value;
+    this.handleValueChange('intervalType', intervalType);
+    if (intervalType === 'monthly') {
+      this.handleValueChange('monthDay', '1');
+    }
+  }
 
   handleTimeOfDayChange = event => this.handleValueChange('timeOfDay', event.target.value);
 


### PR DESCRIPTION
If a user doesn't select a day they see `1st` in the UI but
because the action is onChange which never fired
the system remembers the default value 0

