### PR TITLE
Fix small bug on release task

### DIFF
--- a/tasks/release/ChangelogController.php
+++ b/tasks/release/ChangelogController.php
@@ -43,7 +43,7 @@ class ChangelogController {
   }
 
   private function renderHeading(array $version) {
-    $date = $version['releaseDate'] ?: date('Y-m-d');
+    $date = empty($version['releaseDate']) ? date('Y-m-d') : $version['releaseDate'];
     return "= {$version['name']}" . self::HEADING_GLUE .  "$date =";
   }
 


### PR DESCRIPTION
I had this error while releasing premium plugin, because release date was not specified
```
ERROR: Undefined index: releaseDate 
in /var/www/html/wp-content/plugins/mailpoet/tasks/release/ChangelogController.php:46
```