### PR TITLE
Add index to links url, make models without 'deleted_at' duplicable [PREMIUM-114]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -337,7 +337,8 @@ class Migrator {
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (id),',
       'KEY newsletter_id (newsletter_id),',
-      'KEY queue_id (queue_id)',
+      'KEY queue_id (queue_id),',
+      'KEY url (url(255))',
     );
     return $this->sqlify(__FUNCTION__, $attributes);
   }

--- a/lib/Models/Model.php
+++ b/lib/Models/Model.php
@@ -311,7 +311,9 @@ class Model extends \Sudzy\ValidModel {
     $duplicate->hydrate($model_data);
     $duplicate->set_expr('created_at', 'NOW()');
     $duplicate->set_expr('updated_at', 'NOW()');
-    $duplicate->set_expr('deleted_at', 'NULL');
+    if (isset($model_data['deleted_at'])) {
+      $duplicate->set_expr('deleted_at', 'NULL');
+    }
 
     $duplicate->save();
     return $duplicate;


### PR DESCRIPTION
I've initially added an index on the links table `url` column, but it can produce "key too long" errors on certain DB configurations so I've dropped it.