### PR TITLE
Allow to activate MSS with an expiring key [MAILPOET-1852]

### DIFF
--- a/views/settings/mta.html
+++ b/views/settings/mta.html
@@ -1,5 +1,4 @@
 <% set intervals = [1, 2, 5, 10, 15, 30] %>
-<% set mss_key_valid = settings.mta.mailpoet_api_key_state.state == "valid" %>
 <% set default_frequency = {
   'website': {
     'emails': 25,


### PR DESCRIPTION
The `mss_key_valid` variable gets properly assigned to the template in `Config\Menu`. 

This shouldn't break the 'Behavior changes' from [here](https://mailpoet.atlassian.net/browse/MAILPOET-1441) as `expiring` counts as valid.