### PR TITLE
Revert "Get rid of double html parsing during render" [MAILPOET-1914]

### DIFF
--- a/lib/Util/CSS.php
+++ b/lib/Util/CSS.php
@@ -35,6 +35,7 @@ class CSS {
   */
   function inlineCSS($url, $contents=null) {
     $html = \pQuery::parseStr($contents);
+
     if (!is_object($html)) {
       return false;
     }
@@ -123,7 +124,7 @@ class CSS {
     }
 
     // Let simple_html_dom give us back our HTML with inline CSS!
-    return $html;
+    return (string)$html;
   }
 
   function parseCSS($text) {

--- a/tests/unit/Util/CSSTest.php
+++ b/tests/unit/Util/CSSTest.php
@@ -41,7 +41,7 @@ class CSSTest extends \MailPoetUnitTest {
     $styles = 'p { color: red; }';
     $content = '<p>Foo</p>';
     $html = $this->buildHtml($styles, $content);
-    $result_html = (string)$this->css->inlineCSS(null, $html);
+    $result_html = $this->css->inlineCSS(null, $html);
     $this->assertContains('<p style="color:red">', $result_html);
   }
 
@@ -49,7 +49,7 @@ class CSSTest extends \MailPoetUnitTest {
     $styles = 'p { color: red; } .blue { color: blue; }';
     $content = '<p class="blue">Foo</p>';
     $html = $this->buildHtml($styles, $content);
-    $result_html = (string)$this->css->inlineCSS(null, $html);
+    $result_html = $this->css->inlineCSS(null, $html);
     $this->assertContains('<p class="blue" style="color:blue">', $result_html);
   }
 
@@ -57,7 +57,7 @@ class CSSTest extends \MailPoetUnitTest {
     $styles = 'p { color: red; }';
     $content = '<p style="color:green">Foo</p>';
     $html = $this->buildHtml($styles, $content);
-    $result_html = (string)$this->css->inlineCSS(null, $html);
+    $result_html = $this->css->inlineCSS(null, $html);
     $this->assertContains('<p style="color:green">', $result_html);
   }
 
@@ -65,7 +65,7 @@ class CSSTest extends \MailPoetUnitTest {
     $styles = 'p { color: red !important; }';
     $content = '<p style="color:green !important">Foo</p>';
     $html = $this->buildHtml($styles, $content);
-    $result_html = (string)$this->css->inlineCSS(null, $html);
+    $result_html = $this->css->inlineCSS(null, $html);
     $this->assertContains('<p style="color:red">', $result_html);
   }
 


### PR DESCRIPTION
This reverts commit 6056dcd417bc5ff9996c257335d73e781e3f6576.

I can only reproduce this issue on customers' websites. Please ask supporters for access to them.