### PR TITLE
Move bulkSendConfirmationEmail() method out of the Subscriber model [MAILPOET-1922]

### DIFF
--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -71,6 +71,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\CronTrigger::class)->setPublic(true);
     // Listing
     $container->autowire(\MailPoet\Listing\BulkActionController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Listing\BulkActionFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Listing\Handler::class)->setPublic(true);
     // Router
     $container->autowire(\MailPoet\Router\Endpoints\CronDaemon::class)->setPublic(true);

--- a/lib/Listing/BulkActionController.php
+++ b/lib/Listing/BulkActionController.php
@@ -4,10 +4,14 @@ namespace MailPoet\Listing;
 if (!defined('ABSPATH')) exit;
 
 class BulkActionController {
+  /** @var BulkActionFactory */
+  private $factory;
+
   /** @var Handler */
   private $handler;
 
-  function __construct(Handler $handler) {
+  function __construct(BulkActionFactory $factory, Handler $handler) {
+    $this->factory = $factory;
     $this->handler = $handler;
   }
 
@@ -15,14 +19,10 @@ class BulkActionController {
     $bulk_action_method = 'bulk'.ucfirst($data['action']);
     unset($data['action']);
 
-    if (!method_exists($model_class, $bulk_action_method)) {
-      throw new \Exception(
-        $model_class. ' has no method "'.$bulk_action_method.'"'
-      );
-    }
+    $action_class = $this->factory->getActionClass($model_class, $bulk_action_method);
 
     return call_user_func_array(
-      array($model_class, $bulk_action_method),
+      array($action_class, $bulk_action_method),
       array($this->handler->getSelection($model_class, $data['listing']), $data)
     );
   }

--- a/lib/Listing/BulkActionFactory.php
+++ b/lib/Listing/BulkActionFactory.php
@@ -1,0 +1,31 @@
+<?php
+namespace MailPoet\Listing;
+
+if (!defined('ABSPATH')) exit;
+
+class BulkActionFactory {
+  /** @var array */
+  private $actions = [];
+
+  function registerAction($model_class, $bulk_action_method, $action_class) {
+    $this->ensureMethodExists($action_class, $bulk_action_method);
+    $this->actions[$model_class][$bulk_action_method] = $action_class;
+  }
+
+  function getActionClass($model_class, $bulk_action_method) {
+    $resulting_class = $model_class;
+    if (!empty($this->actions[$model_class][$bulk_action_method])) {
+      $resulting_class = $this->actions[$model_class][$bulk_action_method];
+    }
+    $this->ensureMethodExists($resulting_class, $bulk_action_method);
+    return $resulting_class;
+  }
+
+  private function ensureMethodExists($action_class, $bulk_action_method) {
+    if (!method_exists($action_class, $bulk_action_method)) {
+      throw new \Exception(
+        (is_object($action_class) ? get_class($action_class) : $action_class).' has no method "'.$bulk_action_method.'"'
+      );
+    }
+  }
+}

--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -3,7 +3,6 @@ namespace MailPoet\Models;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Util\Helpers;
 use function MailPoet\Util\array_column;
 use MailPoet\WP\Functions as WPFunctions;
@@ -583,26 +582,6 @@ class Subscriber extends Model {
     );
   }
 
-  static function bulkSendConfirmationEmail($orm) {
-    $subscribers = $orm
-      ->where('status', self::STATUS_UNCONFIRMED)
-      ->findMany();
-
-    $emails_sent = 0;
-    if (!empty($subscribers)) {
-      $sender = new ConfirmationEmailMailer();
-      foreach ($subscribers as $subscriber) {
-        if ($sender->sendConfirmationEmail($subscriber)) {
-          $emails_sent++;
-        }
-      }
-    }
-
-    return array(
-      'count' => $emails_sent
-    );
-  }
-
   static function getTotalSubscribers() {
     return self::whereIn('status', array(
       self::STATUS_SUBSCRIBED,
@@ -819,5 +798,14 @@ class Subscriber extends Model {
     trigger_error('Calling Subscriber::subscribe() is deprecated and will be removed. Use MailPoet\API\MP\v1\API instead. ', E_USER_DEPRECATED);
     $service = ContainerWrapper::getInstance()->get(\MailPoet\Subscribers\SubscriberActions::class);
     return $service->subscribe($subscriber_data, $segment_ids);
+  }
+
+  /**
+   * @deprecated
+   */
+  static function bulkSendConfirmationEmail($orm) {
+    trigger_error('Calling Subscriber::bulkSendConfirmationEmail() is deprecated and will be removed. Use MailPoet\API\MP\v1\API instead. ', E_USER_DEPRECATED);
+    $service = ContainerWrapper::getInstance()->get(\MailPoet\Subscribers\SubscriberActions::class);
+    return $service->bulkSendConfirmationEmail($orm);
   }
 }

--- a/lib/Segments/BulkAction.php
+++ b/lib/Segments/BulkAction.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments;
 
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Listing\Handler;
 use MailPoet\Models\Segment;
 use MailPoet\WP\Functions as WPFunctions;
@@ -41,7 +42,10 @@ class BulkAction {
     if (!$segment
       || in_array($segment['type'], [Segment::TYPE_DEFAULT, Segment::TYPE_WP_USERS, Segment::TYPE_WC_USERS], true)
     ) {
-      $bulk_action = new \MailPoet\Listing\BulkActionController(new Handler());
+      $bulk_action = new \MailPoet\Listing\BulkActionController(
+        ContainerWrapper::getInstance()->get(\MailPoet\Listing\BulkActionFactory::class),
+        new Handler()
+      );
       return $bulk_action->apply('\MailPoet\Models\Subscriber', $this->data);
     } else {
       $handlers = $this->wp->applyFilters('mailpoet_subscribers_in_segment_apply_bulk_action_handlers', array());

--- a/tests/integration/Listing/BulkActionClassStub.php
+++ b/tests/integration/Listing/BulkActionClassStub.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MailPoet\Listing;
+
+class BulkActionClassStub {
+
+  function bulkTestAction() {
+
+  }
+
+}

--- a/tests/integration/Listing/BulkActionFactoryTest.php
+++ b/tests/integration/Listing/BulkActionFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace MailPoet\Listing;
+
+use MailPoet\Models\Subscriber;
+
+require_once('BulkActionClassStub.php');
+
+class BulkActionFactoryTest extends \MailPoetTest {
+  /** @var BulkActionFactory */
+  private $bulk_action_factory;
+
+  function _before() {
+    $this->bulk_action_factory = new BulkActionFactory();
+  }
+
+  function testItReturnsCustomActionClass() {
+    $model_class = Subscriber::class;
+    $method = 'bulkTestAction';
+    $action_class = new BulkActionClassStub;
+    $this->bulk_action_factory->registerAction($model_class, $method, $action_class);
+    $resulting_class = $this->bulk_action_factory->getActionClass($model_class, $method);
+    expect($resulting_class)->equals($action_class);
+  }
+
+  function testItThrowsIfANonExistentActionMethodIsBeingRegistered() {
+    $model_class = Subscriber::class;
+    $method = 'bulkDoesNotExist';
+    $action_class = new BulkActionClassStub;
+    try {
+      $this->bulk_action_factory->registerAction($model_class, $method, $action_class);
+      $this->fail('Exception was not thrown');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->contains('has no method');
+    }
+  }
+
+  function testItThrowsIfANonExistentActionClassIsBeingRegistered() {
+    $model_class = Subscriber::class;
+    $method = 'bulkDoesNotExist';
+    $action_class = '\MailPoet\Some\Non\Existent\Class';
+    try {
+      $this->bulk_action_factory->registerAction($model_class, $method, $action_class);
+      $this->fail('Exception was not thrown');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->contains('has no method');
+    }
+  }
+
+  function testItReturnsModelClassByDefault() {
+    $model_class = Subscriber::class;
+    $method = 'bulkTrash';
+    $resulting_class = $this->bulk_action_factory->getActionClass($model_class, $method);
+    expect($resulting_class)->equals($model_class);
+  }
+
+  function testItThrowsIfANonExistentModelMethodIsProvided() {
+    $model_class = Subscriber::class;
+    $method = 'bulkDoesNotExist';
+    try {
+      $this->bulk_action_factory->getActionClass($model_class, $method);
+      $this->fail('Exception was not thrown');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->contains('has no method');
+    }
+  }
+}


### PR DESCRIPTION
Now `Subscriber` model has no `ConfirmationEmailMailer` dependency and we can use custom classes for bulk actions.

Note for QA: please make sure that different kinds of bulk actions work both in Free (especially "resend confirmation email" for subscribers) and Premium.