### PR TITLE
Larger area for form fields [MAILPOET-1910]

### DIFF
--- a/assets/css/src/components/_formEditor.scss
+++ b/assets/css/src/components/_formEditor.scss
@@ -226,7 +226,7 @@ $handle_icon: '../../img/handle.png';
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
   cursor: pointer;
   margin-bottom: 0;
-  max-height: 1000px;
+  max-height: 2000px;
   min-width: 255px;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
There has to be max-height and 'overflow: hidden' for animations to work properly. I just doubled the height, which gives spaces for 40+ possible fields, which seems like a reasonable limit.

[MAILPOET-1910]

[MAILPOET-1910]: https://mailpoet.atlassian.net/browse/MAILPOET-1910