### PR TITLE
Fix UnauthorizedAddress test button not being clickable

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -192,6 +192,10 @@ class AcceptanceTester extends \Codeception\Actor {
     return $this->_waitForText($text, $this->getDefaultTimeout($timeout), $selector);
   }
 
+  public function scrollToTop() {
+    return $this->scrollTo('#wpcontent');
+  }
+
   private function getDefaultTimeout($timeout) {
     return (int)getenv('WAIT_TIMEOUT') ?: $timeout;
   }

--- a/tests/acceptance/UnauthorizedAddressCest.php
+++ b/tests/acceptance/UnauthorizedAddressCest.php
@@ -50,6 +50,7 @@ class UnauthorizedAddressCest {
 
     // step 5 - Trash newsletter and resume sending
     $I->clickItemRowActionByItemName($newsletter_title, 'Move to trash');
+    $I->scrollToTop();
     $I->click('Resume sending');
     $I->waitForText('Sending has been resumed.');
   }
@@ -89,6 +90,7 @@ class UnauthorizedAddressCest {
 
     // step 5 - Trash newsletter and resume sending
     $I->clickItemRowActionByItemName($newsletter_title, 'Move to trash');
+    $I->scrollToTop();
     $I->click('Resume sending');
     $I->waitForText('Sending has been resumed.');
   }


### PR DESCRIPTION
[MAILPOET-1882]

Tested on specific [group of tests](https://circleci.com/gh/mailpoet/mailpoet/27872), on which it was failing

```tests/acceptance/EditExistingNewsletterCest.php
tests/acceptance/FormsCreationCest.php
tests/acceptance/ManageWelcomeEmailCest.php
tests/acceptance/PreviewPostNotificationNewsletterCest.php
tests/acceptance/ReceiveStandardEmailCest.php
tests/acceptance/SaveNewsletterAsDraftCest.php
tests/acceptance/SaveNewsletterAsTemplateCest.php
tests/acceptance/SavePostNotificationEmailAsTemplateCest.php
tests/acceptance/SearchForNotificationCest.php
tests/acceptance/SearchForStandardNewsletterCest.php
tests/acceptance/SettingsSubscriptionPageCest.php
tests/acceptance/SubscribersListingCest.php
tests/acceptance/UnauthorizedAddressCest.php

[MAILPOET-1882]: https://mailpoet.atlassian.net/browse/MAILPOET-1882