### PR TITLE
Add WooCommerce subscription checkbox on checkout [MAILPOET-1483]

### DIFF
--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -157,6 +157,9 @@ class Hooks {
   }
 
   function setupWooCommerceSubscriptionEvents() {
+    if (!$this->settings->get('woo_commerce_list_sync_enabled')) {
+      return false;
+    }
 
     $woocommerce = $this->settings->get('woocommerce', []);
     // WooCommerce: subscribe on checkout

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -202,7 +202,7 @@ class Migrator {
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'deleted_at timestamp NULL,',
       'unconfirmed_data longtext,',
-      "source enum('form','imported','administrator','api','wordpress_user','woocommerce_user','unknown') DEFAULT 'unknown',",
+      "source enum('form','imported','administrator','api','wordpress_user','woocommerce_user','woocommerce_checkout','unknown') DEFAULT 'unknown',",
       'count_confirmations int(11) unsigned NOT NULL DEFAULT 0,',
       'PRIMARY KEY  (id),',
       'UNIQUE KEY email (email),',

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -239,7 +239,7 @@ class Populator {
     if (empty($woocommerce_optin_on_checkout)) {
       $this->settings->set('woocommerce.optin_on_checkout', [
         'enabled' => empty($settings_db_version), // enable on new installs only
-        'message' => _x('Yes, I would like to be added to your mailing list', "default email opt-in message displayed on checkout page for ecommerce websites"),
+        'message' => WPFunctions::get()->x('Yes, I would like to be added to your mailing list', "default email opt-in message displayed on checkout page for ecommerce websites"),
       ]);
     }
 

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -170,6 +170,7 @@ class Populator {
 
   private function createDefaultSettings() {
     $current_user = WPFunctions::get()->wpGetCurrentUser();
+    $settings_db_version = $this->settings->fetch('db_version');
 
     // set cron trigger option to default method
     if (!$this->settings->fetch(CronTrigger::SETTING_NAME)) {
@@ -231,6 +232,14 @@ class Populator {
       $this->settings->set('stats_notifications', [
         'enabled' => true,
         'address' => isset($sender['address'])? $sender['address'] : null,
+      ]);
+    }
+
+    $woocommerce_optin_on_checkout = $this->settings->fetch('woocommerce.optin_on_checkout');
+    if (empty($woocommerce_optin_on_checkout)) {
+      $this->settings->set('woocommerce.optin_on_checkout', [
+        'enabled' => empty($settings_db_version), // enable on new installs only
+        'message' => _x('Yes, I would like to be added to your mailing list', "default email opt-in message displayed on checkout page for ecommerce websites"),
       ]);
     }
 

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -108,6 +108,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
     // WooCommerce
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);
     // WordPress
     $container->autowire(\MailPoet\WP\Functions::class)->setPublic(true);
     return $container;

--- a/lib/Models/SubscriberSegment.php
+++ b/lib/Models/SubscriberSegment.php
@@ -19,16 +19,13 @@ class SubscriberSegment extends Model {
     $subscriber->save();
 
     $wp_segment = Segment::getWPSegment();
-    $wc_segment = Segment::getWooCommerceSegment();
 
     if (!empty($segment_ids)) {
       // unsubscribe from segments
       foreach ($segment_ids as $segment_id) {
 
-        // do not remove subscriptions to the WP Users or WooCommerce Customers segments
-        if (($wp_segment !== false && (int)$wp_segment->id === (int)$segment_id)
-          || ($wc_segment !== false && (int)$wc_segment->id === (int)$segment_id)
-        ) {
+        // do not remove subscriptions to the WP Users segment
+        if ($wp_segment !== false && (int)$wp_segment->id === (int)$segment_id) {
           continue;
         }
 
@@ -47,11 +44,6 @@ class SubscriberSegment extends Model {
       if ($wp_segment !== false) {
         $subscriptions = $subscriptions->whereNotEqual(
           'segment_id', $wp_segment->id
-        );
-      }
-      if ($wc_segment !== false) {
-        $subscriptions = $subscriptions->whereNotEqual(
-          'segment_id', $wc_segment->id
         );
       }
 

--- a/lib/Models/SubscriberSegment.php
+++ b/lib/Models/SubscriberSegment.php
@@ -4,6 +4,13 @@ namespace MailPoet\Models;
 
 if (!defined('ABSPATH')) exit;
 
+/**
+ * @property int $id
+ * @property int $subscriber_id
+ * @property int $segment_id
+ * @property string $status
+ */
+
 class SubscriberSegment extends Model {
   public static $_table = MP_SUBSCRIBER_SEGMENT_TABLE;
 

--- a/lib/Settings/SettingsController.php
+++ b/lib/Settings/SettingsController.php
@@ -120,7 +120,7 @@ class SettingsController {
   private function getDefaultValue($keys) {
     $default = $this->getAllDefaults();
     foreach ($keys as $key) {
-      if (is_array($default) && array_key_exists($key, $default)) {
+      if (array_key_exists($key, $default)) {
         $default = $default[$key];
       } else {
         return null;

--- a/lib/Settings/SettingsController.php
+++ b/lib/Settings/SettingsController.php
@@ -28,7 +28,7 @@ class SettingsController {
       $default = $this->getDefaultValue($key_parts);
     }
     foreach ($key_parts as $key_part) {
-      if (array_key_exists($key_part, $setting)) {
+      if (is_array($setting) && array_key_exists($key_part, $setting)) {
         $setting = $setting[$key_part];
       } else {
         return $default;
@@ -120,7 +120,7 @@ class SettingsController {
   private function getDefaultValue($keys) {
     $default = $this->getAllDefaults();
     foreach ($keys as $key) {
-      if (array_key_exists($key, $default)) {
+      if (is_array($default) && array_key_exists($key, $default)) {
         $default = $default[$key];
       } else {
         return null;

--- a/lib/Subscribers/Source.php
+++ b/lib/Subscribers/Source.php
@@ -12,6 +12,7 @@ class Source {
   const API = 'api';
   const WORDPRESS_USER = 'wordpress_user';
   const WOOCOMMERCE_USER = 'woocommerce_user';
+  const WOOCOMMERCE_CHECKOUT = 'woocommerce_checkout';
   const UNKNOWN = 'unknown';
 
   private static $allowed_sources = array(
@@ -21,6 +22,7 @@ class Source {
     Source::API,
     Source::WORDPRESS_USER,
     Source::WOOCOMMERCE_USER,
+    Source::WOOCOMMERCE_CHECKOUT,
     Source::UNKNOWN,
   );
 

--- a/lib/WooCommerce/Subscription.php
+++ b/lib/WooCommerce/Subscription.php
@@ -1,0 +1,112 @@
+<?php
+namespace MailPoet\WooCommerce;
+
+use MailPoet\Models\Segment;
+use MailPoet\Models\Subscriber;
+use MailPoet\Models\SubscriberSegment;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\Source;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Subscription {
+  const CHECKOUT_OPTIN_INPUT_NAME = 'mailpoet_woocommerce_checkout_optin';
+  const OPTIN_ENABLED_SETTING_NAME = 'woocommerce.optin_on_checkout.enabled';
+  const OPTIN_MESSAGE_SETTING_NAME = 'woocommerce.optin_on_checkout.message';
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(
+    SettingsController $settings,
+    WPFunctions $wp
+  ) {
+    $this->settings = $settings;
+    $this->wp = $wp;
+  }
+
+  function extendWooCommerceCheckoutForm() {
+    $input_name = self::CHECKOUT_OPTIN_INPUT_NAME;
+    $checked = $this->isCurrentUserSubscribed();
+    $label_string = $this->settings->get(self::OPTIN_MESSAGE_SETTING_NAME);
+    $template = $this->wp->applyFilters(
+      'mailpoet_woocommerce_checkout_optin_template',
+      $this->getSubscriptionField($input_name, $checked, $label_string),
+      $input_name,
+      $checked,
+      $label_string
+    );
+    echo $template;
+  }
+
+  private function getSubscriptionField($input_name, $checked, $label_string) {
+    return '<p class="form-row">
+      <label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">
+      <input type="checkbox" class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" name="'.$this->wp->escAttr($input_name).'" id="'.$this->wp->escAttr($input_name).'" ' . ($checked ? 'checked' : '') . ' />
+        <span class="woocommerce-terms-and-conditions-checkbox-text">' . $this->wp->escHtml($label_string) . '</label>
+    </p>';
+  }
+
+  private function isCurrentUserSubscribed() {
+    $subscriber = Subscriber::getCurrentWPUser();
+    if ($subscriber instanceof Subscriber) {
+      $wc_segment = Segment::getWooCommerceSegment();
+      $subscriber_segment = SubscriberSegment::where('subscriber_id', $subscriber->id)
+        ->where('segment_id', $wc_segment->id)
+        ->findOne();
+      if ($subscriber_segment instanceof SubscriberSegment
+        && $subscriber_segment->status === Subscriber::STATUS_SUBSCRIBED
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function subscribeOnCheckout($order_id, $data) {
+    if (empty($data['billing_email'])) {
+      // no email in posted order data
+      return null;
+    }
+
+    $subscriber = Subscriber::where('email', $data['billing_email'])
+      ->where('is_woocommerce_user', 1)
+      ->findOne();
+    if (!$subscriber) {
+      // no subscriber: WooCommerce sync didn't work
+      return null;
+    }
+
+    $checkout_optin_enabled = (bool)$this->settings->get(self::OPTIN_ENABLED_SETTING_NAME);
+    $wc_segment = Segment::getWooCommerceSegment();
+
+    if ($checkout_optin_enabled) {
+      if (!empty($_POST[self::CHECKOUT_OPTIN_INPUT_NAME])) {
+        // checkbox is checked
+        $subscriber->source = Source::WOOCOMMERCE_CHECKOUT;
+        $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+        if (empty($subscriber->confirmed_ip) && empty($subscriber->confirmed_at)) {
+          $subscriber->confirmed_ip = Helpers::getIP();
+          $subscriber->setExpr('confirmed_at', 'NOW()');
+        }
+        $subscriber->save();
+
+        SubscriberSegment::subscribeToSegments(
+          $subscriber,
+          array($wc_segment->id)
+        );
+        return true;
+      }
+    }
+
+    // Opt-in is disabled or checkbox is unchecked
+    SubscriberSegment::unsubscribeFromSegments(
+      $subscriber,
+      array($wc_segment->id)
+    );
+    return false;
+  }
+}

--- a/tests/DataFactories/Settings.php
+++ b/tests/DataFactories/Settings.php
@@ -97,10 +97,24 @@ class Settings {
 
   function withWooCommerceListImportPageDisplayed($was_shown) {
     $this->settings->set('woocommerce.import_screen_displayed', $was_shown ? 1 : 0);
+    return $this;
   }
 
   function withWooCommerceListSyncEnabled() {
     $this->settings->set('woo_commerce_list_sync_enabled', 1);
+    return $this;
+  }
+
+  function withWooCommerceCheckoutOptinEnabled() {
+    $this->settings->set('woocommerce.optin_on_checkout.enabled', true);
+    $this->settings->set('woocommerce.optin_on_checkout.message', 'Yes, I would like to be added to your mailing list');
+    return $this;
+  }
+
+  function withWooCommerceCheckoutOptinDisabled() {
+    $this->settings->set('woocommerce.optin_on_checkout.enabled', false);
+    $this->settings->set('woocommerce.optin_on_checkout.message', '');
+    return $this;
   }
 
   function withDeactivateSubscriberAfter3Months() {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -246,7 +246,7 @@ class AcceptanceTester extends \Codeception\Actor {
   /**
    * Order a product and create an account within the order process
    */
-  public function orderProduct(array $product, $user_email, $do_register = true) {
+  public function orderProduct(array $product, $user_email, $do_register = true, $do_subscribe = true) {
     $I = $this;
     $I->addProductToCart($product);
     $I->goToCheckout();
@@ -255,6 +255,11 @@ class AcceptanceTester extends \Codeception\Actor {
       $I->optInForRegistration();
     }
     $I->selectPaymentMethod();
+    if ($do_subscribe) {
+      $I->optInForSubscription();
+    } else {
+      $I->optOutOfSubscription();
+    }
     $I->placeOrder();
   }
 
@@ -301,6 +306,22 @@ class AcceptanceTester extends \Codeception\Actor {
     $I = $this;
     $I->scrollTo(['css' => '#createaccount'], 0, -40);
     $I->click('#createaccount');
+  }
+
+  /**
+   * Check the option for subscribing to the WC list
+   */
+  public function optInForSubscription() {
+    $I = $this;
+    $I->checkOption('#mailpoet_woocommerce_checkout_optin');
+  }
+
+  /**
+   * Uncheck the option for subscribing to the WC list
+   */
+  public function optOutOfSubscription() {
+    $I = $this;
+    $I->uncheckOption('#mailpoet_woocommerce_checkout_optin');
   }
 
   /**

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -257,9 +257,11 @@ class AcceptanceTester extends \Codeception\Actor {
     $I->selectPaymentMethod();
     $I->placeOrder();
   }
+
   /**
    * WooCommerce ordering process methods, should be used sequentially
    */
+
   /**
    * Add a product to cart
    */
@@ -269,6 +271,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $I->click('Add to cart');
     $I->waitForText("“{$product['name']}” has been added to your cart.");
   }
+
   /**
    * Go to the checkout page
    */
@@ -276,6 +279,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $I = $this;
     $I->amOnPage('checkout');
   }
+
   /**
    * Fill the customer info
    */
@@ -289,6 +293,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $I->fillField('billing_postcode', '75000');
     $I->fillField('billing_phone', '123456');
   }
+
   /**
    * Check the option for creating an account
    */
@@ -297,15 +302,17 @@ class AcceptanceTester extends \Codeception\Actor {
     $I->scrollTo(['css' => '#createaccount'], 0, -40);
     $I->click('#createaccount');
   }
+
   /**
    * Select a payment method (cheque, cod, ppec_paypal)
    */
   public function selectPaymentMethod($method = 'cod') {
     $I = $this;
     $I->scrollTo('#payment_method_' . $method);
-    $I->waitForElementNotVisible('.blockOverlay', 20); // wait for payment method loading overlay to disappear
+    $I->waitForElementNotVisible('.blockOverlay', 30); // wait for payment method loading overlay to disappear
     $I->click('#payment_method_' . $method);
   }
+
   /**
    * Place the order
    */

--- a/tests/acceptance/WooCommerceCheckoutOptinCest.php
+++ b/tests/acceptance/WooCommerceCheckoutOptinCest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+require_once __DIR__ . '/../DataFactories/Settings.php';
+require_once __DIR__ . '/../DataFactories/WooCommerceProduct.php';
+
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\WooCommerceProduct;
+
+class WooCommerceCheckoutOptinCest {
+
+  /** @var Settings */
+  private $settings_factory;
+
+  /** @var WooCommerceProduct */
+  private $product_factory;
+
+  function _before(\AcceptanceTester $I) {
+    $I->activateWooCommerce();
+    $this->product_factory = new WooCommerceProduct($I);
+    $this->settings_factory = new Settings();
+    $this->settings_factory->withWooCommerceListImportPageDisplayed(true);
+    $this->settings_factory->withWooCommerceListSyncEnabled();
+    $this->settings_factory->withWooCommerceCheckoutOptinEnabled();
+  }
+
+  function checkoutWithOptinCheckboxChecked(\AcceptanceTester $I) {
+    $customer_email = 'wc_customer_checked@example.com';
+    $product = $this->product_factory->create();
+    $I->orderProduct($product, $customer_email);
+
+    $I->login();
+    $I->amOnMailpoetPage('Subscribers');
+    $I->searchFor($customer_email, 2);
+    $I->waitForListingItemsToLoad();
+    $I->waitForText($customer_email);
+    // Customer is subscribed to the WC customers list
+    $I->see('WooCommerce Customers', 'td[data-colname="Lists"]');
+  }
+
+  function checkoutWithOptinCheckboxUnchecked(\AcceptanceTester $I) {
+    $customer_email = 'wc_customer_unchecked@example.com';
+    $product = $this->product_factory->create();
+    $I->orderProduct($product, $customer_email, true, false);
+
+    $I->login();
+    $I->amOnMailpoetPage('Subscribers');
+    $I->searchFor($customer_email, 2);
+    $I->waitForListingItemsToLoad();
+    $I->waitForText($customer_email);
+    // Customer is unsubscribed from the WC customers list
+    $I->dontSee('WooCommerce Customers', 'td[data-colname="Lists"]');
+  }
+
+  function _after(\AcceptanceTester $I) {
+    $I->deactivateWooCommerce();
+  }
+}

--- a/tests/acceptance/WooCommerceCustomerListCest.php
+++ b/tests/acceptance/WooCommerceCustomerListCest.php
@@ -23,6 +23,7 @@ class WooCommerceCustomerListCest {
     $settings_factory = new Settings();
     $settings_factory->withWooCommerceListImportPageDisplayed(true);
     $settings_factory->withWooCommerceListSyncEnabled();
+    $settings_factory->withWooCommerceCheckoutOptinEnabled();
     $customer_factory = new WooCommerceCustomer($I);
     $customer_factory->deleteAll();
   }

--- a/tests/acceptance/WooCommerceSettingsTabCest.php
+++ b/tests/acceptance/WooCommerceSettingsTabCest.php
@@ -2,10 +2,17 @@
 
 namespace MailPoet\Test\Acceptance;
 
+require_once __DIR__ . '/../DataFactories/Settings.php';
+
+use MailPoet\Test\DataFactories\Settings;
+
 class WooCommerceSettingsTabCest {
 
   function _before(\AcceptanceTester $I) {
     $I->activateWooCommerce();
+    $this->settings_factory = new Settings();
+    $this->settings_factory->withWooCommerceListImportPageDisplayed(true);
+    $this->settings_factory->withWooCommerceListSyncEnabled();
   }
 
   function checkWooCommerceTabExists(\AcceptanceTester $I) {

--- a/tests/acceptance/WooCommerceSettingsTabCest.php
+++ b/tests/acceptance/WooCommerceSettingsTabCest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+class WooCommerceSettingsTabCest {
+
+  function _before(\AcceptanceTester $I) {
+    $I->activateWooCommerce();
+  }
+
+  function checkWooCommerceTabExists(\AcceptanceTester $I) {
+    $I->wantTo('Check WooCommerce settings tab exists when the WooCommerce plugin is active');
+
+    $I->login();
+    $I->amOnMailpoetPage('Settings');
+    $I->waitForText('WooCommerce');
+    $I->click('[data-automation-id="woocommerce_settings_tab"]');
+    $I->waitForText('Opt-in on checkout');
+    $I->seeNoJSErrors();
+
+    // The tab is hidden when WooCommerce is deactivated
+    $I->deactivateWooCommerce();
+    $I->amOnMailpoetPage('Settings');
+    $I->dontSee('WooCommerce');
+    $I->seeNoJSErrors();
+  }
+
+  function _after(\AcceptanceTester $I) {
+    $I->deactivateWooCommerce();
+  }
+}

--- a/tests/integration/API/JSON/v1/SetupTest.php
+++ b/tests/integration/API/JSON/v1/SetupTest.php
@@ -29,6 +29,9 @@ class SetupTest extends \MailPoetTest {
     $signup_confirmation = $settings->fetch('signup_confirmation.enabled');
     expect($signup_confirmation)->true();
 
+    $woocommerce_optin_on_checkout = $settings->fetch('woocommerce.optin_on_checkout');
+    expect($woocommerce_optin_on_checkout['enabled'])->true();
+
     $hook_name = 'mailpoet_setup_reset';
     expect(WPHooksHelper::isActionDone($hook_name))->true();
   }

--- a/tests/integration/Models/SubscriberSegmentTest.php
+++ b/tests/integration/Models/SubscriberSegmentTest.php
@@ -79,7 +79,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
     expect($subscribed_segments[0]['name'])->equals($this->segment_2->name);
   }
 
-  function testItDoesNotUnsubscribeFromWPAndWooCommerceSegments() {
+  function testItDoesNotUnsubscribeFromWPSegment() {
     $subscriber = $this->subscriber;
     $segment_1 = $this->segment_1;
     $segment_1->type = Segment::TYPE_WP_USERS;
@@ -126,7 +126,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
     expect($subscriber->subscriptions[0]['segment_id'])->equals($segment_1->id);
     expect($subscriber->subscriptions[1]['status'])->equals(Subscriber::STATUS_UNSUBSCRIBED);
     expect($subscriber->subscriptions[1]['segment_id'])->equals($segment_2->id);
-    expect($subscriber->subscriptions[2]['status'])->equals(Subscriber::STATUS_SUBSCRIBED);
+    expect($subscriber->subscriptions[2]['status'])->equals(Subscriber::STATUS_UNSUBSCRIBED);
     expect($subscriber->subscriptions[2]['segment_id'])->equals($segment_3->id);
   }
 
@@ -301,9 +301,8 @@ class SubscriberSegmentTest extends \MailPoetTest {
 
     // the subscriber should still be subscribed to the WP segment
     $subscribed_segments = $this->subscriber->segments()->findArray();
-    expect($subscribed_segments)->count(2);
+    expect($subscribed_segments)->count(1);
     expect($subscribed_segments[0]['name'])->equals($this->wp_segment->name);
-    expect($subscribed_segments[1]['name'])->equals($this->wc_segment->name);
   }
 
   function testItCannotDeleteSubscriptionToWPAndWooCommerceSegments() {

--- a/tests/integration/Segments/WooCommerceTest.php
+++ b/tests/integration/Segments/WooCommerceTest.php
@@ -146,7 +146,7 @@ class WooCommerceTest extends \MailPoetTest  {
     $random_number = 12345;
     $subscriber = Subscriber::createOrUpdate(array(
       'email' => 'user-sync-test' . $random_number . '@example.com',
-      'status' => Subscriber::STATUS_SUBSCRIBED
+      'status' => Subscriber::STATUS_UNSUBSCRIBED
     ));
     $user = $this->insertRegisteredCustomer($random_number);
     $this->woocommerce_segment->synchronizeCustomers();
@@ -156,13 +156,14 @@ class WooCommerceTest extends \MailPoetTest  {
       ->findOne();
     expect($wp_subscriber)->notEmpty();
     expect($wp_subscriber->id)->equals($subscriber->id);
+    expect($wp_subscriber->status)->equals(Subscriber::STATUS_UNSUBSCRIBED);
   }
 
   function testItSynchronizesPresubscribedGuestCustomers() {
     $random_number = 12345;
     $subscriber = Subscriber::createOrUpdate(array(
       'email' => 'user-sync-test' . $random_number . '@example.com',
-      'status' => Subscriber::STATUS_SUBSCRIBED
+      'status' => Subscriber::STATUS_UNSUBSCRIBED
     ));
     $guest = $this->insertGuestCustomer($random_number);
     $this->woocommerce_segment->synchronizeCustomers();
@@ -172,6 +173,7 @@ class WooCommerceTest extends \MailPoetTest  {
       ->findOne();
     expect($wp_subscriber)->notEmpty();
     expect($wp_subscriber->email)->equals($subscriber->email);
+    expect($wp_subscriber->status)->equals(Subscriber::STATUS_UNSUBSCRIBED);
   }
 
   function testItDoesNotSynchronizeEmptyEmailsForNewUsers() {

--- a/tests/integration/Settings/SettingsControllerTest.php
+++ b/tests/integration/Settings/SettingsControllerTest.php
@@ -39,6 +39,15 @@ class SettingsControllerTest extends \MailPoetTest {
     $this->assertEquals('default', $this->controller->get('test_key.wrong_subkey', 'default'));
   }
 
+  function testItCanFetchValuesFromDB() {
+    $this->assertEquals(null, $this->controller->fetch('test_key'));
+    $this->assertEquals(null, $this->controller->fetch('test_key.sub_key'));
+    $this->assertEquals('default', $this->controller->fetch('test_key.wrong_subkey', 'default'));
+    Setting::createOrUpdate(['name' => 'test_key', 'value' => serialize(['sub_key' => 'value'])]);
+    $this->assertEquals('default', $this->controller->get('test_key.sub_key', 'default'));
+    $this->assertEquals('value', $this->controller->fetch('test_key.sub_key', 'default'));
+  }
+
   function testItReturnsDefaultValueAsFallback() {
     $settings = Stub::make($this->controller, [
       'getAllDefaults' => function () {

--- a/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/tests/integration/WooCommerce/SubscriptionTest.php
@@ -1,0 +1,170 @@
+<?php
+namespace MailPoet\WooCommerce;
+
+use Codeception\Util\Fixtures;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Models\Segment;
+use MailPoet\Models\Subscriber;
+use MailPoet\Models\SubscriberSegment;
+use MailPoet\Segments\WP;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\Source;
+
+class SubscriptionTest extends \MailPoetTest {
+  function _before() {
+    $this->order_id = 123; // dummy
+    $this->subscription = ContainerWrapper::getInstance()->get(Subscription::class);
+    $this->settings = new SettingsController();
+    $this->wc_segment = Segment::getWooCommerceSegment();
+
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(Fixtures::get('subscriber_template'));
+    $subscriber->is_woocommerce_user = 1;
+    $this->subscriber = $subscriber->save();
+
+    // back up settings
+    $this->original_settings = $this->settings->get('woocommerce');
+  }
+
+  function testItDisplaysACheckedCheckboxIfCurrentUserIsSubscribed() {
+    WP::synchronizeUsers();
+    $wp_users = get_users();
+    wp_set_current_user($wp_users[0]->ID);
+    $subscriber = Subscriber::getCurrentWPUser();
+    SubscriberSegment::subscribeToSegments(
+      $subscriber,
+      array($this->wc_segment->id)
+    );
+    expect($this->getRenderedOptinField())->contains('checked');
+  }
+
+  function testItDisplaysAnUncheckedCheckboxIfCurrentUserIsNotSubscribed() {
+    WP::synchronizeUsers();
+    $wp_users = get_users();
+    wp_set_current_user($wp_users[0]->ID);
+    $subscriber = Subscriber::getCurrentWPUser();
+    SubscriberSegment::unsubscribeFromSegments(
+      $subscriber,
+      array($this->wc_segment->id)
+    );
+    expect($this->getRenderedOptinField())->notContains('checked');
+  }
+
+  function testItDisplaysAnUncheckedCheckboxIfCurrentUserIsNotLoggedIn() {
+    wp_set_current_user(0);
+    expect($this->getRenderedOptinField())->notContains('checked');
+  }
+
+  function testItDisplaysCheckboxOptinMessageFromSettings() {
+    $new_message = 'This is a test message.';
+    $this->settings->set(Subscription::OPTIN_MESSAGE_SETTING_NAME, $new_message);
+    expect($this->getRenderedOptinField())->contains($new_message);
+  }
+
+  function testItsTemplateCanBeOverriddenByAHook() {
+    $new_template = 'This is a new template';
+    add_filter(
+      'mailpoet_woocommerce_checkout_optin_template',
+      function ($template, $input_name, $checked, $label_string) use ($new_template) {
+        return $new_template . $input_name . $checked . $label_string;
+      },
+      10,
+      4
+    );
+    $result = $this->getRenderedOptinField();
+    expect($result)->contains($new_template);
+    expect($result)->contains(Subscription::CHECKOUT_OPTIN_INPUT_NAME);
+  }
+
+  function testItDoesNotTryToSubscribeIfThereIsNoEmailInOrderData() {
+    $data = [];
+    $subscribed = $this->subscription->subscribeOnCheckout($this->order_id, $data);
+    expect($subscribed)->equals(null);
+  }
+
+  function testItDoesNotTryToSubscribeIfSubscriberWithTheEmailWasNotSynced() {
+    // non-existent
+    $data['billing_email'] = 'non-existent-subscriber@example.com';
+    $subscribed = $this->subscription->subscribeOnCheckout($this->order_id, $data);
+    expect($subscribed)->equals(null);
+    // not a WooCommerce user
+    $this->subscriber->is_woocommerce_user = 0;
+    $this->subscriber->save();
+    $data['billing_email'] = $this->subscriber->email;
+    $subscribed = $this->subscription->subscribeOnCheckout($this->order_id, $data);
+    expect($subscribed)->equals(null);
+  }
+
+  function testItUnsubscribesIfCheckoutOptinIsDisabled() {
+    SubscriberSegment::subscribeToSegments(
+      $this->subscriber,
+      array($this->wc_segment->id)
+    );
+    $subscribed_segments = $this->subscriber->segments()->findArray();
+    expect($subscribed_segments)->count(1);
+
+    $this->settings->set(Subscription::OPTIN_ENABLED_SETTING_NAME, false);
+    $data['billing_email'] = $this->subscriber->email;
+    $subscribed = $this->subscription->subscribeOnCheckout($this->order_id, $data);
+    expect($subscribed)->equals(false);
+
+    $subscribed_segments = $this->subscriber->segments()->findArray();
+    expect($subscribed_segments)->count(0);
+  }
+
+  function testItUnsubscribesIfCheckboxIsNotChecked() {
+    SubscriberSegment::subscribeToSegments(
+      $this->subscriber,
+      array($this->wc_segment->id)
+    );
+    $subscribed_segments = $this->subscriber->segments()->findArray();
+    expect($subscribed_segments)->count(1);
+
+    $this->settings->set(Subscription::OPTIN_ENABLED_SETTING_NAME, true);
+    $data['billing_email'] = $this->subscriber->email;
+    $subscribed = $this->subscription->subscribeOnCheckout($this->order_id, $data);
+    expect($subscribed)->equals(false);
+
+    $subscribed_segments = $this->subscriber->segments()->findArray();
+    expect($subscribed_segments)->count(0);
+  }
+
+  function testItSubscribesIfCheckboxIsChecked() {
+    $this->subscriber->status = Subscriber::STATUS_UNSUBSCRIBED;
+    $this->subscriber->save();
+
+    $subscribed_segments = $this->subscriber->segments()->findArray();
+    expect($subscribed_segments)->count(0);
+
+    $this->settings->set(Subscription::OPTIN_ENABLED_SETTING_NAME, true);
+    $_POST[Subscription::CHECKOUT_OPTIN_INPUT_NAME] = 'on';
+    $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+    $data['billing_email'] = $this->subscriber->email;
+    $subscribed = $this->subscription->subscribeOnCheckout($this->order_id, $data);
+    expect($subscribed)->equals(true);
+    unset($_POST[Subscription::CHECKOUT_OPTIN_INPUT_NAME]);
+
+    $subscribed_segments = $this->subscriber->segments()->findArray();
+    expect($subscribed_segments)->count(1);
+
+    $subscriber = Subscriber::findOne($this->subscriber->id);
+    expect($subscriber->source)->equals(Source::WOOCOMMERCE_CHECKOUT);
+    expect($subscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
+    expect($subscriber->confirmed_ip)->notEmpty();
+    expect($subscriber->confirmed_at)->notEmpty();
+  }
+
+  private function getRenderedOptinField() {
+    ob_start();
+    $this->subscription->extendWooCommerceCheckoutForm();
+    $result = ob_get_clean();
+    return $result;
+  }
+
+  function _after() {
+    \ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
+    \ORM::raw_execute('TRUNCATE ' . SubscriberSegment::$_table);
+    // restore settings
+    $this->settings->set('woocommerce', $this->original_settings);
+  }
+}

--- a/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/tests/integration/WooCommerce/SubscriptionTest.php
@@ -15,6 +15,7 @@ class SubscriptionTest extends \MailPoetTest {
     $this->order_id = 123; // dummy
     $this->subscription = ContainerWrapper::getInstance()->get(Subscription::class);
     $this->settings = new SettingsController();
+    $this->settings->set('woo_commerce_list_sync_enabled', 1);
     $this->wc_segment = Segment::getWooCommerceSegment();
 
     $subscriber = Subscriber::create();

--- a/views/settings.html
+++ b/views/settings.html
@@ -40,10 +40,12 @@
         <% include 'settings/signup.html' %>
       </div>
 
-      <!-- sign-up confirmation -->
-      <div data-tab="woocommerce" class="mailpoet_tab_panel">
-        <% include 'settings/woocommerce.html' %>
-      </div>
+      <% if is_woocommerce_active %>
+        <!-- woocommerce -->
+        <div data-tab="woocommerce" class="mailpoet_tab_panel">
+          <% include 'settings/woocommerce.html' %>
+        </div>
+      <% endif %>
 
      <!-- advanced -->
       <div data-tab="advanced" class="mailpoet_tab_panel">
@@ -115,6 +117,18 @@
           } else {
             $('#settings_stats_notifications_error').hide();
           }
+          <% if is_woocommerce_active %>
+            // if WooCommerce opt-in on checkout is enabled but the checkbox message is empty, show an error
+            var woocommerce_optin_on_checkout_enabled = $('input[name="woocommerce[optin_on_checkout][enabled]"]:checked').val(),
+              woocommerce_optin_on_checkout_message = $('input[name="woocommerce[optin_on_checkout][message]"]').val().trim();
+            if (woocommerce_optin_on_checkout_enabled && woocommerce_optin_on_checkout_message == '') {
+              $('#settings_woocommerce_optin_on_checkout_error').show();
+              window.location.href = '#woocommerce';
+              errorFound = true;
+            } else {
+              $('#settings_woocommerce_optin_on_checkout_error').hide();
+            }
+          <% endif %>
           // stop processing if an error was found
           if (errorFound) {
             return false;
@@ -200,6 +214,10 @@
 
         $('#settings_subscriber_email_notification_error').hide();
         $('#settings_stats_notifications_error').hide();
+
+        <% if is_woocommerce_active %>
+          $('#settings_woocommerce_optin_on_checkout_error').hide();
+        <% endif %>
 
         function toggleLinuxCronSettings() {
           if ($('input[name="cron_trigger[method]"]:checked').val() === '<%= cron_trigger.linux_cron %>') {

--- a/views/settings/woocommerce.html
+++ b/views/settings/woocommerce.html
@@ -1,15 +1,62 @@
 <table class="form-table">
   <tr>
     <th scope="row">
+      <label for="settings[woocommerce_optin_on_checkout]">
+        <%= _x('Opt-in on checkout', "settings area: add an email opt-in checkbox on the checkout page (e-commerce websites)") %>
+      </label>
+      <p class="description">
+        <%= __('Customers can subscribe to the "WooCommerce Customers" list via a checkbox on the checkout page.') %>
+      </p>
+    </th>
+    <td>
+      <p>
+        <input
+        data-toggle="mailpoet_woocommerce_optin_on_checkout"
+        type="checkbox"
+        value="1"
+        id="settings[woocommerce_optin_on_checkout]"
+        name="woocommerce[optin_on_checkout][enabled]"
+        <% if(settings.woocommerce.optin_on_checkout.enabled) %>checked="checked"<% endif %>
+        >
+      </p>
+    </td>
+  </tr>
+  <tr id="mailpoet_woocommerce_optin_on_checkout">
+    <th scope="row">
+      <label for="settings[woocommerce_checkbox_optin_message]">
+        <%= _x('Checkbox opt-in message', "settings area: set the email opt-in message on the checkout page (e-commerce websites)") %>
+      </label>
+      <p class="description">
+        <%= __('This is the checkbox message your customers will see on your WooCommerce checkout page to subscribe to the "WooCommerce Customers" list.') %>
+      </p>
+    </th>
+    <td>
+      <p>
+        <input type="text"
+          id="woocommerce_checkbox_optin_message"
+          name="woocommerce[optin_on_checkout][message]"
+          value="<%= settings.woocommerce.optin_on_checkout.message %>"
+          placeholder="<%= _x('Checkbox opt-in message', "placeholder text for the WooCommerce checkout opt-in message") %>"
+          class="regular-text" />
+          <br>
+          <div id="settings_woocommerce_optin_on_checkout_error" class="mailpoet_error_item mailpoet_error">
+            <%= __('The checkbox opt-in message cannot be empty.') %>
+          </div>
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th scope="row">
       <label for="settings[mailpoet_subscribe_old_woocommerce_customers]">
         <%= __('Subscribe old WooCommerce customers') %>
       </label>
       <p class="description">
         <%= __('Subscribe all my past customers to this list because they agreed to receive marketing emails from me.') %>
+      </p>
+    </th>
     <td>
       <p>
         <input
-        data-toggle="mailpoet_subscribe_old_woocommerce_customers"
         type="checkbox"
         value="1"
         id="settings[mailpoet_subscribe_old_woocommerce_customers]"
@@ -30,5 +77,7 @@
           value="1"
           name="mailpoet_subscribe_old_woocommerce_customers[dummy]"
         >
+      </p>
+    </td>
+  </tr>
 </table>
-

--- a/views/settings/woocommerce.html
+++ b/views/settings/woocommerce.html
@@ -1,4 +1,5 @@
 <table class="form-table">
+  <% if settings.woo_commerce_list_sync_enabled %>
   <tr>
     <th scope="row">
       <label for="settings[woocommerce_optin_on_checkout]">
@@ -45,6 +46,7 @@
       </p>
     </td>
   </tr>
+  <% endif %>
   <tr>
     <th scope="row">
       <label for="settings[mailpoet_subscribe_old_woocommerce_customers]">


### PR DESCRIPTION
Customer synchronization is performed by the existing WC sync functionality, with this checkbox we only manage WC list subscription status and occasionally a few other fields.