### PR TITLE
Use WP function to parse DB_HOST [MAILPOET-1907]

### DIFF
--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -523,4 +523,13 @@ class Functions {
   function wpautop($pee, $br = true) {
     return wpautop($pee, $br);
   }
+
+  /**
+   * @param string $host
+   * @return array|bool
+   */
+  function parseDbHost($host) {
+    global $wpdb;
+    return $wpdb->parse_db_host($host);
+  }
 }

--- a/tests/integration/Config/EnvTest.php
+++ b/tests/integration/Config/EnvTest.php
@@ -41,6 +41,18 @@ class EnvTest extends \MailPoetTest {
     expect(Env::$db_source_name)->equals('mysql:host=localhost;port=3306;dbname=db_name;unix_socket=/var/lib/mysql/mysql55.sock;charset='. ENV::$db_charset);
   }
 
+  function testItProcessDBHostWithIpV6Address() {
+    Env::init('file', '1.0.0', '::1', 'db_user', 'pass123', 'db_name');
+    expect(Env::$db_host)->equals('::1');
+    expect(Env::$db_socket)->equals(null);
+    expect(Env::$db_source_name)->equals('mysql:host=[::1];port=3306;dbname=db_name;charset='. ENV::$db_charset);
+
+    Env::init('file', '1.0.0', 'b57e:9b70:ab96:6a0b:5ba2:49e3:ebba:a036', 'db_user', 'pass123', 'db_name');
+    expect(Env::$db_host)->equals('b57e:9b70:ab96:6a0b:5ba2:49e3:ebba:a036');
+    expect(Env::$db_socket)->equals(null);
+    expect(Env::$db_source_name)->equals('mysql:host=[b57e:9b70:ab96:6a0b:5ba2:49e3:ebba:a036];port=3306;dbname=db_name;charset='. ENV::$db_charset);
+
+  }
   function testItCanReturnDbName() {
     expect(Env::$db_name)->equals(DB_NAME);
   }


### PR DESCRIPTION
This change will enable using MailPoet on sites which are using ipv6 addresses in DB_HOST
