### PR TITLE
Automate the next release version bump [MAILPOET-1869]

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -594,10 +594,17 @@ class RoboFile extends \Robo\Tasks {
       ->run();
   }
 
-  public function jiraReleaseVersion($version = null, $opts = []) {
-    if ($version) {
-      $this->validateVersion($version);
+  public function nextReleaseVersion($version = null) {
+    if (!$version) {
+      $version = $this->getReleaseVersionController()
+        ->determineNextVersion();
     }
+    $this->validateVersion($version);
+    return $version;
+  }
+
+  public function jiraReleaseVersion($version = null, $opts = []) {
+    $version = $this->nextReleaseVersion($version);
     try {
       list($version, $output) = $this->getReleaseVersionController()
         ->assignVersionToCompletedTickets($version);
@@ -656,7 +663,7 @@ class RoboFile extends \Robo\Tasks {
   }
 
   protected function validateVersion($version) {
-    if (!preg_match('/\d+\.\d+\.\d+/', $version)) {
+    if (!\MailPoetTasks\Release\VersionHelper::validateVersion($version)) {
       $this->yell('Incorrect version format', 40, 'red');
       exit(1);
     }

--- a/tasks/release/JiraController.php
+++ b/tasks/release/JiraController.php
@@ -119,8 +119,4 @@ class JiraController {
   function updateIssue($key, $data) {
     $this->http_client->put("issue/$key", ['json' => $data]);
   }
-
-  function setProject($project) {
-    $this->project = $project;
-  }
 }

--- a/tasks/release/JiraController.php
+++ b/tasks/release/JiraController.php
@@ -8,6 +8,7 @@ class JiraController {
 
   const CHANGELOG_FIELD_ID = 'customfield_10500';
   const RELEASENOTE_FIELD_ID = 'customfield_10504';
+  const VERSION_INCREMENT_FIELD_ID = 'customfield_10509';
 
   const WONT_DO_RESOLUTION_ID = '10001';
 
@@ -59,6 +60,17 @@ class JiraController {
     throw new \Exception('Unknown project version');
   }
 
+  function getLastReleasedVersion() {
+    $response = $this->http_client->get("project/$this->project/versions");
+    $versions = json_decode($response->getBody()->getContents(), true);
+    foreach (array_reverse($versions) as $version) {
+      if ($version['released']) {
+        return $version;
+      }
+    }
+    throw new \Exception('No released versions found');
+  }
+
   /**
    * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-version-post
    */
@@ -106,5 +118,9 @@ class JiraController {
    */
   function updateIssue($key, $data) {
     $this->http_client->put("issue/$key", ['json' => $data]);
+  }
+
+  function setProject($project) {
+    $this->project = $project;
   }
 }

--- a/tasks/release/ReleaseVersionController.php
+++ b/tasks/release/ReleaseVersionController.php
@@ -38,40 +38,38 @@ class ReleaseVersionController {
 
   function determineNextVersion() {
     $last_version = $this->jira->getLastReleasedVersion();
-    $parsed_last_version = VersionHelper::parseVersion($last_version['name']);
 
-    $version_to_increment = VersionHelper::PATCH;
+    $part_to_increment = VersionHelper::PATCH;
 
     if ($this->project === JiraController::PROJECT_MAILPOET) {
       $free_increment = $this->checkProjectVersionIncrement(JiraController::PROJECT_MAILPOET);
       $premium_increment = $this->checkProjectVersionIncrement(JiraController::PROJECT_PREMIUM);
 
       if (in_array(VersionHelper::MINOR, [$free_increment, $premium_increment])) {
-        $version_to_increment = VersionHelper::MINOR;
+        $part_to_increment = VersionHelper::MINOR;
       }
     }
 
-    $parsed_last_version[$version_to_increment]++;
-    $next_version = VersionHelper::buildVersion($parsed_last_version);
+    $next_version = VersionHelper::incrementVersion($last_version['name'], $part_to_increment);
     return $next_version;
   }
 
   private function checkProjectVersionIncrement($project) {
     $issues = $this->getUnreleasedDoneIssues($project);
 
-    $version_to_increment = VersionHelper::PATCH;
+    $part_to_increment = VersionHelper::PATCH;
     $field_id = JiraController::VERSION_INCREMENT_FIELD_ID;
 
     foreach ($issues as $issue) {
       if (!empty($issue['fields'][$field_id]['value'])
         && $issue['fields'][$field_id]['value'] === VersionHelper::MINOR
       ) {
-        $version_to_increment = VersionHelper::MINOR;
+        $part_to_increment = VersionHelper::MINOR;
         break;
       }
     }
 
-    return $version_to_increment;
+    return $part_to_increment;
   }
 
   private function getUnreleasedDoneIssues($project = null) {

--- a/tasks/release/ReleaseVersionController.php
+++ b/tasks/release/ReleaseVersionController.php
@@ -57,9 +57,7 @@ class ReleaseVersionController {
   }
 
   private function checkProjectVersionIncrement($project) {
-    $this->jira->setProject($project);
-    $issues = $this->getUnreleasedDoneIssues();
-    $this->jira->setProject(JiraController::PROJECT_MAILPOET); // restore project
+    $issues = $this->getUnreleasedDoneIssues($project);
 
     $version_to_increment = VersionHelper::PATCH;
     $field_id = JiraController::VERSION_INCREMENT_FIELD_ID;
@@ -76,8 +74,9 @@ class ReleaseVersionController {
     return $version_to_increment;
   }
 
-  private function getUnreleasedDoneIssues() {
-    $jql = "project = $this->project AND status = Done AND (fixVersion = EMPTY OR fixVersion IN unreleasedVersions()) AND updated >= -52w";
+  private function getUnreleasedDoneIssues($project = null) {
+    $project = $project ?: $this->project;
+    $jql = "project = $project AND status = Done AND (fixVersion = EMPTY OR fixVersion IN unreleasedVersions()) AND updated >= -52w";
     $result = $this->jira->search($jql, ['key', JiraController::VERSION_INCREMENT_FIELD_ID]);
     return $result['issues'];
   }

--- a/tasks/release/VersionHelper.php
+++ b/tasks/release/VersionHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MailPoetTasks\Release;
+
+class VersionHelper {
+  const VERSION_REGEXP = '/^(\d+)\.(\d+)\.(\d+)$/';
+
+  const MAJOR = 'Major';
+  const MINOR = 'Minor';
+  const PATCH = 'Patch';
+
+  static function parseVersion($version) {
+    if (!preg_match(self::VERSION_REGEXP, $version, $matches)) {
+      throw new \Exception('Incorrect version format');
+    }
+    return [
+      self::MAJOR => $matches[1],
+      self::MINOR => $matches[2],
+      self::PATCH => $matches[3],
+    ];
+  }
+
+  static function buildVersion(array $parts) {
+    return sprintf('%d.%d.%d', $parts[self::MAJOR], $parts[self::MINOR], $parts[self::PATCH]);
+  }
+
+  static function validateVersion($version) {
+    return preg_match(self::VERSION_REGEXP, $version);
+  }
+}

--- a/tasks/release/VersionHelper.php
+++ b/tasks/release/VersionHelper.php
@@ -9,6 +9,23 @@ class VersionHelper {
   const MINOR = 'Minor';
   const PATCH = 'Patch';
 
+  static function incrementVersion($version, $part_to_increment = self::PATCH) {
+    $parsed_version = is_array($version) ? $version : self::parseVersion($version);
+
+    switch ($part_to_increment) {
+      case self::MINOR:
+        $parsed_version[self::MINOR]++;
+        $parsed_version[self::PATCH] = 0;
+        break;
+      case self::PATCH:
+      default:
+        $parsed_version[self::PATCH]++;
+        break;
+    }
+
+    return is_array($version) ? $parsed_version : self::buildVersion($parsed_version);
+  }
+
   static function parseVersion($version) {
     if (!preg_match(self::VERSION_REGEXP, $version, $matches)) {
       throw new \Exception('Incorrect version format');


### PR DESCRIPTION
Now the `jira:release-version` command will automatically determine the next release version according to the "Required version increment" field of Jira tickets.

You can also check what the next version will be with `next:release-version`.