### PR TITLE
Fix typo in jQuery selector

### DIFF
--- a/views/settings/advanced.html
+++ b/views/settings/advanced.html
@@ -381,7 +381,7 @@
 <script type="text/javascript">
   jQuery(function($) {
     $(function() {
-      $('input[name="tracking[enabled]"').on('change', function() {
+      $('input[name="tracking[enabled]"]').on('change', function() {
         var trackingEnabled = $(this).val();
         if (trackingEnabled) {
           $('.mailpoet_inactive_subscribers_enabled').removeClass('mailpoet_hidden');


### PR DESCRIPTION
Fixes #1983. It was working in Chrome and Firefox but was throwing an error in Safari.