### PR TITLE
Check if all issues PRs are merged [MAILPOET-2010]

### DIFF
--- a/tasks/release/JiraController.php
+++ b/tasks/release/JiraController.php
@@ -9,6 +9,7 @@ class JiraController {
   const CHANGELOG_FIELD_ID = 'customfield_10500';
   const RELEASENOTE_FIELD_ID = 'customfield_10504';
   const VERSION_INCREMENT_FIELD_ID = 'customfield_10509';
+  const PULL_REQUESTS_ID = 'customfield_10000';
 
   const WONT_DO_RESOLUTION_ID = '10001';
 
@@ -100,7 +101,8 @@ class JiraController {
   function getIssuesDataForVersion($version) {
     $changelog_id = self::CHANGELOG_FIELD_ID;
     $release_note_id = self::RELEASENOTE_FIELD_ID;
-    $issues_data = $this->search("fixVersion={$version['id']}", ['key', $changelog_id, $release_note_id, 'status', 'resolution']);
+    $pull_requests_id = self::PULL_REQUESTS_ID;
+    $issues_data = $this->search("fixVersion={$version['id']}", ['key', $changelog_id, $release_note_id, 'status', 'resolution', $pull_requests_id]);
     // Sort issues by importance of change (Added -> Updated -> Improved -> Changed -> Fixed -> Others)
     usort($issues_data['issues'], function($a, $b) use ($changelog_id) {
       $order = array_flip(['added', 'updat', 'impro', 'chang', 'fixed']);


### PR DESCRIPTION
To test this I did the following

- Created this dummy task https://mailpoet.atlassian.net/browse/MAILPOET-2048
- Created two PRs associated with it
https://github.com/mailpoet/release-notes/pull/6
https://github.com/mailpoet/mailpoet-dev-env/pull/16
- I merged the first PR and kept the second one open.
- Created a release `3.25.2` and assigned it to the dummy task
- Run `./do release:check-issues 3.25.2` which gives the error
```
Some pull request associated to task MAILPOET-2048 is not merged yet!
```
- closed the second dummy PR and tried again, have no error.

You should be able to test that by opening/closing that PR and running the command.