### PR TITLE
Don't look up a subscriber for guest WP users [MAILPOET-2047]

### DIFF
--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -104,6 +104,9 @@ class Subscriber extends Model {
 
   static function getCurrentWPUser() {
     $wp_user = WPFunctions::get()->wpGetCurrentUser();
+    if (empty($wp_user->ID)) {
+      return false; // Don't look up a subscriber for guests
+    }
     return self::where('wp_user_id', $wp_user->ID)->findOne();
   }
 


### PR DESCRIPTION
This fixes archive newsletter URLs not working for guests if there is a subscriber with `wp_user_id = 0` in the DB. And shaves off one query.