### PR TITLE
Skip deleted segments in SubscribersFinder [MAILPOET-2026]

### DIFF
--- a/lib/Segments/SubscribersFinder.php
+++ b/lib/Segments/SubscribersFinder.php
@@ -21,6 +21,9 @@ class SubscribersFinder {
     $result = array();
     foreach ($newsletter_segments_ids as $segment_id) {
       $segment = Segment::findOne($segment_id);
+      if (!$segment instanceof Segment) {
+        continue; // skip deleted segments
+      }
       $result = array_merge($result, $this->findSubscribersInSegment($segment, $subscribers_to_process_ids));
     }
     return $this->unique($result);

--- a/tests/integration/Segments/SubscribersFinderTest.php
+++ b/tests/integration/Segments/SubscribersFinderTest.php
@@ -56,7 +56,8 @@ class SubscribersFinderTest extends \MailPoetTest {
 
   function testFindSubscribersInSegmentInSegmentDefaultSegment() {
     $finder = new SubscribersFinder();
-    $subscribers = $finder->findSubscribersInSegments(array($this->subscriber_2->id), array($this->segment_1->id));
+    $deleted_segment_id = 1000; // non-existent segment
+    $subscribers = $finder->findSubscribersInSegments(array($this->subscriber_2->id), array($this->segment_1->id, $deleted_segment_id));
     expect($subscribers)->count(1);
     expect($subscribers[$this->subscriber_2->id])->equals($this->subscriber_2->id);
   }


### PR DESCRIPTION
A newsletter can have deleted segments, i.e. orphaned relations to segments (see here: https://github.com/mailpoet/mailpoet/blob/master/lib/Models/Newsletter.php#L488). Thus we should not clean up these relations but skip them during processing.