### PR TITLE
Add newsletter sending status page [MAILPOET-1155]

### DIFF
--- a/assets/js/src/newsletters/listings/mixins.jsx
+++ b/assets/js/src/newsletters/listings/mixins.jsx
@@ -86,7 +86,7 @@ const QueueMixin = {
 
     if (newsletter.queue.status === 'completed') {
       label = (
-        <Link to={`/sending-status/${newsletter.id}`}>
+        <Link to={`/sending-status/${newsletter.id}`} data-automation-id={`sending_status_${newsletter.id}`}>
           <span>
             {
               MailPoet.I18n.t('newsletterQueueCompleted')

--- a/assets/js/src/newsletters/listings/mixins.jsx
+++ b/assets/js/src/newsletters/listings/mixins.jsx
@@ -86,13 +86,15 @@ const QueueMixin = {
 
     if (newsletter.queue.status === 'completed') {
       label = (
-        <span>
-          {
-            MailPoet.I18n.t('newsletterQueueCompleted')
-              .replace('%$1d', parseInt(newsletter.queue.count_processed, 10).toLocaleString())
-              .replace('%$2d', parseInt(newsletter.queue.count_total, 10).toLocaleString())
-          }
-        </span>
+        <Link to={`/sending-status/${newsletter.id}`}>
+          <span>
+            {
+              MailPoet.I18n.t('newsletterQueueCompleted')
+                .replace('%$1d', parseInt(newsletter.queue.count_processed, 10).toLocaleString())
+                .replace('%$2d', parseInt(newsletter.queue.count_total, 10).toLocaleString())
+            }
+          </span>
+        </Link>
       );
     } else {
       const resumeSendingClick = _.partial(QueueMixin.resumeSending, newsletter);

--- a/assets/js/src/newsletters/listings/welcome.jsx
+++ b/assets/js/src/newsletters/listings/welcome.jsx
@@ -215,7 +215,12 @@ const NewsletterListWelcome = createReactClass({ // eslint-disable-line react/pr
           </select>
         </p>
         <p>
-          <Link to={`/sending-status/${newsletter.id}`}>{ totalSentMessage }</Link>
+          <Link
+            to={`/sending-status/${newsletter.id}`}
+            data-automation-id={`sending_status_${newsletter.id}`}
+          >
+            { totalSentMessage }
+          </Link>
           {' '}
           <br />
           { totalScheduledMessage }

--- a/assets/js/src/newsletters/listings/welcome.jsx
+++ b/assets/js/src/newsletters/listings/welcome.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import Listing from 'listing/listing.jsx';
 import ListingTabs from 'newsletters/listings/tabs.jsx';
@@ -214,7 +215,7 @@ const NewsletterListWelcome = createReactClass({ // eslint-disable-line react/pr
           </select>
         </p>
         <p>
-          { totalSentMessage }
+          <Link to={`/sending-status/${newsletter.id}`}>{ totalSentMessage }</Link>
           {' '}
           <br />
           { totalScheduledMessage }

--- a/assets/js/src/newsletters/newsletters.jsx
+++ b/assets/js/src/newsletters/newsletters.jsx
@@ -19,6 +19,7 @@ import NewsletterListStandard from 'newsletters/listings/standard.jsx';
 import NewsletterListWelcome from 'newsletters/listings/welcome.jsx';
 import NewsletterListNotification from 'newsletters/listings/notification.jsx';
 import NewsletterListNotificationHistory from 'newsletters/listings/notification_history.jsx';
+import NewsletterSendingStatus from 'newsletters/sending_status.jsx';
 
 class App extends React.Component {
   render() {
@@ -97,6 +98,10 @@ if (container) {
     {
       path: '/send/:id',
       component: NewsletterSend,
+    },
+    {
+      path: '/sending-status/:id',
+      component: NewsletterSendingStatus,
     },
   ];
 

--- a/assets/js/src/newsletters/newsletters.jsx
+++ b/assets/js/src/newsletters/newsletters.jsx
@@ -100,7 +100,7 @@ if (container) {
       component: NewsletterSend,
     },
     {
-      path: '/sending-status/:id',
+      path: '/sending-status/:id/(.*)?',
       component: NewsletterSendingStatus,
     },
   ];

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -145,7 +145,7 @@ const ListingItem = ({
   }
   return (
     <>
-      <td className={rowClasses}>
+      <td data-automation-id={`name_${taskId}_${subscriberId}`} className={rowClasses}>
         <strong>
           <a
             className="row-title"
@@ -158,10 +158,10 @@ const ListingItem = ({
           { `${firstName} ${lastName}` }
         </p>
       </td>
-      <td className="column" data-colname={MailPoet.I18n.t('sendingStatus')}>
+      <td className="column" data-automation-id={`status_${taskId}_${subscriberId}`} data-colname={MailPoet.I18n.t('sendingStatus')}>
         { status }
       </td>
-      <td className="column" data-colname={MailPoet.I18n.t('failureReason')}>
+      <td className="column" data-automation-id={`error_${taskId}_${subscriberId}`} data-colname={MailPoet.I18n.t('failureReason')}>
         { error }
       </td>
     </>

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -1,7 +1,7 @@
+import React from 'react';
 import MailPoet from 'mailpoet';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import Listing from 'listing/listing.jsx';
 import { CronMixin, MailerMixin } from 'newsletters/listings/mixins.jsx';
@@ -50,7 +50,7 @@ const SendingStatus = (props) => {
   }, [newsletterId]);
 
   return (
-    <Fragment>
+    <>
       <h1>{MailPoet.I18n.t('sendingStatusTitle')}</h1>
       <StatsLink
         newsletterId={newsletterId}
@@ -73,7 +73,7 @@ const SendingStatus = (props) => {
           CronMixin.checkCronStatus(state);
         }}
       />
-    </Fragment>
+    </>
   );
 };
 SendingStatus.propTypes = {
@@ -144,7 +144,7 @@ const ListingItem = ({
     }
   }
   return (
-    <Fragment>
+    <>
       <td className={rowClasses}>
         <strong>
           <a
@@ -164,7 +164,7 @@ const ListingItem = ({
       <td className="column" data-colname={MailPoet.I18n.t('failureReason')}>
         { error }
       </td>
-    </Fragment>
+    </>
   );
 };
 ListingItem.propTypes = {

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -1,13 +1,19 @@
 import Hooks from 'wp-js-hooks';
 import MailPoet from 'mailpoet';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import React, {Fragment} from 'react';
 import { Link } from 'react-router-dom';
+import Listing from 'listing/listing.jsx';
+import { CronMixin, MailerMixin } from 'newsletters/listings/mixins.jsx';
 
 const SendingStatus = props => {
   const newsletterId = props.match.params.id;
-  const [error, setError] = React.useState(null);
-  const [newsletterSubject, setNewsletterSubject] = React.useState(null);
+  const [state, setState] = React.useState({
+    error: null,
+    newsletterSubject: null,
+  });
+
   React.useEffect(() => {
     MailPoet.Ajax.post({
       api_version: window.mailpoet_api_version,
@@ -17,50 +23,145 @@ const SendingStatus = props => {
         id: newsletterId,
       },
     })
-    .done(response => setNewsletterSubject(response.data.subject))
-    .fail(() => setError('loadingNewsletterError'));
+    .done(res => setState({
+      error: null,
+      newsletterSubject: res.data.subject,
+    }))
+    .fail(() => setState({
+      newsletterSubject: null,
+      error: 'loadingNewsletterError',
+    }));
   }, [newsletterId]);
 
-  const title = <h1>{MailPoet.I18n.t('sendingStatusTitle')}</h1>;
-  if (error) {
-    return (
-      <Fragment>
-        {title}
-        <div className="notice notice-error">
-          <p>{ MailPoet.I18n.t(error) }</p>
-        </div>
-      </Fragment>
-    );
-  }
+  const {error, newsletterSubject} = state;
   return (
     <Fragment>
-      {title}
-      <StatsLink id={newsletterId} subject={newsletterSubject} />
-      <SubscribersListing id={newsletterId} />
+      <h1>{MailPoet.I18n.t('sendingStatusTitle')}</h1>
+      <LoadingError error={error} />
+      <StatsLink
+        newsletterId={newsletterId}
+        newsletterSubject={newsletterSubject}
+      />
+      {newsletterSubject && <Listing
+        limit={window.mailpoet_listing_per_page}
+        location={props.location}
+        params={props.match.params}
+        endpoint="sending_task_subscribers"
+        base_url="sending-status/:id"
+        onRenderItem={item => <div><ListingItem {...item} /></div>}
+        getListingItemKey={item => item.taskId + '-' + item.subscriberId}
+        columns={columns}
+        messages={messages}
+        auto_refresh
+        sort_by="created_at"
+        afterGetItems={(state) => {
+          MailerMixin.checkMailerStatus(state);
+          CronMixin.checkCronStatus(state);
+        }}
+      /> }
     </Fragment>
   );
 };
-
 SendingStatus.propTypes = {
+  location: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   match: PropTypes.shape({
     params: PropTypes.shape({
-      id: PropTypes.string,
+      id: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
 };
 
-const StatsLink = ({id, subject}) => {
+const LoadingError = ({error}) => {
+  if (!error) return null;
+  return (
+    <div className="notice notice-error">
+      <p>{ MailPoet.I18n.t(error) }</p>
+    </div>
+  );
+}
+LoadingError.propTypes = {
+  error: PropTypes.string,
+};
+
+const StatsLink = ({newsletterId, newsletterSubject}) => {
+  if (!newsletterId || !newsletterSubject) return null;
   if (window.mailpoet_premium_active) {
-    return <p><Link to={`/stats/${id}`}>{subject}</Link></p>;
+    return <p><Link to={`/stats/${newsletterId}`}>{ newsletterSubject }</Link></p>;
   }
-  return <p><a href="admin.php?page=mailpoet-premium">{subject}</a></p>;
+  return <p><a href="admin.php?page=mailpoet-premium">{newsletterSubject}</a></p>;
 };
-
 StatsLink.propTypes = {
-  id: PropTypes.string.isRequired,
-  subject: PropTypes.string.isRequired,
+  newsletterId: PropTypes.string,
+  newsletterSubject: PropTypes.string,
 };
 
-const SubscribersListing = () => null
+const ListingItem = ({error, failed, taskId, processed, email, subscriberId, lastName, firstName}) => {
+  const rowClasses = classNames(
+    'manage-column',
+    'column-primary',
+    'has-row-actions'
+  );
+  let status = MailPoet.I18n.t('unprocessed');
+  if (processed === '1') {
+    if (failed === '1') {
+      status = MailPoet.I18n.t('failed');
+    } else {
+      status = MailPoet.I18n.t('sent');
+    }
+  }
+  return (
+    <Fragment>
+      <td className={rowClasses}>
+        <strong>
+          <a
+            className="row-title"
+            href={`admin.php?page=mailpoet-subscribers#/edit/1`}
+          >
+            { email }
+          </a>
+        </strong>
+        <p style={{ margin: 0 }}>
+          { firstName + ' ' + lastName }
+        </p>
+      </td>
+      <td className="column" data-colname={MailPoet.I18n.t('sendingStatus')}>
+        { status }
+      </td>
+      <td className="column" data-colname={MailPoet.I18n.t('failureReason')}>
+        { error }
+      </td>
+    </Fragment>
+  );
+};
+ListingItem.propTypes = {
+  error: PropTypes.string,
+  email: PropTypes.string.isRequired,
+  failed: PropTypes.string.isRequired,
+  taskId: PropTypes.string.isRequired,
+  lastName: PropTypes.string.isRequired,
+  firstName: PropTypes.string.isRequired,
+  processed: PropTypes.string.isRequired,
+  subscriberId: PropTypes.string.isRequired,
+};
 
-export default SendingStatus
+const columns = [
+  {
+    name: 'subscriber_id',
+    label: MailPoet.I18n.t('subscriber'),
+    sortable: true,
+  },
+  {
+    name: 'status',
+    label: MailPoet.I18n.t('sendingStatus'),
+  },
+  {
+    name: 'failureReason',
+    label: MailPoet.I18n.t('failureReason'),
+  },
+];
+
+const messages = {
+  onNoItemsFound: () => MailPoet.I18n.t('noSendingTaskFound')
+};
+
+export default SendingStatus;

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import MailPoet from 'mailpoet';
+import PropTypes from 'prop-types';
+
+const SendingStatus = props => {
+  const newsletterId = props.match.params.id
+  return <h1>{MailPoet.I18n.t('sendingStatusTitle')}</h1>
+}
+
+export default SendingStatus

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -96,6 +96,20 @@ StatsLink.propTypes = {
 };
 
 const ListingItem = ({error, failed, taskId, processed, email, subscriberId, lastName, firstName}) => {
+  const resend = () => {
+    MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'sending_task_subscribers',
+      action: 'resend',
+      data: {taskId, subscriberId},
+    })
+    .done(res => window.mailpoet_listing.forceUpdate())
+    .fail((res) => MailPoet.Notice.error(
+      res.errors.map(error => error.message),
+      { scroll: true }
+    ));
+  }
+
   const rowClasses = classNames(
     'manage-column',
     'column-primary',
@@ -104,7 +118,19 @@ const ListingItem = ({error, failed, taskId, processed, email, subscriberId, las
   let status = MailPoet.I18n.t('unprocessed');
   if (processed === '1') {
     if (failed === '1') {
-      status = MailPoet.I18n.t('failed');
+      status = (
+        <span>
+          {MailPoet.I18n.t('failed')}
+          <br/>
+          <a
+            className="button"
+            href="javascript:;"
+            onClick={resend}
+          >
+            {MailPoet.I18n.t('resend')}
+          </a>
+        </span>
+      );
     } else {
       status = MailPoet.I18n.t('sent');
     }
@@ -115,7 +141,7 @@ const ListingItem = ({error, failed, taskId, processed, email, subscriberId, las
         <strong>
           <a
             className="row-title"
-            href={`admin.php?page=mailpoet-subscribers#/edit/1`}
+            href={`admin.php?page=mailpoet-subscribers#/edit/${subscriberId}`}
           >
             { email }
           </a>

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -1,10 +1,66 @@
-import React from 'react';
+import Hooks from 'wp-js-hooks';
 import MailPoet from 'mailpoet';
 import PropTypes from 'prop-types';
+import React, {Fragment} from 'react';
+import { Link } from 'react-router-dom';
 
 const SendingStatus = props => {
-  const newsletterId = props.match.params.id
-  return <h1>{MailPoet.I18n.t('sendingStatusTitle')}</h1>
-}
+  const newsletterId = props.match.params.id;
+  const [error, setError] = React.useState(null);
+  const [newsletterSubject, setNewsletterSubject] = React.useState(null);
+  React.useEffect(() => {
+    MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'newsletters',
+      action: 'get',
+      data: {
+        id: newsletterId,
+      },
+    })
+    .done(response => setNewsletterSubject(response.data.subject))
+    .fail(() => setError('loadingNewsletterError'));
+  }, [newsletterId]);
+
+  const title = <h1>{MailPoet.I18n.t('sendingStatusTitle')}</h1>;
+  if (error) {
+    return (
+      <Fragment>
+        {title}
+        <div className="notice notice-error">
+          <p>{ MailPoet.I18n.t(error) }</p>
+        </div>
+      </Fragment>
+    );
+  }
+  return (
+    <Fragment>
+      {title}
+      <StatsLink id={newsletterId} subject={newsletterSubject} />
+      <SubscribersListing id={newsletterId} />
+    </Fragment>
+  );
+};
+
+SendingStatus.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+};
+
+const StatsLink = ({id, subject}) => {
+  if (window.mailpoet_premium_active) {
+    return <p><Link to={`/stats/${id}`}>{subject}</Link></p>;
+  }
+  return <p><a href="admin.php?page=mailpoet-premium">{subject}</a></p>;
+};
+
+StatsLink.propTypes = {
+  id: PropTypes.string.isRequired,
+  subject: PropTypes.string.isRequired,
+};
+
+const SubscribersListing = () => null
 
 export default SendingStatus

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -82,7 +82,8 @@ const SendingStatusListing = React.memo(({ location, params }) => (
     columns={columns}
     messages={messages}
     auto_refresh
-    sort_by="created_at"
+    sort_by="failed"
+    sort_order="desc"
     afterGetItems={(state) => {
       MailerMixin.checkMailerStatus(state);
       CronMixin.checkCronStatus(state);

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -42,10 +42,7 @@ const SendingStatus = (props) => {
       .done(res => setNewsletterSubject(res.data.subject))
       .fail((res) => {
         setNewsletterSubject('');
-        MailPoet.Notice.error(
-          res.errors.map(error => error.message),
-          { scroll: true }
-        );
+        MailPoet.Notice.showApiErrorNotice(res);
       });
   }, [newsletterId]);
 
@@ -77,7 +74,9 @@ const SendingStatus = (props) => {
   );
 };
 SendingStatus.propTypes = {
-  location: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -112,10 +111,7 @@ const ListingItem = ({
       data: { taskId, subscriberId },
     })
       .done(() => window.mailpoet_listing.forceUpdate())
-      .fail(res => MailPoet.Notice.error(
-        res.errors.map(err => err.message),
-        { scroll: true }
-      ));
+      .fail(res => MailPoet.Notice.showApiErrorNotice(res));
   };
 
   const rowClasses = classNames(

--- a/assets/js/src/newsletters/sending_status.jsx
+++ b/assets/js/src/newsletters/sending_status.jsx
@@ -28,6 +28,7 @@ const messages = {
 
 const SendingStatus = (props) => {
   const newsletterId = props.match.params.id;
+  const [isLoading, setIsLoading] = React.useState(true);
   const [newsletterSubject, setNewsletterSubject] = React.useState('');
 
   React.useEffect(() => {
@@ -39,9 +40,11 @@ const SendingStatus = (props) => {
         id: newsletterId,
       },
     })
-      .done(res => setNewsletterSubject(res.data.subject))
+      .done((res) => {
+        setNewsletterSubject(res.data.subject);
+        setIsLoading(false);
+      })
       .fail((res) => {
-        setNewsletterSubject('');
         MailPoet.Notice.showApiErrorNotice(res);
       });
   }, [newsletterId]);
@@ -53,6 +56,7 @@ const SendingStatus = (props) => {
         newsletterId={newsletterId}
         newsletterSubject={newsletterSubject}
       />
+      {!isLoading && (
       <Listing
         limit={window.mailpoet_listing_per_page}
         location={props.location}
@@ -70,6 +74,7 @@ const SendingStatus = (props) => {
           CronMixin.checkCronStatus(state);
         }}
       />
+      )}
     </>
   );
 };

--- a/lib/API/JSON/v1/Newsletters.php
+++ b/lib/API/JSON/v1/Newsletters.php
@@ -92,7 +92,7 @@ class Newsletters extends APIEndpoint {
       return $this->successResponse($newsletter, ['preview_url' => $preview_url]);
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }
@@ -226,7 +226,7 @@ class Newsletters extends APIEndpoint {
 
     if ($newsletter === false) {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
 
@@ -274,7 +274,7 @@ class Newsletters extends APIEndpoint {
       );
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }
@@ -293,7 +293,7 @@ class Newsletters extends APIEndpoint {
       );
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }
@@ -306,7 +306,7 @@ class Newsletters extends APIEndpoint {
       return $this->successResponse(null, ['count' => 1]);
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }
@@ -335,7 +335,7 @@ class Newsletters extends APIEndpoint {
       }
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }
@@ -370,7 +370,7 @@ class Newsletters extends APIEndpoint {
       );
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }
@@ -445,7 +445,7 @@ class Newsletters extends APIEndpoint {
       }
     } else {
       return $this->errorResponse([
-        APIError::NOT_FOUND => WPFunctions::get()->__('This newsletter does not exist.', 'mailpoet'),
+        APIError::NOT_FOUND => WPFunctions::get()->__('This email does not exist.', 'mailpoet'),
       ]);
     }
   }

--- a/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MailPoet\API\JSON\v1;
+
+use MailPoet\Listing;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Config\AccessControl;
+use MailPoet\Models\ScheduledTask;
+use MailPoet\Models\SendingQueue;
+use MailPoet\API\JSON\Error as APIError;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\API\JSON\Endpoint as APIEndpoint;
+
+if (!defined('ABSPATH')) exit;
+
+class SendingTaskSubscribers extends APIEndpoint {
+  public $permissions = array(
+    'global' => AccessControl::PERMISSION_MANAGE_EMAILS
+  );
+
+  /** @var Listing\Handler */
+  private $listing_handler;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    Listing\Handler $listing_handler,
+    SettingsController $settings,
+    WPFunctions $wp
+  ) {
+    $this->listing_handler = $listing_handler;
+    $this->settings = $settings;
+    $this->wp = $wp;
+  }
+
+  public function listing($data = array()) {
+    $newsletter_id = !empty($data['params']['id']) ? (int)$data['params']['id'] : false;
+    $tasks_ids = SendingQueue::select('task_id')
+      ->where('newsletter_id', $newsletter_id)
+      ->findArray();
+    if (empty($tasks_ids)) {
+      return $this->errorResponse(array(
+        APIError::NOT_FOUND => __('This newsletter is not being sent to any subcriber yet.', 'mailpoet')
+      ));
+    }
+    $data['params']['task_ids'] = array_map(function($item) {
+      return $item['task_id'];
+    }, $tasks_ids);
+    $listing_data = $this->listing_handler->get('\MailPoet\Models\ScheduledTaskSubscriber', $data);
+
+    $items = [];
+    foreach ($listing_data['items'] as $item) {
+      $items[] = $item->asArray();
+    }
+
+    return $this->successResponse($items, array(
+      'count' => $listing_data['count'],
+      'filters' => $listing_data['filters'],
+      'groups' => $listing_data['groups'],
+      'mta_log' => $this->settings->get('mta_log'),
+      'mta_method' => $this->settings->get('mta.method'),
+      'cron_accessible' => CronHelper::isDaemonAccessible(),
+      'current_time' => $this->wp->currentTime('mysql')
+    ));
+  }
+}

--- a/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -50,9 +50,7 @@ class SendingTaskSubscribers extends APIEndpoint {
         APIError::NOT_FOUND => __('This newsletter is not being sent to any subcriber yet.', 'mailpoet'),
       ]);
     }
-    $data['params']['task_ids'] = array_map(function($item) {
-      return $item['task_id'];
-    }, $tasks_ids);
+    $data['params']['task_ids'] = array_column($tasks_ids, 'task_id');
     $listing_data = $this->listing_handler->get('\MailPoet\Models\ScheduledTaskSubscriber', $data);
 
     $items = [];

--- a/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -47,7 +47,7 @@ class SendingTaskSubscribers extends APIEndpoint {
       ->findArray();
     if (empty($tasks_ids)) {
       return $this->errorResponse([
-        APIError::NOT_FOUND => __('This newsletter is not being sent to any subcriber yet.', 'mailpoet'),
+        APIError::NOT_FOUND => __( 'This email has not been sent yet.', 'mailpoet'),
       ]);
     }
     $data['params']['task_ids'] = array_column($tasks_ids, 'task_id');

--- a/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -47,7 +47,7 @@ class SendingTaskSubscribers extends APIEndpoint {
       ->findArray();
     if (empty($tasks_ids)) {
       return $this->errorResponse([
-        APIError::NOT_FOUND => __( 'This email has not been sent yet.', 'mailpoet'),
+        APIError::NOT_FOUND => __('This email has not been sent yet.', 'mailpoet'),
       ]);
     }
     $data['params']['task_ids'] = array_column($tasks_ids, 'task_id');

--- a/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -239,8 +239,6 @@ class SendingQueue {
     if ($send_result['response'] === false) {
       $error = $send_result['error'];
       assert($error instanceof MailerError);
-      // Always switch error level to hard until we implement UI for individual subscriber errors
-      $error->switchLevelToHard();
       $this->error_handler->processError($error, $sending_task, $prepared_subscribers_ids, $prepared_subscribers);
     }
     // update processed/to process list

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -51,6 +51,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\API\JSON\v1\Services::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\UserFlags::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\SendingTaskSubscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Setup::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
     // Config

--- a/lib/Mailer/MailerError.php
+++ b/lib/Mailer/MailerError.php
@@ -77,13 +77,6 @@ class MailerError {
     return $this->subscribers_errors;
   }
 
-  /**
-   * Temporary method until we implement UI for subscriber errors
-   */
-  function switchLevelToHard() {
-    $this->level = self::LEVEL_HARD;
-  }
-
   function getMessageWithFailedSubscribers() {
     $message = $this->message ?: '';
     if (!$this->subscribers_errors) {

--- a/lib/Models/Model.php
+++ b/lib/Models/Model.php
@@ -44,6 +44,7 @@ if (!defined('ABSPATH')) exit;
  * @method $this rawJoin(string $table, string|array $constraint, string $table_alias, array $parameters = array())
  * @method $this innerJoin(string $table, string|array $constraint, string $table_alias=null)
  * @method $this join(string $table, string|array $constraint, string $table_alias=null)
+ * @method static static join(string $table, string|array $constraint, string $table_alias=null)
  * @method $this leftOuterJoin(string $table, string|array $constraint, string $table_alias=null)
  * @method $this rightOuterJoin(string $table, string|array $constraint, string $table_alias=null)
  * @method $this fullOuterJoin(string $table, string|array $constraint, string $table_alias=null)

--- a/lib/Models/ScheduledTaskSubscriber.php
+++ b/lib/Models/ScheduledTaskSubscriber.php
@@ -5,6 +5,13 @@ use MailPoet\WP\Functions as WPFunctions;
 
 if (!defined('ABSPATH')) exit;
 
+/**
+ * @property int $task_id
+ * @property int $subscriber_id
+ * @property int $processed
+ * @property int $failed
+ * @property string $error
+ */
 class ScheduledTaskSubscriber extends Model {
   const STATUS_UNPROCESSED = 0;
   const STATUS_PROCESSED = 1;
@@ -70,7 +77,7 @@ class ScheduledTaskSubscriber extends Model {
 
   static function listingQuery($data) {
     $group = isset($data['group']) ? $data['group'] : 'all';
-    return self::join(Subscriber::$_table, array("subscriber_id", "=", "subscribers.id"), "subscribers")
+    return self::join(Subscriber::$_table, ["subscriber_id", "=", "subscribers.id"], "subscribers")
       ->filter($group, $data['params'])
       ->select('error', 'error')
       ->select('failed', 'failed')
@@ -92,17 +99,17 @@ class ScheduledTaskSubscriber extends Model {
       ],
       [
         'name' => self::SENDING_STATUS_SENT,
-        'label' => WPFunctions::get()->x('Sent', 'status when a newsletter has been sent', 'mailpoet'),
+        'label' => WPFunctions::get()->_x('Sent', 'status when a newsletter has been sent', 'mailpoet'),
         'count' => self::filter(self::SENDING_STATUS_SENT, $params)->count(),
       ],
       [
         'name' => self::SENDING_STATUS_FAILED,
-        'label' => WPFunctions::get()->x('Failed', 'status when the sending of a newsletter has failed', 'mailpoet'),
+        'label' => WPFunctions::get()->_x('Failed', 'status when the sending of a newsletter has failed', 'mailpoet'),
         'count' => self::filter(self::SENDING_STATUS_FAILED, $params)->count(),
       ],
       [
         'name' => self::SENDING_STATUS_UNPROCESSED,
-        'label' => WPFunctions::get()->x('Unprocessed', 'status when the sending of a newsletter has not been processed', 'mailpoet'),
+        'label' => WPFunctions::get()->_x('Unprocessed', 'status when the sending of a newsletter has not been processed', 'mailpoet'),
         'count' => self::filter(self::SENDING_STATUS_UNPROCESSED, $params)->count(),
       ],
     ];

--- a/tests/DataFactories/Newsletter.php
+++ b/tests/DataFactories/Newsletter.php
@@ -225,7 +225,7 @@ class Newsletter {
     return $this;
   }
 
-  public function beingSentToSubscriber($subscriber, array $data = []) {
+  public function withSubscriber($subscriber, array $data = []) {
     $this->task_subscribers[] = array_merge([
       'subscriber_id' => $subscriber->id,
       'processed' => 1,

--- a/tests/_data/acceptanceDump.sql
+++ b/tests/_data/acceptanceDump.sql
@@ -302,6 +302,8 @@ CREATE TABLE `mp_mailpoet_scheduled_task_subscribers` (
   `task_id` int(11) unsigned NOT NULL,
   `subscriber_id` int(11) unsigned NOT NULL,
   `processed` int(1) NOT NULL,
+  `failed` smallint(1) NOT NULL DEFAULT 0,
+  `error` text NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`task_id`,`subscriber_id`),
   KEY subscriber_id (subscriber_id)

--- a/tests/acceptance/SendingStatusCest.php
+++ b/tests/acceptance/SendingStatusCest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+require_once __DIR__ . '/../DataFactories/Settings.php';
+require_once __DIR__ . '/../DataFactories/Newsletter.php';
+require_once __DIR__ . '/../DataFactories/Subscriber.php';
+
+use Codeception\Util\Locator;
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class SendingStatusCest {
+  function newsletterSendingStatus(\AcceptanceTester $I) {
+    $I->wantTo('Check the sending status page for a standard newsletter');
+    // Having a standard newsletter sent to 2 subscribers
+    $lucky_subscriber = (new Subscriber)
+      ->withFirstName('Lucky')
+      ->withLastName('Luke')
+      ->create();
+    $unlucky_subscriber = (new Subscriber)
+      ->withFirstName('Unlucky')
+      ->withLastName('John')
+      ->create();
+    $newsletter = (new Newsletter)
+      ->withSubject('Testing newsletter sending status')
+      ->withSentStatus()
+      ->withSendingQueue([
+        'count_processed' => 2,
+        'count_total' => 2,
+      ])
+      ->beingSentToSubscriber($lucky_subscriber)
+      ->beingSentToSubscriber($unlucky_subscriber, [
+        'failed' => 1,
+        'error' => 'Oh no!',
+      ])
+      ->create();
+    // When I visit the newsletters page
+    $I->login();
+    $I->amOnMailPoetPage('Emails');
+    $I->waitForText($newsletter->subject);
+    // I click on the "Sent to 3 of 3" link
+    $I->click('[data-automation-id="sending_status_' . $newsletter->id . '"]');
+    // Check I am on the sending status page
+    $I->seeInCurrentUrl('?page=mailpoet-newsletters#/sending-status/' . $newsletter->id);
+    $I->waitForText('Sending status');
+    // I see the subscribers with related statuses
+    $task_id = $newsletter->getQueue()->task_id;
+    $this->checkSubscriber($I, $task_id, $lucky_subscriber, 'Sent');
+    $this->checkSubscriber($I, $task_id, $unlucky_subscriber, 'Failed', 'Oh no!');
+  }
+
+  private function checkSubscriber($I, $task_id, $subscriber, $status, $error = false) {
+    $name_selector = '[data-automation-id="name_' . $task_id . '_' . $subscriber->id . '"]';
+    $status_selector = '[data-automation-id="status_' . $task_id . '_' . $subscriber->id . '"]';
+    $full_name = $subscriber->first_name . ' ' . $subscriber->last_name;
+    $I->waitForText($subscriber->email, 10, $name_selector);
+    $I->waitForText($full_name, 10, $name_selector);
+    $I->waitForText($status, 10, $status_selector);
+    if ($error) {
+      $error_selector = '[data-automation-id="error_' . $task_id . '_' . $subscriber->id . '"]';
+      $I->waitForText($error, 10, $error_selector);
+    }
+  }
+}

--- a/tests/acceptance/SendingStatusCest.php
+++ b/tests/acceptance/SendingStatusCest.php
@@ -42,8 +42,6 @@ class SendingStatusCest {
     $I->waitForText($newsletter->subject);
     // I click on the "Sent to 3 of 3" link
     $I->click('[data-automation-id="sending_status_' . $newsletter->id . '"]');
-    // Check I am on the sending status page
-    $I->seeInCurrentUrl('?page=mailpoet-newsletters#/sending-status/' . $newsletter->id);
     $I->waitForText('Sending status');
     // I see the subscribers with related statuses
     $task_id = $newsletter->getQueue()->task_id;

--- a/tests/acceptance/SendingStatusCest.php
+++ b/tests/acceptance/SendingStatusCest.php
@@ -30,8 +30,8 @@ class SendingStatusCest {
         'count_processed' => 2,
         'count_total' => 2,
       ])
-      ->beingSentToSubscriber($lucky_subscriber)
-      ->beingSentToSubscriber($unlucky_subscriber, [
+      ->withSubscriber($lucky_subscriber)
+      ->withSubscriber($unlucky_subscriber, [
         'failed' => 1,
         'error' => 'Oh no!',
       ])

--- a/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -111,12 +111,12 @@ class NewslettersTest extends \MailPoetTest {
     $response = $this->endpoint->get(); // missing id
     expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
     expect($response->errors[0]['message'])
-      ->equals('This newsletter does not exist.');
+      ->equals('This email does not exist.');
 
     $response = $this->endpoint->get(['id' => 'not_an_id']);
     expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
     expect($response->errors[0]['message'])
-      ->equals('This newsletter does not exist.');
+      ->equals('This email does not exist.');
 
     $wp = Stub::make(new WPFunctions, [
       'applyFilters' => asCallable([WPHooksHelper::class, 'applyFilters']),
@@ -421,7 +421,7 @@ class NewslettersTest extends \MailPoetTest {
     );
     expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
     expect($response->errors[0]['message'])
-      ->equals('This newsletter does not exist.');
+      ->equals('This email does not exist.');
   }
 
   function testItReschedulesPastDuePostNotificationsWhenStatusIsSetBackToActive() {

--- a/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
+++ b/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace MailPoet\Test\API\JSON\v1;
+
+use Codeception\Util\Fixtures;
+use MailPoet\Models\Newsletter;
+use MailPoet\Models\Subscriber;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Models\SendingQueue;
+use MailPoet\Models\ScheduledTask;
+use MailPoet\Models\ScheduledTaskSubscriber;
+use MailPoet\API\JSON\Response as APIResponse;
+use MailPoet\API\JSON\v1\SendingTaskSubscribers;
+
+class SendingTaskSubscribersTest extends \MailPoetTest {
+
+  function _before() {
+    parent::_before();
+    $this->endpoint = ContainerWrapper::getInstance()->get(SendingTaskSubscribers::class);
+    $this->newsletter_id = Newsletter::createOrUpdate([
+      'type' => Newsletter::TYPE_STANDARD,
+      'subject' => 'My Standard Newsletter',
+      'body' => Fixtures::get('newsletter_body_template'),
+    ])->id;
+    $this->task_id = ScheduledTask::createOrUpdate([
+      'status' => ScheduledTask::STATUS_SCHEDULED,
+    ])->id;
+    SendingQueue::createOrUpdate([
+      'task_id' => $this->task_id,
+      'newsletter_id' => $this->newsletter_id,
+    ]);
+    $this->sent_subscriber = Subscriber::createOrUpdate([
+      'last_name' => 'Test',
+      'first_name' => 'Sent',
+      'email' => 'sent@example.com',
+    ]);
+    ScheduledTaskSubscriber::createOrUpdate([
+      'failed' => 0,
+      'processed' => 1,
+      'task_id' => $this->task_id,
+      'subscriber_id' => $this->sent_subscriber->id,
+    ]);
+    $this->failed_subscriber = Subscriber::createOrUpdate([
+      'last_name' => 'Test',
+      'first_name' => 'Failed',
+      'email' => 'failed@example.com',
+    ]);
+    ScheduledTaskSubscriber::createOrUpdate([
+      'failed' => 1,
+      'processed' => 1,
+      'task_id' => $this->task_id,
+      'error' => 'Something went wrong!',
+      'subscriber_id' => $this->failed_subscriber->id,
+    ]);
+    $this->unprocessed_subscriber = Subscriber::createOrUpdate([
+      'last_name' => 'Test',
+      'first_name' => 'Unprocessed',
+      'email' => 'unprocessed@example.com',
+    ]);
+    ScheduledTaskSubscriber::createOrUpdate([
+      'failed' => 0,
+      'processed' => 0,
+      'task_id' => $this->task_id,
+      'subscriber_id' => $this->unprocessed_subscriber->id,
+    ]);
+  }
+
+  function testListingReturnsErrorIfMissingNewsletter() {
+    $res = $this->endpoint->listing([
+      'sort_by' => 'created_at',
+      'params' => ['id' => $this->newsletter_id + 1],
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($res->errors[0]['message'])
+      ->equals('This newsletter is not being sent to any subcriber yet.');
+  }
+
+  function testListingReturnsErrorIfNewsletterNotBeingSent() {
+    $newsletter = Newsletter::createOrUpdate([
+      'type' => Newsletter::TYPE_STANDARD,
+      'subject' => 'Draft',
+      'body' => '',
+    ]);
+    $res = $this->endpoint->listing([
+      'sort_by' => 'created_at',
+      'params' => ['id' => $newsletter->id],
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($res->errors[0]['message'])
+      ->equals('This newsletter is not being sent to any subcriber yet.');
+  }
+
+  function testItReturnsListing() {
+    $sent_subscriber_status = [
+      'error' => '',
+      'failed' => 0,
+      'processed' => 1,
+      'taskId' => $this->task_id,
+      'email' => $this->sent_subscriber->email,
+      'subscriberId' => $this->sent_subscriber->id,
+      'lastName' => $this->sent_subscriber->last_name,
+      'firstName' => $this->sent_subscriber->first_name,
+    ];
+    $unprocessed_subscriber_status = [
+      'error' => '',
+      'failed' => 0,
+      'processed' => 0,
+      'taskId' => $this->task_id,
+      'email' => $this->unprocessed_subscriber->email,
+      'subscriberId' => $this->unprocessed_subscriber->id,
+      'lastName' => $this->unprocessed_subscriber->last_name,
+      'firstName' => $this->unprocessed_subscriber->first_name,
+    ];
+    $failed_subscriber_status = [
+      'error' => 'Something went wrong!',
+      'failed' => 1,
+      'processed' => 1,
+      'taskId' => $this->task_id,
+      'email' => $this->failed_subscriber->email,
+      'subscriberId' => $this->failed_subscriber->id,
+      'lastName' => $this->failed_subscriber->last_name,
+      'firstName' => $this->failed_subscriber->first_name,
+    ];
+
+    $res = $this->endpoint->listing([
+      'sort_by' => 'created_at',
+      'params' => ['id' => $this->newsletter_id],
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_OK);
+    expect($res->data)->equals([
+      $sent_subscriber_status,
+      $failed_subscriber_status,
+      $unprocessed_subscriber_status,
+    ]);
+
+    $res = $this->endpoint->listing([
+      'group' => 'sent',
+      'sort_by' => 'created_at',
+      'params' => ['id' => $this->newsletter_id],
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_OK);
+    expect($res->data)->equals([
+      $sent_subscriber_status,
+    ]);
+
+    $res = $this->endpoint->listing([
+      'group' => 'failed',
+      'sort_by' => 'created_at',
+      'params' => ['id' => $this->newsletter_id],
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_OK);
+    expect($res->data)->equals([
+      $failed_subscriber_status,
+    ]);
+
+    $res = $this->endpoint->listing([
+      'group' => 'unprocessed',
+      'sort_by' => 'created_at',
+      'params' => ['id' => $this->newsletter_id],
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_OK);
+    expect($res->data)->equals([
+      $unprocessed_subscriber_status,
+    ]);
+  }
+
+  function testResendReturnsErrorIfWrongData() {
+    $res = $this->endpoint->resend([
+      'taskId' => $this->task_id + 1,
+      'subscriberId' => $this->sent_subscriber->id,
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($res->errors[0]['message'])
+      ->equals('Failed sending task not found!');
+
+    $res = $this->endpoint->resend([
+      'taskId' => $this->task_id,
+      'subscriberId' => $this->sent_subscriber->id,
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($res->errors[0]['message'])
+      ->equals('Failed sending task not found!');
+  }
+
+  function testItCanResend() {
+    $res = $this->endpoint->resend([
+      'taskId' => $this->task_id,
+      'subscriberId' => $this->failed_subscriber->id,
+    ]);
+    expect($res->status)->equals(APIResponse::STATUS_OK);
+
+    $task_subscriber = ScheduledTaskSubscriber::where('task_id', $this->task_id)
+      ->where('subscriber_id', $this->failed_subscriber->id)
+      ->findOne();
+    expect($task_subscriber->error)->equals('');
+    expect($task_subscriber->failed)->equals(0);
+    expect($task_subscriber->processed)->equals(0);
+
+    $task = ScheduledTask::findOne($this->task_id);
+    expect($task->status)->equals(null);
+
+    $newsletter = Newsletter::findOne($this->newsletter_id);
+    expect($newsletter->status)->equals(Newsletter::STATUS_SENDING);
+  }
+
+  function _after() {
+    \ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
+    \ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
+    \ORM::raw_execute('TRUNCATE ' . SendingQueue::$_table);
+    \ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
+    \ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
+  }
+}

--- a/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
+++ b/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
@@ -72,7 +72,7 @@ class SendingTaskSubscribersTest extends \MailPoetTest {
     ]);
     expect($res->status)->equals(APIResponse::STATUS_NOT_FOUND);
     expect($res->errors[0]['message'])
-      ->equals('This newsletter is not being sent to any subcriber yet.');
+      ->equals('This email has not been sent yet.');
   }
 
   function testListingReturnsErrorIfNewsletterNotBeingSent() {
@@ -87,7 +87,7 @@ class SendingTaskSubscribersTest extends \MailPoetTest {
     ]);
     expect($res->status)->equals(APIResponse::STATUS_NOT_FOUND);
     expect($res->errors[0]['message'])
-      ->equals('This newsletter is not being sent to any subcriber yet.');
+      ->equals('This email has not been sent yet.');
   }
 
   function testItReturnsListing() {

--- a/views/newsletters.html
+++ b/views/newsletters.html
@@ -347,6 +347,15 @@
     'reviewRequestUsingForMonths': _n('You’ve been using MailPoet for [months] month now, and we would love to read your own review.', 'You’ve been using MailPoet for [months] months now, and we would love to read your own review.', (installed_days_ago / 30) | round),
     'reviewRequestRateUsNow': _x('Rate us now', 'Review our plugin on WordPress.org.'),
     'reviewRequestNotNow': __('Not now'),
+
+    'sendingStatusTitle': _x('Sending status', 'Page title. This page displays a list of emails along with their sending status: unprocessed, sent or failed.'),
+    'subscriber': __('Subscriber'),
+    'sendingStatus': _x('Sending status', 'an email sending status: unprocessed, sent or failed.'),
+    'failureReason': __('Failure reason (if applicable)'),
+    'resend': __('Resend'),
+    'unprocessed': _x('Unprocessed', 'status when the sending of a newsletter has not being processed'),
+    'sent': _x('Sent', 'status when a newsletter has being sent'),
+    'failed': _x('Failed', 'status when the sending of a newsletter has failed'),
   }) %>
 <% endblock %>
 

--- a/views/newsletters.html
+++ b/views/newsletters.html
@@ -356,7 +356,6 @@
     'unprocessed': _x('Unprocessed', 'status when the sending of a newsletter has not been processed'),
     'sent': _x('Sent', 'status when a newsletter has been sent'),
     'failed': _x('Failed', 'status when the sending of a newsletter has failed'),
-    'loadingNewsletterError': __('An error occured while loading the newsletter.'),
     'noSendingTaskFound': __('No sending task found.')
   }) %>
 <% endblock %>

--- a/views/newsletters.html
+++ b/views/newsletters.html
@@ -353,10 +353,11 @@
     'sendingStatus': _x('Sending status', 'an email sending status: unprocessed, sent or failed.'),
     'failureReason': __('Failure reason (if applicable)'),
     'resend': __('Resend'),
-    'unprocessed': _x('Unprocessed', 'status when the sending of a newsletter has not being processed'),
-    'sent': _x('Sent', 'status when a newsletter has being sent'),
+    'unprocessed': _x('Unprocessed', 'status when the sending of a newsletter has not been processed'),
+    'sent': _x('Sent', 'status when a newsletter has been sent'),
     'failed': _x('Failed', 'status when the sending of a newsletter has failed'),
     'loadingNewsletterError': __('An error occured while loading the newsletter.'),
+    'noSendingTaskFound': __('No sending task found.')
   }) %>
 <% endblock %>
 

--- a/views/newsletters.html
+++ b/views/newsletters.html
@@ -356,6 +356,7 @@
     'unprocessed': _x('Unprocessed', 'status when the sending of a newsletter has not being processed'),
     'sent': _x('Sent', 'status when a newsletter has being sent'),
     'failed': _x('Failed', 'status when the sending of a newsletter has failed'),
+    'loadingNewsletterError': __('An error occured while loading the newsletter.'),
   }) %>
 <% endblock %>
 


### PR DESCRIPTION
[MAILPOET-1155]

## Note about tests

Instead of writing acceptance test for every type of newsletters. I have written generic integration tests and then tested only one newsletter type on the acceptance test. The sending status page should work the same for other types. 


[MAILPOET-1155]: https://mailpoet.atlassian.net/browse/MAILPOET-1155