### PR TITLE
 Use the official WP JS hooks library [MAILPOET-2081] 

### DIFF
--- a/assets/js/src/hooks.js
+++ b/assets/js/src/hooks.js
@@ -1,0 +1,8 @@
+import { createHooks } from '@wordpress/hooks';
+
+// Make sure the hooks library is available globally
+// because it is used in views (e.g. newsletter/editor.html)
+window.wp = window.wp || {};
+window.wp.hooks = window.wp.hooks || createHooks();
+
+export default window.wp.hooks;

--- a/assets/js/src/newsletter_editor/initializer.jsx
+++ b/assets/js/src/newsletter_editor/initializer.jsx
@@ -82,4 +82,4 @@ const initializeEditor = (config) => {
     });
 };
 
-Hooks.addAction('mailpoet_newsletters_editor_initialize', initializeEditor);
+Hooks.addAction('mailpoet_newsletters_editor_initialize', 'mailpoet', initializeEditor);

--- a/assets/js/src/newsletters/listings/mixins.jsx
+++ b/assets/js/src/newsletters/listings/mixins.jsx
@@ -208,7 +208,7 @@ const StatisticsMixin = {
     }
 
     let params = {};
-    Hooks.addFilter('mailpoet_newsletters_listing_stats_before', StatisticsMixin.addStatsCTALink);
+    Hooks.addFilter('mailpoet_newsletters_listing_stats_before', 'mailpoet', StatisticsMixin.addStatsCTALink);
     params = Hooks.applyFilters('mailpoet_newsletters_listing_stats_before', params, newsletter);
 
     // welcome emails provide explicit total_sent value

--- a/assets/js/src/newsletters/listings/notification_history.jsx
+++ b/assets/js/src/newsletters/listings/notification_history.jsx
@@ -57,7 +57,7 @@ let newsletterActions = [
   },
 ];
 
-Hooks.addFilter('mailpoet_newsletters_listings_notification_history_actions', StatisticsMixin.addStatsCTAAction);
+Hooks.addFilter('mailpoet_newsletters_listings_notification_history_actions', 'mailpoet', StatisticsMixin.addStatsCTAAction);
 newsletterActions = Hooks.applyFilters('mailpoet_newsletters_listings_notification_history_actions', newsletterActions);
 
 const NewsletterListNotificationHistory = createReactClass({ // eslint-disable-line react/prefer-es6-class, max-len

--- a/assets/js/src/newsletters/listings/standard.jsx
+++ b/assets/js/src/newsletters/listings/standard.jsx
@@ -169,7 +169,7 @@ let newsletterActions = [
   },
 ];
 
-Hooks.addFilter('mailpoet_newsletters_listings_standard_actions', StatisticsMixin.addStatsCTAAction);
+Hooks.addFilter('mailpoet_newsletters_listings_standard_actions', 'mailpoet', StatisticsMixin.addStatsCTAAction);
 newsletterActions = Hooks.applyFilters('mailpoet_newsletters_listings_standard_actions', newsletterActions);
 
 const NewsletterListStandard = createReactClass({ // eslint-disable-line react/prefer-es6-class

--- a/assets/js/src/newsletters/listings/welcome.jsx
+++ b/assets/js/src/newsletters/listings/welcome.jsx
@@ -153,7 +153,7 @@ let newsletterActions = [
   },
 ];
 
-Hooks.addFilter('mailpoet_newsletters_listings_welcome_notification_actions', StatisticsMixin.addStatsCTAAction);
+Hooks.addFilter('mailpoet_newsletters_listings_welcome_notification_actions', 'mailpoet', StatisticsMixin.addStatsCTAAction);
 newsletterActions = Hooks.applyFilters('mailpoet_newsletters_listings_welcome_notification_actions', newsletterActions);
 
 const NewsletterListWelcome = createReactClass({ // eslint-disable-line react/prefer-es6-class

--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,6 +1629,29 @@
         "@xtuc/long": "4.2.1"
       }
     },
+    "@wordpress/hooks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.3.0.tgz",
+      "integrity": "sha512-N7ijZUcBbcTO6AsITS66On3X14fkT3+e3rNbx/w4AANnUDmP4Nqkl+OiMWqM3gjr936hReAqIqprKKTQ98DBYQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1640,10 +1663,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
-    },
-    "WP-JS-Hooks": {
-      "version": "github:mailpoet/WP-JS-Hooks#dd16692e4275728c6f3cb511011f4a68122605a3",
-      "from": "github:mailpoet/WP-JS-Hooks"
     },
     "abab": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@babel/runtime-corejs2": "^7.2.0",
-    "WP-JS-Hooks": "github:mailpoet/WP-JS-Hooks",
+    "@wordpress/hooks": "^2.3.0",
     "backbone": "1.3.3",
     "backbone.marionette": "3.2.0",
     "backbone.radio": "2.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ const baseConfig = {
       'sticky-kit': 'vendor/jquery.sticky-kit.js',
       'interact$': 'interact.js/interact.js',
       'spectrum$': 'spectrum-colorpicker/spectrum.js',
-      'wp-js-hooks': 'WP-JS-Hooks/src/event-manager.js',
+      'wp-js-hooks': path.resolve(__dirname, 'assets/js/src/hooks.js'),
       'blob$': 'blob-tmp/Blob.js',
       'papaparse': 'papaparse/papaparse.min.js',
       'html2canvas': 'html2canvas/dist/html2canvas.js',
@@ -106,11 +106,8 @@ const baseConfig = {
         loader: 'expose-loader?' + globalPrefix + '.ReactStringReplace',
       },
       {
-        test: /wp-js-hooks/i,
-        use: [
-          'expose-loader?' + globalPrefix + '.Hooks',
-          'exports-loader?window.wp.hooks',
-        ]
+        include: path.resolve(__dirname, 'assets/js/src/hooks.js'),
+        use: 'expose-loader?' + globalPrefix + '.Hooks',
       },
       {
         test: /listing.jsx/i,
@@ -395,7 +392,7 @@ const testConfig = {
       'backbone.marionette': 'backbone.marionette/lib/backbone.marionette',
       'backbone.supermodel$': 'backbone.supermodel/build/backbone.supermodel.js',
       'blob$': 'blob-tmp/Blob.js',
-      'wp-js-hooks': 'WP-JS-Hooks/src/event-manager.js',
+      'wp-js-hooks': path.resolve(__dirname, 'assets/js/src/hooks.js'),
     },
   },
   externals: {


### PR DESCRIPTION
While working on the JS hooks library transition I've noticed a hook invocation in the `newsletter/editor.html` view (https://github.com/mailpoet/mailpoet/blob/master/views/newsletter/editor.html#L1472) didn't work unless the existing global `wp.hooks` variable was reused. This means since WP 5.0 we were actually using the hooks library bundled with WP using ours as a fallback for WP below 5.0. I wonder how did it work because as I mentioned earlier the official library has slightly different arguments for `addAction`/`addFilter` calls (namespaces added). And we were using the old function signatures till today.

Anyway, I have updated our library. When we drop support for WP < 5.0 we may try to remove it altogether.

**Note to QA:**

Please test that:
* All Free & Premium functionality where hooks are involved works normally in supported WP versions below and above 5.0;
* There are no JS errors in the console.
