### PR TITLE
Fix registration of rejected users [MAILPOET-2114]

### DIFF
--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -132,8 +132,12 @@ class Hooks {
           'register_form',
           [$this->subscription_registration, 'extendForm']
         );
-        $this->wp->addAction(
-          'register_post',
+        // we need to process new users while they are registered.
+        // We used `register_post` before but that is too soon
+        //   because if registration fails during `registration_errors` we will keep the user as subscriber.
+        // So we are hooking to `registration_error` with a low priority.
+        $this->wp->addFilter(
+          'registration_errors',
           [$this->subscription_registration, 'onRegister'],
           60,
           3

--- a/lib/Subscription/Registration.php
+++ b/lib/Subscription/Registration.php
@@ -54,9 +54,9 @@ class Registration {
   }
 
   function onRegister(
+    $errors,
     $user_login,
-    $user_email = null,
-    $errors = null
+    $user_email = null
   ) {
     if (
       empty($errors->errors)
@@ -68,6 +68,7 @@ class Registration {
         $user_email
       );
     }
+    return $errors;
   }
 
   private function subscribeNewUser($name, $email) {


### PR DESCRIPTION
There are multiple hooks for user registration.
https://usersinsights.com/wp/wp-content/uploads/2018/07/user-registration-hooks-2.png
The `register_post` hook is executed first and
after that, there is `registration_errors`.
The captcha verification is done in `registration_errors` hook.
But because we were using `register_post` we were saved
the subscriber before the post request was verified.

