### PR TITLE
Enforce base64 when email encoding needed for PHPMail & mail() function [MAILPOET-2065]

### DIFF
--- a/lib/Mailer/Methods/PHPMail.php
+++ b/lib/Mailer/Methods/PHPMail.php
@@ -67,6 +67,18 @@ class PHPMail {
     if (!empty($extra_params['unsubscribe_url'])) {
       $this->mailer->addCustomHeader('List-Unsubscribe', $extra_params['unsubscribe_url']);
     }
+
+    // Enforce base64 encoding when lines are too long, otherwise quoted-printable encoding
+    // is automatically used which can occasionally break the email body.
+    // Explanation:
+    //   The bug occurs on Unix systems where mail() function passes email to a variation of
+    //   sendmail command which expects only NL as line endings (POSIX). Since quoted-printable
+    //   requires CRLF some of those commands convert LF to CRLF which can break the email body
+    //   because it already (correctly) uses CRLF. Such CRLF then (wrongly) becomes CRCRLF.
+    if (\PHPMailer::hasLineLongerThanMax($mailer->Body)) {
+      $mailer->Encoding = 'base64';
+    }
+
     return $mailer;
   }
 


### PR DESCRIPTION
Litmus test with base64: https://litmus.com/checklist/tests/13634155 (and source code https://litmus.com/checklist/tests/13634155/download.eml).