### PR TITLE
Introduce React component to replace MailPoet.Notice [MAILPOET-2156]

### DIFF
--- a/assets/css/src/components/_notice.scss
+++ b/assets/css/src/components/_notice.scss
@@ -22,28 +22,23 @@
 
 .mailpoet_base_notice {
   background: #fff;
-  border-left: 4px solid transparent;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .1);
   margin: 5px 0 15px;
   padding: 1px 12px;
 }
 
 .mailpoet_success_notice {
-  @extend .mailpoet_base_notice;
-  border-left-color: #46b450;
+  border-left: 4px solid #46b450;
 }
 
 .mailpoet_error_notice {
-  @extend .mailpoet_base_notice;
-  border-left-color: #dc3232;
+  border-left: 4px solid #dc3232;
 }
 
 .mailpoet_warning_notice {
-  @extend .mailpoet_base_notice;
-  border-left-color: #ffb900;
+  border-left: 4px solid #ffb900;
 }
 
 .mailpoet_info_notice {
-  @extend .mailpoet_base_notice;
-  border-left-color: #00a0d2;
+  border-left: 4px solid #00a0d2;
 }

--- a/assets/css/src/components/_notice.scss
+++ b/assets/css/src/components/_notice.scss
@@ -19,3 +19,31 @@
     margin: 0;
   }
 }
+
+.mailpoet_base_notice {
+  background: #fff;
+  border-left: 4px solid transparent;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .1);
+  margin: 5px 0 15px;
+  padding: 1px 12px;
+}
+
+.mailpoet_success_notice {
+  @extend .mailpoet_base_notice;
+  border-left-color: #46b450;
+}
+
+.mailpoet_error_notice {
+  @extend .mailpoet_base_notice;
+  border-left-color: #dc3232;
+}
+
+.mailpoet_warning_notice {
+  @extend .mailpoet_base_notice;
+  border-left-color: #ffb900;
+}
+
+.mailpoet_info_notice {
+  @extend .mailpoet_base_notice;
+  border-left-color: #00a0d2;
+}

--- a/assets/js/src/notices/api_errors_notice.jsx
+++ b/assets/js/src/notices/api_errors_notice.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Notice from 'notices/notice.jsx';
+
+const APIErrorsNotice = ({ errors }) => {
+  if (errors.length < 1) return null;
+  return <Notice type="error">{errors.map(err => <p key={err.message}>{err.message}</p>)}</Notice>;
+};
+APIErrorsNotice.propTypes = {
+  errors: PropTypes.arrayOf(PropTypes.shape({
+    message: PropTypes.string.isRequired,
+  })).isRequired,
+};
+
+export default APIErrorsNotice;

--- a/assets/js/src/notices/mailer_status_notice.jsx
+++ b/assets/js/src/notices/mailer_status_notice.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Notice from 'notices/notice.jsx';
+
+const MailerStatusNotice = ({ error }) => {
+  if (!error || error.operation !== 'authorization') return null;
+  return <Notice type="error" timeout={false}><p>{error.error_message}</p></Notice>;
+};
+MailerStatusNotice.propTypes = {
+  error: PropTypes.shape({
+    operation: PropTypes.string,
+    error_message: PropTypes.string,
+  }),
+};
+MailerStatusNotice.defaultProps = {
+  error: null,
+};
+
+export default MailerStatusNotice;

--- a/assets/js/src/notices/notice.jsx
+++ b/assets/js/src/notices/notice.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+const Notice = (props) => {
+  const [hidden, setHidden] = React.useState(false);
+  const elementRef = React.useRef(null);
+  const timeoutRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (props.timeout) {
+      timeoutRef.current = setTimeout(() => setHidden(true), props.timeout);
+    }
+    return () => (timeoutRef.current ? clearTimeout(timeoutRef.current) : null);
+  }, [props.timeout]);
+
+  React.useLayoutEffect(() => {
+    if (props.scroll && elementRef.current) {
+      elementRef.current.scrollIntoView(false);
+    }
+  }, [props.scroll]);
+
+  if (hidden) return null;
+  return ReactDOM.createPortal(
+    <div ref={elementRef} className={`mailpoet_${props.type}_notice`}>{props.children}</div>,
+    document.getElementById('mailpoet_notices')
+  );
+};
+Notice.propTypes = {
+  type: PropTypes.oneOf(['success', 'info', 'warning', 'error']).isRequired,
+  scroll: PropTypes.bool,
+  timeout: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([false])]),
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element),
+  ]).isRequired,
+};
+Notice.defaultProps = {
+  timeout: 10000,
+  scroll: false,
+};
+
+export default Notice;

--- a/assets/js/src/notices/notice.jsx
+++ b/assets/js/src/notices/notice.jsx
@@ -22,7 +22,7 @@ const Notice = (props) => {
 
   if (hidden) return null;
   return ReactDOM.createPortal(
-    <div ref={elementRef} className={`mailpoet_${props.type}_notice`}>{props.children}</div>,
+    <div ref={elementRef} className={`mailpoet_base_notice mailpoet_${props.type}_notice`}>{props.children}</div>,
     document.getElementById('mailpoet_notices')
   );
 };

--- a/views/layout.html
+++ b/views/layout.html
@@ -20,6 +20,8 @@ jQuery('.toplevel_page_mailpoet-newsletters.menu-top-last')
   <!-- notices -->
   <div id="mailpoet_notice_error" class="mailpoet_notice" style="display:none;"></div>
   <div id="mailpoet_notice_success" class="mailpoet_notice" style="display:none;"></div>
+  <!-- React notices -->
+  <div id="mailpoet_notices"></div>
 
   <!-- title block -->
   <% block title %><% endblock %>


### PR DESCRIPTION
The plan was:
1. Write a `Notice` React component which uses React Portals to render itself into the `#mailpoet_notices` div (which I will add to `layout.html`).
2. Replace as much instances of `MailPoet.Notice` as possible with the `Notice` component.

I started by looking into the existing `MailPoet.Notice` object. It has the following options:
- type: can be `success`, `info`, `warning` or `error`.
- message: the **HTML** content of the notice.
- static: if `true` the notice will not have a timeout.
- hideClose: if `false` the notice will closable (via a small icon on top-right).
- id: a string to identify the notice.
- positionAfter: a selector. When specified, the notice is inserted after that element.
- scroll: if `true` the view will scroll to the notice when it's shown.
- timeout: the timeout after which the notice will disappear.
- onOpen: something to do when the notice is shown.
- onClose: something to do when the notice is closed.

But the `onOpen` and `onClose` options are never used in our code. The `hideClose` and `positionAfter` are mostly used in the newsletters editor code. The `id` will not be used in React. So The React component would only have the following props:
- type: can be `success`, `info`, `warning` or `error`.
- scroll: if `true` the view will scroll to the notice when it's shown.
- timeout: the number of milliseconds to show the notice, or `false` to have a static one.
The content of the notice is provided via the `children` prop.

When using WP notice CSS classes (`.notice`, `.is-dismissible`, `.notice-success`,...), the WP javascript code steps in and starts manipulating the DOM, which is the wrong way to do things in React. So I had to create my own CSS classes:
- `mailpoet_success_notice`
- `mailpoet_error_notice`
- `mailpoet_warning_notice`
- `mailpoet_info_notice`

Having the `Notice` component. I started by replacing the `MailPoet.Notice` calls on the `QueueStatus` component. I had just written it from a Mixin a week ago and it used the `Notice.error()` the way it's mostly used in our code (to show errors of an API response). So refactoring it will make it easy to refactor other components.

While working on that, I noticed that declarations of propTypes are duplicated and can be shared between components. But since we are willing to use Typescript in the future, this issue will be solved by then.

I then tried to get rid of `checkMailerStatus` and replace it with a `MailerStatusNotice` component. **But this revealed a big issue within our notices: They are coupled!**. In order to solve this problem, while keeping the current behavior, I had to introduce a shared React context offering the possibility to show/hide any specific notice from any React component. But I was already out of time so I will keep this for my next hacking day.