### PR TITLE
Add a built-in captcha [MAILPOET-2015]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build_and_code_qa:
     working_directory: /home/circleci/mailpoet
     docker:
-      - image: mailpoet/wordpress:7.3_20190306.1
+      - image: mailpoet/wordpress:7.3_20190705.2
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
     steps:
@@ -58,7 +58,7 @@ jobs:
   static_analysis:
     working_directory: /home/circleci/mailpoet
     docker:
-    - image: mailpoet/wordpress:7.3_20190306.1
+    - image: mailpoet/wordpress:7.3_20190705.2
     - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -76,7 +76,7 @@ jobs:
   php5_unit:
     working_directory: /home/circleci/mailpoet
     docker:
-    - image: mailpoet/wordpress:5.6.30_20180417.1
+    - image: mailpoet/wordpress:5.6.40_20190709.2
     - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -104,7 +104,7 @@ jobs:
   php5_integration_and_js:
     working_directory: /home/circleci/mailpoet
     docker:
-    - image: mailpoet/wordpress:5.6.30_20180417.1
+    - image: mailpoet/wordpress:5.6.40_20190709.2
     - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -289,7 +289,7 @@ jobs:
   php7_unit:
     working_directory: /home/circleci/mailpoet
     docker:
-      - image: mailpoet/wordpress:7.3_20190306.1
+      - image: mailpoet/wordpress:7.3_20190705.2
       - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -320,7 +320,7 @@ jobs:
   php7_integration:
     working_directory: /home/circleci/mailpoet
     docker:
-      - image: mailpoet/wordpress:7.3_20190306.1
+      - image: mailpoet/wordpress:7.3_20190705.2
       - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -351,7 +351,7 @@ jobs:
   php7_integration_multisite:
     working_directory: /home/circleci/mailpoet
     docker:
-      - image: mailpoet/wordpress:7.3_20190306.1
+      - image: mailpoet/wordpress:7.3_20190705.2
       - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -382,7 +382,7 @@ jobs:
   build_release_zip:
     working_directory: /home/circleci/mailpoet
     docker:
-      - image: mailpoet/wordpress:7.3_20190306.1
+      - image: mailpoet/wordpress:7.3_20190705.2
       - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
   php5_unit:
     working_directory: /home/circleci/mailpoet
     docker:
-    - image: mailpoet/wordpress:5.6.40_20190709.2
+    - image: mailpoet/wordpress:5.6_20190709.3
     - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
@@ -104,7 +104,7 @@ jobs:
   php5_integration_and_js:
     working_directory: /home/circleci/mailpoet
     docker:
-    - image: mailpoet/wordpress:5.6.40_20190709.2
+    - image: mailpoet/wordpress:5.6_20190709.3
     - image: circleci/mysql:5.7-ram
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC

--- a/assets/css/src/components/_public.scss
+++ b/assets/css/src/components/_public.scss
@@ -44,6 +44,15 @@
   margin: 0 7px;
 }
 
+.mailpoet_captcha_form {
+  .mailpoet_validate_success { color: #468847; }
+  .mailpoet_validate_error { color: #b94a48; }
+}
+
+.mailpoet_captcha_update {
+  cursor: pointer;
+}
+
 @keyframes mailpoet-bouncedelay {
   0%,
   80%,

--- a/assets/js/src/public.js
+++ b/assets/js/src/public.js
@@ -23,12 +23,18 @@ jQuery(function ($) { // eslint-disable-line func-names
   }
 
   function updateCaptcha(e) {
-    var captcha = $('img.mailpoet_captcha');
-    var captchaSrc = captcha.attr('src');
-    var hashPos = captchaSrc.indexOf('#');
-    var newSrc = hashPos > 0 ? captchaSrc.substring(0, hashPos) : captchaSrc;
+    var captcha;
+    var captchaSrc;
+    var hashPos;
+    var newSrc;
+    captcha = $('img.mailpoet_captcha');
+    if (!captcha.length) return false;
+    captchaSrc = captcha.attr('src');
+    hashPos = captchaSrc.indexOf('#');
+    newSrc = hashPos > 0 ? captchaSrc.substring(0, hashPos) : captchaSrc;
     captcha.attr('src', newSrc + '#' + new Date().getTime());
     if (e) e.preventDefault();
+    return true;
   }
 
   $(function () { // eslint-disable-line func-names

--- a/assets/js/src/public.js
+++ b/assets/js/src/public.js
@@ -22,6 +22,15 @@ jQuery(function ($) { // eslint-disable-line func-names
     return (window.location.hostname === link.hostname);
   }
 
+  function updateCaptcha(e) {
+    var captcha = $('img.mailpoet_captcha');
+    var captchaSrc = captcha.attr('src');
+    var hashPos = captchaSrc.indexOf('#');
+    var newSrc = hashPos > 0 ? captchaSrc.substring(0, hashPos) : captchaSrc;
+    captcha.attr('src', newSrc + '#' + new Date().getTime());
+    if (e) e.preventDefault();
+  }
+
   $(function () { // eslint-disable-line func-names
     // setup form validation
     $('form.mailpoet_form').each(function () { // eslint-disable-line func-names
@@ -68,7 +77,7 @@ jQuery(function ($) { // eslint-disable-line func-names
               window.top.location.href = response.meta.redirect_url;
             } else {
               if (response.meta && response.meta.refresh_captcha) {
-                $('.mailpoet_captcha_update').click();
+                updateCaptcha();
               }
               form.find('.mailpoet_validate_error').html(
                 response.errors.map(function buildErrorMessage(error) {
@@ -125,13 +134,6 @@ jQuery(function ($) { // eslint-disable-line func-names
       });
     });
 
-    $('.mailpoet_captcha_update').click(function updateCaptcha(e) {
-      var captcha = $('img.mailpoet_captcha');
-      var captchaSrc = captcha.attr('src');
-      var hashPos = captchaSrc.indexOf('#');
-      var newSrc = hashPos > 0 ? captchaSrc.substring(0, hashPos) : captchaSrc;
-      captcha.attr('src', newSrc + '#' + new Date().getTime());
-      e.preventDefault();
-    });
+    $('.mailpoet_captcha_update').on('click', updateCaptcha);
   });
 });

--- a/build.sh
+++ b/build.sh
@@ -97,6 +97,8 @@ rm -rf $plugin_name/vendor/twig/twig/test
 echo '[BUILD] Removing risky and demo files from vendor libraries'
 rm -f $plugin_name/vendor/j4mie/idiorm/demo.php
 rm -f $plugin_name/vendor/cerdic/css-tidy/css_optimiser.php
+rm -rf $plugin_name/vendor-prefixed/gregwar/captcha/demo
+rm -rf $plugin_name/vendor-prefixed/gregwar/captcha/src/Gregwar/Captcha/Font/captcha4.ttf # big font
 rm -f $plugin_name/assets/js/lib/tinymce/package.json
 
 # Remove unused TinyMCE files

--- a/lib/API/JSON/API.php
+++ b/lib/API/JSON/API.php
@@ -3,6 +3,7 @@ namespace MailPoet\API\JSON;
 
 use MailPoet\Config\AccessControl;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoetVendor\Psr\Container\ContainerInterface;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Security;
@@ -79,7 +80,7 @@ class API {
     $this->setRequestData($_POST);
 
     $ignoreToken = (
-      $this->settings->get('re_captcha.enabled') &&
+      $this->settings->get('captcha.type') != Captcha::TYPE_DISABLED &&
       $this->_request_endpoint === 'subscribers' &&
       $this->_request_method === 'subscribe'
     );

--- a/lib/API/JSON/v1/Setup.php
+++ b/lib/API/JSON/v1/Setup.php
@@ -6,8 +6,9 @@ use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\Activator;
-use MailPoet\Settings\SettingsController;
 use MailPoet\Config\Populator;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 
 if (!defined('ABSPATH')) exit;
 
@@ -24,7 +25,8 @@ class Setup extends APIEndpoint {
   function reset() {
     try {
       $settings = new SettingsController();
-      $activator = new Activator($settings, new Populator($settings, $this->wp));
+      $captcha = new Captcha();
+      $activator = new Activator($settings, new Populator($settings, $this->wp, $captcha));
       $activator->deactivate();
       $activator->activate();
       $this->wp->doAction('mailpoet_setup_reset');

--- a/lib/API/JSON/v1/Subscribers.php
+++ b/lib/API/JSON/v1/Subscribers.php
@@ -206,7 +206,8 @@ class Subscribers extends APIEndpoint {
     $timeout = SubscriptionThrottling::throttle();
 
     if ($timeout > 0) {
-      throw new \Exception(sprintf(__('You need to wait %d seconds before subscribing again.', 'mailpoet'), $timeout));
+      $time_to_wait = SubscriptionThrottling::secondsToTimeString($timeout);
+      throw new \Exception(sprintf(__('You need to wait %s before subscribing again.', 'mailpoet'), $time_to_wait));
     }
 
     $subscriber = $this->subscriber_actions->subscribe($data, $segment_ids);

--- a/lib/AdminPages/Pages/Settings.php
+++ b/lib/AdminPages/Pages/Settings.php
@@ -13,6 +13,7 @@ use MailPoet\Services\Bridge;
 use MailPoet\Settings\Hosts;
 use MailPoet\Settings\Pages;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Util\Installation;
 use MailPoet\Util\License\License;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
@@ -89,6 +90,7 @@ class Settings {
         'web' => Hosts::getWebHosts(),
         'smtp' => Hosts::getSMTPHosts(),
       ],
+      'built_in_captcha_supported' => (new Captcha)->isSupported(),
     ];
 
     $data['is_new_user'] = $this->installation->isNewInstallation();

--- a/lib/AdminPages/Pages/Settings.php
+++ b/lib/AdminPages/Pages/Settings.php
@@ -37,6 +37,9 @@ class Settings {
   /** @var ServicesChecker */
   private $services_checker;
 
+  /** @var Captcha */
+  private $captcha;
+
   /** @var FeaturesController */
   private $features_controller;
 
@@ -50,7 +53,8 @@ class Settings {
     WPFunctions $wp,
     ServicesChecker $services_checker,
     FeaturesController $features_controller,
-    Installation $installation
+    Installation $installation,
+    Captcha $captcha
   ) {
     $this->page_renderer = $page_renderer;
     $this->settings = $settings;
@@ -59,6 +63,7 @@ class Settings {
     $this->services_checker = $services_checker;
     $this->features_controller = $features_controller;
     $this->installation = $installation;
+    $this->captcha = $captcha;
   }
 
   function render() {
@@ -90,7 +95,7 @@ class Settings {
         'web' => Hosts::getWebHosts(),
         'smtp' => Hosts::getSMTPHosts(),
       ],
-      'built_in_captcha_supported' => (new Captcha)->isSupported(),
+      'built_in_captcha_supported' => $this->captcha->isSupported(),
     ];
 
     $data['is_new_user'] = $this->installation->isNewInstallation();

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -179,6 +179,7 @@ class Initializer {
 
   function initialize() {
     try {
+      $this->setupSession();
       $this->maybeDbUpdate();
       $this->setupInstaller();
       $this->setupUpdater();
@@ -205,6 +206,11 @@ class Initializer {
     }
 
     define(self::INITIALIZED, true);
+  }
+
+  function setupSession() {
+    $session = new Session;
+    $session->init();
   }
 
   function maybeDbUpdate() {

--- a/lib/Config/MP2Migrator.php
+++ b/lib/Config/MP2Migrator.php
@@ -10,6 +10,7 @@ use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberCustomField;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Util\Notices\AfterMigrationNotice;
 use MailPoet\Util\ProgressBar;
 use MailPoet\WP\Functions as WPFunctions;
@@ -217,7 +218,8 @@ class MP2Migrator {
    */
   private function eraseMP3Data() {
     $settings = new SettingsController();
-    $activator = new Activator($settings, new Populator($settings, WPFunctions::get()));
+    $captcha = new Captcha();
+    $activator = new Activator($settings, new Populator($settings, WPFunctions::get(), $captcha));
     $activator->deactivate();
     $activator->activate();
 

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -175,6 +175,7 @@ class Populator {
         'unsubscribe' => $mailpoet_page_id,
         'manage' => $mailpoet_page_id,
         'confirmation' => $mailpoet_page_id,
+        'captcha' => $mailpoet_page_id,
       ]);
     }
   }

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -38,11 +38,18 @@ class Populator {
   private $settings;
   /** @var WPFunctions */
   private $wp;
+  /** @var Captcha */
+  private $captcha;
   const TEMPLATES_NAMESPACE = '\MailPoet\Config\PopulatorData\Templates\\';
 
-  function __construct(SettingsController $settings, WPFunctions $wp) {
+  function __construct(
+    SettingsController $settings,
+    WPFunctions $wp,
+    Captcha $captcha
+  ) {
     $this->settings = $settings;
     $this->wp = $wp;
+    $this->captcha = $captcha;
     $this->prefix = Env::$db_prefix;
     $this->models = [
       'newsletter_option_fields',
@@ -226,11 +233,10 @@ class Populator {
     $captcha = $this->settings->fetch('captcha');
     $re_captcha = $this->settings->fetch('re_captcha');
     if (empty($captcha)) {
-      $subscription_captcha = new Captcha;
       $captcha_type = Captcha::TYPE_DISABLED;
       if (!empty($re_captcha['enabled'])) {
         $captcha_type = Captcha::TYPE_RECAPTCHA;
-      } elseif ($subscription_captcha->isSupported()) {
+      } elseif ($this->captcha->isSupported()) {
         $captcha_type = Captcha::TYPE_BUILTIN;
       }
       $this->settings->set('captcha', [

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -177,6 +177,9 @@ class Populator {
         'confirmation' => $mailpoet_page_id,
         'captcha' => $mailpoet_page_id,
       ]);
+    } elseif (empty($subscription['captcha'])) {
+      // For existing installations
+      $this->settings->set('subscription.pages', array_merge($subscription, ['captcha' => $mailpoet_page_id]));
     }
   }
 

--- a/lib/Config/Session.php
+++ b/lib/Config/Session.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MailPoet\Config;
+
+if (!defined('ABSPATH')) exit;
+
+class Session {
+  function init() {
+    if (!session_id()) {
+      return session_start();
+    }
+  }
+}

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -145,6 +145,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // User Flags
     $container->autowire(\MailPoet\Settings\UserFlagsController::class);
     // Subscription
+    $container->autowire(\MailPoet\Subscription\Captcha::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Comment::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Form::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Manage::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -146,6 +146,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Settings\UserFlagsController::class);
     // Subscription
     $container->autowire(\MailPoet\Subscription\Captcha::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscription\CaptchaRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Comment::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Form::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Manage::class)->setPublic(true);

--- a/lib/Form/Block/Base.php
+++ b/lib/Form/Block/Base.php
@@ -111,6 +111,8 @@ abstract class Base {
   protected static function getFieldName($block = []) {
     if ((int)$block['id'] > 0) {
       return 'cf_' . $block['id'];
+    } elseif (isset($block['params']['obfuscate']) && !$block['params']['obfuscate']) {
+      return $block['id'];
     } else {
       $obfuscator = new FieldNameObfuscator();
       return $obfuscator->obfuscate($block['id']);//obfuscate field name for spambots

--- a/lib/Form/Renderer.php
+++ b/lib/Form/Renderer.php
@@ -2,6 +2,7 @@
 namespace MailPoet\Form;
 
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -50,8 +51,8 @@ class Renderer {
       '<label class="mailpoet_hp_email_label">' . WPFunctions::get()->__('Please leave this field empty', 'mailpoet') . '<input type="email" name="data[email]"></label>' :
       '';
     foreach ($blocks as $key => $block) {
-      if ($block['type'] == 'submit' && $settings->get('re_captcha.enabled')) {
-        $site_key = $settings->get('re_captcha.site_token');
+      if ($block['type'] == 'submit' && $settings->get('captcha.type') === Captcha::TYPE_RECAPTCHA) {
+        $site_key = $settings->get('captcha.recaptcha_site_token');
         $html .= '<div class="mailpoet_recaptcha" data-sitekey="' . $site_key . '">
           <div class="mailpoet_recaptcha_container"></div>
           <noscript>

--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -8,6 +8,7 @@ use MailPoet\Config\Renderer as ConfigRenderer;
 use MailPoet\Form\Renderer as FormRenderer;
 use MailPoet\Models\Form;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -117,8 +118,8 @@ class Widget extends \WP_Widget {
       true
     );
 
-    $captcha = $this->settings->get('re_captcha');
-    if (!empty($captcha['enabled'])) {
+    $captcha = $this->settings->get('captcha');
+    if (!empty($captcha['type']) && $captcha['type'] === Captcha::TYPE_RECAPTCHA) {
       WPFunctions::get()->wpEnqueueScript(
         'mailpoet_recaptcha',
         self::RECAPTCHA_API_URL,

--- a/lib/Router/Endpoints/Subscription.php
+++ b/lib/Router/Endpoints/Subscription.php
@@ -33,7 +33,7 @@ class Subscription {
   }
 
   function captcha($data) {
-    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CAPTCHA, $data);
+    $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CAPTCHA, $data);
   }
 
   function captchaImage($data) {
@@ -49,7 +49,7 @@ class Subscription {
   }
 
   function manage($data) {
-    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_MANAGE, $data);
+    $this->initSubscriptionPage(UserSubscription\Pages::ACTION_MANAGE, $data);
   }
 
   function unsubscribe($data) {

--- a/lib/Router/Endpoints/Subscription.php
+++ b/lib/Router/Endpoints/Subscription.php
@@ -9,10 +9,14 @@ if (!defined('ABSPATH')) exit;
 
 class Subscription {
   const ENDPOINT = 'subscription';
+  const ACTION_CAPTCHA = 'captcha';
+  const ACTION_CAPTCHA_IMAGE = 'captchaImage';
   const ACTION_CONFIRM = 'confirm';
   const ACTION_MANAGE = 'manage';
   const ACTION_UNSUBSCRIBE = 'unsubscribe';
   public $allowed_actions = [
+    self::ACTION_CAPTCHA,
+    self::ACTION_CAPTCHA_IMAGE,
     self::ACTION_CONFIRM,
     self::ACTION_MANAGE,
     self::ACTION_UNSUBSCRIBE,
@@ -26,6 +30,17 @@ class Subscription {
 
   function __construct(UserSubscription\Pages $subscription_pages) {
     $this->subscription_pages = $subscription_pages;
+  }
+
+  function captcha($data) {
+    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CAPTCHA, $data);
+  }
+
+  function captchaImage($data) {
+    $captcha = new UserSubscription\Captcha;
+    $width = !empty($data['width']) ? (int)$data['width'] : null;
+    $height = !empty($data['height']) ? (int)$data['height'] : null;
+    return $captcha->renderImage($width, $height);
   }
 
   function confirm($data) {

--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MailPoet\Subscription;
+
+class Captcha {
+  const TYPE_BUILTIN = 'built-in';
+  const TYPE_RECAPTCHA = 'recaptcha';
+  const TYPE_DISABLED = null;
+
+  function isSupported() {
+    return extension_loaded('gd') && function_exists('imagettftext');
+  }
+}

--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -51,16 +51,18 @@ class Captcha {
 
     $subscriber_ip = Helpers::getIP();
 
-    if (!empty($subscriber_ip)) {
-      $subscription_count = SubscriberIP::where('ip', $subscriber_ip)
-        ->whereRaw(
-          '(`created_at` >= NOW() - INTERVAL ? SECOND)',
-          [(int)$subscription_captcha_window]
-        )->count();
+    if (empty($subscriber_ip)) {
+      return false;
+    }
 
-      if ($subscription_count > 0) {
-        return true;
-      }
+    $subscription_count = SubscriberIP::where('ip', $subscriber_ip)
+      ->whereRaw(
+        '(`created_at` >= NOW() - INTERVAL ? SECOND)',
+        [(int)$subscription_captcha_window]
+      )->count();
+
+    if ($subscription_count > 0) {
+      return true;
     }
 
     return false;

--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -31,7 +31,7 @@ class Captcha {
   }
 
   function isRequired($subscriber_email = null) {
-    if ($this->wp->isUserLoggedIn()) {
+    if ($this->isUserExemptFromCaptcha()) {
       return false;
     }
 
@@ -66,6 +66,15 @@ class Captcha {
     }
 
     return false;
+  }
+
+  private function isUserExemptFromCaptcha() {
+    if (!$this->wp->isUserLoggedIn()) {
+      return false;
+    }
+    $user = $this->wp->wpGetCurrentUser();
+    $roles = $this->wp->applyFilters('mailpoet_subscription_captcha_exclude_roles', ['administrator', 'editor']);
+    return !empty(array_intersect($roles, (array)$user->roles));
   }
 
   function renderImage($width = null, $height = null, $return = false) {

--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -2,12 +2,42 @@
 
 namespace MailPoet\Subscription;
 
+use MailPoetVendor\Gregwar\Captcha\CaptchaBuilder;
+
 class Captcha {
   const TYPE_BUILTIN = 'built-in';
   const TYPE_RECAPTCHA = 'recaptcha';
   const TYPE_DISABLED = null;
 
+  const SESSION_KEY = 'mailpoet_captcha';
+  const SESSION_FORM_KEY = 'mailpoet_captcha_form';
+
   function isSupported() {
     return extension_loaded('gd') && function_exists('imagettftext');
+  }
+
+  function renderImage($width = null, $height = null) {
+    if (!$this->isSupported()) {
+      return false;
+    }
+
+    $font_numbers = array_merge(range(0, 3), [5]); // skip font #4
+    $font_number = $font_numbers[mt_rand(0, count($font_numbers) - 1)];
+
+    $reflector = new \ReflectionClass(CaptchaBuilder::class);
+    $captcha_directory = dirname($reflector->getFileName());
+    $font = $captcha_directory . '/Font/captcha' . $font_number . '.ttf';
+
+    $builder = CaptchaBuilder::create()
+      ->setBackgroundColor(255, 255, 255)
+      ->setTextColor(1, 1, 1)
+      ->setMaxBehindLines(0)
+      ->build($width ?: 220, $height ?: 60, $font);
+
+    $_SESSION[self::SESSION_KEY] = $builder->getPhrase();
+
+    header('Content-Type: image/jpeg');
+    $builder->output();
+    exit;
   }
 }

--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -90,6 +90,14 @@ class Captcha {
       return $builder->get();
     }
 
+    header("Expires: Sat, 01 Jan 2019 01:00:00 GMT"); // time in the past
+    header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+    header("Cache-Control: no-store, no-cache, must-revalidate");
+    header("Cache-Control: post-check=0, pre-check=0", false);
+    header("Pragma: no-cache");
+    header('X-Cache-Enabled: False');
+    header('X-LiteSpeed-Cache-Control: no-cache');
+
     header('Content-Type: image/jpeg');
     $builder->output();
     exit;

--- a/lib/Subscription/CaptchaRenderer.php
+++ b/lib/Subscription/CaptchaRenderer.php
@@ -11,12 +11,16 @@ class CaptchaRenderer {
   /** @var UrlHelper */
   private $url_helper;
 
-  function __construct() {
-    $this->url_helper = new UrlHelper(new WPFunctions());
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(UrlHelper $url_helper, WPFunctions $wp) {
+    $this->url_helper = $url_helper;
+    $this->wp = $wp;
   }
 
   public function getCaptchaPageTitle() {
-    return WPFunctions::get()->__("Confirm you’re not a robot", 'mailpoet');
+    return $this->wp->__("Confirm you’re not a robot", 'mailpoet');
   }
 
   public function getCaptchaPageContent() {
@@ -25,7 +29,7 @@ class CaptchaRenderer {
         'id' => 'captcha',
         'type' => 'text',
         'params' => [
-          'label' => WPFunctions::get()->__('Type in the input the characters you see in the picture above:', 'mailpoet'),
+          'label' => $this->wp->__('Type in the input the characters you see in the picture above:', 'mailpoet'),
           'value' => '',
           'obfuscate' => false,
         ],
@@ -39,7 +43,7 @@ class CaptchaRenderer {
           'id' => 'submit',
           'type' => 'submit',
           'params' => [
-            'label' => WPFunctions::get()->__('Subscribe', 'mailpoet'),
+            'label' => $this->wp->__('Subscribe', 'mailpoet'),
           ],
         ],
       ]
@@ -69,7 +73,7 @@ class CaptchaRenderer {
 
     $form_html .= '<div class="mailpoet_form_hide_on_success">';
     $form_html .= '<p class="mailpoet_paragraph">';
-    $form_html .= '<img class="mailpoet_captcha mailpoet_captcha_update" src="' . $captcha_url . '" width="' . $width . '" height="' . $height . '" title="' . WPFunctions::get()->__('Click to refresh the captcha', 'mailpoet') . '" />';
+    $form_html .= '<img class="mailpoet_captcha mailpoet_captcha_update" src="' . $captcha_url . '" width="' . $width . '" height="' . $height . '" title="' . $this->wp->__('Click to refresh the captcha', 'mailpoet') . '" />';
     $form_html .= '</p>';
 
     // subscription form

--- a/lib/Subscription/CaptchaRenderer.php
+++ b/lib/Subscription/CaptchaRenderer.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace MailPoet\Subscription;
+
+use MailPoet\Models\Form as FormModel;
+use MailPoet\Util\Url as UrlHelper;
+use MailPoet\Form\Renderer as FormRenderer;
+use MailPoet\WP\Functions as WPFunctions;
+
+class CaptchaRenderer {
+  /** @var UrlHelper */
+  private $url_helper;
+
+  function __construct() {
+    $this->url_helper = new UrlHelper(new WPFunctions());
+  }
+
+  public function getCaptchaPageTitle() {
+    return WPFunctions::get()->__("Confirm you’re not a robot", 'mailpoet');
+  }
+
+  public function getCaptchaPageContent() {
+    $fields = [
+      [
+        'id' => 'captcha',
+        'type' => 'text',
+        'params' => [
+          'label' => WPFunctions::get()->__('Type in the input the characters you see in the picture above:', 'mailpoet'),
+          'value' => '',
+          'obfuscate' => false,
+        ],
+      ],
+    ];
+
+    $form = array_merge(
+      $fields,
+      [
+        [
+          'id' => 'submit',
+          'type' => 'submit',
+          'params' => [
+            'label' => WPFunctions::get()->__('Subscribe', 'mailpoet'),
+          ],
+        ],
+      ]
+    );
+
+    $form_id = isset($_SESSION[Captcha::SESSION_FORM_KEY]['form_id']) ? (int)$_SESSION[Captcha::SESSION_FORM_KEY]['form_id'] : 0;
+    $form_model = FormModel::findOne($form_id);
+    if (!$form_model instanceof FormModel) {
+      return false;
+    }
+    $form_model = $form_model->asArray();
+
+    $form_html = '<form method="POST" ' .
+      'action="' . admin_url('admin-post.php?action=mailpoet_subscription_form') . '" ' .
+      'class="mailpoet_form mailpoet_captcha_form" ' .
+      'novalidate>';
+    $form_html .= '<input type="hidden" name="data[form_id]" value="' . $form_id . '" />';
+    $form_html .= '<input type="hidden" name="api_version" value="v1" />';
+    $form_html .= '<input type="hidden" name="endpoint" value="subscribers" />';
+    $form_html .= '<input type="hidden" name="mailpoet_method" value="subscribe" />';
+    $form_html .= '<input type="hidden" name="mailpoet_redirect" ' .
+      'value="' . htmlspecialchars($this->url_helper->getCurrentUrl(), ENT_QUOTES) . '" />';
+
+    $width = 220;
+    $height = 60;
+    $captcha_url = Url::getCaptchaImageUrl($width, $height);
+
+    $form_html .= '<div class="mailpoet_form_hide_on_success">';
+    $form_html .= '<p class="mailpoet_paragraph">';
+    $form_html .= '<img class="mailpoet_captcha mailpoet_captcha_update" src="' . $captcha_url . '" width="' . $width . '" height="' . $height . '" title="' . WPFunctions::get()->__('Click to refresh the captcha', 'mailpoet') . '" />';
+    $form_html .= '</p>';
+
+    // subscription form
+    $form_html .= FormRenderer::renderBlocks($form, $honeypot = false);
+    $form_html .= '</div>';
+    $form_html .= '<div class="mailpoet_message">';
+    $form_html .= '<p class="mailpoet_validate_success" style="display:none;">' . $form_model['settings']['success_message'] . '</p>';
+    $form_html .= '<p class="mailpoet_validate_error" style="display:none;"></p>';
+    $form_html .= '</div>';
+    $form_html .= '</form>';
+    return $form_html;
+  }
+}

--- a/lib/Subscription/Form.php
+++ b/lib/Subscription/Form.php
@@ -25,7 +25,9 @@ class Form {
     $form_id = (!empty($request_data['data']['form_id'])) ? (int)$request_data['data']['form_id'] : false;
     $response = $this->api->processRoute();
     if ($response->status !== APIResponse::STATUS_OK) {
-      return $this->url_helper->redirectBack(
+      return (isset($response->meta['redirect_url'])) ?
+      $this->url_helper->redirectTo($response->meta['redirect_url']) :
+      $this->url_helper->redirectBack(
         [
           'mailpoet_error' => ($form_id) ? $form_id : true,
           'mailpoet_success' => null,

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -292,6 +292,9 @@ class Pages {
 
     $form_id = isset($_SESSION[Captcha::SESSION_FORM_KEY]['form_id']) ? (int)$_SESSION[Captcha::SESSION_FORM_KEY]['form_id'] : 0;
     $form_model = FormModel::findOne($form_id);
+    if (!$form_model instanceof FormModel) {
+      return false;
+    }
     $form_model = $form_model->asArray();
 
     $form_html = '<form method="POST" ' .

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Subscription;
 
+use MailPoet\Models\Form as FormModel;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Models\CustomField;
@@ -290,6 +291,8 @@ class Pages {
     );
 
     $form_id = isset($_SESSION[Captcha::SESSION_FORM_KEY]['form_id']) ? (int)$_SESSION[Captcha::SESSION_FORM_KEY]['form_id'] : 0;
+    $form_model = FormModel::findOne($form_id);
+    $form_model = $form_model->asArray();
 
     $form_html = '<form method="POST" ' .
       'action="' . admin_url('admin-post.php?action=mailpoet_subscription_form') . '" ' .
@@ -315,7 +318,7 @@ class Pages {
     $form_html .= FormRenderer::renderBlocks($form, $honeypot = false);
     $form_html .= '</div>';
     $form_html .= '<div class="mailpoet_message">';
-    $form_html .= '<p class="mailpoet_validate_success" style="display:none;">Check your inbox or spam folder to confirm your subscription.</p>';
+    $form_html .= '<p class="mailpoet_validate_success" style="display:none;">' . $form_model['settings']['success_message'] . '</p>';
     $form_html .= '<p class="mailpoet_validate_error" style="display:none;"></p>';
     $form_html .= '</div>';
     $form_html .= '</form>';

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -46,18 +46,20 @@ class Pages {
     NewSubscriberNotificationMailer $new_subscriber_notification_sender,
     WPFunctions $wp,
     SettingsController $settings,
-    UrlHelper $url_helper
+    UrlHelper $url_helper,
+    CaptchaRenderer $captcha_renderer
   ) {
     $this->wp = $wp;
     $this->new_subscriber_notification_sender = $new_subscriber_notification_sender;
     $this->settings = $settings;
     $this->url_helper = $url_helper;
-    $this->captcha_renderer = new CaptchaRenderer;
+    $this->captcha_renderer = $captcha_renderer;
   }
 
   function init($action = false, $data = [], $init_shortcodes = false, $init_page_filters = false) {
     $this->action = $action;
     $this->data = $data;
+    $this->wp = new WPFunctions();
     $this->subscriber = $this->getSubscriber();
     if ($init_page_filters) $this->initPageFilters();
     if ($init_shortcodes) $this->initShortcodes();

--- a/lib/Subscription/Throttling.php
+++ b/lib/Subscription/Throttling.php
@@ -14,7 +14,6 @@ class Throttling {
     $subscription_limit_base = $wp->applyFilters('mailpoet_subscription_limit_base', MINUTE_IN_SECONDS);
 
     $subscriber_ip = Helpers::getIP();
-    $wp = new WPFunctions;
 
     if ($subscription_limit_enabled && !$wp->isUserLoggedIn()) {
       if (!empty($subscriber_ip)) {
@@ -43,12 +42,14 @@ class Throttling {
     $ip->ip = $subscriber_ip;
     $ip->save();
 
-    self::purge($subscription_limit_window);
+    self::purge();
 
     return false;
   }
 
-  static function purge($interval) {
+  static function purge() {
+    $wp = new WPFunctions;
+    $interval = $wp->applyFilters('mailpoet_subscription_purge_window', MONTH_IN_SECONDS);
     return SubscriberIP::whereRaw(
       '(`created_at` < NOW() - INTERVAL ? SECOND)',
       [$interval]

--- a/lib/Subscription/Throttling.php
+++ b/lib/Subscription/Throttling.php
@@ -55,4 +55,17 @@ class Throttling {
       [$interval]
     )->deleteMany();
   }
+
+  static function secondsToTimeString($seconds) {
+    $wp = new WPFunctions;
+    $hrs = floor($seconds / 3600);
+    $min = floor($seconds % 3600 / 60);
+    $sec = $seconds % 3600 % 60;
+    $result = [
+      'hours' => $hrs ? sprintf($wp->__('%d hours', 'mailpoet'), $hrs) : '',
+      'minutes' => $min ? sprintf($wp->__('%d minutes', 'mailpoet'), $min) : '',
+      'seconds' => $sec ? sprintf($wp->__('%d seconds', 'mailpoet'), $sec) : '',
+    ];
+    return join(' ', array_filter($result));
+  }
 }

--- a/lib/Subscription/Url.php
+++ b/lib/Subscription/Url.php
@@ -8,6 +8,16 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Url {
+  static function getCaptchaUrl(Subscriber $subscriber = null) {
+    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.captcha'));
+    return self::getSubscriptionUrl($post, 'captcha', $subscriber);
+  }
+
+  static function getCaptchaImageUrl($width, $height) {
+    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.captcha'));
+    return self::getSubscriptionUrl($post, 'captchaImage', null, ['width' => $width, 'height' => $height]);
+  }
+
   static function getConfirmationUrl(Subscriber $subscriber = null) {
     $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.confirmation'));
     return self::getSubscriptionUrl($post, 'confirm', $subscriber);
@@ -24,7 +34,10 @@ class Url {
   }
 
   static function getSubscriptionUrl(
-    $post = null, $action = null, Subscriber $subscriber = null
+    $post = null,
+    $action = null,
+    Subscriber $subscriber = null,
+    $data = null
   ) {
     if ($post === null || $action === null) return;
 
@@ -35,7 +48,7 @@ class Url {
         'token' => Subscriber::generateToken($subscriber->email),
         'email' => $subscriber->email,
       ];
-    } else {
+    } elseif (is_null($data)) {
       $data = [
         'preview' => 1,
       ];

--- a/lib/Subscription/Url.php
+++ b/lib/Subscription/Url.php
@@ -4,32 +4,33 @@ namespace MailPoet\Subscription;
 use MailPoet\Router\Router;
 use MailPoet\Router\Endpoints\Subscription as SubscriptionEndpoint;
 use MailPoet\Models\Subscriber;
+use MailPoet\Settings\Pages as SettingsPages;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Url {
-  static function getCaptchaUrl(Subscriber $subscriber = null) {
-    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.captcha'));
-    return self::getSubscriptionUrl($post, 'captcha', $subscriber);
+  static function getCaptchaUrl() {
+    $post = self::getPost(self::getSetting('subscription.pages.captcha'));
+    return self::getSubscriptionUrl($post, 'captcha', null);
   }
 
   static function getCaptchaImageUrl($width, $height) {
-    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.captcha'));
+    $post = self::getPost(self::getSetting('subscription.pages.captcha'));
     return self::getSubscriptionUrl($post, 'captchaImage', null, ['width' => $width, 'height' => $height]);
   }
 
   static function getConfirmationUrl(Subscriber $subscriber = null) {
-    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.confirmation'));
+    $post = self::getPost(self::getSetting('subscription.pages.confirmation'));
     return self::getSubscriptionUrl($post, 'confirm', $subscriber);
   }
 
   static function getManageUrl(Subscriber $subscriber = null) {
-    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.manage'));
+    $post = self::getPost(self::getSetting('subscription.pages.manage'));
     return self::getSubscriptionUrl($post, 'manage', $subscriber);
   }
 
   static function getUnsubscribeUrl(Subscriber $subscriber = null) {
-    $post = WPFunctions::get()->getPost(self::getSetting('subscription.pages.unsubscribe'));
+    $post = self::getPost(self::getSetting('subscription.pages.unsubscribe'));
     return self::getSubscriptionUrl($post, 'unsubscribe', $subscriber);
   }
 
@@ -70,6 +71,18 @@ class Url {
     }
 
     return $url;
+  }
+
+  static private function getPost($post = null) {
+    if ($post) {
+      $post_object = WPFunctions::get()->getPost($post);
+      if ($post_object) {
+        return $post_object;
+      }
+    }
+    // Resort to a default MailPoet page if no page is selected
+    $pages = SettingsPages::getMailPoetPages();
+    return reset($pages);
   }
 
   static private function getSetting($key) {

--- a/prefixer/composer.json
+++ b/prefixer/composer.json
@@ -6,7 +6,8 @@
     "sabberworm/php-css-parser": "^8.1",
     "twig/twig": "1.38.4",
     "symfony/polyfill-php72": "^1.11",
-    "symfony/polyfill-mbstring": "^1.11"
+    "symfony/polyfill-mbstring": "^1.11",
+    "gregwar/captcha": "^1.1"
   },
   "scripts": {
     "post-update-cmd": "@process",

--- a/prefixer/composer.lock
+++ b/prefixer/composer.lock
@@ -4,8 +4,61 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9f6881379554e1622849284518d33d8",
+    "content-hash": "12db0ff7da561923463454e3da7f3b32",
     "packages": [
+        {
+            "name": "gregwar/captcha",
+            "version": "v1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Gregwar/Captcha.git",
+                "reference": "cf953dd79748406e0292cea8c565399681e4d345"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Gregwar/Captcha/zipball/cf953dd79748406e0292cea8c565399681e4d345",
+                "reference": "cf953dd79748406e0292cea8c565399681e4d345",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.3.0",
+                "symfony/finder": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "captcha",
+            "autoload": {
+                "psr-4": {
+                    "Gregwar\\": "src/Gregwar"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Passault",
+                    "email": "g.passault@gmail.com",
+                    "homepage": "http://www.gregwar.com/"
+                },
+                {
+                    "name": "Jeremy Livingston",
+                    "email": "jeremy.j.livingston@gmail.com"
+                }
+            ],
+            "description": "Captcha generator",
+            "homepage": "https://github.com/Gregwar/Captcha",
+            "keywords": [
+                "bot",
+                "captcha",
+                "spam"
+            ],
+            "time": "2018-08-17T22:57:28+00:00"
+        },
         {
             "name": "monolog/monolog",
             "version": "1.24.0",
@@ -296,6 +349,55 @@
             "time": "2019-04-16T11:13:42+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v3.4.29",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "5f80266a729e30bbcc37f8bf0e62c3d5a38c8208"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5f80266a729e30bbcc37f8bf0e62c3d5a38c8208",
+                "reference": "5f80266a729e30bbcc37f8bf0e62c3d5a38c8208",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-05-30T15:47:52+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.11.0",
             "source": {
@@ -340,7 +442,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/tests/DataFactories/Settings.php
+++ b/tests/DataFactories/Settings.php
@@ -136,6 +136,11 @@ class Settings {
     return $this;
   }
 
+  function withCaptchaType($type = null) {
+    $this->settings->set('captcha.type', $type);
+    return $this;
+  }
+
   function withInstalledAt(\DateTime $date) {
     $this->settings->set('installed_at', $date);
     return $this;

--- a/tests/DataFactories/Subscriber.php
+++ b/tests/DataFactories/Subscriber.php
@@ -57,6 +57,15 @@ class Subscriber {
   }
 
   /**
+   * @param int $count
+   * @return $this
+   */
+  public function withCountConfirmations($count) {
+    $this->data['count_confirmations'] = $count;
+    return $this;
+  }
+
+  /**
    * @param \MailPoet\Models\Segment[] $segments
    * @return $this
    */

--- a/tests/_data/acceptanceDump.sql
+++ b/tests/_data/acceptanceDump.sql
@@ -385,7 +385,8 @@ INSERT INTO `mp_mailpoet_settings` (`id`, `name`, `value`, `created_at`, `update
 (22,	'analytics',	'a:1:{s:7:\"enabled\";s:0:\"\";}',	'2017-10-30 00:58:13',	'2017-10-30 00:58:13'),
 (23,	'premium',	'a:1:{s:11:\"premium_key\";s:0:\"\";}',	'2017-10-30 00:58:13',	'2017-10-30 00:58:13'),
 (24,	'user_seen_editor_tutorial1',	'1',	'2017-10-30 00:58:13',	'2017-10-30 00:58:13'),
-(25,	'display_nps_poll',	'0',	'2018-12-13 14:20:00',	'2018-12-13 14:20:00');
+(25,	'display_nps_poll',	'0',	'2018-12-13 14:20:00',	'2018-12-13 14:20:00'),
+(26,	'captcha',	'a:3:{s:20:"recaptcha_site_token";s:0:"";s:22:"recaptcha_secret_token";s:0:"";s:4:"type";s:0:"";}',	'2019-07-11 15:35:00',	'2019-07-11 15:35:00');
 
 DROP TABLE IF EXISTS `mp_mailpoet_statistics_clicks`;
 CREATE TABLE `mp_mailpoet_statistics_clicks` (

--- a/tests/_data/acceptanceDump.sql
+++ b/tests/_data/acceptanceDump.sql
@@ -473,6 +473,7 @@ CREATE TABLE `mp_mailpoet_subscribers` (
   `unconfirmed_data` longtext COLLATE utf8mb4_unicode_520_ci,
   `is_woocommerce_user` int(1) NOT NULL DEFAULT 0,
   `source` ENUM("form", "imported", "administrator", "api", "wordpress_user", "unknown") DEFAULT "unknown",
+  `count_confirmations` int(11) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`),
   KEY `wp_user_id` (`wp_user_id`),

--- a/tests/acceptance/SubscriptionCaptchaCest.php
+++ b/tests/acceptance/SubscriptionCaptchaCest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Subscription\Captcha;
+use MailPoet\Test\DataFactories\Form;
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class SubscriptionCaptchaCest {
+
+  /** @var Settings */
+  private $settings_factory;
+
+  /** @var string */
+  private $subscriber_email;
+
+  function _before(\AcceptanceTester $I) {
+    $this->subscriber_email = 'test-form@example.com';
+    $this->settings_factory = new Settings();
+    $this->settings_factory->withCaptchaType(Captcha::TYPE_BUILTIN);
+    $this->settings_factory
+      ->withConfirmationEmailSubject()
+      ->withConfirmationEmailBody()
+      ->withConfirmationEmailEnabled();
+
+    $form_name = 'Subscription Acceptance Test Form';
+    $form_factory = new Form();
+    $form = $form_factory->withName($form_name)->create();
+
+    $subscriber_factory = new Subscriber();
+    $subscriber_factory->withEmail($this->subscriber_email)->withCountConfirmations(1)->create();
+
+    $I->cli('widget add mailpoet_form sidebar-1 2 --form=' . $form->id . ' --title="Subscribe to Our Newsletter" --allow-root');
+  }
+
+  function checkCaptchaPageExistsAfterSubscription(\AcceptanceTester $I) {
+    $I->wantTo('See the built-in captcha after subscribing using form widget');
+    $I->amOnPage('/');
+    $I->fillField('[data-automation-id="form_email"]', $this->subscriber_email);
+    $I->click('.mailpoet_submit');
+    $I->waitForText('Confirm you’re not a robot');
+    $I->seeNoJSErrors();
+  }
+
+  function checkCaptchaPageIsNotShownToLoggedInUsers(\AcceptanceTester $I) {
+    $I->wantTo('check that captcha page is not shown to logged in users');
+    $I->login();
+    $I->amOnPage('/');
+    $I->fillField('[data-automation-id="form_email"]', $this->subscriber_email);
+    $I->click('.mailpoet_submit');
+    $I->waitForText('Check your inbox or spam folder to confirm your subscription.');
+    $I->seeNoJSErrors();
+  }
+
+  function _after(\AcceptanceTester $I) {
+    $I->cli('widget reset sidebar-1 --allow-root');
+    $I->cli('db query "TRUNCATE TABLE mp_mailpoet_subscriber_ips" --allow-root');
+  }
+}

--- a/tests/acceptance/SubscriptionCaptchaCest.php
+++ b/tests/acceptance/SubscriptionCaptchaCest.php
@@ -56,5 +56,6 @@ class SubscriptionCaptchaCest {
   function _after(\AcceptanceTester $I) {
     $I->cli('widget reset sidebar-1 --allow-root');
     $I->cli('db query "TRUNCATE TABLE mp_mailpoet_subscriber_ips" --allow-root');
+    $this->settings_factory->withCaptchaType(Captcha::TYPE_DISABLED);
   }
 }

--- a/tests/integration/API/JSON/v1/SetupTest.php
+++ b/tests/integration/API/JSON/v1/SetupTest.php
@@ -8,6 +8,7 @@ use MailPoet\WP\Functions as WPFunctions;
 use Helper\WordPressHooks as WPHooksHelper;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 
 class SetupTest extends \MailPoetTest {
   function _before() {
@@ -28,6 +29,13 @@ class SetupTest extends \MailPoetTest {
     $settings = new SettingsController();
     $signup_confirmation = $settings->fetch('signup_confirmation.enabled');
     expect($signup_confirmation)->true();
+
+    $captcha = $settings->fetch('captcha');
+    $subscription_captcha = new Captcha;
+    $captcha_type = $subscription_captcha->isSupported() ? Captcha::TYPE_BUILTIN : Captcha::TYPE_DISABLED;
+    expect($captcha['type'])->equals($captcha_type);
+    expect($captcha['recaptcha_site_token'])->equals('');
+    expect($captcha['recaptcha_secret_token'])->equals('');
 
     $woocommerce_optin_on_checkout = $settings->fetch('woocommerce.optin_on_checkout');
     expect($woocommerce_optin_on_checkout['enabled'])->true();

--- a/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -608,7 +608,7 @@ class SubscribersTest extends \MailPoetTest {
       ]);
       $this->fail('It should not be possible to subscribe a second time so soon');
     } catch (\Exception $e) {
-      expect($e->getMessage())->equals('You need to wait 60 seconds before subscribing again.');
+      expect($e->getMessage())->equals('You need to wait 1 minutes before subscribing again.');
     }
   }
 
@@ -635,7 +635,7 @@ class SubscribersTest extends \MailPoetTest {
       ]);
       $this->fail('It should not be possible to resubscribe a second time so soon');
     } catch (\Exception $e) {
-      expect($e->getMessage())->equals('You need to wait 60 seconds before subscribing again.');
+      expect($e->getMessage())->equals('You need to wait 1 minutes before subscribing again.');
     }
   }
 

--- a/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -600,16 +600,14 @@ class SubscribersTest extends \MailPoetTest {
       $this->obfuscatedSegments => [$this->segment_1->id, $this->segment_2->id],
     ]);
 
-    try {
-      $this->endpoint->subscribe([
-        $this->obfuscatedEmail => 'tata@mailpoet.com',
-        'form_id' => $this->form->id,
-        $this->obfuscatedSegments => [$this->segment_1->id, $this->segment_2->id],
-      ]);
-      $this->fail('It should not be possible to subscribe a second time so soon');
-    } catch (\Exception $e) {
-      expect($e->getMessage())->equals('You need to wait 1 minutes before subscribing again.');
-    }
+    $response = $this->endpoint->subscribe([
+      $this->obfuscatedEmail => 'tata@mailpoet.com',
+      'form_id' => $this->form->id,
+      $this->obfuscatedSegments => [$this->segment_1->id, $this->segment_2->id],
+    ]);
+
+    expect($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    expect($response->errors[0]['message'])->equals('You need to wait 1 minutes before subscribing again.');
   }
 
   function testItCannotMassResubscribe() {
@@ -627,16 +625,14 @@ class SubscribersTest extends \MailPoetTest {
     $subscriber->updated_at = Carbon::now();
     $subscriber->save();
 
-    try {
-      $this->endpoint->subscribe([
-        $this->obfuscatedEmail => $subscriber->email,
-        'form_id' => $this->form->id,
-        $this->obfuscatedSegments => [$this->segment_1->id, $this->segment_2->id],
-      ]);
-      $this->fail('It should not be possible to resubscribe a second time so soon');
-    } catch (\Exception $e) {
-      expect($e->getMessage())->equals('You need to wait 1 minutes before subscribing again.');
-    }
+    $response = $this->endpoint->subscribe([
+      $this->obfuscatedEmail => $subscriber->email,
+      'form_id' => $this->form->id,
+      $this->obfuscatedSegments => [$this->segment_1->id, $this->segment_2->id],
+    ]);
+
+    expect($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    expect($response->errors[0]['message'])->equals('You need to wait 1 minutes before subscribing again.');
   }
 
   function testItSchedulesWelcomeEmailNotificationWhenSubscriberIsAdded() {

--- a/tests/integration/Config/SessionTest.php
+++ b/tests/integration/Config/SessionTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace MailPoet\Test\Config;
+
+use MailPoet\Config\Session;
+
+class SessionTest extends \MailPoetTest {
+  function _before() {
+    $this->destroySessionIfExists();
+  }
+
+  function testItStartsSessionIfItIsNotStarted() {
+    expect(session_id())->isEmpty();
+    $session = new Session;
+    $result = $session->init();
+    expect($result)->equals(true);
+    expect(session_id())->notEmpty();
+    session_destroy();
+  }
+
+  function testItDoesNotStartSessionIfItIsAlreadyStarted() {
+    session_start();
+    expect(session_id())->notEmpty();
+    $session = new Session;
+    $result = $session->init();
+    expect($result)->equals(false);
+    expect(session_id())->notEmpty();
+    session_destroy();
+  }
+
+  private function destroySessionIfExists() {
+    if (session_id()) {
+      session_destroy();
+    }
+  }
+}

--- a/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -30,6 +30,7 @@ use MailPoet\Newsletter\Links\Links;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\Url;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\WP\Functions as WPFunctions;
@@ -47,7 +48,7 @@ class SendingQueueTest extends \MailPoetTest {
     $wp_users = get_users();
     wp_set_current_user($wp_users[0]->ID);
     $this->settings = new SettingsController();
-    $populator = new Populator($this->settings, WPFunctions::get());
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha);
     $populator->up();
     $this->subscriber = Subscriber::create();
     $this->subscriber->email = 'john@doe.com';

--- a/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -9,6 +9,7 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Models\Setting;
 use MailPoet\Models\Subscriber;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\WP\Functions as WPFunctions;
 
 if (!defined('ABSPATH')) exit;
@@ -25,7 +26,7 @@ class MailerTest extends \MailPoetTest {
     $wp_users = get_users();
     wp_set_current_user($wp_users[0]->ID);
     $this->settings = new SettingsController();
-    $populator = new Populator($this->settings, WPFunctions::get());
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha);
     $populator->up();
     $this->mailer_task = new MailerTask();
     $this->sender = $this->settings->get('sender');

--- a/tests/integration/Newsletter/ShortcodesTest.php
+++ b/tests/integration/Newsletter/ShortcodesTest.php
@@ -10,6 +10,7 @@ use MailPoet\Models\SubscriberCustomField;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\Url as SubscriptionUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -25,7 +26,7 @@ class ShortcodesTest extends \MailPoetTest {
   function _before() {
     parent::_before();
     $this->settings = new SettingsController();
-    $populator = new Populator($this->settings, WPFunctions::get());
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha);
     $populator->up();
     $this->WP_user = $this->_createWPUser();
     $this->WP_post = $this->_createWPPost();

--- a/tests/integration/Subscription/CaptchaTest.php
+++ b/tests/integration/Subscription/CaptchaTest.php
@@ -40,6 +40,7 @@ class CaptchaTest extends \MailPoetTest {
   }
 
   function testItRendersImage() {
+    if (!$this->captcha->isSupported()) return;
     expect_that(empty($_SESSION[Captcha::SESSION_KEY]));
     $image = $this->captcha->renderImage(null, null, true);
     expect($image)->notEmpty();

--- a/tests/integration/Subscription/CaptchaTest.php
+++ b/tests/integration/Subscription/CaptchaTest.php
@@ -40,7 +40,6 @@ class CaptchaTest extends \MailPoetTest {
   }
 
   function testItRendersImage() {
-    if (!$this->captcha->isSupported()) return;
     expect_that(empty($_SESSION[Captcha::SESSION_KEY]));
     $image = $this->captcha->renderImage(null, null, true);
     expect($image)->notEmpty();

--- a/tests/integration/Subscription/CaptchaTest.php
+++ b/tests/integration/Subscription/CaptchaTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace MailPoet\Test\Subscription;
+
+use Carbon\Carbon;
+use Codeception\Util\Fixtures;
+use MailPoet\Models\Subscriber;
+use MailPoet\Models\SubscriberIP;
+use MailPoet\Subscription\Captcha;
+use MailPoet\WP\Functions as WPFunctions;
+
+class CaptchaTest extends \MailPoetTest {
+  function _before() {
+    $this->captcha = new Captcha(new WPFunctions);
+    $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+  }
+
+  function testItDoesNotRequireCaptchaForTheFirstSubscription() {
+    $email = 'non-existent-subscriber@example.com';
+    $result = $this->captcha->isRequired($email);
+    expect($result)->equals(false);
+  }
+
+  function testItRequiresCaptchaForRepeatedRecipient() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate(Fixtures::get('subscriber_template'));
+    $subscriber->count_confirmations = 1;
+    $subscriber->save();
+    $result = $this->captcha->isRequired($subscriber->email);
+    expect($result)->equals(true);
+  }
+
+  function testItRequiresCaptchaForRepeatedIPAddress() {
+    $ip = SubscriberIP::create();
+    $ip->ip = '127.0.0.1';
+    $ip->created_at = Carbon::now()->subMinutes(1);
+    $ip->save();
+    $email = 'non-existent-subscriber@example.com';
+    $result = $this->captcha->isRequired($email);
+    expect($result)->equals(true);
+  }
+
+  function testItRendersImage() {
+    expect_that(empty($_SESSION[Captcha::SESSION_KEY]));
+    $image = $this->captcha->renderImage(null, null, true);
+    expect($image)->notEmpty();
+    expect_that(!empty($_SESSION[Captcha::SESSION_KEY]));
+  }
+
+  function _after() {
+    SubscriberIP::deleteMany();
+  }
+}

--- a/tests/integration/Subscription/ThrottlingTest.php
+++ b/tests/integration/Subscription/ThrottlingTest.php
@@ -55,6 +55,16 @@ class ThrottlingTest extends \MailPoetTest {
     expect(SubscriberIP::count())->equals(1);
   }
 
+  function testItConvertsSecondsToTimeString() {
+    expect(Throttling::secondsToTimeString(122885))->equals('34 hours 8 minutes 5 seconds');
+    expect(Throttling::secondsToTimeString(3660))->equals('1 hours 1 minutes');
+    expect(Throttling::secondsToTimeString(3601))->equals('1 hours 1 seconds');
+    expect(Throttling::secondsToTimeString(3600))->equals('1 hours');
+    expect(Throttling::secondsToTimeString(61))->equals('1 minutes 1 seconds');
+    expect(Throttling::secondsToTimeString(60))->equals('1 minutes');
+    expect(Throttling::secondsToTimeString(59))->equals('59 seconds');
+  }
+
   function _after() {
     SubscriberIP::deleteMany();
   }

--- a/tests/integration/Subscription/ThrottlingTest.php
+++ b/tests/integration/Subscription/ThrottlingTest.php
@@ -47,7 +47,7 @@ class ThrottlingTest extends \MailPoetTest {
 
     $ip2 = SubscriberIP::create();
     $ip2->ip = '127.0.0.1';
-    $ip2->created_at = Carbon::now()->subDays(1)->subSeconds(1);
+    $ip2->created_at = Carbon::now()->subMonths(1)->subSeconds(1);
     $ip2->save();
 
     expect(SubscriberIP::count())->equals(2);

--- a/tests/integration/Subscription/UrlTest.php
+++ b/tests/integration/Subscription/UrlTest.php
@@ -16,6 +16,20 @@ class UrlTest extends \MailPoetTest {
     $populator->up();
   }
 
+  function testItReturnsTheCaptchaUrl() {
+    $url = Url::getCaptchaUrl();
+    expect($url)->notNull();
+    expect($url)->contains('action=captcha');
+    expect($url)->contains('endpoint=subscription');
+  }
+
+  function testItReturnsTheCaptchaImageUrl() {
+    $url = Url::getCaptchaImageUrl(250, 100);
+    expect($url)->notNull();
+    expect($url)->contains('action=captchaImage');
+    expect($url)->contains('endpoint=subscription');
+  }
+
   function testItReturnsTheConfirmationUrl() {
     // preview
     $url = Url::getConfirmationUrl(null);

--- a/tests/integration/Subscription/UrlTest.php
+++ b/tests/integration/Subscription/UrlTest.php
@@ -7,12 +7,13 @@ use MailPoet\Models\Subscriber;
 use MailPoet\Models\Setting;
 use MailPoet\Config\Populator;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
 use MailPoet\WP\Functions as WPFunctions;
 
 class UrlTest extends \MailPoetTest {
   function _before() {
     parent::_before();
-    $populator = new Populator(new SettingsController, WPFunctions::get());
+    $populator = new Populator(new SettingsController, WPFunctions::get(), new Captcha);
     $populator->up();
   }
 

--- a/tests/integration/Subscription/UrlTest.php
+++ b/tests/integration/Subscription/UrlTest.php
@@ -13,8 +13,23 @@ use MailPoet\WP\Functions as WPFunctions;
 class UrlTest extends \MailPoetTest {
   function _before() {
     parent::_before();
-    $populator = new Populator(new SettingsController, WPFunctions::get(), new Captcha);
+    $this->settings = new SettingsController;
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha);
     $populator->up();
+  }
+
+  function testItReturnsTheDefaultPageUrlIfNoPageIsSetInSettings() {
+    $this->settings->delete('subscription');
+
+    $url = Url::getCaptchaUrl();
+    expect($url)->notNull();
+    expect($url)->contains('action=captcha');
+    expect($url)->contains('endpoint=subscription');
+
+    $url = Url::getUnsubscribeUrl(null);
+    expect($url)->notNull();
+    expect($url)->contains('action=unsubscribe');
+    expect($url)->contains('endpoint=subscription');
   }
 
   function testItReturnsTheCaptchaUrl() {

--- a/views/settings.html
+++ b/views/settings.html
@@ -88,15 +88,15 @@
             errorFound = true;
           }
           // if reCAPTCHA is enabled but keys are emty, show error
-          var enabled = $('input[name="re_captcha[enabled]"]:checked').val(),
-              site_key = $('input[name="re_captcha[site_token]"]').val().trim(),
-              secret_key = $('input[name="re_captcha[secret_token]"]').val().trim();
+          var enabled = $('input[name="captcha[type]"]:checked').val() == 'recaptcha',
+              site_key = $('input[name="captcha[recaptcha_site_token]"]').val().trim(),
+              secret_key = $('input[name="captcha[recaptcha_secret_token]"]').val().trim();
           if (enabled && (site_key == '' || secret_key == '')) {
-            $('#settings_re_captcha_tokens_error').show();
+            $('#settings_recaptcha_tokens_error').show();
             window.location.href = '#advanced';
             errorFound = true;
           } else {
-            $('#settings_re_captcha_tokens_error').hide();
+            $('#settings_recaptcha_tokens_error').hide();
           }
           // if new subscriber notification is enabled but sender is empty, show error
           var notifications_enabled = $('input[name="subscriber_email_notification[enabled]"]:checked').val(),
@@ -202,15 +202,15 @@
         $('input[data-toggle]').each(toggleContent);
 
         function toggleReCaptchaSettings() {
-          if ($('input[name="re_captcha[enabled]"]:checked').val()) {
-            $('#settings_re_captcha_tokens').show();
+          if ($('input[name="captcha[type]"]:checked').val() == 'recaptcha') {
+            $('#settings_recaptcha_tokens').show();
           } else {
-            $('#settings_re_captcha_tokens').hide();
+            $('#settings_recaptcha_tokens').hide();
           }
         }
-        $('input[name="re_captcha[enabled]"]').on('click', toggleReCaptchaSettings);
+        $('input[name="captcha[type]"]').on('click', toggleReCaptchaSettings);
         toggleReCaptchaSettings();
-        $('#settings_re_captcha_tokens_error').hide();
+        $('#settings_recaptcha_tokens_error').hide();
 
         $('#settings_subscriber_email_notification_error').hide();
         $('#settings_stats_notifications_error').hide();

--- a/views/settings/advanced.html
+++ b/views/settings/advanced.html
@@ -297,7 +297,7 @@
               <% endif %>
             /><%= __('Built-in captcha (default)') %>
               <% if(not(built_in_captcha_supported)) %>
-                <%= __('(disabled because GD and FreeType extensions are missing)') %>
+                <%= __('(disabled because GD or FreeType extension is missing)') %>
               <% endif %>
           </label>
           <input type="hidden" name="subscription[pages][captcha]" value="<%= settings.subscription.pages.manage %>" />

--- a/views/settings/advanced.html
+++ b/views/settings/advanced.html
@@ -268,14 +268,14 @@
         </p>
       </td>
     </tr>
-    <!-- reCaptcha settings -->
+    <!-- captcha settings -->
     <tr>
       <th scope="row">
         <label>
-          <%= __('Enable reCAPTCHA') %>
+          <%= __('Protect your forms against spam signups') %>
         </label>
         <p class="description">
-          <%= __('Use reCAPTCHA to protect MailPoet subscription forms.') %>
+          <%= __('Built-in captcha protects your subscription forms after a second signup attempt by a bot. Alternatively, use reCAPTCHA by Google.') %>
           <a
             href="https://www.google.com/recaptcha/admin"
             target="_blank"
@@ -287,46 +287,66 @@
           <label>
             <input
               type="radio"
-              name="re_captcha[enabled]"
-              value="1"
-              <% if(settings.re_captcha.enabled) %>
+              name="captcha[type]"
+              value="built-in"
+              <% if(not(built_in_captcha_supported)) %>
+                disabled="disabled"
+              <% endif %>
+              <% if(settings.captcha.type == 'built-in') %>
                 checked="checked"
               <% endif %>
-            /><%= __('Yes') %>
+            /><%= __('Built-in captcha (default)') %>
+              <% if(not(built_in_captcha_supported)) %>
+                <%= __('(disabled because GD and FreeType extensions are missing)') %>
+              <% endif %>
           </label>
-          &nbsp;
+          <input type="hidden" name="subscription[pages][captcha]" value="<%= settings.subscription.pages.manage %>" />
+        </p>
+        <p>
           <label>
             <input
               type="radio"
-              name="re_captcha[enabled]"
-              value=""
-              <% if not(settings.re_captcha.enabled) %>
+              name="captcha[type]"
+              value="recaptcha"
+              <% if(settings.captcha.type == 'recaptcha') %>
                 checked="checked"
               <% endif %>
-            /><%= __('No') %>
+            /><%= __('Google reCAPTCHA') %>
           </label>
         </p>
-        <div id="settings_re_captcha_tokens">
+        <div id="settings_recaptcha_tokens">
           <p>
             <input type="text"
-              name="re_captcha[site_token]"
-              value="<%= settings.re_captcha.site_token %>"
+              name="captcha[recaptcha_site_token]"
+              value="<%= settings.captcha.recaptcha_site_token %>"
               placeholder="<%= __('Your reCAPTCHA Site Key') %>"
               class="regular-text"
             />
           </p>
           <p>
             <input type="text"
-              name="re_captcha[secret_token]"
-              value="<%= settings.re_captcha.secret_token %>"
+              name="captcha[recaptcha_secret_token]"
+              value="<%= settings.captcha.recaptcha_secret_token %>"
               placeholder="<%= __('Your reCAPTCHA Secret Key') %>"
               class="regular-text"
             />
           </p>
-          <div id="settings_re_captcha_tokens_error" class="mailpoet_error_item mailpoet_error">
+          <div id="settings_recaptcha_tokens_error" class="mailpoet_error_item mailpoet_error">
             <%= __('Please fill the reCAPTCHA keys.') %>
           </div>
         </div>
+        <p>
+          <label>
+            <input
+              type="radio"
+              name="captcha[type]"
+              value=""
+              <% if not(settings.captcha.type) %>
+                checked="checked"
+              <% endif %>
+            /><%= __('Disable') %>
+          </label>
+        </p>
       </td>
     </tr>
     <!-- reinstall -->


### PR DESCRIPTION
**Note to reviewer:**
*Please first check this PR: https://github.com/mailpoet/wordpress-images/pull/9 After it is approved and the Docker image is uploaded, I will re-enable the itegration test for the captcha image generation method.*

**How the built-in captcha works:**
Upon submitting a subscription form, if all validations pass, the form data is stored in the session and the user is redirected to the captcha page. When he submits the captcha, the form data is taken from the session and merged with the captcha input value, then the captcha check is performed and the user is subscribed.

**Why does captcha check come after the form validation?**
Our subscription logic has many checks and validations which, if they fail, show errors back in the form. Since we have the captcha on a separate page, we have to perform all validation beforehand. This way in case of errors we don't have to ping-pong between the captcha and the subscription form pages where the data is already gone or it will increase the complexity of the whole interaction.

**Notes to QA:**
* Please check that all types of subscription forms (widget, shortcode, PHP, iframe) work correctly in all three modes: built-in captcha, recaptcha, no captcha. All possible errors should be handled correctly in the UI;
* Make sure that MP API and other subscription methods 3rd parties may depend on still work with captcha enabled.