### PR TITLE
Refactor Menu [MAILPOET-2200]

### DIFF
--- a/lib/AdminPages/PageRenderer.php
+++ b/lib/AdminPages/PageRenderer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MailPoet\AdminPages;
+
+use MailPoet\Config\Renderer;
+use MailPoet\Features\FeaturesController;
+use MailPoet\WP\Notice as WPNotice;
+
+if (!defined('ABSPATH')) exit;
+
+class PageRenderer {
+  /** @var Renderer */
+  private $renderer;
+
+  /** @var FeaturesController */
+  private $features_controller;
+
+  function __construct(Renderer $renderer, FeaturesController $features_controller) {
+    $this->renderer = $renderer;
+    $this->features_controller = $features_controller;
+  }
+
+  /**
+   * Set common data for template and display template
+   * @param string $template
+   * @param array $data
+   */
+  function displayPage($template, array $data = []) {
+    $defaults = [
+      'feature_flags' => $this->features_controller->getAllFlags(),
+    ];
+    try {
+      echo $this->renderer->render($template, $data + $defaults);
+    } catch (\Exception $e) {
+      $notice = new WPNotice(WPNotice::TYPE_ERROR, $e->getMessage());
+      $notice->displayWPNotice();
+    }
+  }
+}

--- a/lib/AdminPages/Pages/ExperimentalFeatures.php
+++ b/lib/AdminPages/Pages/ExperimentalFeatures.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+
+if (!defined('ABSPATH')) exit;
+
+class ExperimentalFeatures {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  function __construct(PageRenderer $page_renderer) {
+    $this->page_renderer = $page_renderer;
+  }
+
+  function render() {
+    $this->page_renderer->displayPage('experimental-features.html', []);
+  }
+}

--- a/lib/AdminPages/Pages/FormEditor.php
+++ b/lib/AdminPages/Pages/FormEditor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Form\Renderer as FormRenderer;
+use MailPoet\Form\Block;
+use MailPoet\Models\Form;
+use MailPoet\Models\Segment;
+use MailPoet\Settings\Pages;
+
+if (!defined('ABSPATH')) exit;
+
+class FormEditor {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  function __construct(PageRenderer $page_renderer) {
+    $this->page_renderer = $page_renderer;
+  }
+
+  function render() {
+    $id = (isset($_GET['id']) ? (int)$_GET['id'] : 0);
+    $form = Form::findOne($id);
+    if ($form instanceof Form) {
+      $form = $form->asArray();
+    }
+
+    $data = [
+      'form' => $form,
+      'pages' => Pages::getAll(),
+      'segments' => Segment::getSegmentsWithSubscriberCount(),
+      'styles' => FormRenderer::getStyles($form),
+      'date_types' => Block\Date::getDateTypes(),
+      'date_formats' => Block\Date::getDateFormats(),
+      'month_names' => Block\Date::getMonthNames(),
+      'sub_menu' => 'mailpoet-forms',
+    ];
+
+    $this->page_renderer->displayPage('form/editor.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/Forms.php
+++ b/lib/AdminPages/Pages/Forms.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Listing\PageLimit;
+use MailPoet\Models\Segment;
+use MailPoet\Util\Installation;
+
+if (!defined('ABSPATH')) exit;
+
+class Forms {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var PageLimit */
+  private $listing_page_limit;
+
+  /** @var Installation */
+  private $installation;
+
+  function __construct(
+    PageRenderer $page_renderer,
+    PageLimit $listing_page_limit,
+    Installation $installation
+  ) {
+    $this->page_renderer = $page_renderer;
+    $this->listing_page_limit = $listing_page_limit;
+    $this->installation = $installation;
+  }
+
+  function render() {
+    $data = [];
+    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('forms');
+    $data['segments'] = Segment::findArray();
+    $data['is_new_user'] = $this->installation->isNewInstallation();
+
+    $this->page_renderer->displayPage('forms.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/Help.php
+++ b/lib/AdminPages/Pages/Help.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Helpscout\Beacon;
+use MailPoet\Mailer\MailerLog;
+use MailPoet\Router\Endpoints\CronDaemon;
+use MailPoet\Services\Bridge;
+use MailPoet\Tasks\Sending;
+use MailPoet\Tasks\State;
+
+if (!defined('ABSPATH')) exit;
+
+class Help {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var State */
+  private $tasks_state;
+
+  function __construct(PageRenderer $page_renderer, State $tasks_state) {
+    $this->page_renderer = $page_renderer;
+    $this->tasks_state = $tasks_state;
+  }
+
+  function render() {
+    $system_info_data = Beacon::getData();
+    $system_status_data = [
+      'cron' => [
+        'url' => CronHelper::getCronUrl(CronDaemon::ACTION_PING),
+        'isReachable' => CronHelper::pingDaemon(true),
+      ],
+      'mss' => [
+        'enabled' => (Bridge::isMPSendingServiceEnabled()) ?
+          ['isReachable' => Bridge::pingBridge()] :
+          false,
+      ],
+      'cronStatus' => CronHelper::getDaemon(),
+      'queueStatus' => MailerLog::getMailerLog(),
+    ];
+    $system_status_data['cronStatus']['accessible'] = CronHelper::isDaemonAccessible();
+    $system_status_data['queueStatus']['tasksStatusCounts'] = $this->tasks_state->getCountsPerStatus();
+    $system_status_data['queueStatus']['latestTasks'] = $this->tasks_state->getLatestTasks(Sending::TASK_TYPE);
+    $this->page_renderer->displayPage(
+      'help.html',
+      [
+        'systemInfoData' => $system_info_data,
+        'systemStatusData' => $system_status_data,
+      ]
+    );
+  }
+}

--- a/lib/AdminPages/Pages/MP2Migration.php
+++ b/lib/AdminPages/Pages/MP2Migration.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\MP2Migrator;
+
+if (!defined('ABSPATH')) exit;
+
+class MP2Migration {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var MP2Migrator */
+  private $mp2_migrator;
+
+  function __construct(PageRenderer $page_renderer, MP2Migrator $mp2_migrator) {
+    $this->page_renderer = $page_renderer;
+    $this->mp2_migrator = $mp2_migrator;
+  }
+
+  function render() {
+    $this->mp2_migrator->init();
+    $data = [
+      'log_file_url' => $this->mp2_migrator->log_file_url,
+      'progress_url' => $this->mp2_migrator->progressbar->url,
+    ];
+    $this->page_renderer->displayPage('mp2migration.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/lib/AdminPages/Pages/NewsletterEditor.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Menu;
+use MailPoet\Models\Subscriber;
+use MailPoet\Newsletter\Shortcodes\ShortcodesHelper;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\UserFlagsController;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class NewsletterEditor {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var UserFlagsController */
+  private $user_flags;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(
+    PageRenderer $page_renderer,
+    SettingsController $settings,
+    UserFlagsController $user_flags,
+    WPFunctions $wp
+  ) {
+    $this->page_renderer = $page_renderer;
+    $this->settings = $settings;
+    $this->user_flags = $user_flags;
+    $this->wp = $wp;
+  }
+
+  function render() {
+    $subscriber = Subscriber::getCurrentWPUser();
+    $subscriber_data = $subscriber ? $subscriber->asArray() : [];
+    $data = [
+      'shortcodes' => ShortcodesHelper::getShortcodes(),
+      'settings' => $this->settings->getAll(),
+      'editor_tutorial_seen' => $this->user_flags->get('editor_tutorial_seen'),
+      'current_wp_user' => array_merge($subscriber_data, $this->wp->wpGetCurrentUser()->to_array()),
+      'sub_menu' => Menu::MAIN_PAGE_SLUG,
+      'mss_active' => Bridge::isMPSendingServiceEnabled(),
+    ];
+    $this->wp->wpEnqueueMedia();
+    $this->wp->wpEnqueueScript('tinymce-wplink', $this->wp->includesUrl('js/tinymce/plugins/wplink/plugin.js'));
+    $this->wp->wpEnqueueStyle('editor', $this->wp->includesUrl('css/editor.css'));
+
+    $this->page_renderer->displayPage('newsletter/editor.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/Newsletters.php
+++ b/lib/AdminPages/Pages/Newsletters.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Env;
+use MailPoet\Config\Menu;
+use MailPoet\Listing\PageLimit;
+use MailPoet\Models\Segment;
+use MailPoet\Models\Subscriber;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\UserFlagsController;
+use MailPoet\Util\Installation;
+use MailPoet\Util\License\License;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\DateTime;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class Newsletters {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var PageLimit */
+  private $listing_page_limit;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var UserFlagsController */
+  private $user_flags;
+
+  /** @var WooCommerceHelper */
+  private $woocommerce_helper;
+
+  /** @var Installation */
+  private $installation;
+
+  function __construct(
+    PageRenderer $page_renderer,
+    PageLimit $listing_page_limit,
+    WPFunctions $wp,
+    SettingsController $settings,
+    UserFlagsController $user_flags,
+    WooCommerceHelper $woocommerce_helper,
+    Installation $installation
+  ) {
+    $this->page_renderer = $page_renderer;
+    $this->listing_page_limit = $listing_page_limit;
+    $this->wp = $wp;
+    $this->settings = $settings;
+    $this->user_flags = $user_flags;
+    $this->woocommerce_helper = $woocommerce_helper;
+    $this->installation = $installation;
+  }
+
+  function render() {
+    global $wp_roles;
+
+    $data = [];
+
+    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('newsletters');
+    $segments = Segment::getSegmentsWithSubscriberCount($type = false);
+    $segments = $this->wp->applyFilters('mailpoet_segments_with_subscriber_count', $segments);
+    usort($segments, function ($a, $b) {
+      return strcasecmp($a["name"], $b["name"]);
+    });
+    $data['segments'] = $segments;
+    $data['settings'] = $this->settings->getAll();
+    $data['mss_active'] = Bridge::isMPSendingServiceEnabled();
+    $data['current_wp_user'] = $this->wp->wpGetCurrentUser()->to_array();
+    $data['current_wp_user_firstname'] = $this->wp->wpGetCurrentUser()->user_firstname;
+    $data['site_url'] = $this->wp->siteUrl();
+    $data['roles'] = $wp_roles->get_names();
+    $data['roles']['mailpoet_all'] = $this->wp->__('In any WordPress role', 'mailpoet');
+
+    $installedAtDateTime = new \DateTime($data['settings']['installed_at']);
+    $data['installed_days_ago'] = (int)$installedAtDateTime->diff(new \DateTime())->format('%a');
+
+    $date_time = new DateTime();
+    $data['current_date'] = $date_time->getCurrentDate(DateTime::DEFAULT_DATE_FORMAT);
+    $data['current_time'] = $date_time->getCurrentTime();
+    $data['schedule_time_of_day'] = $date_time->getTimeInterval(
+      '00:00:00',
+      '+1 hour',
+      24
+    );
+    $data['mailpoet_main_page'] = $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
+    $data['show_congratulate_after_first_newsletter'] = isset($data['settings']['show_congratulate_after_first_newsletter']) ? $data['settings']['show_congratulate_after_first_newsletter'] : 'false';
+
+    $data['tracking_enabled'] = $this->settings->get('tracking.enabled');
+    $data['premium_plugin_active'] = License::getLicense();
+    $data['is_woocommerce_active'] = $this->woocommerce_helper->isWooCommerceActive();
+    $data['is_mailpoet_update_available'] = array_key_exists(Env::$plugin_path, $this->wp->getPluginUpdates());
+    if (!$data['premium_plugin_active']) {
+      $data['subscribers_count'] = Subscriber::getTotalSubscribers();
+      $data['free_premium_subscribers_limit'] = License::FREE_PREMIUM_SUBSCRIBERS_LIMIT;
+    }
+
+    $last_announcement_date = $this->settings->get('last_announcement_date');
+    $last_announcement_seen = $this->user_flags->get('last_announcement_seen');
+    $data['feature_announcement_has_news'] = (
+      empty($last_announcement_seen) ||
+      $last_announcement_seen < $last_announcement_date
+    );
+    $data['last_announcement_seen'] = $last_announcement_seen;
+
+    $data['automatic_emails'] = [
+      [
+        'slug' => 'woocommerce',
+        'beta' => true,
+        'premium' => true,
+        'title' => $this->wp->__('WooCommerce', 'mailpoet'),
+        'description' => $this->wp->__('Automatically send an email when there is a new WooCommerce product, order and some other action takes place.', 'mailpoet'),
+        'events' => [
+          [
+            'slug' => 'woocommerce_abandoned_shopping_cart',
+            'title' => $this->wp->__('Abandoned Shopping Cart', 'mailpoet'),
+            'description' => $this->wp->__('Send an email to logged-in visitors who have items in their shopping carts but left your website without checking out. Can convert up to 5% of abandoned carts.', 'mailpoet'),
+            'soon' => true,
+            'badge' => [
+              'text' => $this->wp->__('Must-have', 'mailpoet'),
+              'style' => 'red',
+            ],
+          ],
+          [
+            'slug' => 'woocommerce_first_purchase',
+            'title' => $this->wp->__('First Purchase', 'mailpoet'),
+            'description' => $this->wp->__('Let MailPoet send an email to customers who make their first purchase.', 'mailpoet'),
+            'badge' => [
+              'text' => $this->wp->__('Must-have', 'mailpoet'),
+              'style' => 'red',
+            ],
+          ],
+          [
+            'slug' => 'woocommerce_product_purchased_in_category',
+            'title' => $this->wp->__('Purchased In This Category', 'mailpoet'),
+            'description' => $this->wp->__('Let MailPoet send an email to customers who purchase a product from a specific category.', 'mailpoet'),
+            'soon' => true,
+          ],
+          [
+            'slug' => 'woocommerce_product_purchased',
+            'title' => $this->wp->__('Purchased This Product', 'mailpoet'),
+            'description' => $this->wp->__('Let MailPoet send an email to customers who purchase a specific product.', 'mailpoet'),
+          ],
+        ],
+      ],
+    ];
+
+    $data['is_new_user'] = $this->installation->isNewInstallation();
+
+    $this->wp->wpEnqueueScript('jquery-ui');
+    $this->wp->wpEnqueueScript('jquery-ui-datepicker');
+
+    $this->page_renderer->displayPage('newsletters.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/Premium.php
+++ b/lib/AdminPages/Pages/Premium.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Menu;
+use MailPoet\Models\Subscriber;
+
+if (!defined('ABSPATH')) exit;
+
+class Premium {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  function __construct(PageRenderer $page_renderer) {
+    $this->page_renderer = $page_renderer;
+  }
+
+  function render() {
+    $data = [
+      'subscriber_count' => Subscriber::getTotalSubscribers(),
+      'sub_menu' => Menu::MAIN_PAGE_SLUG,
+      'display_discount' => time() <= strtotime('2018-11-30 23:59:59'),
+    ];
+
+    $this->page_renderer->displayPage('premium.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/RevenueTrackingPermission.php
+++ b/lib/AdminPages/Pages/RevenueTrackingPermission.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Menu;
+use MailPoet\Features\FeaturesController;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class RevenueTrackingPermission {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var FeaturesController */
+  private $features_controller;
+
+  function __construct(
+    PageRenderer $page_renderer,
+    WPFunctions $wp,
+    FeaturesController $features_controller
+  ) {
+    $this->page_renderer = $page_renderer;
+    $this->wp = $wp;
+    $this->features_controller = $features_controller;
+  }
+
+  function render() {
+    if (!$this->features_controller->isSupported(FeaturesController::FEATURE_DISPLAY_WOOCOMMERCE_REVENUES)) {
+      return;
+    }
+    if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
+    $data = [
+      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
+    ];
+    $this->page_renderer->displayPage('revenue_tracking_permission.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/Segments.php
+++ b/lib/AdminPages/Pages/Segments.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Listing\PageLimit;
+
+if (!defined('ABSPATH')) exit;
+
+class Segments {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var PageLimit */
+  private $listing_page_limit;
+
+  function __construct(PageRenderer $page_renderer, PageLimit $listing_page_limit) {
+    $this->page_renderer = $page_renderer;
+    $this->listing_page_limit = $listing_page_limit;
+  }
+
+  function render() {
+    $data = [];
+    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('segments');
+    $this->page_renderer->displayPage('segments.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/Settings.php
+++ b/lib/AdminPages/Pages/Settings.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Installer;
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Cron\CronTrigger;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Models\Segment;
+use MailPoet\Models\Subscriber;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\Hosts;
+use MailPoet\Settings\Pages;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Installation;
+use MailPoet\Util\License\License;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class Settings {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WooCommerceHelper */
+  private $woocommerce_helper;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var ServicesChecker */
+  private $services_checker;
+
+  /** @var FeaturesController */
+  private $features_controller;
+
+  /** @var Installation */
+  private $installation;
+
+  function __construct(
+    PageRenderer $page_renderer,
+    SettingsController $settings,
+    WooCommerceHelper $woocommerce_helper,
+    WPFunctions $wp,
+    ServicesChecker $services_checker,
+    FeaturesController $features_controller,
+    Installation $installation
+  ) {
+    $this->page_renderer = $page_renderer;
+    $this->settings = $settings;
+    $this->woocommerce_helper = $woocommerce_helper;
+    $this->wp = $wp;
+    $this->services_checker = $services_checker;
+    $this->features_controller = $features_controller;
+    $this->installation = $installation;
+  }
+
+  function render() {
+    $settings = $this->settings->getAll();
+    $flags = $this->getFlags();
+
+    // force MSS key check even if the method isn't active
+    $mp_api_key_valid = $this->services_checker->isMailPoetAPIKeyValid(false, true);
+
+    $data = [
+      'settings' => $settings,
+      'segments' => Segment::getSegmentsWithSubscriberCount(),
+      'cron_trigger' => CronTrigger::getAvailableMethods(),
+      'total_subscribers' => Subscriber::getTotalSubscribers(),
+      'premium_plugin_active' => License::getLicense(),
+      'premium_key_valid' => !empty($this->premium_key_valid),
+      'mss_active' => Bridge::isMPSendingServiceEnabled(),
+      'mss_key_valid' => !empty($mp_api_key_valid),
+      'members_plugin_active' => $this->wp->isPluginActive('members/members.php'),
+      'pages' => Pages::getAll(),
+      'flags' => $flags,
+      'current_user' => $this->wp->wpGetCurrentUser(),
+      'linux_cron_path' => dirname(dirname(__DIR__)),
+      'is_woocommerce_active' => $this->woocommerce_helper->isWooCommerceActive(),
+      'display_revenues' => $this->features_controller->isSupported(FeaturesController::FEATURE_DISPLAY_WOOCOMMERCE_REVENUES),
+      'ABSPATH' => ABSPATH,
+      'hosts' => [
+        'web' => Hosts::getWebHosts(),
+        'smtp' => Hosts::getSMTPHosts(),
+      ],
+    ];
+
+    $data['is_new_user'] = $this->installation->isNewInstallation();
+
+    $data = array_merge($data, Installer::getPremiumStatus());
+
+    $this->page_renderer->displayPage('settings.html', $data);
+  }
+
+  private function getFlags() {
+    // flags (available features on WP install)
+    $flags = [];
+    if ($this->wp->isMultisite()) {
+      // get multisite registration option
+      $registration = $this->wp->applyFilters(
+        'wpmu_registration_enabled',
+        $this->wp->getSiteOption('registration', 'all')
+      );
+
+      // check if users can register
+      $flags['registration_enabled'] =
+        !(in_array($registration, [
+          'none',
+          'blog',
+        ]));
+    } else {
+      // check if users can register
+      $flags['registration_enabled'] =
+        (bool)$this->wp->getOption('users_can_register', false);
+    }
+
+    return $flags;
+  }
+}

--- a/lib/AdminPages/Pages/Settings.php
+++ b/lib/AdminPages/Pages/Settings.php
@@ -64,6 +64,7 @@ class Settings {
     $settings = $this->settings->getAll();
     $flags = $this->getFlags();
 
+    $premium_key_valid = $this->services_checker->isPremiumKeyValid(false);
     // force MSS key check even if the method isn't active
     $mp_api_key_valid = $this->services_checker->isMailPoetAPIKeyValid(false, true);
 
@@ -73,7 +74,7 @@ class Settings {
       'cron_trigger' => CronTrigger::getAvailableMethods(),
       'total_subscribers' => Subscriber::getTotalSubscribers(),
       'premium_plugin_active' => License::getLicense(),
-      'premium_key_valid' => !empty($this->premium_key_valid),
+      'premium_key_valid' => !empty($premium_key_valid),
       'mss_active' => Bridge::isMPSendingServiceEnabled(),
       'mss_key_valid' => !empty($mp_api_key_valid),
       'members_plugin_active' => $this->wp->isPluginActive('members/members.php'),

--- a/lib/AdminPages/Pages/Subscribers.php
+++ b/lib/AdminPages/Pages/Subscribers.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Form\Block;
+use MailPoet\Listing\PageLimit;
+use MailPoet\Models\CustomField;
+use MailPoet\Models\Segment;
+use MailPoet\Services\Bridge;
+use MailPoet\Util\License\License;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class Subscribers {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var PageLimit */
+  private $listing_page_limit;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(PageRenderer $page_renderer, PageLimit $listing_page_limit, WPFunctions $wp) {
+    $this->page_renderer = $page_renderer;
+    $this->listing_page_limit = $listing_page_limit;
+    $this->wp = $wp;
+  }
+
+  function render() {
+    $data = [];
+
+    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('subscribers');
+    $segments = Segment::getSegmentsWithSubscriberCount($type = false);
+    $segments = $this->wp->applyFilters('mailpoet_segments_with_subscriber_count', $segments);
+    usort($segments, function ($a, $b) {
+      return strcasecmp($a["name"], $b["name"]);
+    });
+    $data['segments'] = $segments;
+
+    $data['custom_fields'] = array_map(function($field) {
+      $field['params'] = unserialize($field['params']);
+
+      if (!empty($field['params']['values'])) {
+        $values = [];
+
+        foreach ($field['params']['values'] as $value) {
+          $values[$value['value']] = $value['value'];
+        }
+        $field['params']['values'] = $values;
+      }
+      return $field;
+    }, CustomField::findArray());
+
+    $data['date_formats'] = Block\Date::getDateFormats();
+    $data['month_names'] = Block\Date::getMonthNames();
+
+    $data['premium_plugin_active'] = License::getLicense();
+    $data['mss_active'] = Bridge::isMPSendingServiceEnabled();
+
+    $this->page_renderer->displayPage('subscribers/subscribers.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/SubscribersAPIKeyInvalid.php
+++ b/lib/AdminPages/Pages/SubscribersAPIKeyInvalid.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Models\Subscriber;
+
+if (!defined('ABSPATH')) exit;
+
+class SubscribersAPIKeyInvalid {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  function __construct(PageRenderer $page_renderer) {
+    $this->page_renderer = $page_renderer;
+  }
+
+  function render() {
+    $this->page_renderer->displayPage('invalidkey.html', [
+      'subscriber_count' => Subscriber::getTotalSubscribers(),
+    ]);
+  }
+}

--- a/lib/AdminPages/Pages/SubscribersExport.php
+++ b/lib/AdminPages/Pages/SubscribersExport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Subscribers\ImportExport\ImportExportFactory;
+
+if (!defined('ABSPATH')) exit;
+
+class SubscribersExport {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  function __construct(PageRenderer $page_renderer) {
+    $this->page_renderer = $page_renderer;
+  }
+
+  function render() {
+    $export = new ImportExportFactory(ImportExportFactory::EXPORT_ACTION);
+    $data = $export->bootstrap();
+    $data['sub_menu'] = 'mailpoet-subscribers';
+    $this->page_renderer->displayPage('subscribers/importExport/export.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/SubscribersImport.php
+++ b/lib/AdminPages/Pages/SubscribersImport.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Form\Block;
+use MailPoet\Models\ModelValidator;
+use MailPoet\Subscribers\ImportExport\ImportExportFactory;
+use MailPoet\Util\Installation;
+
+if (!defined('ABSPATH')) exit;
+
+class SubscribersImport {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var Installation */
+  private $installation;
+
+  function __construct(PageRenderer $page_renderer, Installation $installation) {
+    $this->page_renderer = $page_renderer;
+    $this->installation = $installation;
+  }
+
+  function render() {
+    $import = new ImportExportFactory(ImportExportFactory::IMPORT_ACTION);
+    $data = $import->bootstrap();
+    $data = array_merge($data, [
+      'date_types' => Block\Date::getDateTypes(),
+      'date_formats' => Block\Date::getDateFormats(),
+      'month_names' => Block\Date::getMonthNames(),
+      'sub_menu' => 'mailpoet-subscribers',
+      'role_based_emails' => json_encode(ModelValidator::ROLE_EMAILS),
+    ]);
+
+    $data['is_new_user'] = $this->installation->isNewInstallation();
+
+    $this->page_renderer->displayPage('subscribers/importExport/import.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/SubscribersLimitExceeded.php
+++ b/lib/AdminPages/Pages/SubscribersLimitExceeded.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+
+if (!defined('ABSPATH')) exit;
+
+class SubscribersLimitExceeded {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  function __construct(PageRenderer $page_renderer) {
+    $this->page_renderer = $page_renderer;
+  }
+
+  function render() {
+    $this->page_renderer->displayPage('limit.html', [
+      'limit' => SubscribersFeature::SUBSCRIBERS_LIMIT,
+    ]);
+  }
+}

--- a/lib/AdminPages/Pages/Update.php
+++ b/lib/AdminPages/Pages/Update.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use Carbon\Carbon;
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Env;
+use MailPoet\Config\Menu;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Readme;
+
+if (!defined('ABSPATH')) exit;
+
+class Update {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SettingsController */
+  private $settings;
+
+  function __construct(PageRenderer $page_renderer, WPFunctions $wp, SettingsController $settings) {
+    $this->page_renderer = $page_renderer;
+    $this->wp = $wp;
+    $this->settings = $settings;
+  }
+
+  function render() {
+    global $wp;
+    $current_url = $this->wp->homeUrl(add_query_arg($wp->query_string, $wp->request));
+    $redirect_url =
+      (!empty($_GET['mailpoet_redirect']))
+        ? urldecode($_GET['mailpoet_redirect'])
+        : $this->wp->wpGetReferer();
+
+    if (
+      $redirect_url === $current_url
+      or
+      strpos($redirect_url, 'mailpoet') === false
+    ) {
+      $redirect_url = $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
+    }
+
+    $data = [
+      'settings' => $this->settings->getAll(),
+      'current_user' => $this->wp->wpGetCurrentUser(),
+      'redirect_url' => $redirect_url,
+      'sub_menu' => Menu::MAIN_PAGE_SLUG,
+    ];
+
+    $data['is_new_user'] = true;
+    $data['is_old_user'] = false;
+    if (!empty($data['settings']['installed_at'])) {
+      $installed_at = Carbon::createFromTimestamp(strtotime($data['settings']['installed_at']));
+      $current_time = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
+      $data['is_new_user'] = $current_time->diffInDays($installed_at) <= 30;
+      $data['is_old_user'] = $current_time->diffInMonths($installed_at) >= 6;
+      $data['stop_call_for_rating'] = isset($data['settings']['stop_call_for_rating']) ? $data['settings']['stop_call_for_rating'] : false;
+    }
+
+    $readme_file = Env::$path . '/readme.txt';
+    if (is_readable($readme_file)) {
+      $changelog = Readme::parseChangelog(file_get_contents($readme_file), 1);
+      if ($changelog) {
+        $data['changelog'] = $changelog;
+      }
+    }
+
+    $this->page_renderer->displayPage('update.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/lib/AdminPages/Pages/WelcomeWizard.php
@@ -43,7 +43,7 @@ class WelcomeWizard {
       'is_woocommerce_active' => $this->woocommerce_helper->isWooCommerceActive(),
       'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
       'sender' => $this->settings->get('sender'),
-      'admin_email' => get_option('admin_email'),
+      'admin_email' => $this->wp->getOption('admin_email'),
     ];
     $this->page_renderer->displayPage('welcome_wizard.html', $data);
   }

--- a/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/lib/AdminPages/Pages/WelcomeWizard.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Menu;
+use MailPoet\Config\MP2Migrator;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class WelcomeWizard {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WooCommerceHelper */
+  private $woocommerce_helper;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(
+    PageRenderer $page_renderer,
+    SettingsController $settings,
+    WooCommerceHelper $woocommerce_helper,
+    WPFunctions $wp
+  ) {
+    $this->page_renderer = $page_renderer;
+    $this->settings = $settings;
+    $this->woocommerce_helper = $woocommerce_helper;
+    $this->wp = $wp;
+  }
+
+  function render() {
+    if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
+    $data = [
+      'is_mp2_migration_complete' => (bool)$this->settings->get(MP2Migrator::MIGRATION_COMPLETE_SETTING_KEY),
+      'is_woocommerce_active' => $this->woocommerce_helper->isWooCommerceActive(),
+      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
+      'sender' => $this->settings->get('sender'),
+      'admin_email' => get_option('admin_email'),
+    ];
+    $this->page_renderer->displayPage('welcome_wizard.html', $data);
+  }
+}

--- a/lib/AdminPages/Pages/WooCommerceListImport.php
+++ b/lib/AdminPages/Pages/WooCommerceListImport.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Menu;
+use MailPoet\WP\Functions as WPFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+class WooCommerceListImport {
+  /** @var PageRenderer */
+  private $page_renderer;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(PageRenderer $page_renderer, WPFunctions $wp) {
+    $this->page_renderer = $page_renderer;
+    $this->wp = $wp;
+  }
+
+  function render() {
+    if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
+    $data = [
+      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
+    ];
+    $this->page_renderer->displayPage('woocommerce_list_import.html', $data);
+  }
+}

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -7,7 +7,9 @@ use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\MP2Migration;
 use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
+use MailPoet\AdminPages\Pages\Premium;
 use MailPoet\AdminPages\Pages\RevenueTrackingPermission;
+use MailPoet\AdminPages\Pages\Segments;
 use MailPoet\AdminPages\Pages\Settings;
 use MailPoet\AdminPages\Pages\Subscribers;
 use MailPoet\AdminPages\Pages\Update;
@@ -427,13 +429,7 @@ class Menu {
   }
 
   function premium() {
-    $data = [
-      'subscriber_count' => Subscriber::getTotalSubscribers(),
-      'sub_menu' => self::MAIN_PAGE_SLUG,
-      'display_discount' => time() <= strtotime('2018-11-30 23:59:59'),
-    ];
-
-    $this->page_renderer->displayPage('premium.html', $data);
+    $this->container->get(Premium::class)->render();
   }
 
   function settings() {
@@ -453,9 +449,7 @@ class Menu {
   }
 
   function segments() {
-    $data = [];
-    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('segments');
-    $this->page_renderer->displayPage('segments.html', $data);
+    $this->container->get(Segments::class)->render();
   }
 
   function forms() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -39,8 +39,9 @@ class Menu {
 
   /** @var WPFunctions */
   private $wp;
+
   /** @var ServicesChecker */
-  private $servicesChecker;
+  private $services_checker;
 
   /** @var ContainerWrapper */
   private $container;
@@ -50,13 +51,13 @@ class Menu {
   function __construct(
     AccessControl $access_control,
     WPFunctions $wp,
-    ServicesChecker $servicesChecker,
-    ContainerWrapper $containerWrapper
+    ServicesChecker $services_checker,
+    ContainerWrapper $container
   ) {
     $this->access_control = $access_control;
     $this->wp = $wp;
-    $this->servicesChecker = $servicesChecker;
-    $this->container = $containerWrapper;
+    $this->services_checker = $services_checker;
+    $this->container = $container;
   }
 
   function init() {
@@ -532,7 +533,7 @@ class Menu {
     if (self::isOnMailPoetAdminPage()) {
       $show_notices = isset($_REQUEST['page'])
         && stripos($_REQUEST['page'], self::MAIN_PAGE_SLUG) === false;
-      $checker = $checker ?: $this->servicesChecker;
+      $checker = $checker ?: $this->services_checker;
       $this->mp_api_key_valid = $checker->isMailPoetAPIKeyValid($show_notices);
     }
   }
@@ -540,7 +541,7 @@ class Menu {
   function checkPremiumKey(ServicesChecker $checker = null) {
     $show_notices = isset($_SERVER['SCRIPT_NAME'])
       && stripos($_SERVER['SCRIPT_NAME'], 'plugins.php') !== false;
-    $checker = $checker ?: $this->servicesChecker;
+    $checker = $checker ?: $this->services_checker;
     $this->premium_key_valid = $checker->isPremiumKeyValid($show_notices);
   }
 }

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -4,31 +4,26 @@ namespace MailPoet\Config;
 
 use Carbon\Carbon;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\Newsletters;
 use MailPoet\AdminPages\Pages\Settings;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
-use MailPoet\Cron\CronHelper;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Block;
 use MailPoet\Form\Renderer as FormRenderer;
-use MailPoet\Helpscout\Beacon;
 use MailPoet\Listing;
-use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\CustomField;
 use MailPoet\Models\Form;
 use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\Shortcodes\ShortcodesHelper;
-use MailPoet\Router\Endpoints\CronDaemon;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\Pages;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
-use MailPoet\Tasks\Sending;
-use MailPoet\Tasks\State;
 use MailPoet\Util\Installation;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\License\License;
@@ -520,31 +515,7 @@ class Menu {
   }
 
   function help() {
-    $tasks_state = new State();
-    $system_info_data = Beacon::getData();
-    $system_status_data = [
-      'cron' => [
-        'url' => CronHelper::getCronUrl(CronDaemon::ACTION_PING),
-        'isReachable' => CronHelper::pingDaemon(true),
-      ],
-      'mss' => [
-        'enabled' => (Bridge::isMPSendingServiceEnabled()) ?
-          ['isReachable' => Bridge::pingBridge()] :
-          false,
-      ],
-      'cronStatus' => CronHelper::getDaemon(),
-      'queueStatus' => MailerLog::getMailerLog(),
-    ];
-    $system_status_data['cronStatus']['accessible'] = CronHelper::isDaemonAccessible();
-    $system_status_data['queueStatus']['tasksStatusCounts'] = $tasks_state->getCountsPerStatus();
-    $system_status_data['queueStatus']['latestTasks'] = $tasks_state->getLatestTasks(Sending::TASK_TYPE);
-    $this->page_renderer->displayPage(
-      'help.html',
-      [
-        'systemInfoData' => $system_info_data,
-        'systemStatusData' => $system_status_data,
-      ]
-    );
+    $this->container->get(Help::class)->render();
   }
 
   function experimentalFeatures() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -10,6 +10,7 @@ use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
 use MailPoet\AdminPages\Pages\Settings;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
+use MailPoet\AdminPages\Pages\WooCommerceListImport;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Block;
@@ -426,11 +427,7 @@ class Menu {
   }
 
   function wooCommerceListImport() {
-    if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
-    $data = [
-      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . self::MAIN_PAGE_SLUG),
-    ];
-    $this->page_renderer->displayPage('woocommerce_list_import.html', $data);
+    $this->container->get(WooCommerceListImport::class)->render();
   }
 
   function revenueTrackingPermission() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Config;
 
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\AdminPages\Pages\ExperimentalFeatures;
 use MailPoet\AdminPages\Pages\Forms;
 use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\MP2Migration;
@@ -437,7 +438,7 @@ class Menu {
   }
 
   function experimentalFeatures() {
-    $this->page_renderer->displayPage('experimental-features.html', []);
+    $this->container->get(ExperimentalFeatures::class)->render();
   }
 
   function subscribers() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Config;
 
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\AdminPages\Pages\Forms;
 use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\MP2Migration;
 use MailPoet\AdminPages\Pages\NewsletterEditor;
@@ -49,9 +50,6 @@ class Menu {
   /** @var PageRenderer */
   private $page_renderer;
 
-  /** @var Listing\PageLimit */
-  private $listing_page_limit;
-
   /** @var Installation */
   private $installation;
 
@@ -65,7 +63,6 @@ class Menu {
     WPFunctions $wp,
     ServicesChecker $servicesChecker,
     PageRenderer $page_renderer,
-    Listing\PageLimit $listing_page_limit,
     Installation $installation,
     ContainerWrapper $containerWrapper
   ) {
@@ -73,7 +70,6 @@ class Menu {
     $this->wp = $wp;
     $this->servicesChecker = $servicesChecker;
     $this->page_renderer = $page_renderer;
-    $this->listing_page_limit = $listing_page_limit;
     $this->installation = $installation;
     $this->container = $containerWrapper;
   }
@@ -454,15 +450,7 @@ class Menu {
 
   function forms() {
     if ($this->subscribers_over_limit) return $this->displaySubscriberLimitExceededTemplate();
-
-    $data = [];
-
-    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('forms');
-    $data['segments'] = Segment::findArray();
-
-    $data['is_new_user'] = $this->installation->isNewInstallation();
-
-    $this->page_renderer->displayPage('forms.html', $data);
+    $this->container->get(Forms::class)->render();
   }
 
   function newsletters() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -14,20 +14,18 @@ use MailPoet\AdminPages\Pages\RevenueTrackingPermission;
 use MailPoet\AdminPages\Pages\Segments;
 use MailPoet\AdminPages\Pages\Settings;
 use MailPoet\AdminPages\Pages\Subscribers;
+use MailPoet\AdminPages\Pages\SubscribersExport;
+use MailPoet\AdminPages\Pages\SubscribersImport;
 use MailPoet\AdminPages\Pages\Update;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceListImport;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Form\Block;
 use MailPoet\Form\Renderer as FormRenderer;
-use MailPoet\Listing;
 use MailPoet\Models\Form;
-use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Settings\Pages;
-use MailPoet\Subscribers\ImportExport\ImportExportFactory;
-use MailPoet\Util\Installation;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
@@ -51,9 +49,6 @@ class Menu {
   /** @var PageRenderer */
   private $page_renderer;
 
-  /** @var Installation */
-  private $installation;
-
   /** @var ContainerWrapper */
   private $container;
 
@@ -64,14 +59,12 @@ class Menu {
     WPFunctions $wp,
     ServicesChecker $servicesChecker,
     PageRenderer $page_renderer,
-    Installation $installation,
     ContainerWrapper $containerWrapper
   ) {
     $this->access_control = $access_control;
     $this->wp = $wp;
     $this->servicesChecker = $servicesChecker;
     $this->page_renderer = $page_renderer;
-    $this->installation = $installation;
     $this->container = $containerWrapper;
   }
 
@@ -467,26 +460,11 @@ class Menu {
   }
 
   function import() {
-    $import = new ImportExportFactory(ImportExportFactory::IMPORT_ACTION);
-    $data = $import->bootstrap();
-    $data = array_merge($data, [
-      'date_types' => Block\Date::getDateTypes(),
-      'date_formats' => Block\Date::getDateFormats(),
-      'month_names' => Block\Date::getMonthNames(),
-      'sub_menu' => 'mailpoet-subscribers',
-      'role_based_emails' => json_encode(ModelValidator::ROLE_EMAILS),
-    ]);
-
-    $data['is_new_user'] = $this->installation->isNewInstallation();
-
-    $this->page_renderer->displayPage('subscribers/importExport/import.html', $data);
+    $this->container->get(SubscribersImport::class)->render();
   }
 
   function export() {
-    $export = new ImportExportFactory(ImportExportFactory::EXPORT_ACTION);
-    $data = $export->bootstrap();
-    $data['sub_menu'] = 'mailpoet-subscribers';
-    $this->page_renderer->displayPage('subscribers/importExport/export.html', $data);
+    $this->container->get(SubscribersExport::class)->render();
   }
 
   function formEditor() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -4,6 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AdminPages\Pages\ExperimentalFeatures;
+use MailPoet\AdminPages\Pages\FormEditor;
 use MailPoet\AdminPages\Pages\Forms;
 use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\MP2Migration;
@@ -20,12 +21,7 @@ use MailPoet\AdminPages\Pages\Update;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceListImport;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Form\Block;
-use MailPoet\Form\Renderer as FormRenderer;
-use MailPoet\Models\Form;
-use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
-use MailPoet\Settings\Pages;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
@@ -468,24 +464,7 @@ class Menu {
   }
 
   function formEditor() {
-    $id = (isset($_GET['id']) ? (int)$_GET['id'] : 0);
-    $form = Form::findOne($id);
-    if ($form instanceof Form) {
-      $form = $form->asArray();
-    }
-
-    $data = [
-      'form' => $form,
-      'pages' => Pages::getAll(),
-      'segments' => Segment::getSegmentsWithSubscriberCount(),
-      'styles' => FormRenderer::getStyles($form),
-      'date_types' => Block\Date::getDateTypes(),
-      'date_formats' => Block\Date::getDateFormats(),
-      'month_names' => Block\Date::getMonthNames(),
-      'sub_menu' => 'mailpoet-forms',
-    ];
-
-    $this->page_renderer->displayPage('form/editor.html', $data);
+    $this->container->get(FormEditor::class)->render();
   }
 
   function setPageTitle($title) {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -5,6 +5,7 @@ namespace MailPoet\Config;
 use Carbon\Carbon;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AdminPages\Pages\Help;
+use MailPoet\AdminPages\Pages\MP2Migration;
 use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
 use MailPoet\AdminPages\Pages\Settings;
@@ -417,13 +418,7 @@ class Menu {
   }
 
   function migration() {
-    $mp2_migrator = new MP2Migrator();
-    $mp2_migrator->init();
-    $data = [
-      'log_file_url' => $mp2_migrator->log_file_url,
-      'progress_url' => $mp2_migrator->progressbar->url,
-    ];
-    $this->page_renderer->displayPage('mp2migration.html', $data);
+    $this->container->get(MP2Migration::class)->render();
   }
 
   function welcomeWizard() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -9,6 +9,7 @@ use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
 use MailPoet\AdminPages\Pages\RevenueTrackingPermission;
 use MailPoet\AdminPages\Pages\Settings;
+use MailPoet\AdminPages\Pages\Subscribers;
 use MailPoet\AdminPages\Pages\Update;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceListImport;
@@ -16,12 +17,10 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Form\Block;
 use MailPoet\Form\Renderer as FormRenderer;
 use MailPoet\Listing;
-use MailPoet\Models\CustomField;
 use MailPoet\Models\Form;
 use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
-use MailPoet\Services\Bridge;
 use MailPoet\Settings\Pages;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
 use MailPoet\Util\Installation;
@@ -450,37 +449,7 @@ class Menu {
   }
 
   function subscribers() {
-    $data = [];
-
-    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('subscribers');
-    $segments = Segment::getSegmentsWithSubscriberCount($type = false);
-    $segments = $this->wp->applyFilters('mailpoet_segments_with_subscriber_count', $segments);
-    usort($segments, function ($a, $b) {
-      return strcasecmp($a["name"], $b["name"]);
-    });
-    $data['segments'] = $segments;
-
-    $data['custom_fields'] = array_map(function($field) {
-      $field['params'] = unserialize($field['params']);
-
-      if (!empty($field['params']['values'])) {
-        $values = [];
-
-        foreach ($field['params']['values'] as $value) {
-          $values[$value['value']] = $value['value'];
-        }
-        $field['params']['values'] = $values;
-      }
-      return $field;
-    }, CustomField::findArray());
-
-    $data['date_formats'] = Block\Date::getDateFormats();
-    $data['month_names'] = Block\Date::getMonthNames();
-
-    $data['premium_plugin_active'] = License::getLicense();
-    $data['mss_active'] = Bridge::isMPSendingServiceEnabled();
-
-    $this->page_renderer->displayPage('subscribers/subscribers.html', $data);
+    $this->container->get(Subscribers::class)->render();
   }
 
   function segments() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -8,11 +8,11 @@ use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\MP2Migration;
 use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
+use MailPoet\AdminPages\Pages\RevenueTrackingPermission;
 use MailPoet\AdminPages\Pages\Settings;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceListImport;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Block;
 use MailPoet\Form\Renderer as FormRenderer;
 use MailPoet\Listing;
@@ -44,9 +44,6 @@ class Menu {
   /** @var SettingsController */
   private $settings;
 
-  /** @var FeaturesController */
-  private $features_controller;
-
   /** @var WPFunctions */
   private $wp;
   /** @var ServicesChecker */
@@ -69,7 +66,6 @@ class Menu {
   function __construct(
     AccessControl $access_control,
     SettingsController $settings,
-    FeaturesController $featuresController,
     WPFunctions $wp,
     ServicesChecker $servicesChecker,
     PageRenderer $page_renderer,
@@ -80,7 +76,6 @@ class Menu {
     $this->access_control = $access_control;
     $this->wp = $wp;
     $this->settings = $settings;
-    $this->features_controller = $featuresController;
     $this->servicesChecker = $servicesChecker;
     $this->page_renderer = $page_renderer;
     $this->listing_page_limit = $listing_page_limit;
@@ -431,14 +426,7 @@ class Menu {
   }
 
   function revenueTrackingPermission() {
-    if (!$this->features_controller->isSupported(FeaturesController::FEATURE_DISPLAY_WOOCOMMERCE_REVENUES)) {
-      return;
-    }
-    if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
-    $data = [
-      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . self::MAIN_PAGE_SLUG),
-    ];
-    $this->page_renderer->displayPage('revenue_tracking_permission.html', $data);
+    $this->container->get(RevenueTrackingPermission::class)->render();
   }
 
   function update() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -4,6 +4,7 @@ namespace MailPoet\Config;
 
 use Carbon\Carbon;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\AdminPages\Pages\Newsletters;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\CronTrigger;
@@ -33,7 +34,6 @@ use MailPoet\Util\Installation;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\License\License;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
-use MailPoet\WP\DateTime;
 use MailPoet\WP\Readme;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -677,107 +677,7 @@ class Menu {
     if (isset($this->mp_api_key_valid) && $this->mp_api_key_valid === false) {
       return $this->displayMailPoetAPIKeyInvalidTemplate();
     }
-
-    global $wp_roles;
-
-    $data = [];
-
-    $data['items_per_page'] = $this->listing_page_limit->getLimitPerPage('newsletters');
-    $segments = Segment::getSegmentsWithSubscriberCount($type = false);
-    $segments = $this->wp->applyFilters('mailpoet_segments_with_subscriber_count', $segments);
-    usort($segments, function ($a, $b) {
-      return strcasecmp($a["name"], $b["name"]);
-    });
-    $data['segments'] = $segments;
-    $data['settings'] = $this->settings->getAll();
-    $data['mss_active'] = Bridge::isMPSendingServiceEnabled();
-    $data['current_wp_user'] = $this->wp->wpGetCurrentUser()->to_array();
-    $data['current_wp_user_firstname'] = $this->wp->wpGetCurrentUser()->user_firstname;
-    $data['site_url'] = $this->wp->siteUrl();
-    $data['roles'] = $wp_roles->get_names();
-    $data['roles']['mailpoet_all'] = $this->wp->__('In any WordPress role', 'mailpoet');
-
-    $installedAtDateTime = new \DateTime($data['settings']['installed_at']);
-    $data['installed_days_ago'] = (int)$installedAtDateTime->diff(new \DateTime())->format('%a');
-
-    $date_time = new DateTime();
-    $data['current_date'] = $date_time->getCurrentDate(DateTime::DEFAULT_DATE_FORMAT);
-    $data['current_time'] = $date_time->getCurrentTime();
-    $data['schedule_time_of_day'] = $date_time->getTimeInterval(
-      '00:00:00',
-      '+1 hour',
-      24
-    );
-    $data['mailpoet_main_page'] = $this->wp->adminUrl('admin.php?page=' . self::MAIN_PAGE_SLUG);
-    $data['show_congratulate_after_first_newsletter'] = isset($data['settings']['show_congratulate_after_first_newsletter']) ? $data['settings']['show_congratulate_after_first_newsletter'] : 'false';
-
-    $data['tracking_enabled'] = $this->settings->get('tracking.enabled');
-    $data['premium_plugin_active'] = License::getLicense();
-    $data['is_woocommerce_active'] = $this->woocommerce_helper->isWooCommerceActive();
-    $data['is_mailpoet_update_available'] = array_key_exists(Env::$plugin_path, $this->wp->getPluginUpdates());
-    if (!$data['premium_plugin_active']) {
-      $data['subscribers_count'] = Subscriber::getTotalSubscribers();
-      $data['free_premium_subscribers_limit'] = License::FREE_PREMIUM_SUBSCRIBERS_LIMIT;
-    }
-
-    $user_id = $data['current_wp_user']['ID'];
-
-    $last_announcement_date = $this->settings->get('last_announcement_date');
-    $last_announcement_seen = $this->user_flags->get('last_announcement_seen');
-    $data['feature_announcement_has_news'] = (
-      empty($last_announcement_seen) ||
-      $last_announcement_seen < $last_announcement_date
-    );
-    $data['last_announcement_seen'] = $last_announcement_seen;
-
-    $data['automatic_emails'] = [
-      [
-        'slug' => 'woocommerce',
-        'beta' => true,
-        'premium' => true,
-        'title' => $this->wp->__('WooCommerce', 'mailpoet'),
-        'description' => $this->wp->__('Automatically send an email when there is a new WooCommerce product, order and some other action takes place.', 'mailpoet'),
-        'events' => [
-          [
-            'slug' => 'woocommerce_abandoned_shopping_cart',
-            'title' => $this->wp->__('Abandoned Shopping Cart', 'mailpoet'),
-            'description' => $this->wp->__('Send an email to logged-in visitors who have items in their shopping carts but left your website without checking out. Can convert up to 5% of abandoned carts.', 'mailpoet'),
-            'soon' => true,
-            'badge' => [
-              'text' => $this->wp->__('Must-have', 'mailpoet'),
-              'style' => 'red',
-            ],
-          ],
-          [
-            'slug' => 'woocommerce_first_purchase',
-            'title' => $this->wp->__('First Purchase', 'mailpoet'),
-            'description' => $this->wp->__('Let MailPoet send an email to customers who make their first purchase.', 'mailpoet'),
-            'badge' => [
-              'text' => $this->wp->__('Must-have', 'mailpoet'),
-              'style' => 'red',
-            ],
-          ],
-          [
-            'slug' => 'woocommerce_product_purchased_in_category',
-            'title' => $this->wp->__('Purchased In This Category', 'mailpoet'),
-            'description' => $this->wp->__('Let MailPoet send an email to customers who purchase a product from a specific category.', 'mailpoet'),
-            'soon' => true,
-          ],
-          [
-            'slug' => 'woocommerce_product_purchased',
-            'title' => $this->wp->__('Purchased This Product', 'mailpoet'),
-            'description' => $this->wp->__('Let MailPoet send an email to customers who purchase a specific product.', 'mailpoet'),
-          ],
-        ],
-      ],
-    ];
-
-    $data['is_new_user'] = $this->installation->isNewInstallation();
-
-    $this->wp->wpEnqueueScript('jquery-ui');
-    $this->wp->wpEnqueueScript('jquery-ui-datepicker');
-
-    $this->page_renderer->displayPage('newsletters.html', $data);
+    $this->container->get(Newsletters::class)->render();
   }
 
   function newletterEditor() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -5,6 +5,7 @@ namespace MailPoet\Config;
 use Carbon\Carbon;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AdminPages\Pages\Help;
+use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
 use MailPoet\AdminPages\Pages\Settings;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
@@ -18,11 +19,9 @@ use MailPoet\Models\Form;
 use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
-use MailPoet\Newsletter\Shortcodes\ShortcodesHelper;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\Pages;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\UserFlagsController;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
 use MailPoet\Util\Installation;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -35,8 +34,6 @@ if (!defined('ABSPATH')) exit;
 class Menu {
   const MAIN_PAGE_SLUG = 'mailpoet-newsletters';
 
-  /** @var Renderer */
-  public $renderer;
   public $mp_api_key_valid;
   public $premium_key_valid;
 
@@ -48,8 +45,6 @@ class Menu {
   /** @var FeaturesController */
   private $features_controller;
 
-  /** @var UserFlagsController */
-  private $user_flags;
   /** @var WPFunctions */
   private $wp;
   /** @var ServicesChecker */
@@ -75,7 +70,6 @@ class Menu {
     FeaturesController $featuresController,
     WPFunctions $wp,
     ServicesChecker $servicesChecker,
-    UserFlagsController $user_flags,
     PageRenderer $page_renderer,
     Listing\PageLimit $listing_page_limit,
     Installation $installation,
@@ -86,7 +80,6 @@ class Menu {
     $this->settings = $settings;
     $this->features_controller = $featuresController;
     $this->servicesChecker = $servicesChecker;
-    $this->user_flags = $user_flags;
     $this->page_renderer = $page_renderer;
     $this->listing_page_limit = $listing_page_limit;
     $this->installation = $installation;
@@ -584,21 +577,7 @@ class Menu {
   }
 
   function newletterEditor() {
-    $subscriber = Subscriber::getCurrentWPUser();
-    $subscriber_data = $subscriber ? $subscriber->asArray() : [];
-    $data = [
-      'shortcodes' => ShortcodesHelper::getShortcodes(),
-      'settings' => $this->settings->getAll(),
-      'editor_tutorial_seen' => $this->user_flags->get('editor_tutorial_seen'),
-      'current_wp_user' => array_merge($subscriber_data, $this->wp->wpGetCurrentUser()->to_array()),
-      'sub_menu' => self::MAIN_PAGE_SLUG,
-      'mss_active' => Bridge::isMPSendingServiceEnabled(),
-    ];
-    $this->wp->wpEnqueueMedia();
-    $this->wp->wpEnqueueScript('tinymce-wplink', $this->wp->includesUrl('js/tinymce/plugins/wplink/plugin.js'));
-    $this->wp->wpEnqueueStyle('editor', $this->wp->includesUrl('css/editor.css'));
-
-    $this->page_renderer->displayPage('newsletter/editor.html', $data);
+    $this->container->get(NewsletterEditor::class)->render();
   }
 
   function import() {

--- a/lib/Config/Menu.php
+++ b/lib/Config/Menu.php
@@ -4,8 +4,10 @@ namespace MailPoet\Config;
 
 use Carbon\Carbon;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\CronTrigger;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Block;
 use MailPoet\Form\Renderer as FormRenderer;
@@ -72,6 +74,9 @@ class Menu {
   /** @var Installation */
   private $installation;
 
+  /** @var ContainerWrapper */
+  private $container;
+
   private $subscribers_over_limit;
 
   function __construct(
@@ -84,7 +89,8 @@ class Menu {
     UserFlagsController $user_flags,
     PageRenderer $page_renderer,
     Listing\PageLimit $listing_page_limit,
-    Installation $installation
+    Installation $installation,
+    ContainerWrapper $containerWrapper
   ) {
     $this->access_control = $access_control;
     $this->wp = $wp;
@@ -96,6 +102,7 @@ class Menu {
     $this->page_renderer = $page_renderer;
     $this->listing_page_limit = $listing_page_limit;
     $this->installation = $installation;
+    $this->container = $containerWrapper;
   }
 
   function init() {
@@ -439,15 +446,7 @@ class Menu {
   }
 
   function welcomeWizard() {
-    if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
-    $data = [
-      'is_mp2_migration_complete' => (bool)$this->settings->get(MP2Migrator::MIGRATION_COMPLETE_SETTING_KEY),
-      'is_woocommerce_active' => $this->woocommerce_helper->isWooCommerceActive(),
-      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . self::MAIN_PAGE_SLUG),
-      'sender' => $this->settings->get('sender'),
-      'admin_email' => get_option('admin_email'),
-    ];
-    $this->page_renderer->displayPage('welcome_wizard.html', $data);
+    $this->container->get(WelcomeWizard::class)->render();
   }
 
   function wooCommerceListImport() {

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -30,6 +30,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ]);
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -30,6 +30,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ]);
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);
     // API

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -133,6 +133,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
     // Util
     $container->autowire(\MailPoet\Util\Url::class)->setPublic(true);
+    $container->autowire(\MailPoet\Util\Installation::class);
     // WooCommerce
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -36,6 +36,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
     $container->autowire(\MailPoet\AdminPages\Pages\RevenueTrackingPermission::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Update::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -89,6 +89,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Listing\BulkActionController::class)->setPublic(true);
     $container->autowire(\MailPoet\Listing\BulkActionFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Listing\Handler::class)->setPublic(true);
+    $container->autowire(\MailPoet\Listing\PageLimit::class);
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);
     // Router

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -33,6 +33,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     // Analytics
@@ -69,6 +70,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Config\Hooks::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Initializer::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Menu::class)->setPublic(true);
+    $container->autowire(\MailPoet\Config\MP2Migrator::class);
     $container->autowire(\MailPoet\Config\RendererFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\ServicesChecker::class);
     $container->autowire(\MailPoet\Config\Shortcodes::class)

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -30,6 +30,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ]);
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Forms::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -41,6 +41,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\Segments::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersExport::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Update::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -34,6 +34,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
     $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\RevenueTrackingPermission::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -31,6 +31,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
     $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Forms::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -42,8 +42,10 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\Segments::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersAPIKeyInvalid::class);
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersExport::class);
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersLimitExceeded::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Update::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -36,6 +36,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);
     // API

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -30,25 +30,25 @@ class ContainerConfigurator implements IContainerConfigurator {
       ]);
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Forms::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Premium::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\RevenueTrackingPermission::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Segments::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersAPIKeyInvalid::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersExport::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersLimitExceeded::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\Update::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
-    $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Forms::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Help::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Premium::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\RevenueTrackingPermission::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Segments::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Settings::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersAPIKeyInvalid::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersExport::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\SubscribersLimitExceeded::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Update::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class)->setPublic(true);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);
     // API

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -36,6 +36,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
     $container->autowire(\MailPoet\AdminPages\Pages\RevenueTrackingPermission::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Update::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceListImport::class);
     // Analytics

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -31,6 +31,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -29,7 +29,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       'getInstance',
       ]);
     // AdminPages
-    $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
+    $container->autowire(\MailPoet\AdminPages\PageRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Forms::class)->setPublic(true);
@@ -109,7 +109,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Listing\BulkActionController::class)->setPublic(true);
     $container->autowire(\MailPoet\Listing\BulkActionFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Listing\Handler::class)->setPublic(true);
-    $container->autowire(\MailPoet\Listing\PageLimit::class);
+    $container->autowire(\MailPoet\Listing\PageLimit::class)->setPublic(true);
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);
     // Router

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -30,6 +30,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ]);
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Forms::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -34,7 +34,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
     $container->autowire(\MailPoet\AdminPages\Pages\MP2Migration::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Premium::class);
     $container->autowire(\MailPoet\AdminPages\Pages\RevenueTrackingPermission::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Segments::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Update::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -31,6 +31,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -28,6 +28,8 @@ class ContainerConfigurator implements IContainerConfigurator {
       ContainerWrapper::class,
       'getInstance',
       ]);
+    // AdminPages
+    $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);
     // API

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -30,6 +30,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ]);
     // AdminPages
     $container->autowire(\MailPoet\AdminPages\PageRenderer::class);
+    $container->autowire(\MailPoet\AdminPages\Pages\Help::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class);
     $container->autowire(\MailPoet\AdminPages\Pages\Settings::class);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class);
@@ -121,6 +122,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Services
     $container->autowire(\MailPoet\Services\Bridge::class);
     $container->autowire(\MailPoet\Services\AuthorizedEmailsController::class);
+    // Tasks
+    $container->autowire(\MailPoet\Tasks\State::class);
     // Settings
     $container->autowire(\MailPoet\Settings\SettingsController::class)->setPublic(true);
     // User Flags

--- a/lib/Listing/Handler.php
+++ b/lib/Listing/Handler.php
@@ -141,7 +141,7 @@ class Handler {
       'offset' => (isset($data['offset']) ? (int)$data['offset'] : 0),
       'limit' => (isset($data['limit'])
         ? (int)$data['limit']
-        : self::DEFAULT_LIMIT_PER_PAGE
+        : PageLimit::DEFAULT_LIMIT_PER_PAGE
       ),
       // searching
       'search' => (isset($data['search']) ? $data['search'] : null),

--- a/lib/Listing/PageLimit.php
+++ b/lib/Listing/PageLimit.php
@@ -1,0 +1,30 @@
+<?php
+namespace MailPoet\Listing;
+
+if (!defined('ABSPATH')) exit;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class PageLimit {
+  const DEFAULT_LIMIT_PER_PAGE = 20;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(WPFunctions $wp) {
+    $this->wp = $wp;
+  }
+
+  function getLimitPerPage($model = null) {
+    if ($model === null) {
+      return self::DEFAULT_LIMIT_PER_PAGE;
+    }
+
+    $listing_per_page = $this->wp->getUserMeta(
+      $this->wp->getCurrentUserId(), 'mailpoet_' . $model . '_per_page', true
+    );
+    return (!empty($listing_per_page))
+      ? (int)$listing_per_page
+      : self::DEFAULT_LIMIT_PER_PAGE;
+  }
+}

--- a/lib/Util/Installation.php
+++ b/lib/Util/Installation.php
@@ -1,0 +1,31 @@
+<?php
+namespace MailPoet\Util;
+
+use Carbon\Carbon;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\Settings\SettingsController;
+
+class Installation {
+  const NEW_INSTALLATION_DAYS_LIMIT = 30;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  function __construct(SettingsController $settings, WPFunctions $wp) {
+    $this->settings = $settings;
+    $this->wp = $wp;
+  }
+
+  function isNewInstallation() {
+    $installed_at = $this->settings->get('installed_at');
+    if (is_null($installed_at)) {
+      return true;
+    }
+    $installed_at = Carbon::createFromTimestamp(strtotime($installed_at));
+    $current_time = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
+    return $current_time->diffInDays($installed_at) <= self::NEW_INSTALLATION_DAYS_LIMIT;
+  }
+}

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -8,7 +8,6 @@ use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Installation;
@@ -94,7 +93,6 @@ class MenuTest extends \MailPoetTest {
     return new Menu(
       new AccessControl(),
       $settings,
-      new FeaturesController(),
       $wp,
       new ServicesChecker,
       $renderer,

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -92,7 +92,6 @@ class MenuTest extends \MailPoetTest {
     $settings = new SettingsController;
     return new Menu(
       new AccessControl(),
-      $settings,
       $wp,
       new ServicesChecker,
       $renderer,

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -6,13 +6,13 @@ use Codeception\Util\Stub;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
-use MailPoet\Config\Renderer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Features\FeaturesController;
+use MailPoet\Listing\PageLimit;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
-use MailPoet\WP\Functions;
+use MailPoet\WP\Functions as WPFunctions;
 
 class MenuTest extends \MailPoetTest {
   function testItReturnsTrueIfCurrentPageBelongsToMailpoet() {
@@ -89,15 +89,17 @@ class MenuTest extends \MailPoetTest {
   }
 
   private function getMenu(PageRenderer $renderer) {
+    $wp = new WPFunctions;
     return new Menu(
       new AccessControl(),
       new SettingsController(),
       new FeaturesController(),
-      new Functions(),
-      new WooCommerceHelper(new Functions()),
+      $wp,
+      new WooCommerceHelper($wp),
       new ServicesChecker,
       new UserFlagsController,
-      $renderer
+      $renderer,
+      new PageLimit($wp)
     );
   }
 }

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -8,8 +8,6 @@ use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Settings\SettingsController;
-use MailPoet\Util\Installation;
 use MailPoet\WP\Functions as WPFunctions;
 
 class MenuTest extends \MailPoetTest {
@@ -88,13 +86,11 @@ class MenuTest extends \MailPoetTest {
 
   private function getMenu(PageRenderer $renderer) {
     $wp = new WPFunctions;
-    $settings = new SettingsController;
     return new Menu(
       new AccessControl(),
       $wp,
       new ServicesChecker,
       $renderer,
-      new Installation($settings, $wp),
       ContainerWrapper::getInstance()
     );
   }

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -11,6 +11,7 @@ use MailPoet\Features\FeaturesController;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
+use MailPoet\Util\Installation;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -90,16 +91,18 @@ class MenuTest extends \MailPoetTest {
 
   private function getMenu(PageRenderer $renderer) {
     $wp = new WPFunctions;
+    $settings = new SettingsController;
     return new Menu(
       new AccessControl(),
-      new SettingsController(),
+      $settings,
       new FeaturesController(),
       $wp,
       new WooCommerceHelper($wp),
       new ServicesChecker,
       new UserFlagsController,
       $renderer,
-      new PageLimit($wp)
+      new PageLimit($wp),
+      new Installation($settings, $wp)
     );
   }
 }

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -7,12 +7,12 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\Util\Installation;
-use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
 class MenuTest extends \MailPoetTest {
@@ -97,12 +97,12 @@ class MenuTest extends \MailPoetTest {
       $settings,
       new FeaturesController(),
       $wp,
-      new WooCommerceHelper($wp),
       new ServicesChecker,
       new UserFlagsController,
       $renderer,
       new PageLimit($wp),
-      new Installation($settings, $wp)
+      new Installation($settings, $wp),
+      ContainerWrapper::getInstance()
     );
   }
 }

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -8,7 +8,6 @@ use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Listing\PageLimit;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Installation;
 use MailPoet\WP\Functions as WPFunctions;
@@ -95,7 +94,6 @@ class MenuTest extends \MailPoetTest {
       $wp,
       new ServicesChecker,
       $renderer,
-      new PageLimit($wp),
       new Installation($settings, $wp),
       ContainerWrapper::getInstance()
     );

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -11,7 +11,6 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\UserFlagsController;
 use MailPoet\Util\Installation;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -98,7 +97,6 @@ class MenuTest extends \MailPoetTest {
       new FeaturesController(),
       $wp,
       new ServicesChecker,
-      new UserFlagsController,
       $renderer,
       new PageLimit($wp),
       new Installation($settings, $wp),

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\Config;
 
 use Codeception\Util\Stub;
-use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
@@ -41,8 +40,7 @@ class MenuTest extends \MailPoetTest {
   }
 
   function testItChecksMailpoetAPIKey() {
-    $renderer = Stub::make(PageRenderer::class);
-    $menu = $this->getMenu($renderer);
+    $menu = $this->getMenu();
 
     $_REQUEST['page'] = 'mailpoet-newsletters';
     $checker = Stub::make(
@@ -63,8 +61,7 @@ class MenuTest extends \MailPoetTest {
   }
 
   function testItChecksPremiumKey() {
-    $renderer = Stub::make(PageRenderer::class);
-    $menu = $this->getMenu($renderer);
+    $menu = $this->getMenu();
 
     $_REQUEST['page'] = 'mailpoet-newsletters';
     $checker = Stub::make(
@@ -84,13 +81,12 @@ class MenuTest extends \MailPoetTest {
     expect($menu->premium_key_valid)->false();
   }
 
-  private function getMenu(PageRenderer $renderer) {
+  private function getMenu() {
     $wp = new WPFunctions;
     return new Menu(
       new AccessControl(),
       $wp,
       new ServicesChecker,
-      $renderer,
       ContainerWrapper::getInstance()
     );
   }

--- a/tests/integration/Config/MenuTest.php
+++ b/tests/integration/Config/MenuTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Config;
 
 use Codeception\Util\Stub;
+use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\Renderer;
@@ -44,7 +45,7 @@ class MenuTest extends \MailPoetTest {
   }
 
   function testItChecksMailpoetAPIKey() {
-    $renderer = Stub::make(new Renderer());
+    $renderer = Stub::make(PageRenderer::class);
     $menu = $this->getMenu($renderer);
 
     $_REQUEST['page'] = 'mailpoet-newsletters';
@@ -66,7 +67,7 @@ class MenuTest extends \MailPoetTest {
   }
 
   function testItChecksPremiumKey() {
-    $renderer = Stub::make(new Renderer());
+    $renderer = Stub::make(PageRenderer::class);
     $menu = $this->getMenu($renderer);
 
     $_REQUEST['page'] = 'mailpoet-newsletters';
@@ -87,16 +88,16 @@ class MenuTest extends \MailPoetTest {
     expect($menu->premium_key_valid)->false();
   }
 
-  private function getMenu(Renderer $renderer) {
+  private function getMenu(PageRenderer $renderer) {
     return new Menu(
-      $renderer,
       new AccessControl(),
       new SettingsController(),
       new FeaturesController(),
       new Functions(),
       new WooCommerceHelper(new Functions()),
       new ServicesChecker,
-      new UserFlagsController
+      new UserFlagsController,
+      $renderer
     );
   }
 }


### PR DESCRIPTION
I've added a new namespace `MailPoet\AdminPages` and refactored all methods used for fetching data for templates to extra classes and injected container so that a class for a particular page is instantiated when it is needed for rendering.

## QA Notes
I would be good to go thru all MailPoet admin pages and check that all renders correctly.
Here are all pages which are handled by Menu class:

mailpoet/lib/AdminPages/Pages/ExperimentalFeatures.php
mailpoet/lib/AdminPages/Pages/FormEditor.php
mailpoet/lib/AdminPages/Pages/Forms.php
mailpoet/lib/AdminPages/Pages/Help.php
mailpoet/lib/AdminPages/Pages/MP2Migration.php
mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
mailpoet/lib/AdminPages/Pages/Newsletters.php
mailpoet/lib/AdminPages/Pages/Premium.php
mailpoet/lib/AdminPages/Pages/RevenueTrackingPermission.php
mailpoet/lib/AdminPages/Pages/Segments.php
mailpoet/lib/AdminPages/Pages/Settings.php
mailpoet/lib/AdminPages/Pages/Subscribers.php
mailpoet/lib/AdminPages/Pages/SubscribersAPIKeyInvalid.php
mailpoet/lib/AdminPages/Pages/SubscribersExport.php
mailpoet/lib/AdminPages/Pages/SubscribersImport.php
mailpoet/lib/AdminPages/Pages/SubscribersLimitExceeded.php
mailpoet/lib/AdminPages/Pages/Update.php
mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
mailpoet/lib/AdminPages/Pages/WooCommerceListImport.php