### PR TITLE
Refactor Shortcodes, Pages and Blacklist to DI [MAILPOET-2208] 

### DIFF
--- a/lib/API/JSON/v1/UserFlags.php
+++ b/lib/API/JSON/v1/UserFlags.php
@@ -5,7 +5,6 @@ namespace MailPoet\API\JSON\v1;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\Config\AccessControl;
-use MailPoet\Services\Bridge;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\WP\Functions as WPFunctions;
 

--- a/lib/Config/DeactivationSurvey.php
+++ b/lib/Config/DeactivationSurvey.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Config;
 
-use MailPoet\WP\Notice;
 use MailPoet\WP\Functions as WPFunctions;
 
 class DeactivationSurvey {

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -10,7 +10,6 @@ use MailPoet\Util\ConflictResolver;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Notices\PermanentNotices;
 use MailPoet\WP\Notice as WPNotice;
-use MailPoetVendor\Psr\Container\ContainerInterface;
 use MailPoet\WP\Functions as WPFunctions;
 
 if (!defined('ABSPATH')) exit;

--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -55,6 +55,9 @@ class Initializer {
   /** @var PermanentNotices */
   private $permanent_notices;
 
+  /** @var Shortcodes */
+  private $shortcodes;
+
   const INITIALIZED = 'MAILPOET_INITIALIZED';
 
   function __construct(
@@ -68,7 +71,8 @@ class Initializer {
     Changelog $changelog,
     Menu $menu,
     CronTrigger $cron_trigger,
-    PermanentNotices $permanent_notices
+    PermanentNotices $permanent_notices,
+    Shortcodes $shortcodes
   ) {
       $this->renderer_factory = $renderer_factory;
       $this->access_control = $access_control;
@@ -81,6 +85,7 @@ class Initializer {
       $this->menu = $menu;
       $this->cron_trigger = $cron_trigger;
       $this->permanent_notices = $permanent_notices;
+      $this->shortcodes = $shortcodes;
   }
 
   function init() {
@@ -248,8 +253,7 @@ class Initializer {
   }
 
   function setupShortcodes() {
-    $shortcodes = new Shortcodes();
-    $shortcodes->init();
+    $this->shortcodes->init();
   }
 
   function setupImages() {

--- a/lib/Config/ServicesChecker.php
+++ b/lib/Config/ServicesChecker.php
@@ -1,7 +1,6 @@
 <?php
 namespace MailPoet\Config;
 
-use MailPoet\Mailer\MailerError;
 use MailPoet\Models\Subscriber;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;

--- a/lib/Config/Shortcodes.php
+++ b/lib/Config/Shortcodes.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Config;
 
+use MailPoet\Form\Widget;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
@@ -10,26 +11,31 @@ use MailPoet\Subscription\Pages;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Shortcodes {
+  /** @var Pages */
+  private $subscription_pages;
+
+  /** @var WPFunctions */
   private $wp;
 
-  function __construct() {
-    $this->wp = new WPFunctions;
+  function __construct(Pages $subscription_pages, WPFunctions $wp) {
+    $this->subscription_pages = $subscription_pages;
+    $this->wp = $wp;
   }
 
   function init() {
     // form widget shortcode
-    WPFunctions::get()->addShortcode('mailpoet_form', [$this, 'formWidget']);
+    $this->wp->addShortcode('mailpoet_form', [$this, 'formWidget']);
 
     // subscribers count shortcode
-    WPFunctions::get()->addShortcode('mailpoet_subscribers_count', [
+    $this->wp->addShortcode('mailpoet_subscribers_count', [
       $this, 'getSubscribersCount',
     ]);
-    WPFunctions::get()->addShortcode('wysija_subscribers_count', [
+    $this->wp->addShortcode('wysija_subscribers_count', [
       $this, 'getSubscribersCount',
     ]);
 
     // archives page
-    WPFunctions::get()->addShortcode('mailpoet_archive', [
+    $this->wp->addShortcode('mailpoet_archive', [
       $this, 'getArchive',
     ]);
 
@@ -39,18 +45,18 @@ class Shortcodes {
     $this->wp->addFilter('mailpoet_archive_subject', [
       $this, 'renderArchiveSubject',
     ], 2, 3);
-
+    // initialize subscription pages data
+    $this->subscription_pages->init();
     // initialize subscription management shortcodes
-    $subscription_page = new Pages();
-    $subscription_page->initShortcodes();
+    $this->subscription_pages->initShortcodes();
   }
 
   function formWidget($params = []) {
     // IMPORTANT: fixes conflict with MagicMember
-    WPFunctions::get()->removeShortcode('user_list');
+    $this->wp->removeShortcode('user_list');
 
     if (isset($params['id']) && (int)$params['id'] > 0) {
-      $form_widget = new \MailPoet\Form\Widget();
+      $form_widget = new Widget();
       return $form_widget->widget([
         'form' => (int)$params['id'],
         'form_type' => 'shortcode',
@@ -66,9 +72,9 @@ class Shortcodes {
     }
 
     if (empty($segment_ids)) {
-      return WPFunctions::get()->numberFormatI18n(Subscriber::filter('subscribed')->count());
+      return $this->wp->numberFormatI18n(Subscriber::filter('subscribed')->count());
     } else {
-      return WPFunctions::get()->numberFormatI18n(
+      return $this->wp->numberFormatI18n(
         SubscriberSegment::whereIn('segment_id', $segment_ids)
           ->select('subscriber_id')->distinct()
           ->filter('subscribed')
@@ -94,7 +100,7 @@ class Shortcodes {
     if (empty($newsletters)) {
       return $this->wp->applyFilters(
         'mailpoet_archive_no_newsletters',
-        WPFunctions::get()->__('Oops! There are no newsletters to display.', 'mailpoet')
+        $this->wp->__('Oops! There are no newsletters to display.', 'mailpoet')
       );
     } else {
       $title = $this->wp->applyFilters('mailpoet_archive_title', '');
@@ -119,8 +125,8 @@ class Shortcodes {
   }
 
   function renderArchiveDate($newsletter) {
-    return WPFunctions::get()->dateI18n(
-      WPFunctions::get()->getOption('date_format'),
+    return $this->wp->dateI18n(
+      $this->wp->getOption('date_format'),
       strtotime($newsletter->processed_at)
     );
   }

--- a/lib/Cron/Daemon.php
+++ b/lib/Cron/Daemon.php
@@ -2,7 +2,6 @@
 namespace MailPoet\Cron;
 
 use MailPoet\Cron\Workers\WorkersFactory;
-use MailPoet\Settings\SettingsController;
 
 if (!defined('ABSPATH')) exit;
 

--- a/lib/Cron/Workers/AuthorizedSendingEmailsCheck.php
+++ b/lib/Cron/Workers/AuthorizedSendingEmailsCheck.php
@@ -1,12 +1,9 @@
 <?php
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Cron\CronHelper;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
-use MailPoet\Settings\SettingsController;
-use MailPoet\Subscribers\InactiveSubscribersController;
 
 if (!defined('ABSPATH')) exit;
 

--- a/lib/Cron/Workers/Beamer.php
+++ b/lib/Cron/Workers/Beamer.php
@@ -3,7 +3,6 @@ namespace MailPoet\Cron\Workers;
 
 use Carbon\Carbon;
 use MailPoet\Models\ScheduledTask;
-use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 

--- a/lib/Cron/Workers/WooCommerceSync.php
+++ b/lib/Cron/Workers/WooCommerceSync.php
@@ -2,7 +2,6 @@
 namespace MailPoet\Cron\Workers;
 
 use Carbon\Carbon;
-use MailPoet\Cron\CronHelper;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -64,6 +64,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Config\Menu::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\RendererFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\ServicesChecker::class);
+    $container->autowire(\MailPoet\Config\Shortcodes::class)
+      ->setShared(false);
     $container->register(\MailPoet\Config\Renderer::class)
       ->setPublic(true)
       ->setFactory([new Reference(\MailPoet\Config\RendererFactory::class), 'getRenderer']);
@@ -121,6 +123,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscription\Comment::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Form::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Manage::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscription\Pages::class)->setPublic(true)
+      ->setShared(false);
     $container->autowire(\MailPoet\Subscription\Registration::class)->setPublic(true);
     // Newsletter
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -99,6 +99,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setArgument('$container', new Reference(ContainerWrapper::class));
     // Mailer
     $container->autowire(\MailPoet\Mailer\Mailer::class);
+    $container->autowire(\MailPoet\Mailer\Methods\Common\BlacklistCheck::class);
     // Subscribers
     $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -65,7 +65,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Config\RendererFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\ServicesChecker::class);
     $container->autowire(\MailPoet\Config\Shortcodes::class)
-      ->setShared(false);
+      ->setShared(false); // Get a new instance each time $container->get() is called, needed for tests
     $container->register(\MailPoet\Config\Renderer::class)
       ->setPublic(true)
       ->setFactory([new Reference(\MailPoet\Config\RendererFactory::class), 'getRenderer']);
@@ -124,7 +124,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscription\Form::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Manage::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Pages::class)->setPublic(true)
-      ->setShared(false);
+      ->setShared(false); // Get a new instance each time $container->get() is called, needed for tests
     $container->autowire(\MailPoet\Subscription\Registration::class)->setPublic(true);
     // Newsletter
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);

--- a/lib/Mailer/Methods/AmazonSES.php
+++ b/lib/Mailer/Methods/AmazonSES.php
@@ -2,14 +2,13 @@
 namespace MailPoet\Mailer\Methods;
 
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\AmazonSESMapper;
 use MailPoet\WP\Functions as WPFunctions;
 
 if (!defined('ABSPATH')) exit;
 
 class AmazonSES {
-  use BlacklistTrait;
-
   public $aws_access_key;
   public $aws_secret_key;
   public $aws_region;
@@ -33,6 +32,9 @@ class AmazonSES {
 
   /** @var AmazonSESMapper */
   private $error_mapper;
+
+  /** @var BlacklistCheck */
+  private $blacklist;
 
   private $wp;
 
@@ -66,10 +68,11 @@ class AmazonSES {
     $this->date_without_time = gmdate('Ymd');
     $this->error_mapper = $error_mapper;
     $this->wp = new WPFunctions();
+    $this->blacklist = new BlacklistCheck();
   }
 
   function send($newsletter, $subscriber, $extra_params = []) {
-    if ($this->isBlacklisted($subscriber)) {
+    if ($this->blacklist->isBlacklisted($subscriber)) {
       $error = $this->error_mapper->getBlacklistError($subscriber);
       return Mailer::formatMailerErrorResult($error);
     }

--- a/lib/Mailer/Methods/Common/BlacklistCheck.php
+++ b/lib/Mailer/Methods/Common/BlacklistCheck.php
@@ -1,15 +1,22 @@
 <?php
-namespace MailPoet\Mailer\Methods;
+namespace MailPoet\Mailer\Methods\Common;
 
 use MailPoet\Subscription\Blacklist;
 
-trait BlacklistTrait {
+class BlacklistCheck {
   /** @var Blacklist */
   private $blacklist;
 
+  public function __construct(Blacklist $blacklist = null) {
+    if (is_null($blacklist)) {
+      $blacklist = new Blacklist();
+    }
+    $this->blacklist = $blacklist;
+  }
+
   function isBlacklisted($subscriber) {
     $email = $this->getSubscriberEmailForBlacklistCheck($subscriber);
-    return $this->getBlacklist()->isBlacklisted($email);
+    return $this->blacklist->isBlacklisted($email);
   }
 
   private function getSubscriberEmailForBlacklistCheck($subscriber_string) {
@@ -18,12 +25,5 @@ trait BlacklistTrait {
       return $subscriber_string;
     }
     return $subscriber_data['email'];
-  }
-
-  private function getBlacklist() {
-    if (!$this->blacklist instanceof Blacklist) {
-      $this->blacklist = new Blacklist();
-    }
-    return $this->blacklist;
   }
 }

--- a/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -6,7 +6,6 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\SubscriberError;
 use MailPoet\Services\Bridge\API;
 use InvalidArgumentException;
-use MailPoet\Util\FreeDomains;
 use MailPoet\Util\Helpers;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/lib/Mailer/Methods/SMTP.php
+++ b/lib/Mailer/Methods/SMTP.php
@@ -2,14 +2,13 @@
 namespace MailPoet\Mailer\Methods;
 
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\SMTPMapper;
 use MailPoet\WP\Functions as WPFunctions;
 
 if (!defined('ABSPATH')) exit;
 
 class SMTP {
-  use BlacklistTrait;
-
   public $host;
   public $port;
   public $authentication;
@@ -25,6 +24,9 @@ class SMTP {
 
   /** @var SMTPMapper */
   private $error_mapper;
+
+  /** @var BlacklistCheck */
+  private $blacklist;
 
   private $wp;
 
@@ -47,10 +49,11 @@ class SMTP {
     $this->mailer_logger = new \Swift_Plugins_Loggers_ArrayLogger();
     $this->mailer->registerPlugin(new \Swift_Plugins_LoggerPlugin($this->mailer_logger));
     $this->error_mapper = $error_mapper;
+    $this->blacklist = new BlacklistCheck();
   }
 
   function send($newsletter, $subscriber, $extra_params = []) {
-    if ($this->isBlacklisted($subscriber)) {
+    if ($this->blacklist->isBlacklisted($subscriber)) {
       $error = $this->error_mapper->getBlacklistError($subscriber);
       return Mailer::formatMailerErrorResult($error);
     }

--- a/lib/Mailer/Methods/SendGrid.php
+++ b/lib/Mailer/Methods/SendGrid.php
@@ -3,14 +3,13 @@
 namespace MailPoet\Mailer\Methods;
 
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\SendGridMapper;
 use MailPoet\WP\Functions as WPFunctions;
 
 if (!defined('ABSPATH')) exit;
 
 class SendGrid {
-  use BlacklistTrait;
-
   public $url = 'https://api.sendgrid.com/api/mail.send.json';
   public $api_key;
   public $sender;
@@ -18,6 +17,9 @@ class SendGrid {
 
   /** @var SendGridMapper */
   private $error_mapper;
+
+  /** @var BlacklistCheck */
+  private $blacklist;
 
   private $wp;
 
@@ -27,10 +29,11 @@ class SendGrid {
     $this->reply_to = $reply_to;
     $this->error_mapper = $error_mapper;
     $this->wp = new WPFunctions();
+    $this->blacklist = new BlacklistCheck();
   }
 
   function send($newsletter, $subscriber, $extra_params = []) {
-    if ($this->isBlacklisted($subscriber)) {
+    if ($this->blacklist->isBlacklisted($subscriber)) {
       $error = $this->error_mapper->getBlacklistError($subscriber);
       return Mailer::formatMailerErrorResult($error);
     }

--- a/lib/Router/Endpoints/Subscription.php
+++ b/lib/Router/Endpoints/Subscription.php
@@ -21,6 +21,13 @@ class Subscription {
     'global' => AccessControl::NO_ACCESS_RESTRICTION,
   ];
 
+  /** @var UserSubscription\Pages */
+  private $subscription_pages;
+
+  function __construct(UserSubscription\Pages $subscription_pages) {
+    $this->subscription_pages = $subscription_pages;
+  }
+
   function confirm($data) {
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM, $data);
     $subscription->confirm();
@@ -36,6 +43,6 @@ class Subscription {
   }
 
   private function initSubscriptionPage($action, $data) {
-    return new UserSubscription\Pages($action, $data, true, true);
+    return $this->subscription_pages->init($action, $data, true, true);
   }
 }

--- a/lib/Services/Bridge.php
+++ b/lib/Services/Bridge.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Services;
 
-use Carbon\Carbon;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Models\Subscriber;
 use MailPoet\Services\Bridge\API;

--- a/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/lib/Subscribers/ConfirmationEmailMailer.php
@@ -4,7 +4,6 @@ namespace MailPoet\Subscribers;
 
 use Html2Text\Html2Text;
 use MailPoet\Mailer\Mailer;
-use MailPoet\Mailer\MailerError;
 use MailPoet\Models\Subscriber;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;

--- a/lib/Subscribers/NewSubscriberNotificationMailer.php
+++ b/lib/Subscribers/NewSubscriberNotificationMailer.php
@@ -5,7 +5,6 @@ use MailPoet\Config\Renderer;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
-use MailPoet\WP\Functions;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 

--- a/lib/Subscription/Comment.php
+++ b/lib/Subscription/Comment.php
@@ -1,7 +1,6 @@
 <?php
 namespace MailPoet\Subscription;
 
-use MailPoet\Models\Subscriber;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscriberActions;
 use MailPoet\WP\Functions as WPFunctions;

--- a/tests/DataFactories/Newsletter.php
+++ b/tests/DataFactories/Newsletter.php
@@ -2,7 +2,6 @@
 namespace MailPoet\Test\DataFactories;
 
 use Carbon\Carbon;
-use MailPoet\Models\Subscriber;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\NewsletterSegment;
 use MailPoet\Settings\SettingsController;

--- a/tests/DataGenerator/DataGenerator.php
+++ b/tests/DataGenerator/DataGenerator.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\DataGenerator;
 
 use Codeception\Lib\Console\Output;
-use MailPoet\Test\DataGenerator\Generators\GeneratorHelper;
 use MailPoet\Test\DataGenerator\Generators\WooCommercePastRevenues;
 
 class DataGenerator {

--- a/tests/acceptance/FreePlanAnnouncementCest.php
+++ b/tests/acceptance/FreePlanAnnouncementCest.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
-use MailPoet\Test\DataFactories\Features;
 
 class FreePlanAnnouncementCest {
   const NOTICE_SELECTOR = '[data-automation-id="free-plan-announcement"]';

--- a/tests/acceptance/SendingStatusCest.php
+++ b/tests/acceptance/SendingStatusCest.php
@@ -6,8 +6,6 @@ require_once __DIR__ . '/../DataFactories/Settings.php';
 require_once __DIR__ . '/../DataFactories/Newsletter.php';
 require_once __DIR__ . '/../DataFactories/Subscriber.php';
 
-use Codeception\Util\Locator;
-use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Subscriber;
 

--- a/tests/acceptance/StatsPageCest.php
+++ b/tests/acceptance/StatsPageCest.php
@@ -2,16 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
-use MailPoet\Test\DataFactories\NewsletterLink;
-use MailPoet\Test\DataFactories\Settings;
-use MailPoet\Test\DataFactories\StatisticsClicks;
-use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
-use MailPoet\Test\DataFactories\Subscriber;
-use MailPoet\Test\DataFactories\WooCommerceOrder;
-use MailPoet\Test\DataFactories\WooCommerceProduct;
 
 class StatsPageCest {
 

--- a/tests/acceptance/WooCommerceCustomerListCest.php
+++ b/tests/acceptance/WooCommerceCustomerListCest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\WooCommerceCustomer;
-use MailPoet\Test\DataFactories\WooCommerceOrder;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 
 class WooCommerceCustomerListCest {

--- a/tests/integration/API/JSON/v1/UserFlagsTest.php
+++ b/tests/integration/API/JSON/v1/UserFlagsTest.php
@@ -7,7 +7,6 @@ use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\v1\UserFlags;
 use MailPoet\Models\UserFlag;
 use MailPoet\Settings\UserFlagsController;
-use MailPoet\WP\Functions as WPFunctions;
 
 class UserFlagsTest extends \MailPoetTest {
 

--- a/tests/integration/Config/AccessControlTest.php
+++ b/tests/integration/Config/AccessControlTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\Config;
 
 use Codeception\Stub;
-use Codeception\Stub\Expected;
 use MailPoet\Config\AccessControl;
 use MailPoet\WP\Functions as WPFunctions;
 

--- a/tests/integration/Config/ShortcodesTest.php
+++ b/tests/integration/Config/ShortcodesTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Config;
 use Codeception\Util\Fixtures;
 use Helper\WordPress;
 use MailPoet\Config\Shortcodes;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
@@ -27,7 +28,7 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   function testItGetsArchives() {
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     WordPress::interceptFunction('apply_filters', function() use($shortcodes) {
       $args = func_get_args();
       $filter_name = array_shift($args);
@@ -65,7 +66,7 @@ class ShortcodesTest extends \MailPoetTest {
     $subscriber->wp_user_id = $wp_user->ID;
     $subscriber->save();
 
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage_subscription]');
     expect($result)->contains('form method="POST"');
@@ -77,7 +78,7 @@ class ShortcodesTest extends \MailPoetTest {
     expect((new WPFunctions)->isUserLoggedIn())->true();
     expect(Subscriber::findOne($wp_user->data->user_email))->false();
 
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage_subscription]');
     expect($result)->contains('Subscription management form is only available to mailing lists subscribers.');
@@ -87,7 +88,7 @@ class ShortcodesTest extends \MailPoetTest {
     wp_set_current_user(0);
     expect((new WPFunctions)->isUserLoggedIn())->false();
 
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage_subscription]');
     expect($result)->contains('Subscription management form is only available to mailing lists subscribers.');
@@ -102,7 +103,7 @@ class ShortcodesTest extends \MailPoetTest {
     $subscriber->wp_user_id = $wp_user->ID;
     $subscriber->save();
 
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage]');
     expect($result)->contains('Manage your subscription');
@@ -113,7 +114,7 @@ class ShortcodesTest extends \MailPoetTest {
     expect((new WPFunctions)->isUserLoggedIn())->true();
     expect(Subscriber::findOne($wp_user->data->user_email))->false();
 
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage]');
     expect($result)->contains('Link to subscription management page is only available to mailing lists subscribers.');
@@ -123,7 +124,7 @@ class ShortcodesTest extends \MailPoetTest {
     wp_set_current_user(0);
     expect((new WPFunctions)->isUserLoggedIn())->false();
 
-    $shortcodes = new Shortcodes();
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage]');
     expect($result)->contains('Link to subscription management page is only available to mailing lists subscribers.');

--- a/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -5,7 +5,7 @@ use Codeception\Stub;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\AmazonSES;
 use MailPoet\Mailer\Methods\ErrorMappers\AmazonSESMapper;
-use MailPoet\Subscription\Blacklist;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 
 class AmazonSESTest extends \MailPoetTest {
   function _before() {
@@ -237,7 +237,7 @@ class AmazonSESTest extends \MailPoetTest {
 
   function testItChecksBlacklistBeforeSending() {
     $blacklisted_subscriber = 'blacklist_test@example.com';
-    $blacklist = Stub::make(new Blacklist(), ['isBlacklisted' => true], $this);
+    $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);
     $mailer = Stub::make(
       $this->mailer,
       ['blacklist' => $blacklist, 'error_mapper' => new AmazonSESMapper()],

--- a/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -9,7 +9,7 @@ use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Mailer\Methods\MailPoet;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge\API;
-use MailPoet\Subscription\Blacklist;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 
 class MailPoetAPITest extends \MailPoetTest {
   function _before() {
@@ -259,7 +259,7 @@ class MailPoetAPITest extends \MailPoetTest {
 
   function testItChecksBlacklistBeforeSendingToASingleSubscriber() {
     $blacklisted_subscriber = 'blacklist_test@example.com';
-    $blacklist = Stub::make(new Blacklist(), ['isBlacklisted' => true], $this);
+    $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);
     $mailer = Stub::make(
       $this->mailer,
       [
@@ -285,7 +285,7 @@ class MailPoetAPITest extends \MailPoetTest {
 
   function testItChecksBlacklistBeforeSendingToMultipleSubscribers() {
     $blacklisted_subscriber = 'blacklist_test@example.com';
-    $blacklist = Stub::make(new Blacklist(), ['isBlacklisted' => true], $this);
+    $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);
     $mailer = Stub::make(
       $this->mailer,
       [

--- a/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -5,7 +5,7 @@ use Codeception\Stub;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\ErrorMappers\PHPMailMapper;
 use MailPoet\Mailer\Methods\PHPMail;
-use MailPoet\Subscription\Blacklist;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 
 class PHPMailTest extends \MailPoetTest {
   function _before() {
@@ -117,7 +117,7 @@ class PHPMailTest extends \MailPoetTest {
 
   function testItChecksBlacklistBeforeSending() {
     $blacklisted_subscriber = 'blacklist_test@example.com';
-    $blacklist = Stub::make(new Blacklist(), ['isBlacklisted' => true], $this);
+    $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);
     $mailer = Stub::make(
       $this->mailer,
       ['blacklist' => $blacklist, 'error_mapper' => new PHPMailMapper()],

--- a/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/tests/integration/Mailer/Methods/SMTPTest.php
@@ -5,7 +5,7 @@ use Codeception\Stub;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\ErrorMappers\SMTPMapper;
 use MailPoet\Mailer\Methods\SMTP;
-use MailPoet\Subscription\Blacklist;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SMTPTest extends \MailPoetTest {
@@ -176,7 +176,7 @@ class SMTPTest extends \MailPoetTest {
 
   function testItChecksBlacklistBeforeSending() {
     $blacklisted_subscriber = 'blacklist_test@example.com';
-    $blacklist = Stub::make(new Blacklist(), ['isBlacklisted' => true], $this);
+    $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);
     $mailer = Stub::make(
       $this->mailer,
       ['blacklist' => $blacklist, 'error_mapper' => new SMTPMapper()],

--- a/tests/integration/Mailer/Methods/SendGridTest.php
+++ b/tests/integration/Mailer/Methods/SendGridTest.php
@@ -5,7 +5,7 @@ use Codeception\Stub;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\ErrorMappers\SendGridMapper;
 use MailPoet\Mailer\Methods\SendGrid;
-use MailPoet\Subscription\Blacklist;
+use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 
 class SendGridTest extends \MailPoetTest {
   function _before() {
@@ -87,7 +87,7 @@ class SendGridTest extends \MailPoetTest {
 
   function testItChecksBlacklistBeforeSending() {
     $blacklisted_subscriber = 'blacklist_test@example.com';
-    $blacklist = Stub::make(new Blacklist(), ['isBlacklisted' => true], $this);
+    $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);
     $mailer = Stub::make(
       $this->mailer,
       ['blacklist' => $blacklist, 'error_mapper' => new SendGridMapper()],

--- a/tests/integration/Router/Endpoints/SubscriptionTest.php
+++ b/tests/integration/Router/Endpoints/SubscriptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MailPoet\Test\Router\Endpoints;
+
+use Codeception\Stub;
+use Codeception\Stub\Expected;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Router\Endpoints\Subscription;
+use MailPoet\Subscription\Pages;
+use MailPoet\WP\Functions as WPFunctions;
+
+class SubscriptionTest extends \MailPoetTest {
+  function _before() {
+    $this->data = [];
+    // instantiate class
+    $this->subscription = ContainerWrapper::getInstance()->get(Subscription::class);
+  }
+
+  function testItDisplaysConfirmPage() {
+    $pages = Stub::make(Pages::class, [
+      'wp' => new WPFunctions,
+      'confirm' => Expected::exactly(1),
+    ], $this);
+    $subscription = new Subscription($pages);
+    $subscription->confirm($this->data);
+  }
+
+  function testItDisplaysManagePage() {
+    $pages = Stub::make(Pages::class, [
+      'wp' => new WPFunctions,
+      'getManageLink' => Expected::exactly(1),
+      'getManageContent' => Expected::exactly(1),
+    ], $this);
+    $subscription = new Subscription($pages);
+    $subscription->manage($this->data);
+    do_shortcode('[mailpoet_manage]');
+    do_shortcode('[mailpoet_manage_subscription]');
+  }
+
+  function testItDisplaysUnsubscribePage() {
+    $pages = Stub::make(Pages::class, [
+      'wp' => new WPFunctions,
+      'unsubscribe' => Expected::exactly(1),
+    ], $this);
+    $subscription = new Subscription($pages);
+    $subscription->unsubscribe($this->data);
+  }
+}

--- a/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -13,7 +13,6 @@ use MailPoet\Tasks\Sending;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use PHPUnit_Framework_MockObject_MockObject;
 use WC_Order;
-use function MailPoet\Util\array_column;
 
 class WooCommercePurchasesTest extends \MailPoetTest {
   /** @var Subscriber */

--- a/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -9,7 +9,6 @@ use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Services\AuthorizedEmailsController;
-use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 

--- a/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
+++ b/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
@@ -9,7 +9,6 @@ use MailPoet\Models\Segment;
 use MailPoet\Models\Setting;
 use MailPoet\Models\Subscriber;
 
-use MailPoet\WP\Functions;
 use MailPoet\Settings\SettingsController;
 
 class NewSubscriberNotificationMailerTest extends \MailPoetTest {

--- a/tests/integration/WP/FunctionsTest.php
+++ b/tests/integration/WP/FunctionsTest.php
@@ -2,7 +2,6 @@
 namespace MailPoet\Test\WP;
 
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoet\Config\Env;
 
 class FunctionsTest extends \MailPoetTest {
   function _before() {

--- a/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Test\Mailer\Methods\ErrorMappers;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Services\Bridge\API;
-use MailPoet\Util\Helpers;
 
 class MailPoetMapperTest extends \MailPoetUnitTest {
   /** @var MailPoetMapper */


### PR DESCRIPTION
The `Subscription\Pages` constructor via the `getSubscriber` method called WP functions which weren't loaded yet during DI initialization, so I have moved this class initialization to an `init` method.