### PR TITLE
Make header line in CSV optional in subscribers import [MAILPOET-2225]

### DIFF
--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/match_table.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/match_table.jsx
@@ -30,7 +30,6 @@ function ColumnDataMatch({ header, subscribers }) {
   );
 }
 ColumnDataMatch.propTypes = {
-  header: PropTypes.arrayOf(PropTypes.string).isRequired,
   subscribers: PropTypes.arrayOf( // all subscribers
     PropTypes.arrayOf( // single subscribers
       PropTypes.oneOfType( // properties of a subscriber
@@ -38,6 +37,11 @@ ColumnDataMatch.propTypes = {
       )
     )
   ).isRequired,
+  header: PropTypes.arrayOf(PropTypes.string),
+};
+
+ColumnDataMatch.defaultProps = {
+  header: [],
 };
 
 function Header({ header }) {
@@ -132,7 +136,7 @@ function MatchTable({
           <ColumnDataMatch header={header} subscribers={subscribers} />
         </thead>
         <tbody>
-          <Header header={header} />
+          {header ? <Header header={header} /> : null}
           <Subscribers subscribers={subscribers} subscribersCount={subscribersCount} />
         </tbody>
       </table>


### PR DESCRIPTION
I compared version before and after refactor and fixed a behaviour so that it works same way as it worked before the changes introduced in refactor.

Before refactor we were able to process CSV without first row containing column names.

Importing with column names:
![Screen Shot 2019-07-29 at 2 10 52 PM](https://user-images.githubusercontent.com/1082140/62049167-f159ef00-b20e-11e9-9711-3aefad73ef0d.png)
Importing without column names (this one was broken):
![Screen Shot 2019-07-29 at 2 11 25 PM](https://user-images.githubusercontent.com/1082140/62049168-f159ef00-b20e-11e9-93a3-fa75aa62919d.png)
