### PR TITLE
Fix stats notification scheduling after sending a post notification [MAILPOET-2231]

### DIFF
--- a/lib/Cron/Workers/StatsNotifications/Scheduler.php
+++ b/lib/Cron/Workers/StatsNotifications/Scheduler.php
@@ -19,6 +19,11 @@ class Scheduler {
   /** @var SettingsController */
   private $settings;
 
+  private $supported_types = [
+    Newsletter::TYPE_NOTIFICATION_HISTORY,
+    Newsletter::TYPE_STANDARD,
+  ];
+
   function __construct(SettingsController $settings) {
     $this->settings = $settings;
   }
@@ -47,7 +52,7 @@ class Scheduler {
     if ($this->isTaskScheduled($newsletter->id)) {
       return false;
     }
-    if (($newsletter->type !== Newsletter::TYPE_NOTIFICATION) && ($newsletter->type !== Newsletter::TYPE_STANDARD)) {
+    if (!in_array($newsletter->type, $this->supported_types)) {
       return false;
     }
     return true;

--- a/tests/integration/Cron/Workers/StatsNotifications/SchedulerTest.php
+++ b/tests/integration/Cron/Workers/StatsNotifications/SchedulerTest.php
@@ -36,6 +36,16 @@ class SchedulerTest extends \MailPoetTest {
     expect($task)->isInstanceOf(ScheduledTask::class);
   }
 
+  function testShouldScheduleForNotificationHistory() {
+    $newsletter_id = 4;
+    $newsletter = Newsletter::createOrUpdate(['id' => $newsletter_id, 'type' => Newsletter::TYPE_NOTIFICATION_HISTORY]);
+    $this->stats_notifications->schedule($newsletter);
+    $notification = StatsNotification::where('newsletter_id', $newsletter_id)->findOne();
+    expect($notification)->isInstanceOf(StatsNotification::class);
+    $task = ScheduledTask::where('id', $notification->task_id)->findOne();
+    expect($task)->isInstanceOf(ScheduledTask::class);
+  }
+
   function testShouldNotScheduleIfTrackingIsDisabled() {
     $this->settings->set('tracking.enabled', false);
     $newsletter_id = 13;


### PR DESCRIPTION
The problem was that we don't not actually send `notification` emails but we create and send `notification_history` emails.