### PR TITLE
Add fixes for cron CPU usage on SiteGround [MAILPOET-2181] [MAILPOET-2202]

### DIFF
--- a/lib/API/JSON/v1/SendingQueue.php
+++ b/lib/API/JSON/v1/SendingQueue.php
@@ -5,6 +5,7 @@ namespace MailPoet\API\JSON\v1;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\Config\AccessControl;
+use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\SendingQueue as SendingQueueModel;
 use MailPoet\Newsletter\Scheduler\Scheduler;
@@ -66,6 +67,8 @@ class SendingQueue extends APIEndpoint {
       $queue = SendingTask::create();
       $queue->newsletter_id = $newsletter->id;
     }
+
+    WordPress::resetRunInterval();
 
     if ((bool)$newsletter->isScheduled) {
       // set newsletter status

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -130,6 +130,7 @@ class Migrator {
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'deleted_at timestamp NULL,',
+      'reschedule_count int(11) NOT NULL DEFAULT 0,',
       'meta longtext,',
       'PRIMARY KEY  (id),',
       'KEY type (type),',

--- a/lib/Cron/Triggers/WordPress.php
+++ b/lib/Cron/Triggers/WordPress.php
@@ -26,12 +26,36 @@ if (!defined('ABSPATH')) exit;
 class WordPress {
   const SCHEDULED_IN_THE_PAST = 'past';
   const SCHEDULED_IN_THE_FUTURE = 'future';
+
+  const RUN_INTERVAL = 10; // seconds
+  const LAST_RUN_AT_SETTING = 'cron_trigger_wordpress.last_run_at';
+
   static private $tasks_counts;
 
   static function run() {
+    if (!self::checkRunInterval()) {
+      return false;
+    }
     return (self::checkExecutionRequirements()) ?
       MailPoet::run() :
       self::stop();
+  }
+
+  private static function checkRunInterval() {
+    $settings = new SettingsController();
+    $last_run_at = (int)$settings->get(self::LAST_RUN_AT_SETTING, 0);
+    $run_interval = WPFunctions::get()->applyFilters('mailpoet_cron_trigger_wordpress_run_interval', self::RUN_INTERVAL);
+    $run_interval_elapsed = (time() - $last_run_at) >= $run_interval;
+    if ($run_interval_elapsed) {
+      $settings->set(self::LAST_RUN_AT_SETTING, time());
+      return true;
+    }
+    return false;
+  }
+
+  static function resetRunInterval() {
+    $settings = new SettingsController();
+    $settings->set(self::LAST_RUN_AT_SETTING, 0);
   }
 
   static function checkExecutionRequirements(WPFunctions $wp = null) {

--- a/lib/Cron/Workers/KeyCheck/KeyCheckWorker.php
+++ b/lib/Cron/Workers/KeyCheck/KeyCheckWorker.php
@@ -8,8 +8,6 @@ use MailPoet\Services\Bridge;
 if (!defined('ABSPATH')) exit;
 
 abstract class KeyCheckWorker extends SimpleWorker {
-  const UNAVAILABLE_SERVICE_RESCHEDULE_TIMEOUT = 60;
-
   public $bridge;
 
   function init() {
@@ -26,7 +24,7 @@ abstract class KeyCheckWorker extends SimpleWorker {
     }
 
     if (empty($result['code']) || $result['code'] == Bridge::CHECK_ERROR_UNAVAILABLE) {
-      $this->reschedule($task, self::UNAVAILABLE_SERVICE_RESCHEDULE_TIMEOUT);
+      $task->rescheduleProgressively();
       return false;
     }
 

--- a/lib/Cron/Workers/SimpleWorker.php
+++ b/lib/Cron/Workers/SimpleWorker.php
@@ -50,11 +50,19 @@ abstract class SimpleWorker {
       return false;
     }
 
-    foreach ($scheduled_tasks as $i => $task) {
-      $this->prepareTask($task);
-    }
-    foreach ($running_tasks as $i => $task) {
-      $this->processTask($task);
+    $task = null;
+    try {
+      foreach ($scheduled_tasks as $i => $task) {
+        $this->prepareTask($task);
+      }
+      foreach ($running_tasks as $i => $task) {
+        $this->processTask($task);
+      }
+    } catch (\Exception $e) {
+      if ($task) {
+        $task->rescheduleProgressively();
+      }
+      throw $e;
     }
 
     return true;

--- a/lib/Cron/Workers/WooCommerceSync.php
+++ b/lib/Cron/Workers/WooCommerceSync.php
@@ -49,7 +49,13 @@ class WooCommerceSync extends SimpleWorker {
     $task->meta = ['in_progress' => true];
     $task->save();
 
-    $this->woocommerce_segment->synchronizeCustomers();
+    try {
+      $this->woocommerce_segment->synchronizeCustomers();
+    } catch (\Exception $e) {
+      $task->meta = null;
+      $task->save();
+      throw $e;
+    }
 
     return true;
   }

--- a/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
+++ b/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
@@ -35,11 +35,14 @@ class KeyCheckWorkerTest extends \MailPoetTest {
         'checkKey' => function () {
           throw new \Exception;
         },
-        'reschedule' => Expected::once(),
       ],
       $this
     );
-    $task = $this->createRunningTask();
+    $task = Stub::make(
+      ScheduledTask::class,
+      ['rescheduleProgressively' => Expected::once()],
+      $this
+    );
     $result = $worker->processTaskStrategy($task);
     expect($result)->false();
   }
@@ -49,11 +52,14 @@ class KeyCheckWorkerTest extends \MailPoetTest {
       $this->worker,
       [
         'checkKey' => ['code' => Bridge::CHECK_ERROR_UNAVAILABLE],
-        'reschedule' => Expected::once(),
       ],
       $this
     );
-    $task = $this->createRunningTask();
+    $task = Stub::make(
+      ScheduledTask::class,
+      ['rescheduleProgressively' => Expected::once()],
+      $this
+    );
     $result = $worker->processTaskStrategy($task);
     expect($result)->false();
   }

--- a/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/tests/integration/Cron/Workers/SchedulerTest.php
@@ -21,10 +21,6 @@ use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Tasks\Sending as SendingTask;
 
 class SchedulerTest extends \MailPoetTest {
-  function testItDefinesConstants() {
-    expect(Scheduler::UNCONFIRMED_SUBSCRIBER_RESCHEDULE_TIMEOUT)->equals(5);
-  }
-
   function testItConstructs() {
     $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class));
     expect($scheduler->timer)->greaterOrEquals(5);
@@ -329,7 +325,7 @@ class SchedulerTest extends \MailPoetTest {
     $updated_queue = SendingTask::createFromQueue(SendingQueue::findOne($queue->id));
     expect(Carbon::parse($updated_queue->scheduled_at))->equals(
       Carbon::createFromTimestamp(current_time('timestamp'))
-        ->addMinutes(Scheduler::UNCONFIRMED_SUBSCRIBER_RESCHEDULE_TIMEOUT)
+        ->addMinutes(ScheduledTask::BASIC_RESCHEDULE_TIMEOUT)
     );
   }
 

--- a/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -42,6 +42,20 @@ class WooCommerceSyncTest extends \MailPoetTest {
     expect($task->getMeta())->notEmpty();
   }
 
+  function testItWillResetTheInProgressFlagOnFail() {
+    $task = $this->createScheduledTask();
+    $this->woocommerce_segment->expects($this->once())
+      ->method('synchronizeCustomers')
+      ->willThrowException(new \Exception('test error'));
+    try {
+      $this->worker->processTaskStrategy($task);
+      $this->fail('An exception should be thrown');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('test error');
+      expect($task->getMeta())->isEmpty();
+    }
+  }
+
   function testItWillRescheduleTaskIfItIsRunningForTooLong() {
     $this->woocommerce_segment->expects($this->once())
       ->method('synchronizeCustomers');


### PR DESCRIPTION
Changes in this PR:

1. WordPress cron trigger now runs no often than once per 10 seconds (customizable with the `mailpoet_cron_trigger_wordpress_run_interval` hook). This is more to shave off the load during peaks of traffic. Still, any delay may not be acceptable in some cases such as immediate newsletter sending, so I've introduced the `resetRunInterval` method which has an effect of triggering cron immedately on the next request like it was before, the method should be called on certain events, e.g. when a user adds a sending job.
2. A mechanism for rescheduling tasks progressively is introduced. Depending on the `reschedule_count` task property each rescheduling will be set from 5 minutes to 24 hours in the future. All tasks that are descendants of `SimpleWorker` will be rescheduled if they throw exceptions during processing. Also special cases that previously employed fixed-interval rescheduling (MSS/Premium key validation errors and sending welcome emails to unconfirmed users) now feature progressive rescheduling. Some tasks are not rescheduled: stats notification worker has logic that marks the task complete even if it throws an exception, and sending queue worker has own error handling.
3. If the WP sync task fails (throws an exception), its `in_progress` flag is cleared allowing it to be progressively rescheduled on next runs by the above mechanism.
4. If cron works under WP cron trigger, it can now deactivate itself without waiting for the next trigger by a visitor. This can reduce CPU time usage by an idle cron process on very low-traffic sites, but this can also cause more delays in scheduling, so for now this option is disabled by default an can be enabled using the `mailpoet_cron_enable_self_deactivation` hook.

Essential fixes are 2 and 3, the other two are more experimental.