### PR TITLE
Don't auto refresh listings besides Emails [MAILPOET-2191]

### DIFF
--- a/assets/js/src/listing/listing.jsx
+++ b/assets/js/src/listing/listing.jsx
@@ -56,7 +56,7 @@ class Listing extends React.Component {
     limit: 10,
     sort_by: null,
     sort_order: undefined,
-    auto_refresh: true,
+    auto_refresh: false,
     location: undefined,
     base_url: '',
     type: undefined,


### PR DESCRIPTION
I just switched the default value of `auto_refresh` to `false`. All email listings already have `auto_refresh` set to `true`.