### PR TITLE
i18n: merge similar translations strings

### DIFF
--- a/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
@@ -113,7 +113,7 @@ class NewsletterBlank12Column {
                     "type" => "image",
                     "link" => "",
                     "src" => $this->template_image_url . "/fake-logo.png",
-                    "alt" => WPFunctions::get()->__("Fake Logo", 'mailpoet'),
+                    "alt" => WPFunctions::get()->__("Fake logo", 'mailpoet'),
                     "fullWidth" => false,
                     "width" => "598px",
                     "height" => "71px",


### PR DESCRIPTION
"Fake logo" is used 6 times, "Fake Logo" (capital L) only one time.

See this:
https://translate.wordpress.org/projects/wp-plugins/mailpoet/stable/he/default/?filters%5Bterm%5D=Fake&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=original&sort%5Bhow%5D=asc

This PR merges two similar translations strings to reduce the total number of strings.