### PR TITLE
i18n: avoid using HTML tags in translation strings

### DIFF
--- a/lib/Config/PopulatorData/Templates/NewsletterBlank121Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank121Column.php
@@ -163,7 +163,7 @@ class NewsletterBlank121Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h2>'.__('This template has...', 'mailpoet').'</h2>',
+                    "text" => '<h2>' . WPFunctions::get()->__('This template has...', 'mailpoet') . '</h2>',
                   ],
                   [
                     "type" => "text",
@@ -182,11 +182,11 @@ class NewsletterBlank121Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h2>'.__('... a 2-column layout.', 'mailpoet').'</h2>',
+                    "text" => '<h2>' . WPFunctions::get()->__('... a 2-column layout.', 'mailpoet') . '</h2>',
                   ],
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<p>'.__("You can change a layout's background color by clicking on the settings icon on the right edge of the Designer. Simply hover over this area to see the Settings (gear) icon.", 'mailpoet').'</p>',
+                    "text" => '<p>' . WPFunctions::get()->__("You can change a layout's background color by clicking on the settings icon on the right edge of the Designer. Simply hover over this area to see the Settings (gear) icon.", 'mailpoet') . '</p>',
                   ],
                 ],
               ],

--- a/lib/Config/PopulatorData/Templates/NewsletterBlank121Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank121Column.php
@@ -163,7 +163,7 @@ class NewsletterBlank121Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h2>This template has...</h2>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h2>'.__('This template has...', 'mailpoet').'</h2>',
                   ],
                   [
                     "type" => "text",
@@ -182,11 +182,11 @@ class NewsletterBlank121Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h2>... a 2-column layout.</h2>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h2>'.__('... a 2-column layout.', 'mailpoet').'</h2>',
                   ],
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<p>You can change a layout's background color by clicking on the settings icon on the right edge of the Designer. Simply hover over this area to see the Settings (gear) icon.</p>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<p>'.__("You can change a layout's background color by clicking on the settings icon on the right edge of the Designer. Simply hover over this area to see the Settings (gear) icon.", 'mailpoet').'</p>',
                   ],
                 ],
               ],

--- a/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
@@ -163,7 +163,7 @@ class NewsletterBlank12Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h2>'.__('This template has...', 'mailpoet').'</h2>',
+                    "text" => '<h2>' . WPFunctions::get()->__('This template has...', 'mailpoet') . '</h2>',
                   ],
                   [
                     "type" => "text",
@@ -182,7 +182,7 @@ class NewsletterBlank12Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h2>'.__('... a 2-column layout.', 'mailpoet').'</h2>',
+                    "text" => '<h2>' . WPFunctions::get()->__('... a 2-column layout.', 'mailpoet') . '</h2>',
                   ],
                   [
                     "type" => "text",

--- a/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
@@ -163,7 +163,7 @@ class NewsletterBlank12Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h2>This template has...</h2>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h2>'.__('This template has...', 'mailpoet').'</h2>',
                   ],
                   [
                     "type" => "text",
@@ -182,7 +182,7 @@ class NewsletterBlank12Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h2>... a 2-column layout.</h2>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h2>'.__('... a 2-column layout.', 'mailpoet').'</h2>',
                   ],
                   [
                     "type" => "text",

--- a/lib/Config/PopulatorData/Templates/NewsletterBlank13Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank13Column.php
@@ -163,11 +163,11 @@ class NewsletterBlank13Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h3>'.__('This template...', 'mailpoet').'</h3>',
+                    "text" => '<h3>' . WPFunctions::get()->__('This template...', 'mailpoet') . '</h3>',
                   ],
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<p>'.__('In the right sidebar, you can add layout blocks to your newsletter.', 'mailpoet').'</p>',
+                    "text" => '<p>' . WPFunctions::get()->__('In the right sidebar, you can add layout blocks to your newsletter.', 'mailpoet') . '</p>',
                   ],
                 ],
               ],
@@ -182,7 +182,7 @@ class NewsletterBlank13Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h3>'.__('... has a...', 'mailpoet').'</h3>',
+                    "text" => '<h3>' . WPFunctions::get()->__('... has a...', 'mailpoet') . '</h3>',
                   ],
                   [
                     "type" => "text",
@@ -201,11 +201,11 @@ class NewsletterBlank13Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<h3>'.__('3-column layout.', 'mailpoet').'</h3>',
+                    "text" => '<h3>' . WPFunctions::get()->__('3-column layout.', 'mailpoet') . '</h3>',
                   ],
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->'<p>'.__('You can add as many layout blocks as you want!', 'mailpoet').'</p>',
+                    "text" => '<p>' . WPFunctions::get()->__('You can add as many layout blocks as you want!', 'mailpoet') . '</p>',
                   ],
                   [
                     "type" => "text",

--- a/lib/Config/PopulatorData/Templates/NewsletterBlank13Column.php
+++ b/lib/Config/PopulatorData/Templates/NewsletterBlank13Column.php
@@ -163,11 +163,11 @@ class NewsletterBlank13Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h3>This template... </h3>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h3>'.__('This template...', 'mailpoet').'</h3>',
                   ],
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<p>In the right sidebar, you can add layout blocks to your newsletter.</p>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<p>'.__('In the right sidebar, you can add layout blocks to your newsletter.', 'mailpoet').'</p>',
                   ],
                 ],
               ],
@@ -182,7 +182,7 @@ class NewsletterBlank13Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h3>... has a... </h3>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h3>'.__('... has a...', 'mailpoet').'</h3>',
                   ],
                   [
                     "type" => "text",
@@ -201,11 +201,11 @@ class NewsletterBlank13Column {
                 "blocks" => [
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<h3>3-column layout.</h3>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<h3>'.__('3-column layout.', 'mailpoet').'</h3>',
                   ],
                   [
                     "type" => "text",
-                    "text" => WPFunctions::get()->__("<p>You can add as many layout blocks as you want!</p>", 'mailpoet'),
+                    "text" => WPFunctions::get()->'<p>'.__('You can add as many layout blocks as you want!', 'mailpoet').'</p>',
                   ],
                   [
                     "type" => "text",


### PR DESCRIPTION
The HTML tags `<h2>`, `<h3>` and `<p>` should be removed from the translation strings.

**Why?**

1. We did the same in WordPress core.

2. If the HTML tag is inside the translation string, the translator can accidentally change it from `<h2>` to let's say `<h1>`, or even worse, to forget to properly close the tag and break the code.

3. In RTL languages it's hard to translate strings with HTML code inside. The string is in RTL but the HTML tags are LTR. Very hard to translate this way.

**The Solution**

The best practice is to avoid using HTML tags in translation strings if possible.