### PR TITLE
i18n: merge two similar translation strings

### DIFF
--- a/lib/Config/PrivacyPolicy.php
+++ b/lib/Config/PrivacyPolicy.php
@@ -48,14 +48,14 @@ class PrivacyPolicy {
         '<p>' .
         WPFunctions::get()->__('Cookie name: mailpoet_revenue_tracking', 'mailpoet') .
         '<br>' .
-        WPFunctions::get()->__('Cookie expiry: 14 days.', 'mailpoet') .
+        WPFunctions::get()->sprintf( __('Cookie expiry: % days.', 'mailpoet'), '14' ) .
         '<br>' .
         WPFunctions::get()->__('Cookie description: The purpose of this cookie is to track which newsletter sent from your website has acquired a click-through and a subsequent purchase in your WooCommerce store.', 'mailpoet') .
         '</p> ' .
         '<p>' .
         WPFunctions::get()->__('Cookie name: mailpoet_abandoned_cart_tracking', 'mailpoet') .
         '<br>' .
-        WPFunctions::get()->__('Cookie expiry: 3,650 days.', 'mailpoet') .
+        WPFunctions::get()->sprintf( __('Cookie expiry: %s days.', 'mailpoet'), '3,650' ) .
         '<br>' .
         WPFunctions::get()->__('Cookie description: The purpose of this cookie is to track a user that has abandoned their cart in your WooCommerce store to then be able to send them an abandoned cart newsletter from MailPoet. <br>', 'mailpoet') .
         '<br>' .


### PR DESCRIPTION
This PR merges two similar translation strings, the same way we do it in WordPress Core - using `sprintf()` function and `%s` placeholder.

**Old Strings:**

* `Cookie expiry: 14 days.`
* `Cookie expiry: 3,650 days.`

**New String:**

* `Cookie expiry: % days.`

**Note:**

* The `%s` placeholder makes sure the translator won't accidentally change the value while translating the string. 