### PR TITLE
i18n: Avoid using HTML tags in translation strings

### DIFF
--- a/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -95,7 +95,7 @@ class MailPoetMapper {
   private function getUnauthorizedEmailMessage($sender, $newsletter) {
     $email = $sender ? $sender['from_email'] : null;
     $message = '<p>';
-    $message .= sprintf(WPFunctions::get()->__('The MailPoet Sending Service did not send your latest email because the address <i>%s</i> is not yet authorized.', 'mailpoet'), $email ?: WPFunctions::get()->__('Unknown address'));
+    $message .= sprintf(WPFunctions::get()->__('The MailPoet Sending Service did not send your latest email because the address %s is not yet authorized.', 'mailpoet'), $email ?: '<i>' . WPFunctions::get()->__('Unknown address') . '</i>' );
     $message .= '</p><p>';
     $message .= Helpers::replaceLinkTags(
       WPFunctions::get()->__('[link]Authorize your email in your account now.[/link]', 'mailpoet'),


### PR DESCRIPTION
Replace `<i>%s</i>` with a simple `%s`. Move the HTML tags outside the strings, to `sprintf()` parameter.

Why?

In RTL languages it's hard to translate strings with HTML code inside. The string is in RTL but the HTML tags are LTR. Very hard to translate this way.

Besides, this is WordPress core codding standard.