### PR TITLE
Send meta to mss [MAILPOET-2333]

### DIFF
--- a/lib/API/JSON/v1/Mailer.php
+++ b/lib/API/JSON/v1/Mailer.php
@@ -6,6 +6,7 @@ use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\Config\AccessControl;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -22,14 +23,18 @@ class Mailer extends APIEndpoint {
   /** @var SettingsController */
   private $settings;
 
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
   public $permissions = [
     'global' => AccessControl::PERMISSION_MANAGE_EMAILS,
   ];
 
-  function __construct(AuthorizedEmailsController $authorized_emails_controller, SettingsController $settings, Bridge $bridge) {
+  function __construct(AuthorizedEmailsController $authorized_emails_controller, SettingsController $settings, Bridge $bridge, MetaInfo $mailerMetaInfo) {
     $this->authorized_emails_controller = $authorized_emails_controller;
     $this->settings = $settings;
     $this->bridge = $bridge;
+    $this->mailerMetaInfo = $mailerMetaInfo;
   }
 
   function send($data = []) {
@@ -40,7 +45,10 @@ class Mailer extends APIEndpoint {
         (isset($data['sender'])) ? $data['sender'] : false,
         (isset($data['reply_to'])) ? $data['reply_to'] : false
       );
-      $result = $mailer->send($data['newsletter'], $data['subscriber']);
+      $extra_params = [
+        'meta' => $this->mailerMetaInfo->getSendingTestMetaInfo(),
+      ];
+      $result = $mailer->send($data['newsletter'], $data['subscriber'], $extra_params);
     } catch (\Exception $e) {
       return $this->errorResponse([
         $e->getCode() => $e->getMessage(),

--- a/lib/API/JSON/v1/Mailer.php
+++ b/lib/API/JSON/v1/Mailer.php
@@ -45,6 +45,7 @@ class Mailer extends APIEndpoint {
         (isset($data['sender'])) ? $data['sender'] : false,
         (isset($data['reply_to'])) ? $data['reply_to'] : false
       );
+      // report this as 'sending_test' in metadata since this endpoint is only used to test sending methods for now
       $extra_params = [
         'meta' => $this->mailerMetaInfo->getSendingTestMetaInfo(),
       ];

--- a/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -18,6 +18,8 @@ use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Tasks\Subscribers\BatchIterator;
 use MailPoet\WP\Functions as WPFunctions;
 
+use function MailPoet\Util\array_column;
+
 class SendingQueue {
   public $mailer_task;
   public $newsletter_task;

--- a/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -9,6 +9,7 @@ use MailPoet\Cron\Workers\StatsNotifications\Scheduler as StatsNotificationsSche
 use MailPoet\Logging\Logger;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\ScheduledTask as ScheduledTaskModel;
 use MailPoet\Models\StatisticsNewsletters as StatisticsNewslettersModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
@@ -31,12 +32,16 @@ class SendingQueue {
   /** @var SendingErrorHandler */
   private $error_handler;
 
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
   function __construct(SendingErrorHandler $error_handler, StatsNotificationsScheduler $stats_notifications_scheduler, $timer = false, $mailer_task = false, $newsletter_task = false) {
     $this->error_handler = $error_handler;
     $this->stats_notifications_scheduler = $stats_notifications_scheduler;
     $this->mailer_task = ($mailer_task) ? $mailer_task : new MailerTask();
     $this->newsletter_task = ($newsletter_task) ? $newsletter_task : new NewsletterTask();
     $this->timer = ($timer) ? $timer : microtime(true);
+    $this->mailerMetaInfo = new MetaInfo;
     $wp = new WPFunctions;
     $this->batch_size = $wp->applyFilters('mailpoet_cron_worker_sending_queue_batch_size', self::BATCH_SIZE);
   }
@@ -67,6 +72,11 @@ class SendingQueue {
       }
       // clone the original object to be used for processing
       $_newsletter = (object)$newsletter->asArray();
+      $options = $newsletter->options()->findMany();
+      if (!empty($options)) {
+        $options = array_column($options, 'value', 'name');
+      }
+      $_newsletter->options = $options;
       // configure mailer
       $this->mailer_task->configureMailer($newsletter);
       // get newsletter segments
@@ -138,6 +148,7 @@ class SendingQueue {
     $prepared_subscribers_ids = [];
     $unsubscribe_urls = [];
     $statistics = [];
+    $metas = [];
     foreach ($subscribers as $subscriber) {
       // render shortcodes and replace subscriber data in tracked links
       $prepared_newsletters[] =
@@ -153,6 +164,7 @@ class SendingQueue {
       $prepared_subscribers_ids[] = $subscriber->id;
       // save personalized unsubsribe link
       $unsubscribe_urls[] = Links::getUnsubscribeUrl($queue, $subscriber->id);
+      $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriber);
       // keep track of values for statistics purposes
       $statistics[] = [
         'newsletter_id' => $newsletter->id,
@@ -166,7 +178,7 @@ class SendingQueue {
           $prepared_newsletters[0],
           $prepared_subscribers[0],
           $statistics[0],
-          ['unsubscribe_url' => $unsubscribe_urls[0]]
+          ['unsubscribe_url' => $unsubscribe_urls[0], 'meta' => $metas[0]]
         );
         $prepared_newsletters = [];
         $prepared_subscribers = [];
@@ -182,7 +194,7 @@ class SendingQueue {
         $prepared_newsletters,
         $prepared_subscribers,
         $statistics,
-        ['unsubscribe_url' => $unsubscribe_urls]
+        ['unsubscribe_url' => $unsubscribe_urls, 'meta' => $metas]
       );
     }
     return $queue;

--- a/lib/Cron/Workers/WorkersFactory.php
+++ b/lib/Cron/Workers/WorkersFactory.php
@@ -20,6 +20,7 @@ use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Statistics\Track\WooCommercePurchases;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\InactiveSubscribersController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -61,6 +62,9 @@ class WorkersFactory {
   /** @var SubscribersFinder */
   private $subscribers_finder;
 
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
   public function __construct(
     SendingErrorHandler $sending_error_handler,
     StatsNotificationScheduler $statsNotificationsScheduler,
@@ -72,7 +76,8 @@ class WorkersFactory {
     WooCommerceHelper $woocommerce_helper,
     WooCommercePurchases $woocommerce_purchases,
     AuthorizedEmailsController $authorized_emails_controller,
-    SubscribersFinder $subscribers_finder
+    SubscribersFinder $subscribers_finder,
+    MetaInfo $mailerMetaInfo
   ) {
     $this->sending_error_handler = $sending_error_handler;
     $this->statsNotificationsScheduler = $statsNotificationsScheduler;
@@ -85,6 +90,7 @@ class WorkersFactory {
     $this->woocommerce_purchases = $woocommerce_purchases;
     $this->authorized_emails_controller = $authorized_emails_controller;
     $this->subscribers_finder = $subscribers_finder;
+    $this->mailerMetaInfo = $mailerMetaInfo;
   }
 
   /** @return SchedulerWorker */
@@ -99,12 +105,12 @@ class WorkersFactory {
 
   /** @return StatsNotificationsWorker */
   function createStatsNotificationsWorker($timer) {
-    return new StatsNotificationsWorker($this->mailer, $this->renderer, $this->settings, $this->woocommerce_helper, $timer);
+    return new StatsNotificationsWorker($this->mailer, $this->renderer, $this->settings, $this->woocommerce_helper, $this->mailerMetaInfo, $timer);
   }
 
   /** @return StatsNotificationsWorkerForAutomatedEmails */
   function createStatsNotificationsWorkerForAutomatedEmails($timer) {
-    return new StatsNotificationsWorkerForAutomatedEmails($this->mailer, $this->renderer, $this->settings, $this->woocommerce_helper, $timer);
+    return new StatsNotificationsWorkerForAutomatedEmails($this->mailer, $this->renderer, $this->settings, $this->woocommerce_helper, $this->mailerMetaInfo, $timer);
   }
 
   /** @return SendingServiceKeyCheckWorker */

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -151,6 +151,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Mailer\Mailer::class);
     $container->autowire(\MailPoet\Mailer\WordPress\WordpressMailerReplacer::class);
     $container->autowire(\MailPoet\Mailer\Methods\Common\BlacklistCheck::class);
+    $container->autowire(\MailPoet\Mailer\MetaInfo::class);
     // Subscribers
     $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -1,6 +1,7 @@
 <?php
 namespace MailPoet\Mailer;
 
+use MailPoet\Models\Newsletter;
 use MailPoet\Models\Subscriber;
 
 class MetaInfo {
@@ -26,6 +27,28 @@ class MetaInfo {
 
   function getNewSubscriberNotificationMetaInfo() {
     return $this->makeMetaInfo('new_subscriber_notification', 'unknown', 'administrator');
+  }
+
+  function getNewsletterMetaInfo($newsletter, Subscriber $subscriber) {
+    $type = 'unknown';
+    switch ($newsletter->type) {
+      case Newsletter::TYPE_AUTOMATIC:
+        $group = isset($newsletter->options['group']) ? $newsletter->options['group'] : 'unknown';
+        $event = isset($newsletter->options['event']) ? $newsletter->options['event'] : 'unknown';
+        $type = sprintf('automatic_%s_%s', $group, $event);
+        break;
+      case Newsletter::TYPE_STANDARD:
+        $type = 'newsletter';
+        break;
+      case Newsletter::TYPE_WELCOME:
+        $type = 'welcome';
+        break;
+      case Newsletter::TYPE_NOTIFICATION:
+      case Newsletter::TYPE_NOTIFICATION_HISTORY:
+        $type = 'post_notification';
+        break;
+    }
+    return $this->makeMetaInfo($type, $subscriber->status, $subscriber->source);
   }
 
   private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -2,5 +2,15 @@
 namespace MailPoet\Mailer;
 
 class MetaInfo {
+  function getSendingTestMetaInfo() {
+    return $this->makeMetaInfo('sending_test', 'unknown', 'administrator');
+  }
 
+  private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {
+    return [
+      'email_type' => $email_type,
+      'subscriber_status' => $subscriber_status,
+      'subscriber_source' => $subscriber_source,
+    ];
+  }
 }

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -6,6 +6,10 @@ class MetaInfo {
     return $this->makeMetaInfo('sending_test', 'unknown', 'administrator');
   }
 
+  function getPreviewMetaInfo() {
+    return $this->makeMetaInfo('preview', 'unknown', 'administrator');
+  }
+
   private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {
     return [
       'email_type' => $email_type,

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -24,6 +24,10 @@ class MetaInfo {
     return $this->makeMetaInfo('confirmation', $subscriber->status, $subscriber->source);
   }
 
+  function getNewSubscriberNotificationMetaInfo() {
+    return $this->makeMetaInfo('new_subscriber_notification', 'unknown', 'administrator');
+  }
+
   private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {
     return [
       'email_type' => $email_type,

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -1,6 +1,8 @@
 <?php
 namespace MailPoet\Mailer;
 
+use MailPoet\Models\Subscriber;
+
 class MetaInfo {
   function getSendingTestMetaInfo() {
     return $this->makeMetaInfo('sending_test', 'unknown', 'administrator');
@@ -16,6 +18,10 @@ class MetaInfo {
 
   function getWordPressTransactionalMetaInfo() {
     return $this->makeMetaInfo('transactional', 'unknown', 'administrator');
+  }
+
+  function getConfirmationMetaInfo(Subscriber $subscriber) {
+    return $this->makeMetaInfo('confirmation', $subscriber->status, $subscriber->source);
   }
 
   private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -1,0 +1,6 @@
+<?php
+namespace MailPoet\Mailer;
+
+class MetaInfo {
+
+}

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -10,6 +10,10 @@ class MetaInfo {
     return $this->makeMetaInfo('preview', 'unknown', 'administrator');
   }
 
+  function getStatsNotificationMetaInfo() {
+    return $this->makeMetaInfo('email_stats_notification', 'unknown', 'administrator');
+  }
+
   private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {
     return [
       'email_type' => $email_type,

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -14,6 +14,10 @@ class MetaInfo {
     return $this->makeMetaInfo('email_stats_notification', 'unknown', 'administrator');
   }
 
+  function getWordPressTransactionalMetaInfo() {
+    return $this->makeMetaInfo('transactional', 'unknown', 'administrator');
+  }
+
   private function makeMetaInfo($email_type,  $subscriber_status, $subscriber_source) {
     return [
       'email_type' => $email_type,

--- a/lib/Mailer/Methods/MailPoet.php
+++ b/lib/Mailer/Methods/MailPoet.php
@@ -96,20 +96,22 @@ class MailPoet {
         $body[] = $this->composeBody(
           $newsletter[$record],
           $this->processSubscriber($subscriber[$record]),
-          (!empty($extra_params['unsubscribe_url'][$record])) ? $extra_params['unsubscribe_url'][$record] : false
+          (!empty($extra_params['unsubscribe_url'][$record])) ? $extra_params['unsubscribe_url'][$record] : false,
+          (!empty($extra_params['meta'][$record])) ? $extra_params['meta'][$record] : false
         );
       }
     } else {
       $body[] = $this->composeBody(
         $newsletter,
         $this->processSubscriber($subscriber),
-        (!empty($extra_params['unsubscribe_url'])) ? $extra_params['unsubscribe_url'] : false
+        (!empty($extra_params['unsubscribe_url'])) ? $extra_params['unsubscribe_url'] : false,
+        (!empty($extra_params['meta'])) ? $extra_params['meta'] : false
       );
     }
     return $body;
   }
 
-  private function composeBody($newsletter, $subscriber, $unsubscribe_url) {
+  private function composeBody($newsletter, $subscriber, $unsubscribe_url, $meta) {
     $body = [
       'to' => ([
         'address' => $subscriber['email'],
@@ -133,6 +135,9 @@ class MailPoet {
     }
     if ($unsubscribe_url) {
       $body['list_unsubscribe'] = $unsubscribe_url;
+    }
+    if ($meta) {
+      $body['meta'] = $meta;
     }
     return $body;
   }

--- a/lib/Mailer/Methods/MailPoet.php
+++ b/lib/Mailer/Methods/MailPoet.php
@@ -90,49 +90,49 @@ class MailPoet {
   }
 
   function getBody($newsletter, $subscriber, $extra_params = []) {
-    $_this = $this;
-    $composeBody = function($newsletter, $subscriber, $unsubscribe_url) use($_this) {
-      $body = [
-        'to' => ([
-          'address' => $subscriber['email'],
-          'name' => $subscriber['name'],
-        ]),
-        'from' => ([
-          'address' => $_this->sender['from_email'],
-          'name' => $_this->sender['from_name'],
-        ]),
-        'reply_to' => ([
-          'address' => $_this->reply_to['reply_to_email'],
-          'name' => $_this->reply_to['reply_to_name'],
-        ]),
-        'subject' => $newsletter['subject'],
-      ];
-      if (!empty($newsletter['body']['html'])) {
-        $body['html'] = $newsletter['body']['html'];
-      }
-      if (!empty($newsletter['body']['text'])) {
-        $body['text'] = $newsletter['body']['text'];
-      }
-      if ($unsubscribe_url) {
-        $body['list_unsubscribe'] = $unsubscribe_url;
-      }
-      return $body;
-    };
     if (is_array($newsletter) && is_array($subscriber)) {
       $body = [];
       for ($record = 0; $record < count($newsletter); $record++) {
-        $body[] = $composeBody(
+        $body[] = $this->composeBody(
           $newsletter[$record],
           $this->processSubscriber($subscriber[$record]),
           (!empty($extra_params['unsubscribe_url'][$record])) ? $extra_params['unsubscribe_url'][$record] : false
         );
       }
     } else {
-      $body[] = $composeBody(
+      $body[] = $this->composeBody(
         $newsletter,
         $this->processSubscriber($subscriber),
         (!empty($extra_params['unsubscribe_url'])) ? $extra_params['unsubscribe_url'] : false
       );
+    }
+    return $body;
+  }
+
+  private function composeBody($newsletter, $subscriber, $unsubscribe_url) {
+    $body = [
+      'to' => ([
+        'address' => $subscriber['email'],
+        'name' => $subscriber['name'],
+      ]),
+      'from' => ([
+        'address' => $this->sender['from_email'],
+        'name' => $this->sender['from_name'],
+      ]),
+      'reply_to' => ([
+        'address' => $this->reply_to['reply_to_email'],
+        'name' => $this->reply_to['reply_to_name'],
+      ]),
+      'subject' => $newsletter['subject'],
+    ];
+    if (!empty($newsletter['body']['html'])) {
+      $body['html'] = $newsletter['body']['html'];
+    }
+    if (!empty($newsletter['body']['text'])) {
+      $body['text'] = $newsletter['body']['text'];
+    }
+    if ($unsubscribe_url) {
+      $body['list_unsubscribe'] = $unsubscribe_url;
     }
     return $body;
   }

--- a/lib/Mailer/WordPress/WordPressMailer.php
+++ b/lib/Mailer/WordPress/WordPressMailer.php
@@ -4,6 +4,7 @@ namespace MailPoet\Mailer\WordPress;
 
 use Html2Text\Html2Text;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 
 if (!class_exists('PHPMailer')) {
   require_once ABSPATH . WPINC . '/class-phpmailer.php';
@@ -14,9 +15,13 @@ class WordPressMailer extends \PHPMailer {
   /** @var Mailer */
   private $mailer;
 
-  function __construct(Mailer $mailer) {
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
+  function __construct(Mailer $mailer, MetaInfo $mailerMetaInfo) {
     parent::__construct(true);
     $this->mailer = $mailer;
+    $this->mailerMetaInfo = $mailerMetaInfo;
   }
 
   function send() {
@@ -27,7 +32,10 @@ class WordPressMailer extends \PHPMailer {
     $this->preSend();
 
     try {
-      $result = $this->mailer->send($this->getEmail(), $this->formatAddress($this->getToAddresses()));
+      $extra_params = [
+        'meta' => $this->mailerMetaInfo->getWordPressTransactionalMetaInfo(),
+      ];
+      $result = $this->mailer->send($this->getEmail(), $this->formatAddress($this->getToAddresses()), $extra_params);
     } catch (\Exception $e) {
       throw new \phpmailerException($e->getMessage(), $e->getCode(), $e);
     }

--- a/lib/Mailer/WordPress/WordpressMailerReplacer.php
+++ b/lib/Mailer/WordPress/WordpressMailerReplacer.php
@@ -4,6 +4,7 @@ namespace MailPoet\Mailer\WordPress;
 
 use MailPoet\Features\FeaturesController;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 
 class WordpressMailerReplacer {
 
@@ -13,9 +14,13 @@ class WordpressMailerReplacer {
   /** @var Mailer */
   private $mailer;
 
-  function __construct(FeaturesController $features_controller, Mailer $mailer) {
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
+  function __construct(FeaturesController $features_controller, Mailer $mailer, MetaInfo $mailerMetaInfo) {
     $this->features_controller = $features_controller;
     $this->mailer = $mailer;
+    $this->mailerMetaInfo = $mailerMetaInfo;
   }
 
   public function replaceWordPressMailer() {
@@ -28,7 +33,7 @@ class WordpressMailerReplacer {
   }
 
   private function replaceWithCustomPhpMailer(&$obj = null) {
-    $obj = new WordPressMailer($this->mailer);
+    $obj = new WordPressMailer($this->mailer, $this->mailerMetaInfo);
     return $obj;
   }
 }

--- a/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/lib/Subscribers/ConfirmationEmailMailer.php
@@ -4,6 +4,7 @@ namespace MailPoet\Subscribers;
 
 use Html2Text\Html2Text;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Subscriber;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
@@ -25,6 +26,9 @@ class ConfirmationEmailMailer {
   /** @var SettingsController */
   private $settings;
 
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
   /**
    * @param Mailer|null $mailer
    */
@@ -38,6 +42,7 @@ class ConfirmationEmailMailer {
       $this->wp = new WPFunctions;
     }
     $this->settings = new SettingsController();
+    $this->mailerMetaInfo = new MetaInfo;
   }
 
   function sendConfirmationEmail(Subscriber $subscriber) {
@@ -96,7 +101,10 @@ class ConfirmationEmailMailer {
         $this->mailer = new Mailer();
       }
       $this->mailer->init();
-      $result = $this->mailer->send($email, $subscriber);
+      $extra_params = [
+        'meta' => $this->mailerMetaInfo->getConfirmationMetaInfo($subscriber),
+      ];
+      $result = $this->mailer->send($email, $subscriber, $extra_params);
       if ($result['response'] === false) {
         $subscriber->setError(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
         return false;

--- a/lib/Subscribers/NewSubscriberNotificationMailer.php
+++ b/lib/Subscribers/NewSubscriberNotificationMailer.php
@@ -3,6 +3,7 @@ namespace MailPoet\Subscribers;
 
 use MailPoet\Config\Renderer;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Settings\SettingsController;
@@ -21,6 +22,9 @@ class NewSubscriberNotificationMailer {
   /** @var SettingsController */
   private $settings;
 
+  /** @var MetaInfo */
+  private $mailerMetaInfo;
+
   /**
    * @param \MailPoet\Mailer\Mailer|null $mailer
    * @param Renderer|null $renderer
@@ -35,6 +39,7 @@ class NewSubscriberNotificationMailer {
     }
     $this->mailer = $mailer;
     $this->settings = new SettingsController();
+    $this->mailerMetaInfo = new MetaInfo();
   }
 
   /**
@@ -49,7 +54,10 @@ class NewSubscriberNotificationMailer {
       return;
     }
     try {
-      $this->getMailer()->send($this->constructNewsletter($subscriber, $segments), $settings['address']);
+      $extra_params = [
+        'meta' => $this->mailerMetaInfo->getNewSubscriberNotificationMetaInfo(),
+      ];
+      $this->getMailer()->send($this->constructNewsletter($subscriber, $segments), $settings['address'], $extra_params);
     } catch (\Exception $e) {
       if (WP_DEBUG) {
         throw $e;

--- a/tests/integration/API/JSON/v1/MailerTest.php
+++ b/tests/integration/API/JSON/v1/MailerTest.php
@@ -5,6 +5,7 @@ use Codeception\Stub\Expected;
 use MailPoet\API\JSON\v1\Mailer;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -20,7 +21,7 @@ class MailerTest extends \MailPoetTest {
     $authorized_emails_controller = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::never()]);
     // resumeSending() method should clear the mailer log's status
     $bridge = new Bridge($settings);
-    $mailer_endpoint = new Mailer($authorized_emails_controller, $settings, $bridge);
+    $mailer_endpoint = new Mailer($authorized_emails_controller, $settings, $bridge, new MetaInfo);
     $response = $mailer_endpoint->resumeSending();
     expect($response->status)->equals(APIResponse::STATUS_OK);
     $mailer_log = MailerLog::getMailerLog();
@@ -32,7 +33,7 @@ class MailerTest extends \MailPoetTest {
     $settings->set(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, ['invalid_sender_address' => 'a@b.c']);
     $authorized_emails_controller = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::once()]);
     $bridge = new Bridge($settings);
-    $mailer_endpoint = new Mailer($authorized_emails_controller, $settings, $bridge);
+    $mailer_endpoint = new Mailer($authorized_emails_controller, $settings, $bridge, new MetaInfo);
     $mailer_endpoint->resumeSending();
   }
 }

--- a/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -58,6 +58,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->subscriber->first_name = 'John';
     $this->subscriber->last_name = 'Doe';
     $this->subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+    $this->subscriber->source = 'administrator';
     $this->subscriber->save();
     $this->segment = Segment::create();
     $this->segment->name = 'segment';
@@ -248,6 +249,12 @@ class SendingQueueTest extends \MailPoetTest {
           'send' => Expected::exactly(1, function($newsletter, $subscriber, $extra_params) use ($directUnsubscribeURL) {
             expect(isset($extra_params['unsubscribe_url']))->true();
             expect($extra_params['unsubscribe_url'])->equals($directUnsubscribeURL);
+            expect(isset($extra_params['meta']))->true();
+            expect($extra_params['meta'])->equals([
+              'email_type' => 'newsletter',
+              'subscriber_status' => 'subscribed',
+              'subscriber_source' => 'administrator',
+            ]);
             return true;
           }),
         ],
@@ -270,6 +277,12 @@ class SendingQueueTest extends \MailPoetTest {
           'send' => Expected::exactly(1, function($newsletter, $subscriber, $extra_params) use ($trackedUnsubscribeURL) {
             expect(isset($extra_params['unsubscribe_url']))->true();
             expect($extra_params['unsubscribe_url'])->equals($trackedUnsubscribeURL);
+            expect(isset($extra_params['meta']))->true();
+            expect($extra_params['meta'])->equals([
+              'email_type' => 'newsletter',
+              'subscriber_status' => 'subscribed',
+              'subscriber_source' => 'administrator',
+            ]);
             return true;
           }),
         ],

--- a/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron\Workers\StatsNotifications;
 
 use MailPoet\Config\Renderer;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Settings\SettingsController;
@@ -43,6 +44,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
         $this->renderer,
         $this->settings,
         $this->makeEmpty(WCHelper::class),
+        new MetaInfo,
       ])
       ->setMethods(['getNewsletters'])
       ->getMock();

--- a/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron\Workers\StatsNotifications;
 
 use MailPoet\Config\Renderer;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterLink;
 use MailPoet\Models\ScheduledTask;
@@ -45,7 +46,7 @@ class WorkerTest extends \MailPoetTest {
     $this->mailer = $this->createMock(Mailer::class);
     $this->renderer = $this->createMock(Renderer::class);
     $this->settings = new SettingsController();
-    $this->stats_notifications = new Worker($this->mailer, $this->renderer, $this->settings, $this->makeEmpty(WCHelper::class));
+    $this->stats_notifications = new Worker($this->mailer, $this->renderer, $this->settings, $this->makeEmpty(WCHelper::class), new MetaInfo);
     $this->settings->set(Worker::SETTINGS_KEY, [
       'enabled' => true,
       'address' => 'email@example.com',

--- a/tests/integration/Mailer/MetaInfoTest.php
+++ b/tests/integration/Mailer/MetaInfoTest.php
@@ -3,12 +3,14 @@ namespace MailPoet\Test\Mailer;
 
 use Codeception\Stub;
 use MailPoet\Mailer\MetaInfo;
+use MailPoet\Models\Subscriber;
 
-class MetaInfoTest extends \MailPoetUnitTest {
+class MetaInfoTest extends \MailPoetTest {
   /** @var MetaInfo */
   private $meta;
 
   function _before() {
+    parent::_before();
     $this->meta = new MetaInfo;
   }
 
@@ -44,4 +46,20 @@ class MetaInfoTest extends \MailPoetUnitTest {
     ]);
   }
 
+  function testItGetsMetaInfoForConfirmationEmails() {
+    $subscriber = Subscriber::createOrUpdate([
+      'email' => 'meta@test.fake',
+      'status' => 'unconfirmed',
+      'source' => 'form',
+    ]);
+    expect($this->meta->getConfirmationMetaInfo($subscriber))->equals([
+      'email_type' => 'confirmation',
+      'subscriber_status' => 'unconfirmed',
+      'subscriber_source' => 'form',
+    ]);
+  }
+
+  function _after() {
+    Subscriber::deleteMany();
+  }
 }

--- a/tests/integration/Mailer/MetaInfoTest.php
+++ b/tests/integration/Mailer/MetaInfoTest.php
@@ -59,6 +59,14 @@ class MetaInfoTest extends \MailPoetTest {
     ]);
   }
 
+  function testItGetsMetaInfoForNewSubscriberNotifications() {
+    expect($this->meta->getNewSubscriberNotificationMetaInfo())->equals([
+      'email_type' => 'new_subscriber_notification',
+      'subscriber_status' => 'unknown',
+      'subscriber_source' => 'administrator',
+    ]);
+  }
+
   function _after() {
     Subscriber::deleteMany();
   }

--- a/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -45,6 +45,11 @@ class MailPoetAPITest extends \MailPoetTest {
         'text' => 'TEXT body',
       ],
     ];
+    $this->metaInfo = [
+      'email_type' => 'sending_test',
+      'subscriber_status' => 'unknown',
+      'subscriber_source' => 'administrator',
+    ];
   }
 
   function testItCanGenerateBodyForSingleMessage() {
@@ -79,29 +84,29 @@ class MailPoetAPITest extends \MailPoetTest {
   }
 
   function testItCanAddExtraParametersToSingleMessage() {
-    $extra_params = ['unsubscribe_url' => 'http://example.com'];
+    $extra_params = [
+      'unsubscribe_url' => 'http://example.com',
+      'meta' => $this->metaInfo,
+    ];
     $body = $this->mailer->getBody($this->newsletter, $this->subscriber, $extra_params);
     expect($body[0]['list_unsubscribe'])->equals($extra_params['unsubscribe_url']);
+    expect($body[0]['meta'])->equals($extra_params['meta']);
   }
 
   function testItCanAddExtraParametersToMultipleMessages() {
-    $extra_params = ['unsubscribe_url' => 'http://example.com'];
     $newsletters = array_fill(0, 10, $this->newsletter);
     $subscribers = array_fill(0, 10, $this->subscriber);
-    $body = $this->mailer->getBody($newsletters, $subscribers, $extra_params);
-    expect($body[0]['list_unsubscribe'])->equals($extra_params['unsubscribe_url'][0]);
-    expect($body[9]['list_unsubscribe'])->equals($extra_params['unsubscribe_url'][9]);
-  }
-
-  function testItCanAddUnsubscribeUrlToMultipleMessages() {
-    $newsletters = array_fill(0, 10, $this->newsletter);
-    $subscribers = array_fill(0, 10, $this->subscriber);
-    $extra_params = ['unsubscribe_url' => array_fill(0, 10, 'http://example.com')];
+    $extra_params = [
+      'unsubscribe_url' => array_fill(0, 10, 'http://example.com'),
+      'meta' => array_fill(0, 10, $this->metaInfo),
+    ];
 
     $body = $this->mailer->getBody($newsletters, $subscribers, $extra_params);
     expect(count($body))->equals(10);
     expect($body[0]['list_unsubscribe'])->equals($extra_params['unsubscribe_url'][0]);
     expect($body[9]['list_unsubscribe'])->equals($extra_params['unsubscribe_url'][9]);
+    expect($body[0]['meta'])->equals($extra_params['meta'][0]);
+    expect($body[9]['meta'])->equals($extra_params['meta'][9]);
   }
 
   function testItCanProcessSubscriber() {

--- a/tests/integration/Mailer/WordPress/WordpressMailerTest.php
+++ b/tests/integration/Mailer/WordPress/WordpressMailerTest.php
@@ -9,13 +9,14 @@ if (!class_exists('PHPMailer')) {
 
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
+use MailPoet\Mailer\MetaInfo;
 
 class WordpressMailerTest extends \MailPoetTest {
 
   function testItdoesNotSendWhenPreSendCheckFails() {
     $mailer = $this->createMock(Mailer::class);
     $mailer->expects($this->never())->method('send');
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $this->expectException(\phpmailerException::class);
     $wpMailer->send();
   }
@@ -32,7 +33,7 @@ class WordpressMailerTest extends \MailPoetTest {
         ],
       ]))
       ->willReturn(['response' => true]);
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com');
     $wpMailer->Subject = 'Subject';
     $wpMailer->Body = 'Email Text Body';
@@ -50,7 +51,7 @@ class WordpressMailerTest extends \MailPoetTest {
         'address' => 'email@example.com',
       ])
       ->willReturn(['response' => true]);
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com', 'Full Name');
     $wpMailer->Subject = 'Subject';
     $wpMailer->Body = 'Body';
@@ -71,7 +72,7 @@ class WordpressMailerTest extends \MailPoetTest {
         ],
       ]))
       ->willReturn(['response' => true]);
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com');
     $wpMailer->Subject = 'Subject';
     $wpMailer->Body = 'Email Html Body';
@@ -85,7 +86,7 @@ class WordpressMailerTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('send')
       ->willReturn(['response' => true]);
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com');
     $wpMailer->Body = 'body';
     expect($wpMailer->send())->true();
@@ -97,7 +98,7 @@ class WordpressMailerTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('send')
       ->willReturn(['response' => false, 'error' => new MailerError('send', 1, 'Big Error')]);
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com');
     $wpMailer->Body = 'body';
     $this->expectException(\phpmailerException::class);
@@ -109,7 +110,7 @@ class WordpressMailerTest extends \MailPoetTest {
     $mailer
       ->expects($this->never())
       ->method('send');
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com');
     $wpMailer->Body = 'body';
     $wpMailer->ContentType = 'application/json';
@@ -123,7 +124,7 @@ class WordpressMailerTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('send')
       ->willThrowException(new \Exception('Big Error'));
-    $wpMailer = new WordPressMailer($mailer);
+    $wpMailer = new WordPressMailer($mailer, new MetaInfo);
     $wpMailer->addAddress('email@example.com');
     $wpMailer->Body = 'body';
     $this->expectException(\phpmailerException::class);

--- a/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -23,13 +23,20 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       'first_name' => 'John',
       'last_name' => 'Mailer',
       'email' => 'john@mailpoet.com',
+      'status' => 'unconfirmed',
+      'source' => 'api',
     ]);
 
     $mailer = Stub::makeEmpty(Mailer::class, [
       'send' =>
-        Stub\Expected::once(function($email) {
+        Stub\Expected::once(function($email, $subscriber, $extra_params) {
           expect($email['body']['html'])->contains('<strong>Test segment</strong>');
           expect($email['body']['html'])->contains('<a target="_blank" href="http://example.com">I confirm my subscription!</a>');
+          expect($extra_params['meta'])->equals([
+            'email_type' => 'confirmation',
+            'subscriber_status' => 'unconfirmed',
+            'subscriber_source' => 'api',
+          ]);
         }),
     ], $this);
 

--- a/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
+++ b/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
@@ -65,7 +65,7 @@ class NewSubscriberNotificationMailerTest extends \MailPoetTest {
 
     $mailer = Stub::makeEmpty(Mailer::class, [
       'send' =>
-        Expected::once(function($newsletter, $subscriber) {
+        Expected::once(function($newsletter, $subscriber, $extra_params) {
           expect($subscriber)->equals('a@b.c');
           expect($newsletter)->hasKey('subject');
           expect($newsletter)->hasKey('body');
@@ -76,6 +76,11 @@ class NewSubscriberNotificationMailerTest extends \MailPoetTest {
           expect($newsletter['body'])->count(2);
           expect($newsletter['body']['text'])->contains('subscriber@example.com');
           expect($newsletter['body']['html'])->contains('subscriber@example.com');
+          expect($extra_params['meta'])->equals([
+            'email_type' => 'new_subscriber_notification',
+            'subscriber_status' => 'unknown',
+            'subscriber_source' => 'administrator',
+          ]);
         }),
     ], $this);
 

--- a/tests/unit/Mailer/MetaInfoTest.php
+++ b/tests/unit/Mailer/MetaInfoTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace MailPoet\Test\Mailer;
+
+use Codeception\Stub;
+use MailPoet\Mailer\MetaInfo;
+
+class MetaInfoTest extends \MailPoetUnitTest {
+  /** @var MetaInfo */
+  private $meta;
+
+  function _before() {
+    $this->meta = new MetaInfo;
+  }
+
+  function testItGetsMetaInfoForSendingTest() {
+    expect($this->meta->getSendingTestMetaInfo())->equals([
+      'email_type' => 'sending_test',
+      'subscriber_status' => 'unknown',
+      'subscriber_source' => 'administrator',
+    ]);
+  }
+}

--- a/tests/unit/Mailer/MetaInfoTest.php
+++ b/tests/unit/Mailer/MetaInfoTest.php
@@ -27,4 +27,13 @@ class MetaInfoTest extends \MailPoetUnitTest {
       'subscriber_source' => 'administrator',
     ]);
   }
+
+  function testItGetsMetaInfoForStatsNotifications() {
+    expect($this->meta->getStatsNotificationMetaInfo())->equals([
+      'email_type' => 'email_stats_notification',
+      'subscriber_status' => 'unknown',
+      'subscriber_source' => 'administrator',
+    ]);
+  }
+
 }

--- a/tests/unit/Mailer/MetaInfoTest.php
+++ b/tests/unit/Mailer/MetaInfoTest.php
@@ -36,4 +36,12 @@ class MetaInfoTest extends \MailPoetUnitTest {
     ]);
   }
 
+  function testItGetsMetaInfoForWordPressTransactionalEmails() {
+    expect($this->meta->getWordPressTransactionalMetaInfo())->equals([
+      'email_type' => 'transactional',
+      'subscriber_status' => 'unknown',
+      'subscriber_source' => 'administrator',
+    ]);
+  }
+
 }

--- a/tests/unit/Mailer/MetaInfoTest.php
+++ b/tests/unit/Mailer/MetaInfoTest.php
@@ -19,4 +19,12 @@ class MetaInfoTest extends \MailPoetUnitTest {
       'subscriber_source' => 'administrator',
     ]);
   }
+
+  function testItGetsMetaInfoForPreview() {
+    expect($this->meta->getPreviewMetaInfo())->equals([
+      'email_type' => 'preview',
+      'subscriber_status' => 'unknown',
+      'subscriber_source' => 'administrator',
+    ]);
+  }
 }


### PR DESCRIPTION
[MAILPOET-2333]

I added the following email types that were not mentioned in the specs:

**The sending method test email** 
```
email_type = 'sending_test'
subscriber_status = 'unknown'
subscriber_source = 'administrator'
```

**Preview email**
```
email_type = 'preview'
subscriber_status = 'unknown'
subscriber_source = 'administrator'
```

I have also used `administrator` as `subscriber_source` for stats notifications, new subscriber notifications, and WordPress transactional emails.

[MAILPOET-2333]: https://mailpoet.atlassian.net/browse/MAILPOET-2333