### PR TITLE
i18n: use WordPress `%s` placeholders

### DIFF
--- a/assets/js/src/common/sender_email_address_warning.jsx
+++ b/assets/js/src/common/sender_email_address_warning.jsx
@@ -21,10 +21,10 @@ const SenderEmailAddressWarning = ({ emailAddress, mssActive }) => {
         <p className="sender_email_address_warning">
           {ReactStringReplace(
             MailPoet.I18n.t('senderEmailAddressWarning2'),
-            /(%suggested|%originalSender|<em>.*<\/em>)/,
+            /(%1\$s|%2\$s|<em>.*<\/em>)/,
             (match) => {
-              if (match === '%suggested') return suggestedEmailAddress;
-              if (match === '%originalSender') return <em key="sender-email">{ emailAddress }</em>;
+              if (match === '%1$s') return suggestedEmailAddress;
+              if (match === '%2$s') return <em key="sender-email">{ emailAddress }</em>;
               return <em key="reply-to">{match.replace(/<\/?em>/g, '')}</em>;
             }
           )}

--- a/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
+++ b/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
@@ -52,8 +52,8 @@ class UnauthorizedEmailInNewslettersNotice {
   private function getNewslettersLinks($validation_error) {
     $links = '';
     foreach ($validation_error['invalid_senders_in_newsletters'] as $error) {
-      $link_text = $this->wp->_x('Update the from address of %subject', '%subject will be replaced by a newsletter subject');
-      $link_text = str_replace('%subject', EscapeHelper::escapeHtmlText($error['subject']), $link_text);
+      $link_text = $this->wp->_x('Update the from address of %s', '%s will be replaced by a newsletter subject');
+      $link_text = str_replace('%s', EscapeHelper::escapeHtmlText($error['subject']), $link_text);
       $link_url = $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG . '#/send/' . $error['newsletter_id']);
       $link = Helpers::replaceLinkTags("[link]{$link_text}[/link]", $link_url, ['target' => '_blank']);
       $links .= "<p>$link</p>";
@@ -64,12 +64,12 @@ class UnauthorizedEmailInNewslettersNotice {
   private function getAuthorizationLink($validation_error) {
     $emails = array_unique(array_column($validation_error['invalid_senders_in_newsletters'], 'sender_address'));
     if (count($emails) > 1) {
-      $authorize_link = $this->wp->_x('Authorize %email1 and %email2', 'Link for user to authorize their email address');
-      $authorize_link = str_replace('%email2', EscapeHelper::escapeHtmlText(array_pop($emails)), $authorize_link);
-      $authorize_link = str_replace('%email1', EscapeHelper::escapeHtmlText(implode(', ', $emails)), $authorize_link);
+      $authorize_link = $this->wp->_x('Authorize %1$s and %2$s', 'Link for user to authorize their email address');
+      $authorize_link = str_replace('%2$s', EscapeHelper::escapeHtmlText(array_pop($emails)), $authorize_link);
+      $authorize_link = str_replace('%1$s', EscapeHelper::escapeHtmlText(implode(', ', $emails)), $authorize_link);
     } else {
-      $authorize_link = $this->wp->_x('Authorize %email', 'Link for user to authorize their email address');
-      $authorize_link = str_replace('%email', EscapeHelper::escapeHtmlText($emails[0]), $authorize_link);
+      $authorize_link = $this->wp->_x('Authorize %s', 'Link for user to authorize their email address');
+      $authorize_link = str_replace('%s', EscapeHelper::escapeHtmlText($emails[0]), $authorize_link);
     }
 
     $authorize_link = Helpers::replaceLinkTags("[link]{$authorize_link}[/link]", 'https://account.mailpoet.com/authorization', ['target' => '_blank']);

--- a/lib/Util/Notices/UnauthorizedEmailNotice.php
+++ b/lib/Util/Notices/UnauthorizedEmailNotice.php
@@ -41,10 +41,10 @@ class UnauthorizedEmailNotice {
   }
 
   private function getMessageText($validation_error) {
-    $text = $this->wp->_x('<b>Sending all of your emails has been paused</b> because your email address %email-address hasn’t been authorized yet.</b>',
-      'Email addresses have to be authorized to be used to send emails. %email-address will be replaced by an email address.'
+    $text = $this->wp->_x('<b>Sending all of your emails has been paused</b> because your email address %s hasn’t been authorized yet.</b>',
+      'Email addresses have to be authorized to be used to send emails. %s will be replaced by an email address.'
     );
-    $message = str_replace('%email-address', EscapeHelper::escapeHtmlText($validation_error['invalid_sender_address']), $text);
+    $message = str_replace('%s', EscapeHelper::escapeHtmlText($validation_error['invalid_sender_address']), $text);
     return "<p>$message</p>";
   }
 
@@ -60,8 +60,8 @@ class UnauthorizedEmailNotice {
 
   private function getAuthorizationLink($validation_error) {
     $email = $validation_error['invalid_sender_address'];
-    $authorize_link = $this->wp->_x('Authorize %email', 'Link for user to authorize their email address');
-    $authorize_link = str_replace('%email', EscapeHelper::escapeHtmlText($email), $authorize_link);
+    $authorize_link = $this->wp->_x('Authorize %s', 'Link for user to authorize their email address');
+    $authorize_link = str_replace('%s', EscapeHelper::escapeHtmlText($email), $authorize_link);
     $authorize_link = Helpers::replaceLinkTags("[link]{$authorize_link}[/link]", 'https://account.mailpoet.com/authorization', ['target' => '_blank']);
     $html = '<p><b>' . $this->wp->_x('OR', 'User has to choose between two options') . '</b></p>';
     $html .= "<p>$authorize_link</p>";

--- a/views/layout.html
+++ b/views/layout.html
@@ -72,7 +72,7 @@ jQuery('.toplevel_page_mailpoet-newsletters.menu-top-last')
 <%= localize({
   'ajaxFailedErrorMessage': __('An error has happened while performing a request, the server has responded with response code %d'),
   'senderEmailAddressWarning1': _x('You might not reach the inbox of your subscribers if you use this email address.', 'In the last step, before sending a newsletter. URL: ?page=mailpoet-newsletters#/send/2'),
-  'senderEmailAddressWarning2': _x('Use an address like %suggested for the Sender and put %originalSender in the <em>Reply-to</em> field below.', 'In the last step, before sending a newsletter. URL: ?page=mailpoet-newsletters#/send/2'),
+  'senderEmailAddressWarning2': _x('Use an address like %1$s for the Sender and put %2$s in the <em>Reply-to</em> field below.', 'In the last step, before sending a newsletter. URL: ?page=mailpoet-newsletters#/send/2'),
   'senderEmailAddressWarning3': _x('Read more.'),
   'mailerSendingResumedNotice': __('Sending has been resumed.'),
 


### PR DESCRIPTION
The current translation strings use `%subject`, `%email1`, and `%email2` placeholders.

Those custom placeholders are not recognized by Transifex, making it harder to translate the strings.

This PR updates the placeholders to the standard `%s`, `%1$s`, `%2$s` placeholders used by WordPress core.

Original PR #2280