### PR TITLE
Disable WooCommerce plugin's email settings [MAILPOET-2283]

### DIFF
--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -12,6 +12,7 @@ use MailPoet\Subscription\Comment;
 use MailPoet\Subscription\Form;
 use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
+use MailPoet\WooCommerce\Settings as WooCommerceSettings;
 use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -41,6 +42,9 @@ class Hooks {
   /** @var WooCommerceSegment */
   private $woocommerce_segment;
 
+  /** @var WooCommerceSettings */
+  private $woocommerce_settings;
+
   /** @var WooCommercePurchases */
   private $woocommerce_purchases;
 
@@ -59,6 +63,7 @@ class Hooks {
     WPFunctions $wp,
     WooCommerceSubscription $woocommerce_subscription,
     WooCommerceSegment $woocommerce_segment,
+    WooCommerceSettings $woocommerce_settings,
     WooCommercePurchases $woocommerce_purchases,
     PostNotificationScheduler $post_notification_scheduler,
     WordpressMailerReplacer $wordpress_mailer_replacer
@@ -71,6 +76,7 @@ class Hooks {
     $this->wp = $wp;
     $this->woocommerce_subscription = $woocommerce_subscription;
     $this->woocommerce_segment = $woocommerce_segment;
+    $this->woocommerce_settings = $woocommerce_settings;
     $this->woocommerce_purchases = $woocommerce_purchases;
     $this->post_notification_scheduler = $post_notification_scheduler;
     $this->wordpress_mailer_replacer = $wordpress_mailer_replacer;
@@ -85,6 +91,7 @@ class Hooks {
     $this->setupSubscriptionEvents();
     $this->setupWooCommerceSubscriptionEvents();
     $this->setupPostNotifications();
+    $this->setupWooCommerceSettings();
   }
 
   function initEarlyHooks() {
@@ -249,6 +256,13 @@ class Hooks {
       '\MailPoet\Segments\WP::synchronizeUser',
       1
     );
+  }
+
+  function setupWooCommerceSettings() {
+    $this->wp->addAction('woocommerce_settings_start', [
+      $this->woocommerce_settings,
+      'disableWooCommerceSettings',
+    ]);
   }
 
   function setupWooCommerceUsers() {

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -194,6 +194,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Util\Installation::class);
     // WooCommerce
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails::class);
     // WordPress

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -2,29 +2,29 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Config\Renderer;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
-use MailPoet\WP\Functions as WPFunctions;
 
 class Settings {
 
   /** @var FeaturesController */
   private $features_controller;
 
+  /** @var Renderer */
+  private $renderer;
+
   /** @var SettingsController */
   private $settings;
 
-  /** @var WPFunctions */
-  private $wp;
-
   function __construct(
     FeaturesController $features_controller,
-    SettingsController $settings,
-    WPFunctions $wp
+    Renderer $renderer,
+    SettingsController $settings
   ) {
     $this->features_controller = $features_controller;
+    $this->renderer = $renderer;
     $this->settings = $settings;
-    $this->wp = $wp;
   }
 
   function disableWooCommerceSettings() {
@@ -37,40 +37,9 @@ class Settings {
     if (!(bool)$this->settings->get('woocommerce.use_mailpoet_editor')) {
       return;
     }
-    $woocommerce_template_id = $this->settings->get('woocommerce.transactional_email_id');
-    ?>
 
-    <style>
-      /* Hide WooCommerce section with template styling */
-      #email_template_options-description + .form-table {
-        opacity: 0.2;
-        pointer-events: none;
-      }
-
-      /* Position MailPoet buttons over hidden table */
-      .mailpoet-woocommerce-email-overlay {
-        bottom: 320px;
-        left: 0;
-        max-width: 100%;
-        text-align: left;
-        position: absolute;
-        text-align: center;
-        width: 640px;
-        z-index: 1;
-      }
-    </style>
-
-    <div class="mailpoet-woocommerce-email-overlay">
-      <a class="button button-primary" href="?page=mailpoet-newsletter-editor&id=<?php echo $woocommerce_template_id; ?>">
-        <?php echo $this->wp->_x('Customize with MailPoet', 'Button in WooCommerce settings page'); ?>
-      </a>
-      <br>
-      <br>
-      <a href="?page=mailpoet-settings#woocommerce">
-        <?php echo $this->wp->_x('Disable MailPoet customizer', 'Link from WooCommerce plugin to MailPoet'); ?>
-      </a>
-    </div>
-
-    <?php
+    echo $this->renderer->render('woocommerce/settings_overlay.html', [
+      'woocommerce_template_id' => $this->settings->get('woocommerce.transactional_email_id'),
+    ]);
   }
 }

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -28,7 +28,7 @@ class Settings {
   }
 
   function disableWooCommerceSettings() {
-    if ($_GET['tab'] !== 'email') {
+    if ($_GET['tab'] !== 'email' || $_GET['section']) {
       return;
     }
     if (!$this->features_controller->isSupported(FeaturesController::WC_TRANSACTIONAL_EMAILS_CUSTOMIZER)) {

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -2,19 +2,30 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 
 class Settings {
 
+  /** @var FeaturesController */
+  private $features_controller;
+
   /** @var SettingsController */
   private $settings;
 
-  function __construct(SettingsController $settings) {
+  function __construct(
+    FeaturesController $features_controller,
+    SettingsController $settings
+  ) {
+    $this->features_controller = $features_controller;
     $this->settings = $settings;
   }
 
   function disableWooCommerceSettings() {
     if ($_GET['tab'] !== 'email') {
+      return;
+    }
+    if (!$this->features_controller->isSupported(FeaturesController::WC_TRANSACTIONAL_EMAILS_CUSTOMIZER)) {
       return;
     }
     if (!(bool)$this->settings->get('woocommerce.use_mailpoet_editor')) {

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MailPoet\WooCommerce;
+
+class Settings {
+  function disableWooCommerceSettings() {
+    // TODO
+  }
+}

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -4,6 +4,7 @@ namespace MailPoet\WooCommerce;
 
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Settings {
 
@@ -13,12 +14,17 @@ class Settings {
   /** @var SettingsController */
   private $settings;
 
+  /** @var WPFunctions */
+  private $wp;
+
   function __construct(
     FeaturesController $features_controller,
-    SettingsController $settings
+    SettingsController $settings,
+    WPFunctions $wp
   ) {
     $this->features_controller = $features_controller;
     $this->settings = $settings;
+    $this->wp = $wp;
   }
 
   function disableWooCommerceSettings() {
@@ -56,12 +62,12 @@ class Settings {
 
     <div class="mailpoet-woocommerce-email-overlay">
       <a class="button button-primary" href="?page=mailpoet-newsletter-editor&id=<?php echo $woocommerce_template_id; ?>">
-        <?php echo _x('Customize with MailPoet', 'Button in WooCommerce settings page'); ?>
+        <?php echo $this->wp->_x('Customize with MailPoet', 'Button in WooCommerce settings page'); ?>
       </a>
       <br>
       <br>
       <a href="?page=mailpoet-settings#woocommerce">
-        <?php echo _x('Disable MailPoet customizer', ''); ?>
+        <?php echo $this->wp->_x('Disable MailPoet customizer', 'Link from WooCommerce plugin to MailPoet'); ?>
       </a>
     </div>
 

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -28,7 +28,11 @@ class Settings {
   }
 
   function disableWooCommerceSettings() {
-    if ($_GET['tab'] !== 'email' || $_GET['section']) {
+    if (
+      !isset($_GET['tab'])
+      || $_GET['tab'] !== 'email'
+      || isset($_GET['section'])
+    ) {
       return;
     }
     if (!$this->features_controller->isSupported(FeaturesController::WC_TRANSACTIONAL_EMAILS_CUSTOMIZER)) {

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -2,8 +2,58 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Settings\SettingsController;
+
 class Settings {
+
+  /** @var SettingsController */
+  private $settings;
+
+  function __construct(SettingsController $settings) {
+    $this->settings = $settings;
+  }
+
   function disableWooCommerceSettings() {
-    // TODO
+    if ($_GET['tab'] !== 'email') {
+      return;
+    }
+    if (!(bool)$this->settings->get('woocommerce.use_mailpoet_editor')) {
+      return;
+    }
+    $woocommerce_template_id = $this->settings->get('woocommerce.transactional_email_id');
+    ?>
+
+    <style>
+      /* Hide WooCommerce section with template styling */
+      #email_template_options-description + .form-table {
+        opacity: 0.2;
+        pointer-events: none;
+      }
+
+      /* Position MailPoet buttons over hidden table */
+      .mailpoet-woocommerce-email-overlay {
+        bottom: 320px;
+        left: 0;
+        max-width: 100%;
+        text-align: left;
+        position: absolute;
+        text-align: center;
+        width: 640px;
+        z-index: 1;
+      }
+    </style>
+
+    <div class="mailpoet-woocommerce-email-overlay">
+      <a class="button button-primary" href="?page=mailpoet-newsletter-editor&id=<?php echo $woocommerce_template_id; ?>">
+        <?php echo _x('Customize with MailPoet', 'Button in WooCommerce settings page'); ?>
+      </a>
+      <br>
+      <br>
+      <a href="?page=mailpoet-settings#woocommerce">
+        <?php echo _x('Disable MailPoet customizer', ''); ?>
+      </a>
+    </div>
+
+    <?php
   }
 }

--- a/tests/acceptance/WooCommerceSettingsTabCest.php
+++ b/tests/acceptance/WooCommerceSettingsTabCest.php
@@ -2,9 +2,21 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use MailPoet\Features\FeaturesController;
+use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Settings;
 
 class WooCommerceSettingsTabCest {
+
+  const CUSTOMIZE_SELECTOR = '[data-automation-id="mailpoet_woocommerce_customize"]';
+  const DISABLE_SELECTOR = '[data-automation-id="mailpoet_woocommerce_disable"]';
+
+  /** @var Features */
+  private $features;
+
+  protected function _inject(Features $features) {
+    $this->features = $features;
+  }
 
   function _before(\AcceptanceTester $I) {
     $I->activateWooCommerce();
@@ -28,5 +40,26 @@ class WooCommerceSettingsTabCest {
     $I->amOnMailpoetPage('Settings');
     $I->dontSeeElement('[data-automation-id="woocommerce_settings_tab"]');
     $I->seeNoJSErrors();
+  }
+
+  function checkWooCommercePluginSettingsAreDisabled(\AcceptanceTester $I) {
+    $this->features->withFeatureEnabled(FeaturesController::WC_TRANSACTIONAL_EMAILS_CUSTOMIZER);
+    $this->settings_factory->withWooCommerceEmailCustomizerEnabled();
+
+    $I->wantTo('Check WooCommerce plugin email settings are overlayed with link to MailPoet');
+
+    $I->login();
+    $I->amOnPage("/wp-admin/admin.php?page=wc-settings&tab=general");
+    $I->dontSeeElementInDOM(self::CUSTOMIZE_SELECTOR);
+
+    $I->amOnPage("/wp-admin/admin.php?page=wc-settings&tab=email");
+    $I->scrollTo(self::CUSTOMIZE_SELECTOR);
+    $href = $I->grabAttributeFrom(self::CUSTOMIZE_SELECTOR, 'href');
+    expect($href)->contains('?page=mailpoet-newsletter-editor&id=');
+    $href = $I->grabAttributeFrom(self::DISABLE_SELECTOR, 'href');
+    expect($href)->contains('?page=mailpoet-settings#woocommerce');
+
+    $I->amOnPage("/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order");
+    $I->dontSeeElementInDOM(self::CUSTOMIZE_SELECTOR);
   }
 }

--- a/views/woocommerce/settings_overlay.html
+++ b/views/woocommerce/settings_overlay.html
@@ -19,12 +19,15 @@
 </style>
 
 <div class="mailpoet-woocommerce-email-overlay">
-  <a class="button button-primary" href="?page=mailpoet-newsletter-editor&id=<%= woocommerce_template_id %>">
+  <a class="button button-primary"
+    href="?page=mailpoet-newsletter-editor&id=<%= woocommerce_template_id %>"
+    data-automation-id="mailpoet_woocommerce_customize"
+  >
   	<%= _x('Customize with MailPoet', 'Button in WooCommerce settings page') %>
   </a>
   <br>
   <br>
-  <a href="?page=mailpoet-settings#woocommerce">
+  <a href="?page=mailpoet-settings#woocommerce" data-automation-id="mailpoet_woocommerce_disable">
     <%= _x('Disable MailPoet customizer', 'Link from WooCommerce plugin to MailPoet') %>
   </a>
 </div>

--- a/views/woocommerce/settings_overlay.html
+++ b/views/woocommerce/settings_overlay.html
@@ -1,0 +1,30 @@
+<style>
+  /* Hide WooCommerce section with template styling */
+  #email_template_options-description + .form-table {
+    opacity: 0.2;
+    pointer-events: none;
+  }
+
+  /* Position MailPoet buttons over hidden table */
+  .mailpoet-woocommerce-email-overlay {
+    bottom: 320px;
+    left: 0;
+    max-width: 100%;
+    text-align: left;
+    position: absolute;
+    text-align: center;
+    width: 640px;
+    z-index: 1;
+  }
+</style>
+
+<div class="mailpoet-woocommerce-email-overlay">
+  <a class="button button-primary" href="?page=mailpoet-newsletter-editor&id=<%= woocommerce_template_id %>">
+  	<%= _x('Customize with MailPoet', 'Button in WooCommerce settings page') %>
+  </a>
+  <br>
+  <br>
+  <a href="?page=mailpoet-settings#woocommerce">
+    <%= _x('Disable MailPoet customizer', 'Link from WooCommerce plugin to MailPoet') %>
+  </a>
+</div>


### PR DESCRIPTION
There is a bit of a difference from specs - I'm not using `woocommerce_email_settings_after` hook as suggested, because it's a hook for specific email settings. Instead, I'm using `woocommerce_settings_start` (which is called on every settings page) and then filtering in MailPoet which tab is shown. 

It's done without JS so the positioning of buttons is fixed and not calculated. It may break if they change the settings page layout, but that might break even if JS would be included. 

[MAILPOET-2283]

[MAILPOET-2283]: https://mailpoet.atlassian.net/browse/MAILPOET-2283