### PR TITLE
Show TinyMCE toolbar above WP menu [MAILPOET-2404]

### DIFF
--- a/assets/css/src/components/newsletterEditor/_libraryOverrides.scss
+++ b/assets/css/src/components/newsletterEditor/_libraryOverrides.scss
@@ -29,7 +29,9 @@
     border: 1px solid $content-border-color;
     border-radius: 3px;
     box-shadow: 0 0 3px 1px rgba(0, 0, 0, .05);
-    z-index: 1;
+
+    /* Fix for fixed TinyMCE toolbar to be above WP menu */
+    z-index: 50001;
   }
 
   /* Fix for TinyMCE modals are above WP menu */


### PR DESCRIPTION
I didn't find any option in docs to set offset for the fixed TinyMCE toolbar. So the "solution" here is, that it's shown above the WordPress menu.

[MAILPOET-2404]

[MAILPOET-2404]: https://mailpoet.atlassian.net/browse/MAILPOET-2404