### PR TITLE
Process each entry only once in unsubscribe tokens worker [MAILPOET-2447]

### DIFF
--- a/lib/Util/Security.php
+++ b/lib/Util/Security.php
@@ -43,12 +43,10 @@ class Security {
   }
 
   static public function generateUnsubscribeToken($model) {
-    $token = self::generateRandomString(self::UNSUBSCRIBE_TOKEN_LENGTH);
-    $found = $model::whereEqual('unsubscribe_token', $token)->count();
-    while ($found > 0) {
+    do {
       $token = self::generateRandomString(self::UNSUBSCRIBE_TOKEN_LENGTH);
       $found = $model::whereEqual('unsubscribe_token', $token)->count();
-    }
+    } while ($found > 0);
     return $token;
   }
 }


### PR DESCRIPTION
Changes: 

* Each entry is processed only once by keeping track of the last processed ID in the task's `meta` field, so no endless cycle if we're unable to save a particular model;
* Unnecessary scheduling of new tasks is removed, one task is enough to do the job if it returns its boolean completion status correctly;
* Some code duplication is avoided by replacing `while` with `do ... while`.