### PR TITLE
Refactor emoji encoding/decoding out of models [MAILPOET-2460]

### DIFF
--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -208,6 +208,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails::class);
     // WordPress
+    $container->autowire(\MailPoet\WP\Emoji::class)->setPublic(true);
     $container->autowire(\MailPoet\WP\Functions::class)->setPublic(true);
     return $container;
   }

--- a/lib/Models/Newsletter.php
+++ b/lib/Models/Newsletter.php
@@ -14,7 +14,6 @@ use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Security;
 use MailPoet\WooCommerce\Helper as WCHelper;
-use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 
 use function MailPoet\Util\array_column;
@@ -58,14 +57,11 @@ class Newsletter extends Model {
   // automatic newsletters status
   const STATUS_ACTIVE = NewsletterEntity::STATUS_ACTIVE;
 
-  private $emoji;
-
   function __construct() {
     parent::__construct();
     $this->addValidations('type', [
       'required' => WPFunctions::get()->__('Please specify a type.', 'mailpoet'),
     ]);
-    $this->emoji = new Emoji();
   }
 
   function queue() {
@@ -125,7 +121,7 @@ class Newsletter extends Model {
       }
       $this->set(
         'body',
-        $this->emoji->encodeForUTF8Column(self::$_table, 'body', $this->body)
+        $this->body
       );
     }
 

--- a/lib/Newsletter/ViewInBrowser.php
+++ b/lib/Newsletter/ViewInBrowser.php
@@ -5,14 +5,18 @@ namespace MailPoet\Newsletter;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
+use MailPoet\WP\Emoji;
 
 class ViewInBrowser {
+  /** @var Emoji */
+  private $emoji;
 
   /** @var bool */
   private $is_tracking_enabled;
 
-  function __construct($is_tracking_enabled) {
+  function __construct(Emoji $emoji, $is_tracking_enabled) {
     $this->is_tracking_enabled = $is_tracking_enabled;
+    $this->emoji = $emoji;
   }
 
   function view($data) {
@@ -31,6 +35,7 @@ class ViewInBrowser {
   function renderNewsletter($newsletter, $subscriber, $queue, $wp_user_preview) {
     if ($queue && $queue->getNewsletterRenderedBody()) {
       $newsletter_body = $queue->getNewsletterRenderedBody('html');
+      $newsletter_body = $this->emoji->decodeEmojisInBody($newsletter_body);
       // rendered newsletter body has shortcodes converted to links; we need to
       // isolate "view in browser", "unsubscribe" and "manage subscription" links
       // and convert them to shortcodes, which later will be replaced with "#" when

--- a/lib/Router/Endpoints/ViewInBrowser.php
+++ b/lib/Router/Endpoints/ViewInBrowser.php
@@ -10,6 +10,7 @@ use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Newsletter\ViewInBrowser as NewsletterViewInBrowser;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\LinkTokens;
+use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 
 class ViewInBrowser {
@@ -28,15 +29,19 @@ class ViewInBrowser {
   /** @var LinkTokens */
   private $link_tokens;
 
-  function __construct(AccessControl $access_control, SettingsController $settings, LinkTokens $link_tokens) {
+  /** @var Emoji */
+  private $emoji;
+
+  function __construct(AccessControl $access_control, SettingsController $settings, LinkTokens $link_tokens, Emoji $emoji) {
     $this->access_control = $access_control;
     $this->settings = $settings;
     $this->link_tokens = $link_tokens;
+    $this->emoji = $emoji;
   }
 
   function view($data) {
     $data = $this->_processBrowserPreviewData($data);
-    $view_in_browser = new NewsletterViewInBrowser((bool)$this->settings->get('tracking.enabled'));
+    $view_in_browser = new NewsletterViewInBrowser($this->emoji, (bool)$this->settings->get('tracking.enabled'));
     return $this->_displayNewsletter($view_in_browser->view($data));
   }
 

--- a/lib/WP/Emoji.php
+++ b/lib/WP/Emoji.php
@@ -14,6 +14,28 @@ class Emoji {
     $this->wp = $wp;
   }
 
+  function encodeEmojisInBody($newsletter_rendered_body) {
+    if (is_array($newsletter_rendered_body)) {
+      return array_map([$this, 'encodeRenderedBodyForUTF8Column'], $newsletter_rendered_body);
+    }
+    return $this->encodeRenderedBodyForUTF8Column($newsletter_rendered_body);
+  }
+
+  function decodeEmojisInBody($newsletter_rendered_body) {
+    if (is_array($newsletter_rendered_body)) {
+      return array_map([$this, 'decodeEntities'], $newsletter_rendered_body);
+    }
+    return $this->decodeEntities($newsletter_rendered_body);
+  }
+
+  private function encodeRenderedBodyForUTF8Column($value) {
+    return $this->encodeForUTF8Column(
+      MP_SENDING_QUEUES_TABLE,
+      'newsletter_rendered_body',
+      $value
+    );
+  }
+
   function encodeForUTF8Column($table, $field, $value) {
     global $wpdb;
     $charset = $wpdb->get_col_charset($table, $field);

--- a/tests/integration/Models/SendingQueueTest.php
+++ b/tests/integration/Models/SendingQueueTest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Test\Models;
 
-use AspectMock\Test as Mock;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
@@ -21,26 +20,6 @@ class SendingQueueTest extends \MailPoetTest {
       'html' => 'some html',
       'text' => 'some text',
     ];
-  }
-
-  function testItCanEncodeEmojisInBody() {
-    $mock = Mock::double('MailPoet\WP\Emoji', [
-      'encodeForUTF8Column' => function($params) {
-        return $params;
-      },
-    ]);
-    $this->queue->encodeEmojisInBody($this->rendered_body);
-    $mock->verifyInvokedMultipleTimes('encodeForUTF8Column', 2);
-  }
-
-  function testItCanDecodeEmojisInBody() {
-    $mock = Mock::double('MailPoet\WP\Emoji', [
-      'decodeEntities' => function($params) {
-        return $params;
-      },
-    ]);
-    $this->queue->decodeEmojisInBody($this->rendered_body);
-    $mock->verifyInvokedMultipleTimes('decodeEntities', 2);
   }
 
   function testItChecksProcessedSubscribersForOldQueues() {
@@ -149,7 +128,6 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   function _after() {
-    Mock::clean();
     \ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
     \ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
     \ORM::raw_execute('TRUNCATE ' . SendingQueue::$_table);

--- a/tests/integration/Router/Endpoints/ViewInBrowserTest.php
+++ b/tests/integration/Router/Endpoints/ViewInBrowserTest.php
@@ -13,6 +13,7 @@ use MailPoet\Router\Endpoints\ViewInBrowser;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions;
 
 class ViewInBrowserTest extends \MailPoetTest {
@@ -44,7 +45,7 @@ class ViewInBrowserTest extends \MailPoetTest {
       'preview' => false,
     ];
     // instantiate class
-    $this->view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens());
+    $this->view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens(), new Emoji());
   }
 
   function testItAbortsWhenBrowserPreviewDataIsMissing() {
@@ -154,12 +155,12 @@ class ViewInBrowserTest extends \MailPoetTest {
     $wp_user = wp_set_current_user(0);
     // when WP user does not have 'manage options' permission, false should be returned
     $wp_user->remove_role('administrator');
-    $view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens());
+    $view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens(), new Emoji());
     expect($view_in_browser->_validateBrowserPreviewData($data))->false();
 
     // when WP has 'manage options' permission, data should be returned
     $wp_user->add_role('administrator');
-    $view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens());
+    $view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens(), new Emoji());
     expect($view_in_browser->_validateBrowserPreviewData($data))->equals($data);
   }
 
@@ -175,7 +176,7 @@ class ViewInBrowserTest extends \MailPoetTest {
     );
     $data->preview = true;
     wp_set_current_user(1);
-    $view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens(), new LinkTokens());
+    $view_in_browser = new ViewInBrowser(new AccessControl(new Functions()), new SettingsController(), new LinkTokens(), new Emoji());
     $result = $view_in_browser->_validateBrowserPreviewData($data);
     expect($result->subscriber->id)->equals(1);
   }
@@ -211,6 +212,7 @@ class ViewInBrowserTest extends \MailPoetTest {
       'link_tokens' => new LinkTokens,
       '_displayNewsletter' => Expected::exactly(1),
       'settings' => new SettingsController(),
+      'emoji' => new Emoji(),
     ], $this);
     $view_in_browser->view($this->browser_preview_data);
   }

--- a/tests/integration/WP/EmojiTest.php
+++ b/tests/integration/WP/EmojiTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\WP;
 
+use Codeception\Stub\Expected;
 use MailPoet\Config\Env;
 use MailPoet\WP\Emoji;
 
@@ -13,6 +14,30 @@ class EmojiTest extends \MailPoetTest {
 
     $this->column = 'dummycol';
     $this->emoji = new Emoji();
+  }
+
+  function testItCanEncodeNewsletterRenderedBody() {
+    $emoji = $this->make(
+      Emoji::class,
+      ['encodeForUTF8Column' => Expected::exactly(3, function ($params) {
+        return $params;
+      })],
+      $this
+    );
+    $emoji->encodeEmojisInBody(['text' => 'call 1', 'html' => 'call 2']);
+    $emoji->encodeEmojisInBody('string, call 3');
+  }
+
+  function testItCanDecodeNewsletterBody() {
+    $emoji = $this->make(
+      Emoji::class,
+      ['decodeEntities' => Expected::exactly(3, function ($params) {
+        return $params;
+      })],
+      $this
+    );
+    $emoji->decodeEmojisInBody(['text' => 'call 1', 'html' => 'call 2']);
+    $emoji->decodeEmojisInBody('string, call 3');
   }
 
   function testItCanEncodeForUTF8Column() {


### PR DESCRIPTION
Since emoji handling is now decoupled from models, we need to put it anywhere newsletter source/rendered body is saved to the database or retrieved for rendering. Hope I didn't miss such cases.