### PR TITLE
Create WC transactional email only when it's first invoked [MAILPOET-2514]

### DIFF
--- a/assets/js/src/newsletters/types.jsx
+++ b/assets/js/src/newsletters/types.jsx
@@ -98,9 +98,10 @@ class NewsletterTypes extends React.Component {
       'MailPoet Free version': window.mailpoet_version,
       'Email type': 'wc_transactional',
     });
+    let emailId = window.mailpoet_woocommerce_transactional_email_id;
     if (!window.mailpoet_woocommerce_customizer_enabled) {
       try {
-        await MailPoet.Ajax.post({
+        const response = await MailPoet.Ajax.post({
           api_version: window.mailpoet_api_version,
           endpoint: 'settings',
           action: 'set',
@@ -108,12 +109,13 @@ class NewsletterTypes extends React.Component {
             'woocommerce.use_mailpoet_editor': 1,
           },
         });
+        emailId = response.data.woocommerce.transactional_email_id;
       } catch (response) {
         MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         return;
       }
     }
-    window.location.href = `?page=mailpoet-newsletter-editor&id=${window.mailpoet_woocommerce_transactional_email_id}`;
+    window.location.href = `?page=mailpoet-newsletter-editor&id=${emailId}`;
   };
 
   createNewsletter = (type) => {

--- a/lib/API/JSON/v1/Settings.php
+++ b/lib/API/JSON/v1/Settings.php
@@ -13,6 +13,7 @@ use MailPoet\Models\ScheduledTask;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
+use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Settings extends APIEndpoint {
@@ -26,6 +27,9 @@ class Settings extends APIEndpoint {
   /** @var AuthorizedEmailsController */
   private $authorized_emails_controller;
 
+  /** @var TransactionalEmails */
+  private $wc_transactional_emails;
+
   public $permissions = [
     'global' => AccessControl::PERMISSION_MANAGE_SETTINGS,
   ];
@@ -34,11 +38,13 @@ class Settings extends APIEndpoint {
   public function __construct(
     SettingsController $settings,
     Bridge $bridge,
-    AuthorizedEmailsController $authorized_emails_controller
+    AuthorizedEmailsController $authorized_emails_controller,
+    TransactionalEmails $wc_transactional_emails
   ) {
     $this->settings = $settings;
     $this->bridge = $bridge;
     $this->authorized_emails_controller = $authorized_emails_controller;
+    $this->wc_transactional_emails = $wc_transactional_emails;
   }
 
   function get() {
@@ -87,6 +93,10 @@ class Settings extends APIEndpoint {
       : '0';
     if ($old_subscribe_old_woocommerce_customers !== $new_subscribe_old_woocommerce_customers) {
       $this->onSubscribeOldWoocommerceCustomersChange();
+    }
+
+    if (!empty($new_settings['woocommerce']['use_mailpoet_editor'])) {
+      $this->wc_transactional_emails->init();
     }
   }
 

--- a/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/lib/AdminPages/Pages/NewsletterEditor.php
@@ -50,7 +50,7 @@ class NewsletterEditor {
 
   function render() {
     $newsletter_id = (isset($_GET['id']) ? (int)$_GET['id'] : 0);
-    $woocommerce_template_id = (int)$this->settings->get('woocommerce.transactional_email_id', null);
+    $woocommerce_template_id = (int)$this->settings->get(TransactionalEmails::SETTING_EMAIL_ID, null);
     if (
       $woocommerce_template_id
       && $newsletter_id === $woocommerce_template_id

--- a/lib/AdminPages/Pages/Newsletters.php
+++ b/lib/AdminPages/Pages/Newsletters.php
@@ -16,6 +16,7 @@ use MailPoet\Settings\UserFlagsController;
 use MailPoet\Util\Installation;
 use MailPoet\Util\License\License;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\DateTime;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -162,7 +163,7 @@ class Newsletters {
     $data['is_new_user'] = $this->installation->isNewInstallation();
     $data['sent_newsletters_count'] = (int)Newsletter::where('status', Newsletter::STATUS_SENT)->count();
     $data['woocommerce_customizer_enabled'] = (bool)$this->settings->get('woocommerce.use_mailpoet_editor');
-    $data['woocommerce_transactional_email_id'] = $this->settings->get('woocommerce.transactional_email_id');
+    $data['woocommerce_transactional_email_id'] = $this->settings->get(TransactionalEmails::SETTING_EMAIL_ID);
     $this->wp->wpEnqueueScript('jquery-ui');
     $this->wp->wpEnqueueScript('jquery-ui-datepicker');
 

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -31,7 +31,6 @@ use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscription\Captcha;
 use MailPoet\Util\Helpers;
-use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Populator {
@@ -50,16 +49,12 @@ class Populator {
   /** @var FeaturesController */
   private $flags_controller;
 
-  /** @var TransactionalEmails */
-  private $wc_transactional_emails;
-
   function __construct(
     SettingsController $settings,
     WPFunctions $wp,
     Captcha $captcha,
     ReferralDetector $referralDetector,
-    FeaturesController $flags_controller,
-    TransactionalEmails $wc_transactional_emails
+    FeaturesController $flags_controller
   ) {
     $this->settings = $settings;
     $this->wp = $wp;
@@ -147,7 +142,6 @@ class Populator {
       'FarmersMarket',
     ];
     $this->flags_controller = $flags_controller;
-    $this->wc_transactional_emails = $wc_transactional_emails;
   }
 
   function up() {
@@ -173,7 +167,6 @@ class Populator {
     $this->scheduleSubscriberLinkTokens();
     $this->detectReferral();
     $this->updateFormsSuccessMessages();
-    $this->initWooCommerceTransactionalEmails();
     $this->moveGoogleAnalyticsFromPremium();
   }
 
@@ -723,12 +716,5 @@ class Populator {
 
   private function detectReferral() {
     $this->referralDetector->detect();
-  }
-
-  private function initWooCommerceTransactionalEmails() {
-    $feature_enabled = $this->flags_controller->isSupported(FeaturesController::WC_TRANSACTIONAL_EMAILS_CUSTOMIZER);
-    if ($feature_enabled) {
-      $this->wc_transactional_emails->init();
-    }
   }
 }

--- a/lib/WooCommerce/Settings.php
+++ b/lib/WooCommerce/Settings.php
@@ -5,6 +5,7 @@ namespace MailPoet\WooCommerce;
 use MailPoet\Config\Renderer;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\WooCommerce\TransactionalEmails;
 
 class Settings {
 
@@ -43,7 +44,7 @@ class Settings {
     }
 
     echo $this->renderer->render('woocommerce/settings_overlay.html', [
-      'woocommerce_template_id' => $this->settings->get('woocommerce.transactional_email_id'),
+      'woocommerce_template_id' => $this->settings->get(TransactionalEmails::SETTING_EMAIL_ID),
     ]);
   }
 }

--- a/tests/acceptance/WooCommerceEmailCustomizationCest.php
+++ b/tests/acceptance/WooCommerceEmailCustomizationCest.php
@@ -28,14 +28,13 @@ class WooCommerceEmailCustomizationCest {
     $I->amOnPluginsPage();
     $I->deactivatePlugin('mailpoet');
     $I->activatePlugin('mailpoet');
-
-    $woocommerce_settings = $I->grabFromDatabase(MP_SETTINGS_TABLE, 'value', ['name' => 'woocommerce']);
-    $woocommerce_settings = unserialize($woocommerce_settings);
-    $this->woocommerce_email_template_id = $woocommerce_settings['transactional_email_id'];
   }
 
   function openEmailCustomizerWhenSettingIsEnabled(\AcceptanceTester $I) {
     $I->wantTo('Open WooCommerce email customizer while setting is enabled');
+
+    $this->createEmailTemplate($I);
+    $this->woocommerce_email_template_id = $this->getWooCommerceEmailTemplateId($I);
 
     $this->settings->withWooCommerceEmailCustomizerEnabled();
 
@@ -68,11 +67,15 @@ class WooCommerceEmailCustomizationCest {
     $I->click($button_selector);
 
     $I->waitForText('Edit template for WooCommerce emails');
+    $this->woocommerce_email_template_id = $this->getWooCommerceEmailTemplateId($I);
     $I->seeInCurrentUrl('?page=mailpoet-newsletter-editor&id=' . $this->woocommerce_email_template_id);
   }
 
   function showNoticeWhenWooCommerceCustomizerIsDisabled(\AcceptanceTester $I) {
     $I->wantTo('Show notice when WooCommerce Customizer is disabled');
+
+    $this->createEmailTemplate($I);
+    $this->woocommerce_email_template_id = $this->getWooCommerceEmailTemplateId($I);
 
     $this->settings->withWooCommerceEmailCustomizerDisabled();
 
@@ -80,5 +83,20 @@ class WooCommerceEmailCustomizationCest {
     $I->amOnPage('/wp-admin/admin.php?page=mailpoet-newsletter-editor&id=' . $this->woocommerce_email_template_id);
     $I->waitForText('You need to enable MailPoet email customizer for WooCommerce if you want to access to the customizer.');
     $I->seeInCurrentUrl('?page=mailpoet-settings&enable-customizer-notice#woocommerce');
+  }
+
+  private function createEmailTemplate(\AcceptanceTester $I) {
+    $I->login();
+    $I->amOnMailpoetPage('Emails');
+    $I->click('[data-automation-id="new_email"]');
+    $button_selector = '[data-automation-id="customize_woocommerce"]';
+    $I->click($button_selector);
+    $I->waitForText('Edit template for WooCommerce emails');
+  }
+
+  private function getWooCommerceEmailTemplateId(\AcceptanceTester $I) {
+    $woocommerce_settings = $I->grabFromDatabase(MP_SETTINGS_TABLE, 'value', ['name' => 'woocommerce']);
+    $woocommerce_settings = unserialize($woocommerce_settings);
+    return $woocommerce_settings['transactional_email_id'];
   }
 }

--- a/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/tests/integration/API/JSON/v1/SettingsTest.php
@@ -13,6 +13,7 @@ use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
+use MailPoet\WooCommerce\TransactionalEmails;
 
 class SettingsTest extends \MailPoetTest {
 
@@ -30,7 +31,8 @@ class SettingsTest extends \MailPoetTest {
     $this->endpoint = new Settings(
       $this->settings,
       new Bridge,
-      $this->make(AuthorizedEmailsController::class, ['onSettingsSave' => true ])
+      $this->make(AuthorizedEmailsController::class, ['onSettingsSave' => true ]),
+      $this->make(TransactionalEmails::class)
     );
   }
 
@@ -61,7 +63,8 @@ class SettingsTest extends \MailPoetTest {
     $this->endpoint = new Settings(
       $this->settings,
       $this->make(Bridge::class, ['onSettingsSave' => Expected::once()]),
-      $this->make(AuthorizedEmailsController::class, ['onSettingsSave' => Expected::once()])
+      $this->make(AuthorizedEmailsController::class, ['onSettingsSave' => Expected::once()]),
+      $this->make(TransactionalEmails::class)
     );
 
     $response = $this->endpoint->set(/* missing data */);

--- a/tests/integration/API/JSON/v1/SetupTest.php
+++ b/tests/integration/API/JSON/v1/SetupTest.php
@@ -13,7 +13,6 @@ use MailPoet\Referrals\ReferralDetector;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscription\Captcha;
-use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SetupTest extends \MailPoetTest {
@@ -32,8 +31,7 @@ class SetupTest extends \MailPoetTest {
 
     $settings = SettingsController::getInstance();
     $referral_detector = new ReferralDetector($wp, $settings);
-    $wc_transactional_emails = new TransactionalEmails($wp, $settings);
-    $populator = new Populator($settings, $wp, new Captcha(), $referral_detector, $features_controller, $wc_transactional_emails);
+    $populator = new Populator($settings, $wp, new Captcha(), $referral_detector, $features_controller);
     $router = new Setup($wp, new Activator($settings, $populator));
     $response = $router->reset();
     expect($response->status)->equals(APIResponse::STATUS_OK);

--- a/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -40,7 +40,6 @@ use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\SubscriptionUrlFactory;
 use MailPoet\Tasks\Sending as SendingTask;
-use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -61,8 +60,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->settings = SettingsController::getInstance();
     $referral_detector = new ReferralDetector(WPFunctions::get(), $this->settings);
     $features_controller = Stub::makeEmpty(FeaturesController::class);
-    $wc_transactional_emails = new TransactionalEmails(WPFunctions::get(), $this->settings);
-    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller, $wc_transactional_emails);
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller);
     $populator->up();
     $this->subscriber = Subscriber::create();
     $this->subscriber->email = 'john@doe.com';

--- a/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -13,7 +13,6 @@ use MailPoet\Referrals\ReferralDetector;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscription\Captcha;
-use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 
 class MailerTest extends \MailPoetTest {
@@ -30,8 +29,7 @@ class MailerTest extends \MailPoetTest {
     $this->settings = SettingsController::getInstance();
     $referral_detector = new ReferralDetector(WPFunctions::get(), $this->settings);
     $features_controller = Stub::makeEmpty(FeaturesController::class);
-    $wc_transactional_emails = new TransactionalEmails(WPFunctions::get(), $this->settings);
-    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller, $wc_transactional_emails);
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller);
     $populator->up();
     $this->mailer_task = new MailerTask();
     $this->sender = $this->settings->get('sender');

--- a/tests/integration/Newsletter/ShortcodesTest.php
+++ b/tests/integration/Newsletter/ShortcodesTest.php
@@ -17,7 +17,6 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\SubscriptionUrlFactory;
-use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 
 require_once(ABSPATH . 'wp-admin/includes/user.php');
@@ -36,8 +35,7 @@ class ShortcodesTest extends \MailPoetTest {
     $this->settings = SettingsController::getInstance();
     $referral_detector = new ReferralDetector(WPFunctions::get(), $this->settings);
     $features_controller = Stub::makeEmpty(FeaturesController::class);
-    $wc_transactional_emails = new TransactionalEmails(WPFunctions::get(), $this->settings);
-    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller, $wc_transactional_emails);
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller);
     $populator->up();
     $this->WP_user = $this->_createWPUser();
     $this->WP_post = $this->_createWPPost();

--- a/tests/integration/Subscription/UrlTest.php
+++ b/tests/integration/Subscription/UrlTest.php
@@ -13,7 +13,6 @@ use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\SubscriptionUrlFactory;
-use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\Functions as WPFunctions;
 
 class UrlTest extends \MailPoetTest {
@@ -29,8 +28,7 @@ class UrlTest extends \MailPoetTest {
     $this->settings = SettingsController::getInstance();
     $referral_detector = new ReferralDetector(WPFunctions::get(), $this->settings);
     $features_controller = Stub::makeEmpty(FeaturesController::class);
-    $wc_transactional_emails = new TransactionalEmails(WPFunctions::get(), $this->settings);
-    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller, $wc_transactional_emails);
+    $populator = new Populator($this->settings, WPFunctions::get(), new Captcha, $referral_detector, $features_controller);
     $populator->up();
     $this->url = new SubscriptionUrlFactory(WPFunctions::get(), $this->settings, new LinkTokens);
   }


### PR DESCRIPTION
The template is now created on the 'Activate & Customize' button click.