### PR TITLE
Fix stats redirect [MAILPOET-2554]

### DIFF
--- a/lib/AdminPages/Pages/Newsletters.php
+++ b/lib/AdminPages/Pages/Newsletters.php
@@ -75,6 +75,15 @@ class Newsletters {
   public function render() {
     global $wp_roles; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.NotCamelCaps
 
+    if (isset($_GET['stats'])) {
+      $this->wp->wpSafeRedirect(
+        $this->wp->getSiteUrl(null,
+          '/wp-admin/admin.php?page=mailpoet-newsletters#/stats/' . $_GET['stats']
+        )
+      );
+      exit;
+    }
+
     $data = [];
 
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('newsletters');

--- a/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -139,7 +139,7 @@ class Worker {
       ),
       'topLinkClicks' => 0,
       'linkSettings' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings#basics'),
-      'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters#/stats/' . $newsletter->getId()),
+      'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters&stats=' . $newsletter->getId()),
       'clicked' => $clicked,
       'opened' => $opened,
       'subscribersLimitReached' => $this->subscribersFeature->check(),

--- a/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -209,7 +209,7 @@ class WorkerTest extends \MailPoetTest {
         $this->anything(),
         $this->callback(function($context){
           return strpos($context['linkSettings'], 'mailpoet-settings')
-            && strpos($context['linkStats'], 'mailpoet-newsletters#/stats');
+            && strpos($context['linkStats'], 'mailpoet-newsletters&stats');
         }));
 
     $this->statsNotifications->process();


### PR DESCRIPTION
When an unauthenticated user comes to any page they are redirected
to the login screen. After they authenticate they are redirected
to the original page. But the # part of the URL is ignored.
So we have to use regular query params from the email and
redirect the user to the canonical URL later.

[MAILPOET-2554]

[MAILPOET-2554]: https://mailpoet.atlassian.net/browse/MAILPOET-2554