### PR TITLE
Fix deprecated functions in the makepot command [MAILPOET-2523]

### DIFF
--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/add-textdomain.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/add-textdomain.php
@@ -13,7 +13,7 @@ class AddTextdomain {
 	public $modified_contents = '';
 	public $funcs;
 
-	public function AddTextdomain() {
+	public function __construct() {
 		$makepot = new MakePOT;
 		$this->funcs = array_keys( $makepot->rules );
 	}

--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/makepot.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/makepot.php
@@ -178,7 +178,7 @@ class MakePOT {
 		$placeholders = array_merge( $meta, $placeholders );
 		$meta['output'] = $this->realpath_missing( $output_file );
 		$placeholders['year'] = gmdate( 'Y' );
-		$placeholder_keys = array_map( create_function( '$x', 'return "{".$x."}";' ), array_keys( $placeholders ) );
+		$placeholder_keys = array_map( function ($x) { return "{".$x."}"; }, array_keys( $placeholders ) );
 		$placeholder_values = array_values( $placeholders );
 		foreach( $meta as $key => $value ) {
 			$meta[ $key ] = str_replace( $placeholder_keys, $placeholder_values, $value );

--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/not-gettexted.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/not-gettexted.php
@@ -76,12 +76,18 @@ class NotGettexted {
 
 	public function make_string_aggregator( $global_array_name, $filename ) {
 		$a = $global_array_name;
-		return create_function( '$string, $comment_id, $line_number', 'global $' . $a . '; $' . $a . '[] = array($string, $comment_id, ' . var_export( $filename, true ) . ', $line_number);' );
+		return function ($string, $comment_id, $line_number) use ($a, $filename) {
+			global ${$a};
+			${$a}[] = array($string, $comment_id, var_export( $filename, true ), $line_number);
+		};
 	}
 
 	public function make_mo_replacer( $global_mo_name ) {
 		$m = $global_mo_name;
-		return create_function( '$token, $string', 'global $' . $m . '; return var_export($' . $m . '->translate($string), true);' );
+		return function ($token, $string) use ($m) {
+			global ${$m};
+			return var_export(${$m}->translate($string), true);
+		};
 	}
 
 	public function walk_tokens( &$tokens, $string_action, $other_action, $register_action = null ) {

--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/entry.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/entry.php
@@ -40,7 +40,7 @@ class Translation_Entry {
 	 * 	- references (array) -- places in the code this strings is used, in relative_to_root_path/file.php:linenum form
 	 * 	- flags (array) -- flags like php-format
 	 */
-	public function Translation_Entry( $args=array() ) {
+	public function __construct( $args=array() ) {
 		// if no singular -- empty object
 		if ( !isset( $args['singular'] ) ) {
 			return;

--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/po.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/po.php
@@ -163,11 +163,10 @@ class PO extends Gettext_Translations {
 	 * @param string $with prepend lines with this string
 	 */
 	public static function prepend_each_line( $string, $with ) {
-		$php_with = var_export( $with, true );
 		$lines = explode( "\n", $string );
 		// do not prepend the string on the last empty line, artefact by explode
 		if ("\n" == substr( $string, -1 ) ) unset( $lines[count( $lines ) - 1] );
-		$res = implode( "\n", array_map( create_function( '$x', "return $php_with.\$x;" ), $lines )) ;
+		$res = implode( "\n", array_map( function ($x) use ($with) { return $with.$x; }, $lines )) ;
 		// give back the empty line, we ignored above
 		if ( "\n" == substr( $string, -1 ) ) $res .= "\n";
 		return $res;
@@ -246,7 +245,7 @@ class PO extends Gettext_Translations {
 		// can be: comment, msgctxt, msgid, msgid_plural, msgstr, msgstr_plural
 		$context = '';
 		$msgstr_index = 0;
-		$is_final = create_function( '$context', 'return $context == "msgstr" || $context == "msgstr_plural";' );
+		$is_final = function ($context) { return $context == "msgstr" || $context == "msgstr_plural"; };
 		while ( true ) {
 			$lineno++;
 			$line = PO::read_line( $f );
@@ -339,7 +338,7 @@ class PO extends Gettext_Translations {
 				return false;
 			}
 		}
-		if ( array() == array_filter( $entry->translations, create_function( '$t', 'return $t || "0" === $t;' ) ) ) {
+		if ( array() == array_filter( $entry->translations, function ($t) { return $t || "0" === $t; } ) ) {
 			$entry->translations = array();
 		}
 		return array( 'entry' => $entry, 'lineno' => $lineno );

--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/streams.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/streams.php
@@ -14,7 +14,7 @@ class POMO_Reader {
 	var $endian = 'little';
 	var $_post = '';
 
-	function POMO_Reader() {
+	function __construct() {
 		$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr');
 		$this->_pos = 0;
 	}
@@ -104,8 +104,8 @@ endif;
 
 if ( !class_exists( 'POMO_FileReader' ) ):
 class POMO_FileReader extends POMO_Reader {
-	function POMO_FileReader ($filename ) {
-		parent::POMO_Reader();
+	function __construct($filename ) {
+		parent::__construct();
 		$this->_f = fopen( $filename, 'rb' );
 	}
 
@@ -151,8 +151,8 @@ class POMO_StringReader extends POMO_Reader {
 
 	var $_str = '';
 
-	public function POMO_StringReader( $str = '' ) {
-		parent::POMO_Reader();
+	public function __construct( $str = '' ) {
+		parent::__construct();
 		$this->_str = $str;
 		$this->_pos = 0;
 	}
@@ -187,8 +187,8 @@ if ( !class_exists( 'POMO_CachedFileReader' ) ):
  * Reads the contents of the file in the beginning.
  */
 class POMO_CachedFileReader extends POMO_StringReader {
-	public function POMO_CachedFileReader( $filename ) {
-		parent::POMO_StringReader();
+	public function __construct( $filename ) {
+		parent::__construct();
 		$this->_str = file_get_contents( $filename );
 		if ( false === $this->_str )
 			return false;
@@ -202,8 +202,8 @@ if ( !class_exists( 'POMO_CachedIntFileReader' ) ):
  * Reads the contents of the file in the beginning.
  */
 class POMO_CachedIntFileReader extends POMO_CachedFileReader {
-	public function POMO_CachedIntFileReader( $filename ) {
-		parent::POMO_CachedFileReader( $filename );
+	public function __construct( $filename ) {
+		parent::__construct( $filename );
 	}
 }
 endif;

--- a/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/translations.php
+++ b/tasks/makepot/node_modules/grunt-wp-i18n/vendor/wp-i18n-tools/pomo/translations.php
@@ -174,10 +174,10 @@ class Gettext_Translations extends Translations {
 	 */
 	public function make_plural_form_function( $nplurals, $expression ) {
 		$expression = str_replace( 'n', '$n', $expression );
-		$func_body = "
-			\$index = (int)($expression);
-			return (\$index < $nplurals)? \$index : $nplurals - 1;";
-		return create_function( '$n', $func_body );
+		return function ($n) use ($nplurals) {
+			$index = (int)(eval($expression));
+			return ($index < $nplurals)? $index : $nplurals - 1;
+		};
 	}
 
 	/**


### PR DESCRIPTION
Please check that functions were refactored correctly, e.g. you can compare a POT file generated on `master` and in this branch so they match.