### PR TITLE
Update stats page banners for new free plan limit [MAILPOET-2492]

### DIFF
--- a/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
+++ b/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
@@ -2,13 +2,8 @@ import React from 'react';
 import MailPoet from 'mailpoet';
 
 const PremiumBanner = () => {
-  if (window.mailpoet_display_detailed_stats) {
-    return null;
-  }
-
-  let ctaButton = null;
-  if (window.mailpoet_subscribers_count <= window.mailpoet_free_premium_subscribers_limit) {
-    ctaButton = (
+  if (!window.mailpoet_display_detailed_stats) {
+    const ctaButton = (
       <a
         className="button"
         href={MailPoet.MailPoetComUrlFactory.getFreePlanUrl({ utm_medium: 'stats', utm_campaign: 'signup' })}
@@ -18,26 +13,43 @@ const PremiumBanner = () => {
         {MailPoet.I18n.t('premiumBannerCtaFree')}
       </a>
     );
-  } else {
-    ctaButton = (
-      <a
-        className="button"
-        href={MailPoet.MailPoetComUrlFactory.getPricingPageUrl(window.mailpoet_subscribers_count)}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {MailPoet.I18n.t('premiumBannerCtaPremium')}
-      </a>
+
+    return (
+      <div className="mailpoet_stats_premium_banner">
+        <h1>{MailPoet.I18n.t('premiumBannerTitle')}</h1>
+        <p>{ctaButton}</p>
+        <a href="admin.php?page=mailpoet-premium">{MailPoet.I18n.t('premiumBannerLink')}</a>
+      </div>
     );
   }
+  if (window.mailpoet_subscribers_limit_reached) {
+    const hasValidApiKey = window.mailpoet_has_valid_api_key;
+    const title = MailPoet.I18n.t('subscribersLimitNoticeTitle')
+      .replace('[subscribersLimit]', window.mailpoet_subscribers_limit);
+    const youReachedTheLimit = MailPoet.I18n.t(hasValidApiKey ? 'yourPlanLimit' : 'freeVersionLimit')
+      .replace('[subscribersLimit]', window.mailpoet_subscribers_limit);
+    const upgradeLink = hasValidApiKey
+      ? 'https://account.mailpoet.com/upgrade'
+      : `https://account.mailpoet.com/?s=${window.mailpoet_subscribers_count + 1}`;
 
-  return (
-    <div className="mailpoet_stats_premium_banner">
-      <h1>{MailPoet.I18n.t('premiumBannerTitle')}</h1>
-      <p>{ctaButton}</p>
-      <a href="admin.php?page=mailpoet-premium">{MailPoet.I18n.t('premiumBannerLink')}</a>
-    </div>
-  );
+    return (
+      <div className="mailpoet_stats_premium_banner">
+        <h1>{title}</h1>
+        <p>{youReachedTheLimit}</p>
+        <p>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            className="button"
+            href={upgradeLink}
+          >
+            {MailPoet.I18n.t('upgradeNow')}
+          </a>
+        </p>
+      </div>
+    );
+  }
+  return null;
 };
 
 export default PremiumBanner;

--- a/lib/Util/License/Features/Subscribers.php
+++ b/lib/Util/License/Features/Subscribers.php
@@ -54,7 +54,8 @@ class Subscribers {
   }
 
   private function hasValidMssKey() {
-    return $this->settings->get(self::MSS_KEY_STATE) === 'valid';
+    $state = $this->settings->get(self::MSS_KEY_STATE);
+    return $state === Bridge::KEY_VALID || $state === Bridge::KEY_EXPIRING;
   }
 
   private function hasMssSubscribersLimit() {
@@ -66,7 +67,8 @@ class Subscribers {
   }
 
   private function hasValidPremiumKey() {
-    return $this->settings->get(self::PREMIUM_KEY_STATE) === 'valid';
+    $state = $this->settings->get(self::PREMIUM_KEY_STATE);
+    return $state === Bridge::KEY_VALID || $state === Bridge::KEY_EXPIRING;
   }
 
   private function hasPremiumSubscribersLimit() {


### PR DESCRIPTION
There is an accompanying Premium PR too.

**For QA:**

Please check that all possible combinations of the following conditions display correct banners or data tables on the stats page:
* Premium plugin active / inactive;
* API key is valid / expiring (still valid) / not valid or empty;
* Subscribers limit is reached / not reached.
