### PR TITLE
Ensure consistend order for tasks with equal timestamp (fixes flaky test) [MAILPOET-2623]

### DIFF
--- a/lib/Tasks/State.php
+++ b/lib/Tasks/State.php
@@ -51,6 +51,7 @@ class State
     $tasks = [];
     foreach ($statuses as $status) {
       $query = ScheduledTask::orderByDesc('created_at')
+        ->orderByAsc('id') // consistent order for tasks with equal timestamps
         ->whereNull('deleted_at')
         ->limit($limit);
       if ($type) {


### PR DESCRIPTION
[MAILPOET-2623]

[MAILPOET-2623]: https://mailpoet.atlassian.net/browse/MAILPOET-2623