### PR TITLE
Fix Swiftmailer autoloader to handle only Swift_* classes in MailPoetVendor namespace [MAILPOET-2722]

### DIFF
--- a/prefixer/fix-swiftmailer.php
+++ b/prefixer/fix-swiftmailer.php
@@ -19,10 +19,11 @@ foreach ($files as $file) {
   }
 }
 
-// fix Swiftmailer autoloader by injecting code that strips 'MailPoetVendor\' from class names
+// fix Swiftmailer autoloader by injecting code that strips 'MailPoetVendor\' from path names
 $file = __DIR__ . '/../vendor-prefixed/swiftmailer/swiftmailer/lib/classes/Swift.php';
 $data = file_get_contents($file);
-$data = preg_replace('/(function autoload\(\$class\)\s*\{)/', "$1\n        \$class = str_replace('MailPoetVendor\\\\\\\\', '', \$class);\n", $data);
+$data = str_replace("'Swift_'", "'MailPoetVendor\\\\Swift_'", $data);
+$data = preg_replace('/(\$path.*?)\$class/', "$1str_replace('MailPoetVendor\\\\\\\\', '', \$class)", $data);
 file_put_contents($file, $data);
 
 # remove unused PHP file that starts with shebang line instead of <?php and causes PHP lint on WP repo to fail


### PR DESCRIPTION
[MAILPOET-2722]

[MAILPOET-2722]: https://mailpoet.atlassian.net/browse/MAILPOET-2722

The new code produces the following in Swiftmailer's autoloader:
```
// Don't interfere with other autoloaders
if (0 !== \strpos($class, 'MailPoetVendor\\Swift_')) {
    return;
}
$path = __DIR__ . '/' . \str_replace('_', '/', str_replace('MailPoetVendor\\', '', $class)) . '.php';
```

The `MailPoetVendor\\` is kept in the IF condition which means it should never interfere with non-MailPoetVendor classes.