### PR TITLE
Shortcodes cannot spread to multiple lines [MAILPOET-2660]

### DIFF
--- a/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -28,7 +28,7 @@ class Shortcodes {
     // match: [category:shortcode] or [category|category|...:shortcode]
     // dot not match: [category://shortcode] - avoids matching http/ftp links
     $regex = sprintf(
-      '/\[%s:(?!\/\/).*?\]/ism',
+      '/\[%s:(?!\/\/).*?\]/i',
       ($categories) ? '(?:' . $categories . ')' : '(?:\w+)'
     );
     preg_match_all($regex, $content, $shortcodes);


### PR DESCRIPTION
Wordpress as well doesn't use those modifiers

[MAILPOET-2660]

[MAILPOET-2660]: https://mailpoet.atlassian.net/browse/MAILPOET-2660