### PR TITLE
Restore newsletters trashed when sending as paused [MAILPOET-2819]

### DIFF
--- a/lib/Models/Newsletter.php
+++ b/lib/Models/Newsletter.php
@@ -7,6 +7,7 @@ use MailPoet\AutomaticEmails\WooCommerce\Events\FirstPurchase;
 use MailPoet\AutomaticEmails\WooCommerce\Events\PurchasedInCategory;
 use MailPoet\AutomaticEmails\WooCommerce\Events\PurchasedProduct;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -289,6 +290,13 @@ class Newsletter extends Model {
         'SET t.`deleted_at` = null ' .
         'WHERE q.`newsletter_id` = ' . $this->id
       );
+      // Pause associated running scheduled task
+      ScheduledTask::rawExecute(
+        'UPDATE `' . ScheduledTask::$_table . '` t ' .
+        'JOIN `' . SendingQueue::$_table . '` q ON t.`id` = q.`task_id` ' .
+        'SET t.`status` = "' . ScheduledTaskEntity::STATUS_PAUSED . '" ' .
+        'WHERE q.`newsletter_id` = ' . $this->id . ' AND t.`status` IS NULL'
+      );
       SendingQueue::rawExecute(
         'UPDATE `' . SendingQueue::$_table . '` ' .
         'SET `deleted_at` = null ' .
@@ -326,6 +334,13 @@ class Newsletter extends Model {
           ->whereNotNull('tasks.deleted_at')
           ->findResultSet()
           ->set('deleted_at', null)
+          ->save();
+        // Pause associated running scheduled tasks
+        SendingQueue::getTasks()
+          ->whereIn('queues.newsletter_id', $ids)
+          ->whereNull('tasks.status')
+          ->findResultSet()
+          ->set('status', ScheduledTaskEntity::STATUS_PAUSED)
           ->save();
         SendingQueue::whereIn('newsletter_id', $ids)
           ->whereNotNull('deleted_at')

--- a/lib/Models/Newsletter.php
+++ b/lib/Models/Newsletter.php
@@ -296,10 +296,6 @@ class Newsletter extends Model {
       );
     }
 
-    if ($this->status == self::STATUS_SENDING) {
-      $this->set('status', self::STATUS_DRAFT);
-      $this->save();
-    }
     return parent::restore();
   }
 
@@ -337,14 +333,6 @@ class Newsletter extends Model {
           ->set('deleted_at', null)
           ->save();
       }
-    });
-
-    parent::bulkAction($orm, function($ids) {
-      Newsletter::whereIn('id', $ids)
-        ->where('status', Newsletter::STATUS_SENDING)
-        ->findResultSet()
-        ->set('status', Newsletter::STATUS_DRAFT)
-        ->save();
     });
 
     return parent::bulkRestore($orm);

--- a/lib/Models/SendingQueue.php
+++ b/lib/Models/SendingQueue.php
@@ -59,6 +59,7 @@ class SendingQueue extends Model {
     if ($this->countProcessed === $this->countTotal) {
       return $this->complete();
     } else {
+      $this->newsletter()->findOne()->setStatus(Newsletter::STATUS_SENDING);
       return $this->task()->findOne()->resume();
     }
   }

--- a/tests/integration/Models/NewsletterTest.php
+++ b/tests/integration/Models/NewsletterTest.php
@@ -341,13 +341,6 @@ class NewsletterTest extends \MailPoetTest {
     $this->newsletter->restore();
     expect($this->newsletter->deleted_at)->equals('NULL');
     expect($this->newsletter->status)->equals(Newsletter::STATUS_SENT);
-
-    // if the restored newsletter was trashed while in sending,
-    // its status should be set to 'draft' to be able to send it again
-    $this->newsletter->status = Newsletter::STATUS_SENDING;
-    $this->newsletter->trash();
-    $this->newsletter->restore();
-    expect($this->newsletter->status)->equals(Newsletter::STATUS_DRAFT);
   }
 
   public function testItCanBulkRestoreNewsletters() {
@@ -371,11 +364,9 @@ class NewsletterTest extends \MailPoetTest {
 
     Newsletter::filter('bulkTrash');
     expect(Newsletter::whereNull('deleted_at')->findArray())->isEmpty();
-    expect(Newsletter::where('status', Newsletter::STATUS_SENDING)->findArray())->count(1);
 
     Newsletter::filter('bulkRestore');
     expect(Newsletter::whereNotNull('deleted_at')->findArray())->isEmpty();
-    expect(Newsletter::where('status', Newsletter::STATUS_SENDING)->findArray())->count(0);
   }
 
   public function testItDeletesSegmentAndQueueAssociationsWhenNewsletterIsDeleted() {


### PR DESCRIPTION
[MAILPOET-2819]

I was not able to find another case apart from deleting where a newsletter switches to an incorrect state.
I've added a commit (https://github.com/mailpoet/mailpoet/commit/ff15116fe69020b7e371ec4ddef7d0507ab9ad50) to ensure the correct state when a user resumes sending.

[MAILPOET-2819]: https://mailpoet.atlassian.net/browse/MAILPOET-2819