### PR TITLE
Add confirm unsubscribe page [MAILPOET-2736]

### DIFF
--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -186,10 +186,17 @@ class Populator {
         'manage' => $mailpoetPageId,
         'confirmation' => $mailpoetPageId,
         'captcha' => $mailpoetPageId,
+        'confirm_unsubscribe' => $mailpoetPageId,
       ]);
-    } elseif (empty($subscription['captcha']) || $subscription['captcha'] !== $mailpoetPageId) {
+    } elseif (
+      (empty($subscription['captcha']) || $subscription['captcha'] !== $mailpoetPageId)
+      || (empty($subscription['confirm_unsubscribe']) || $subscription['confirm_unsubscribe'] !== $mailpoetPageId)
+    ) {
       // For existing installations
-      $this->settings->set('subscription.pages', array_merge($subscription, ['captcha' => $mailpoetPageId]));
+      $this->settings->set('subscription.pages', array_merge($subscription, [
+        'captcha' => $mailpoetPageId,
+        'confirm_unsubscribe' => $mailpoetPageId,
+      ]));
     }
   }
 

--- a/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -194,7 +194,7 @@ class SendingQueue {
         $subscriber
       );
       $preparedSubscribersIds[] = $subscriber->id;
-      // save personalized unsubsribe link
+      // create personalized instant unsubsribe link
       $unsubscribeUrls[] = Links::getUnsubscribeUrl($queue, $subscriber->id);
       $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriber);
       // keep track of values for statistics purposes

--- a/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -24,7 +24,7 @@ class Links {
     // join HTML and TEXT rendered body into a text string
     $content = Helpers::joinObject($renderedNewsletter);
     list($content, $links) = NewsletterLinks::process($content, $newsletterId, $queueId);
-    $links = NewsletterLinks::ensureUnsubscribeLink($links);
+    $links = NewsletterLinks::ensureInstantUnsubscribeLink($links);
     // split the processed body with hashed links back to HTML and TEXT
     list($renderedNewsletter['html'], $renderedNewsletter['text'])
       = Helpers::splitObject($content);
@@ -43,7 +43,7 @@ class Links {
     $settings = SettingsController::getInstance();
     if ((boolean)$settings->get('tracking.enabled')) {
       $linkHash = NewsletterLinkModel::where('queue_id', $queue->id)
-        ->where('url', NewsletterLinkModel::UNSUBSCRIBE_LINK_SHORT_CODE)
+        ->where('url', NewsletterLinkModel::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE)
         ->findOne();
       if (!$linkHash instanceof NewsletterLinkModel) {
         return '';

--- a/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -63,7 +63,7 @@ class Links {
       );
     } else {
       $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
-      $url = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber);
+      $url = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber, $queue->id);
     }
     return $url;
   }

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -215,6 +215,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Statistics\Track\Clicks::class);
     $container->autowire(\MailPoet\Statistics\Track\Opens::class);
     $container->autowire(\MailPoet\Statistics\Track\WooCommercePurchases::class);
+    $container->autowire(\MailPoet\Statistics\Track\Unsubscribes::class)->setPublic(true);
+    $container->autowire(\MailPoet\Statistics\StatisticsUnsubscribesRepository::class);
     $container->autowire(\MailPoet\Router\Router::class)
       ->setArgument('$container', new Reference(ContainerWrapper::class));
     // Mailer
@@ -265,6 +267,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository::class);
     $container->autowire(\MailPoet\Newsletter\Scheduler\WelcomeScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\PostNotificationScheduler::class);
+    $container->autowire(\MailPoet\Newsletter\Sending\SendingQueuesRepository::class);
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserController::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserRenderer::class)->setPublic(true);
     // Newsletter templates

--- a/lib/Entities/StatisticsUnsubscribeEntity.php
+++ b/lib/Entities/StatisticsUnsubscribeEntity.php
@@ -36,6 +36,16 @@ class StatisticsUnsubscribeEntity {
    */
   private $subscriberId;
 
+  public function __construct(
+    NewsletterEntity $newsletter,
+    SendingQueueEntity $queue,
+    int $subscriberId
+  ) {
+    $this->newsletter = $newsletter;
+    $this->queue = $queue;
+    $this->subscriberId = $subscriberId;
+  }
+
   /**
    * @return NewsletterEntity|null
    */

--- a/lib/Models/NewsletterLink.php
+++ b/lib/Models/NewsletterLink.php
@@ -12,4 +12,5 @@ namespace MailPoet\Models;
 class NewsletterLink extends Model {
   public static $_table = MP_NEWSLETTER_LINKS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
   const UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_unsubscribe_url]';
+  const INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_instant_unsubscribe_url]';
 }

--- a/lib/Newsletter/Links/Links.php
+++ b/lib/Newsletter/Links/Links.php
@@ -136,15 +136,15 @@ class Links {
     }
   }
 
-  public static function ensureUnsubscribeLink(array $processedLinks) {
+  public static function ensureInstantUnsubscribeLink(array $processedLinks) {
     if (in_array(
-      NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE,
+      NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
       array_column($processedLinks, 'link'))
     ) {
       return $processedLinks;
     }
     $processedLinks[] = self::hashLink(
-      NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE,
+      NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
       Links::LINK_TYPE_SHORTCODE
     );
     return $processedLinks;

--- a/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Doctrine\Repository;
+use MailPoet\Entities\SendingQueueEntity;
+
+/**
+ * @method SendingQueueEntity[] findBy(array $criteria, array $orderBy = null, int $limit = null, int $offset = null)
+ * @method SendingQueueEntity|null findOneBy(array $criteria, array $orderBy = null)
+ * @method SendingQueueEntity|null findOneById(mixed $id)
+ * @method void persist(SendingQueueEntity $entity)
+ * @method void remove(SendingQueueEntity $entity)
+ */
+class SendingQueuesRepository extends Repository {
+  protected function getEntityClassName() {
+    return SendingQueueEntity::class;
+  }
+}

--- a/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -84,11 +84,9 @@ class Link {
     $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
     switch ($shortcodeAction) {
       case 'subscription_unsubscribe_url':
-        self::trackUnsubscribe($newsletter, $subscriber, $queue, $wpUserPreview);
         $url = $subscriptionUrlFactory->getConfirmUnsubscribeUrl($subscriber);
         break;
       case 'subscription_instant_unsubscribe_url':
-        self::trackUnsubscribe($newsletter, $subscriber, $queue, $wpUserPreview);
         $url = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber);
         break;
       case 'subscription_manage_url':
@@ -122,12 +120,6 @@ class Link {
     return sprintf('[link:%s]', $action);
   }
 
-  private static function trackUnsubscribe($newsletter, $subscriber, $queue, $wpUserPreview) {
-    $settings = SettingsController::getInstance();
-    // track unsubscribe event
-    if ((boolean)$settings->get('tracking.enabled') && !$wpUserPreview) {
-      $unsubscribeEvent = new Unsubscribes();
-      $unsubscribeEvent->track($newsletter->id, $subscriber->id, $queue->id);
     }
   }
 }

--- a/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -4,8 +4,8 @@ namespace MailPoet\Newsletter\Shortcodes\Categories;
 
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Subscription\SubscriptionUrlFactory;
+use MailPoet\Tasks\Sending;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Link {
@@ -20,11 +20,12 @@ class Link {
     $wpUserPreview
   ) {
     $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
+
     switch ($shortcodeDetails['action']) {
       case 'subscription_unsubscribe_url':
         return self::processUrl(
           $shortcodeDetails['action'],
-          $subscriptionUrlFactory->getConfirmUnsubscribeUrl($wpUserPreview ? null : $subscriber),
+          $subscriptionUrlFactory->getConfirmUnsubscribeUrl($wpUserPreview ? null : $subscriber, self::getSendingQueueId($queue)),
           $queue,
           $wpUserPreview
         );
@@ -32,7 +33,7 @@ class Link {
       case 'subscription_instant_unsubscribe_url':
         return self::processUrl(
           $shortcodeDetails['action'],
-          $subscriptionUrlFactory->getUnsubscribeUrl($wpUserPreview ? null : $subscriber),
+          $subscriptionUrlFactory->getUnsubscribeUrl($wpUserPreview ? null : $subscriber, self::getSendingQueueId($queue)),
           $queue,
           $wpUserPreview
         );
@@ -84,10 +85,10 @@ class Link {
     $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
     switch ($shortcodeAction) {
       case 'subscription_unsubscribe_url':
-        $url = $subscriptionUrlFactory->getConfirmUnsubscribeUrl($subscriber);
+        $url = $subscriptionUrlFactory->getConfirmUnsubscribeUrl($subscriber, self::getSendingQueueId($queue));
         break;
       case 'subscription_instant_unsubscribe_url':
-        $url = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber);
+        $url = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber, self::getSendingQueueId($queue));
         break;
       case 'subscription_manage_url':
         $url = $subscriptionUrlFactory->getManageUrl($subscriber);
@@ -120,6 +121,13 @@ class Link {
     return sprintf('[link:%s]', $action);
   }
 
+  /**
+   * @return int|null
+   */
+  private static function getSendingQueueId($queue) {
+    if ($queue instanceof Sending) {
+      return (int)$queue->id;
     }
+    return null;
   }
 }

--- a/lib/Router/Endpoints/Subscription.php
+++ b/lib/Router/Endpoints/Subscription.php
@@ -12,12 +12,14 @@ class Subscription {
   const ACTION_CONFIRM = 'confirm';
   const ACTION_MANAGE = 'manage';
   const ACTION_UNSUBSCRIBE = 'unsubscribe';
+  const ACTION_CONFIRM_UNSUBSCRIBE = 'confirmUnsubscribe';
   public $allowedActions = [
     self::ACTION_CAPTCHA,
     self::ACTION_CAPTCHA_IMAGE,
     self::ACTION_CONFIRM,
     self::ACTION_MANAGE,
     self::ACTION_UNSUBSCRIBE,
+    self::ACTION_CONFIRM_UNSUBSCRIBE,
   ];
   public $permissions = [
     'global' => AccessControl::NO_ACCESS_RESTRICTION,
@@ -45,6 +47,10 @@ class Subscription {
   public function confirm($data) {
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM, $data);
     $subscription->confirm();
+  }
+
+  public function confirmUnsubscribe($data) {
+    $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM_UNSUBSCRIBE, $data);
   }
 
   public function manage($data) {

--- a/lib/Router/Endpoints/Subscription.php
+++ b/lib/Router/Endpoints/Subscription.php
@@ -4,6 +4,7 @@ namespace MailPoet\Router\Endpoints;
 
 use MailPoet\Config\AccessControl;
 use MailPoet\Subscription as UserSubscription;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Subscription {
   const ENDPOINT = 'subscription';
@@ -28,8 +29,12 @@ class Subscription {
   /** @var UserSubscription\Pages */
   private $subscriptionPages;
 
-  public function __construct(UserSubscription\Pages $subscriptionPages) {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(UserSubscription\Pages $subscriptionPages, WPFunctions $wp) {
     $this->subscriptionPages = $subscriptionPages;
+    $this->wp = $wp;
   }
 
   public function captcha($data) {
@@ -50,7 +55,12 @@ class Subscription {
   }
 
   public function confirmUnsubscribe($data) {
-    $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM_UNSUBSCRIBE, $data);
+    $enableUnsubscribeConfirmation = $this->wp->applyFilters('mailpoet_unsubscribe_confirmation_enabled', true);
+    if ($enableUnsubscribeConfirmation) {
+      $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM_UNSUBSCRIBE, $data);
+    } else {
+      $this->unsubscribe($data);
+    }
   }
 
   public function manage($data) {

--- a/lib/Statistics/StatisticsUnsubscribesRepository.php
+++ b/lib/Statistics/StatisticsUnsubscribesRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MailPoet\Statistics;
+
+use MailPoet\Doctrine\Repository;
+use MailPoet\Entities\StatisticsUnsubscribeEntity;
+
+/**
+ * @method StatisticsUnsubscribeEntity[] findBy(array $criteria, array $orderBy = null, int $limit = null, int $offset = null)
+ * @method StatisticsUnsubscribeEntity|null findOneBy(array $criteria, array $orderBy = null)
+ * @method StatisticsUnsubscribeEntity|null findOneById(mixed $id)
+ * @method void persist(StatisticsUnsubscribeEntity $entity)
+ * @method void remove(StatisticsUnsubscribeEntity $entity)
+ */
+class StatisticsUnsubscribesRepository extends Repository {
+  protected function getEntityClassName() {
+    return StatisticsUnsubscribeEntity::class;
+  }
+}

--- a/lib/Statistics/Track/Unsubscribes.php
+++ b/lib/Statistics/Track/Unsubscribes.php
@@ -2,20 +2,44 @@
 
 namespace MailPoet\Statistics\Track;
 
-use MailPoet\Models\StatisticsUnsubscribes;
+use MailPoet\Entities\StatisticsUnsubscribeEntity;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 
 class Unsubscribes {
-  public function track($newsletterId, $subscriberId, $queueId) {
-    $statistics = StatisticsUnsubscribes::where('subscriber_id', $subscriberId)
-      ->where('newsletter_id', $newsletterId)
-      ->where('queue_id', $queueId)
-      ->findOne();
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
+  /** @var StatisticsUnsubscribesRepository */
+  private $statisticsUnsubscribesRepository;
+
+  public function __construct(
+    SendingQueuesRepository $sendingQueuesRepository,
+    StatisticsUnsubscribesRepository $statisticsUnsubscribesRepository
+  ) {
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->statisticsUnsubscribesRepository = $statisticsUnsubscribesRepository;
+  }
+
+  public function track(int $subscriberId, int $queueId) {
+    $queue = $this->sendingQueuesRepository->findOneById($queueId);
+    if ($queue === null) {
+      return;
+    }
+    $newsletter = $queue->getNewsletter();
+    if ($newsletter === null) {
+      return;
+    }
+    $statistics = $this->statisticsUnsubscribesRepository->findOneBy([
+      'queue' => $queue,
+      'newsletter' => $newsletter,
+      'subscriberId' => $subscriberId,
+    ]);
+
     if (!$statistics) {
-      $statistics = StatisticsUnsubscribes::create();
-      $statistics->newsletterId = $newsletterId;
-      $statistics->subscriberId = $subscriberId;
-      $statistics->queueId = $queueId;
-      $statistics->save();
+      $statistics = new StatisticsUnsubscribeEntity($newsletter, $queue, $subscriberId);
+      $this->statisticsUnsubscribesRepository->persist($statistics);
+      $this->statisticsUnsubscribesRepository->flush();
     }
   }
 }

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -322,7 +322,7 @@ class Pages {
 
   private function getConfirmUnsubscribeTitle() {
     if ($this->isPreview() || $this->subscriber !== false) {
-      return $this->wp->__("Confirm you want to unsubscribe.", 'mailpoet');
+      return $this->wp->__('Confirm you want to unsubscribe', 'mailpoet');
     }
   }
 

--- a/lib/Subscription/Pages.php
+++ b/lib/Subscription/Pages.php
@@ -547,7 +547,10 @@ class Pages {
     $templateData = [
       'unsubscribeUrl' => $this->subscriptionUrlFactory->getUnsubscribeUrl($this->subscriber),
     ];
-    return $this->templateRenderer->render('subscription/confirm_unsubscribe.html', $templateData);
+    return $this->wp->applyFilters(
+      'mailpoet_unsubscribe_confirmation_page',
+      $this->templateRenderer->render('subscription/confirm_unsubscribe.html', $templateData)
+    );
   }
 
   public function getManageLink($params) {

--- a/lib/Subscription/SubscriptionUrlFactory.php
+++ b/lib/Subscription/SubscriptionUrlFactory.php
@@ -50,6 +50,11 @@ class SubscriptionUrlFactory {
     return $this->getSubscriptionUrl($post, 'confirm', $subscriber);
   }
 
+  public function getConfirmUnsubscribeUrl(Subscriber $subscriber = null) {
+    $post = $this->getPost($this->settings->get('subscription.pages.confirm_unsubscribe'));
+    return $this->getSubscriptionUrl($post, 'confirm_unsubscribe', $subscriber);
+  }
+
   public function getManageUrl(Subscriber $subscriber = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.manage'));
     return $this->getSubscriptionUrl($post, 'manage', $subscriber);

--- a/lib/Subscription/SubscriptionUrlFactory.php
+++ b/lib/Subscription/SubscriptionUrlFactory.php
@@ -50,9 +50,10 @@ class SubscriptionUrlFactory {
     return $this->getSubscriptionUrl($post, 'confirm', $subscriber);
   }
 
-  public function getConfirmUnsubscribeUrl(Subscriber $subscriber = null) {
+  public function getConfirmUnsubscribeUrl(Subscriber $subscriber = null, int $queueId = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.confirm_unsubscribe'));
-    return $this->getSubscriptionUrl($post, 'confirm_unsubscribe', $subscriber);
+    $data = $queueId && $subscriber ? ['queueId' => $queueId] : null;
+    return $this->getSubscriptionUrl($post, 'confirm_unsubscribe', $subscriber, $data);
   }
 
   public function getManageUrl(Subscriber $subscriber = null) {
@@ -60,9 +61,10 @@ class SubscriptionUrlFactory {
     return $this->getSubscriptionUrl($post, 'manage', $subscriber);
   }
 
-  public function getUnsubscribeUrl(Subscriber $subscriber = null) {
+  public function getUnsubscribeUrl(Subscriber $subscriber = null, int $queueId = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.unsubscribe'));
-    return $this->getSubscriptionUrl($post, 'unsubscribe', $subscriber);
+    $data = $queueId && $subscriber ? ['queueId' => $queueId] : null;
+    return $this->getSubscriptionUrl($post, 'unsubscribe', $subscriber, $data);
   }
 
   public function getSubscriptionUrl(
@@ -75,10 +77,11 @@ class SubscriptionUrlFactory {
 
     $url = $this->wp->getPermalink($post);
     if ($subscriber !== null) {
-      $data = [
+      $subscriberData = [
         'token' => $this->linkTokens->getToken($subscriber),
         'email' => $subscriber->email,
       ];
+      $data = array_merge($data ?? [], $subscriberData);
     } elseif (is_null($data)) {
       $data = [
         'preview' => 1,

--- a/tests/acceptance/ManageSubscriptionLinkCest.php
+++ b/tests/acceptance/ManageSubscriptionLinkCest.php
@@ -82,7 +82,7 @@ class ManageSubscriptionLinkCest {
     $i->click(Locator::contains('span.subject', $this->newsletterTitle));
     $i->click('#show-headers');
     $i->waitForText('List-Unsubscribe');
-    $link = $i->grabTextFrom('.headers tbody tr:nth-child(4) td');
+    $link = $i->grabTextFrom('//div[@class="row headers"]//th[text()="List-Unsubscribe"]/following-sibling::td');
     $link = trim($link, '<>');
     $i->amOnUrl($link);
     $i->waitForText('You are now unsubscribed');

--- a/tests/acceptance/ManageSubscriptionLinkCest.php
+++ b/tests/acceptance/ManageSubscriptionLinkCest.php
@@ -108,9 +108,9 @@ class ManageSubscriptionLinkCest {
     );
     $i->click('Unsubscribe');
     $i->switchToNextTab();
-    $confirmUnsubscribeLink = '[data-automation-id="confirm-unsubscribe"]';
-    $i->waitForElement($confirmUnsubscribeLink);
-    $i->click($confirmUnsubscribeLink);
+    $confirmUnsubscribe = 'Yes, unsubscribe me';
+    $i->waitForText($confirmUnsubscribe);
+    $i->click($confirmUnsubscribe, '.mailpoet_confirm_unsubscribe');
     $i->waitForText('You are now unsubscribed');
     $i->click('Manage your subscription');
     $i->seeOptionIsSelected($formStatusElement, 'Unsubscribed');

--- a/tests/acceptance/ManageSubscriptionLinkCest.php
+++ b/tests/acceptance/ManageSubscriptionLinkCest.php
@@ -78,6 +78,9 @@ class ManageSubscriptionLinkCest {
     );
     $i->click('Unsubscribe');
     $i->switchToNextTab();
+    $confirmUnsubscribeLink = '[data-automation-id="confirm-unsubscribe"]';
+    $i->waitForElement($confirmUnsubscribeLink);
+    $i->click($confirmUnsubscribeLink);
     $i->waitForText('You are now unsubscribed');
     $i->click('Manage your subscription');
     $i->seeOptionIsSelected($formStatusElement, 'Unsubscribed');

--- a/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -885,7 +885,7 @@ class NewslettersTest extends \MailPoetTest {
         Mailer::class,
         [
           'send' => function ($newsletter, $subscriber, $extraParams) {
-            $unsubscribeLink = $this->subscriptionUrlFactory->getUnsubscribeUrl(null);
+            $unsubscribeLink = $this->subscriptionUrlFactory->getConfirmUnsubscribeUrl(null);
             $manageLink = $this->subscriptionUrlFactory->getManageUrl(null);
             $viewInBrowserLink = Url::getViewInBrowserUrl($this->newsletter);
             $mailerMetaInfo = new MetaInfo;

--- a/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -121,7 +121,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   private function getDirectUnsubscribeURL() {
-    return SubscriptionUrlFactory::getInstance()->getUnsubscribeUrl($this->subscriber);
+    return SubscriptionUrlFactory::getInstance()->getUnsubscribeUrl($this->subscriber, $this->queue->id);
   }
 
   private function getTrackedUnsubscribeURL() {

--- a/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -104,7 +104,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->newsletterLink = NewsletterLink::create();
     $this->newsletterLink->newsletterId = $this->newsletter->id;
     $this->newsletterLink->queueId = $this->queue->id;
-    $this->newsletterLink->url = '[link:subscription_unsubscribe_url]';
+    $this->newsletterLink->url = '[link:subscription_instant_unsubscribe_url]';
     $this->newsletterLink->hash = 'abcde';
     $this->newsletterLink->save();
     $this->sendingErrorHandler = new SendingErrorHandler();

--- a/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -55,7 +55,7 @@ class LinksTest extends \MailPoetTest {
     expect($result['html'])->contains($newsletterLink->hash);
   }
 
-  public function testItCanEnsureThatUnsubscribeLinkIsAlwaysPresent() {
+  public function testItCanEnsureThatInstantUnsubscribeLinkIsAlwaysPresent() {
     $newsletter = Newsletter::create();
     $newsletter->type = Newsletter::TYPE_STANDARD;
     $newsletter->save();
@@ -66,7 +66,7 @@ class LinksTest extends \MailPoetTest {
     $queue = (object)['id' => 2];
     Links::process($renderedNewsletter, $newsletter, $queue);
     $unsubscribeCount = NewsletterLink::where('newsletter_id', $newsletter->id)
-      ->where('url', NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE)->count();
+      ->where('url', NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE)->count();
     expect($unsubscribeCount)->equals(1);
   }
 

--- a/tests/integration/Newsletter/Links/LinksTest.php
+++ b/tests/integration/Newsletter/Links/LinksTest.php
@@ -246,13 +246,13 @@ class LinksTest extends \MailPoetTest {
         'hash' => 'abcdfgh',
       ],
     ];
-    $links = Links::ensureUnsubscribeLink($links);
+    $links = Links::ensureInstantUnsubscribeLink($links);
     expect(count($links))->equals(2);
-    expect($links[1]['link'])->equals(NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE);
+    expect($links[1]['link'])->equals(NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE);
     expect($links[1]['type'])->equals(Links::LINK_TYPE_SHORTCODE);
     expect($links[1])->hasKey('processed_link');
     expect($links[1])->hasKey('hash');
-    $links = Links::ensureUnsubscribeLink($links);
+    $links = Links::ensureInstantUnsubscribeLink($links);
     expect(count($links))->equals(2);
   }
 

--- a/tests/integration/Router/Endpoints/SubscriptionTest.php
+++ b/tests/integration/Router/Endpoints/SubscriptionTest.php
@@ -4,27 +4,27 @@ namespace MailPoet\Test\Router\Endpoints;
 
 use Codeception\Stub;
 use Codeception\Stub\Expected;
-use MailPoet\DI\ContainerWrapper;
 use MailPoet\Router\Endpoints\Subscription;
 use MailPoet\Subscription\Pages;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SubscriptionTest extends \MailPoetTest {
   public $data;
-  public $subscription;
+
+  /** @var WPFunctions */
+  private $wp;
 
   public function _before() {
     $this->data = [];
-    // instantiate class
-    $this->subscription = ContainerWrapper::getInstance()->get(Subscription::class);
+    $this->wp = WPFunctions::get();
   }
 
   public function testItDisplaysConfirmPage() {
     $pages = Stub::make(Pages::class, [
-      'wp' => new WPFunctions,
+      'wp' => $this->wp,
       'confirm' => Expected::exactly(1),
     ], $this);
-    $subscription = new Subscription($pages);
+    $subscription = new Subscription($pages, $this->wp);
     $subscription->confirm($this->data);
   }
 
@@ -34,7 +34,7 @@ class SubscriptionTest extends \MailPoetTest {
       'getManageLink' => Expected::exactly(1),
       'getManageContent' => Expected::exactly(1),
     ], $this);
-    $subscription = new Subscription($pages);
+    $subscription = new Subscription($pages, $this->wp);
     $subscription->manage($this->data);
     do_shortcode('[mailpoet_manage]');
     do_shortcode('[mailpoet_manage_subscription]');
@@ -45,7 +45,7 @@ class SubscriptionTest extends \MailPoetTest {
       'wp' => new WPFunctions,
       'unsubscribe' => Expected::exactly(1),
     ], $this);
-    $subscription = new Subscription($pages);
+    $subscription = new Subscription($pages, $this->wp);
     $subscription->unsubscribe($this->data);
   }
 }

--- a/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Statistics\Track;
 
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsUnsubscribes;
@@ -11,7 +12,9 @@ use MailPoet\Tasks\Sending as SendingTask;
 use MailPoetVendor\Idiorm\ORM;
 
 class UnsubscribesTest extends \MailPoetTest {
-  public $unsubscribes;
+  /** @var Unsubscribes */
+  private $unsubscribes;
+
   public $queue;
   public $subscriber;
   public $newsletter;
@@ -35,12 +38,11 @@ class UnsubscribesTest extends \MailPoetTest {
     $queue->updateProcessedSubscribers([$subscriber->id]);
     $this->queue = $queue->save();
     // instantiate class
-    $this->unsubscribes = new Unsubscribes();
+    $this->unsubscribes = ContainerWrapper::getInstance()->get(Unsubscribes::class);
   }
 
   public function testItTracksUnsubscribeEvent() {
     $this->unsubscribes->track(
-      $this->newsletter->id,
       $this->subscriber->id,
       $this->queue->id
     );
@@ -50,7 +52,6 @@ class UnsubscribesTest extends \MailPoetTest {
   public function testItDoesNotTrackRepeatedUnsubscribeEvents() {
     for ($count = 0; $count <= 2; $count++) {
       $this->unsubscribes->track(
-        $this->newsletter->id,
         $this->subscriber->id,
         $this->queue->id
       );

--- a/tests/integration/Subscription/PagesTest.php
+++ b/tests/integration/Subscription/PagesTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Subscription;
 
 use Codeception\Stub;
 use Codeception\Util\Fixtures;
+use MailPoet\Config\Renderer;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Form\AssetsController;
 use MailPoet\Form\Block\Date as FormBlockDate;
@@ -178,7 +179,8 @@ class PagesTest extends \MailPoetTest {
       $container->get(SubscriptionUrlFactory::class),
       $container->get(AssetsController::class),
       $container->get(FormRenderer::class),
-      $container->get(FormBlockDate::class)
+      $container->get(FormBlockDate::class),
+      $container->get(Renderer::class)
     );
   }
 }

--- a/views/subscription/confirm_unsubscribe.html
+++ b/views/subscription/confirm_unsubscribe.html
@@ -1,0 +1,7 @@
+<% block content %>
+<p class="mailpoet_confirm_unsubscribe">
+  <%= __('Simply click on this link to stop receiving emails from us.') %>
+  <br>
+  <a href="<%= unsubscribeUrl %>"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
+</p>
+<% endblock %>

--- a/views/subscription/confirm_unsubscribe.html
+++ b/views/subscription/confirm_unsubscribe.html
@@ -2,6 +2,6 @@
 <p class="mailpoet_confirm_unsubscribe">
   <%= __('Simply click on this link to stop receiving emails from us.') %>
   <br>
-  <a data-automation-id="confirm-unsubscribe" href="<%= unsubscribeUrl %>"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
+  <a href="<%= unsubscribeUrl %>"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
 </p>
 <% endblock %>

--- a/views/subscription/confirm_unsubscribe.html
+++ b/views/subscription/confirm_unsubscribe.html
@@ -2,6 +2,6 @@
 <p class="mailpoet_confirm_unsubscribe">
   <%= __('Simply click on this link to stop receiving emails from us.') %>
   <br>
-  <a href="<%= unsubscribeUrl %>"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
+  <a data-automation-id="confirm-unsubscribe" href="<%= unsubscribeUrl %>"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
 </p>
 <% endblock %>


### PR DESCRIPTION
[MAILPOET-2736]

**Note for QA:**
Old unsubscribe links from newsletters sent prior upgrading to this version should unsubscribe a subscriber just by opening the link.

[MAILPOET-2736]: https://mailpoet.atlassian.net/browse/MAILPOET-2736