### PR TITLE
Oxygen Gutenberg conflict fix [MAILPOET-2894]

### DIFF
--- a/lib/Form/AssetsController.php
+++ b/lib/Form/AssetsController.php
@@ -51,14 +51,6 @@ class AssetsController {
     );
 
     $this->wp->wpEnqueueScript(
-      'mailpoet_vendor',
-      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('vendor.js'),
-      [],
-      Env::$version,
-      true
-    );
-
-    $this->wp->wpEnqueueScript(
       'mailpoet_public',
       Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.js'),
       ['jquery'],


### PR DESCRIPTION
[MAILPOET-2894]

vendor.js is an admin script. This was left in frontend assets probably because historically we used to enqueue FE and backend assets for both FE and backend (widgets page) altogether.

Oxygen Gutenberg integration loads all assets for any shortcode placed within their special Gutenberg block. They do so on every admin page. This resulted in vendor.js being loaded twice and causing conflict with itself.

## Note for QA
This change is related to FE assets for MailPoet forms. Please check it doesn't break subscription forms functionality. 

[MAILPOET-2894]: https://mailpoet.atlassian.net/browse/MAILPOET-2894