### PR TITLE
Fix newsletter saving after nonce expiration, add new error message [MAILPOET-2839]

### DIFF
--- a/assets/js/src/ajax.js
+++ b/assets/js/src/ajax.js
@@ -15,6 +15,14 @@ function requestFailed(errorMessage, xhr) {
   };
 }
 
+// Renew MailPoet nonce via heartbeats to keep auth
+// for AJAX requests on long-open pages
+jQuery(document).on('heartbeat-tick.mailpoet-ajax', (event, data) => {
+  if (data.mailpoet_token) {
+    window.mailpoet_token = data.mailpoet_token;
+  }
+});
+
 MailPoet.Ajax = {
   version: 0.5,
   options: {},

--- a/lib/API/JSON/API.php
+++ b/lib/API/JSON/API.php
@@ -77,6 +77,12 @@ class API {
       'wp_ajax_nopriv_mailpoet',
       [$this, 'setupAjax']
     );
+
+    // nonce refreshing via heartbeats
+    WPFunctions::get()->addAction(
+      'wp_refresh_nonces',
+      [$this, 'addTokenToHeartbeatResponse']
+    );
   }
 
   public function setupAjax() {
@@ -223,6 +229,11 @@ class API {
       Security::generateToken(),
       self::CURRENT_VERSION
     );
+  }
+
+  public function addTokenToHeartbeatResponse($response) {
+    $response['mailpoet_token'] = Security::generateToken();
+    return $response;
   }
 
   public function addEndpointNamespace($namespace, $version) {

--- a/tests/javascript_newsletter_editor/newsletter_editor/components/save.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/components/save.spec.js
@@ -103,6 +103,15 @@ describe('Save', function () {
   });
 
   describe('view', function () {
+    var validNewsletter = {
+      body: {
+        content: {
+          blocks: [
+            { type: 'footer' },
+          ],
+        },
+      },
+    };
     before(function () {
       var newsletter = { get: sinon.stub().withArgs('type').returns('newsletter') };
       EditorApplication._contentContainer = { isValid: sinon.stub().returns(true) };
@@ -134,7 +143,7 @@ describe('Save', function () {
       });
 
       it('hides errors for valid newsletter', function () {
-        view.validateNewsletter({});
+        view.validateNewsletter(validNewsletter);
         expect(hideValidationErrorStub.callCount).to.be.equal(1);
       });
 
@@ -157,7 +166,7 @@ describe('Save', function () {
         var newsletter = { get: sinon.stub().withArgs('type').returns('notification') };
         var showValidationErrorStub = sinon.stub(view, 'showValidationError');
         EditorApplication.getNewsletter = sinon.stub().returns(newsletter);
-        view.validateNewsletter({});
+        view.validateNewsletter(validNewsletter);
         expect(showValidationErrorStub.callCount).to.be.equal(1);
       });
     });

--- a/views/newsletter/editor.html
+++ b/views/newsletter/editor.html
@@ -348,6 +348,7 @@
     'failedToFetchAvailablePosts': __('Failed to fetch available posts'),
     'failedToFetchRenderedPosts': __('Failed to fetch rendered posts'),
     'shortcodesWindowTitle': __('Select a shortcode'),
+    'newsletterSavingError': __('The email could not be saved. Please, clear browser cache and reload the page. If the problem persists, duplicate the email and try again.'),
     'unsubscribeLinkMissing': __('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.'),
     'newsletterIsEmpty': __('Poet, please add prose to your masterpiece before you send it to your followers.'),
     'emailAlreadySent': __('This email has already been sent. It can be edited, but not sent again. Duplicate this email if you want to send it again.'),


### PR DESCRIPTION
*Note to QA:* to test nonce expiration, you can add this code to your theme's `functions.php`:
```php
add_filter('nonce_life', function () {
  return 60; //seconds
});
```
Then a nonce will expire every minute. Prior to this fix, newsletter saving would stop working.