### PR TITLE
Fix form style changes resetting other form settings [MAILPOET-2932]

### DIFF
--- a/assets/js/src/form_editor/components/form_settings/styles_settings_panel.jsx
+++ b/assets/js/src/form_editor/components/form_settings/styles_settings_panel.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import {
   Panel,
   PanelBody,
@@ -22,6 +22,9 @@ const BasicSettingsPanel = ({ onToggle, isOpened }) => {
     []
   );
   const settingsRef = useRef(settings);
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
   const updateStyles = (property, value) => {
     const updated = { ...settingsRef.current };
     updated[property] = value;


### PR DESCRIPTION
The problem originated [in this commit](https://github.com/mailpoet/mailpoet/pull/2634/commits/c455dcfd062450ee9902abc9a3e5c08cb96f7a47#diff-572a8b4d8a2a72bbe46586df88bd3c52) while trying to fix another issue with color picker (Gutenberg's custom color picker resets other form styles because it is not rerendered when the `onChange` callback is updated with a new state, so its callback holds a stale state): https://github.com/mailpoet/mailpoet/pull/2634#pullrequestreview-374972553

The problem above was solved with `useRef` so all `onChange` callbacks referred to the same mutable state value. But this also caused the form styles panel state to be detached from everything else, and when it updated the global state it was undoing all changes made outside of it (e.g. basic and placement settings). I've added `useEffect` to update the local settings ref by external changes, this should fix the problem.

*Note for QA:* Please ensure that the above bug with colors did not re-emerge and, in general, that all form settings have no undesired effects on each other.