### PR TITLE
Form: Adjust form borders rendering [MAILPOET-2912]

### DIFF
--- a/lib/Form/Util/Styles.php
+++ b/lib/Form/Util/Styles.php
@@ -164,16 +164,19 @@ EOL;
     // Width styles
     $widthStyles = $this->renderWidthStyles($formSettings, $selector, $displayType);
 
+    $typeSpecificStyles = $this->getFormTypeSpecificStyles($selector, $displayType);
+
     $messagesStyles = $this->renderMessagesStyles($formSettings, $selector);
 
     return $formWrapperStyles
       . $formElementStyles
       . $widthStyles
       . $messagesStyles
+      . $typeSpecificStyles
       . $media;
   }
 
-  private function renderWidthStyles($formSettings, $selector, $displayType) {
+  private function renderWidthStyles(array $formSettings, string $selector, string $displayType): string {
     $styles = [];
 
     if ($displayType === FormEntity::DISPLAY_TYPE_POPUP) {
@@ -251,5 +254,15 @@ EOL;
       ";
     }
     return $styles;
+  }
+
+  private function getFormTypeSpecificStyles(string $selector, string $displayType): string {
+    $styles = [];
+    if ($displayType === FormEntity::DISPLAY_TYPE_SLIDE_IN) {
+      $styles[] = $selector . '.mailpoet_form_slide_in { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }';
+      $styles[] = $selector . '.mailpoet_form_position_right { border-top-right-radius: 0; }';
+      $styles[] = $selector . '.mailpoet_form_position_left { border-top-left-radius: 0; }';
+    }
+    return join('', $styles);
   }
 }

--- a/tests/unit/Form/Util/StylesTest.php
+++ b/tests/unit/Form/Util/StylesTest.php
@@ -219,4 +219,14 @@ class StylesTest extends \MailPoetUnitTest {
     expect($styleWithoutMedia)->contains('width: 90%;');
     expect($styleWithoutMedia)->notContains('max-width:');
   }
+
+  public function testItRendersSlideInSpecificStyles() {
+    $form = Fixtures::get('simple_form_body');
+    $form['settings'] = ['background_color' => 'red'];
+    // BC Style
+    $styles = $this->styles->renderFormSettingsStyles($form, '#prefix', FormEntity::DISPLAY_TYPE_SLIDE_IN);
+    expect($styles)->contains('#prefix.mailpoet_form_slide_in { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }');
+    expect($styles)->contains('#prefix.mailpoet_form_position_right { border-top-right-radius: 0; }');
+    expect($styles)->contains('#prefix.mailpoet_form_position_left { border-top-left-radius: 0; }');
+  }
 }


### PR DESCRIPTION
The border rendering was already fixed in [MAILPOET-2811] so this PR only adjusts border radius for slide-in form.

[MAILPOET-2912]

[MAILPOET-2811]: https://mailpoet.atlassian.net/browse/MAILPOET-2811
[MAILPOET-2912]: https://mailpoet.atlassian.net/browse/MAILPOET-2912