### PR TITLE
Prepare for PHPMailer upgrade in WP 5.5 [MAILPOET-3040]

### DIFF
--- a/lib/Mailer/Methods/PHPMail.php
+++ b/lib/Mailer/Methods/PHPMail.php
@@ -5,8 +5,9 @@ namespace MailPoet\Mailer\Methods;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\PHPMailMapper;
+use MailPoet\Mailer\WordPress\PHPMailerLoader;
 
-require_once ABSPATH . WPINC . '/class-phpmailer.php';
+PHPMailerLoader::load();
 
 class PHPMail {
   public $sender;

--- a/lib/Mailer/WordPress/PHPMailerLoader.php
+++ b/lib/Mailer/WordPress/PHPMailerLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MailPoet\Mailer\WordPress;
+
+/**
+ * This class and its usage should be removed
+ * in favor of the new loading method when support
+ * for WordPress below 5.5 is dropped.
+ */
+
+class PHPMailerLoader {
+  /**
+   * Conditionally load PHPMailer the old or the new way
+   * to not get a deprecated file notice.
+   */
+  public static function load() {
+    if (class_exists('PHPMailer')) {
+      return false;
+    }
+    if (is_readable(ABSPATH . WPINC . '/PHPMailer/PHPMailer.php')) {
+      // WordPress 5.5+
+      require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+      require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+      class_alias(\PHPMailer\PHPMailer\PHPMailer::class, 'PHPMailer');
+      class_alias(\PHPMailer\PHPMailer\Exception::class, 'phpmailerException');
+    } else {
+      // WordPress < 5.5
+      require_once ABSPATH . WPINC . '/class-phpmailer.php';
+    }
+  }
+}

--- a/lib/Mailer/WordPress/WordPressMailer.php
+++ b/lib/Mailer/WordPress/WordPressMailer.php
@@ -7,9 +7,7 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Subscribers\SubscribersRepository;
 
-if (!class_exists('PHPMailer')) {
-  require_once ABSPATH . WPINC . '/class-phpmailer.php';
-}
+PHPMailerLoader::load();
 
 class WordPressMailer extends \PHPMailer {
 

--- a/tasks/phpstan/bootstrap.php
+++ b/tasks/phpstan/bootstrap.php
@@ -5,7 +5,10 @@ define('ABSPATH', getenv('WP_ROOT') . '/');
 require_once ABSPATH . 'wp-load.php';
 require_once ABSPATH . 'wp-admin/includes/admin.php';
 require_once(ABSPATH . 'wp-admin/includes/ms.php');
-require_once ABSPATH . 'wp-includes/class-phpmailer.php';
+
+use MailPoet\Mailer\WordPress\PHPMailerLoader;
+
+PHPMailerLoader::load();
 
 if (!class_exists('\MailPoet\Premium\DI\ContainerConfigurator')) {
   require_once __DIR__ . '/PremiumContainerConfigurator.php';

--- a/tasks/phpstan/phpstan-baseline.neon
+++ b/tasks/phpstan/phpstan-baseline.neon
@@ -248,3 +248,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$segment of class MailPoet\\\\Entities\\\\NewsletterSegmentEntity constructor expects MailPoet\\\\Entities\\\\SegmentEntity, object given\\.$#"
 			count: 1
 			path: ../../lib/Newsletter/NewsletterSaveController.php
+		-
+			message: "#^Class PHPMailer\\\\PHPMailer\\\\PHPMailer not found\\.$#"
+			count: 1
+			path: ../../lib/Mailer/WordPress/PHPMailerLoader.php
+		-
+			message: "#^Class PHPMailer\\\\PHPMailer\\\\Exception not found\\.$#"
+			count: 1
+			path: ../../lib/Mailer/WordPress/PHPMailerLoader.php


### PR DESCRIPTION
[MAILPOET-3040](https://mailpoet.atlassian.net/browse/MAILPOET-3040)

**To QA:**

Please test this in both WP 5.4 and 5.5 beta (install the latter using the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin). Enable `WP_DEBUG`, set the sending method to "Your web host" and check that the following actions work without errors:
* "Test the sending method" button in the bottom of "Send with... > Other";
* Newsletter editor preview sending;
* Standard newsletter sending;
* WordPress transactional email sending (e.g. changing admin email). 
