### PR TITLE
Allow ONLY_FULL_GROUP_BY MySQL mode [MAILPOET-2630]

### DIFF
--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -102,7 +102,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Config\RendererFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\ServicesChecker::class);
     $container->autowire(\MailPoet\Config\Shortcodes::class)
-      ->setShared(false); // Get a new instance each time $container->get() is called, needed for tests
+      ->setShared(false) // Get a new instance each time $container->get() is called, needed for tests
+      ->setPublic(true);
     $container->register(\MailPoet\Config\Renderer::class)
       ->setPublic(true)
       ->setFactory([new Reference(\MailPoet\Config\RendererFactory::class), 'getRenderer']);

--- a/lib/Doctrine/ConnectionFactory.php
+++ b/lib/Doctrine/ConnectionFactory.php
@@ -55,7 +55,6 @@ class ConnectionFactory {
   private function getDriverOptions($timezoneOffset, $charset, $collation) {
     $driverOptions = [
       "@@session.time_zone = '$timezoneOffset'",
-      '@@session.sql_mode = REPLACE(@@sql_mode, "ONLY_FULL_GROUP_BY", "")',
       // We need to use CONVERT for MySQL 8, Maria DB bug which triggers #1232 - Incorrect argument type to variable 'wait_timeout`
       // https://stackoverflow.com/questions/35187378/mariadb-type-error-when-setting-session-variable
       "@@session.wait_timeout = GREATEST(CONVERT(COALESCE(@@wait_timeout, 0), SIGNED), $this->minWaitTimeout)",

--- a/lib/Models/Newsletter.php
+++ b/lib/Models/Newsletter.php
@@ -516,6 +516,7 @@ class Newsletter extends Model {
     $orm = self::tableAlias('newsletters')
       ->distinct()->select('newsletters.*')
       ->select('newsletter_rendered_subject')
+      ->select('task_id')
       ->whereIn('newsletters.type', [
         self::TYPE_STANDARD,
         self::TYPE_NOTIFICATION_HISTORY,
@@ -534,7 +535,7 @@ class Newsletter extends Model {
       ->whereNull('newsletters.deleted_at')
       ->select('tasks.processed_at')
       ->orderByDesc('tasks.processed_at')
-      ->orderByAsc('tasks.id');
+      ->orderByAsc('task_id');
 
     if (!empty($segmentIds)) {
       $orm->join(

--- a/tests/integration/Config/DatabaseTest.php
+++ b/tests/integration/Config/DatabaseTest.php
@@ -36,8 +36,6 @@ class DatabaseTest extends \MailPoetTest {
         '@@session.time_zone as timeZone'
       )
       ->findOne();
-    // disable ONLY_FULL_GROUP_BY
-    expect($result->sqlMode)->notContains('ONLY_FULL_GROUP_BY');
     // time zone should be set based on WP's time zone
     expect($result->timeZone)->equals(Env::$dbTimezoneOffset);
   }

--- a/tests/integration/Doctrine/ConnectionFactoryTest.php
+++ b/tests/integration/Doctrine/ConnectionFactoryTest.php
@@ -100,7 +100,6 @@ class ConnectionFactoryTest extends \MailPoetTest {
     ')->fetch();
 
     // check timezone, SQL mode, wait timeout
-    expect($result['@@session.sql_mode'])->notContains('ONLY_FULL_GROUP_BY');
     expect($result['@@session.time_zone'])->equals(Env::$dbTimezoneOffset);
     expect($result['@@session.wait_timeout'])->greaterOrEquals(60);
 


### PR DESCRIPTION
[MAILPOET-2630]

It seems that we added the removal of ONLY_FULL_GROUP_BY for our DB connection as a hotfix after it was added to MySQL. 
see https://mailpoet.atlassian.net/browse/MAILPOET-739 and https://mailpoet.slack.com/archives/G0A1L2KHV/p1481209868000199

We have fixed knows issues and we want to get rid of this hotfix. It probably doesn't work on some third part MySQL distribution like Percona server.



[MAILPOET-2630]: https://mailpoet.atlassian.net/browse/MAILPOET-2630