### PR TITLE
Fix subscriber status resetting on WP user creation [MAILPOET-3016]

### DIFF
--- a/lib/Segments/WP.php
+++ b/lib/Segments/WP.php
@@ -43,6 +43,11 @@ class WP {
     $wpSegment = Segment::getWPSegment();
     if (!$wpSegment) return;
 
+    // find subscriber by email when is false
+    if (!$subscriber) {
+      $subscriber = Subscriber::where('email', $wpUser->user_email)->findOne(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.NotCamelCaps
+    }
+
     $scheduleWelcomeNewsletter = false;
     if (in_array($currentFilter, ['profile_update', 'user_register'])) {
       $scheduleWelcomeNewsletter = true;

--- a/tests/integration/Segments/WPTest.php
+++ b/tests/integration/Segments/WPTest.php
@@ -32,6 +32,19 @@ class WPTest extends \MailPoetTest {
     expect($dbSubscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
   }
 
+  public function testSynchronizeUserKeepsStatusOfOldSubscriber() {
+    $randomNumber = rand();
+    $subscriber = Subscriber::createOrUpdate([
+      'email' => 'user-sync-test' . $randomNumber . '@example.com',
+      'status' => Subscriber::STATUS_SUBSCRIBED,
+      'wp_user_id' => null,
+    ]);
+    $id = $this->insertUser($randomNumber);
+    WP::synchronizeUser($id);
+    $dbSubscriber = Subscriber::where('wp_user_id', $id)->findOne();
+    expect($dbSubscriber->status)->equals($subscriber->status);
+  }
+
   public function testSynchronizeUserStatusIsSubscribedForNewUserWithSignUpConfirmationDisabled() {
     $this->settings->set('signup_confirmation', ['enabled' => '0']);
     $randomNumber = rand();


### PR DESCRIPTION
Fixes:#2960
[MAILPOET-3016]

[MAILPOET-3016]: https://mailpoet.atlassian.net/browse/MAILPOET-3016