### PR TITLE
Subscribers listing hotfix [MAILPOET-3132]

### DIFF
--- a/lib/Models/Subscriber.php
+++ b/lib/Models/Subscriber.php
@@ -790,6 +790,46 @@ class Subscriber extends Model {
       ->findArray();
   }
 
+  public static function groups($data) {
+    return [
+      [
+        'name' => 'all',
+        'label' => WPFunctions::get()->__('All', 'mailpoet'),
+        'count' => self::getPublished()->count(),
+      ],
+      [
+        'name' => self::STATUS_SUBSCRIBED,
+        'label' => WPFunctions::get()->__('Subscribed', 'mailpoet'),
+        'count' => self::filter(self::STATUS_SUBSCRIBED)->count(),
+      ],
+      [
+        'name' => self::STATUS_UNCONFIRMED,
+        'label' => WPFunctions::get()->__('Unconfirmed', 'mailpoet'),
+        'count' => self::filter(self::STATUS_UNCONFIRMED)->count(),
+      ],
+      [
+        'name' => self::STATUS_UNSUBSCRIBED,
+        'label' => WPFunctions::get()->__('Unsubscribed', 'mailpoet'),
+        'count' => self::filter(self::STATUS_UNSUBSCRIBED)->count(),
+      ],
+      [
+        'name' => self::STATUS_INACTIVE,
+        'label' => WPFunctions::get()->__('Inactive', 'mailpoet'),
+        'count' => self::filter(self::STATUS_INACTIVE)->count(),
+      ],
+      [
+        'name' => self::STATUS_BOUNCED,
+        'label' => WPFunctions::get()->__('Bounced', 'mailpoet'),
+        'count' => self::filter(self::STATUS_BOUNCED)->count(),
+      ],
+      [
+        'name' => 'trash',
+        'label' => WPFunctions::get()->__('Trash', 'mailpoet'),
+        'count' => self::getTrashed()->count(),
+      ],
+    ];
+  }
+
   /**
    * This method is here only for BC fix of 3rd party plugin integration.
    * @see https://kb.mailpoet.com/article/195-add-subscribers-through-your-own-form-or-plugin

--- a/lib/Subscribers/SubscriberListingRepository.php
+++ b/lib/Subscribers/SubscriberListingRepository.php
@@ -154,15 +154,13 @@ class SubscriberListingRepository extends ListingRepository {
 
     $queryBuilder
       ->select('sg.id, sg.name, COUNT(s) AS subscribersCount')
-      ->leftJoin('s.subscriberSegments', 'ssg', Join::WITH, (string)$queryBuilderNoSegment->expr()->eq('ssg.status', ':statusSubscribed'))
+      ->leftJoin('s.subscriberSegments', 'ssg')
       ->join('ssg.segment', 'sg')
       ->groupBy('sg.id')
       ->andWhere('sg.deletedAt IS NULL')
       ->andWhere('s.deletedAt IS NULL')
-      ->andWhere('s.status = :statusSubscribed')
       ->orderBy('sg.name')
-      ->having('subscribersCount > 0')
-      ->setParameter('statusSubscribed', SubscriberEntity::STATUS_SUBSCRIBED);
+      ->having('subscribersCount > 0');
 
     // format segment list
     $segmentList = [

--- a/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -59,7 +59,7 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     expect($filters['segment'])->count(3);
     expect($filters['segment'][0]['label'])->equals('All Lists');
     expect($filters['segment'][1]['label'])->equals('Subscribers without a list (3)');
-    expect($filters['segment'][2]['label'])->endsWith('(1)');
+    expect($filters['segment'][2]['label'])->endsWith('(2)');
   }
 
   public function testItBuildsGroups() {


### PR DESCRIPTION
[MAILPOET-3132]

The fix reintroduces a behaviour that subscribers who unsubscribed from a list are still counted as members of the list. I did that so that numbers in refactored part of listing match numbers coming from old code.

I've also updated [the subsequent issue](https://mailpoet.atlassian.net/browse/MAILPOET-3077) with a note about that.

[MAILPOET-3132]: https://mailpoet.atlassian.net/browse/MAILPOET-3132