### PR TITLE
Detect whitespace in output that can break tracking images and captcha [MAILPOET-2983]

### DIFF
--- a/lib/Util/Notices/HeadersAlreadySentNotice.php
+++ b/lib/Util/Notices/HeadersAlreadySentNotice.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class HeadersAlreadySentNotice {
+
+  const DISMISS_NOTICE_TIMEOUT_SECONDS = YEAR_IN_SECONDS;
+  const OPTION_NAME = 'dismissed-headers-already-sent-notice';
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(SettingsController $settings, WPFunctions $wp) {
+    $this->settings = $settings;
+    $this->wp = $wp;
+  }
+
+  public function init($shouldDisplay) {
+    if (!$shouldDisplay) {
+      return null;
+    }
+    $captchaEnabled = $this->settings->get('captcha.type') === Captcha::TYPE_BUILTIN;
+    $trackingEnabled = $this->settings->get('tracking.enabled');
+    if ($this->areHeadersAlreadySent()) {
+      return $this->display($captchaEnabled, $trackingEnabled);
+    }
+  }
+
+  public function areHeadersAlreadySent() {
+    return !get_transient(self::OPTION_NAME) && headers_sent();
+  }
+
+  public function display($captchaEnabled, $trackingEnabled) {
+    if (!$captchaEnabled && !$trackingEnabled) {
+      return null;
+    }
+
+    $errorString = __('It looks like there\'s an issue with some of the PHP files on your website which is preventing MailPoet from functioning correctly. If not resolved, you may experience:', 'mailpoet');
+    $errorStringTracking = __('Inaccurate tracking of email opens and clicks', 'mailpoet');
+    $errorStringCaptcha = __('CAPTCHA not rendering correctly', 'mailpoet');
+    $errorString = $errorString . '<br>'
+      . ($trackingEnabled ? ('<br> - ' . $errorStringTracking) : '')
+      . ($captchaEnabled ? ('<br> - ' . $errorStringCaptcha) : '');
+
+    $howToResolveString = __('[link]Learn how to fix this issue and restore functionality[/link]', 'mailpoet');
+    $error = $errorString . '<br><br>' . Helpers::replaceLinkTags($howToResolveString, 'https://kb.mailpoet.com/article/325-the-captcha-image-doesnt-show-up', [
+      'target' => '_blank',
+      'data-beacon-article' => '5f20fb5904286306f8078acb',
+      'class' => 'button-primary',
+    ]);
+
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+
+    return Notice::displayError($error, $extraClasses, self::OPTION_NAME, true, false);
+  }
+
+  public function disable() {
+    $this->wp->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+  }
+}

--- a/lib/Util/Notices/HeadersAlreadySentNotice.php
+++ b/lib/Util/Notices/HeadersAlreadySentNotice.php
@@ -36,7 +36,11 @@ class HeadersAlreadySentNotice {
   }
 
   public function areHeadersAlreadySent() {
-    return !get_transient(self::OPTION_NAME) && headers_sent();
+    return !get_transient(self::OPTION_NAME) && $this->headersSent();
+  }
+
+  protected function headersSent() {
+    return headers_sent();
   }
 
   public function display($captchaEnabled, $trackingEnabled) {

--- a/lib/Util/Notices/HeadersAlreadySentNotice.php
+++ b/lib/Util/Notices/HeadersAlreadySentNotice.php
@@ -36,11 +36,20 @@ class HeadersAlreadySentNotice {
   }
 
   public function areHeadersAlreadySent() {
-    return !get_transient(self::OPTION_NAME) && $this->headersSent();
+    return !get_transient(self::OPTION_NAME)
+      && ($this->headersSent() || $this->isWhitespaceInBuffer());
   }
 
   protected function headersSent() {
     return headers_sent();
+  }
+
+  public function isWhitespaceInBuffer() {
+    $content = ob_get_contents();
+    if (!$content) {
+      return false;
+    }
+    return preg_match('/^\s+$/', $content);
   }
 
   public function display($captchaEnabled, $trackingEnabled) {

--- a/lib/Util/Notices/PermanentNotices.php
+++ b/lib/Util/Notices/PermanentNotices.php
@@ -29,6 +29,9 @@ class PermanentNotices {
   /** @var BlackFridayNotice */
   private $blackFridayNotice;
 
+  /** @var HeadersAlreadySentNotice */
+  private $headersAlreadySentNotice;
+
   public function __construct(WPFunctions $wp) {
     $this->wp = $wp;
     $this->phpVersionWarnings = new PHPVersionWarnings();
@@ -37,6 +40,7 @@ class PermanentNotices {
     $this->unauthorizedEmailsInNewslettersNotice = new UnauthorizedEmailInNewslettersNotice(SettingsController::getInstance(), $wp);
     $this->inactiveSubscribersNotice = new InactiveSubscribersNotice(SettingsController::getInstance(), $wp);
     $this->blackFridayNotice = new BlackFridayNotice();
+    $this->headersAlreadySentNotice = new HeadersAlreadySentNotice(SettingsController::getInstance(), $wp);
   }
 
   public function init() {
@@ -68,6 +72,9 @@ class PermanentNotices {
     $this->blackFridayNotice->init(
       Menu::isOnMailPoetAdminPage($excludeWizard)
     );
+    $this->headersAlreadySentNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeWizard)
+    );
   }
 
   public function ajaxDismissNoticeHandler() {
@@ -81,6 +88,9 @@ class PermanentNotices {
         break;
       case (BlackFridayNotice::OPTION_NAME):
         $this->blackFridayNotice->disable();
+        break;
+      case (HeadersAlreadySentNotice::OPTION_NAME):
+        $this->headersAlreadySentNotice->disable();
         break;
       case (InactiveSubscribersNotice::OPTION_NAME):
         $this->inactiveSubscribersNotice->disable();

--- a/lib/WP/Notice.php
+++ b/lib/WP/Notice.php
@@ -37,7 +37,7 @@ class Notice {
         $message
       );
     }
-    self::createNotice(self::TYPE_ERROR, $message, $classes, $dataNoticeName, $renderInParagraph);
+    return self::createNotice(self::TYPE_ERROR, $message, $classes, $dataNoticeName, $renderInParagraph);
   }
 
   public static function displayWarning($message, $classes = '', $dataNoticeName = '', $renderInParagraph = true) {
@@ -45,11 +45,11 @@ class Notice {
   }
 
   public static function displaySuccess($message, $classes = '', $dataNoticeName = '', $renderInParagraph = true) {
-    self::createNotice(self::TYPE_SUCCESS, $message, $classes, $dataNoticeName, $renderInParagraph);
+    return self::createNotice(self::TYPE_SUCCESS, $message, $classes, $dataNoticeName, $renderInParagraph);
   }
 
   public static function displayInfo($message, $classes = '', $dataNoticeName = '', $renderInParagraph = true) {
-    self::createNotice(self::TYPE_INFO, $message, $classes, $dataNoticeName, $renderInParagraph);
+    return self::createNotice(self::TYPE_INFO, $message, $classes, $dataNoticeName, $renderInParagraph);
   }
 
   protected static function createNotice($type, $message, $classes, $dataNoticeName, $renderInParagraph) {

--- a/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
+++ b/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
@@ -45,6 +45,19 @@ class HeadersAlreadySentNoticeTest extends \MailPoetTest {
     expect($notice)->null();
   }
 
+  public function testItPrintsWarningWhenWhitespaceIsInBuffer() {
+    ob_start();
+    echo "  \n \t  \r\n  ";
+    $headersAlreadySentNotice = Stub::construct(
+      HeadersAlreadySentNotice::class,
+      [$this->settings, $this->wp],
+      ['headersSent' => false]
+    );
+    $notice = $headersAlreadySentNotice->init(true);
+    expect($notice->getMessage())->contains('It looks like there\'s an issue with some of the PHP files on your website');
+    ob_end_clean();
+  }
+
   public function testItPrintsNoWarningWhenDisabled() {
     $headersAlreadySentNotice = Stub::construct(
       HeadersAlreadySentNotice::class,

--- a/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
+++ b/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace MailPoet\Util\Notices;
+
+use Codeception\Util\Stub;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+
+class HeadersAlreadySentNoticeTest extends \MailPoetTest {
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->settings = SettingsController::getInstance();
+    $this->wp = new WPFunctions;
+    delete_transient(HeadersAlreadySentNotice::OPTION_NAME);
+  }
+
+  public function _after() {
+    delete_transient(HeadersAlreadySentNotice::OPTION_NAME);
+  }
+
+  public function testItPrintsWarningWhenHeadersAreSent() {
+    $headersAlreadySentNotice = Stub::construct(
+      HeadersAlreadySentNotice::class,
+      [$this->settings, $this->wp],
+      ['headersSent' => true]
+    );
+    $notice = $headersAlreadySentNotice->init(true);
+    expect($notice->getMessage())->contains('It looks like there\'s an issue with some of the PHP files on your website');
+    expect($notice->getMessage())->contains('https://kb.mailpoet.com/article/325-the-captcha-image-doesnt-show-up');
+  }
+
+  public function testItPrintsNoWarningWhenHeadersAreNotSent() {
+    $headersAlreadySentNotice = Stub::construct(
+      HeadersAlreadySentNotice::class,
+      [$this->settings, $this->wp],
+      ['headersSent' => false]
+    );
+    $notice = $headersAlreadySentNotice->init(true);
+    expect($notice)->null();
+  }
+
+  public function testItPrintsNoWarningWhenDisabled() {
+    $headersAlreadySentNotice = Stub::construct(
+      HeadersAlreadySentNotice::class,
+      [$this->settings, $this->wp],
+      ['headersSent' => true]
+    );
+    $warning = $headersAlreadySentNotice->init(false);
+    expect($warning)->null();
+  }
+
+  public function testItPrintsNoWarningWhenDismissed() {
+    $headersAlreadySentNotice = Stub::construct(
+      HeadersAlreadySentNotice::class,
+      [$this->settings, $this->wp],
+      ['headersSent' => true]
+    );
+    $headersAlreadySentNotice->disable();
+    $warning = $headersAlreadySentNotice->init(true);
+    expect($warning)->null();
+  }
+
+  public function testItPrintsCaptchaAndTrackingMessagesIfEnabled() {
+    $headersAlreadySentNotice = Stub::make(HeadersAlreadySentNotice::class);
+    $notice = $headersAlreadySentNotice->display(true, true);
+    expect($notice->getMessage())->contains('Inaccurate tracking');
+    expect($notice->getMessage())->contains('CAPTCHA not rendering');
+  }
+
+  public function testItPrintsNoCaptchaMessageIfCaptchaDisabled() {
+    $headersAlreadySentNotice = Stub::make(HeadersAlreadySentNotice::class);
+    $notice = $headersAlreadySentNotice->display(false, true);
+    expect($notice->getMessage())->contains('Inaccurate tracking');
+    expect($notice->getMessage())->notContains('CAPTCHA not rendering');
+  }
+
+  public function testItPrintsNoTrackingMessageIftrackingDisabled() {
+    $headersAlreadySentNotice = Stub::make(HeadersAlreadySentNotice::class);
+    $notice = $headersAlreadySentNotice->display(true, false);
+    expect($notice->getMessage())->notContains('Inaccurate tracking');
+    expect($notice->getMessage())->contains('CAPTCHA not rendering');
+  }
+
+  public function testItPrintsNoMessagesWhenCaptchaAndTrackingDisabled() {
+    $headersAlreadySentNotice = Stub::make(HeadersAlreadySentNotice::class);
+    $notice = $headersAlreadySentNotice->display(false, false);
+    expect($notice)->null();
+  }
+}


### PR DESCRIPTION
[MAILPOET-2983](https://mailpoet.atlassian.net/browse/MAILPOET-2983)

I formatted the captcha message as a separate sentence for easier translation.

**For QA:**

To test this, try adding `?>` followed by some whitespace at the end of theme's `functions.php` or in some 3rd-party plugin files. 
