### PR TITLE
Fix Normalizer prefixing [MAILPOET-3148]

### DIFF
--- a/prefixer/fix-symfony-polyfill.php
+++ b/prefixer/fix-symfony-polyfill.php
@@ -8,9 +8,16 @@ set_error_handler(function ($severity, $message, $file, $line) {
 $file = __DIR__ . '/../vendor-prefixed/symfony/polyfill-intl-idn/Idn.php';
 $data = file_get_contents($file);
 $data = str_replace('\\Normalizer::', '\\MailPoetVendor\\Normalizer::', $data);
+$data = str_replace('use Normalizer;', 'use MailPoetVendor\\Normalizer;', $data);
 file_put_contents($file, $data);
 
 $file = __DIR__ . '/../vendor-prefixed/symfony/polyfill-intl-normalizer/Normalizer.php';
+$data = file_get_contents($file);
+$data = str_replace('\\Normalizer::', '\\MailPoetVendor\\Normalizer::', $data);
+$data = str_replace('\'Normalizer::', '\'\\MailPoetVendor\\Normalizer::', $data); // for use in strings like defined('...')
+file_put_contents($file, $data);
+
+$file = __DIR__ . '/../vendor-prefixed/symfony/polyfill-iconv/Iconv.php';
 $data = file_get_contents($file);
 $data = str_replace('\\Normalizer::', '\\MailPoetVendor\\Normalizer::', $data);
 file_put_contents($file, $data);


### PR DESCRIPTION
Please double-check that all necessary cases are prefixed now.

*For QA:*

If possible, please test this on a host where Intl extension functions are missing to make sure errors do not occur. Test with WooCommerce enabled.
