### PR TITLE
Fixed three flaky tests

### DIFF
--- a/tests/acceptance/EditorProductsCest.php
+++ b/tests/acceptance/EditorProductsCest.php
@@ -90,6 +90,7 @@ class EditorProductsCest {
 
     // Create products block (added wait checks to avoid flakiness)
     $i->waitForText('Content');
+    $i->scrollTo('[data-automation-id="newsletter_title"]');
     $i->dragAndDrop('#automation_editor_block_products', '#mce_0');
     $i->waitForText('There is no content to display.');
     $i->waitForText('Display options');

--- a/tests/acceptance/ManageListsCest.php
+++ b/tests/acceptance/ManageListsCest.php
@@ -52,6 +52,7 @@ class ManageListsCest {
 
     // Edit existing list
     $i->clickItemRowActionByItemName($newListTitle, 'Edit');
+    $i->clearFormField('#field_name');
     $i->fillField('Name', $editedListTitle);
     $i->fillField('Description', $editedListDesc);
     $i->click('Save');

--- a/tests/acceptance/SettingsPageBasicsCest.php
+++ b/tests/acceptance/SettingsPageBasicsCest.php
@@ -71,10 +71,12 @@ class SettingsPageBasicsCest {
     $i->click('Post Comment');
     $i->waitForText($comment, 10, '.comment-content');
     //check if user is really subscribed to a list
-    $i->amOnMailpoetPage('Subscribers');
+    $i->amOnMailpoetPage('Lists');
+    $i->waitForText('Lists');
+    $i->clickItemRowActionByItemName('Newsletter mailing list', 'View Subscribers');
     $i->waitForText('Subscribers');
+    $i->click('[data-automation-id="filters_unconfirmed"]');
     $i->waitForText('test@test.com');
-    $i->waitForText('Unconfirmed');
     //clear checkbox to hide Select2 from next test
     $i->amOnMailPoetPage('Settings');
     $i->uncheckOption('[data-automation-id="subscribe-on_comment-checkbox"]');

--- a/tests/acceptance/SettingsPageBasicsCest.php
+++ b/tests/acceptance/SettingsPageBasicsCest.php
@@ -61,8 +61,9 @@ class SettingsPageBasicsCest {
     $i->click($postTitle);
     $i->waitForText($postTitle);
     $i->scrollTo('#commentform');
+    $i->scrollTo('.comment-form-comment');
     $i->waitForElementVisible(['css' => '.comment-form-mailpoet']);
-    $i->see($optinMessage);
+    $i->waitForText($optinMessage);
     $i->click('#comment');
     $i->fillField('#comment', $comment);
     $i->waitForText($optinMessage);
@@ -70,8 +71,7 @@ class SettingsPageBasicsCest {
     $i->click('Post Comment');
     $i->waitForText($comment, 10, '.comment-content');
     //check if user is really subscribed to a list
-    $i->amOnMailpoetPage('Lists');
-    $i->clickItemRowActionByItemName('Newsletter mailing list', 'View Subscribers');
+    $i->amOnMailpoetPage('Subscribers');
     $i->waitForText('Subscribers');
     $i->waitForText('test@test.com');
     $i->waitForText('Unconfirmed');


### PR DESCRIPTION
[MAILPOET-3153](https://mailpoet.atlassian.net/browse/MAILPOET-3153)

In this task I will fix flaky tests that keep failing in nightly build.

Flaky tests:

- EditorProductsCest:filterProducts (keep failing because warning message for PHP update is present)
- SettingsPageBasicsCest:allowSubscribeInComments (failing because require additional scroll)
- ManageListsCest:editTrashRestoreAndDeleteExistingList (failing because we redesigned fields recently)