### PR TITLE
Fix radio button displaying [MAILPOET-3126]

### DIFF
--- a/assets/css/src/components-form-editor/_preview.scss
+++ b/assets/css/src/components-form-editor/_preview.scss
@@ -14,6 +14,10 @@
     display: flex;
     flex-direction: column;
     position: relative;
+
+    *:before {
+      box-sizing: inherit;
+    }
   }
 
   .mailpoet_browser_preview {


### PR DESCRIPTION
The issue was with the box sizing.
The Gutenberg component expects the box sizing to be set to border-box
that is done on the newsletter editor by Gutenberg styles.
But that rule was not applied on the preview page so I added it there.

[MAILPOET-3126]

[MAILPOET-3126]: https://mailpoet.atlassian.net/browse/MAILPOET-3126