### PR TITLE
Fix flakiness in Acceptance Tester [MAILPOET-3245]

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -412,6 +412,7 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function placeOrder() {
     $i = $this;
+    $i->waitForText('Place order');
     $i->click('Place order');
     $i->waitForText('Your order has been received');
   }


### PR DESCRIPTION
[MAILPOET-3245](https://mailpoet.atlassian.net/browse/MAILPOET-3245)

I also thought at first that the issue was with 10s of waiting time, so I have increased that to 20s but again issue has occured.
The problem was that it needed a bit of waiting time in order to focus and click on Place Order button.

Test results:
- With added waitForText: Passed 20 out of 20 tries
- Without added waitForText: Failed 2 out of 10 tries