### PR TITLE
Handling corrupted form settings data [MAILPOET-3294]

### DIFF
--- a/lib/AdminPages/Pages/FormEditor.php
+++ b/lib/AdminPages/Pages/FormEditor.php
@@ -211,11 +211,7 @@ class FormEditor {
     if (isset($_GET['action']) && $_GET['action'] === 'create') {
       $this->createForm();
     }
-    $form = Form::findOne((int)$_GET['id']);
-    if ($form instanceof Form) {
-      $form = $form->asArray();
-    }
-    $form['styles'] = $this->formRenderer->getCustomStyles($form);
+    $form = $this->getFormData((int)$_GET['id']);
     $customFields = $this->customFieldsRepository->findAll();
     $dateTypes = $this->dateBlock->getDateTypes();
     $data = [
@@ -335,6 +331,21 @@ class FormEditor {
       }
     }
     return $translations;
+  }
+
+  private function getFormData(int $id) {
+    $form = Form::findOne($id);
+    if (!$form instanceof Form) {
+      return null;
+    }
+    $form = $form->asArray();
+    $form['styles'] = $this->formRenderer->getCustomStyles($form);
+    // Use empty settings in case they are corrupted or missing
+    if (!is_array($form['settings'])) {
+      $initialFormTemplate = $this->templatesRepository->getFormTemplate(TemplateRepository::INITIAL_FORM_TEMPLATE);
+      $form['settings'] = $initialFormTemplate->getSettings();
+    }
+    return $form;
   }
 
   private function getAllPosts() {

--- a/lib/Form/Renderer.php
+++ b/lib/Form/Renderer.php
@@ -45,7 +45,7 @@ class Renderer {
   }
 
   public function renderHTML(array $form = []): string {
-    if (isset($form['body']) && !empty($form['body'])) {
+    if (isset($form['body']) && !empty($form['body']) && is_array($form['settings'])) {
       return $this->renderBlocks($form['body'], $form['settings'] ?? []);
     }
     return '';

--- a/lib/Form/Util/Styles.php
+++ b/lib/Form/Util/Styles.php
@@ -26,7 +26,7 @@ class Styles {
   }
 
   public function renderFormSettingsStyles(array $form, string $selector, string $displayType): string {
-    if (!isset($form['settings'])) return '';
+    if (!isset($form['settings']) || !is_array($form['settings'])) return '';
     $formSettings = $form['settings'];
     // Wrapper styles
     $styles = [];

--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -215,7 +215,7 @@ class Widget extends \WP_Widget {
     $body = (isset($form['body']) ? $form['body'] : []);
     $output = '';
 
-    if (!empty($body)) {
+    if (!empty($body) && isset($form['settings']) && is_array($form['settings'])) {
       $formId = $this->id_base . '_' . $form['id']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.NotCamelCaps
       $data = [
         'form_html_id' => $formId,


### PR DESCRIPTION
This PR adds handling of corrupted serialized form settings data, that can't be unserialized.

1.  Prevents rendering such a form on the front end
2. Uses initial form's settings as fallback value for form editor

[MAILPOET-3294]

[MAILPOET-3294]: https://mailpoet.atlassian.net/browse/MAILPOET-3294