### PR TITLE
Add "US East (Ohio)" region to Amazon SES options

### DIFF
--- a/lib/Mailer/Methods/AmazonSES.php
+++ b/lib/Mailer/Methods/AmazonSES.php
@@ -26,6 +26,7 @@ class AmazonSES {
   public $dateWithoutTime;
   private $availableRegions = [
     'US East (N. Virginia)' => 'us-east-1',
+    'US East (Ohio) => 'us-east-2',
     'US West (Oregon)' => 'us-west-2',
     'EU (Ireland)' => 'eu-west-1',
     'EU (London)' => 'eu-west-2',

--- a/lib/Mailer/Methods/AmazonSES.php
+++ b/lib/Mailer/Methods/AmazonSES.php
@@ -26,7 +26,7 @@ class AmazonSES {
   public $dateWithoutTime;
   private $availableRegions = [
     'US East (N. Virginia)' => 'us-east-1',
-    'US East (Ohio) => 'us-east-2',
+    'US East (Ohio)' => 'us-east-2',
     'US West (Oregon)' => 'us-west-2',
     'EU (Ireland)' => 'eu-west-1',
     'EU (London)' => 'eu-west-2',

--- a/lib/Settings/Hosts.php
+++ b/lib/Settings/Hosts.php
@@ -15,6 +15,7 @@ class Hosts {
       ],
       'regions' => [
         'US East (N. Virginia)' => 'us-east-1',
+        'US East (Ohio)' => 'us-east-2',
         'US West (Oregon)' => 'us-west-2',
         'EU (Ireland)' => 'eu-west-1',
         'EU (London)' => 'eu-west-2',


### PR DESCRIPTION
New AWS accounts in US East are automatically assigned to the region "us-east-2", which corresponds to "US East (Ohio)".

This PR adds the corresponding strings where there are AWS regions listed in the code. Editing "US East (N. Virginia)" in place is not sufficient.