### PR TITLE
Don't clear new sub/list forms on save, fix loading opacity [MAILPOET-3347]

### DIFF
--- a/assets/css/src/components-plugin/_listing.scss
+++ b/assets/css/src/components-plugin/_listing.scss
@@ -76,7 +76,7 @@ input.mailpoet-listing-current-page {
 }
 
 .mailpoet-listing-loading tbody tr,
-.mailpoet_form_loading tbody tr {
+.mailpoet_form_loading div.mailpoet-form-grid {
   opacity: .2;
 }
 

--- a/assets/js/src/form/form.jsx
+++ b/assets/js/src/form/form.jsx
@@ -30,8 +30,10 @@ class Form extends React.Component {
     }
   }
 
-  componentDidUpdate() {
-    if (this.props.params.id === undefined && this.state.loading) {
+  componentDidUpdate(prevProps) {
+    if (this.props.params.id === undefined
+      && prevProps.location.pathname !== this.props.location.pathname
+    ) {
       setImmediate(() => {
         this.setState({
           loading: false,
@@ -250,6 +252,9 @@ Form.propTypes = {
   params: PropTypes.shape({
     id: PropTypes.string,
   }),
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
   item: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   errors: PropTypes.arrayOf(PropTypes.object),
   endpoint: PropTypes.string,
@@ -276,6 +281,7 @@ Form.propTypes = {
 
 Form.defaultProps = {
   params: {},
+  location: {},
   errors: undefined,
   fields: undefined,
   item: undefined,


### PR DESCRIPTION
[MAILPOET-3347]

There are actually two bugs in one. Loading not shown is easy, we just forgot to update CSS for it during the redesign.

The second issue (new sub/list forms cleared on save) needs some explanation. The line that triggers the problematic form clearing is this one: 
https://github.com/mailpoet/mailpoet/blob/c3cca1b040fd69d43c22cbe420929f3ac226e8de/assets/js/src/form/form.jsx#L34
It appeared more than 5 years ago in one of the first commits to MP3:
https://github.com/mailpoet/mailpoet/commit/e471d45827e4e27fee2d67e3a3a0c52addd35a3e#diff-e90b4aa64ac86af261543916331c172d6f2741cab3c53f7a5431480484475a17R56
At some point the method it was invoked in was changed from `componentWillReceiveProps` to `componentDidUpdate`:
https://github.com/mailpoet/mailpoet/commit/65653b458943cdfd4248cdd3540cdaf41bfe3bf3#diff-e90b4aa64ac86af261543916331c172d6f2741cab3c53f7a5431480484475a17R55
The condition for it to be executed also changed here. That's when the problem started. I've reproduced it on 3.31.0, long before the redesign. 

I could not actually find a legitimate case for clearing the form except directly switching from `/edit/123` to `/new` path, e.g. by directly typing in the address bar. So I didn't remove that code, but restricted it only to location changes. If you think there may be other use cases, please comment or fix it.

[MAILPOET-3347]: https://mailpoet.atlassian.net/browse/MAILPOET-3347