### PR TITLE
Minor updates to the instructions on how to setup a MailPoet development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ MailPoet done the right way.
 - PHP 7.0
 - NodeJS
 - WordPress
-- Docker & Docker Compose
 
 ## Installation
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ MailPoet done the right way.
 - WordPress
 
 ## Installation
+
+The instructions below assume you already have a working WordPress development environment.
+
 ```bash
 # go to WP plugins directory
 $ cd path_to_wp_directory/wp-content/plugins

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ MailPoet done the right way.
 # Setup
 
 ## Requirements
-- PHP 7.0
+- PHP >= 7.3 (only for the development environment, to run the plugin PHP >= 7.1 is required)
 - NodeJS
 - WordPress
 


### PR DESCRIPTION
This PR makes three minor adjustments to the portion of the README.md file that details how to setup a MailPoet development environment:

- Removes docker and docker compose as requirements as they are used to run the acceptance tests but not MailPoet itself
- Adds composer as a MailPoet requirement
- Adds a note making it explicit that the instructions assume that there is already a working WP dev environment configured on the machine.

Since I'm new to MailPoet there is a high chance that I'm missing something and that the changes that I'm suggesting don't make sense for some reason. If that is the case, just let me know :-)