### PR TITLE
Remove minimum required PHP version

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -9,7 +9,7 @@ Developers integrating MailPoet functionality in their own plugins or projects a
 
 ### Basics
 MailPoet API is distributed within MailPoet3 plugin and it is implemented as a PHP class.
-Currently supported version is `v1` and it works with PHP version 5.6 and higher.
+Currently supported version is `v1`.
 
 ### Instantiation
 ```php


### PR DESCRIPTION
This PR removes a reference to the minimum required PHP version (which is presumably outdated as it mentions PHP 5.6) from the MailPoet API documentation.

I'm assuming that the minimum required version to use the API is the same as the one to run MailPoet. If that is the case, I don't see a reason to mention it in the API documentation, and removing it has the benefit of reducing the maintenance burden when the minimum required version is updated.

As usual please let me know if I'm missing something and this change doesn't make sense as I'm still a MailPoet newbie.