### PR TITLE
Fix a syntax issue in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,12 +6,12 @@ WP_TEST_MAILER_ENABLE_SENDING="false"
 # Optional: for multisite acceptance tests
 WP_ROOT_MULTISITE="/var/www/wordpress"
 WP_TEST_MULTISITE_SLUG=""
-HTTP_HOST="" // URL of your site (used for multisite env and equals to DOMAIN_CURRENT_SITE from wp-config.php)
+HTTP_HOST="" # URL of your site (used for multisite env and equals to DOMAIN_CURRENT_SITE from wp-config.php)
 
 # Optional: for sending tests
 # These are required if WP_TEST_MAILER_ENABLE_SENDING is "true"
 WP_TEST_IMPORT_MAILCHIMP_API=""
-WP_TEST_IMPORT_MAILCHIMP_LISTS="" // (separated with comma)
+WP_TEST_IMPORT_MAILCHIMP_LISTS="" # (separated with comma)
 WP_TEST_MAILER_AMAZON_ACCESS=""
 WP_TEST_MAILER_AMAZON_SECRET=""
 WP_TEST_MAILER_AMAZON_REGION=""
@@ -25,10 +25,10 @@ WP_TEST_MAILER_SMTP_PASSWORD=""
 WP_SVN_USERNAME=""
 WP_SVN_PASSWORD=""
 WP_TRANSIFEX_API_TOKEN=""
-WP_JIRA_USER="" // JIRA username/email
-WP_JIRA_TOKEN="" // JIRA token from https://id.atlassian.com/manage/api-tokens
-WP_CIRCLECI_USERNAME="" // CircleCI organization or user
-WP_CIRCLECI_TOKEN="" // CircleCI token from https://circleci.com/gh/{user|org}/{project}/edit#api
-WP_GITHUB_USERNAME="" // GitHub username (not email)
-WP_GITHUB_TOKEN="" // GitHub token from https://github.com/settings/tokens
-WP_SLACK_WEBHOOK_URL="" // Webhook URL from https://mailpoet.slack.com/services/BHRB9AHSQ
+WP_JIRA_USER="" # JIRA username/email
+WP_JIRA_TOKEN="" # JIRA token from https://id.atlassian.com/manage/api-tokens
+WP_CIRCLECI_USERNAME="" # CircleCI organization or user
+WP_CIRCLECI_TOKEN="" # CircleCI token from https://circleci.com/gh/{user|org}/{project}/edit#api
+WP_GITHUB_USERNAME="" # GitHub username (not email)
+WP_GITHUB_TOKEN="" # GitHub token from https://github.com/settings/tokens
+WP_SLACK_WEBHOOK_URL="" # Webhook URL from https://mailpoet.slack.com/services/BHRB9AHSQ


### PR DESCRIPTION
The .env.sample file contained a few comments using `//`. The problem is that `//` is not supported by vlucas/phpdotenv and this was resulting in the following fatal error when following the dev environment setup instructions and running `./do install`:

```
ERROR: Uncaught Dotenv\Exception\InvalidFileException: Failed to parse dotenv file due to unexpected whitespace. Failed at ["" // URL of your site (used for multisite env and equals to DOMAIN_CURRENT_SITE from wp-config.php)]. in /srv/www/mailpoet/public_html/wp-content/plugins/mailpoet/vendor/vlucas/phpdotenv/src/Parser.php:148
```

To fix this problem, this commit replaces all instances of `//` in .env.sample with the `#` (see
https://github.com/vlucas/phpdotenv#comments).

Quick test show that `//` doesn't work and `#` does:

```
>>> Dotenv\Dotenv::parse("FOO=Bar // some comment")
Dotenv\Exception\InvalidFileException with message 'Failed to parse dotenv file. Encountered unexpected whitespace at [Bar // some comment].'
>>> Dotenv\Dotenv::parse("FOO=Bar # some comment")
=> [
     "FOO" => "Bar",
   ]
```

Related slack discussion: https://a8c.slack.com/archives/C01H71ZLBGQ/p1610740191014600