### PR TITLE
Override #wpbody color to default for form-editor [MAILPOET-3305]

### DIFF
--- a/assets/css/src/generic/_typography.scss
+++ b/assets/css/src/generic/_typography.scss
@@ -5,6 +5,10 @@
   line-height: $line-height;
 }
 
+.admin_page_mailpoet-form-editor #wpbody {
+  color: inherit;
+}
+
 a {
   text-decoration: underline;
 


### PR DESCRIPTION
[MAILPOET-3305]

[MAILPOET-3305]: https://mailpoet.atlassian.net/browse/MAILPOET-3305