### PR TITLE
Remove duplicated username from user reviews in the premium page [MAILPOET-3392]

### DIFF
--- a/views/premium.html
+++ b/views/premium.html
@@ -306,15 +306,15 @@
         <b> – loogaroo</b>
       </p>
       <p>
-        <%= _x('“I’ve been a customer for a few years I have received the best support every single time. Thank you guys, you are great.” – disneyfamilytees', 'This text resides in the Premium page: /wp-admin/admin.php?page=mailpoet-premium') %>
+        <%= _x('“I’ve been a customer for a few years I have received the best support every single time. Thank you guys, you are great.”', 'This text resides in the Premium page: /wp-admin/admin.php?page=mailpoet-premium') %>
         <b> – disneyfamilytees</b>
       </p>
       <p>
-        <%= _x('“I had a little problem and Jack wrote me back to help very soon. His way to interact is very kind and professional… Very good customer support in case you have a problem. The plugin works very well and it has a lot of fantastic new features. I’m satisfied!” – anselmo', 'This text resides in the Premium page: /wp-admin/admin.php?page=mailpoet-premium') %>
+        <%= _x('“I had a little problem and Jack wrote me back to help very soon. His way to interact is very kind and professional… Very good customer support in case you have a problem. The plugin works very well and it has a lot of fantastic new features. I’m satisfied!”', 'This text resides in the Premium page: /wp-admin/admin.php?page=mailpoet-premium') %>
         <b> – anselmo</b>
       </p>
       <p>
-        <%= _x('“Hard to fault MailPoet plugin and the support team behind it. Very happy with the speed and quality of help and the regular upgrades.” – tpoulos', 'This text resides in the Premium page: /wp-admin/admin.php?page=mailpoet-premium') %>
+        <%= _x('“Hard to fault MailPoet plugin and the support team behind it. Very happy with the speed and quality of help and the regular upgrades.”', 'This text resides in the Premium page: /wp-admin/admin.php?page=mailpoet-premium') %>
         <b> – tpoulos</b>
       </p>
     </div>


### PR DESCRIPTION
In the page admin.php?page=mailpoet-premium, we display six reviews that customers gave us. In three of those reviews, we were displaying the name of the username of the customer twice. This PR simply removes the duplicate usernames.

Related issue: https://mailpoet.atlassian.net/browse/MAILPOET-3392