### PR TITLE
Bump "Tested up to" tag in readme.txt and remove it from mailpoet.php [MAILPOET-3394]

### DIFF
--- a/mailpoet.php
+++ b/mailpoet.php
@@ -8,7 +8,6 @@
  * Author: MailPoet
  * Author URI: http://www.mailpoet.com
  * Requires at least: 5.3
- * Tested up to: 5.5
  *
  * @package WordPress
  * @author MailPoet

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mailpoet, wysija
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 5.3
-Tested up to: 5.5
+Tested up to: 5.6
 Stable tag: 3.59.0
 Requires PHP: 7.1
 License: GPLv3


### PR DESCRIPTION
This PR bumps the "Tested up to" tag in the readme.txt file to 5.6 and it also removes the same tag from mailpoet.php. See bf24a8b commit message for an explanation on why I believe we can remove the tag from mailpoet.php.

[MAILPOET-3394]

[MAILPOET-3394]: https://mailpoet.atlassian.net/browse/MAILPOET-3394