### PR TITLE
Use the woocommerce_email action to customize WC emails [MAILPOET-3421]

### DIFF
--- a/lib/WooCommerce/TransactionalEmailHooks.php
+++ b/lib/WooCommerce/TransactionalEmailHooks.php
@@ -29,11 +29,11 @@ class TransactionalEmailHooks {
   }
 
   public function useTemplateForWoocommerceEmails() {
-    $this->wp->addAction('woocommerce_init', function() {
+    $this->wp->addAction('woocommerce_email', function($wcEmails) {
       /** @var callable */
-      $emailHeaderCallback = [\WC()->mailer(), 'email_header'];
+      $emailHeaderCallback = [$wcEmails, 'email_header'];
       /** @var callable */
-      $emailFooterCallback = [\WC()->mailer(), 'email_footer'];
+      $emailFooterCallback = [$wcEmails, 'email_footer'];
       $this->wp->removeAction('woocommerce_email_header', $emailHeaderCallback);
       $this->wp->removeAction('woocommerce_email_footer', $emailFooterCallback);
       $this->wp->addAction('woocommerce_email_header', function($emailHeading) {

--- a/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -164,8 +164,8 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
     );
     $transactionalEmails->useTemplateForWoocommerceEmails();
     expect($addedActions)->count(1);
-    expect($addedActions['woocommerce_init'])->callable();
-    $addedActions['woocommerce_init']();
+    expect($addedActions['woocommerce_email'])->callable();
+    $addedActions['woocommerce_email'](new \stdClass());
     expect($removedActions)->count(2);
     expect($addedActions)->count(4);
     expect($addedActions['woocommerce_email_header'])->callable();

--- a/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -156,6 +156,7 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
         return 'prefixed ' . $css;
       },
     ]);
+    $wcEmails = $this->makeEmpty("\WC_Emails");
 
     $transactionalEmails = new TransactionalEmailHooks(
       $wp,
@@ -165,7 +166,7 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
     $transactionalEmails->useTemplateForWoocommerceEmails();
     expect($addedActions)->count(1);
     expect($addedActions['woocommerce_email'])->callable();
-    $addedActions['woocommerce_email'](new \stdClass());
+    $addedActions['woocommerce_email']($wcEmails);
     expect($removedActions)->count(2);
     expect($addedActions)->count(4);
     expect($addedActions['woocommerce_email_header'])->callable();

--- a/tests/integration/_bootstrap.php
+++ b/tests/integration/_bootstrap.php
@@ -264,6 +264,8 @@ if (!function_exists('WC')) {
     public function get_product_id() { // phpcs:ignore
     }
   }
+
+  class WC_Emails {} // phpcs:ignore
 }
 
 require_once '_fixtures.php';


### PR DESCRIPTION
This PR changes the WC action that MailPoet uses to hook into WC and customize the footer and the header of WC e-mails. Before, MailPoet was using the woommerce_init action. The problem with using this action to customize the e-mails is that it runs on every request. Furthermore, since we were calling WC->mailer() inside the callback, we were instantiating WC_Emails on every single request (WooCommerce instantiate this class only when needed).

Replacing woocommerce_init with woocommerce_email means that our code will run only when needed (right after WooCommerce adds callbacks to the actions woocommerce_email_header and woocommerce_email_footer) and that we won't be unnecessarily instantiating WC_Emails ourselves. We get the singleton instance of this class as a parameter.

I'm not familiar with the framework that we are using for the integration tests. They are passing now, but I'm not sure if there is a better way to change them than what I did. Specifically, the fact that I'm passing a stdClass instance here: https://github.com/mailpoet/mailpoet/compare/change-woocommerce-action?expand=1#diff-ee4f49cf7516570bf9037239d7485963e8a5827daa7a37f8712a5921f02ca5c2R168. Any input on a better way to change this test is appreciated.

**How to test the changes**
- Make sure that "Use MailPoet to customize WooCommerce emails" is enabled in /wp-admin/admin.php?page=mailpoet-settings#/woocommerce
- Check that on the master branch when any WP page is loaded the code inside the `woocommerce_init` action in `TransactionalEmailHooks::useTemplateForWoocommerceEmails()` is executed.
- Switch to this branch and check that for the same page the code inside the `woocommerce_init` action in `TransactionalEmailHooks::useTemplateForWoocommerceEmails()` is not executed anymore.
- Customize a WooCommerce e-mail in the template editor (for example, the order completed email), perform the action that triggers this email, and use MailHog to check that the customization still works.

[MAILPOET-3421]

[MAILPOET-3421]: https://mailpoet.atlassian.net/browse/MAILPOET-3421