### PR TITLE
Fix searching segments in subscribers import [MAILPOET-3423]

### DIFF
--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_segment_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_segment_selection.jsx
@@ -17,7 +17,7 @@ export function createSelection(segments, onSelectionChange) {
   segmentSelectElement.html('');
   segmentSelectElement
     .select2({
-      data: segments,
+      data: segments.map((segment) => ({ ...segment, text: segment.name })),
       dropdownCssClass: 'mailpoet-form-select2-dropdown',
       escapeMarkup: (markup) => markup,
       templateResult: templateRendered,


### PR DESCRIPTION
[MAILPOET-3423]

The bug was introduced [in this commit](https://github.com/mailpoet/mailpoet/pull/3278/commits/31e0be8feabe3e21beb2e36c545d92b3b3e06c10) that caused that `segment.text` property was not set. We don't use `segment.text` property in our code, but it is needed inside select2 for search.

[MAILPOET-3423]: https://mailpoet.atlassian.net/browse/MAILPOET-3423