### PR TITLE
Drop MailPoet tables when a site is deleted in a multisite install [MAILPOET-3265]

### DIFF
--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -168,6 +168,12 @@ class Initializer {
       new DeferredAdminNotices,
       'printAndClean',
     ]);
+
+    WPFunctions::get()->addFilter('wpmu_drop_tables', [
+      $this,
+      'multisiteDropTables',
+    ]);
+
     $this->hooks->initEarlyHooks();
   }
 
@@ -343,6 +349,13 @@ class Initializer {
     $automaticEmails = new AutomaticEmails();
     $automaticEmails->init();
     $automaticEmails->getAutomaticEmails();
+  }
+
+  public function multisiteDropTables($tables) {
+    global $wpdb;
+    $tablePrefix = $wpdb->prefix . Env::$pluginPrefix;
+    $mailpoetTables = $wpdb->get_col("SHOW TABLES LIKE '$tablePrefix%'");
+    return array_merge($tables, $mailpoetTables);
   }
 
   private function setupWoocommerceTransactionalEmails() {


### PR DESCRIPTION
This PR makes sure that MailPoet tables are dropped when a site is deleted in a multisite install. It uses the filter `wpmu_drop_tables` to add the list of MailPoet tables to the list of tables that WP drops whenever a site is deleted in a multisite install.

This will only work if MailPoet is network active. If it is not, MailPoet code is not executed inside the WP network admin panel, and thus our filter is not added to `wpmu_drop_tables`, and MP tables are not deleted.

**How to test this PR**
- On a multisite install, network activate MailPoet and create a few sites.
- Open the dashboard of the new sites so that MP tables are created.
- Delete one of the new sites and check that MP tables for the correct site were deleted.

Important: if there is a bug in this code, we have the potential to delete tables from other sites in the same multisite install or to not delete tables that should be deleted. I kept this in mind while creating this PR, but it is important that the reviewer considers this as well and thinks of edge cases that I might have missed to mitigate the chance of destroying data that shouldn't be destroyed.

[MAILPOET-3265]

[MAILPOET-3265]: https://mailpoet.atlassian.net/browse/MAILPOET-3265