### PR TITLE
Keep old sending settings when activating MSS via key validation [MAILPOET-3401]

### DIFF
--- a/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -31,7 +31,7 @@ export function* verifyMssKey(key: string) {
 
   const data = select(STORE_NAME).getSettings();
   data.mta_group = 'mailpoet';
-  data.mta = { method: 'MailPoet', mailpoet_api_key: key };
+  data.mta = { ...data.mta, method: 'MailPoet', mailpoet_api_key: key };
   data.signup_confirmation.enabled = '1';
 
   const call = yield {


### PR DESCRIPTION
I fixed the saving of settings so that it doesn't "forget" other mta properties. It copies [the same logic that is used in send with tab](https://github.com/mailpoet/mailpoet/blob/master/assets/js/src/settings/pages/send_with/send_with_choice.tsx#L26-L29).
I was thinking about refactoring it to some specific action + reducer but for some reason, we need to save data on API and then we set the data from API response to the store and replace all settings. I think this is needed to prevent setting an invalid MSS key to the store.

[MAILPOET-3401]

[MAILPOET-3401]: https://mailpoet.atlassian.net/browse/MAILPOET-3401