### PR TITLE
Fix "Purchased In This Category" email for product variations [MAILPOET-3416]

### DIFF
--- a/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -115,6 +115,11 @@ class PurchasedInCategory {
       if (!$product instanceof \WC_Product) {
         continue;
       }
+      if ($product->get_type() === 'variation') {
+        // WooCommerce returns a empty list when get_category_ids() is called for a product variation,
+        // so we need to get the parent product
+        $product = $this->woocommerceHelper->wcGetProduct($product->get_parent_id());
+      }
       $orderedProductCategories = array_merge($orderedProductCategories, $product->get_category_ids());
     }
 

--- a/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
+++ b/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
@@ -134,7 +134,7 @@ class PurchasedInCategoryTest extends \MailPoetTest {
       ->disableOriginalConstructor()
       ->disableOriginalClone()
       ->disableArgumentCloning()
-      ->setMethods(['get_category_ids'])
+      ->setMethods(['get_category_ids', 'get_type'])
       ->getMock();
 
     $productMock->method('get_category_ids')->willReturn($categories);


### PR DESCRIPTION
The "Purchased In This Category" email was not working for variable products. This was happening because MailPoet calls
WC_Product::get_category_ids() to get the list of WooCommerce categories associated with a given product, but this method doesn't work for product variations (see https://github.com/woocommerce/woocommerce/issues/12942).

In this PR, I'm implementing a workaround. I changed the code to check if the product is a product variation and, if so, get the
categories from the parent product instead of the product itself. But I also plan to raise this issue with the WooCommerce team as, in my opinion, it is odd that WC_Product::get_category_ids() doesn't work with product variations and fails silently.

Testing instructions in the Jira issue.

[MAILPOET-3416]

[MAILPOET-3416]: https://mailpoet.atlassian.net/browse/MAILPOET-3416