### PR TITLE
Fix flaky integration tests [MAILPOET-3412][MAILPOET-3411]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ executors:
   wpcli_php_latest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.0_20210126.1
+      - image: mailpoet/wordpress:8.0_20210218.1
 
   wpcli_php_mysql_oldest:
     <<: *default_job_config
@@ -99,7 +99,7 @@ executors:
   wpcli_php_mysql_latest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.0_20210126.1
+      - image: mailpoet/wordpress:8.0_20210218.1
       - image: circleci/mysql:8.0-ram
         command: [--default-authentication-plugin=mysql_native_password]
 

--- a/.circleci/setup.bash
+++ b/.circleci/setup.bash
@@ -28,6 +28,9 @@ function setup {
 	# Generate `wp-config.php` file with debugging enabled
 	echo "define(\"WP_DEBUG\", true);" | wp core config --dbname=wordpress --dbuser=root --dbhost=127.0.0.1 --extra-php $wp_cli_wordpress_path $wp_cli_allow_root
 
+  # Disable WP Cron so that it doesn't interfere with tests
+  wp config set DISABLE_WP_CRON true --raw $wp_cli_wordpress_path $wp_cli_allow_root
+
 	# Change default table prefix
 	sed -i "s/\$table_prefix = 'wp_';/\$table_prefix = 'mp_';/" ./wordpress/wp-config.php
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "MailPoet3",
   "engines": {
-    "npm": "~7.4"
+    "npm": "^7.4"
   },
   "browserslist": [
     "last 2 major versions",

--- a/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -65,8 +65,8 @@ class ImportTest extends \MailPoetTest {
     $this->subscriberRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
     $customField = $this->customFieldsRepository->createOrUpdate([
-      'name' => 'country', 
-      'type' => CustomFieldEntity::TYPE_TEXT, 
+      'name' => 'country',
+      'type' => CustomFieldEntity::TYPE_TEXT,
     ]);
     assert($customField instanceof CustomFieldEntity);
     $this->subscribersCustomFields = [$customField->getId()];
@@ -501,9 +501,12 @@ class ImportTest extends \MailPoetTest {
     expect($newSubscribers[1]->getSource())->equals('imported');
     expect(strlen((string)$newSubscribers[0]->getLinkToken()))->equals(SubscriberEntity::LINK_TOKEN_LENGTH);
     expect(strlen((string)$newSubscribers[1]->getLinkToken()))->equals(SubscriberEntity::LINK_TOKEN_LENGTH);
-    $testTime = Carbon::createFromTimestamp($this->testData['timestamp']);
-    expect($newSubscribers[0]->getLastSubscribedAt())->equals($testTime);
-    expect($newSubscribers[1]->getLastSubscribedAt())->equals($testTime);
+    $lastSubscribed1 = $newSubscribers[0]->getLastSubscribedAt();
+    $lastSubscribed2 = $newSubscribers[1]->getLastSubscribedAt();
+    assert($lastSubscribed1 instanceof \DateTimeInterface);
+    assert($lastSubscribed2 instanceof \DateTimeInterface);
+    expect($lastSubscribed1->getTimestamp())->equals($this->testData['timestamp'], 1);
+    expect($lastSubscribed2->getTimestamp())->equals($this->testData['timestamp'], 1);
   }
 
   public function testItDoesNotUpdateExistingSubscribersLastSubscribedAtWhenItIsPresent() {

--- a/tests/integration/_bootstrap.php
+++ b/tests/integration/_bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -181,6 +182,8 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->connection = $this->diContainer->get(Connection::class);
     $this->entityManager = $this->diContainer->get(EntityManager::class);
     $this->diContainer->get(SettingsController::class)->resetCache();
+    // Cleanup scheduled tasks from previous tests
+    $this->truncateEntity(ScheduledTaskEntity::class);
     $this->entityManager->clear();
     parent::setUp();
   }


### PR DESCRIPTION
[MAILPOET-3412]
[MAILPOET-3411]

There wasn't only one reason why the tests became flaky, but it was a combination of 2 things:

### 1) Cron jobs running during tests
I've added some logging into the test run and you can [see in the output](https://115581-38753514-gh.circle-artifacts.com/0/codeception/cronLog.txt) that both WP Cron and MailPoet Cron run during tests (look for `wp-cron.php` and `mailpoet_router&endpoint=cron_daemon&action=run`).

Either WP Cron or MailPoet cron triggers the plugin initialization for every run and this combined with the fact that we truncate various tables during tests may cause e.g. that Populator runs and add some data into tables. Overall these background initialization may cause random issues and failures.

To fix that I've disabled WP cron in wp-config used on CI and added scheduled tasks cleanup on every run.

This issue was present in the test runtime for a long time and was not causing problems until the other issue appeared.

### 2) Extremely slow loopback cURL calls
I found out that a simple cURL call on the homepage of the website running in Circle CI took often more than 5 seconds.
When we trigger cron we call the cron's URL, [wait 5 seconds](https://github.com/mailpoet/mailpoet/blob/master/lib/Cron/CronHelper.php#L161) and then continue with code execution.
Because of the delay cron often started after more than 5 seconds and at that time there was already another test in progress and it often failed because the cron save something in the database in the background (see point 1)).

I found out that the slowness was caused by active Xdebug on `circleci/php:8.0-apache`. I've [disabled the Xdebug on the image level](https://github.com/mailpoet/wordpress-images/pull/24) and configured those images to be used on Circle CI for integration tests and for a build.

### Note
When I built those images newer versions of nodejs 15  and npm were installed. That is why I had to allow higher minor versions of npm in package.json. I would say that a different minor version shouldn't cause issues especially when we install using `npm ci`, but I'm not 100% sure.

I've also fixed a flaky test for Import subscribers, which failed a couple of times during my debugging because of the exact time comparison. 

### Results
I ran tests multiple times to confirm that tests are stable on a different branch that also contained these fixes. See results [here](https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=fix-integration-tests).

[MAILPOET-3412]: https://mailpoet.atlassian.net/browse/MAILPOET-3412
[MAILPOET-3411]: https://mailpoet.atlassian.net/browse/MAILPOET-3411