### PR TITLE
Add PHPCS checks to the pre-commit hook [MAILPOET-3439]

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -407,7 +407,6 @@ class RoboFile extends \Robo\Tasks {
 
     return $this
       ->taskExec($task)
-      ->rawArg('--runtime-set testVersion 7.1-8.0')
       ->arg('--ignore=' . implode(',', $foldersToIgnore))
       ->rawArg($stringFilesToCheck)
       ->run();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "*.js": "eslint -c .eslintrc.es5.json --ignore-pattern helpscout.js --max-warnings 0",
     "*.jsx": "eslint -c .eslintrc.es6.json --max-warnings 0",
     "*.{tsx,ts}": "eslint -c .eslintrc.ts.json --max-warnings 0",
-    "*.php": "phplint"
+    "*.php": ["phplint", "./do qa:code-sniffer"]
   },
   "husky": {
     "hooks": {

--- a/tasks/code_sniffer/MailPoet/ruleset.xml
+++ b/tasks/code_sniffer/MailPoet/ruleset.xml
@@ -3,6 +3,7 @@
   <config name="installed_paths" value="tasks/code_sniffer/vendor/squizlabs/php_codesniffer,tasks/code_sniffer/vendor/phpcompatibility/php-compatibility,tasks/code_sniffer/vendor/slevomat/coding-standard"/>
   <description>MailPoet specific rule set</description>
   <exclude-pattern>*/phpstan/woocommerce.php</exclude-pattern>
+  <config name="testVersion" value="7.1-"/>
 
   <!-- Files -->
   <rule ref="Generic.Files.ByteOrderMark"/> <!-- Disallow usage of BOMs -->


### PR DESCRIPTION
This PR adds PHPCS checks, using `./do qa:code-sniffer`, to the pre-commit hook. To be able to do this, I had to modify `./do
qa:code-sniffer` to call PHPCS only once and change its signature to accept an optional parameter with the list of files to check. If this parameter is not passed, all files are checked.

As discussed with the rest of the team, before we were calling PHPCS multiple times to be able to check for compatibility with different versions of PHP, but as far as we can tell this is not necessary, and we can check for compatibility with PHP >= 7.1 for all files.

As far as I know, changing the signature of RoboFile::qaCodeSniffer() is not a problem and I updated the only instance where this method is called. But it would be good if someone with more experience with this part of the code could confirm that I'm not missing something.

Since I was already working on PHPCS related stuff, on a separate commit, I moved the definition of the supported PHP versions from the RoboFile.php file to the PHPCS configuration file, ruleset.xml. This should make it easier to configure PHPCS in other places like the IDE. I also removed the constraint of the highest supported PHP version (previously, it was hard-coded to 8.0) as I believe we support new PHP versions as soon as they are released. With this change, we don't need to remember to update testVersion tag whenever there is a new PHP version.

[MAILPOET-3439]

[MAILPOET-3439]: https://mailpoet.atlassian.net/browse/MAILPOET-3439