### PR TITLE
Check that plugins are ready for jQuery 3 [MAILPOET-3386]

### DIFF
--- a/assets/css/src/generic/_forms-select2.scss
+++ b/assets/css/src/generic/_forms-select2.scss
@@ -50,6 +50,7 @@
     border: 0 !important;
     height: auto !important;
     outline: none;
+    padding: 10px 5px 5px 16px !important;
   }
 
   .select2-selection__arrow {
@@ -59,7 +60,7 @@
   .select2-selection__rendered {
     color: $color-text !important;
     line-height: 22px !important;
-    padding: 7px 24px 9px 16px !important;
+    padding: 7px 0 9px !important;
     vertical-align: top;
   }
 
@@ -73,7 +74,7 @@
     font-size: 14px;
     height: 24px !important;
     margin: 0 7px 7px 0 !important;
-    padding: 1px 24px 1px 6px !important;
+    padding: 1px 6px 1px 28px !important;
   }
 
   .select2-selection__choice__remove {
@@ -90,13 +91,22 @@
     width: 24px;
   }
 
+  .select2-selection__choice__display {
+    align-items: center;
+    display: flex;
+  }
+
   .select2-search--inline {
-    margin-bottom: 7px;
+    display: inline-block;
+    margin-bottom: 9px;
   }
 
   .select2-search__field {
+    font-family: $font-family !important;
     font-size: $font-size !important;
     line-height: 24px;
+    margin-bottom: 2px !important;
+    margin-left: 0 !important;
     margin-top: 0 !important;
 
     &::placeholder {
@@ -164,7 +174,6 @@
 }
 
 .mailpoet-form-select .select2-selection__choice,
-.mailpoet-form-select.mailpoet-form-input .select2-selection__rendered,
 .mailpoet-form-select2-dropdown .select2-results__option {
   align-items: center;
   box-sizing: border-box;
@@ -172,6 +181,10 @@
   flex-wrap: wrap;
   max-width: 100%;
   position: relative;
+}
+
+.mailpoet-form-select.mailpoet-form-input .select2-selection__rendered {
+  display: inline;
 }
 
 .mailpoet-form-select2-text {

--- a/assets/js/src/form_editor/form_preview.ts
+++ b/assets/js/src/form_editor/form_preview.ts
@@ -3,12 +3,12 @@ import { camelCase } from 'lodash';
 
 jQuery(($) => {
   $(() => {
-    const previewForm = $('div.mailpoet_form[data-is-preview="1"]');
-    if (!previewForm.length) {
+    const $previewForm = $('div.mailpoet_form[data-is-preview="1"]');
+    if (!$previewForm.length) {
       return;
     }
 
-    previewForm.submit((e) => { e.preventDefault(); return false; });
+    $previewForm.on('submit', (e) => { e.preventDefault(); return false; });
 
     const toggleClass = (form, from, to): void => {
       form.removeClass(from);
@@ -21,7 +21,7 @@ jQuery(($) => {
         return;
       }
       // Allow message processing only when send from editor's origin
-      const editorUrl = new URL(previewForm.data('editor-url'));
+      const editorUrl = new URL($previewForm.data('editor-url'));
       if (editorUrl.origin !== event.origin) {
         return;
       }
@@ -39,10 +39,10 @@ jQuery(($) => {
       const unit = width.unit === 'pixel' ? 'px' : '%';
       const newWidth = `${width.value}${unit}`;
       if (formType === 'fixed_bar') {
-        const formElement = previewForm.find('form.mailpoet_form');
+        const formElement = $previewForm.find('form.mailpoet_form');
         formElement.css('width', newWidth);
       } else {
-        previewForm.css('width', newWidth);
+        $previewForm.css('width', newWidth);
         if (unit === 'px') { // Update others container width to render full pixel size
           $('#mailpoet_widget_preview #sidebar').css('width', newWidth);
         } else { // Reset container size to default render percent size
@@ -58,9 +58,9 @@ jQuery(($) => {
 
       const animation = event.data.formSettings?.formPlacement?.[placementName]?.animation;
       if (animation !== '' && allowAnimation) {
-        previewForm.removeClass((index, className) => (className.match(/(^|\s)mailpoet_form_animation\S+/g) || []).join(' '));
-        setTimeout(() => previewForm.addClass(`mailpoet_form_animation_${animation}`));
-        toggleClass(previewForm.prev('.mailpoet_form_popup_overlay'), 'mailpoet_form_overlay_animation', 'mailpoet_form_overlay_animation');
+        $previewForm.removeClass((index, className) => (className.match(/(^|\s)mailpoet_form_animation\S+/g) || []).join(' '));
+        setTimeout(() => $previewForm.addClass(`mailpoet_form_animation_${animation}`));
+        toggleClass($previewForm.prev('.mailpoet_form_popup_overlay'), 'mailpoet_form_overlay_animation', 'mailpoet_form_overlay_animation');
       }
 
       const position = event.data.formSettings?.formPlacement?.[placementName]?.position;
@@ -75,25 +75,25 @@ jQuery(($) => {
       }
 
       if (formType === 'slide_in') {
-        if (previewForm.hasClass('mailpoet_form_position_left') && position === 'right') {
-          toggleClass(previewForm, 'mailpoet_form_position_left', 'mailpoet_form_position_right');
-        } else if (previewForm.hasClass('mailpoet_form_position_right') && position === 'left') {
-          toggleClass(previewForm, 'mailpoet_form_position_right', 'mailpoet_form_position_left');
+        if ($previewForm.hasClass('mailpoet_form_position_left') && position === 'right') {
+          toggleClass($previewForm, 'mailpoet_form_position_left', 'mailpoet_form_position_right');
+        } else if ($previewForm.hasClass('mailpoet_form_position_right') && position === 'left') {
+          toggleClass($previewForm, 'mailpoet_form_position_right', 'mailpoet_form_position_left');
         }
       }
 
       if (formType === 'fixed_bar') {
-        if (previewForm.hasClass('mailpoet_form_position_bottom') && position === 'top') {
-          toggleClass(previewForm, 'mailpoet_form_position_bottom', 'mailpoet_form_position_top');
-        } else if (previewForm.hasClass('mailpoet_form_position_top') && position === 'bottom') {
-          toggleClass(previewForm, 'mailpoet_form_position_top', 'mailpoet_form_position_bottom');
+        if ($previewForm.hasClass('mailpoet_form_position_bottom') && position === 'top') {
+          toggleClass($previewForm, 'mailpoet_form_position_bottom', 'mailpoet_form_position_top');
+        } else if ($previewForm.hasClass('mailpoet_form_position_top') && position === 'bottom') {
+          toggleClass($previewForm, 'mailpoet_form_position_top', 'mailpoet_form_position_bottom');
         }
       }
 
       // Detect tight container
-      previewForm.removeClass('mailpoet_form_tight_container');
-      if (previewForm.width() < 400) {
-        previewForm.addClass('mailpoet_form_tight_container');
+      $previewForm.removeClass('mailpoet_form_tight_container');
+      if ($previewForm.width() < 400) {
+        $previewForm.addClass('mailpoet_form_tight_container');
       }
     };
     window.addEventListener('message', updateForm, false);

--- a/assets/js/src/jquery.serialize_object.js
+++ b/assets/js/src/jquery.serialize_object.js
@@ -79,7 +79,7 @@ $.fn.mailpoetSerializeObject = function (coerce) { // eslint-disable-line func-n
           : val;
         cur = cur[key];
       }
-    } else if ($.isArray(obj[key])) {
+    } else if (Array.isArray(obj[key])) {
       // val is already an array, so push on the next value.
       obj[key].push(val);
     } else if (obj[key] !== undefined) {

--- a/assets/js/src/modal.js
+++ b/assets/js/src/modal.js
@@ -423,11 +423,11 @@ MailPoet.Modal = {
   },
   focus: function () {
     if (this.options.type === 'popup') {
-      jQuery('#mailpoet_' + this.options.type).focus();
+      jQuery('#mailpoet_' + this.options.type).trigger('focus');
     } else {
       // panel and subpanel
       jQuery('#mailpoet_' + this.options.type + ' .mailpoet_panel_wrapper')
-        .filter(':visible').focus();
+        .filter(':visible').trigger('focus');
     }
     return this;
   },

--- a/assets/js/src/modal.js
+++ b/assets/js/src/modal.js
@@ -231,8 +231,8 @@ MailPoet.Modal = {
     return this;
   },
   removeEvents: function () {
-    jQuery(document).unbind('keyup.mailpoet_modal');
-    jQuery(window).unbind('resize.mailpoet_modal');
+    jQuery(document).off('keyup.mailpoet_modal');
+    jQuery(window).off('resize.mailpoet_modal');
     jQuery('#mailpoet_modal_close').off('click');
     if (this.options.overlay === true) {
       jQuery('#mailpoet_modal_overlay').off('click');

--- a/assets/js/src/mp2migrator.js
+++ b/assets/js/src/mp2migrator.js
@@ -190,22 +190,22 @@ jQuery(function () {
   jQuery('#progressbar').progressbar({ value: 0 });
 
   // Import button
-  jQuery('#import').click(function () {
+  jQuery('#import').on('click', function () {
     MailPoet.MP2Migrator.startImport();
   });
 
   // Stop import button
-  jQuery('#stop-import').click(function () {
+  jQuery('#stop-import').on('click', function () {
     MailPoet.MP2Migrator.stopImport();
   });
 
   // Skip import link
-  jQuery('#skip-import').click(function () {
+  jQuery('#skip-import').on('click', function () {
     MailPoet.MP2Migrator.skipImport();
   });
 
   // Go to welcome page
-  jQuery('#goto-welcome').click(function () {
+  jQuery('#goto-welcome').on('click', function () {
     MailPoet.MP2Migrator.gotoWelcomePage();
   });
 

--- a/assets/js/src/newsletter_editor/blocks/container.js
+++ b/assets/js/src/newsletter_editor/blocks/container.js
@@ -242,7 +242,7 @@ Module.ContainerBlockView = base.BlockView.extend({
       that.$el.addClass('mailpoet_container_layer_active');
       $toggleButton.addClass('mailpoet_container_layer_active');
       $container.addClass('mailpoet_layer_highlight');
-      $overlay.click(disableContainerLayer);
+      $overlay.on('click', disableContainerLayer);
       $overlay.show();
     };
     if ($toggleButton.hasClass('mailpoet_container_layer_active')) {

--- a/assets/js/src/notice.js
+++ b/assets/js/src/notice.js
@@ -183,7 +183,7 @@ MailPoet.Notice = {
     if (all !== undefined && all === true) {
       // all notices
       jQuery('.mailpoet_notice:not([id])').trigger('close');
-    } else if (all !== undefined && jQuery.isArray(all)) {
+    } else if (all !== undefined && Array.isArray(all)) {
       // array of ids
       Object.keys(all).forEach(function close(id) {
         jQuery('[data-id="' + all[id] + '"]').trigger('close');

--- a/assets/js/src/public.jsx
+++ b/assets/js/src/public.jsx
@@ -143,7 +143,7 @@ jQuery(($) => {
     Cookies.set('popup_form_dismissed', '1', { expires: 365, path: '/' });
   };
 
-  $(document).keyup((e) => {
+  $(document).on('keyup', (e) => {
     if (e.key === 'Escape') {
       $('div.mailpoet_form').each((index, element) => {
         if ($(element).children('.mailpoet_form_close_icon').length !== 0) {
@@ -163,7 +163,7 @@ jQuery(($) => {
         renderFontFamily(form.data('font-family'), form.parent());
       }
     });
-    $('.mailpoet_form_close_icon').click((event) => {
+    $('.mailpoet_form_close_icon').on('click', (event) => {
       const closeIcon = $(event.target);
       const formDiv = closeIcon.parent();
       if (formDiv.data('is-preview')) return; // Do not close popup in preview
@@ -185,7 +185,7 @@ jQuery(($) => {
       showForm(formDiv, showOverlay);
     });
 
-    $(window).resize(() => {
+    $(window).on('resize', () => {
       $('.mailpoet_form').each((index, element) => {
         // Detect form is placed in tight container
         const formDiv = $(element);

--- a/assets/js/src/subscribers/importExport/export.ts
+++ b/assets/js/src/subscribers/importExport/export.ts
@@ -128,7 +128,7 @@ jQuery(document).ready(() => {
     'confirmed_ip',
   ]).trigger('change');
 
-  nextStepButton.click((event) => {
+  nextStepButton.on('click', (event) => {
     if (jQuery(event.target).hasClass('mailpoet-disabled')) {
       return;
     }

--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/create_new_segment.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/create_new_segment.jsx
@@ -7,12 +7,12 @@ export default (onCreateSegment) => {
     title: MailPoet.I18n.t('addNewList'),
     template: jQuery('#new_segment_template').html(),
   });
-  jQuery('#new_segment_name').keypress((e) => {
+  jQuery('#new_segment_name').on('keypress', (e) => {
     if (e.which === 13) {
-      jQuery('#new_segment_process').click();
+      jQuery('#new_segment_process').trigger('click');
     }
   });
-  jQuery('#new_segment_process').click(() => {
+  jQuery('#new_segment_process').on('click', () => {
     const segmentName = jQuery('#new_segment_name').val().trim();
     const segmentDescription = jQuery('#new_segment_description').val().trim();
 
@@ -43,7 +43,7 @@ export default (onCreateSegment) => {
       }
     });
   });
-  jQuery('#new_segment_cancel').click(() => {
+  jQuery('#new_segment_cancel').on('click', () => {
     MailPoet.Modal.close();
   });
 };

--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_segment_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_segment_selection.jsx
@@ -23,7 +23,7 @@ export function createSelection(segments, onSelectionChange) {
       templateResult: templateRendered,
       templateSelection: templateRendered,
     })
-    .change((event) => {
+    .on('change', (event) => {
       const segmentSelectionNotice = jQuery('[data-id="notice_segmentSelection"]');
       if (!event.currentTarget.value) {
         if (!segmentSelectionNotice.length) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "select2": "^4.0.13",
         "setimmediate": "^1.0.5",
         "slugify": "^1.4.0",
-        "spectrum-colorpicker": "^1.6.2",
+        "spectrum-colorpicker": "^1.8.1",
         "tinymce": "^5.6.0",
         "underscore": "1.8.3",
         "velocity-animate": "^1.5.2"
@@ -27354,9 +27354,9 @@
       }
     },
     "node_modules/spectrum-colorpicker": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.0.tgz",
-      "integrity": "sha1-uSbPUALAp3hgtfg1HhwJPGUgAQc="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.1.tgz",
+      "integrity": "sha512-x1picQ5giVso71ESII7jZ3+ZFdit8WthNkzwJqLNdPDPzrltKUQGpTohWyPfSAID+bK1zGdO6bDbSh1S6GoLYA=="
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -56866,9 +56866,9 @@
       "dev": true
     },
     "spectrum-colorpicker": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.0.tgz",
-      "integrity": "sha1-uSbPUALAp3hgtfg1HhwJPGUgAQc="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.1.tgz",
+      "integrity": "sha512-x1picQ5giVso71ESII7jZ3+ZFdit8WthNkzwJqLNdPDPzrltKUQGpTohWyPfSAID+bK1zGdO6bDbSh1S6GoLYA=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "moment": "^2.26.0",
         "mousetrap": "^1.6.5",
         "papaparse": "^5.2.0",
-        "parsleyjs": "^2.8.1",
+        "parsleyjs": "^2.9.2",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-beautiful-dnd": "^13.0.0",
@@ -22194,9 +22194,9 @@
       }
     },
     "node_modules/parsleyjs": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/parsleyjs/-/parsleyjs-2.8.1.tgz",
-      "integrity": "sha1-oEq/kcIUZHXm1NVAS0WUCtb7uKQ=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/parsleyjs/-/parsleyjs-2.9.2.tgz",
+      "integrity": "sha512-DKS2XXTjEUZ1BJWUzgXAr+550kFBZrom2WYweubqdV7WzdNC1hjOajZDfeBPoAZMkXumJPlB3v37IKatbiW8zQ==",
       "dependencies": {
         "jquery": ">=1.8.0"
       }
@@ -52484,9 +52484,9 @@
       "dev": true
     },
     "parsleyjs": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/parsleyjs/-/parsleyjs-2.8.1.tgz",
-      "integrity": "sha1-oEq/kcIUZHXm1NVAS0WUCtb7uKQ=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/parsleyjs/-/parsleyjs-2.9.2.tgz",
+      "integrity": "sha512-DKS2XXTjEUZ1BJWUzgXAr+550kFBZrom2WYweubqdV7WzdNC1hjOajZDfeBPoAZMkXumJPlB3v37IKatbiW8zQ==",
       "requires": {
         "jquery": ">=1.8.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "react-string-replace": "^0.3.2",
         "react-tooltip": "^4.2.6",
         "satismeter-loader": "^1.1.0",
-        "select2": "^4.0.13",
+        "select2": "^4.1.0-rc.0",
         "setimmediate": "^1.0.5",
         "slugify": "^1.4.0",
         "spectrum-colorpicker": "^1.8.1",
@@ -26448,9 +26448,9 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "node_modules/select2": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
+      "version": "4.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.1.0-rc.0.tgz",
+      "integrity": "sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A=="
     },
     "node_modules/semver": {
       "version": "5.5.0",
@@ -56101,9 +56101,9 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "select2": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
+      "version": "4.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.1.0-rc.0.tgz",
+      "integrity": "sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A=="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "moment": "^2.26.0",
     "mousetrap": "^1.6.5",
     "papaparse": "^5.2.0",
-    "parsleyjs": "^2.8.1",
+    "parsleyjs": "^2.9.2",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-beautiful-dnd": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "select2": "^4.0.13",
     "setimmediate": "^1.0.5",
     "slugify": "^1.4.0",
-    "spectrum-colorpicker": "^1.6.2",
+    "spectrum-colorpicker": "^1.8.1",
     "tinymce": "^5.6.0",
     "underscore": "1.8.3",
     "velocity-animate": "^1.5.2"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   },
   "lint-staged": {
     "*.{scss,css}": "npm run stylelint",
-    "*.js": "eslint -c .eslintrc.es5.json --ignore-pattern helpscout.js --max-warnings 0",
+    "!(*spec).js": "eslint -c .eslintrc.es5.json --ignore-pattern helpscout.js --max-warnings 0",
     "*.jsx": "eslint -c .eslintrc.es6.json --max-warnings 0",
     "*.{tsx,ts}": "eslint -c .eslintrc.ts.json --max-warnings 0",
+    "*spec.js": "eslint -c .eslintrc.tests_newsletter_editor.json --max-warnings 0",
     "*.php": ["phplint", "./do qa:code-sniffer"]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "react-string-replace": "^0.3.2",
     "react-tooltip": "^4.2.6",
     "satismeter-loader": "^1.1.0",
-    "select2": "^4.0.13",
+    "select2": "^4.1.0-rc.0",
     "setimmediate": "^1.0.5",
     "slugify": "^1.4.0",
     "spectrum-colorpicker": "^1.8.1",

--- a/tasks/npm_post_install.sh
+++ b/tasks/npm_post_install.sh
@@ -7,3 +7,7 @@ echo "import tinymce from 'tinymce/tinymce';
 " >> $INIT_CWD/assets/js/src/newsletter_editor/behaviors/tinymce_icons.js
 
 cat $INIT_CWD/node_modules/tinymce/icons/default/icons.min.js >> $INIT_CWD/assets/js/src/newsletter_editor/behaviors/tinymce_icons.js
+
+# Replace deprecated jQuery methods in the spectrum-colorpicker dependency
+# Remove this when a patch is included in a package update
+git apply $INIT_CWD/tasks/patches/spectrum-replace-jquery-deprecated.patch || true

--- a/tasks/npm_post_install.sh
+++ b/tasks/npm_post_install.sh
@@ -11,3 +11,8 @@ cat $INIT_CWD/node_modules/tinymce/icons/default/icons.min.js >> $INIT_CWD/asset
 # Replace deprecated jQuery methods in the spectrum-colorpicker dependency
 # Remove this when a patch is included in a package update
 git apply $INIT_CWD/tasks/patches/spectrum-replace-jquery-deprecated.patch || true
+
+# Replace deprecated jQuery methods in the parsley dependency
+# Remove this when a patch is included in a package update.
+# Note: deferred.pipe() fix is not implemented yet, see https://github.com/guillaumepotier/Parsley.js/pull/1347
+sed -i -- "s/_focusedField\.focus()/_focusedField\.trigger('focus')/g" node_modules/parsleyjs/dist/parsley*.js

--- a/tasks/patches/spectrum-replace-jquery-deprecated.patch
+++ b/tasks/patches/spectrum-replace-jquery-deprecated.patch
@@ -1,0 +1,48 @@
+From 8fd0a3a5f6a478f319763f999aaf5d8531c52b1d Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Tue, 21 Jul 2020 20:52:17 -0700
+Subject: [PATCH] Replace deprecated jQuery methods
+
+Fixes these warnings from jquery-migrate:
+
+JQMIGRATE: jQuery.isArray is deprecated; use Array.isArray
+JQMIGRATE: jQuery.fn.click() event shorthand is deprecated
+JQMIGRATE: jQuery.fn.change() event shorthand is deprecated
+JQMIGRATE: jQuery.fn.keydown() event shorthand is deprecated
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ node_modules/spectrum-colorpicker/spectrum.js | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/node_modules/spectrum-colorpicker/spectrum.js b/node_modules/spectrum-colorpicker/spectrum.js
+index e2e0687..6c48c12 100644
+--- a/node_modules/spectrum-colorpicker/spectrum.js
++++ b/node_modules/spectrum-colorpicker/spectrum.js
+@@ -249,7 +249,7 @@
+
+             if (opts.palette) {
+                 palette = opts.palette.slice(0);
+-                paletteArray = $.isArray(palette[0]) ? palette : [palette];
++                paletteArray = Array.isArray(palette[0]) ? palette : [palette];
+                 paletteLookup = {};
+                 for (var i = 0; i < paletteArray.length; i++) {
+                     for (var j = 0; j < paletteArray[i].length; j++) {
+@@ -321,14 +321,14 @@
+             }
+
+             // Prevent clicks from bubbling up to document.  This would cause it to be hidden.
+-            container.click(stopPropagation);
++            container.on("click", stopPropagation);
+
+             // Handle user typed input
+-            textInput.change(setFromTextInput);
++            textInput.on("change", setFromTextInput);
+             textInput.on("paste", function () {
+                 setTimeout(setFromTextInput, 1);
+             });
+-            textInput.keydown(function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
++            textInput.on("keydown", function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
+
+             cancelButton.text(opts.cancelText);
+             cancelButton.on("click.spectrum", function (e) {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -116,11 +116,13 @@ class AcceptanceTester extends \Codeception\Actor {
 
   /**
    * Select a value from select2 input field.
+   * For multiple selection the element is textarea.select2-search__field (default),
+   * for single selection specify the input.select2-search__field element.
    *
    * @param string $value
    * @param string $element
    */
-  public function selectOptionInSelect2($value, $element = 'input.select2-search__field') {
+  public function selectOptionInSelect2($value, $element = 'textarea.select2-search__field') {
     $i = $this;
     $i->waitForElement($element);
     $i->fillField($element, $value);

--- a/tests/acceptance/EditExistingPostNotificationEmailCest.php
+++ b/tests/acceptance/EditExistingPostNotificationEmailCest.php
@@ -35,7 +35,7 @@ class EditExistingPostNotificationEmailCest {
 
     // step 5 - Change schedule, list and activate
     $i->click('Next');
-    $i->waitForElement('input.select2-search__field');
+    $i->waitForElement('textarea.select2-search__field');
     $i->selectOption('[data-automation-id="newsletter_interval_type"]', 'Weekly on...');
     $i->selectOptionInSelect2($segmentName);
     $newsletterListingElement = '[data-automation-id="listing_item_' . basename($i->getCurrentUrl()) . '"]';

--- a/tests/acceptance/FormEditorPlaceFormOnSpecifiedPageCest.php
+++ b/tests/acceptance/FormEditorPlaceFormOnSpecifiedPageCest.php
@@ -36,7 +36,7 @@ class FormEditorPlaceFormOnSpecifiedPageCest {
     $i->click('[data-automation-id="form-placement-option-Pop-up"]');
     $i->checkOption('Enable');
     $i->waitForText('Display on all posts');
-    $i->selectOptionInSelect2($pageTitle, '[data-automation-id="form-placement-select-page"] input.select2-search__field');
+    $i->selectOptionInSelect2($pageTitle, '[data-automation-id="form-placement-select-page"] textarea.select2-search__field');
     $i->wantTo('Save the form and check the output');
     $i->saveFormInEditor();
     $i->amOnUrl($pageUrl);

--- a/tests/acceptance/ManageSegmentsCest.php
+++ b/tests/acceptance/ManageSegmentsCest.php
@@ -163,8 +163,8 @@ class ManageSegmentsCest {
     $i->fillField(['name' => 'description'], $segmentDesc);
     $i->selectOption('form select[name=segmentType]', 'Email');
     $i->selectOption('form select[name=action]', 'opened');
-    $i->click('#select2-newsletter_id-container');
-    $i->selectOptionInSelect2($emailSubject);
+    $i->click('.select2-selection--single');
+    $i->selectOptionInSelect2($emailSubject, 'input.select2-search__field');
     $i->click('Save');
     $i->amOnMailpoetPage('Lists');
     $i->waitForElement('[data-automation-id="dynamic-segments-tab"]');

--- a/tests/acceptance/ManageSubscriptionLinkCest.php
+++ b/tests/acceptance/ManageSubscriptionLinkCest.php
@@ -137,7 +137,7 @@ class ManageSubscriptionLinkCest {
     $i->click('Next');
 
     // step 4 - send
-    $searchFieldElement = 'input.select2-search__field';
+    $searchFieldElement = 'textarea.select2-search__field';
     $i->waitForElement($searchFieldElement);
     $i->selectOptionInSelect2($segmentName);
     $i->click('Send');

--- a/tests/acceptance/NewsletterCreationCest.php
+++ b/tests/acceptance/NewsletterCreationCest.php
@@ -35,7 +35,7 @@ class NewsletterCreationCest {
     $i->click('Next');
 
     // step 5 - activate
-    $searchFieldElement = 'input.select2-search__field';
+    $searchFieldElement = 'textarea.select2-search__field';
     $i->waitForElement($searchFieldElement);
     $i->see('Select a frequency');
     $newsletterListingElement = '[data-automation-id="listing_item_' . basename($i->getCurrentUrl()) . '"]';
@@ -46,7 +46,7 @@ class NewsletterCreationCest {
     $i->see('Immediately', $newsletterListingElement);
     $i->see('Send to ' . $segmentName, $newsletterListingElement);
   }
-  
+
   public function createStandardNewsletter(\AcceptanceTester $i) {
     $i->wantTo('Create and configure standard newsletter');
 

--- a/tests/acceptance/SubscriberManageImportExportCest.php
+++ b/tests/acceptance/SubscriberManageImportExportCest.php
@@ -140,7 +140,7 @@ class SubscriberManageImportExportCest {
   private function chooseListAndConfirm(\AcceptanceTester $i) {
     $i->waitForText('Pick one or more list');
     // trigger dropdown to display selections
-    $i->click('input.select2-search__field');
+    $i->click('textarea.select2-search__field');
     // choose first list
     $i->click(['xpath' => '//*[@id="select2-mailpoet_segments_select-results"]/li[1]']);
     $i->click('[data-automation-id="import-next-step"]');
@@ -157,7 +157,7 @@ class SubscriberManageImportExportCest {
     $i->seeInField('textarea#new_segment_description', 'This is just a simple list.');
     $i->click('input#new_segment_process');
     // trigger dropdown to display selections and search for recently created list
-    $i->waitForElementVisible('input.select2-search__field');
+    $i->waitForElementVisible('textarea.select2-search__field');
     $i->selectOptionInSelect2($newListName);
     $i->click('[data-automation-id="import-next-step"]');
     $i->waitForText('Import again');

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/abandonedCartContent.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/abandonedCartContent.spec.js
@@ -242,49 +242,49 @@ describe('Abandoned Cart Content', function () {
     describe('once rendered', function () {
       it('changes the model if post status changes', function () {
         var newValue = 'pending';
-        view.$('.mailpoet_products_post_status').val(newValue).change();
+        view.$('.mailpoet_products_post_status').val(newValue).trigger('change');
         expect(model.get('postStatus')).to.equal(newValue);
       });
 
       it('changes the model if display type changes', function () {
         var newValue = 'full';
-        view.$('.mailpoet_products_display_type').val(newValue).change();
+        view.$('.mailpoet_products_display_type').val(newValue).trigger('change');
         expect(model.get('displayType')).to.equal(newValue);
       });
 
       it('changes the model if title format changes', function () {
         var newValue = 'h3';
-        view.$('.mailpoet_products_title_format').val(newValue).change();
+        view.$('.mailpoet_products_title_format').val(newValue).trigger('change');
         expect(model.get('titleFormat')).to.equal(newValue);
       });
 
       it('changes the model if title alignment changes', function () {
         var newValue = 'right';
-        view.$('.mailpoet_products_title_alignment').val(newValue).change();
+        view.$('.mailpoet_products_title_alignment').val(newValue).trigger('change');
         expect(model.get('titleAlignment')).to.equal(newValue);
       });
 
       it('changes the model if title link changes', function () {
         var newValue = true;
-        view.$('.mailpoet_products_title_as_links').val(newValue).change();
+        view.$('.mailpoet_products_title_as_links').val(newValue).trigger('change');
         expect(model.get('titleIsLink')).to.equal(newValue);
       });
 
       it('changes the model if image alignment changes', function () {
         var newValue = false;
-        view.$('.mailpoet_products_image_full_width').val(newValue).change();
+        view.$('.mailpoet_products_image_full_width').val(newValue).trigger('change');
         expect(model.get('imageFullWidth')).to.equal(newValue);
       });
 
       it('changes the model if image position changes', function () {
         var newValue = 'aboveTitle';
-        view.$('.mailpoet_products_featured_image_position').val(newValue).change();
+        view.$('.mailpoet_products_featured_image_position').val(newValue).trigger('change');
         expect(model.get('featuredImagePosition')).to.equal(newValue);
       });
 
       it('changes the model if price position changes', function () {
         var newValue = 'below';
-        view.$('.mailpoet_products_price_position').val(newValue).change();
+        view.$('.mailpoet_products_price_position').val(newValue).trigger('change');
         expect(model.get('pricePosition')).to.equal(newValue);
       });
 
@@ -298,7 +298,7 @@ describe('Abandoned Cart Content', function () {
             model: innerModel,
           });
           innerView.render();
-          innerView.$('.mailpoet_products_display_type').val('titleOnly').change();
+          innerView.$('.mailpoet_products_display_type').val('titleOnly').trigger('change');
         });
 
         it('hides "title position" option', function () {
@@ -309,7 +309,7 @@ describe('Abandoned Cart Content', function () {
 
       it('changes the model if show divider changes', function () {
         var newValue = true;
-        view.$('.mailpoet_products_show_divider').val(newValue).change();
+        view.$('.mailpoet_products_show_divider').val(newValue).trigger('change');
         expect(model.get('showDivider')).to.equal(newValue);
       });
     });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/automatedLatestContentLayout.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/automatedLatestContentLayout.spec.js
@@ -436,50 +436,50 @@ describe('Automated latest content layout', function () {
 
       it('changes the model if post type changes', function () {
         var newValue = 'mailpoet_page';
-        view.$('.mailpoet_automated_latest_content_content_type').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_content_type').val(newValue).trigger('change');
         expect(model.get('contentType')).to.equal(newValue);
       });
 
       it('changes the model if inclusion type changes', function () {
         var newValue = 'exclude';
-        view.$('.mailpoet_automated_latest_content_include_or_exclude').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_include_or_exclude').val(newValue).trigger('change');
         expect(model.get('inclusionType')).to.equal(newValue);
       });
 
       it('changes the model if display type changes', function () {
         var newValue = 'full';
-        view.$('.mailpoet_automated_latest_content_display_type').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_display_type').val(newValue).trigger('change');
         expect(model.get('displayType')).to.equal(newValue);
       });
 
       it('changes the model if title format changes', function () {
         var newValue = 'h3';
-        view.$('.mailpoet_automated_latest_content_title_format').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_title_format').val(newValue).trigger('change');
         expect(model.get('titleFormat')).to.equal(newValue);
       });
 
       it('changes the model if title alignment changes', function () {
         var newValue = 'right';
-        view.$('.mailpoet_automated_latest_content_title_alignment').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_title_alignment').val(newValue).trigger('change');
         expect(model.get('titleAlignment')).to.equal(newValue);
       });
 
       it('changes the model if title link changes', function () {
         var newValue = true;
-        view.$('.mailpoet_automated_latest_content_title_as_links').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_title_as_links').val(newValue).trigger('change');
         expect(model.get('titleIsLink')).to.equal(newValue);
       });
 
       it('changes the model if image alignment changes', function () {
         var newValue = false;
-        view.$('.mailpoet_automated_latest_content_image_full_width').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_image_full_width').val(newValue).trigger('change');
         expect(model.get('imageFullWidth')).to.equal(newValue);
       });
 
       it('changes the model if featured image position changes for excerpt display type', function () {
         var newValue = 'right';
         model.set('displayType', 'excerpt');
-        view.$('.mailpoet_automated_latest_content_featured_image_position').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_featured_image_position').val(newValue).trigger('change');
         expect(model.get('featuredImagePosition')).to.equal(newValue);
         expect(model.get('_featuredImagePosition')).to.equal(newValue);
       });
@@ -487,20 +487,20 @@ describe('Automated latest content layout', function () {
       it('changes the model if featured image position changes for full post display type', function () {
         var newValue = 'alternate';
         model.set('displayType', 'full');
-        view.$('.mailpoet_automated_latest_content_featured_image_position').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_featured_image_position').val(newValue).trigger('change');
         expect(model.get('fullPostFeaturedImagePosition')).to.equal(newValue);
         expect(model.get('_featuredImagePosition')).to.equal(newValue);
       });
 
       it('changes the model if featured image position changes', function () {
         var newValue = 'aboveExcerpt';
-        view.$('.mailpoet_automated_latest_content_title_position').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_title_position').val(newValue).trigger('change');
         expect(model.get('titlePosition')).to.equal(newValue);
       });
 
       it('changes the model if show author changes', function () {
         var newValue = 'belowText';
-        view.$('.mailpoet_automated_latest_content_show_author').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_show_author').val(newValue).trigger('change');
         expect(model.get('showAuthor')).to.equal(newValue);
       });
 
@@ -512,7 +512,7 @@ describe('Automated latest content layout', function () {
 
       it('changes the model if show categories changes', function () {
         var newValue = 'belowText';
-        view.$('.mailpoet_automated_latest_content_show_categories').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_show_categories').val(newValue).trigger('change');
         expect(model.get('showCategories')).to.equal(newValue);
       });
 
@@ -524,7 +524,7 @@ describe('Automated latest content layout', function () {
 
       it('changes the model if read more button type changes', function () {
         var newValue = 'link';
-        view.$('.mailpoet_automated_latest_content_read_more_type').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_read_more_type').val(newValue).trigger('change');
         expect(model.get('readMoreType')).to.equal(newValue);
       });
 
@@ -536,13 +536,13 @@ describe('Automated latest content layout', function () {
 
       it('changes the model if sort by changes', function () {
         var newValue = 'oldest';
-        view.$('.mailpoet_automated_latest_content_sort_by').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_sort_by').val(newValue).trigger('change');
         expect(model.get('sortBy')).to.equal(newValue);
       });
 
       it('changes the model if show divider changes', function () {
         var newValue = true;
-        view.$('.mailpoet_automated_latest_content_show_divider').val(newValue).change();
+        view.$('.mailpoet_automated_latest_content_show_divider').val(newValue).trigger('change');
         expect(model.get('showDivider')).to.equal(newValue);
       });
 
@@ -551,7 +551,7 @@ describe('Automated latest content layout', function () {
           model = new (module.AutomatedLatestContentLayoutBlockModel)();
           view = new (module.AutomatedLatestContentLayoutBlockSettingsView)({ model: model });
           view.render();
-          view.$('.mailpoet_automated_latest_content_display_type').val('titleOnly').change();
+          view.$('.mailpoet_automated_latest_content_display_type').val('titleOnly').trigger('change');
         });
 
         it('shows "title as list" option', function () {
@@ -563,8 +563,8 @@ describe('Automated latest content layout', function () {
             model = new (module.AutomatedLatestContentLayoutBlockModel)();
             view = new (module.AutomatedLatestContentLayoutBlockSettingsView)({ model: model });
             view.render();
-            view.$('.mailpoet_automated_latest_content_display_type').val('titleOnly').change();
-            view.$('.mailpoet_automated_latest_content_title_format').val('ul').change();
+            view.$('.mailpoet_automated_latest_content_display_type').val('titleOnly').trigger('change');
+            view.$('.mailpoet_automated_latest_content_title_format').val('ul').trigger('change');
           });
 
           describe('"title is link" option', function () {
@@ -580,8 +580,8 @@ describe('Automated latest content layout', function () {
 
         describe('when "title as list" is deselected', function () {
           before(function () {
-            view.$('.mailpoet_automated_latest_content_title_format').val('ul').change();
-            view.$('.mailpoet_automated_latest_content_title_format').val('h3').change();
+            view.$('.mailpoet_automated_latest_content_title_format').val('ul').trigger('change');
+            view.$('.mailpoet_automated_latest_content_title_format').val('h3').trigger('change');
           });
 
           describe('"title is link" option', function () {

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/button.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/button.spec.js
@@ -276,7 +276,7 @@ describe('Button', function () {
       it('opens settings if clicked', function () {
         var mock = sinon.mock().once();
         innerModel.on('startEditing', mock);
-        view.$('.mailpoet_editor_button').click();
+        view.$('.mailpoet_editor_button').trigger('click');
         mock.verify();
       });
     });
@@ -382,7 +382,7 @@ describe('Button', function () {
       it('updates the model when font color changes', function () {
         var newValue = '#cccccc';
 
-        view.$('.mailpoet_field_button_font_color').val(newValue).change();
+        view.$('.mailpoet_field_button_font_color').val(newValue).trigger('change');
 
         expect(model.get('styles.block.fontColor')).to.equal(newValue);
       });
@@ -390,27 +390,27 @@ describe('Button', function () {
       it('updates the model when font family changes', function () {
         var newValue = 'Tahoma';
 
-        view.$('.mailpoet_field_button_font_family').val(newValue).change();
+        view.$('.mailpoet_field_button_font_family').val(newValue).trigger('change');
 
         expect(model.get('styles.block.fontFamily')).to.equal(newValue);
       });
 
       it('updates the model when font size changes', function () {
         var newValue = '20px';
-        view.$('.mailpoet_field_button_font_size').val(newValue).change();
+        view.$('.mailpoet_field_button_font_size').val(newValue).trigger('change');
         expect(model.get('styles.block.fontSize')).to.equal(newValue);
       });
 
       it('updates the model when font weight changes', function () {
         var newValue = 'bold';
-        view.$('.mailpoet_field_button_font_weight').prop('checked', true).change();
+        view.$('.mailpoet_field_button_font_weight').prop('checked', true).trigger('change');
         expect(model.get('styles.block.fontWeight')).to.equal(newValue);
       });
 
       it('updates the model when background color changes', function () {
         var newValue = '#cccccc';
 
-        view.$('.mailpoet_field_button_background_color').val(newValue).change();
+        view.$('.mailpoet_field_button_background_color').val(newValue).trigger('change');
 
         expect(model.get('styles.block.backgroundColor')).to.equal(newValue);
       });
@@ -418,13 +418,13 @@ describe('Button', function () {
       it('updates the model when border color changes', function () {
         var newValue = '#cccccc';
 
-        view.$('.mailpoet_field_button_border_color').val(newValue).change();
+        view.$('.mailpoet_field_button_border_color').val(newValue).trigger('change');
 
         expect(model.get('styles.block.borderColor')).to.equal(newValue);
       });
 
       it('updates the model when border width changes', function () {
-        view.$('.mailpoet_field_button_border_width').val('3').change();
+        view.$('.mailpoet_field_button_border_width').val('3').trigger('change');
         expect(model.get('styles.block.borderWidth')).to.equal('3px');
       });
       it('updates the range slider when border width input changes', function () {
@@ -432,12 +432,12 @@ describe('Button', function () {
         expect(view.$('.mailpoet_field_button_border_width').val()).to.equal('5');
       });
       it('updates the input when border width range slider changes', function () {
-        view.$('.mailpoet_field_button_border_width').val('4').change();
+        view.$('.mailpoet_field_button_border_width').val('4').trigger('change');
         expect(view.$('.mailpoet_field_button_border_width_input').val()).to.equal('4');
       });
 
       it('updates the model when border radius changes', function () {
-        view.$('.mailpoet_field_button_border_radius').val('7').change();
+        view.$('.mailpoet_field_button_border_radius').val('7').trigger('change');
         expect(model.get('styles.block.borderRadius')).to.equal('7px');
       });
       it('updates the range slider when border radius input changes', function () {
@@ -445,12 +445,12 @@ describe('Button', function () {
         expect(view.$('.mailpoet_field_button_border_radius').val()).to.equal('7');
       });
       it('updates the input when border radius range slider changes', function () {
-        view.$('.mailpoet_field_button_border_radius').val('7').change();
+        view.$('.mailpoet_field_button_border_radius').val('7').trigger('change');
         expect(view.$('.mailpoet_field_button_border_radius_input').val()).to.equal('7');
       });
 
       it('updates the model when width changes', function () {
-        view.$('.mailpoet_field_button_width').val('127').change();
+        view.$('.mailpoet_field_button_width').val('127').trigger('change');
         expect(model.get('styles.block.width')).to.equal('127px');
       });
       it('updates the range slider when width input changes', function () {
@@ -458,12 +458,12 @@ describe('Button', function () {
         expect(view.$('.mailpoet_field_button_width').val()).to.equal('127');
       });
       it('updates the input when width range slider changes', function () {
-        view.$('.mailpoet_field_button_width').val('127').change();
+        view.$('.mailpoet_field_button_width').val('127').trigger('change');
         expect(view.$('.mailpoet_field_button_width_input').val()).to.equal('127');
       });
 
       it('updates the model when line height changes', function () {
-        view.$('.mailpoet_field_button_line_height').val('37').change();
+        view.$('.mailpoet_field_button_line_height').val('37').trigger('change');
         expect(model.get('styles.block.lineHeight')).to.equal('37px');
       });
       it('updates the range slider when line height input changes', function () {
@@ -471,7 +471,7 @@ describe('Button', function () {
         expect(view.$('.mailpoet_field_button_line_height').val()).to.equal('37');
       });
       it('updates the input when line height range slider changes', function () {
-        view.$('.mailpoet_field_button_line_height').val('37').change();
+        view.$('.mailpoet_field_button_line_height').val('37').trigger('change');
         expect(view.$('.mailpoet_field_button_line_height_input').val()).to.equal('37');
       });
 
@@ -512,7 +512,7 @@ describe('Button', function () {
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/container.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/container.spec.js
@@ -253,12 +253,12 @@ describe('Container', function () {
       });
 
       it('updates the model when background color changes', function () {
-        view.$('.mailpoet_field_container_background_color').val('#123456').change();
+        view.$('.mailpoet_field_container_background_color').val('#123456').trigger('change');
         expect(model.get('styles.block.backgroundColor')).to.equal('#123456');
       });
 
       it('updates the model background image display type changes', function () {
-        view.$('.mailpoet_field_display_type:nth(2)').attr('checked', true).change();
+        view.$('.mailpoet_field_display_type:nth(2)').attr('checked', true).trigger('change');
         expect(model.get('image.display')).to.equal('tile');
       });
 
@@ -293,7 +293,7 @@ describe('Container', function () {
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/divider.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/divider.spec.js
@@ -142,7 +142,7 @@ describe('Divider', function () {
       var mock = sinon.mock().once();
       model.on('startEditing', mock);
       view.render();
-      view.$('.mailpoet_divider').click();
+      view.$('.mailpoet_divider').trigger('click');
       mock.verify();
     });
 
@@ -150,7 +150,7 @@ describe('Divider', function () {
       var mock = sinon.mock().never();
       model.on('startEditing', mock);
       view.render();
-      view.$('.mailpoet_resize_handle').click();
+      view.$('.mailpoet_resize_handle').trigger('click');
       mock.verify();
     });
   });
@@ -189,12 +189,12 @@ describe('Divider', function () {
       });
 
       it('updates the model when divider style changes', function () {
-        view.$('.mailpoet_field_divider_style').last().click();
+        view.$('.mailpoet_field_divider_style').last().trigger('click');
         expect(model.get('styles.block.borderStyle')).to.equal('inset');
       });
 
       it('updates the model when divider width slider changes', function () {
-        view.$('.mailpoet_field_divider_border_width').val('17').change();
+        view.$('.mailpoet_field_divider_border_width').val('17').trigger('change');
         expect(model.get('styles.block.borderWidth')).to.equal('17px');
       });
 
@@ -204,23 +204,23 @@ describe('Divider', function () {
       });
 
       it('updates the input when divider width range slider changes', function () {
-        view.$('.mailpoet_field_divider_border_width').val('19').change();
+        view.$('.mailpoet_field_divider_border_width').val('19').trigger('change');
         expect(view.$('.mailpoet_field_divider_border_width_input').val()).to.equal('19');
       });
 
       it('updates the model when divider color changes', function () {
-        view.$('.mailpoet_field_divider_border_color').val('#123457').change();
+        view.$('.mailpoet_field_divider_border_color').val('#123457').trigger('change');
         expect(model.get('styles.block.borderColor')).to.equal('#123457');
       });
 
       it('updates the model when divider background color changes', function () {
-        view.$('.mailpoet_field_divider_background_color').val('#cccccc').change();
+        view.$('.mailpoet_field_divider_background_color').val('#cccccc').trigger('change');
         expect(model.get('styles.block.backgroundColor')).to.equal('#cccccc');
       });
 
       it('changes color of available divider styles when actual divider color changes', function () {
         var newColor = '#889912';
-        view.$('.mailpoet_field_divider_border_color').val(newColor).change();
+        view.$('.mailpoet_field_divider_border_color').val(newColor).trigger('change');
         expect(view.$('.mailpoet_field_divider_style div')).to.have.$css('border-top-color', newColor);
       });
 
@@ -238,7 +238,7 @@ describe('Divider', function () {
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/footer.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/footer.spec.js
@@ -187,41 +187,41 @@ describe('Footer', function () {
       });
 
       it('updates the model when text font color changes', function () {
-        view.$('.mailpoet_field_footer_text_color').val('#123456').change();
+        view.$('.mailpoet_field_footer_text_color').val('#123456').trigger('change');
         expect(model.get('styles.text.fontColor')).to.equal('#123456');
       });
 
       it('updates the model when text font family changes', function () {
         var value = 'Tahoma';
-        view.$('.mailpoet_field_footer_text_font_family').val(value).change();
+        view.$('.mailpoet_field_footer_text_font_family').val(value).trigger('change');
         expect(model.get('styles.text.fontFamily')).to.equal(value);
       });
 
       it('updates the model when text font size changes', function () {
         var value = '20px';
-        view.$('.mailpoet_field_footer_text_size').val(value).change();
+        view.$('.mailpoet_field_footer_text_size').val(value).trigger('change');
         expect(model.get('styles.text.fontSize')).to.equal(value);
       });
 
       it('updates the model when link font color changes', function () {
-        view.$('#mailpoet_field_footer_link_color').val('#123456').change();
+        view.$('#mailpoet_field_footer_link_color').val('#123456').trigger('change');
         expect(model.get('styles.link.fontColor')).to.equal('#123456');
       });
 
       it('updates the model when link text decoration changes', function () {
-        view.$('#mailpoet_field_footer_link_underline').prop('checked', true).change();
+        view.$('#mailpoet_field_footer_link_underline').prop('checked', true).trigger('change');
         expect(model.get('styles.link.textDecoration')).to.equal('underline');
       });
 
       it('updates the model when text alignment changes', function () {
-        view.$('.mailpoet_field_footer_alignment').last().prop('checked', true).change();
+        view.$('.mailpoet_field_footer_alignment').last().prop('checked', true).trigger('change');
         expect(model.get('styles.text.textAlign')).to.equal('right');
       });
 
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/header.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/header.spec.js
@@ -187,41 +187,41 @@ describe('Header', function () {
       });
 
       it('updates the model when text font color changes', function () {
-        view.$('.mailpoet_field_header_text_color').val('#123456').change();
+        view.$('.mailpoet_field_header_text_color').val('#123456').trigger('change');
         expect(model.get('styles.text.fontColor')).to.equal('#123456');
       });
 
       it('updates the model when text font family changes', function () {
         var value = 'Tahoma';
-        view.$('.mailpoet_field_header_text_font_family').val(value).change();
+        view.$('.mailpoet_field_header_text_font_family').val(value).trigger('change');
         expect(model.get('styles.text.fontFamily')).to.equal(value);
       });
 
       it('updates the model when text font size changes', function () {
         var value = '20px';
-        view.$('.mailpoet_field_header_text_size').val(value).change();
+        view.$('.mailpoet_field_header_text_size').val(value).trigger('change');
         expect(model.get('styles.text.fontSize')).to.equal(value);
       });
 
       it('updates the model when link font color changes', function () {
-        view.$('#mailpoet_field_header_link_color').val('#123456').change();
+        view.$('#mailpoet_field_header_link_color').val('#123456').trigger('change');
         expect(model.get('styles.link.fontColor')).to.equal('#123456');
       });
 
       it('updates the model when link text decoration changes', function () {
-        view.$('#mailpoet_field_header_link_underline').prop('checked', true).change();
+        view.$('#mailpoet_field_header_link_underline').prop('checked', true).trigger('change');
         expect(model.get('styles.link.textDecoration')).to.equal('underline');
       });
 
       it('updates the model when text alignment changes', function () {
-        view.$('.mailpoet_field_header_alignment').last().prop('checked', true).change();
+        view.$('.mailpoet_field_header_alignment').last().prop('checked', true).trigger('change');
         expect(model.get('styles.text.textAlign')).to.equal('right');
       });
 
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/image.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/image.spec.js
@@ -195,7 +195,7 @@ describe('Image', function () {
       it('opens settings if clicked on the image', function () {
         var mock = sinon.mock().once();
         model.on('startEditing', mock);
-        view.$('img').click();
+        view.$('img').trigger('click');
         mock.verify();
       });
     });
@@ -251,19 +251,19 @@ describe('Image', function () {
       });
 
       it('updates the model when padding changes', function () {
-        view.$('.mailpoet_field_image_full_width').prop('checked', false).change();
+        view.$('.mailpoet_field_image_full_width').prop('checked', false).trigger('change');
         expect(model.get('fullWidth')).to.equal(false);
       });
 
       it('updates the model when alignment changes', function () {
-        view.$('.mailpoet_field_image_alignment').first().prop('checked', true).change();
+        view.$('.mailpoet_field_image_alignment').first().prop('checked', true).trigger('change');
         expect(model.get('styles.block.textAlign')).to.equal('left');
       });
 
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/posts.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/posts.spec.js
@@ -346,13 +346,13 @@ describe('Posts', function () {
     describe('once rendered', function () {
       it('changes the model if post type changes', function () {
         var newValue = 'mailpoet_page';
-        view.$('.mailpoet_settings_posts_content_type').val(newValue).change();
+        view.$('.mailpoet_settings_posts_content_type').val(newValue).trigger('change');
         expect(model.get('contentType')).to.equal(newValue);
       });
 
       it('changes the model if post status changes', function () {
         var newValue = 'pending';
-        view.$('.mailpoet_posts_post_status').val(newValue).change();
+        view.$('.mailpoet_posts_post_status').val(newValue).trigger('change');
         expect(model.get('postStatus')).to.equal(newValue);
       });
 
@@ -364,38 +364,38 @@ describe('Posts', function () {
 
       it('changes the model if display type changes', function () {
         var newValue = 'full';
-        view.$('.mailpoet_posts_display_type').val(newValue).change();
+        view.$('.mailpoet_posts_display_type').val(newValue).trigger('change');
         expect(model.get('displayType')).to.equal(newValue);
       });
 
       it('changes the model if title format changes', function () {
         var newValue = 'h3';
-        view.$('.mailpoet_posts_title_format').val(newValue).change();
+        view.$('.mailpoet_posts_title_format').val(newValue).trigger('change');
         expect(model.get('titleFormat')).to.equal(newValue);
       });
 
       it('changes the model if title alignment changes', function () {
         var newValue = 'right';
-        view.$('.mailpoet_posts_title_alignment').val(newValue).change();
+        view.$('.mailpoet_posts_title_alignment').val(newValue).trigger('change');
         expect(model.get('titleAlignment')).to.equal(newValue);
       });
 
       it('changes the model if title link changes', function () {
         var newValue = true;
-        view.$('.mailpoet_posts_title_as_links').val(newValue).change();
+        view.$('.mailpoet_posts_title_as_links').val(newValue).trigger('change');
         expect(model.get('titleIsLink')).to.equal(newValue);
       });
 
       it('changes the model if image alignment changes', function () {
         var newValue = false;
-        view.$('.mailpoet_posts_image_full_width').val(newValue).change();
+        view.$('.mailpoet_posts_image_full_width').val(newValue).trigger('change');
         expect(model.get('imageFullWidth')).to.equal(newValue);
       });
 
       it('changes the model if featured image position changes for excerpt display type', function () {
         var newValue = 'right';
         model.set('displayType', 'excerpt');
-        view.$('.mailpoet_posts_featured_image_position').val(newValue).change();
+        view.$('.mailpoet_posts_featured_image_position').val(newValue).trigger('change');
         expect(model.get('featuredImagePosition')).to.equal(newValue);
         expect(model.get('_featuredImagePosition')).to.equal(newValue);
       });
@@ -403,14 +403,14 @@ describe('Posts', function () {
       it('changes the model if featured image position changes for full post display type', function () {
         var newValue = 'alternate';
         model.set('displayType', 'full');
-        view.$('.mailpoet_posts_featured_image_position').val(newValue).change();
+        view.$('.mailpoet_posts_featured_image_position').val(newValue).trigger('change');
         expect(model.get('fullPostFeaturedImagePosition')).to.equal(newValue);
         expect(model.get('_featuredImagePosition')).to.equal(newValue);
       });
 
       it('changes the model if show author changes', function () {
         var newValue = 'belowText';
-        view.$('.mailpoet_posts_show_author').val(newValue).change();
+        view.$('.mailpoet_posts_show_author').val(newValue).trigger('change');
         expect(model.get('showAuthor')).to.equal(newValue);
       });
 
@@ -422,7 +422,7 @@ describe('Posts', function () {
 
       it('changes the model if show categories changes', function () {
         var newValue = 'belowText';
-        view.$('.mailpoet_posts_show_categories').val(newValue).change();
+        view.$('.mailpoet_posts_show_categories').val(newValue).trigger('change');
         expect(model.get('showCategories')).to.equal(newValue);
       });
 
@@ -434,7 +434,7 @@ describe('Posts', function () {
 
       it('changes the model if read more button type changes', function () {
         var newValue = 'link';
-        view.$('.mailpoet_posts_read_more_type').val(newValue).change();
+        view.$('.mailpoet_posts_read_more_type').val(newValue).trigger('change');
         expect(model.get('readMoreType')).to.equal(newValue);
       });
 
@@ -452,7 +452,7 @@ describe('Posts', function () {
           innerModel.request = sinon.stub().returns({ $el: {} });
           innerView = new (PostsBlock.PostsBlockSettingsView)({ model: innerModel });
           innerView.render();
-          innerView.$('.mailpoet_posts_display_type').val('titleOnly').change();
+          innerView.$('.mailpoet_posts_display_type').val('titleOnly').trigger('change');
         });
 
         it('shows "title as list" option', function () {
@@ -461,8 +461,8 @@ describe('Posts', function () {
 
         describe('when "title as list" is selected', function () {
           beforeEach(function () {
-            innerView.$('.mailpoet_posts_display_type').val('titleOnly').change();
-            innerView.$('.mailpoet_posts_title_format').val('ul').change();
+            innerView.$('.mailpoet_posts_display_type').val('titleOnly').trigger('change');
+            innerView.$('.mailpoet_posts_title_format').val('ul').trigger('change');
           });
 
           describe('"title is link" option', function () {
@@ -478,8 +478,8 @@ describe('Posts', function () {
 
         describe('when "title as list" is deselected', function () {
           before(function () {
-            innerView.$('.mailpoet_posts_title_format').val('ul').change();
-            innerView.$('.mailpoet_posts_title_format').val('h3').change();
+            innerView.$('.mailpoet_posts_title_format').val('ul').trigger('change');
+            innerView.$('.mailpoet_posts_title_format').val('h3').trigger('change');
           });
 
           describe('"title is link" option', function () {
@@ -492,7 +492,7 @@ describe('Posts', function () {
 
       it('changes the model if show divider changes', function () {
         var newValue = true;
-        view.$('.mailpoet_posts_show_divider').val(newValue).change();
+        view.$('.mailpoet_posts_show_divider').val(newValue).trigger('change');
         expect(model.get('showDivider')).to.equal(newValue);
       });
     });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/products.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/products.spec.js
@@ -308,7 +308,7 @@ describe('Products', function () {
     describe('once rendered', function () {
       it('changes the model if post status changes', function () {
         var newValue = 'pending';
-        view.$('.mailpoet_products_post_status').val(newValue).change();
+        view.$('.mailpoet_products_post_status').val(newValue).trigger('change');
         expect(model.get('postStatus')).to.equal(newValue);
       });
 
@@ -320,49 +320,49 @@ describe('Products', function () {
 
       it('changes the model if display type changes', function () {
         var newValue = 'full';
-        view.$('.mailpoet_products_display_type').val(newValue).change();
+        view.$('.mailpoet_products_display_type').val(newValue).trigger('change');
         expect(model.get('displayType')).to.equal(newValue);
       });
 
       it('changes the model if title format changes', function () {
         var newValue = 'h3';
-        view.$('.mailpoet_products_title_format').val(newValue).change();
+        view.$('.mailpoet_products_title_format').val(newValue).trigger('change');
         expect(model.get('titleFormat')).to.equal(newValue);
       });
 
       it('changes the model if title alignment changes', function () {
         var newValue = 'right';
-        view.$('.mailpoet_products_title_alignment').val(newValue).change();
+        view.$('.mailpoet_products_title_alignment').val(newValue).trigger('change');
         expect(model.get('titleAlignment')).to.equal(newValue);
       });
 
       it('changes the model if title link changes', function () {
         var newValue = true;
-        view.$('.mailpoet_products_title_as_links').val(newValue).change();
+        view.$('.mailpoet_products_title_as_links').val(newValue).trigger('change');
         expect(model.get('titleIsLink')).to.equal(newValue);
       });
 
       it('changes the model if image alignment changes', function () {
         var newValue = false;
-        view.$('.mailpoet_products_image_full_width').val(newValue).change();
+        view.$('.mailpoet_products_image_full_width').val(newValue).trigger('change');
         expect(model.get('imageFullWidth')).to.equal(newValue);
       });
 
       it('changes the model if image position changes', function () {
         var newValue = 'aboveTitle';
-        view.$('.mailpoet_products_featured_image_position').val(newValue).change();
+        view.$('.mailpoet_products_featured_image_position').val(newValue).trigger('change');
         expect(model.get('featuredImagePosition')).to.equal(newValue);
       });
 
       it('changes the model if price position changes', function () {
         var newValue = 'below';
-        view.$('.mailpoet_products_price_position').val(newValue).change();
+        view.$('.mailpoet_products_price_position').val(newValue).trigger('change');
         expect(model.get('pricePosition')).to.equal(newValue);
       });
 
       it('changes the model if buy now button type changes', function () {
         var newValue = 'link';
-        view.$('.mailpoet_products_read_more_type').val(newValue).change();
+        view.$('.mailpoet_products_read_more_type').val(newValue).trigger('change');
         expect(model.get('readMoreType')).to.equal(newValue);
       });
 
@@ -380,7 +380,7 @@ describe('Products', function () {
           innerModel.request = sinon.stub().returns({ $el: {} });
           innerView = new (ProductsBlock.ProductsBlockSettingsView)({ model: innerModel });
           innerView.render();
-          innerView.$('.mailpoet_products_display_type').val('titleOnly').change();
+          innerView.$('.mailpoet_products_display_type').val('titleOnly').trigger('change');
         });
 
         it('hides "title position" option', function () {
@@ -391,7 +391,7 @@ describe('Products', function () {
 
       it('changes the model if show divider changes', function () {
         var newValue = true;
-        view.$('.mailpoet_products_show_divider').val(newValue).change();
+        view.$('.mailpoet_products_show_divider').val(newValue).trigger('change');
         expect(model.get('showDivider')).to.equal(newValue);
       });
     });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/social.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/social.spec.js
@@ -290,34 +290,34 @@ describe('Social', function () {
       });
 
       it('updates icons in settings if iconset changes', function () {
-        view.$('.mailpoet_social_icon_set').last().click();
+        view.$('.mailpoet_social_icon_set').last().trigger('click');
         expect(view.$('.mailpoet_social_icon_field_image').val()).to.equal(EditorApplication.getAvailableStyles().get('socialIconSets.light.custom'));
       });
 
       it('removes the icon when "remove" is clicked', function () {
-        view.$('.mailpoet_delete_block').click();
+        view.$('.mailpoet_delete_block').trigger('click');
         expect(model.get('icons').length).to.equal(0);
         expect(view.$('.mailpoet_social_icon_settings').length).to.equal(0);
       });
 
       it('adds another icon when "Add another social network" is pressed', function () {
-        view.$('.mailpoet_add_social_icon').click();
+        view.$('.mailpoet_add_social_icon').trigger('click');
         expect(model.get('icons').length).to.equal(2);
       });
 
       it('updates alignment when it changes', function () {
-        view.$('.mailpoet_social_block_alignment').eq(0).click();
+        view.$('.mailpoet_social_block_alignment').eq(0).trigger('click');
         expect(model.get('styles.block.textAlign')).to.equal('left');
-        view.$('.mailpoet_social_block_alignment').eq(1).click();
+        view.$('.mailpoet_social_block_alignment').eq(1).trigger('click');
         expect(model.get('styles.block.textAlign')).to.equal('center');
-        view.$('.mailpoet_social_block_alignment').eq(2).click();
+        view.$('.mailpoet_social_block_alignment').eq(2).trigger('click');
         expect(model.get('styles.block.textAlign')).to.equal('right');
       });
 
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/blocks/spacer.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/blocks/spacer.spec.js
@@ -115,7 +115,7 @@ describe('Spacer', function () {
       var mock = sinon.mock().once();
       model.on('startEditing', mock);
       view.render();
-      view.$('.mailpoet_spacer').click();
+      view.$('.mailpoet_spacer').trigger('click');
       mock.verify();
     });
 
@@ -123,7 +123,7 @@ describe('Spacer', function () {
       var mock = sinon.mock().never();
       model.on('startEditing', mock);
       view.render();
-      view.$('.mailpoet_resize_handle').click();
+      view.$('.mailpoet_resize_handle').trigger('click');
       mock.verify();
     });
   });
@@ -155,14 +155,14 @@ describe('Spacer', function () {
       });
 
       it('updates the model when background color changes', function () {
-        view.$('.mailpoet_field_spacer_background_color').val('#123456').change();
+        view.$('.mailpoet_field_spacer_background_color').val('#123456').trigger('change');
         expect(model.get('styles.block.backgroundColor')).to.equal('#123456');
       });
 
       it.skip('closes the sidepanel after "Done" is clicked', function () {
         var mock = sinon.mock().once();
         global.MailPoet.Modal.cancel = mock;
-        view.$('.mailpoet_done_editing').click();
+        view.$('.mailpoet_done_editing').trigger('click');
         mock.verify();
         delete (global.MailPoet.Modal.cancel);
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/components/heading.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/components/heading.spec.js
@@ -39,12 +39,12 @@ describe('Heading', function () {
       });
 
       it('changes the model when subject field is changed', function () {
-        view.$('.mailpoet_input_title').val('a new testing subject').keyup();
+        view.$('.mailpoet_input_title').val('a new testing subject').trigger('keyup');
         expect(model.get('subject')).to.equal('a new testing subject');
       });
 
       it('changes the model when preheader field is changed', function () {
-        view.$('.mailpoet_input_preheader').val('a new testing preheader').keyup();
+        view.$('.mailpoet_input_preheader').val('a new testing preheader').trigger('keyup');
         expect(model.get('preheader')).to.equal('a new testing preheader');
       });
     });

--- a/tests/javascript_newsletter_editor/newsletter_editor/components/save.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/components/save.spec.js
@@ -189,13 +189,13 @@ describe('Save', function () {
         global.stubChannel(EditorApplication, {
           request: mock,
         });
-        view.$('.mailpoet_save_button').click();
+        view.$('.mailpoet_save_button').trigger('click');
 
         mock.verify();
       });
 
       it('displays saving options when clicked on save options button', function () {
-        view.$('.mailpoet_save_show_options').click();
+        view.$('.mailpoet_save_show_options').trigger('click');
         expect(view.$('.mailpoet_save_options')).to.not.have.$class('mailpoet_hidden');
       });
 
@@ -248,7 +248,7 @@ describe('Save', function () {
 
         view.$('.mailpoet_save_as_template_name').val('A sample template');
         view.$('.mailpoet_save_as_template_description').val('Sample template description');
-        view.$('.mailpoet_save_as_template').click();
+        view.$('.mailpoet_save_as_template').trigger('click');
 
         mock.verify();
       });
@@ -272,7 +272,7 @@ describe('Save', function () {
         view = new (module.SaveView)({ model: model });
         view.render();
 
-        view.$('.mailpoet_save_next').click();
+        view.$('.mailpoet_save_next').trigger('click');
         expect(spy).to.have.callCount(1);
         expect(spy).to.have.been.calledWith('beforeEditorSave');
       });

--- a/tests/javascript_newsletter_editor/newsletter_editor/components/sidebar.spec.js
+++ b/tests/javascript_newsletter_editor/newsletter_editor/components/sidebar.spec.js
@@ -100,82 +100,82 @@ describe('Sidebar', function () {
       });
 
       it('changes model if text font color field changes', function () {
-        innerView.$('#mailpoet_text_font_color').val('#123456').change();
+        innerView.$('#mailpoet_text_font_color').val('#123456').trigger('change');
         expect(model.get('text.fontColor')).to.equal('#123456');
       });
 
       it('changes model if h1 font color field changes', function () {
-        innerView.$('#mailpoet_h1_font_color').val('#123457').change();
+        innerView.$('#mailpoet_h1_font_color').val('#123457').trigger('change');
         expect(model.get('h1.fontColor')).to.equal('#123457');
       });
 
       it('changes model if h2 font color field changes', function () {
-        innerView.$('#mailpoet_h2_font_color').val('#123458').change();
+        innerView.$('#mailpoet_h2_font_color').val('#123458').trigger('change');
         expect(model.get('h2.fontColor')).to.equal('#123458');
       });
 
       it('changes model if h3 font color field changes', function () {
-        innerView.$('#mailpoet_h3_font_color').val('#123426').change();
+        innerView.$('#mailpoet_h3_font_color').val('#123426').trigger('change');
         expect(model.get('h3.fontColor')).to.equal('#123426');
       });
 
       it('changes model if link font color field changes', function () {
-        innerView.$('#mailpoet_a_font_color').val('#323232').change();
+        innerView.$('#mailpoet_a_font_color').val('#323232').trigger('change');
         expect(model.get('link.fontColor')).to.equal('#323232');
       });
 
       it('changes model if newsletter background color field changes', function () {
-        innerView.$('#mailpoet_newsletter_background_color').val('#636237').change();
+        innerView.$('#mailpoet_newsletter_background_color').val('#636237').trigger('change');
         expect(model.get('wrapper.backgroundColor')).to.equal('#636237');
       });
 
       it('changes model if background color field changes', function () {
-        innerView.$('#mailpoet_background_color').val('#878587').change();
+        innerView.$('#mailpoet_background_color').val('#878587').trigger('change');
         expect(model.get('body.backgroundColor')).to.equal('#878587');
       });
 
       it('changes model if text font family field changes', function () {
-        innerView.$('#mailpoet_text_font_family').val('Times New Roman').change();
+        innerView.$('#mailpoet_text_font_family').val('Times New Roman').trigger('change');
         expect(model.get('text.fontFamily')).to.equal('Times New Roman');
       });
 
       it('changes model if h1 font family field changes', function () {
-        innerView.$('#mailpoet_h1_font_family').val('Comic Sans').change();
+        innerView.$('#mailpoet_h1_font_family').val('Comic Sans').trigger('change');
         expect(model.get('h1.fontFamily')).to.equal('Comic Sans');
       });
 
       it('changes model if h2 font family field changes', function () {
-        innerView.$('#mailpoet_h2_font_family').val('Tahoma').change();
+        innerView.$('#mailpoet_h2_font_family').val('Tahoma').trigger('change');
         expect(model.get('h2.fontFamily')).to.equal('Tahoma');
       });
 
       it('changes model if h3 font family field changes', function () {
-        innerView.$('#mailpoet_h3_font_family').val('Lucida').change();
+        innerView.$('#mailpoet_h3_font_family').val('Lucida').trigger('change');
         expect(model.get('h3.fontFamily')).to.equal('Lucida');
       });
 
       it('changes model if text font size field changes', function () {
-        innerView.$('#mailpoet_text_font_size').val('9px').change();
+        innerView.$('#mailpoet_text_font_size').val('9px').trigger('change');
         expect(model.get('text.fontSize')).to.equal('9px');
       });
 
       it('changes model if h1 font size field changes', function () {
-        innerView.$('#mailpoet_h1_font_size').val('12px').change();
+        innerView.$('#mailpoet_h1_font_size').val('12px').trigger('change');
         expect(model.get('h1.fontSize')).to.equal('12px');
       });
 
       it('changes model if h2 font size field changes', function () {
-        innerView.$('#mailpoet_h2_font_size').val('14px').change();
+        innerView.$('#mailpoet_h2_font_size').val('14px').trigger('change');
         expect(model.get('h2.fontSize')).to.equal('14px');
       });
 
       it('changes model if h3 font size field changes', function () {
-        innerView.$('#mailpoet_h3_font_size').val('16px').change();
+        innerView.$('#mailpoet_h3_font_size').val('16px').trigger('change');
         expect(model.get('h3.fontSize')).to.equal('16px');
       });
 
       it('changes model if link underline field changes', function () {
-        innerView.$('#mailpoet_a_font_underline').prop('checked', true).change();
+        innerView.$('#mailpoet_a_font_underline').prop('checked', true).trigger('change');
         expect(model.get('link.textDecoration')).to.equal('underline');
       });
     });

--- a/views/deactivationSurvey/js.html
+++ b/views/deactivationSurvey/js.html
@@ -18,7 +18,7 @@
       location.href = deactivateLink.attr('href');
     });
 
-    $(document).keyup(function(event) {
+    $(document).on('keyup', function(event) {
       if ((event.keyCode === 27) && formOpen) {
         location.href = deactivateLink.attr('href');
       }


### PR DESCRIPTION
[MAILPOET-3386]

I fixed as much deprecations as I could find, but I still may have missed something. If you want to double-check, add `define('SCRIPT_DEBUG', true);` to your `wp-config.php` to see JQMIGRATE warnings. 

There are a lot of assorted changes. While deprecations in our own code were fairly straightforward to fix, with some of our dependencies it was tricky:
* Fixes for `spectrum-colorpicker` were only on GitHub, not on npm, so I applied a patch;
* `select2` had a patched version released, but it also had breaking changes in the HTML layout of the control, so I had to fix styles and tests. Hope I didn't miss anything;
* `parsleyjs` only has a `deferred.pipe()` fix in an unmerged PR on GitHub, to incorporate it we would have to set up a whole development environment to build the package. At this point I suggest to wait until it's officially merged and released, since this functionality isn't yet being removed from jQuery. I'll create a ticket to track that.

I don't recommend merging this without QA, let's wait for @veljkho to test and approve it.

**For QA:**
Please test this on WP 5.7 beta with console open and `SCRIPT_DEBUG` mode on.

Areas of particular focus:
* select2 fields, both multiple-selection and single-selection (e.g. in segments creation);
* public subscription forms validation;
* color picker in the newsletter editor;
* form preview;
* import/export;
* modals;
* notices.

[MAILPOET-3386]: https://mailpoet.atlassian.net/browse/MAILPOET-3386