### PR TITLE
Update CustomFonts.php

### DIFF
--- a/lib/Form/Util/CustomFonts.php
+++ b/lib/Form/Util/CustomFonts.php
@@ -80,7 +80,7 @@ class CustomFonts {
   public function enqueueStyle() {
     $displayCustomFonts = $this->wp->applyFilters('mailpoet_display_custom_fonts', true);
     if ($displayCustomFonts) {
-      $this->wp->wpEnqueueStyle('mailpoet_custom_fonts_css', $this->generateLink());
+      $this->wp->wpEnqueueStyle('mailpoet_custom_fonts', $this->generateLink());
     }
   }
 


### PR DESCRIPTION
WordPress automatically appends -css to the handle, so at the moment it's being output like this: 

`<link rel='stylesheet' id='mailpoet_custom_fonts_css-css'`