### PR TITLE
Display the HelpScout chat for all plans with premium support [MAILPOET-3438]

### DIFF
--- a/lib/AdminPages/PageRenderer.php
+++ b/lib/AdminPages/PageRenderer.php
@@ -58,6 +58,7 @@ class PageRenderer {
       'feature_flags' => $this->featuresController->getAllFlags(),
       'referral_id' => $this->settings->get(ReferralDetector::REFERRAL_SETTING_NAME),
       'mailpoet_api_key_state' => $this->settings->get('mta.mailpoet_api_key_state'),
+      'premium_key_state' => $this->settings->get('premium.premium_key_state'),
       'last_announcement_seen' => $lastAnnouncementSeen,
       'feature_announcement_has_news' => (empty($lastAnnouncementSeen) || $lastAnnouncementSeen < $lastAnnouncementDate),
       'wp_segment_state' => $wpSegmentState,

--- a/views/layout.html
+++ b/views/layout.html
@@ -130,7 +130,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   <%= javascript('lib/analytics.js') %>
 
   <% set helpscout_form_id = '1c666cab-c0f6-4614-bc06-e5d0ad78db2b' %>
-  <%if mailpoet_api_key_state.data.support_tier == 'premium' %>
+  <%if mailpoet_api_key_state.data.support_tier == 'premium' or premium_key_state.data.support_tier == 'premium' %>
     <% set helpscout_form_id = 'e93d0423-1fa6-4bbc-9df9-c174f823c35f' %>
   <% endif %>
 


### PR DESCRIPTION
This PR fixes a problem in the logic used to decide whether or not the HelpScout chat should be available on the MailPoet admin pages. Before, we were displaying the chat for plans that include premium support and access to MSS. But we also have plans, like the Blogger plan, that include premium support, and should see the chat, but don't include access to MSS. Those plans were not seeing the chat.

This was happening because the code was checking just for `mailpoet_api_key_state.data.support_tier == 'premium'`. The mailpoet_api_key_state setting is added to the database based on the response from the bridge.mailpoet.com/me endpoint. This endpoint returns a 403 error for plans that don't include the sending service.

In this PR to fix this problem, the code now checks for both `mailpoet_api_key_state.data.support_tier == 'premium'` and `premium_key_state.data.support_tier == 'premium'`. The former setting is added to the database based on the response of the
bridge.mailpoet.com/premium endpoint. This endpoint works for plans that have access to MailPoet Premium, but don't have access to MSS. We need to check for both settings as we also have some plans that include the sending service, but don't include MailPoet Premium.

[MAILPOET-3438]

[MAILPOET-3438]: https://mailpoet.atlassian.net/browse/MAILPOET-3438