### PR TITLE
Fix PHP notice when the plugin user-switching is active [MAILPOET-3374]

### DIFF
--- a/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
+++ b/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
@@ -130,7 +130,7 @@ class AbandonedCart {
 
   public function handleCartChange() {
     $cart = $this->wooCommerceHelper->WC()->cart;
-    if ($cart && !$cart->is_empty()) {
+    if (current_action() !== 'woocommerce_cart_emptied' && $cart && !$cart->is_empty()) {
       $this->scheduleAbandonedCartEmail($this->getCartProductIds($cart));
     } else {
       $this->cancelAbandonedCartEmail();


### PR DESCRIPTION
Some users were getting the PHP notice below when using the user-switching (https://wordpress.org/plugins/user-switching/) plugin to switch to a different user.

```
PHP Notice: get_cart was called incorrectly. Get cart should not be called before the wp_loaded action.
```

This notice is generated by WooCommerce when `WC_Cart::get_cart()` is called before the `wp_loaded` action. user-switching calls a WooCommerce method to empty the user session and the cart when switching users, and this happens before wp_loaded. MailPoet hooks into the woocommerce_cart_emptied action (https://github.com/mailpoet/mailpoet/blob/c9ca134d300f788bb14bf7475b98e1126a07264a/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php#L118) to decide whether it should schedule or cancel an abandoned cart email. When doing so, it calls WC_Cart::is_empty() which calls WC_Cart::get_cart(). This is why the PHP notice is generated.

When the cart is emptied, we don't need to check it again, calling WC_Cart::is_empty(). So, to get rid of the PHP notice, this commit adds an extra condition to the if statement to only run WC_Cart::is_empty() if the current action is not `woocommerce_cart_emptied`.

[MAILPOET-3374]

[MAILPOET-3374]: https://mailpoet.atlassian.net/browse/MAILPOET-3374