### PR TITLE
Truncate first and last names before adding to wp_mailpoet_subscribers [MAILPOET-3246]

### DIFF
--- a/lib/Segments/WP.php
+++ b/lib/Segments/WP.php
@@ -229,7 +229,7 @@ class WP {
     Subscriber::rawExecute(sprintf('
       UPDATE %1$s
         JOIN %2$s as wpum ON %1$s.wp_user_id = wpum.user_id AND wpum.meta_key = "first_name"
-      SET %1$s.first_name = wpum.meta_value
+      SET %1$s.first_name = SUBSTRING(wpum.meta_value, 1, 255)
         WHERE %1$s.first_name = ""
         AND %1$s.wp_user_id IS NOT NULL
         AND wpum.meta_value IS NOT NULL
@@ -242,7 +242,7 @@ class WP {
     Subscriber::rawExecute(sprintf('
       UPDATE %1$s
         JOIN %2$s as wpum ON %1$s.wp_user_id = wpum.user_id AND wpum.meta_key = "last_name"
-      SET %1$s.last_name = wpum.meta_value
+      SET %1$s.last_name = SUBSTRING(wpum.meta_value, 1, 255)
         WHERE %1$s.last_name = ""
         AND %1$s.wp_user_id IS NOT NULL
         AND wpum.meta_value IS NOT NULL

--- a/tests/integration/Segments/WPTest.php
+++ b/tests/integration/Segments/WPTest.php
@@ -198,21 +198,27 @@ class WPTest extends \MailPoetTest {
   }
 
   public function testItSynchronizeFirstNames() {
+    $firstName = 'Very long name over 255 characters lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum';
+    $trucantedFirstName = substr($firstName, 0, 255);
+
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
-    update_user_meta((int)$id, 'first_name', 'First name');
+    update_user_meta((int)$id, 'first_name', $firstName);
     $this->wpSegment->synchronizeUsers();
     $subscriber = Subscriber::where('wp_user_id', $id)->findOne();
-    expect($subscriber->firstName)->equals('First name');
+    expect($subscriber->firstName)->equals($trucantedFirstName);
   }
 
   public function testItSynchronizeLastNames() {
+    $lastName = 'Very long name over 255 characters lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum';
+    $trucantedLastName = substr($lastName, 0, 255);
+
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
-    update_user_meta((int)$id, 'last_name', 'Last name');
+    update_user_meta((int)$id, 'last_name', $lastName);
     $this->wpSegment->synchronizeUsers();
     $subscriber = Subscriber::where('wp_user_id', $id)->findOne();
-    expect($subscriber->lastName)->equals('Last name');
+    expect($subscriber->lastName)->equals($trucantedLastName);
   }
 
   public function testItSynchronizeFirstNamesUsingDisplayName() {


### PR DESCRIPTION
MailPoet syncs users from wp_users to wp_mailpoet_subscribers. The problem is that WP stores first and last names in a longtext field, and MP uses a varchar(255) field. This was causing a fatal error when synchronizing names over 255 characters. This commit fixes this problem by using SUBSTRING() to make sure that the 255 characters limit is enforced when adding values to the columns first_name and last_name of the wp_mailpoet_subscribers table. This should get rid of the fatal error, and it shouldn't be a problem to most users as it is unlikely that a real user has a first or last name that is longer than 255 characters.

@NeosinneR, you mentioned in the issue description performance concerns with SUBSTRING(). As far as I can tell, this should not impact the query in any meaningful way but I didn't check closely. Do you have any specific concerns?

[MAILPOET-3246]

[MAILPOET-3246]: https://mailpoet.atlassian.net/browse/MAILPOET-3246