### PR TITLE
Fix orphan sending tasks [MAILPOET-3379]

### DIFF
--- a/lib/Tasks/Sending.php
+++ b/lib/Tasks/Sending.php
@@ -164,6 +164,14 @@ class Sending {
   public function save() {
     $this->task->save();
     $this->queue->save();
+    $errors = $this->getErrors();
+    if ($errors) {
+      $loggerFactory = LoggerFactory::getInstance();
+      $loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->addError(
+        'error saving sending task',
+        ['task_id' => $this->task->id, 'queue_id' => $this->queue->id, 'errors' => $errors]
+      );
+    }
     return $this;
   }
 

--- a/tests/integration/Tasks/SendingTest.php
+++ b/tests/integration/Tasks/SendingTest.php
@@ -58,6 +58,13 @@ class SendingTest extends \MailPoetTest {
     expect($queue->taskId)->equals($this->task->id);
   }
 
+  public function testItDeletesInvalidTasksWhenCreatingManyFromTasks() {
+    $this->queue->delete();
+    $sendings = SendingTask::createManyFromTasks([$this->task]);
+    expect($sendings)->isEmpty();
+    expect(ScheduledTask::findOne($this->task->id))->equals(false);
+  }
+
   public function testItCanBeCreatedFromScheduledTask() {
     $sending = SendingTask::createFromScheduledTask($this->task);
     $queue = $sending->queue();


### PR DESCRIPTION
I have decided to just log errors when saving a sending task because I think handling those when processing is enough (see below).

When fetching tasks, I think it's okay to delete them like we always did with tasks that [lack a newsletter](https://github.com/mailpoet/mailpoet/blob/master/lib/Cron/Workers/SendingQueue/SendingQueue.php#L96-L100).