### PR TITLE
Preserve new key when saving settings [MAILPOET-3447]

### DIFF
--- a/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -6,7 +6,7 @@ import { STORE_NAME } from 'settings/store';
 import {
   Action, KeyActivationState, MssStatus, PremiumStatus,
 } from 'settings/store/types';
-import { setSettings } from './settings';
+import { setSettings, setSetting } from './settings';
 
 export function updateKeyActivationState(fields: Partial<KeyActivationState>): Action {
   return { type: 'UPDATE_KEY_ACTIVATION_STATE', fields };
@@ -70,6 +70,9 @@ export function* verifyPremiumKey(key: string) {
       code: res?.meta?.code,
     });
   }
+
+  yield setSetting(['premium', 'premium_key'], key);
+
   const pluginActive = res.meta.premium_plugin_active;
 
   let status = PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_ACTIVE;


### PR DESCRIPTION
This PR fixes a bug in the code where a user could override their key if, after validating a new key, they went to a different settings tab and clicked "Save settings". When reloading the page, they would see the old key instead of the new one.

This was happening because the function verifyPremiumKey() was updating the key in the backend but was not updating the settings object in the frontend. So when the user switched to another settings tab and clicked on the "Save settings" button, the function saveSettings() was saving to the backend a settings object containing the old key instead of the new one.

To fix this problem, this PR updates the settings object with the new premium key whenever a new key is validated.

Please note that I'm fairly new to modern JS and React development so there is a chance that the way that I'm fixing this is not the best way or that I'm missing something.

[MAILPOET-3447]

[MAILPOET-3447]: https://mailpoet.atlassian.net/browse/MAILPOET-3447