### PR TITLE
Duplicate the name property as the text for Select2 search [MAILPOET-3458]

### DIFF
--- a/assets/js/src/subscribers/importExport/export.ts
+++ b/assets/js/src/subscribers/importExport/export.ts
@@ -14,9 +14,11 @@ interface ExportWindow extends Window {
   }>;
   subscriberFieldsSelect2: Array<{
     name: string;
+    text: string; // Required select2 property
     children: Array<{
       id: string;
       name: string;
+      text: string; // Required select2 property
       type: string | null;
       custom: boolean;
       params: object;
@@ -112,6 +114,13 @@ jQuery(document).ready(() => {
 
   window.segments.forEach((item) => {
     segmentsContainerElement.append(jQuery('<option></option>').attr('value', item.id).text(item.name));
+  });
+  // Select2 requires the property text, then we fill it with name
+  window.subscriberFieldsSelect2.forEach((group) => {
+    group.text = group.name; // eslint-disable-line no-param-reassign
+    group.children.forEach((item) => {
+      item.text = item.name; // eslint-disable-line no-param-reassign
+    });
   });
   renderSegmentsAndFields(segmentsContainerElement, window.segments);
   renderSegmentsAndFields(subscriberFieldsContainerElement, window.subscriberFieldsSelect2);


### PR DESCRIPTION
[MAILPOET-3458]

I duplicate a property `name` as `text` because Select2 needs properties `id` and `text`.
Maybe it would be a better solution to refactor our code for using the property `text` instead of `name`. When I have tried it then didn't work correctly import. I don't want to spend more time with it but if you think that it's worth it. I don't think because we want to remove Select2 in the future.

[MAILPOET-3458]: https://mailpoet.atlassian.net/browse/MAILPOET-3458