### PR TITLE
Disable WP core autoupdate in tests [MAILPOET-3475]

### DIFF
--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -25,6 +25,8 @@ chown www-data:www-data wp-content/uploads
 chmod 755 wp-content/plugins
 chmod -R 777 wp-content/uploads
 
+# disable automatic updates
+wp config set WP_AUTO_UPDATE_CORE false --raw
 
 # cleanup database
 mysqladmin --host=mysql --user=root --password=wordpress drop wordpress --force

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -25,13 +25,8 @@ chown www-data:www-data wp-content/uploads
 chmod 755 wp-content/plugins
 chmod -R 777 wp-content/uploads
 
-# backup original 'wp-config.php' created by WordPress image
-if [ ! -f wp-config-original.php ]; then
-  cp wp-config.php wp-config-original.php
-fi
 
-# cleanup 'wp-config.php' and database
-rm -f wp-config.php && cp wp-config-original.php wp-config.php
+# cleanup database
 mysqladmin --host=mysql --user=root --password=wordpress drop wordpress --force
 mysqladmin --host=mysql --user=root --password=wordpress create wordpress --force
 


### PR DESCRIPTION
WordPress core auto-update process running during tests bootstrap collides with WPCLI calls and that causes unexpected errors during the bootstrap.

[MAILPOET-3475]

[MAILPOET-3475]: https://mailpoet.atlassian.net/browse/MAILPOET-3475