### PR TITLE
Attempt to fix a flaky integration test [MAILPOET-3451]

### DIFF
--- a/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -212,6 +212,7 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     $this->listingData['filter'] = ['segment' => $list->getId()];
     $this->listingData['limit'] = 2;
     $this->listingData['offset'] = 2;
+    $this->listingData['sort_by'] = 'id';
     $data = $this->repository->getData($this->getListingDefinition());
     expect(count($data))->equals(1);
     expect($data[0]->getEmail())->equals($wpUserEmail3);


### PR DESCRIPTION
This PR attempts to fix the integration test SubscriberListingRepositoryTest::testReturnsCorrectCountForSubscribersInDynamicSegment() that was failing sometimes on CircleCI. My theory is that the test was failing because we were using created_at to order the subscribers in the query that is used to get subscribers in a given dynamic segment. Still, there is a chance the the value of this field is the same for all three subscribers that are created in this test. As this could lead to a situation where the order of the returned subscribers changes, causing the test to fail. To work around that, I changed the test to order the results by ID. This way, we should always get the subscribers in the same order, and I don't expect that the test will fail again.

Running this particular test a few times in my environment, I was able to see if fail once or twice. After this change, it passed all the times that I tried. So we should be could, but unfortunately, that is not enough to be sure.

[MAILPOET-3451]

[MAILPOET-3451]: https://mailpoet.atlassian.net/browse/MAILPOET-3451