### PR TITLE
Use mysql8.0 latest in integration tests [MAILPOET-3497]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ executors:
     <<: *default_job_config
     docker:
       - image: mailpoet/wordpress:8.0_20210218.1
-      - image: circleci/mysql:8.0.21-ram
+      - image: circleci/mysql:8.0-ram
         command: [--default-authentication-plugin=mysql_native_password]
 
 jobs:


### PR DESCRIPTION
This revert the previous [hotfix](https://github.com/mailpoet/mailpoet/pull/3392). The issue was fixed by the CirceCI team.
[MAILPOET-3497]

[MAILPOET-3497]: https://mailpoet.atlassian.net/browse/MAILPOET-3497