### PR TITLE
Disallow jetpack JS on mailpoet admin pages [MAILPOET-3504]

### DIFF
--- a/lib/Util/ConflictResolver.php
+++ b/lib/Util/ConflictResolver.php
@@ -30,7 +30,6 @@ class ConflictResolver {
       'googleapis.com/ajax/libs',
       'wp.com',
       // third-party
-      'jetpack',
       'query-monitor',
       'wpt-tx-updater-network',
     ],


### PR DESCRIPTION
[Allowing loading Jetpack JS](https://github.com/mailpoet/mailpoet/pull/3362) introduced an issue with a broken image library due to some JS conflict. This PR disallows the loading of Jetpacks JS files on MailPoet admin pages and keeps allowed only Jetpack's CSS.

[MAILPOET-3504]

[MAILPOET-3504]: https://mailpoet.atlassian.net/browse/MAILPOET-3504