### PR TITLE
Rewrite Forms::listing() API to use Doctrine [MAILPOET-3036]

### DIFF
--- a/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
+++ b/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
@@ -3,6 +3,7 @@
 namespace MailPoet\API\JSON\ResponseBuilders;
 
 use MailPoet\Entities\FormEntity;
+use MailPoet\Models\StatisticsForms;
 
 class FormsResponseBuilder {
   const DATE_FORMAT = 'Y-m-d H:i:s';
@@ -19,5 +20,23 @@ class FormsResponseBuilder {
       'updated_at' => $form->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $form->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
     ];
+  }
+
+  public function buildForListing(array $forms) {
+    $data = [];
+
+    foreach ($forms as $form) {
+      $form = $this->build($form);
+      $form['signups'] = StatisticsForms::getTotalSignups($form['id']);
+      $form['segments'] = (
+        !empty($form['settings']['segments'])
+        ? $form['settings']['segments']
+        : []
+      );
+
+      $data[] = $form;
+    }
+
+    return $data;
   }
 }

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -200,6 +200,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Form\Block\Textarea::class);
     $container->autowire(\MailPoet\Form\FormFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\FormHtmlSanitizer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Form\Listing\FormListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\PreviewPage::class);
     $container->autowire(\MailPoet\Form\Templates\TemplateRepository::class);
     $container->autowire(\MailPoet\Form\Util\Styles::class);

--- a/lib/Form/Listing/FormListingRepository.php
+++ b/lib/Form/Listing/FormListingRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace MailPoet\Form\Listing;
+
+use MailPoet\Entities\FormEntity;
+use MailPoet\Listing\ListingDefinition;
+use MailPoet\Listing\ListingRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
+
+class FormListingRepository extends ListingRepository {
+  public function getGroups(ListingDefinition $definition): array {
+    $queryBuilder = clone $this->queryBuilder;
+    $this->applyFromClause($queryBuilder);
+    $this->applyParameters($queryBuilder, $definition->getParameters());
+
+    // total count
+    $countQueryBuilder = clone $queryBuilder;
+    $countQueryBuilder->select('COUNT(f) AS formCount');
+    $countQueryBuilder->andWhere('f.deletedAt IS NULL');
+    $totalCount = (int)$countQueryBuilder->getQuery()->getSingleScalarResult();
+
+    // trashed count
+    $trashedCountQueryBuilder = clone $queryBuilder;
+    $trashedCountQueryBuilder->select('COUNT(f) AS formCount');
+    $trashedCountQueryBuilder->andWhere('f.deletedAt IS NOT NULL');
+    $trashedCount = (int)$trashedCountQueryBuilder->getQuery()->getSingleScalarResult();
+
+    return [
+      [
+        'name' => 'all',
+        'label' => WPFunctions::get()->__('All', 'mailpoet'),
+        'count' => $totalCount,
+      ],
+      [
+        'name' => 'trash',
+        'label' => WPFunctions::get()->__('Trash', 'mailpoet'),
+        'count' => $trashedCount,
+      ],
+    ];
+  }
+
+  protected function applySelectClause(QueryBuilder $queryBuilder) {
+    $queryBuilder->select("PARTIAL f.{id,name,status,settings,createdAt,updatedAt,deletedAt}");
+  }
+
+  protected function applyFromClause(QueryBuilder $queryBuilder) {
+    $queryBuilder->from(FormEntity::class, 'f');
+  }
+
+  protected function applyGroup(QueryBuilder $queryBuilder, string $group) {
+    // include/exclude deleted
+    if ($group === 'trash') {
+      $queryBuilder->andWhere('f.deletedAt IS NOT NULL');
+    } else {
+      $queryBuilder->andWhere('f.deletedAt IS NULL');
+    }
+  }
+
+  protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
+    $queryBuilder->addOrderBy("f.$sortBy", $sortOrder);
+  }
+
+  protected function applySearch(QueryBuilder $queryBuilder, string $search) {
+    // TODO: Implement applySearch() method.
+  }
+
+  protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
+    // TODO: Implement applyFilters() method.
+  }
+
+  protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {
+    // TODO: Implement applyParameters() method.
+  }
+}

--- a/tests/integration/Form/Listing/FormListingRepositoryTest.php
+++ b/tests/integration/Form/Listing/FormListingRepositoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace MailPoet\Form\Listing;
+
+use MailPoet\Entities\FormEntity;
+use MailPoet\Listing\Handler;
+
+class FormListingRepositoryTest extends \MailPoetTest {
+  /** @var Handler */
+  protected $listingHandler;
+
+  /** @var FormListingRepository */
+  protected $formListingRepository;
+
+  /** @var FormEntity */
+  protected $form1;
+
+  /** @var FormEntity */
+  protected $form2;
+
+  public function _before() {
+    parent::_before();
+
+    $this->listingHandler = new Handler();
+    $this->formListingRepository = $this->diContainer->get(FormListingRepository::class);
+
+    $this->form1 = new FormEntity('Form 1');
+    $this->entityManager->persist($this->form1);
+    $this->form2 = new FormEntity('Form 2');
+    $this->entityManager->persist($this->form2);
+    $this->entityManager->flush();
+  }
+
+  public function testItAppliesGroup() {
+    // all/trash groups
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition(['group' => 'all']));
+    expect($forms)->count(2);
+
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition(['group' => 'trash']));
+    expect($forms)->count(0);
+
+    // delete one form
+    $this->form1->setDeletedAt(new \DateTime());
+    $this->entityManager->flush();
+
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition(['group' => 'all']));
+    expect($forms)->count(1);
+
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition(['group' => 'trash']));
+    expect($forms)->count(1);
+  }
+
+  public function testItAppliesSort() {
+    // ASC
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'sort_by' => 'name',
+      'sort_order' => 'asc',
+    ]));
+    expect($forms)->count(2);
+    expect($forms[0]->getName())->same('Form 1');
+    expect($forms[1]->getName())->same('Form 2');
+
+    // DESC
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'sort_by' => 'name',
+      'sort_order' => 'desc',
+    ]));
+    expect($forms)->count(2);
+    expect($forms[0]->getName())->same('Form 2');
+    expect($forms[1]->getName())->same('Form 1');
+  }
+
+  public function testItAppliesLimitAndOffset() {
+    // first page
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'limit' => 1,
+      'offset' => 0,
+    ]));
+    expect($forms)->count(1);
+    expect($forms[0]->getName())->same('Form 1');
+
+    // second page
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'limit' => 1,
+      'offset' => 1,
+    ]));
+    expect($forms)->count(1);
+    expect($forms[0]->getName())->same('Form 2');
+
+    // third page
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'limit' => 1,
+      'offset' => 2,
+    ]));
+    expect($forms)->count(0);
+  }
+
+  public function _after() {
+    $this->truncateEntity(FormEntity::class);
+  }
+}


### PR DESCRIPTION
This PR replaces the usage of Paris with Doctrine inside MailPoet\API\JSON\v1\Forms::listing(). It also introduces a new class MailPoet\Form\Listing\FormListingRepository that is used by listing() to prepare the query that is executed by Doctrine and a new MailPoet\API\JSON\ResponseBuilders\FormsResponseBuilder::buildForListing() method to prepare the response that is returned by listing(). A few tests were adjusted and new tests were added for the new class. Parts of FormsTests were refactored in a separate commit to use Doctrine entities instead of Paris objects.

[MAILPOET-3036]