### PR TITLE
Add support for arguments in custom shortcodes [MAILPOET-3465]

### DIFF
--- a/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -85,6 +85,7 @@ class Link implements CategoryInterface {
           $newsletterModel,
           $subscriberModel,
           $queueModel,
+          $shortcodeDetails['arguments'],
           $wpUserPreview
         );
 

--- a/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -80,19 +80,60 @@ class Shortcodes {
       false;
   }
 
+  /**
+   * Parse a MailPoet-style shortcode.
+   * The syntax is [category:action | argument:argument_value], it can have a single argument.
+   */
   public function match($shortcode) {
     preg_match(
       '/\[(?P<category>\w+)?:(?P<action>\w+)(?:.*?\|.*?(?P<argument>\w+):(?P<argument_value>.*?))?\]/',
       $shortcode,
       $match
     );
+    // If argument exists, copy it to the arguments array
+    if (!empty($match['argument'])) {
+      $match['arguments'] = [$match['argument'] => isset($match['argument_value']) ? $match['argument_value'] : ''];
+    }
     return $match;
+  }
+
+  /**
+   * Parse a WordPress-style shortcode.
+   * The syntax is [category:action arg1="value1" arg2="value2"], it can have multiple arguments.
+   */
+  public function matchWPShortcode($shortcode) {
+    $atts = WPFunctions::get()->shortcodeParseAtts(trim($shortcode, '[]/'));
+    if (empty($atts[0])) {
+      return [];
+    }
+    $shortcodeName = $atts[0];
+    list($category, $action) = explode(':', $shortcodeName);
+    $shortcodeDetails = [];
+    $shortcodeDetails['category'] = $category;
+    $shortcodeDetails['action'] = $action;
+    $shortcodeDetails['arguments'] = [];
+    foreach ($atts as $attrName => $attrValue) {
+      if (is_numeric($attrName)) {
+        continue; // Skip unnamed attributes
+      }
+      $shortcodeDetails['arguments'][$attrName] = $attrValue;
+      // Make a shortcut to the first argument
+      if (!isset($shortcodeDetails['argument'])) {
+        $shortcodeDetails['argument'] = $attrName;
+        $shortcodeDetails['argument_value'] = $attrValue;
+      }
+    }
+    return $shortcodeDetails;
   }
 
   public function process($shortcodes, $content = '') {
     $processedShortcodes = [];
     foreach ($shortcodes as $shortcode) {
       $shortcodeDetails = $this->match($shortcode);
+      if (empty($shortcodeDetails)) {
+        // Wrong MailPoet shortcode syntax, try to parse as a native WP shortcode
+        $shortcodeDetails = $this->matchWPShortcode($shortcode);
+      }
       $shortcodeDetails['shortcode'] = $shortcode;
       $shortcodeDetails['category'] = !empty($shortcodeDetails['category']) ?
         $shortcodeDetails['category'] :
@@ -106,6 +147,8 @@ class Shortcodes {
       $shortcodeDetails['action_argument_value'] = !empty($shortcodeDetails['argument_value']) ?
         $shortcodeDetails['argument_value'] :
         false;
+      $shortcodeDetails['arguments'] = !empty($shortcodeDetails['arguments']) ?
+        $shortcodeDetails['arguments'] : [];
 
       $category = strtolower($shortcodeDetails['category']);
       $categoryClass = $this->getCategoryObject($category);
@@ -126,6 +169,7 @@ class Shortcodes {
           $this->subscriber,
           $this->queue,
           $content,
+          $shortcodeDetails['arguments'],
           $this->wpUserPreview
         );
         $processedShortcodes[] = ($customShortcode === $shortcode) ?

--- a/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -37,16 +37,21 @@ class Shortcodes {
   /** @var Subscriber */
   private $subscriberCategory;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     Date $dateCategory,
     Link $linkCategory,
     Newsletter $newsletterCategory,
-    Subscriber $subscriberCategory
+    Subscriber $subscriberCategory,
+    WPFunctions $wp
   ) {
     $this->dateCategory = $dateCategory;
     $this->linkCategory = $linkCategory;
     $this->newsletterCategory = $newsletterCategory;
     $this->subscriberCategory = $subscriberCategory;
+    $this->wp = $wp;
   }
 
   public function setNewsletter(NewsletterEntity $newsletter = null): void {
@@ -102,7 +107,7 @@ class Shortcodes {
    * The syntax is [category:action arg1="value1" arg2="value2"], it can have multiple arguments.
    */
   public function matchWPShortcode($shortcode) {
-    $atts = WPFunctions::get()->shortcodeParseAtts(trim($shortcode, '[]/'));
+    $atts = $this->wp->shortcodeParseAtts(trim($shortcode, '[]/'));
     if (empty($atts[0])) {
       return [];
     }
@@ -162,7 +167,7 @@ class Shortcodes {
           $this->wpUserPreview
         );
       } else {
-        $customShortcode = WPFunctions::get()->applyFilters(
+        $customShortcode = $this->wp->applyFilters(
           'mailpoet_newsletter_shortcode',
           $shortcode,
           $this->newsletter,

--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -435,6 +435,10 @@ class Functions {
     return delete_transient($transient);
   }
 
+  public function shortcodeParseAtts($text) {
+    return shortcode_parse_atts($text);
+  }
+
   public function singlePostTitle($prefix = '', $display = true) {
     return single_post_title($prefix, $display);
   }


### PR DESCRIPTION
[MAILPOET-3465]

We already had limited support for arguments: it was using a different syntax than WordPress (`[category:action | argument:argument_value]`), supported only one argument per shortcode and that argument was not passed to custom shortcode functions.

I have added support for WP-style shortcodes with multiple arguments (`[category:action arg1="value1" arg2="value2"]`), they are now passed to custom functions. The support for MailPoet-style shortcodes is retained for backwards compatibility.

One thing to be aware of is that the shortcode string passed to a custom function can be full (with arguments) or stripped of arguments depending on the `tracking.enabled` setting value. So if arguments are used in a custom function, the check for a proper shortcode inside it should verify only the beginning of a string, e.g. `if (strpos($shortcode, '[some:shortcode') !== 0) return $shortcode;` because the latter part of a shortcode can be changing. We should document this in the KB along with the new `$arguments` argument after the change is released.

[MAILPOET-3465]: https://mailpoet.atlassian.net/browse/MAILPOET-3465