### PR TITLE
Redirect to segments listing after segment editing [MAILPOET-3490]

### DIFF
--- a/assets/js/src/segments/list.jsx
+++ b/assets/js/src/segments/list.jsx
@@ -354,6 +354,7 @@ class SegmentList extends React.Component {
           messages={messages}
           search={false}
           endpoint="segments"
+          base_url="lists"
           onRenderItem={this.renderItem}
           columns={columns}
           bulk_actions={bulkActions}

--- a/assets/js/src/segments/segments.jsx
+++ b/assets/js/src/segments/segments.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HashRouter, Switch, Route } from 'react-router-dom';
+import {
+  HashRouter, Switch, Route, Redirect,
+} from 'react-router-dom';
 
 import MailPoet from 'mailpoet';
 import RoutedTabs from 'common/tabs/routed_tabs';
@@ -18,8 +20,12 @@ const container = document.getElementById('segments_container');
 const Tabs = () => (
   <>
     <ListHeading />
-    <RoutedTabs activeKey="" routerType="switch-only">
-      <Tab key="" route="*" title={MailPoet.I18n.t('pageTitle')}>
+    <RoutedTabs activeKey="lists" routerType="switch-only">
+      <Tab
+        key="lists"
+        route="lists/(.*)?"
+        title={MailPoet.I18n.t('pageTitle')}
+      >
         <SegmentList />
       </Tab>
       <Tab
@@ -39,12 +45,13 @@ const App = () => (
     <HashRouter>
       <Notices />
       <Switch>
+        <Route exact path="/" render={() => <Redirect to="/lists" />} />
         <Route path="/new" component={SegmentForm} />
         <Route path="/edit/:id" component={SegmentForm} />
         <Route path="/new-segment" component={DynamicSegmentForm} />
         <Route path="/edit-segment/:id" component={DynamicSegmentForm} />
         <Route path="/segments/(.*)?" component={Tabs} />
-        <Route path="*" component={Tabs} />
+        <Route path="/lists/(.*)?" component={Tabs} />
       </Switch>
     </HashRouter>
   </GlobalContext.Provider>

--- a/lib/API/JSON/v1/DynamicSegments.php
+++ b/lib/API/JSON/v1/DynamicSegments.php
@@ -195,6 +195,7 @@ class DynamicSegments extends APIEndpoint {
   }
 
   public function listing($data = []) {
+    $data['params'] = $data['params'] ?? ['segments']; // Dummy param to apply constraints properly
     $definition = $this->listingHandler->getListingDefinition($data);
     $items = $this->dynamicSegmentsListingRepository->getData($definition);
     $count = $this->dynamicSegmentsListingRepository->getCount($definition);

--- a/lib/API/JSON/v1/Segments.php
+++ b/lib/API/JSON/v1/Segments.php
@@ -84,6 +84,7 @@ class Segments extends APIEndpoint {
   }
 
   public function listing($data = []) {
+    $data['params'] = $data['params'] ?? ['lists']; // Dummy param to apply constraints properly
     $definition = $this->listingHandler->getListingDefinition($data);
     $items = $this->segmentListingRepository->getData($definition);
     $count = $this->segmentListingRepository->getCount($definition);


### PR DESCRIPTION
[MAILPOET-3490]

The Lists tab had no hash assigned to it (`/`), this caused URL hash tab navigation to be broken. I assigned a hash to the tab, this led to the disappearance of the `params` argument from the request which caused constraints not being applied to listings, i.e. both simple and dynamic segments shown on either tab. So I brought this dummy parameter back on the server side.

**For QA:**

Please verify that all listing functions (sorting, searching, filtering, pagination etc.) work on both Lists page tabs and data is displayed properly.

[MAILPOET-3490]: https://mailpoet.atlassian.net/browse/MAILPOET-3490