### PR TITLE
Refactor Forms::trash(), Forms::restore() and Forms::delete() to use Doctrine [MAILPOET-3039]

### DIFF
--- a/lib/API/JSON/v1/Forms.php
+++ b/lib/API/JSON/v1/Forms.php
@@ -271,14 +271,12 @@ class Forms extends APIEndpoint {
   }
 
   public function restore($data = []) {
-    $id = (isset($data['id']) ? (int)$data['id'] : false);
-    $form = Form::findOne($id);
-    if ($form instanceof Form) {
-      $form->restore();
-      $form = Form::findOne($form->id);
-      if(!$form instanceof Form) return $this->errorResponse();
+    $form = $this->getForm($data);
+
+    if ($form instanceof FormEntity) {
+      $this->formsRepository->restore($form);
       return $this->successResponse(
-        $form->asArray(),
+        $form->toArray(),
         ['count' => 1]
       );
     } else {

--- a/lib/API/JSON/v1/Forms.php
+++ b/lib/API/JSON/v1/Forms.php
@@ -289,14 +289,12 @@ class Forms extends APIEndpoint {
   }
 
   public function trash($data = []) {
-    $id = (isset($data['id']) ? (int)$data['id'] : false);
-    $form = Form::findOne($id);
-    if ($form instanceof Form) {
-      $form->trash();
-      $form = Form::findOne($form->id);
-      if(!$form instanceof Form) return $this->errorResponse();
+    $form = $this->getForm($data);
+
+    if ($form instanceof FormEntity) {
+      $this->formsRepository->trash($form);
       return $this->successResponse(
-        $form->asArray(),
+        $form->toArray(),
         ['count' => 1]
       );
     } else {

--- a/lib/API/JSON/v1/Forms.php
+++ b/lib/API/JSON/v1/Forms.php
@@ -303,10 +303,10 @@ class Forms extends APIEndpoint {
   }
 
   public function delete($data = []) {
-    $id = (isset($data['id']) ? (int)$data['id'] : false);
-    $form = Form::findOne($id);
-    if ($form instanceof Form) {
-      $form->delete();
+    $form = $this->getForm($data);
+
+    if ($form instanceof FormEntity) {
+      $this->formsRepository->delete($form);
 
       return $this->successResponse(null, ['count' => 1]);
     } else {

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -198,6 +198,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Form\Block\Textarea::class);
     $container->autowire(\MailPoet\Form\FormFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\FormHtmlSanitizer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Form\FormSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\Listing\FormListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\PreviewPage::class);
     $container->autowire(\MailPoet\Form\Templates\TemplateRepository::class);

--- a/lib/Form/FormSaveController.php
+++ b/lib/Form/FormSaveController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MailPoet\Form;
+
+use MailPoet\Entities\FormEntity;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class FormSaveController {
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    EntityManager $entityManager,
+    WPFunctions $wp
+  ) {
+    $this->entityManager = $entityManager;
+    $this->wp = $wp;
+  }
+
+  public function duplicate(FormEntity $formEntity): FormEntity {
+    $duplicate = clone $formEntity;
+    $duplicate->setName(sprintf(__('Copy of %s', 'mailpoet'), $formEntity->getName()));
+
+    // reset timestamps
+    $now = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
+    $duplicate->setCreatedAt($now);
+    $duplicate->setUpdatedAt($now);
+    $duplicate->setDeletedAt(null);
+
+    $this->entityManager->persist($duplicate);
+    $this->entityManager->flush();
+
+    return $duplicate;
+  }
+}

--- a/lib/Form/FormsRepository.php
+++ b/lib/Form/FormsRepository.php
@@ -37,7 +37,15 @@ class FormsRepository extends Repository {
   }
 
   public function trash(FormEntity $form) {
-    $form->setDeletedAt(Carbon::now());
+    $this->updateDeletedAt($form, Carbon::now());
+  }
+
+  public function restore(FormEntity $form) {
+    $this->updateDeletedAt($form, null);
+  }
+
+  private function updateDeletedAt(FormEntity $form, ?Carbon $value) {
+    $form->setDeletedAt($value);
     $this->persist($form);
     $this->flush();
   }

--- a/lib/Form/FormsRepository.php
+++ b/lib/Form/FormsRepository.php
@@ -4,6 +4,7 @@ namespace MailPoet\Form;
 
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\FormEntity;
+use MailPoetVendor\Carbon\Carbon;
 
 /**
  * @extends Repository<FormEntity>
@@ -33,5 +34,11 @@ class FormsRepository extends Repository {
       ->select('count(f.id)')
       ->getQuery()
       ->getSingleScalarResult();
+  }
+
+  public function trash(FormEntity $form) {
+    $form->setDeletedAt(Carbon::now());
+    $this->persist($form);
+    $this->flush();
   }
 }

--- a/lib/Form/FormsRepository.php
+++ b/lib/Form/FormsRepository.php
@@ -36,6 +36,11 @@ class FormsRepository extends Repository {
       ->getSingleScalarResult();
   }
 
+  public function delete(FormEntity $form) {
+    $this->remove($form);
+    $this->flush();
+  }
+
   public function trash(FormEntity $form) {
     $this->updateDeletedAt($form, Carbon::now());
   }

--- a/tests/integration/API/JSON/v1/FormsTest.php
+++ b/tests/integration/API/JSON/v1/FormsTest.php
@@ -239,6 +239,13 @@ class FormsTest extends \MailPoetTest {
     expect($response->meta['count'])->equals(1);
   }
 
+  public function testErrorWhenDeletingNonExistentForm() {
+    $response = $this->endpoint->delete(['id' => 'Invalid ID']);
+    expect($response->errors[0]['error'])->equals('not_found');
+    expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($response->meta)->isEmpty();
+  }
+
   public function testItCanDuplicateAForm() {
     $response = $this->endpoint->duplicate(['id' => $this->form1->getId()]);
     expect($response->status)->equals(APIResponse::STATUS_OK);

--- a/tests/integration/API/JSON/v1/FormsTest.php
+++ b/tests/integration/API/JSON/v1/FormsTest.php
@@ -202,10 +202,17 @@ class FormsTest extends \MailPoetTest {
     $response = $this->endpoint->restore(['id' => $this->form1->getId()]);
     expect($response->status)->equals(APIResponse::STATUS_OK);
     expect($response->data)->equals(
-      $this->reloadForm((int)$this->form1->getId())->asArray()
+      $this->form1->toArray()
     );
     expect($response->data['deleted_at'])->null();
     expect($response->meta['count'])->equals(1);
+  }
+
+  public function testErrorWhenRestoringNonExistentForm() {
+    $response = $this->endpoint->restore(['id' => 'Invalid ID']);
+    expect($response->errors[0]['error'])->equals('not_found');
+    expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($response->meta)->isEmpty();
   }
 
   public function testItCanTrashAForm() {

--- a/tests/integration/API/JSON/v1/FormsTest.php
+++ b/tests/integration/API/JSON/v1/FormsTest.php
@@ -228,10 +228,10 @@ class FormsTest extends \MailPoetTest {
   public function testItCanDuplicateAForm() {
     $response = $this->endpoint->duplicate(['id' => $this->form1->getId()]);
     expect($response->status)->equals(APIResponse::STATUS_OK);
-    $form = Form::where('name', 'Copy of Form 1')->findOne();
-    assert($form instanceof Form);
+    $form = $this->formsRepository->findOneBy(['name' => 'Copy of Form 1']);
+    $this->assertInstanceOf(FormEntity::class, $form);
     expect($response->data)->equals(
-      $form->asArray()
+      $form->toArray()
     );
     expect($response->meta['count'])->equals(1);
   }

--- a/tests/integration/API/JSON/v1/FormsTest.php
+++ b/tests/integration/API/JSON/v1/FormsTest.php
@@ -212,10 +212,17 @@ class FormsTest extends \MailPoetTest {
     $response = $this->endpoint->trash(['id' => $this->form2->getId()]);
     expect($response->status)->equals(APIResponse::STATUS_OK);
     expect($response->data)->equals(
-      $this->reloadForm((int)$this->form2->getId())->asArray()
+      $this->form2->toArray()
     );
     expect($response->data['deleted_at'])->notNull();
     expect($response->meta['count'])->equals(1);
+  }
+
+  public function testErrorWhenTrashingNonExistentForm() {
+    $response = $this->endpoint->trash(['id' => 'Invalid ID']);
+    expect($response->errors[0]['error'])->equals('not_found');
+    expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    expect($response->meta)->isEmpty();
   }
 
   public function testItCanDeleteAForm() {

--- a/tests/integration/Form/FormSaveControllerTest.php
+++ b/tests/integration/Form/FormSaveControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MailPoet\Form;
+
+use Codeception\Util\Fixtures;
+use MailPoet\Entities\FormEntity;
+
+class FormSaveControllerTest extends \MailPoetTest {
+  /** @var FormSaveController */
+  private $saveController;
+
+  public function _before() {
+    parent::_before();
+    $this->saveController = $this->diContainer->get(FormSaveController::class);
+  }
+
+  public function testItDuplicatesForms() {
+    $form = $this->createForm();
+    $duplicate = $this->saveController->duplicate($form);
+    expect($duplicate->getName())->equals('Copy of ' . $form->getName());
+    expect($duplicate->getDeletedAt())->equals(null);
+    expect($duplicate->getBody())->equals($form->getBody());
+    expect($duplicate->getStatus())->equals($form->getStatus());
+  }
+
+  public function _after() {
+    $this->cleanup();
+  }
+
+  private function createForm(): FormEntity {
+    $form = new FormEntity('My Form');
+    $form->setBody(Fixtures::get('form_body_template'));
+    $this->entityManager->persist($form);
+    $this->entityManager->flush();
+    return $form;
+  }
+
+  private function cleanup() {
+    $this->truncateEntity(FormEntity::class);
+  }
+}

--- a/tests/integration/Form/FormsRepositoryTest.php
+++ b/tests/integration/Form/FormsRepositoryTest.php
@@ -13,6 +13,13 @@ class FormsRepositoryTest extends \MailPoetTest {
     $this->repository = $this->diContainer->get(FormsRepository::class);
   }
 
+  public function testItCanDeleteForm() {
+    $form = $this->createForm('Form 1');
+    expect($this->repository->findOneById($form->getId()))->isInstanceOf(FormEntity::class);
+    $this->repository->delete($form);
+    expect($form->getId())->null();
+  }
+
   public function testItCanTrashForm() {
     $form = $this->createForm('Form 1');
     expect($form->getDeletedAt())->null();

--- a/tests/integration/Form/FormsRepositoryTest.php
+++ b/tests/integration/Form/FormsRepositoryTest.php
@@ -20,6 +20,14 @@ class FormsRepositoryTest extends \MailPoetTest {
     expect($form->getDeletedAt())->notNull();
   }
 
+  public function testItCanRestoreForm() {
+    $form = $this->createForm('Form 1');
+    $this->repository->trash($form);
+    expect($form->getDeletedAt())->notNull();
+    $this->repository->restore($form);
+    expect($form->getDeletedAt())->null();
+  }
+
   public function _after() {
     $this->truncateEntity(FormEntity::class);
   }

--- a/tests/integration/Form/FormsRepositoryTest.php
+++ b/tests/integration/Form/FormsRepositoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MailPoet\Form;
+
+use MailPoet\Entities\FormEntity;
+
+class FormsRepositoryTest extends \MailPoetTest {
+  /** @var FormsRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(FormsRepository::class);
+  }
+
+  public function testItCanTrashForm() {
+    $form = $this->createForm('Form 1');
+    expect($form->getDeletedAt())->null();
+    $this->repository->trash($form);
+    expect($form->getDeletedAt())->notNull();
+  }
+
+  public function _after() {
+    $this->truncateEntity(FormEntity::class);
+  }
+
+  private function createForm(string $name): FormEntity {
+    $form = new FormEntity($name);
+    $this->repository->persist($form);
+    $this->repository->flush();
+    return $form;
+  }
+}


### PR DESCRIPTION
This PR was created based on the branch of #3431. Please review #3431 first and once it is merged, review this PR.

[MAILPOET-3039]



[MAILPOET-3039]: https://mailpoet.atlassian.net/browse/MAILPOET-3039