### PR TITLE
Fix reset subscriptions in SegmentsRepository [MAILPOET-3551]

### DIFF
--- a/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/lib/Subscribers/SubscriberSegmentRepository.php
@@ -60,6 +60,10 @@ class SubscriberSegmentRepository extends Repository {
         'status' => SubscriberEntity::STATUS_UNSUBSCRIBED,
         'typeWordPress' => SegmentEntity::TYPE_WP_USERS,
       ]);
+      // Refresh SubscriberSegments status
+      foreach ($subscriber->getSubscriberSegments() as $subscriberSegment) {
+        $this->entityManager->refresh($subscriberSegment);
+      }
     }
   }
 


### PR DESCRIPTION
When we update subscriber segment status via executeUpdate,
we have to refresh the state from the DB.

[MAILPOET-3551]

[MAILPOET-3551]: https://mailpoet.atlassian.net/browse/MAILPOET-3551