### PR TITLE
Update PHPStan to 0.12.83 [MAILPOET-3491]

### DIFF
--- a/lib/Entities/NewsletterEntity.php
+++ b/lib/Entities/NewsletterEntity.php
@@ -280,7 +280,7 @@ class NewsletterEntity {
       $task = $queue->getTask();
       if ($task === null) continue;
 
-      $scheduled = new Carbon($task->getScheduledAt());
+      $scheduled = new Carbon($task->getScheduledAt()); // @phpstan-ignore-line - Carbon accepts a instance of DateTimeInterface but that is not mentioned in its phpdoc block causing a PHPStan error in this line.
       if ($scheduled < (new Carbon())->subDays(30)) continue;
 
       if (($status === self::STATUS_DRAFT) && ($task->getStatus() !== ScheduledTaskEntity::STATUS_SCHEDULED)) continue;

--- a/lib/Listing/Handler.php
+++ b/lib/Listing/Handler.php
@@ -12,10 +12,11 @@ class Handler {
     $data = $this->processData($data);
     $tableName = $modelClass::$_table;
     $model = Model::factory($modelClass);
+    $callback = [$modelClass, 'listingQuery'];
 
-    if (method_exists($modelClass, 'listingQuery')) {
+    if (method_exists($modelClass, 'listingQuery') && is_callable($callback)) {
       $customQuery = call_user_func_array(
-        [$modelClass, 'listingQuery'],
+        $callback,
         [$data]
       );
       if (!empty($data['selection'])) {
@@ -40,26 +41,29 @@ class Handler {
     $model = Model::factory($modelClass);
     // get groups
     $groups = [];
-    if (method_exists($modelClass, 'groups')) {
+    $groupsCallback = [$modelClass, 'groups'];
+    if (method_exists($modelClass, 'groups') && is_callable($groupsCallback)) {
       $groups = call_user_func_array(
-        [$modelClass, 'groups'],
+        $groupsCallback,
         [$data]
       );
     }
 
     // get filters
     $filters = [];
-    if (method_exists($modelClass, 'filters')) {
+    $filtersCallback = [$modelClass, 'filters'];
+    if (method_exists($modelClass, 'filters') && is_callable($filtersCallback)) {
       $filters = call_user_func_array(
-        [$modelClass, 'filters'],
+        $filtersCallback,
         [$data]
       );
     }
 
     // get items and total count
-    if (method_exists($modelClass, 'listingQuery')) {
+    $listingCallback = [$modelClass, 'listingQuery'];
+    if (method_exists($modelClass, 'listingQuery') && is_callable($listingCallback)) {
       $customQuery = call_user_func_array(
-        [$modelClass, 'listingQuery'],
+        $listingCallback,
         [$data]
       );
 

--- a/lib/Newsletter/Renderer/Blocks/Footer.php
+++ b/lib/Newsletter/Renderer/Blocks/Footer.php
@@ -14,6 +14,9 @@ class Footer {
     $lineHeight = sprintf(
       '%spx', StylesHelper::$defaultLineHeight * (int)$element['styles']['text']['fontSize']
     );
+    if (!is_string($element['text'])) {
+      throw new \RuntimeException('$element[\'text\'] should be a string.');
+    }
     $dOMParser = new pQuery();
     $DOM = $dOMParser->parseStr($element['text']);
     if (isset($element['styles']['link'])) {

--- a/lib/Newsletter/Renderer/Blocks/Header.php
+++ b/lib/Newsletter/Renderer/Blocks/Header.php
@@ -14,6 +14,9 @@ class Header {
     $lineHeight = sprintf(
       '%spx', StylesHelper::$defaultLineHeight * (int)$element['styles']['text']['fontSize']
     );
+    if (!is_string($element['text'])) {
+      throw new \RuntimeException('$element[\'text\'] should be a string.');
+    }
     $dOMParser = new pQuery();
     $DOM = $dOMParser->parseStr($element['text']);
     if (isset($element['styles']['link'])) {

--- a/tasks/phpstan/composer.json
+++ b/tasks/phpstan/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php-stubs/woocommerce-stubs": "^4.8",
-        "phpstan/phpstan": "0.12.64",
+        "phpstan/phpstan": "0.12.83",
         "phpstan/phpstan-doctrine": "0.12.26",
         "phpstan/phpstan-phpunit": "0.12.17",
         "szepeviktor/phpstan-wordpress": "^0.7.1"

--- a/tasks/phpstan/composer.lock
+++ b/tasks/phpstan/composer.lock
@@ -4,60 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dde8c425ddea68541ebea70a510a3d4c",
+    "content-hash": "b0b363f2808d7584a0e5e70750e57567",
     "packages": [
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "0.0.5",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "time": "2019-11-08T13:50:10+00:00"
-        },
         {
             "name": "php-stubs/woocommerce-stubs",
             "version": "v4.8.0",
@@ -140,16 +88,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.64",
+            "version": "0.12.83",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "23eb1cb7ae125f45f1d0e48051bcf67a9a9b08aa"
+                "reference": "4a967cec6efb46b500dd6d768657336a3ffe699f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/23eb1cb7ae125f45f1d0e48051bcf67a9a9b08aa",
-                "reference": "23eb1cb7ae125f45f1d0e48051bcf67a9a9b08aa",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4a967cec6efb46b500dd6d768657336a3ffe699f",
+                "reference": "4a967cec6efb46b500dd6d768657336a3ffe699f",
                 "shasum": ""
             },
             "require": {
@@ -178,6 +126,10 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.83"
+            },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
@@ -192,7 +144,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-21T11:59:02+00:00"
+            "time": "2021-04-03T15:35:45+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
@@ -453,5 +405,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/tasks/phpstan/php-version-dependent-config-libs.php
+++ b/tasks/phpstan/php-version-dependent-config-libs.php
@@ -9,7 +9,7 @@ $config['parameters']['phpVersion'] = $phpVersion;
 # see https://github.com/phpstan/phpstan/issues/4060
 if ($phpVersion < 80000) {
   $config['parameters']['ignoreErrors'][] = [
-    'message' => '#^Cannot access offset \\(int\\|string\\) on array\\|false#',
+    'message' => '#^Cannot access offset \\(int\\|string\\) on array\\<string#',
     'path' => __DIR__ . '/../../lib/Features/FeatureFlagsController.php',
     'count' => 1,
   ];

--- a/tests/integration/Models/SubscriberTest.php
+++ b/tests/integration/Models/SubscriberTest.php
@@ -737,7 +737,7 @@ class SubscriberTest extends \MailPoetTest {
 
     // it should not find deleted and nonexistent subscribers
     list($subscriber, $segment,) = $prepareData();
-    $subscriber[1]->deleted_at = date("Y-m-d H:i:s");
+    $subscriber[1]->deletedAt = date("Y-m-d H:i:s");
     $subscriber[1]->save();
     $subscriber[2]->delete();
     $subscribers = Subscriber::findSubscribersInSegments(

--- a/tests/unit/Newsletter/Renderer/Blocks/FooterTest.php
+++ b/tests/unit/Newsletter/Renderer/Blocks/FooterTest.php
@@ -52,4 +52,10 @@ class FooterTest extends \MailPoetUnitTest {
     $output = (new Footer)->render($this->block);
     expect($output)->stringContainsString('<a href="http://example.com" style="color:#aaaaaa;text-decoration:none">link</a>');
   }
+
+  public function testItRaisesExceptionIfTextIsNotString() {
+    $this->block['text'] = ['some', 'array'];
+    $this->expectException('RuntimeException');
+    (new Footer)->render($this->block);
+  }
 }

--- a/tests/unit/Newsletter/Renderer/Blocks/HeaderTest.php
+++ b/tests/unit/Newsletter/Renderer/Blocks/HeaderTest.php
@@ -52,4 +52,10 @@ class HeaderTest extends \MailPoetUnitTest {
     $output = (new Footer)->render($this->block);
     expect($output)->stringContainsString('<a href="http://example.com" style="color:#aaaaaa;text-decoration:underline">link</a>');
   }
+
+  public function testItRaisesExceptionIfTextIsNotString() {
+    $this->block['text'] = ['some', 'array'];
+    $this->expectException('RuntimeException');
+    (new Header)->render($this->block);
+  }
 }


### PR DESCRIPTION
This PR updates PHPStan to version 0.12.83 to fix a problem that we had where it was not possible to run PHPStan with PHP > 8.0.0. For more information, see this thread: https://github.com/phpstan/phpstan/discussions/4762.

Please note that I'm running Composer 2, and thus when I used to update PHPStan, it also updated the value of the field `plugin-api-version` in `composer.lock`. I'm not sure if this is a problem or not and if we have a reason to want to keep using Composer 1.

[MAILPOET-3491]

[MAILPOET-3491]: https://mailpoet.atlassian.net/browse/MAILPOET-3491