### PR TITLE
Error messages for product and category segments were inverted [MAILPOET-3561]

### DIFF
--- a/lib/API/JSON/v1/DynamicSegments.php
+++ b/lib/API/JSON/v1/DynamicSegments.php
@@ -132,9 +132,9 @@ class DynamicSegments extends APIEndpoint {
       case InvalidFilterException::MISSING_NEWSLETTER_ID:
         return WPFunctions::get()->__('Please select an email.', 'mailpoet');
       case InvalidFilterException::MISSING_PRODUCT_ID:
-        return WPFunctions::get()->__('Please select category.', 'mailpoet');
-      case InvalidFilterException::MISSING_CATEGORY_ID:
         return WPFunctions::get()->__('Please select product.', 'mailpoet');
+      case InvalidFilterException::MISSING_CATEGORY_ID:
+        return WPFunctions::get()->__('Please select category.', 'mailpoet');
       default:
         return WPFunctions::get()->__('An error occurred while saving data.', 'mailpoet');
     }


### PR DESCRIPTION
Users creating a product based WooCommerce segment without specifying a product were getting an error message asking them to select a category, and the inverse was happening for users creating a category based WooCommerce segment. This PR simply makes sure the proper error message is displayed.

[MAILPOET-3561]

[MAILPOET-3561]: https://mailpoet.atlassian.net/browse/MAILPOET-3561