### PR TITLE
Woo Subscriptions Segment [MAILPOET-3471]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,10 @@ jobs:
           command: |
             ./do test:acceptance-group-tests
       - run:
+          name: Download additional WP Plugins for tests
+          command: |
+            ./do download:woo-commerce-subscriptions-zip 3.0.14
+      - run:
           name: Dump tests ENV variables for acceptance tests
           command: |
             (printenv | grep WP_TEST_ > .env) || true
@@ -296,6 +300,9 @@ jobs:
       wordpress_image_version:
         type: string
         default: ''
+      woo_subscriptions_version:
+        type: string
+        default: ''
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
@@ -306,6 +313,12 @@ jobs:
       - run:
           name: "Set up virtual host"
           command: echo 127.0.0.1 mailpoet.loc | sudo tee -a /etc/hosts
+      - when:
+          condition: << parameters.woo_subscriptions_version >>
+          steps:
+            - run:
+                name: Download additional WP Plugins
+                command: ./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>
       - run:
           name: Run acceptance tests
           command: |
@@ -590,11 +603,13 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
+          woo_subscriptions_version: latest
           requires:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
+          woo_subscriptions_version: 3.0.14
           mysql_command: --max_allowed_packet=100M
           mysql_image_version: 5.5-ram
           wordpress_image_version: wp-5.3_php7.1_20210129.1

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -897,6 +897,17 @@ class RoboFile extends \Robo\Tasks {
     $this->say("Release '$version[name]' info was published on Slack.");
   }
 
+  public function downloadWooCommerceSubscriptionsZip($tag = null) {
+    require_once __DIR__ . '/tasks/GithubClient.php';
+    $help = "Use your GitHub username and a token from https://github.com/settings/tokens with 'repo' scopes.";
+    $githubClient = new \MailPoetTasks\GithubClient(
+      $this->getEnv('WP_GITHUB_USERNAME', $help),
+      $this->getEnv('WP_GITHUB_TOKEN', $help),
+      'woocommerce/woocommerce-subscriptions'
+    );
+    $githubClient->downloadReleaseZip('woocommerce-subscriptions.zip', __DIR__ . '/tools/vendor/', $tag);
+  }
+
   public function generateData($generatorName = null) {
     require_once __DIR__ . '/tests/DataGenerator/_bootstrap.php';
     $generator = new \MailPoet\Test\DataGenerator\DataGenerator(new \Codeception\Lib\Console\Output([]));

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import MailPoet from 'mailpoet';
+import { assign, compose, find } from 'lodash/fp';
+import Select from 'common/form/react_select/react_select';
+
+import {
+  OnFilterChange, SegmentTypes,
+  SelectOption,
+  WooCommerceSubscriptionFormItem,
+} from '../types';
+import { SegmentFormData } from '../segment_form_data';
+
+export const WooCommerceSubscriptionOptions = [
+  { value: 'hasActiveSubscription', label: MailPoet.I18n.t('segmentsActiveSubscription'), group: SegmentTypes.WooCommerceSubscription },
+];
+
+export function validateWooCommerceSubscription(
+  formItems: WooCommerceSubscriptionFormItem
+): boolean {
+  if (formItems.action === 'hasActiveSubscription' && !formItems.product_id) {
+    return false;
+  }
+  return true;
+}
+
+interface Props {
+  onChange: OnFilterChange;
+  item: WooCommerceSubscriptionFormItem;
+}
+
+export const WooCommerceSubscriptionFields: React.FunctionComponent<Props> = (
+  { onChange, item }
+) => {
+  const productOptions = SegmentFormData.subscriptionProducts?.map((product) => ({
+    value: product.id,
+    label: product.name,
+  }));
+
+  return (
+    <div className="mailpoet-form-field">
+      <div className="mailpoet-form-input mailpoet-form-select">
+        <Select
+          placeholder={MailPoet.I18n.t('selectWooSubscription')}
+          options={productOptions}
+          value={find(['value', item.product_id], productOptions)}
+          onChange={(option: SelectOption): void => compose([
+            onChange,
+            assign(item),
+          ])({ product_id: option.value })}
+        />
+      </div>
+    </div>
+  );
+};

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
@@ -4,20 +4,28 @@ import { assign, compose, find } from 'lodash/fp';
 import Select from 'common/form/react_select/react_select';
 
 import {
-  OnFilterChange, SegmentTypes,
+  OnFilterChange,
+  SegmentTypes,
   SelectOption,
   WooCommerceSubscriptionFormItem,
 } from '../types';
 import { SegmentFormData } from '../segment_form_data';
 
+enum WooCommerceSubscriptionsActionTypes {
+  ACTIVE_SUBSCRIPTIONS = 'hasActiveSubscription',
+}
+
 export const WooCommerceSubscriptionOptions = [
-  { value: 'hasActiveSubscription', label: MailPoet.I18n.t('segmentsActiveSubscription'), group: SegmentTypes.WooCommerceSubscription },
+  { value: WooCommerceSubscriptionsActionTypes.ACTIVE_SUBSCRIPTIONS, label: MailPoet.I18n.t('segmentsActiveSubscription'), group: SegmentTypes.WooCommerceSubscription },
 ];
 
 export function validateWooCommerceSubscription(
   formItems: WooCommerceSubscriptionFormItem
 ): boolean {
-  if (formItems.action === 'hasActiveSubscription' && !formItems.product_id) {
+  if (
+    formItems.action === WooCommerceSubscriptionsActionTypes.ACTIVE_SUBSCRIPTIONS
+    && !formItems.product_id
+  ) {
     return false;
   }
   return true;

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
@@ -38,7 +38,7 @@ export const WooCommerceSubscriptionFields: React.FunctionComponent<Props> = (
 
   return (
     <div className="mailpoet-form-field">
-      <div className="mailpoet-form-input mailpoet-form-select">
+      <div className="mailpoet-form-input mailpoet-form-select" data-automation-id="segment-woo-subscription-action">
         <Select
           placeholder={MailPoet.I18n.t('selectWooSubscription')}
           options={productOptions}

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
@@ -45,18 +45,18 @@ export const WooCommerceSubscriptionFields: React.FunctionComponent<Props> = (
   }));
 
   return (
-    <div className="mailpoet-form-field">
-      <div className="mailpoet-form-input mailpoet-form-select" data-automation-id="segment-woo-subscription-action">
-        <Select
-          placeholder={MailPoet.I18n.t('selectWooSubscription')}
-          options={productOptions}
-          value={find(['value', item.product_id], productOptions)}
-          onChange={(option: SelectOption): void => compose([
-            onChange,
-            assign(item),
-          ])({ product_id: option.value })}
-        />
-      </div>
-    </div>
+    <>
+      <div className="mailpoet-gap" />
+      <Select
+        placeholder={MailPoet.I18n.t('selectWooSubscription')}
+        automationId="segment-woo-subscription-action"
+        options={productOptions}
+        value={find(['value', item.product_id], productOptions)}
+        onChange={(option: SelectOption): void => compose([
+          onChange,
+          assign(item),
+        ])({ product_id: option.value })}
+      />
+    </>
   );
 };

--- a/assets/js/src/segments/dynamic/form.tsx
+++ b/assets/js/src/segments/dynamic/form.tsx
@@ -21,6 +21,7 @@ import { WordpressRoleSegmentOptions } from './dynamic_segments_filters/wordpres
 import { WooCommerceSubscriptionOptions } from './dynamic_segments_filters/woocommerce_subscription';
 import { SubscribersCounter } from './subscribers_counter';
 import { FormFilterFields } from './form_filter_fields';
+import { SegmentFormData } from './segment_form_data';
 
 import {
   AnyFormItem,
@@ -62,7 +63,7 @@ function getAvailableFilters(): GroupFilterValue[] {
       options: WooCommerceOptions,
     });
   }
-  if (MailPoet.isWoocommerceActive) {
+  if (MailPoet.isWoocommerceActive && SegmentFormData.canUseWooSubscriptions) {
     filters.push({
       label: MailPoet.I18n.t('woocommerceSubscriptions'),
       options: WooCommerceSubscriptionOptions,

--- a/assets/js/src/segments/dynamic/form.tsx
+++ b/assets/js/src/segments/dynamic/form.tsx
@@ -18,6 +18,7 @@ import Textarea from 'common/form/textarea/textarea';
 import { EmailSegmentOptions } from './dynamic_segments_filters/email';
 import { WooCommerceOptions } from './dynamic_segments_filters/woocommerce';
 import { WordpressRoleSegmentOptions } from './dynamic_segments_filters/wordpress_role';
+import { WooCommerceSubscriptionOptions } from './dynamic_segments_filters/woocommerce_subscription';
 import { SubscribersCounter } from './subscribers_counter';
 import { FormFilterFields } from './form_filter_fields';
 
@@ -59,6 +60,12 @@ function getAvailableFilters(): GroupFilterValue[] {
     filters.push({
       label: MailPoet.I18n.t('woocommerce'),
       options: WooCommerceOptions,
+    });
+  }
+  if (MailPoet.isWoocommerceActive) {
+    filters.push({
+      label: MailPoet.I18n.t('woocommerceSubscriptions'),
+      options: WooCommerceSubscriptionOptions,
     });
   }
   return filters;

--- a/assets/js/src/segments/dynamic/form_filter_fields.tsx
+++ b/assets/js/src/segments/dynamic/form_filter_fields.tsx
@@ -10,6 +10,7 @@ import {
 import { EmailFields } from './dynamic_segments_filters/email';
 import { WordpressRoleFields } from './dynamic_segments_filters/wordpress_role';
 import { WooCommerceFields } from './dynamic_segments_filters/woocommerce';
+import { WooCommerceSubscriptionFields } from './dynamic_segments_filters/woocommerce_subscription';
 
 export interface FilterFieldsProps {
   segmentType: FilterValue;
@@ -21,6 +22,7 @@ const filterFieldsMap = {
   [SegmentTypes.Email]: EmailFields,
   [SegmentTypes.WooCommerce]: WooCommerceFields,
   [SegmentTypes.WordPressRole]: WordpressRoleFields,
+  [SegmentTypes.WooCommerceSubscription]: WooCommerceSubscriptionFields,
 };
 
 export const FormFilterFields: React.FunctionComponent<FilterFieldsProps> = ({

--- a/assets/js/src/segments/dynamic/segment_form_data.ts
+++ b/assets/js/src/segments/dynamic/segment_form_data.ts
@@ -24,6 +24,8 @@ interface SegmentFormDataWindow extends Window {
     subject: string;
     id: string;
   }[];
+
+  mailpoet_can_use_woocommerce_subscriptions: boolean;
 }
 
 declare let window: SegmentFormDataWindow;
@@ -34,4 +36,5 @@ export const SegmentFormData = {
   productCategories: window.mailpoet_product_categories,
   newslettersList: window.mailpoet_newsletters_list,
   wordpressRoles: window.wordpress_editable_roles_list,
+  canUseWooSubscriptions: window.mailpoet_can_use_woocommerce_subscriptions,
 };

--- a/assets/js/src/segments/dynamic/segment_form_data.ts
+++ b/assets/js/src/segments/dynamic/segment_form_data.ts
@@ -8,6 +8,12 @@ interface SegmentFormDataWindow extends Window {
     id: string;
     name: string;
   }[];
+
+  mailpoet_subscription_products: {
+    id: string;
+    name: string;
+  }[];
+
   mailpoet_product_categories: {
     id: string;
     name: string;
@@ -24,6 +30,7 @@ declare let window: SegmentFormDataWindow;
 
 export const SegmentFormData = {
   products: window.mailpoet_products,
+  subscriptionProducts: window.mailpoet_subscription_products,
   productCategories: window.mailpoet_product_categories,
   newslettersList: window.mailpoet_newsletters_list,
   wordpressRoles: window.wordpress_editable_roles_list,

--- a/assets/js/src/segments/dynamic/subscribers_counter.tsx
+++ b/assets/js/src/segments/dynamic/subscribers_counter.tsx
@@ -3,6 +3,7 @@ import MailPoet from 'mailpoet';
 import { validateEmail } from './dynamic_segments_filters/email';
 import { validateWooCommerce } from './dynamic_segments_filters/woocommerce';
 import { validateWordpressRole } from './dynamic_segments_filters/wordpress_role';
+import { validateWooCommerceSubscription } from './dynamic_segments_filters/woocommerce_subscription';
 
 import { loadCount } from './subscribers_calculator';
 
@@ -25,6 +26,7 @@ const validationMap = {
   [SegmentTypes.Email]: validateEmail,
   [SegmentTypes.WooCommerce]: validateWooCommerce,
   [SegmentTypes.WordPressRole]: validateWordpressRole,
+  [SegmentTypes.WooCommerceSubscription]: validateWooCommerceSubscription,
 };
 
 function isFormValid(item: AnyFormItem): boolean {

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -2,6 +2,7 @@ export enum SegmentTypes {
   Email = 'email',
   WordPressRole = 'userRole',
   WooCommerce = 'woocommerce',
+  WooCommerceSubscription = 'woocommerceSubscription'
 }
 
 export enum EmailActionTypes {
@@ -38,6 +39,11 @@ export interface WooCommerceFormItem extends FormItem {
   number_of_orders_type?: string;
   number_of_orders_count?: number;
   number_of_orders_days?: number;
+}
+
+export interface WooCommerceSubscriptionFormItem extends FormItem {
+  action?: string;
+  product_id?: string;
 }
 
 export interface EmailFormItem extends FormItem {

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -55,6 +55,10 @@ export interface EmailFormItem extends FormItem {
   days?: string;
 }
 
-export type AnyFormItem = WordpressRoleFormItem | WooCommerceFormItem | EmailFormItem;
+export type AnyFormItem =
+  WordpressRoleFormItem |
+  WooCommerceFormItem |
+  WooCommerceSubscriptionFormItem |
+  EmailFormItem;
 
 export type OnFilterChange = (value: AnyFormItem) => void;

--- a/lib/AdminPages/Pages/Segments.php
+++ b/lib/AdminPages/Pages/Segments.php
@@ -81,6 +81,7 @@ class Segments {
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();
 
     $data['products'] = $this->wpPostListLoader->getProducts();
+    $data['subscription_products'] = $this->wpPostListLoader->getSubscriptionProducts();
     $data['is_woocommerce_active'] = $this->woocommerceHelper->isWooCommerceActive();
 
     $this->pageRenderer->displayPage('segments.html', $data);

--- a/lib/AdminPages/Pages/Segments.php
+++ b/lib/AdminPages/Pages/Segments.php
@@ -4,8 +4,10 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\ServicesChecker;
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Models\Newsletter;
+use MailPoet\Segments\SegmentDependencyValidator;
 use MailPoet\Services\Bridge;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
@@ -34,6 +36,9 @@ class Segments {
   /** @var WPPostListLoader */
   private $wpPostListLoader;
 
+  /** @var SegmentDependencyValidator */
+  private $segmentDependencyValidator;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
@@ -41,7 +46,8 @@ class Segments {
     WPFunctions $wp,
     WooCommerceHelper $woocommerceHelper,
     WPPostListLoader $wpPostListLoader,
-    SubscribersFeature $subscribersFeature
+    SubscribersFeature $subscribersFeature,
+    SegmentDependencyValidator $segmentDependencyValidator
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
@@ -50,6 +56,7 @@ class Segments {
     $this->wp = $wp;
     $this->woocommerceHelper = $woocommerceHelper;
     $this->wpPostListLoader = $wpPostListLoader;
+    $this->segmentDependencyValidator = $segmentDependencyValidator;
   }
 
   public function render() {
@@ -83,6 +90,9 @@ class Segments {
     $data['products'] = $this->wpPostListLoader->getProducts();
     $data['subscription_products'] = $this->wpPostListLoader->getSubscriptionProducts();
     $data['is_woocommerce_active'] = $this->woocommerceHelper->isWooCommerceActive();
+    $data['can_use_woocommerce_subscriptions'] = $this->segmentDependencyValidator->canUseDynamicFilterType(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION
+    );
 
     $this->pageRenderer->displayPage('segments.html', $data);
   }

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -274,6 +274,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\SegmentSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterDataMapper::class)->setPublic(true);
     // Services

--- a/lib/Entities/DynamicSegmentFilterData.php
+++ b/lib/Entities/DynamicSegmentFilterData.php
@@ -11,6 +11,7 @@ class DynamicSegmentFilterData {
   const TYPE_USER_ROLE = 'userRole';
   const TYPE_EMAIL = 'email';
   const TYPE_WOOCOMMERCE = 'woocommerce';
+  const TYPE_WOOCOMMERCE_SUBSCRIPTION = 'woocommerceSubscription';
 
   /**
    * @ORM\Column(type="serialized_array")

--- a/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -9,6 +9,7 @@ use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 
 class FilterDataMapper {
   public function map(array $data = []): DynamicSegmentFilterData {
@@ -23,6 +24,8 @@ class FilterDataMapper {
         return $this->createEmail($data);
       case DynamicSegmentFilterData::TYPE_WOOCOMMERCE:
         return $this->createWooCommerce($data);
+      case DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION:
+        return $this->createWooCommerceSubscription($data);
       default:
         throw new InvalidFilterException('Invalid type', InvalidFilterException::INVALID_TYPE);
     }
@@ -95,6 +98,24 @@ class FilterDataMapper {
       $filterData['number_of_orders_type'] = $data['number_of_orders_type'];
       $filterData['number_of_orders_count'] = $data['number_of_orders_count'];
       $filterData['number_of_orders_days'] = $data['number_of_orders_days'];
+    } else {
+      throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
+    }
+    return new DynamicSegmentFilterData($filterData);
+  }
+
+  /**
+   * @throws InvalidFilterException
+   */
+  private function createWooCommerceSubscription(array $data): DynamicSegmentFilterData {
+    if (empty($data['action'])) throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    $filterData = [
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
+      'action' => $data['action'],
+    ];
+    if ($data['action'] === WooCommerceSubscription::ACTION_HAS_ACTIVE) {
+      if (!isset($data['product_id'])) throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
+      $filterData['product_id'] = $data['product_id'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/lib/Segments/DynamicSegments/FilterHandler.php
+++ b/lib/Segments/DynamicSegments/FilterHandler.php
@@ -79,7 +79,7 @@ class FilterHandler {
         ->select("DISTINCT $subscribersTable.id as inner_subscriber_id")
         ->from($subscribersTable);
       // When a required plugin is missing we want to return empty result
-      if ($this->segmentDependencyValidator->getMissingPluginByFilter($filter)) {
+      if ($this->segmentDependencyValidator->getMissingPluginsByFilter($filter)) {
         $subscribersIdsQuery->andWhere('1 = 0');
       } else {
         $this->applyFilter($subscribersIdsQuery, $filter);

--- a/lib/Segments/DynamicSegments/FilterHandler.php
+++ b/lib/Segments/DynamicSegments/FilterHandler.php
@@ -13,6 +13,7 @@ use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\SegmentDependencyValidator;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -33,6 +34,9 @@ class FilterHandler {
   /** @var WooCommerceNumberOfOrders */
   private $wooCommerceNumberOfOrders;
 
+  /** @var WooCommerceSubscription */
+  private $wooCommerceSubscription;
+
   /** @var EntityManager */
   private $entityManager;
 
@@ -49,14 +53,16 @@ class FilterHandler {
     WooCommerceProduct $wooCommerceProduct,
     WooCommerceCategory $wooCommerceCategory,
     EmailOpensAbsoluteCountAction $emailOpensAbsoluteCount,
-    SegmentDependencyValidator $segmentDependencyValidator,
-    WooCommerceNumberOfOrders $wooCommerceNumberOfOrders
+    WooCommerceNumberOfOrders $wooCommerceNumberOfOrders,
+    WooCommerceSubscription $wooCommerceSubscription,
+    SegmentDependencyValidator $segmentDependencyValidator
   ) {
     $this->emailAction = $emailAction;
     $this->userRole = $userRole;
     $this->wooCommerceProduct = $wooCommerceProduct;
     $this->wooCommerceCategory = $wooCommerceCategory;
     $this->wooCommerceNumberOfOrders = $wooCommerceNumberOfOrders;
+    $this->wooCommerceSubscription = $wooCommerceSubscription;
     $this->entityManager = $entityManager;
     $this->segmentDependencyValidator = $segmentDependencyValidator;
     $this->emailOpensAbsoluteCount = $emailOpensAbsoluteCount;
@@ -129,6 +135,8 @@ class FilterHandler {
           return $this->emailOpensAbsoluteCount->apply($queryBuilder, $filter);
         }
         return $this->emailAction->apply($queryBuilder, $filter);
+      case DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION:
+        return $this->wooCommerceSubscription->apply($queryBuilder, $filter);
       case DynamicSegmentFilterData::TYPE_WOOCOMMERCE:
         $action = $filterData->getParam('action');
         if ($action === WooCommerceProduct::ACTION_PRODUCT) {

--- a/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class WooCommerceSubscription implements Filter {
+  const ACTION_HAS_ACTIVE = 'hasActiveSubscription';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(EntityManager $entityManager) {
+    $this->entityManager = $entityManager;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    global $wpdb;
+    $filterData = $filter->getFilterData();
+    $productId = (int)$filterData->getParam('product_id');
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return $queryBuilder->innerJoin(
+      $subscribersTable,
+      $wpdb->postmeta,
+      'postmeta',
+      "postmeta.meta_key = '_customer_user' AND $subscribersTable.wp_user_id=postmeta.meta_value"
+    )->innerJoin('postmeta',
+      $wpdb->posts,
+        'posts',
+        'postmeta.post_id = posts.id AND posts.post_type = "shop_subscription" AND posts.post_status = "wc-active"'
+    )->innerJoin('postmeta',
+      $wpdb->prefix . 'woocommerce_order_items',
+      'items',
+      'postmeta.post_id = items.order_id'
+    )->innerJoin(
+      'items',
+      $wpdb->prefix . 'woocommerce_order_itemmeta',
+      'itemmeta',
+      "itemmeta.order_item_id=items.order_item_id AND itemmeta.meta_key='_product_id' AND itemmeta.meta_value=:product" . $filter->getId()
+    )->setParameter('product' . $filter->getId(), $productId);
+  }
+}

--- a/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
@@ -27,11 +27,13 @@ class WooCommerceSubscription implements Filter {
       $wpdb->postmeta,
       'postmeta',
       "postmeta.meta_key = '_customer_user' AND $subscribersTable.wp_user_id=postmeta.meta_value"
-    )->innerJoin('postmeta',
+    )->innerJoin(
+      'postmeta',
       $wpdb->posts,
         'posts',
         'postmeta.post_id = posts.id AND posts.post_type = "shop_subscription" AND posts.post_status = "wc-active"'
-    )->innerJoin('postmeta',
+    )->innerJoin(
+      'postmeta',
       $wpdb->prefix . 'woocommerce_order_items',
       'items',
       'postmeta.post_id = items.order_id'

--- a/lib/Segments/SegmentDependencyValidator.php
+++ b/lib/Segments/SegmentDependencyValidator.php
@@ -42,16 +42,21 @@ class SegmentDependencyValidator {
   }
 
   public function getMissingPluginByFilter(DynamicSegmentFilterEntity $dynamicSegmentFilter): ?array {
-    $requiredPlugin = $this->getRequiredPluginName($dynamicSegmentFilter);
+    $requiredPlugin = $this->getRequiredPluginConfig($dynamicSegmentFilter->getFilterData()->getFilterType() ?? '');
     if (isset($requiredPlugin['id']) && !$this->wp->isPluginActive($requiredPlugin['id'])) {
       return $requiredPlugin;
     }
     return null;
   }
 
-  private function getRequiredPluginName(DynamicSegmentFilterEntity $dynamicSegmentFilter): ?array {
-    if (isset(self::REQUIRED_PLUGINS_BY_TYPE[$dynamicSegmentFilter->getFilterData()->getFilterType()])) {
-      return self::REQUIRED_PLUGINS_BY_TYPE[$dynamicSegmentFilter->getFilterData()->getFilterType()];
+  public function canUseDynamicFilterType(string $type) {
+    $requiredPlugin = $this->getRequiredPluginConfig($type);
+    return isset($requiredPlugin['id']) && $this->wp->isPluginActive($requiredPlugin['id']);
+  }
+
+  private function getRequiredPluginConfig(string $type): ?array {
+    if (isset(self::REQUIRED_PLUGINS_BY_TYPE[$type])) {
+      return self::REQUIRED_PLUGINS_BY_TYPE[$type];
     }
 
     return null;

--- a/lib/Segments/SegmentDependencyValidator.php
+++ b/lib/Segments/SegmentDependencyValidator.php
@@ -13,6 +13,10 @@ class SegmentDependencyValidator {
       'id' => 'woocommerce/woocommerce.php',
       'name' => 'WooCommerce',
     ],
+    DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION => [
+      'id' => 'woocommerce-subscriptions/woocommerce-subscriptions.php',
+      'name' => 'WooCommerce Subscriptions',
+    ],
   ];
 
   /** @var WPFunctions */

--- a/lib/WP/AutocompletePostListLoader.php
+++ b/lib/WP/AutocompletePostListLoader.php
@@ -21,6 +21,18 @@ class AutocompletePostListLoader {
     return $this->formatPosts($products);
   }
 
+  public function getSubscriptionProducts() {
+    $products = $this->wp->getResultsFromWpDb(
+      "SELECT `ID`, `post_title` FROM {$this->wp->getWPTableName('posts')} AS p
+        INNER JOIN {$this->wp->getWPTableName('term_relationships')} AS trel ON trel.object_id = p.id
+        INNER JOIN {$this->wp->getWPTableName('term_taxonomy')} AS ttax ON ttax.term_taxonomy_id = trel.term_taxonomy_id
+        INNER JOIN {$this->wp->getWPTableName('terms')} AS t ON ttax.term_id = t.term_id AND t.slug IN ('subscription', 'variable-subscription')
+        WHERE `p`.`post_type` = %s ORDER BY `post_title` ASC;",
+      'product'
+    );
+    return $this->formatPosts($products);
+  }
+
   public function getWooCommerceCategories() {
     return $this->formatTerms($this->wp->getCategories(['taxonomy' => 'product_cat', 'orderby' => 'name']));
   }

--- a/tasks/GithubClient.php
+++ b/tasks/GithubClient.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MailPoetTasks;
+
+use GuzzleHttp\Client;
+
+class GithubClient {
+  /** @var Client */
+  private $httpClient;
+
+  private const API_BASE_URI = 'https://api.github.com/repos';
+
+  public function __construct($username, $token, $repo) {
+    $this->httpClient = new Client([
+      'auth' => [$username, $token],
+      'headers' => [
+        'Accept' => 'application/vnd.github.v3+json',
+      ],
+      'base_uri' => self::API_BASE_URI . "/$repo/",
+    ]);
+  }
+
+  public function downloadReleaseZip($zip, $downloadDir, $tag = null) {
+    $release = $this->getRelease($tag);
+    if (!$release) {
+      throw new \Exception("Release $tag not found");
+    }
+    $assetDownloadUrl = null;
+    foreach ($release['assets'] as $asset) {
+      if ($asset['name'] === $zip) {
+        $assetDownloadUrl = $asset['url'];
+      }
+    }
+    if (!$assetDownloadUrl) {
+      throw new \Exception("Release zip for $tag not found");
+    }
+    $this->httpClient->get($assetDownloadUrl, ['sink' => $downloadDir . $zip, 'headers' => ['Accept' => 'application/octet-stream']]);
+  }
+
+  private function getRelease($tag = null) {
+    $path = 'releases/' . ($tag ? "tags/$tag" : 'latest');
+    $response = $this->httpClient->get($path);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+}

--- a/tasks/GithubClient.php
+++ b/tasks/GithubClient.php
@@ -38,7 +38,7 @@ class GithubClient {
   }
 
   private function getRelease($tag = null) {
-    $path = 'releases/' . ($tag ? "tags/$tag" : 'latest');
+    $path = 'releases/' . ($tag && $tag !== 'latest' ? "tags/$tag" : 'latest');
     $response = $this->httpClient->get($path);
     return json_decode($response->getBody()->getContents(), true);
   }

--- a/tasks/phpstan/custom-stubs.php
+++ b/tasks/phpstan/custom-stubs.php
@@ -1,0 +1,17 @@
+<?php
+// phpcs:ignoreFile - This file contains stubs for 3rd party functions and classes that might break our PHPCS rules
+
+if (!function_exists('members_get_cap_group')) {
+  function members_get_cap_group($name) {
+  }
+}
+
+if (!class_exists(\WC_Subscription::class)) {
+  class WC_Subscription extends WC_Product {
+  }
+}
+
+if (!function_exists('wcs_create_subscription')) {
+  function wcs_create_subscription($args) {
+  }
+}

--- a/tasks/phpstan/function-stubs.php
+++ b/tasks/phpstan/function-stubs.php
@@ -1,6 +1,0 @@
-<?php
-
-if (!function_exists('members_get_cap_group')) {
-  function members_get_cap_group($name) {
-  }
-}

--- a/tasks/phpstan/phpstan-tests.neon
+++ b/tasks/phpstan/phpstan-tests.neon
@@ -18,7 +18,7 @@ parameters:
   scanFiles:
       - PremiumContainerConfigurator.php
       - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
-      - function-stubs.php
+      - custom-stubs.php
   ignoreErrors:
     - '/Parameter #1 \$cssOrXPath of method AcceptanceTester::moveMouseOver\(\) expects string\|null, array<string, string> given./'
     - '/Function expect invoked with 1 parameter, 0 required\./'

--- a/tests/DataFactories/WooCommerceProduct.php
+++ b/tests/DataFactories/WooCommerceProduct.php
@@ -15,6 +15,8 @@ class WooCommerceProduct {
   const TYPE_DOWNLOADABLE = 'downloadable';
   const TYPE_EXTERNAL = 'external';
   const TYPE_VARIABLE = 'variable';
+  const TYPE_SUBSCRIPTION = 'subscription';
+  const TYPE_VARIABLE_SUBSCRIPTION = 'variable-subscription';
 
   public function __construct(\AcceptanceTester $tester) {
     $this->tester = $tester;

--- a/tests/DataFactories/WooCommerceSubscription.php
+++ b/tests/DataFactories/WooCommerceSubscription.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MailPoet\Test\DataFactories;
+
+class WooCommerceSubscription {
+  public function createSubscription(int $userId, int $subscriptionProductId): \WC_Subscription {
+    $args = [
+      'status' => 'active',
+      'customer_id' => $userId,
+      'billing_period' => 'month',
+      'billing_interval' => 1,
+    ];
+    $sub = wcs_create_subscription($args);
+    codecept_debug($sub);
+    $sub->add_product(wc_get_product($subscriptionProductId));
+    return $sub;
+  }
+}

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -45,6 +45,8 @@ class AcceptanceTester extends \Codeception\Actor {
   const MAIL_URL = 'http://mailhog:8025';
   const AUTHORIZED_SENDING_EMAIL = 'staff@mailpoet.com';
   const LISTING_LOADING_SELECTOR = '.mailpoet-listing-loading';
+  const WOO_COMMERCE_PLUGIN = 'woocommerce';
+  const WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN = 'woocommerce-subscriptions';
 
   /**
    * Define custom actions here
@@ -312,22 +314,22 @@ class AcceptanceTester extends \Codeception\Actor {
 
   public function activateWooCommerce() {
     $i = $this;
-    $i->cli(['plugin', 'activate', 'woocommerce']);
+    $i->cli(['plugin', 'activate', self::WOO_COMMERCE_PLUGIN]);
   }
 
   public function deactivateWooCommerce() {
     $i = $this;
-    $i->cli(['plugin', 'deactivate', 'woocommerce']);
+    $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_PLUGIN]);
   }
 
   public function activateWooCommerceSubscriptions() {
     $i = $this;
-    $i->cli(['plugin', 'activate', 'woocommerce-subscriptions']);
+    $i->cli(['plugin', 'activate', self::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN]);
   }
 
   public function deactivateWooCommerceSubscriptions() {
     $i = $this;
-    $i->cli(['plugin', 'deactivate', 'woocommerce-subscriptions']);
+    $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN]);
   }
 
   /**
@@ -532,5 +534,15 @@ class AcceptanceTester extends \Codeception\Actor {
     for ($j = 0; $j < mb_strlen($value); $j++) {
       $i->pressKey($selector, WebDriverKeys::BACKSPACE);// delete the field
     }
+  }
+
+  public function canTestWithPlugin(string $pluginSlug): bool {
+    $i = $this;
+    try {
+      $result = $i->cli(['plugin', 'is-installed', $pluginSlug]);
+    } catch (\Exception $e) {
+      return false;
+    }
+    return (int)$result === 0;
   }
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -320,6 +320,16 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['plugin', 'deactivate', 'woocommerce']);
   }
 
+  public function activateWooCommerceSubscriptions() {
+    $i = $this;
+    $i->cli(['plugin', 'activate', 'woocommerce-subscriptions']);
+  }
+
+  public function deactivateWooCommerceSubscriptions() {
+    $i = $this;
+    $i->cli(['plugin', 'deactivate', 'woocommerce-subscriptions']);
+  }
+
   /**
    * Order a product and create an account within the order process
    */

--- a/tests/_support/PluginsExtension.php
+++ b/tests/_support/PluginsExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MailPoet\TestsSupport;
+
+use Codeception\Events;
+use Codeception\Extension;
+
+class PluginsExtension extends Extension {
+
+  public static $events = [
+    Events::SUITE_BEFORE => 'setupInitialPluginsState',
+  ];
+
+  public function setupInitialPluginsState() {
+    exec('wp plugin deactivate woocommerce-subscriptions --allow-root');
+    exec('wp plugin deactivate woocommerce --allow-root');
+  }
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -42,6 +42,7 @@ modules:
         allow-root: true
 extensions:
   enabled:
+    - MailPoet\TestsSupport\PluginsExtension
     - ErrorsExtension
     - DefaultsExtension
     - CheckSkippedTestsExtension

--- a/tests/acceptance/WooCommerceSubscriptionsSegmentCest.php
+++ b/tests/acceptance/WooCommerceSubscriptionsSegmentCest.php
@@ -8,7 +8,10 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
 use MailPoet\Test\DataFactories\WooCommerceSubscription;
 
 class WooCommerceSubscriptionsSegmentCest {
-  public function _before(\AcceptanceTester $i) {
+  public function _before(\AcceptanceTester $i, $scenario) {
+    if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN)) {
+      $scenario->skip('Can‘t test without woocommerce-subscriptions');
+    }
     (new Settings())->withWooCommerceListImportPageDisplayed(true);
     (new Settings())->withCookieRevenueTrackingDisabled();
     $i->activateWooCommerce();

--- a/tests/acceptance/WooCommerceSubscriptionsSegmentCest.php
+++ b/tests/acceptance/WooCommerceSubscriptionsSegmentCest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\User;
+use MailPoet\Test\DataFactories\WooCommerceProduct;
+use MailPoet\Test\DataFactories\WooCommerceSubscription;
+
+class WooCommerceSubscriptionsSegmentCest {
+  public function _before(\AcceptanceTester $i) {
+    (new Settings())->withWooCommerceListImportPageDisplayed(true);
+    (new Settings())->withCookieRevenueTrackingDisabled();
+    $i->activateWooCommerce();
+  }
+
+  public function _after(\AcceptanceTester $i) {
+    $i->deactivateWooCommerce();
+  }
+
+  public function createSubscriptionSegmentForActiveSubscriptions(\AcceptanceTester $i) {
+    $i->activateWooCommerceSubscriptions();
+    $productFactory = new WooCommerceProduct($i);
+    $subscriptionProduct1 = $productFactory
+      ->withName('Subscription 1')
+      ->withType(WooCommerceProduct::TYPE_SUBSCRIPTION)
+      ->withPrice(10)
+      ->create();
+    $productFactory
+      ->withName('Subscription Variable')
+      ->withType(WooCommerceProduct::TYPE_VARIABLE_SUBSCRIPTION)
+      ->withPrice(20)
+      ->create();
+
+    $userFactory = new User();
+    $subscriber1 = $userFactory->createUser('Sub Scriber1', 'subscriber', 'subscriber1@example.com');
+    $subscriber2 = $userFactory->createUser('Sub Scriber2', 'subscriber', 'subscriber2@example.com');
+    $subscriptionFactory = new WooCommerceSubscription();
+    $subscriptionFactory->createSubscription($subscriber1->ID, $subscriptionProduct1['id']);
+    $subscriptionFactory->createSubscription($subscriber2->ID, $subscriptionProduct1['id']);
+
+    $segmentActionSelectElement = '[data-automation-id="select-segment-action"]';
+    $segmentTitle = 'Woo Active Subscriptions';
+    $i->wantTo('Create dynamic segment for subscriptions');
+    $i->login();
+    $i->amOnMailpoetPage('Lists');
+    $i->click('[data-automation-id="new-segment"]');
+    $i->fillField(['name' => 'name'], $segmentTitle);
+    $i->fillField(['name' => 'description'], 'Desc ' . $segmentTitle);
+    $i->selectOptionInReactSelect('has an active subscription', $segmentActionSelectElement);
+    $i->selectOptionInReactSelect('Subscription 1', '[data-automation-id="segment-woo-subscription-action"]');
+    $i->waitForText('Calculating segment size…');
+    $i->waitForText('This segment has 2 subscribers.');
+    $i->seeNoJSErrors();
+    $i->click('Save');
+    $i->wantTo('Check that segment contains correct subscribers');
+    $i->waitForElement('[data-automation-id="filters_all"]');
+    $i->waitForText($segmentTitle);
+    $i->clickItemRowActionByItemName($segmentTitle, 'View Subscribers');
+    $i->waitForText('subscriber1@example.com');
+    $i->waitForText('subscriber2@example.com');
+
+    $i->wantTo('Check that MailPoet plugin works when admin disables WooCommerce Subscriptions');
+    $i->deactivateWooCommerceSubscriptions();
+    $i->amOnMailpoetPage('Lists');
+    $i->waitForElement('[data-automation-id="dynamic-segments-tab"]');
+    $i->click('[data-automation-id="dynamic-segments-tab"]');
+    $i->waitForText($segmentTitle);
+    $i->canSee('Activate the WooCommerce Subscriptions plugin to see the number of subscribers and enable the editing of this segment.');
+
+    $i->wantTo('Check that admin can‘t add new subscriptions segment when WooCommerce Subscriptions is not active');
+    $i->click('[data-automation-id="new-segment"]');
+    $i->waitForElement($segmentActionSelectElement);
+    $i->fillField("$segmentActionSelectElement input", 'has an active subscription');
+    $i->canSee('No options', $segmentActionSelectElement);
+  }
+}

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -59,7 +59,7 @@ if [[ $CIRCLE_JOB == *"_latest" ]]; then
   WOOCOMMERCE_VERSION="latest"
 fi
 
-# install WooCommerce (activate & deactivate it to populate DB for backup)
+# install WooCommerce
 if [[ ! -d "/wp-core/wp-content/plugins/woocommerce" ]]; then
   cd /wp-core/wp-content/plugins
   WOOCOMMERCE_SOURCE_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce.zip"
@@ -80,8 +80,6 @@ if [[ ! -d "/wp-core/wp-content/plugins/woocommerce" ]]; then
   echo "Unzip Woocommerce plugin from $WOOCOMMERCE_TARGET_ZIP"
   unzip -q -o "$WOOCOMMERCE_TARGET_ZIP"
 fi
-wp plugin activate woocommerce
-wp plugin deactivate woocommerce
 
 # Install WooCommerce Subscriptions
 if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
@@ -95,6 +93,10 @@ if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
   echo "Unzip Woocommerce Subscription plugin from $WOOCOMMERCE_SUBS_ZIP"
   unzip -q -o "$WOOCOMMERCE_SUBS_ZIP" -d /wp-core/wp-content/plugins/
 fi
+
+# activate all plugins which source code want to access in tests runtime
+wp plugin activate woocommerce
+wp plugin activate woocommerce-subscriptions
 
 # add configuration
 CONFIG=''

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -83,6 +83,19 @@ fi
 wp plugin activate woocommerce
 wp plugin deactivate woocommerce
 
+# Install WooCommerce Subscriptions
+if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
+  WOOCOMMERCE_SUBS_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce-subscriptions.zip"
+  if [ ! -f "$WOOCOMMERCE_SUBS_ZIP" ]; then
+    echo "Downloading WooCommerce Subscription plugin zip"
+    cd /project
+    ./do download:woo-commerce-subscriptions-zip
+    cd /wp-core/wp-content/plugins
+  fi
+  echo "Unzip Woocommerce Subscription plugin from $WOOCOMMERCE_SUBS_ZIP"
+  unzip -q -o "$WOOCOMMERCE_SUBS_ZIP" -d /wp-core/wp-content/plugins/
+fi
+
 # add configuration
 CONFIG=''
 CONFIG+="define('WP_DEBUG', true);\n"

--- a/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -9,6 +9,7 @@ use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 
 class FilterDataMapperTest extends \MailPoetUnitTest {
   /** @var FilterDataMapper */
@@ -257,5 +258,44 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS,
     ]);
+  }
+
+  public function testItMapsWooCommerceSubscription() {
+    $data = [
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
+      'action' => WooCommerceSubscription::ACTION_HAS_ACTIVE,
+      'product_id' => '10',
+      'some_mess' => 'mess',
+    ];
+    $filter = $this->mapper->map($data);
+    expect($filter)->isInstanceOf(DynamicSegmentFilterData::class);
+    expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION);
+    expect($filter->getData())->equals([
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
+      'action' => WooCommerceSubscription::ACTION_HAS_ACTIVE,
+      'product_id' => '10',
+    ]);
+  }
+
+  public function testItChecksWooCommerceSubscriptionAction() {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing action');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
+    $data = [
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
+      'product_id' => '10',
+    ];
+    $this->mapper->map($data);
+  }
+
+  public function testItChecksWooCommerceSubscriptionProductId() {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing product');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_PRODUCT_ID);
+    $data = [
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
+      'action' => WooCommerceSubscription::ACTION_HAS_ACTIVE,
+    ];
+    $this->mapper->map($data);
   }
 }

--- a/views/segments.html
+++ b/views/segments.html
@@ -28,6 +28,7 @@
     var mailpoet_products = <%= json_encode(products) %>;
     var mailpoet_subscription_products = <%= json_encode(subscription_products) %>;
     var is_woocommerce_active = <%= json_encode(is_woocommerce_active)  %>;
+    var mailpoet_can_use_woocommerce_subscriptions = <%= json_encode(can_use_woocommerce_subscriptions)  %>;
 
   </script>
 <% endblock %>

--- a/views/segments.html
+++ b/views/segments.html
@@ -150,6 +150,9 @@
     'segmentsTipText': __('segments allow you to group your subscribers by other criteria, such as events and actions.'),
     'segmentsTipLink': __('Read more.'),
     'segmentsSubscriber': __('has WordPress user role'),
+    'segmentsActiveSubscription': __('has an active subscription'),
+    'woocommerceSubscriptions': _x('WooCommerce Subscriptions', 'Dynamic segment creation: User selects this to use any WooCommerce Subscriptions filters'),
+    'selectWooSubscription': __('Search subscriptions'),
 
     'oneDynamicSegmentTrashed': __('1 segment was moved to the trash.'),
     'multipleDynamicSegmentsTrashed': __('%$1d segments were moved to the trash.'),

--- a/views/segments.html
+++ b/views/segments.html
@@ -26,6 +26,7 @@
     var mailpoet_newsletters_list = <%= json_encode(newsletters_list)  %>;
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
     var mailpoet_products = <%= json_encode(products) %>;
+    var mailpoet_subscription_products = <%= json_encode(subscription_products) %>;
     var is_woocommerce_active = <%= json_encode(is_woocommerce_active)  %>;
 
   </script>


### PR DESCRIPTION
This PR adds a new dynamic segment for active WooCommerce subscriptions.

I tried using [wcs_get_subsciptions](https://github.com/wp-premium/woocommerce-subscriptions/blob/master/wcs-functions.php#L425) for the implementation of the subscriber filter but since it does additional 3 queries per subscriber I decided to go with direct SQL.

The PR also adds a basic infrastructure for working with 3rd party plugins.

[MAILPOET-3471]

[MAILPOET-3471]: https://mailpoet.atlassian.net/browse/MAILPOET-3471