### PR TITLE
WooCommerce versions in test [MAILPOET-3482]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
+            ./do download:woo-commerce-zip 5.2.2
             ./do download:woo-commerce-subscriptions-zip 3.0.14
       - run:
           name: Dump tests ENV variables for acceptance tests
@@ -301,6 +302,9 @@ jobs:
       wordpress_image_version:
         type: string
         default: ''
+      woo_core_version:
+        type: string
+        default: ''
       woo_subscriptions_version:
         type: string
         default: ''
@@ -314,6 +318,14 @@ jobs:
       - run:
           name: "Set up virtual host"
           command: echo 127.0.0.1 mailpoet.loc | sudo tee -a /etc/hosts
+      - when:
+          condition: << parameters.woo_core_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Core
+                command: |
+                    cd tests/docker
+                    docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -606,12 +618,14 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
+          woo_core_version: latest
           woo_subscriptions_version: latest
           requires:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
+          woo_core_version: 4.0.1
           woo_subscriptions_version: 3.0.10
           mysql_command: --max_allowed_packet=100M
           mysql_image_version: 5.5-ram

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,8 +318,10 @@ jobs:
           condition: << parameters.woo_subscriptions_version >>
           steps:
             - run:
-                name: Download additional WP Plugins
-                command: ./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>
+                name: Download WooCommerce Subscriptions
+                command: |
+                    cd tests/docker
+                    docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
       - run:
           name: Run acceptance tests
           command: |
@@ -610,7 +612,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_subscriptions_version: 3.0.14
+          woo_subscriptions_version: 3.0.10
           mysql_command: --max_allowed_packet=100M
           mysql_image_version: 5.5-ram
           wordpress_image_version: wp-5.3_php7.1_20210129.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,8 @@ jobs:
         destination: mocha
   acceptance_tests:
     working_directory: /home/circleci/mailpoet
-    machine: true
+    machine:
+      image: ubuntu-2004:202101-01
     parameters:
       group_arg:
         type: string

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TODO
 /vendor-prefixed-backup
 tests/_output/*
 tests/_support/_generated/*
+tests/plugins
 node_modules
 .env
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ $ ./do test:acceptance [--file=...] [--skip-deps]
   # if --file given then only tests on that file are executed.
   # if --skip-deps then it skips installation of composer dependencies.
 $ ./do test:acceptance-multisite [--file=...] [--skip-deps]
+  # download 3rd party plugins for tests
+  # if you pass tag it will attempt to download zip for the tag otherwise it downloads the latest release
+  # e.g. ./do download:woo-commerce-zip 5.20.0
+$ ./do download:woo-commerce-zip [<tag>]
+$ ./do download:woo-commerce-subscriptions-zip [<tag>]
   # same as test:acceptance but runs into a multisite wordpress setup.
 $ ./do delete:docker      # stop and remove all running docker containers.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ Then use `MailPoet.I18n.t('key')` to get the translated string on your Javascrip
 
 ## Acceptance testing
 
+To run the whole acceptance testing suite you need the docker daemon to be running and after that use a command: `./do test:acceptance`.
+If you want to run only a single test use the parameter `--file`:
+```bash
+./do test:acceptance --skip-deps --file tests/acceptance/ReceiveStandardEmailCest.php
+```
+The argument `--skip-deps` is useful locally to speed up the run.
+
+If there are some unexpected errors you can delete all the runtime and start again.
+To delete all the docker runtime for acceptance tests use the command `./do d:d`.
+
+When debugging you can add `$i->pause();` in to your test which pauses the execution.
+
 We are using Gravity Flow plugin's setup as an example for our acceptance test suite: https://www.stevenhenty.com/learn-acceptance-testing-deeply/
 
 From the article above:

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -903,12 +903,12 @@ class RoboFile extends \Robo\Tasks {
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
     $this->createGithubClient('woocommerce/woocommerce-subscriptions')
-      ->downloadReleaseZip('woocommerce-subscriptions.zip', __DIR__ . '/tools/vendor/', $tag);
+      ->downloadReleaseZip('woocommerce-subscriptions.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
   public function downloadWooCommerceZip($tag = null) {
     $this->createGithubClient('woocommerce/woocommerce')
-      ->downloadReleaseZip('woocommerce.zip', __DIR__ . '/tools/vendor/', $tag);
+      ->downloadReleaseZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
   public function generateData($generatorName = null) {

--- a/tasks/GithubClient.php
+++ b/tasks/GithubClient.php
@@ -29,9 +29,11 @@ class GithubClient {
       throw new \Exception("Release $tag not found");
     }
     $assetDownloadUrl = null;
+    $assetDownloadInfo = null;
     foreach ($release['assets'] as $asset) {
       if ($asset['name'] === $zip) {
         $assetDownloadUrl = $asset['url'];
+        $assetDownloadInfo = $asset['browser_download_url'];
       }
     }
     if (!$assetDownloadUrl) {
@@ -41,6 +43,7 @@ class GithubClient {
       mkdir($downloadDir, 0777, true);
     }
     $this->httpClient->get($assetDownloadUrl, ['sink' => $downloadDir . $zip, 'headers' => ['Accept' => 'application/octet-stream']]);
+    file_put_contents($downloadDir . '/' . $zip . '-info', $assetDownloadInfo);
   }
 
   private function getRelease($tag = null) {

--- a/tasks/GithubClient.php
+++ b/tasks/GithubClient.php
@@ -37,6 +37,9 @@ class GithubClient {
     if (!$assetDownloadUrl) {
       throw new \Exception("Release zip for $tag not found");
     }
+    if (!is_dir($downloadDir)) {
+      mkdir($downloadDir, 0777, true);
+    }
     $this->httpClient->get($assetDownloadUrl, ['sink' => $downloadDir . $zip, 'headers' => ['Accept' => 'application/octet-stream']]);
   }
 

--- a/tasks/GithubClient.php
+++ b/tasks/GithubClient.php
@@ -28,10 +28,15 @@ class GithubClient {
     if (!$release) {
       throw new \Exception("Release $tag not found");
     }
+    $namesToCheck = [
+      $zip,
+      str_replace('.zip', ".$tag.zip", $zip),
+      str_replace('.zip', "-$tag.zip", $zip),
+    ];
     $assetDownloadUrl = null;
     $assetDownloadInfo = null;
     foreach ($release['assets'] as $asset) {
-      if ($asset['name'] === $zip) {
+      if (in_array($asset['name'], $namesToCheck, true)) {
         $assetDownloadUrl = $asset['url'];
         $assetDownloadInfo = $asset['browser_download_url'];
       }

--- a/tasks/GithubClient.php
+++ b/tasks/GithubClient.php
@@ -10,14 +10,17 @@ class GithubClient {
 
   private const API_BASE_URI = 'https://api.github.com/repos';
 
-  public function __construct($username, $token, $repo) {
-    $this->httpClient = new Client([
-      'auth' => [$username, $token],
+  public function __construct($repo, $username = null, $token = null) {
+    $config = [
       'headers' => [
         'Accept' => 'application/vnd.github.v3+json',
       ],
       'base_uri' => self::API_BASE_URI . "/$repo/",
-    ]);
+    ];
+    if ($username && $token) {
+      $config['auth'] = [$username, $token];
+    }
+    $this->httpClient = new Client($config);
   }
 
   public function downloadReleaseZip($zip, $downloadDir, $tag = null) {

--- a/tests/DataFactories/WooCommerceSubscription.php
+++ b/tests/DataFactories/WooCommerceSubscription.php
@@ -11,7 +11,6 @@ class WooCommerceSubscription {
       'billing_interval' => 1,
     ];
     $sub = wcs_create_subscription($args);
-    codecept_debug($sub);
     $sub->add_product(wc_get_product($subscriptionProductId));
     return $sub;
   }

--- a/tests/acceptance/FormEditorAddNamesCest.php
+++ b/tests/acceptance/FormEditorAddNamesCest.php
@@ -15,37 +15,56 @@ class FormEditorAddNamesCest {
     $form->withName($formName)->withSegments([$segment])->withDisplayBelowPosts()->create();
     $firstNameLabelModified = 'Your First Name';
     $lastNameLabelModified = 'Your Last Name';
-    
+
     $i->wantTo('Add first and last name to the editor');
     $i->login();
     $i->amOnMailPoetPage('Forms');
     $i->waitForText($formName);
     $i->clickItemRowActionByItemName($formName, 'Edit');
     $i->waitForElement('[data-automation-id="form_title_input"]');
-    
+
     $i->wantTo('Add First & Last name blocks');
     $i->addFromBlockInEditor('First name');
     $i->addFromBlockInEditor('Last name');
-    
+
     $i->wantTo('Modify First & Last name blocks');
-    $i->click('[data-automation-id="editor_first_name_input"]');
-    $i->fillField('[data-automation-id="settings_first_name_label_input"]', $firstNameLabelModified);
-    $i->click('[data-automation-id="editor_last_name_input"]');
-    $i->fillField('[data-automation-id="settings_last_name_label_input"]', $lastNameLabelModified);
+    $firstNameLabelInput = '[data-automation-id="settings_first_name_label_input"]';
+    $this->openBlockSettings($i, '[data-automation-id="editor_first_name_input"]', $firstNameLabelInput);
+    $i->fillField($firstNameLabelInput, $firstNameLabelModified);
+    $lastNameLabelInput = '[data-automation-id="settings_last_name_label_input"]';
+    $this->openBlockSettings($i, '[data-automation-id="editor_last_name_input"]', $lastNameLabelInput);
+    $i->fillField($lastNameLabelInput, $lastNameLabelModified);
     $i->saveFormInEditor();
-    
+
     $i->wantTo('Reload page and check data were saved');
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');
-    $i->click('[data-automation-id="editor_first_name_input"]');
-    $i->seeInField('[data-automation-id="settings_first_name_label_input"]', $firstNameLabelModified);
-    $i->click('[data-automation-id="editor_last_name_input"]');
-    $i->seeInField('[data-automation-id="settings_last_name_label_input"]', $lastNameLabelModified);
+    $this->openBlockSettings($i, '[data-automation-id="editor_first_name_input"]', $firstNameLabelInput);
+    $i->seeInField($firstNameLabelInput, $firstNameLabelModified);
+    $this->openBlockSettings($i, '[data-automation-id="editor_last_name_input"]', $lastNameLabelInput);
+    $i->seeInField($lastNameLabelInput, $lastNameLabelModified);
 
     $i->wantTo('Check first & last names on front end');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
     $i->assertAttributeContains('[data-automation-id="form_first_name"]', 'placeholder', $firstNameLabelModified);
     $i->assertAttributeContains('[data-automation-id="form_last_name"]', 'placeholder', $lastNameLabelModified);
+  }
+
+  /**
+   * Clicks on block ($blockElement) within the block editor area
+   * and waits until some element is rendered in the sidebar
+   * Sometimes click doesn't open block settings. Can be caused by some react rerendering.
+   */
+  private function openBlockSettings(\AcceptanceTester $i, $blockElement, $sidebarElement) {
+    for ($retry = 0; $retry < 3; $retry++) {
+      try {
+        $i->click($blockElement);
+        $i->waitForElement($sidebarElement);
+      } catch (\Exception $e) {
+        $i->wait(0.2); // Wait for potential re-rendering
+        continue;
+      }
+    }
   }
 }

--- a/tests/acceptance/FormWithColumnsCest.php
+++ b/tests/acceptance/FormWithColumnsCest.php
@@ -65,6 +65,7 @@ class FormWithColumnsCest {
 
   private function addFieldInColumn(\AcceptanceTester $i, $name) {
     $i->click('(//button[@class="components-button block-editor-button-block-appender"])[1]');
+    $i->waitForElementVisible('.block-editor-inserter__search-input');
     $i->fillField('.block-editor-inserter__search-input', $name);
     $i->waitForText($name, 5, '.block-editor-block-types-list__item-title');
     $i->click($name, '.block-editor-block-types-list__list-item');

--- a/tests/acceptance/ManageSegmentsCest.php
+++ b/tests/acceptance/ManageSegmentsCest.php
@@ -135,6 +135,7 @@ class ManageSegmentsCest {
 
     $i->clickItemRowActionByItemName($segmentEditedTitle, 'Move to trash');
     $i->waitForText('1 segment was moved to the trash.');
+    $i->waitForElementClickable('[data-automation-id="filters_trash"]');
     $i->click('[data-automation-id="filters_trash"]');
     $i->waitForText($segmentEditedTitle);
     $i->clickItemRowActionByItemName($segmentEditedTitle, 'Delete permanently');

--- a/tests/acceptance/SubscriberManageImportExportCest.php
+++ b/tests/acceptance/SubscriberManageImportExportCest.php
@@ -158,6 +158,7 @@ class SubscriberManageImportExportCest {
     $i->click('input#new_segment_process');
     // trigger dropdown to display selections and search for recently created list
     $i->waitForElementVisible('textarea.select2-search__field');
+    $i->wait(0.5); // We need to give select 2 some time to rerender after the new list was added
     $i->selectOptionInSelect2($newListName);
     $i->click('[data-automation-id="import-next-step"]');
     $i->waitForText('Import again');

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -97,6 +97,10 @@ sed -i "s/define( *'WP_DEBUG', false *);/$CONFIG/" /wp-core/wp-config.php
 wp plugin activate woocommerce
 wp plugin activate woocommerce-subscriptions
 
+# print info about installed plugins
+wp plugin get woocommerce
+wp plugin get woocommerce-subscriptions
+
 # activate MailPoet
 wp plugin activate mailpoet/mailpoet.php
 

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -79,10 +79,6 @@ if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
   unzip -q -o "$WOOCOMMERCE_SUBS_ZIP" -d /wp-core/wp-content/plugins/
 fi
 
-# activate all plugins which source code want to access in tests runtime
-wp plugin activate woocommerce
-wp plugin activate woocommerce-subscriptions
-
 # add configuration
 CONFIG=''
 CONFIG+="define('WP_DEBUG', true);\n"
@@ -95,7 +91,11 @@ CONFIG+="define('DISABLE_WP_CRON', true);\n"
 # fix for WP CLI bug (https://core.trac.wordpress.org/ticket/44569)
 CONFIG+="if (!isset(\$_SERVER['SERVER_NAME'])) \$_SERVER['SERVER_NAME'] = '';\n"
 
-sed -i "s/define( *'WP_DEBUG', false *);/$CONFIG/" ./wp-config.php
+sed -i "s/define( *'WP_DEBUG', false *);/$CONFIG/" /wp-core/wp-config.php
+
+# activate all plugins which source code want to access in tests runtime
+wp plugin activate woocommerce
+wp plugin activate woocommerce-subscriptions
 
 # activate MailPoet
 wp plugin activate mailpoet/mailpoet.php

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -54,7 +54,7 @@ fi
 # Install WooCommerce
 if [[ ! -d "/wp-core/wp-content/plugins/woocommerce" ]]; then
   cd /wp-core/wp-content/plugins
-  WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce.zip"
+  WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
   if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
     echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin latest zip"
     cd /project
@@ -68,7 +68,7 @@ fi
 
 # Install WooCommerce Subscriptions
 if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
-  WOOCOMMERCE_SUBS_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce-subscriptions.zip"
+  WOOCOMMERCE_SUBS_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce-subscriptions.zip"
   if [ ! -f "$WOOCOMMERCE_SUBS_ZIP" ]; then
     echo "WooCommerce Subscriptions plugin zip not found. Downloading WooCommerce Subscription plugin latest zip"
     cd /project

--- a/tests/docker/codeception/docker-entrypoint.sh
+++ b/tests/docker/codeception/docker-entrypoint.sh
@@ -51,43 +51,28 @@ if [[ -z "${SKIP_DEPS}" ]]; then
   cd - >/dev/null
 fi
 
-WOOCOMMERCE_VERSION="tags/5.0.0"
-if [[ $CIRCLE_JOB == *"_oldest" ]]; then
-  WOOCOMMERCE_VERSION="tags/4.0.1"
-fi
-if [[ $CIRCLE_JOB == *"_latest" ]]; then
-  WOOCOMMERCE_VERSION="latest"
-fi
-
-# install WooCommerce
+# Install WooCommerce
 if [[ ! -d "/wp-core/wp-content/plugins/woocommerce" ]]; then
   cd /wp-core/wp-content/plugins
-  WOOCOMMERCE_SOURCE_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce.zip"
-  WOOCOMMERCE_TARGET_ZIP="/wp-core/wp-content/plugins/woocommerce.zip"
-  # download woocommerce plugin if file doesn't exist
-  if [ -f "$WOOCOMMERCE_SOURCE_ZIP" ] && [[ $CIRCLE_JOB != *"_oldest" ]] && [[ $CIRCLE_JOB != *"_latest" ]]; then
-    echo "Copy Woocommerce plugin from $WOOCOMMERCE_SOURCE_ZIP"
-    cp "$WOOCOMMERCE_SOURCE_ZIP" "$WOOCOMMERCE_TARGET_ZIP"
-  else
-    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/woocommerce/woocommerce/releases/$WOOCOMMERCE_VERSION \
-            | grep browser_download_url \
-            | grep woocommerce \
-            | cut -d '"' -f 4)
-    echo "Downloading Woocommerce plugin from $DOWNLOAD_URL"
-    curl -s -L --create-dirs -o "$WOOCOMMERCE_TARGET_ZIP" "$DOWNLOAD_URL"
+  WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce.zip"
+  if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
+    echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin latest zip"
+    cd /project
+    ./do download:woo-commerce-zip latest
+    cd /wp-core/wp-content/plugins
   fi
 
-  echo "Unzip Woocommerce plugin from $WOOCOMMERCE_TARGET_ZIP"
-  unzip -q -o "$WOOCOMMERCE_TARGET_ZIP"
+  echo "Unzip Woocommerce plugin from $WOOCOMMERCE_CORE_ZIP"
+  unzip -q -o "$WOOCOMMERCE_CORE_ZIP" -d /wp-core/wp-content/plugins/
 fi
 
 # Install WooCommerce Subscriptions
 if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
   WOOCOMMERCE_SUBS_ZIP="/wp-core/wp-content/plugins/mailpoet/tools/vendor/woocommerce-subscriptions.zip"
   if [ ! -f "$WOOCOMMERCE_SUBS_ZIP" ]; then
-    echo "Downloading WooCommerce Subscription plugin zip"
+    echo "WooCommerce Subscriptions plugin zip not found. Downloading WooCommerce Subscription plugin latest zip"
     cd /project
-    ./do download:woo-commerce-subscriptions-zip
+    ./do download:woo-commerce-subscriptions-zip latest
     cd /wp-core/wp-content/plugins
   fi
   echo "Unzip Woocommerce Subscription plugin from $WOOCOMMERCE_SUBS_ZIP"

--- a/tools/install.php
+++ b/tools/install.php
@@ -5,11 +5,6 @@ $tools = [
   'https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar' => 'php-scoper.phar',
   'https://github.com/nette/tracy/releases/download/v2.7.2/tracy.phar' => 'tracy.phar',
 ];
-
-$repositories = [
-  'woocommerce.zip' => 'woocommerce/woocommerce',
-];
-
 // ensure installation in dev-mode only
 $isDevMode = (bool)getenv('COMPOSER_DEV_MODE');
 if (!$isDevMode) {
@@ -46,30 +41,4 @@ foreach ($tools as $url => $path) {
   $pharInfoPath = "$pharPath.info";
 
   downloadFile($url, $pharPath, $pharInfoPath);
-}
-
-$curl = curl_init();
-foreach ($repositories as $filename => $repository) {
-  curl_setopt_array($curl, [
-    CURLOPT_URL => "https://api.github.com/repos/{$repository}/releases/latest",
-    CURLOPT_HTTPGET => true,
-    CURLOPT_RETURNTRANSFER => true,
-    CURLOPT_HTTPHEADER => [
-      'User-Agent: Awesome-Octocat-App',
-      'Content-Type: application/json',
-      'Accept: application/json',
-    ],
-  ]);
-
-  $result = curl_exec($curl);
-  curl_close($curl);
-
-  $result = json_decode($result, true);
-  $assets = reset($result['assets']);
-  $fileUrl = $assets['browser_download_url'];
-
-  $zipPath = "$vendorDir/$filename";
-  $zipInfoPath = "$zipPath.info";
-
-  downloadFile($fileUrl, $zipPath, $zipInfoPath);
 }


### PR DESCRIPTION
This PR contains a few more changes.

- I've refactored download the WooCommerce plugin so that it uses the same mechanism as WooCommere Subscriptions
- Changed directory where we download the 3rd party plugins
- Updated version of the image we use on Circle CI machine executor for acceptance tests. The image version refers to AWS Ami that is available. We were using some old default Ubuntu 14 with a quite old docker version.
- Fixed a couple of flaky acceptance test I run into during testing

[MAILPOET-3482]

[MAILPOET-3482]: https://mailpoet.atlassian.net/browse/MAILPOET-3482