### PR TITLE
Fix flaky Woo Subscriptions test [MAILPOET-3577]

### DIFF
--- a/tests/DataFactories/WooCommerceOrder.php
+++ b/tests/DataFactories/WooCommerceOrder.php
@@ -93,11 +93,15 @@ class WooCommerceOrder {
     $orderOut = $this->tester->cliToArray(['wc', 'shop_order', 'get', $createOutput[0], '--format=json', '--user=admin']);
     $order = json_decode($orderOut[0], true);
     if (isset($this->data['date_created'])) {
-      wp_update_post([
-        'ID' => $order['id'],
-        'post_date' => $this->data['date_created'],
-        'post_date_gmt' => get_gmt_from_date( $this->data['date_created'] ),
-      ]);
+      global $wpdb;
+      $dateCreated = $this->data['date_created'];
+      $dateCreatedGmt = get_gmt_from_date( $this->data['date_created']);
+      $wpdb->query(
+        "UPDATE $wpdb->posts SET
+        `post_date` = '{$dateCreated}',
+        `post_modified_gmt` = '{$dateCreatedGmt}'
+        WHERE ID = {$order['id']};"
+      );
     }
     return $order;
   }


### PR DESCRIPTION
After debugging I found that the test failed when ran after [WooCommerceSetupPageCest:: setupPageRedirectionTest](https://github.com/mailpoet/mailpoet/blob/master/tests/acceptance/WooCommerceSetupPageCest.php#L94). 
It seems that updating order using `wp_update_post` causes that we are not able to use
`wc_get_product` (it returns false) and probably some other functions from WooCommerce.

We needed `wp_update_post` for updating post_created_at in order to create some older orders. I replaced `wp_update_post` with a DB query and it fixed the issue.
[MAILPOET-3577]

[MAILPOET-3577]: https://mailpoet.atlassian.net/browse/MAILPOET-3577