### PR TITLE
Optimise tasks SQL query in inactive subscribers detection [MAILPOET-3582]

### DIFF
--- a/lib/Subscribers/InactiveSubscribersController.php
+++ b/lib/Subscribers/InactiveSubscribersController.php
@@ -94,15 +94,14 @@ class InactiveSubscribersController {
       (INDEX task_id_ids (id))
       SELECT DISTINCT task_id as id FROM $sendingQueuesTable as sq
         JOIN $scheduledTasksTable as st ON sq.task_id = st.id
-        WHERE st.processed_at > '%s'
-        AND st.processed_at < '%s'
-        AND EXISTS (
-          SELECT 1
+        JOIN (
+          SELECT so.newsletter_id
           FROM $statisticsOpensTable as so
-          WHERE so.created_at > '%s'
-          AND so.newsletter_id = sq.newsletter_id
-        )",
-        $thresholdDateIso, $dayAgoIso, $thresholdDateIso
+          GROUP BY so.newsletter_id
+        ) sno ON sno.newsletter_id = sq.newsletter_id
+        WHERE st.processed_at > '%s'
+        AND st.processed_at < '%s'",
+        $thresholdDateIso, $dayAgoIso
       );
       ORM::rawExecute($inactivesTaskIdsTable);
       $this->inactivesTaskIdsTableCreated = true;


### PR DESCRIPTION
There are 2 optimizations in the PR. The first optimization is that the sub query for checking that a newsletter associated with a task has something tracked was moved from where clause to join so that it runs only once instead of for every line. The second was the removal `created_at` condition from the subquery.

We don’t necessarily need to use where `created_at` for statics open since we already restrict the sending task by the `processed_at` date and it is the `created_at` that forces the DB to scan multiple rows. It is impossible for a standard newsletter or post notification to have a record in opens stats before it was sent.  Automated and welcome emails have some opens logged further in the past so the check might not work correctly for sites using welcome emails that turned off tracking for some time and then turned it on again. I think it is something we can accept as a tradeof. 

[MAILPOET-3582]

[MAILPOET-3582]: https://mailpoet.atlassian.net/browse/MAILPOET-3582