### PR TITLE
Fix double escaped button in newsletter [MAILPOET-3538]

### DIFF
--- a/lib/Newsletter/ApiDataSanitizer.php
+++ b/lib/Newsletter/ApiDataSanitizer.php
@@ -6,8 +6,13 @@ class ApiDataSanitizer {
   /** @var NewsletterHtmlSanitizer */
   private $htmlSanitizer;
 
-  private const SANITIZE_KEY_WHITELIST = [
-    'text',
+  /**
+   * Configuration specifies which block types and properties within newsletters content blocks are sanitized
+   */
+  private const SANITIZATION_CONFIG = [
+    'header' => ['text'],
+    'footer' => ['text'],
+    'text' => ['text'],
   ];
 
   public function __construct(NewsletterHtmlSanitizer $htmlSanitizer) {
@@ -15,15 +20,36 @@ class ApiDataSanitizer {
   }
 
   public function sanitizeBody(array $body): array {
-    foreach ($body as $blockName => $block) {
-      if (is_array($block)) {
-        $sanitizedBlock = $this->sanitizeBody($block);
-      } else {
-        $sanitizedBlock = $block && in_array($blockName, self::SANITIZE_KEY_WHITELIST, true) ? $this->htmlSanitizer->sanitize($block) : $block;
-      }
-      $body[$blockName] = $sanitizedBlock;
+    if (isset($body['content']) && isset($body['content']['blocks']) && is_array($body['content']['blocks'])) {
+      $body['content']['blocks'] = $this->sanitizeBlocks($body['content']['blocks']);
     }
-
     return $body;
+  }
+
+  private function sanitizeBlocks(array $blocks): array {
+    foreach ($blocks as $key => $block) {
+      if (!is_array($block) || !isset($block['type'])) {
+        continue;
+      }
+      if (isset($block['blocks']) && is_array($block['blocks'])) {
+        $blocks[$key]['blocks'] = $this->sanitizeBlocks($block['blocks']);
+      } else {
+        $blocks[$key] = $this->sanitizeBlock($block);
+      }
+    };
+    return $blocks;
+  }
+
+  private function sanitizeBlock(array $block): array {
+    if (!isset(self::SANITIZATION_CONFIG[$block['type']])) {
+      return $block;
+    }
+    foreach (self::SANITIZATION_CONFIG[$block['type']] as $property) {
+      if (!isset($block[$property])) {
+        continue;
+      }
+      $block[$property] = $this->htmlSanitizer->sanitize($block[$property]);
+    }
+    return $block;
   }
 }

--- a/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -8,25 +8,29 @@ class ApiDataSanitizerTest extends \MailPoetTest {
   private $sanitizer;
 
   private $body = [
-    [
-      'type' => 'container',
-      'columnLayout' => false,
-      'orientation' => 'vertical',
+    'content' => [
       'blocks' => [
         [
-          'type' => 'text',
-          'text' => '<p>Thanks for reading.<img src=x onerror=alert(4)> See you soon!</p>',
+          'type' => 'container',
+          'columnLayout' => false,
+          'orientation' => 'vertical',
+          'blocks' => [
+            [
+              'type' => 'text',
+              'text' => '<p>Thanks for reading.<img src=x onerror=alert(4)> See you soon!</p>',
+            ],
+            [
+              'type' => 'footer',
+              'text' => '<p><a href="[link:subscription_unsubscribe_url]">Unsubscribe</a><br />Add your postal address here!</p>',
+            ],
+          ],
         ],
         [
-          'type' => 'footer',
-          'text' => '<p><a href="[link:subscription_unsubscribe_url]">Unsubscribe</a><br />Add your postal address here!</p>',
+          'type' => 'header',
+          'link' => '',
+          'text' => 'http://some.url/wp-c\'"><img src=x onerror=alert(2)>ontent/fake-logo.png',
         ],
       ],
-    ],
-    [
-      'type' => 'header',
-      'link' => '',
-      'text' => 'http://some.url/wp-c\'"><img src=x onerror=alert(2)>ontent/fake-logo.png',
     ],
   ];
 
@@ -37,7 +41,7 @@ class ApiDataSanitizerTest extends \MailPoetTest {
 
   public function testItSanitizesBody() {
     $result = $this->sanitizer->sanitizeBody($this->body);
-    $container = $result[0];
+    $container = $result['content']['blocks'][0];
     $block1 = $container['blocks'][0];
     $block2 = $container['blocks'][1];
     expect($container['columnLayout'])->equals(false);
@@ -45,7 +49,7 @@ class ApiDataSanitizerTest extends \MailPoetTest {
     expect($block1['text'])->equals('<p>Thanks for reading. See you soon!</p>');
     expect($block2['type'])->equals('footer');
     expect($block2['text'])->equals('<p><a href="[link:subscription_unsubscribe_url]">Unsubscribe</a><br />Add your postal address here!</p>');
-    $image = $result[1];
+    $image = $result['content']['blocks'][1];
     expect($image['type'])->equals('header');
     expect($image['link'])->equals('');
     expect($image['text'])->equals('http://some.url/wp-c\'"&gt;ontent/fake-logo.png');


### PR DESCRIPTION
I've fixed this by modifying API data sanitiser for newsletter so that it fixes text property only for specific blocks, that are using TinyMCE for editing.

[MAILPOET-3538]

[MAILPOET-3538]: https://mailpoet.atlassian.net/browse/MAILPOET-3538