### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,35 @@
+# This file contains revisions that introduced multiple changes that have no effect on aplication logic.
+# You can add it to you local git config using command: git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Convert PHP property names to camel case
+8c848cfa2883d9a0c9614d0be0e9248c5a02d340
+
+# Convert PHP variables to camel case
+54549ff037d6c2ad868cae6e2117ee862297fdbf
+
+# Convert variable names to camel case in strings
+3bbc8ea2aff78040d1e24995de2d62461db88174
+
+# Convert property names to camel case in strings
+7a66366ab58b1b959c8b59dfc4f90c1f3a28b95b
+
+# Convert variable names to camel case in PHPDoc
+d0292f86249140f4978e6b65c4ed1aed4f40c7fe
+
+# Convert variables not caught by Code Sniffer to camel case
+f49757bd4e129d44102a932246c5e892d362054d
+
+# Convert properties not caught by Code Sniffer to camel case
+94afd663259d6600e51c8e13084f7f126874d29e
+
+# Exclude globals from camel case conversion 
+6522635dc7455e39ca77370a18a9987de13c61b0
+
+# Convert Doctrine specific code to camel case
+fbcaeaadbca33e6cc9aef0925be019e9b4923a93
+
+# Exclude WordPress and WooCommerce variables from camel case conversion
+685b4885c0d54d03df3cd0412ef3bc9e586cbb03
+
+# Exclude MailPoet data structures from camel case conversion
+e66c76133ec3ef667e382203426d91a4b4aa5174


### PR DESCRIPTION
This file contains revision with multiple variable/property renaming so that we could easily exclude them from git blame.
See https://akrabat.com/ignoring-revisions-with-git-blame/