### PR TITLE
Use WP connection db port if missing in config [MAILPOET-3580]

### DIFF
--- a/lib/Config/Env.php
+++ b/lib/Config/Env.php
@@ -80,7 +80,7 @@ class Env {
     self::$dbPrefix = $wpdb->prefix . self::$pluginPrefix;
     self::$dbHost = $host;
     self::$dbIsIpv6 = $isIpv6;
-    self::$dbPort = $port ?: 3306;
+    self::$dbPort = $port;
     self::$dbSocket = $socket;
     self::$dbName = $dbName;
     self::$dbUsername = $dbUser;

--- a/lib/Doctrine/ConnectionFactory.php
+++ b/lib/Doctrine/ConnectionFactory.php
@@ -29,6 +29,7 @@ class ConnectionFactory {
   ];
 
   public function createConnection() {
+    global $wpdb;
     $platformClass = self::PLATFORM_CLASS;
     $connectionParams = [
       'wrapperClass' => SerializableConnection::class,
@@ -49,7 +50,11 @@ class ConnectionFactory {
       $connectionParams['unix_socket'] = Env::$dbSocket;
     } else {
       $connectionParams['host'] = Env::$dbIsIpv6 ? ('[' . Env::$dbHost . ']') : Env::$dbHost;
-      $connectionParams['port'] = Env::$dbPort;
+      if (!empty(Env::$dbPort)) {
+        $connectionParams['port'] = Env::$dbPort;
+      } else {
+        $connectionParams['port'] = $wpdb->get_var('SELECT @@port');
+      }
     }
 
     $this->setupTypes();

--- a/tests/integration/Config/EnvTest.php
+++ b/tests/integration/Config/EnvTest.php
@@ -30,7 +30,7 @@ class EnvTest extends \MailPoetTest {
   public function testItProcessDBHost() {
     Env::init('file', '1.0.0', 'localhost', 'db_user', 'pass123', 'db_name');
     expect(Env::$dbHost)->equals('localhost');
-    expect(Env::$dbPort)->equals('3306');
+    expect(Env::$dbPort)->null();
 
     Env::init('file', '1.0.0', 'localhost:3307', 'db_user', 'pass123', 'db_name');
     expect(Env::$dbHost)->equals('localhost');

--- a/tests/integration/Doctrine/ConnectionFactoryTest.php
+++ b/tests/integration/Doctrine/ConnectionFactoryTest.php
@@ -43,6 +43,18 @@ class ConnectionFactoryTest extends \MailPoetTest {
     expect(Type::getType(JsonOrSerializedType::NAME))->isInstanceOf(JsonOrSerializedType::class);
   }
 
+  public function testItSetsUpPort() {
+    $backup = Env::$dbPort;
+    try {
+      Env::$dbPort = 3456;
+      $connectionFactory = new ConnectionFactory();
+      $connection = $connectionFactory->createConnection();
+      expect($connection->getPort())->equals(3456);
+    } finally {
+      Env::$dbPort = $backup;
+    }
+  }
+
   public function testItIgnoresEmptyCharset() {
     Env::$dbCharset = '';
     $connectionFactory = new ConnectionFactory();

--- a/tests/integration/Doctrine/ConnectionFactoryTest.php
+++ b/tests/integration/Doctrine/ConnectionFactoryTest.php
@@ -33,7 +33,6 @@ class ConnectionFactoryTest extends \MailPoetTest {
     expect($connection->getDriver())->isInstanceOf(PDOMySql\Driver::class);
     expect($connection->getDatabasePlatform())->isInstanceOf(MySqlPlatform::class);
     expect($connection->getHost())->equals(Env::$dbHost);
-    expect($connection->getPort())->equals(Env::$dbPort);
     expect($connection->getParams())->notContains('unix_socket');
     expect($connection->getUsername())->equals(Env::$dbUsername);
     expect($connection->getPassword())->equals(Env::$dbPassword);


### PR DESCRIPTION
[MAILPOET-3580]

[MAILPOET-3580]: https://mailpoet.atlassian.net/browse/MAILPOET-3580