### PR TITLE
Fix the post block in the latest Gutenberg [MAILPOET-3609]

### DIFF
--- a/assets/js/src/post_editor_block/subscription_form/form_block.jsx
+++ b/assets/js/src/post_editor_block/subscription_form/form_block.jsx
@@ -4,6 +4,19 @@ import Edit from './edit.jsx';
 const wp = window.wp;
 const { registerBlockType } = wp.blocks;
 
+registerBlockType('mailpoet/subscription-form-block-render', {
+  title: window.locale.subscriptionForm,
+  attributes: {
+    formId: {
+      type: 'number',
+      default: null,
+    },
+  },
+  supports: {
+    inserter: false,
+  },
+});
+
 registerBlockType('mailpoet/subscription-form-block', {
   title: window.locale.subscriptionForm,
   icon: Icon,


### PR DESCRIPTION
In the latest Gutenberg right after fetching the data
are sanitised using `__experimentalSanitizeBlockAttributes`
that is trying to get block from the store
but our block was not registered in the store.

[MAILPOET-3609]

[MAILPOET-3609]: https://mailpoet.atlassian.net/browse/MAILPOET-3609