### PR TITLE
Fix performance trouble in segment score calculation [MAILPOET-3633]

### DIFF
--- a/lib/Cron/Workers/SubscribersEngagementScore.php
+++ b/lib/Cron/Workers/SubscribersEngagementScore.php
@@ -59,7 +59,7 @@ class SubscribersEngagementScore extends SimpleWorker {
   }
 
   private function recalculateSegments(): int {
-    $segments = $this->segmentsRepository->findByUpdatedScoreNotInLastMonth(self::BATCH_SIZE);
+    $segments = $this->segmentsRepository->findByUpdatedScoreNotInLastDay(self::BATCH_SIZE);
     foreach ($segments as $segment) {
       $this->statisticsOpensRepository->recalculateSegmentScore($segment);
     }

--- a/lib/Segments/SegmentsRepository.php
+++ b/lib/Segments/SegmentsRepository.php
@@ -185,8 +185,8 @@ class SegmentsRepository extends Repository {
     return $rows;
   }
 
-  public function findByUpdatedScoreNotInLastMonth(int $limit): array {
-    $dateTime = (new Carbon())->subMonths(1);
+  public function findByUpdatedScoreNotInLastDay(int $limit): array {
+    $dateTime = (new Carbon())->subDay();
     return $this->entityManager->createQueryBuilder()
       ->select('s')
       ->from(SegmentEntity::class, 's')

--- a/lib/Statistics/Track/Opens.php
+++ b/lib/Statistics/Track/Opens.php
@@ -36,13 +36,6 @@ class Opens {
         $queue->getId()
       );
       $this->statisticsOpensRepository->recalculateSubscriberScore($subscriber);
-      foreach ($newsletter->getNewsletterSegments() as $newsletterSegment) {
-        $segment = $newsletterSegment->getSegment();
-        if (!$segment) {
-          continue;
-        }
-        $this->statisticsOpensRepository->recalculateSegmentScore($segment);
-      }
     }
     return $this->returnResponse($displayImage);
   }


### PR DESCRIPTION
[MAILPOET-3633]

The solution has three steps:

1. I removed the unnecessary problematic query because the check is solved in the subscriber's score calculation, and the aggregation function doesn't compute with null values.
2. I dropped the segment's score calculation from the tracking.
3. The segment score is outdated after a day.

[MAILPOET-3633]: https://mailpoet.atlassian.net/browse/MAILPOET-3633