### PR TITLE
Fix 1px line rendering bug in Outlook 2016 [MAILPOET-3448]

### DIFF
--- a/lib/Newsletter/Renderer/StylesHelper.php
+++ b/lib/Newsletter/Renderer/StylesHelper.php
@@ -16,6 +16,8 @@ class StylesHelper {
     'borderColor' => 'border-color',
     'borderRadius' => 'border-radius',
     'lineHeight' => 'line-height',
+    'msoLineHeightAlt' => 'mso-line-height-alt',
+    'msoFontSize' => 'mso-ansi-font-size',
   ];
   public static $font = [
     'Arial' => "Arial, 'Helvetica Neue', Helvetica, sans-serif",
@@ -147,7 +149,18 @@ class StylesHelper {
     if (!preg_match('/mailpoet_paragraph|h[1-4]/i', $selector)) return $style;
     $lineHeight = isset($style['lineHeight']) ? (float)$style['lineHeight'] : self::$defaultLineHeight;
     $fontSize = (int)$style['fontSize'];
+    $msoLineHeight = round($lineHeight * $fontSize);
+    if ($msoLineHeight % 2 === 1) {
+      $msoLineHeight++;
+    }
+    $msoFontSize = $fontSize;
+    if ($msoFontSize % 2 === 1) {
+      $msoFontSize++;
+    }
+    $style['msoLineHeightAlt'] = sprintf('%spx', $msoLineHeight);
+    $style = ['msoFontSize' => sprintf('%spx', $msoFontSize)] + $style;
     $style['lineHeight'] = sprintf('%spx', $lineHeight * $fontSize);
+
     return $style;
   }
 

--- a/tests/unit/Newsletter/Renderer/StylesHelperTest.php
+++ b/tests/unit/Newsletter/Renderer/StylesHelperTest.php
@@ -66,4 +66,24 @@ class StylesHelperTest extends \MailPoetUnitTest {
     expect(StylesHelper::getCustomFontsLinks($stylesWithoutCustomFonts))
       ->equals('');
   }
+
+  public function testItAddsMsoStyles() {
+    $styles = [
+      "fontSize" => "16px",
+      "lineHeight" => "1",
+    ];
+    $styles = StylesHelper::setStyle($styles, '.mailpoet_paragraph');
+    expect($styles)->stringContainsString('mso-ansi-font-size:16px;');
+    expect($styles)->stringContainsString('mso-line-height-alt:16px;');
+
+    $styles = [
+      "fontSize" => "17px",
+      "lineHeight" => "1.1",
+    ];
+    $styles = StylesHelper::setStyle($styles, '.mailpoet_paragraph');
+    expect($styles)->stringContainsString('mso-ansi-font-size:18px;');
+    expect($styles)->stringContainsString('font-size:17px;');
+    expect($styles)->stringContainsString('line-height:18.7px;');
+    expect($styles)->stringContainsString('mso-line-height-alt:20px;');
+  }
 }


### PR DESCRIPTION
[MAILPOET-3448], closes #3348

[MAILPOET-3448]: https://mailpoet.atlassian.net/browse/MAILPOET-3448