### PR TITLE
Add mailpoet_mailer_smtp_message filter

### DIFF
--- a/lib/Mailer/Methods/SMTP.php
+++ b/lib/Mailer/Methods/SMTP.php
@@ -125,6 +125,7 @@ class SMTP {
     if (!empty($newsletter['body']['text'])) {
       $message = $message->addPart($newsletter['body']['text'], 'text/plain');
     }
+    $message = $this->wp->applyFilters('mailpoet_mailer_smtp_message', $message, $newsletter, $subscriber, $extraParams);
     return $message;
   }
 


### PR DESCRIPTION
For our application, we need the ability to add some custom headers to outgoing SMTP messages. If you would please merge this PR, the filter will let us accomplish this. I imagine others would find this useful as a way to modify the message being sent (similar to WordPress core's default wp_mail filter)