### PR TITLE
Wrap WC content with table [MAILPOET-3638]

### DIFF
--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -373,6 +373,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\Template::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\Renderer::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor::class)->setPublic(true);
     // WordPress
     $container->autowire(\MailPoet\WP\Emoji::class)->setPublic(true);
     $container->autowire(\MailPoet\WP\Functions::class)->setPublic(true);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -330,6 +330,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Footer::class);
     $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Header::class);
     $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Image::class);
+    $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Placeholder::class);
     $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Renderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Social::class);
     $container->autowire(\MailPoet\Newsletter\Renderer\Blocks\Spacer::class);

--- a/lib/Newsletter/Renderer/Blocks/Placeholder.php
+++ b/lib/Newsletter/Renderer/Blocks/Placeholder.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Renderer\Blocks;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class Placeholder {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(WPFunctions $wp) {
+    $this->wp = $wp;
+  }
+
+  public function render($element): string {
+    $placeholder = $element['placeholder'];
+    $class = $element['class'] ?? '';
+    $style = $element['style'] ?? '';
+    return '
+      <tr>
+        <td class="' . $this->wp->escAttr($class) . '" style="' . $this->wp->escAttr($style) . '">
+          ' . $this->wp->escHtml($placeholder) . '
+        </td>
+      </tr>';
+  }
+}

--- a/lib/Newsletter/Renderer/Blocks/Renderer.php
+++ b/lib/Newsletter/Renderer/Blocks/Renderer.php
@@ -34,6 +34,9 @@ class Renderer {
   /** @var Text */
   private $text;
 
+  /** @var Placeholder */
+  private $placeholder;
+
   public function __construct(
     AutomatedLatestContentBlock $ALC,
     Button $button,
@@ -43,7 +46,8 @@ class Renderer {
     Image $image,
     Social $social,
     Spacer $spacer,
-    Text $text
+    Text $text,
+    Placeholder $placeholder
   ) {
     $this->ALC = $ALC;
     $this->button = $button;
@@ -54,6 +58,7 @@ class Renderer {
     $this->social = $social;
     $this->spacer = $spacer;
     $this->text = $text;
+    $this->placeholder = $placeholder;
   }
 
   public function render(NewsletterEntity $newsletter, $data) {
@@ -110,6 +115,8 @@ class Renderer {
         return $this->spacer->render($block);
       case 'text':
         return $this->text->render($block);
+      case 'placeholder':
+        return $this->placeholder->render($block);
     }
     return '';
   }

--- a/lib/Newsletter/Renderer/Preprocessor.php
+++ b/lib/Newsletter/Renderer/Preprocessor.php
@@ -3,16 +3,12 @@
 namespace MailPoet\Newsletter\Renderer;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Newsletter\Editor\LayoutHelper;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
 use MailPoet\Tasks\Sending as SendingTask;
-use MailPoet\WooCommerce\TransactionalEmails;
+use MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor;
 
 class Preprocessor {
-  const WC_HEADING_PLACEHOLDER = '[mailpoet_woocommerce_heading_placeholder]';
-  const WC_CONTENT_PLACEHOLDER = '[mailpoet_woocommerce_content_placeholder]';
-
   const WC_HEADING_BEFORE = '
     <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
             <tr>
@@ -28,17 +24,17 @@ class Preprocessor {
   /** @var AutomatedLatestContentBlock */
   private $automatedLatestContent;
 
-  /** @var TransactionalEmails */
-  private $transactionalEmails;
+  /** @var ContentPreprocessor */
+  private $wooCommerceContentPreprocessor;
 
   public function __construct(
     AbandonedCartContent $abandonedCartContent,
     AutomatedLatestContentBlock $automatedLatestContent,
-    TransactionalEmails $transactionalEmails
+    ContentPreprocessor $wooCommerceContentPreprocessor
   ) {
     $this->abandonedCartContent = $abandonedCartContent;
     $this->automatedLatestContent = $automatedLatestContent;
-    $this->transactionalEmails = $transactionalEmails;
+    $this->wooCommerceContentPreprocessor = $wooCommerceContentPreprocessor;
   }
 
   /**
@@ -68,34 +64,10 @@ class Preprocessor {
       case 'automatedLatestContentLayout':
         return $this->automatedLatestContent->render($newsletter, $block);
       case 'woocommerceHeading':
-        $wcEmailSettings = $this->transactionalEmails->getWCEmailSettings();
-        $content = self::WC_HEADING_BEFORE . '<h1 style="color:' . $wcEmailSettings['base_text_color'] . ';">' . self::WC_HEADING_PLACEHOLDER . '</h1>' . self::WC_HEADING_AFTER;
-        return $this->renderTextBlock($content, ['backgroundColor' => $wcEmailSettings['base_color']]);
+        return $this->wooCommerceContentPreprocessor->preprocessHeader();
       case 'woocommerceContent':
-        return $this->renderPlaceholderBlock(self::WC_CONTENT_PLACEHOLDER);
+        return $this->wooCommerceContentPreprocessor->preprocessContent();
     }
     return [$block];
-  }
-
-  private function renderTextBlock(string $text, array $styles = []): array {
-    return [
-      LayoutHelper::row([
-        LayoutHelper::col([[
-          'type' => 'text',
-          'text' => $text,
-        ]]),
-        ], $styles),
-    ];
-  }
-
-  private function renderPlaceholderBlock(string $placeholder): array {
-    return [
-      LayoutHelper::row([
-        LayoutHelper::col([[
-          'type' => 'placeholder',
-          'placeholder' => $placeholder,
-        ]]),
-      ]),
-    ];
   }
 }

--- a/lib/Newsletter/Renderer/Preprocessor.php
+++ b/lib/Newsletter/Renderer/Preprocessor.php
@@ -70,18 +70,14 @@ class Preprocessor {
       case 'woocommerceHeading':
         $wcEmailSettings = $this->transactionalEmails->getWCEmailSettings();
         $content = self::WC_HEADING_BEFORE . '<h1 style="color:' . $wcEmailSettings['base_text_color'] . ';">' . self::WC_HEADING_PLACEHOLDER . '</h1>' . self::WC_HEADING_AFTER;
-        return $this->placeholder($content, ['backgroundColor' => $wcEmailSettings['base_color']]);
+        return $this->renderTextBlock($content, ['backgroundColor' => $wcEmailSettings['base_color']]);
       case 'woocommerceContent':
-        return $this->placeholder(self::WC_CONTENT_PLACEHOLDER);
+        return $this->renderPlaceholderBlock(self::WC_CONTENT_PLACEHOLDER);
     }
     return [$block];
   }
 
-  /**
-   * @param string $text
-   * @return array
-   */
-  private function placeholder($text, $styles = []) {
+  private function renderTextBlock(string $text, array $styles = []): array {
     return [
       LayoutHelper::row([
         LayoutHelper::col([[
@@ -89,6 +85,17 @@ class Preprocessor {
           'text' => $text,
         ]]),
         ], $styles),
+    ];
+  }
+
+  private function renderPlaceholderBlock(string $placeholder): array {
+    return [
+      LayoutHelper::row([
+        LayoutHelper::col([[
+          'type' => 'placeholder',
+          'placeholder' => $placeholder,
+        ]]),
+      ]),
     ];
   }
 }

--- a/lib/WooCommerce/TransactionalEmails/ContentPreprocessor.php
+++ b/lib/WooCommerce/TransactionalEmails/ContentPreprocessor.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MailPoet\WooCommerce\TransactionalEmails;
+
+use MailPoet\Newsletter\Editor\LayoutHelper;
+use MailPoet\WooCommerce\TransactionalEmails;
+
+class ContentPreprocessor {
+  public const WC_HEADING_PLACEHOLDER = '[mailpoet_woocommerce_heading_placeholder]';
+  public const WC_CONTENT_PLACEHOLDER = '[mailpoet_woocommerce_content_placeholder]';
+
+  public const WC_HEADING_BEFORE = '
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+            <tr>
+              <td class="mailpoet_text" valign="top" style="padding-top:20px;padding-bottom:20px;word-break:break-word;word-wrap:break-word;">';
+  public const WC_HEADING_AFTER = '
+        </td>
+      </tr>
+    </table>';
+
+  /** @var TransactionalEmails */
+  private $transactionalEmails;
+
+  public function __construct(
+    TransactionalEmails $transactionalEmails
+  ) {
+    $this->transactionalEmails = $transactionalEmails;
+  }
+
+  public function preprocessContent() {
+    return $this->renderPlaceholderBlock(self::WC_CONTENT_PLACEHOLDER);
+  }
+
+  public function preprocessHeader() {
+    $wcEmailSettings = $this->transactionalEmails->getWCEmailSettings();
+    $content = self::WC_HEADING_BEFORE . '<h1 style="color:' . $wcEmailSettings['base_text_color'] . ';">' . self::WC_HEADING_PLACEHOLDER . '</h1>' . self::WC_HEADING_AFTER;
+    return $this->renderTextBlock($content, ['backgroundColor' => $wcEmailSettings['base_color']]);
+  }
+
+  private function renderTextBlock(string $text, array $styles = []): array {
+    return [
+      LayoutHelper::row([
+        LayoutHelper::col([[
+          'type' => 'text',
+          'text' => $text,
+        ]]),
+      ], $styles),
+    ];
+  }
+
+  private function renderPlaceholderBlock(string $placeholder): array {
+    return [
+      LayoutHelper::row([
+        LayoutHelper::col([[
+          'type' => 'placeholder',
+          'placeholder' => $placeholder,
+        ]]),
+      ]),
+    ];
+  }
+}

--- a/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -44,14 +44,14 @@ class Renderer {
       throw new \Exception("You should call 'render' before 'getHTMLBeforeContent'");
     }
     $html = str_replace(Preprocessor::WC_HEADING_PLACEHOLDER, $headingText, $this->htmlBeforeContent);
-    return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner">';
+    return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner"><table><tr><td>';
   }
 
   public function getHTMLAfterContent() {
     if (empty($this->htmlAfterContent)) {
       throw new \Exception("You should call 'render' before 'getHTMLAfterContent'");
     }
-    return '</div></div></div>' . $this->htmlAfterContent;
+    return '</td></tr></table></div></div></div>' . $this->htmlAfterContent;
   }
 
   public function prefixCss($css) {

--- a/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -44,7 +44,7 @@ class Renderer {
       throw new \Exception("You should call 'render' before 'getHTMLBeforeContent'");
     }
     $html = str_replace(Preprocessor::WC_HEADING_PLACEHOLDER, $headingText, $this->htmlBeforeContent);
-    return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner"><table><tr><td>';
+    return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner"><table style="width: 100%"><tr><td>';
   }
 
   public function getHTMLAfterContent() {

--- a/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -43,7 +43,7 @@ class Renderer {
       throw new \Exception("You should call 'render' before 'getHTMLBeforeContent'");
     }
     $html = str_replace(ContentPreprocessor::WC_HEADING_PLACEHOLDER, $headingText, $this->htmlBeforeContent);
-    return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner"><table style="width: 100%"><tr><td>';
+    return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner"><table style="width: 100%"><tr><td style="padding: 10px 20px">';
   }
 
   public function getHTMLAfterContent() {

--- a/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -3,7 +3,6 @@
 namespace MailPoet\WooCommerce\TransactionalEmails;
 
 use MailPoet\Models\Newsletter;
-use MailPoet\Newsletter\Renderer\Preprocessor;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
 use MailPoetVendor\csstidy;
 use MailPoetVendor\csstidy_print;
@@ -34,7 +33,7 @@ class Renderer {
   }
 
   public function render(Newsletter $newsletter, ?string $subject = null) {
-    $html = explode(Preprocessor::WC_CONTENT_PLACEHOLDER, $this->renderer->renderAsPreview($newsletter, 'html', $subject));
+    $html = explode(ContentPreprocessor::WC_CONTENT_PLACEHOLDER, $this->renderer->renderAsPreview($newsletter, 'html', $subject));
     $this->htmlBeforeContent = $html[0];
     $this->htmlAfterContent = $html[1];
   }
@@ -43,7 +42,7 @@ class Renderer {
     if (empty($this->htmlBeforeContent)) {
       throw new \Exception("You should call 'render' before 'getHTMLBeforeContent'");
     }
-    $html = str_replace(Preprocessor::WC_HEADING_PLACEHOLDER, $headingText, $this->htmlBeforeContent);
+    $html = str_replace(ContentPreprocessor::WC_HEADING_PLACEHOLDER, $headingText, $this->htmlBeforeContent);
     return $html . '<div id="' . self::CONTENT_CONTAINER_ID . '"><div id="body_content"><div id="body_content_inner"><table style="width: 100%"><tr><td>';
   }
 

--- a/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -35,21 +35,22 @@ class RendererTest extends \MailPoetTest {
   }
 
   public function testGetHTMLBeforeContent() {
+    $wooPreprocessor = new ContentPreprocessor(Stub::make(
+      \MailPoet\WooCommerce\TransactionalEmails::class,
+      [
+        'getWCEmailSettings' => [
+          'base_text_color' => '',
+          'base_color' => '',
+        ],
+      ]
+    ));
     $newsletterRenderer = new NewsletterRenderer(
       $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\Renderer::class),
       $this->diContainer->get(\MailPoet\Newsletter\Renderer\Columns\Renderer::class),
       new Preprocessor(
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent::class),
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock::class),
-        Stub::make(
-          \MailPoet\WooCommerce\TransactionalEmails::class,
-          [
-            'getWCEmailSettings' => [
-              'base_text_color' => '',
-              'base_color' => '',
-            ],
-          ]
-        )
+        $wooPreprocessor
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(Bridge::class),
@@ -67,21 +68,22 @@ class RendererTest extends \MailPoetTest {
   }
 
   public function testGetHTMLAfterContent() {
+    $wooPreprocessor = new ContentPreprocessor(Stub::make(
+      \MailPoet\WooCommerce\TransactionalEmails::class,
+      [
+        'getWCEmailSettings' => [
+          'base_text_color' => '',
+          'base_color' => '',
+        ],
+      ]
+    ));
     $newsletterRenderer = new NewsletterRenderer(
       $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\Renderer::class),
       $this->diContainer->get(\MailPoet\Newsletter\Renderer\Columns\Renderer::class),
       new Preprocessor(
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent::class),
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock::class),
-        Stub::make(
-          \MailPoet\WooCommerce\TransactionalEmails::class,
-          [
-            'getWCEmailSettings' => [
-              'base_text_color' => '',
-              'base_color' => '',
-            ],
-          ]
-        )
+        $wooPreprocessor
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(Bridge::class),

--- a/tests/unit/Newsletter/Renderer/PreprocessorTest.php
+++ b/tests/unit/Newsletter/Renderer/PreprocessorTest.php
@@ -19,7 +19,8 @@ class PreprocessorTest extends \MailPoetUnitTest {
         'base_text_color' => '{base_text_color}',
       ],
     ]);
-    $preprocessor = new Preprocessor($acc, $alc, $transactionalEmails);
+    $wooPreprocessor = new TransactionalEmails\ContentPreprocessor($transactionalEmails);
+    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor);
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceHeading']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',
@@ -45,7 +46,8 @@ class PreprocessorTest extends \MailPoetUnitTest {
   public function testProcessWooCommerceContentBlock() {
     $acc = Stub::make(AbandonedCartContent::class);
     $alc = Stub::make(AutomatedLatestContentBlock::class);
-    $preprocessor = new Preprocessor($acc, $alc, Stub::make(TransactionalEmails::class));
+    $wooPreprocessor = new TransactionalEmails\ContentPreprocessor(Stub::make(TransactionalEmails::class));
+    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor);
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceContent']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',
@@ -59,8 +61,8 @@ class PreprocessorTest extends \MailPoetUnitTest {
           'styles' => ['block' => ['backgroundColor' => 'transparent']],
           'blocks' => [
             [
-              'type' => 'text',
-              'text' => '[mailpoet_woocommerce_content_placeholder]',
+              'type' => 'placeholder',
+              'placeholder' => '[mailpoet_woocommerce_content_placeholder]',
             ],
           ],
         ],


### PR DESCRIPTION
[MAILPOET-3638]

I found out that we need to wrap the WC content with another table. The reason is that WC [use another padding](https://github.com/woocommerce/woocommerce/blob/trunk/templates/emails/email-styles.php#L110-L116)

[MAILPOET-3638]: https://mailpoet.atlassian.net/browse/MAILPOET-3638