### PR TITLE
Refactor woo email global styles settings [MAILPOET-3645]

### DIFF
--- a/lib/Config/Initializer.php
+++ b/lib/Config/Initializer.php
@@ -377,11 +377,9 @@ class Initializer {
   private function setupWoocommerceTransactionalEmails() {
     $wcEnabled = $this->wcHelper->isWooCommerceActive();
     $optInEnabled = $this->settings->get('woocommerce.use_mailpoet_editor', false);
-    if ($wcEnabled) {
-      $this->wcTransactionalEmails->enableEmailSettingsSyncToWooCommerce();
-      if ($optInEnabled) {
-        $this->wcTransactionalEmails->useTemplateForWoocommerceEmails();
-      }
+    if ($wcEnabled && $optInEnabled) {
+      $this->wcTransactionalEmails->overrideStylesForWooEmails();
+      $this->wcTransactionalEmails->useTemplateForWoocommerceEmails();
     }
   }
 }

--- a/lib/Entities/NewsletterEntity.php
+++ b/lib/Entities/NewsletterEntity.php
@@ -459,4 +459,12 @@ class NewsletterEntity {
     $criteria->where($expr->neq('countToProcess', 0));
     return $this->queues->matching($criteria);
   }
+
+  public function getGlobalStyle(string $category, string $style): ?string {
+    $body = $this->getBody();
+    if ($body === null) {
+      return null;
+    }
+    return $body['globalStyles'][$category][$style] ?? null;
+  }
 }

--- a/lib/WooCommerce/TransactionalEmailHooks.php
+++ b/lib/WooCommerce/TransactionalEmailHooks.php
@@ -69,6 +69,10 @@ class TransactionalEmailHooks {
   }
 
   public function overrideStylesForWooEmails() {
+    // Don't override anything if woo email template is not set
+    if (empty($this->settings->get(TransactionalEmails::SETTING_EMAIL_ID))) {
+      return;
+    }
     $this->wp->addAction('option_woocommerce_email_background_color', function($value) {
       $newsletter = $this->getNewsletter();
       return $newsletter->getGlobalStyle('body', 'backgroundColor') ?? $value;

--- a/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -110,6 +110,23 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
     expect($this->wp->getOption('woocommerce_email_text_color'))->equals('#111111');
   }
 
+  public function testItDoesntReplaceWoocommerceEmailStylesIfEmailIsNotSet() {
+    $this->settings->set(TransactionalEmails::SETTING_EMAIL_ID, null);
+    // Set woo options
+    $this->wp->updateOption('woocommerce_email_background_color', 'white');
+    $this->wp->updateOption('woocommerce_email_base_color', 'red');
+    $this->wp->updateOption('woocommerce_email_body_background_color', 'blue');
+    $this->wp->updateOption('woocommerce_email_text_color', 'black');
+
+    $transactionalEmails = $this->diContainer->get(TransactionalEmailHooks::class);
+    $transactionalEmails->overrideStylesForWooEmails();
+
+    expect($this->wp->getOption('woocommerce_email_background_color'))->equals('white');
+    expect($this->wp->getOption('woocommerce_email_base_color'))->equals('red');
+    expect($this->wp->getOption('woocommerce_email_body_background_color'))->equals('blue');
+    expect($this->wp->getOption('woocommerce_email_text_color'))->equals('black');
+  }
+
   public function testUseTemplateForWCEmails() {
     $addedActions = [];
     $removedActions = [];

--- a/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -25,9 +25,8 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
   private $newslettersRepository;
 
   public function _before() {
-    $this->settings = SettingsController::getInstance();
+    $this->settings = $this->diContainer->get(SettingsController::class);
     $this->originalWcSettings = $this->settings->get('woocommerce');
-    $this->newslettersRepository = ContainerWrapper::getInstance()->get(NewslettersRepository::class);
   }
 
   public function testItSynchronizesEmailSettingsToWooCommerce() {
@@ -161,7 +160,8 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
     $transactionalEmails = new TransactionalEmailHooks(
       $wp,
       $this->settings,
-      $renderer
+      $renderer,
+      $this->diContainer->get(NewslettersRepository::class)
     );
     $transactionalEmails->useTemplateForWoocommerceEmails();
     expect($addedActions)->count(1);


### PR DESCRIPTION
[MAILPOET-3645]

I found out that the problematic behavior was added as a feature in [https://mailpoet.atlassian.net/browse/MAILPOET-2569](https://mailpoet.atlassian.net/browse/MAILPOET-2569). The feature added[ sync between global styles of the email template used for WooCommerce emails and WooCommerce email settings](https://github.com/mailpoet/mailpoet/pull/2493/files#diff-e5a46d48bf0c8cf527ad3a169576582428411a4f8522342fbe7ca46fd502d8a6R136-R151). Side effect of this feature was that every time a user saved the WooCoommece template it overwrote WooCommerce settings.

The reason why the sync was added was:

> After testing the WC Email customizer with Bruna, we realized that the UX was not great because when we modified global styles, those new styles were not applied to the WC Email Content widget (which is 80% of the content of the email). This UX might be very confusing for the user.

I was able to find a workaround for how we can achieve the same behavior without the need of overwriting WooCommerce options that store those style settings. 

The change introduced in this PR replaces the synchronization with hooking into WordPress options that WooCommerce uses for storing style settings. Within the hook, it replaces the values from WooCommerce settings with values saved within the email template. Those hooks are active only when the setting for using the WooCommerce template is active. When a user deactivates the template WooCommerce will use original values from its settings.

The drawback of this solution is that we will sync styles from WooCommerce settings to the MailPoet's template only once when a user opens the editor for the first time. With the full sync, a user could turn off usage of MailPoet template alter Woo email styles and those were synced again. I think it is a bit edge-case and the drawback is acceptable. cc @NeosinneR 

[MAILPOET-3645]: https://mailpoet.atlassian.net/browse/MAILPOET-3645