### PR TITLE
fix: avoid double execution of `jQuery.ready`

### DIFF
--- a/assets/js/src/public.jsx
+++ b/assets/js/src/public.jsx
@@ -152,7 +152,7 @@ jQuery(($) => {
     }
   });
 
-  $(() => {
+  (() => {
     $('.mailpoet_form').each((index, element) => {
       $(element).children('.mailpoet_paragraph, .mailpoet_form_image, .mailpoet_form_paragraph').last().addClass('last');
     });
@@ -303,5 +303,5 @@ jQuery(($) => {
     $('.mailpoet-manage-subscription').on('submit', () => {
       $('.mailpoet-manage-subscription .mailpoet-submit-success').hide();
     });
-  });
+  })();
 });


### PR DESCRIPTION
Hey there!

### Context

Here is Matthew, the developer behind [Real Cookie Banner](https://wordpress.org/plugins/real-cookie-banner/). We have now several requests to make a service template for MailPoet. Yesterday, we started to create a compatibility with Real Cookie Banner + MailPoet. Unfortunately, there is some sort of double execution of `jQuery.ready`. This does currently not allow us to block MailPoet forms until the user has given consent to it.

### How we block `jQuery.ready`

Real Cookie Banner (_RCB_) modifies the way `jQuery.ready` work. Before transforming content back (_in other words: A user has given consent and wants to unblock MailPoet forms_), RCB puts all the "unblocks" into transactions and the `jQuery.ready` is modified in that way, that it waits for the transaction has complete and executes the passed handler. In general, this is built in a very safe way, so we have already covered 70+ content blocking cases of other plugins.

### `public.jsx`

You are using the first `jQuery.ready` here:

https://github.com/mailpoet/mailpoet/blob/2b43531c59f0b36150c15551b94eec3640441431/assets/js/src/public.jsx#L1-L8

This is great, Real Cookie Banner can catch that one.

https://github.com/mailpoet/mailpoet/blob/2b43531c59f0b36150c15551b94eec3640441431/assets/js/src/public.jsx#L155-L158

You are defining another `jQuery.ready` here inside a `jQuery..ready`. This callback cannot be caught by Real Cookie Banner as the first transaction is already completed. **In general, I do not think this is needed.**

### PR

I do not know exactly why the second `jQuery.ready` is needed, perhaps variable hoisting or an own "thread"? I want to propose to put the complete callback in an own [IIFE](https://developer.mozilla.org/de/docs/Glossary/IIFE).

Regards,
Matthew 😊