### PR TITLE
Remove segment ids from unconfirmed data on subscribe [MAILPOET-3663]

### DIFF
--- a/lib/Subscribers/SubscriberSubscribeController.php
+++ b/lib/Subscribers/SubscriberSubscribeController.php
@@ -92,7 +92,8 @@ class SubscriberSubscribeController {
       throw new UnexpectedValueException($e->getMessage());
     }
 
-    $segmentIds = $this->getSegmentIds($form, $data);
+    $segmentIds = $this->getSegmentIds($form, $data['segments'] ?? []);
+    unset($data['segments']);
 
     $meta = $this->validateCaptcha($captchaSettings, $data);
     if (isset($meta['error'])) {
@@ -215,8 +216,7 @@ class SubscriberSubscribeController {
     return $meta;
   }
 
-  private function getSegmentIds(FormEntity $form, array $data): array {
-    $segmentIds = !empty($data['segments']) ? (array)$data['segments'] : [];
+  private function getSegmentIds(FormEntity $form, array $segmentIds): array {
 
     // If form contains segment selection blocks allow only segments ids configured in those blocks
     $segmentBlocksSegmentIds = $form->getSegmentBlocksSegmentIds();


### PR DESCRIPTION
The issue was caused by [the refactoring subscribing to Doctrine](https://github.com/mailpoet/mailpoet/pull/3440).
The reason is that we stored the segment ids as unconfirmed data. After that, a user clicked on the confirmation link, and the method createOrUpdate called the method resetSubscriptions that unsubscribe the user from the old segments.

[MAILPOET-3663]

[MAILPOET-3663]: https://mailpoet.atlassian.net/browse/MAILPOET-3663