### PR TITLE
Recalculate subscriber score only when a new open was tracked [MAILPOET-3669]

### DIFF
--- a/lib/Statistics/Track/Opens.php
+++ b/lib/Statistics/Track/Opens.php
@@ -4,8 +4,8 @@ namespace MailPoet\Statistics\Track;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\StatisticsOpens;
 use MailPoet\Statistics\StatisticsOpensRepository;
 
 class Opens {
@@ -30,11 +30,18 @@ class Opens {
     // log statistics only if the action did not come from
     // a WP user previewing the newsletter
     if (!$wpUserPreview) {
-      StatisticsOpens::getOrCreate(
-        $subscriber->getId(),
-        $newsletter->getId(),
-        $queue->getId()
-      );
+      $oldStatistics = $this->statisticsOpensRepository->findOneBy([
+        'subscriber' => $subscriber->getId(),
+        'newsletter' => $newsletter->getId(),
+        'queue' => $queue->getId(),
+      ]);
+      // Open was already tracked
+      if ($oldStatistics) {
+        return $this->returnResponse($displayImage);
+      }
+      $statistics = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
+      $this->statisticsOpensRepository->persist($statistics);
+      $this->statisticsOpensRepository->flush();
       $this->statisticsOpensRepository->recalculateSubscriberScore($subscriber);
     }
     return $this->returnResponse($displayImage);


### PR DESCRIPTION
We count subscriber score based on tracked opens. There is no need to recalculate it when a new open wasn't _added._
[MAILPOET-3669]

[MAILPOET-3669]: https://mailpoet.atlassian.net/browse/MAILPOET-3669