### PR TITLE
Fix some PHPStan errors and update PHPStan configuration accordingly [MAILPOET-3236]

### DIFF
--- a/lib/Doctrine/Repository.php
+++ b/lib/Doctrine/Repository.php
@@ -13,10 +13,10 @@ abstract class Repository {
   /** @var EntityManager */
   protected $entityManager;
 
-  /** @var ClassMetadata */
+  /** @var ClassMetadata<object> */
   protected $classMetadata;
 
-  /** @var DoctrineEntityRepository */
+  /** @var DoctrineEntityRepository<T> */
   protected $doctrineRepository;
 
   /** @var string[] */

--- a/lib/Doctrine/TablePrefixMetadataFactory.php
+++ b/lib/Doctrine/TablePrefixMetadataFactory.php
@@ -25,6 +25,9 @@ class TablePrefixMetadataFactory extends ClassMetadataFactory {
     $this->setProxyClassNameResolver(new ProxyClassNameResolver());
   }
 
+  /**
+   * @return ClassMetadata<object>
+   */
   public function getMetadataFor($className) {
     $classMetadata = parent::getMetadataFor($className);
     if (isset($this->prefixedMap[$classMetadata->getName()])) {
@@ -42,6 +45,9 @@ class TablePrefixMetadataFactory extends ClassMetadataFactory {
     return $classMetadata;
   }
 
+  /**
+   * @param ClassMetadata<object> $classMetadata
+   */
   public function addPrefix(ClassMetadata $classMetadata) {
     if (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName) {
       $classMetadata->setPrimaryTable([

--- a/lib/Entities/NewsletterEntity.php
+++ b/lib/Entities/NewsletterEntity.php
@@ -131,25 +131,25 @@ class NewsletterEntity {
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\NewsletterEntity", mappedBy="parent")
-   * @var NewsletterEntity[]|ArrayCollection
+   * @var ArrayCollection<int, NewsletterEntity>
    */
   private $children;
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\NewsletterSegmentEntity", mappedBy="newsletter", orphanRemoval=true)
-   * @var NewsletterSegmentEntity[]|ArrayCollection
+   * @var ArrayCollection<int, NewsletterSegmentEntity>
    */
   private $newsletterSegments;
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\NewsletterOptionEntity", mappedBy="newsletter", orphanRemoval=true)
-   * @var NewsletterOptionEntity[]|ArrayCollection
+   * @var ArrayCollection<int, NewsletterOptionEntity>
    */
   private $options;
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\SendingQueueEntity", mappedBy="newsletter")
-   * @var SendingQueueEntity[]|ArrayCollection
+   * @var ArrayCollection<int, SendingQueueEntity>
    */
   private $queues;
 
@@ -404,21 +404,21 @@ class NewsletterEntity {
   }
 
   /**
-   * @return NewsletterEntity[]|ArrayCollection
+   * @return ArrayCollection<int, NewsletterEntity>
    */
   public function getChildren() {
     return $this->children;
   }
 
   /**
-   * @return NewsletterSegmentEntity[]|ArrayCollection
+   * @return ArrayCollection<int, NewsletterSegmentEntity>
    */
   public function getNewsletterSegments() {
     return $this->newsletterSegments;
   }
 
   /**
-   * @return NewsletterOptionEntity[]|ArrayCollection
+   * @return ArrayCollection<int, NewsletterOptionEntity>
    */
   public function getOptions() {
     return $this->options;
@@ -437,7 +437,7 @@ class NewsletterEntity {
   }
 
   /**
-   * @return SendingQueueEntity[]|ArrayCollection
+   * @return ArrayCollection<int, SendingQueueEntity>
    */
   public function getQueues() {
     return $this->queues;
@@ -453,6 +453,9 @@ class NewsletterEntity {
     return $this->queues->matching($criteria)->first() ?: null;
   }
 
+  /**
+   * @return Collection<int, SendingQueueEntity>
+   */
   private function getUnfinishedQueues(): Collection {
     $criteria = new Criteria();
     $expr = Criteria::expr();

--- a/lib/Entities/NewsletterLinkEntity.php
+++ b/lib/Entities/NewsletterLinkEntity.php
@@ -50,7 +50,7 @@ class NewsletterLinkEntity {
    * If we didn't specify extra lazy the function would load all clicks and count them. This way it uses a single count query.
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\StatisticsClickEntity", mappedBy="link", fetch="EXTRA_LAZY")
    *
-   * @var StatisticsClickEntity[]|ArrayCollection
+   * @var ArrayCollection<int, StatisticsClickEntity>
    */
   private $clicks;
 

--- a/lib/Entities/SegmentEntity.php
+++ b/lib/Entities/SegmentEntity.php
@@ -50,7 +50,7 @@ class SegmentEntity {
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\DynamicSegmentFilterEntity", mappedBy="segment")
-   * @var DynamicSegmentFilterEntity[]|ArrayCollection
+   * @var ArrayCollection<int, DynamicSegmentFilterEntity>
    */
   private $dynamicFilters;
 
@@ -121,7 +121,7 @@ class SegmentEntity {
   }
 
   /**
-   * @return DynamicSegmentFilterEntity[]|ArrayCollection
+   * @return ArrayCollection<int, DynamicSegmentFilterEntity>
    */
   public function getDynamicFilters() {
     return $this->dynamicFilters;

--- a/lib/Entities/StatisticsClickEntity.php
+++ b/lib/Entities/StatisticsClickEntity.php
@@ -48,7 +48,7 @@ class StatisticsClickEntity {
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\StatisticsWooCommercePurchaseEntity", mappedBy="click", fetch="EXTRA_LAZY")*
-   * @var StatisticsWooCommercePurchaseEntity[]|ArrayCollection
+   * @var ArrayCollection<int, StatisticsWooCommercePurchaseEntity>
    */
   private $wooCommercePurchases;
 
@@ -140,7 +140,7 @@ class StatisticsClickEntity {
   }
 
   /**
-   * @return StatisticsWooCommercePurchaseEntity[]|ArrayCollection
+   * @return ArrayCollection<int, StatisticsWooCommercePurchaseEntity>
    */
   public function getWooCommercePurchases() {
     return $this->wooCommercePurchases;

--- a/lib/Entities/SubscriberEntity.php
+++ b/lib/Entities/SubscriberEntity.php
@@ -139,7 +139,7 @@ class SubscriberEntity {
 
   /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\SubscriberSegmentEntity", mappedBy="subscriber")
-   * @var iterable<SubscriberSegmentEntity>&Collection
+   * @var Collection<int, SubscriberSegmentEntity>
    */
   private $subscriberSegments;
 
@@ -395,7 +395,7 @@ class SubscriberEntity {
   }
 
   /**
-   * @return Collection
+   * @return Collection<int, SubscriberSegmentEntity>
    */
   public function getSubscriberSegments() {
     return $this->subscriberSegments;

--- a/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
+++ b/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
@@ -36,8 +36,8 @@ class AbandonedCartContent {
       $optionField = $newsletterOption->getOptionField();
       return $optionField && $optionField->getName() === 'event';
     })->first();
-    if ($groupOption->getValue() !== WooCommerceEmail::SLUG
-      || $eventOption->getValue() !== AbandonedCart::SLUG
+    if (($groupOption instanceof NewsletterOptionEntity && $groupOption->getValue() !== WooCommerceEmail::SLUG)
+      || ($eventOption instanceof NewsletterOptionEntity && $eventOption->getValue() !== AbandonedCart::SLUG)
     ) {
       // Do not display the block if not an AbandonedCart email
       return [];

--- a/lib/Segments/SegmentsRepository.php
+++ b/lib/Segments/SegmentsRepository.php
@@ -111,8 +111,10 @@ class SegmentsRepository extends Repository {
     // We want to remove redundant filters before update
     while ($segment->getDynamicFilters()->count() > count($filtersData)) {
       $filterEntity = $segment->getDynamicFilters()->last();
-      $segment->getDynamicFilters()->removeElement($filterEntity);
-      $this->entityManager->remove($filterEntity);
+      if ($filterEntity) {
+        $segment->getDynamicFilters()->removeElement($filterEntity);
+        $this->entityManager->remove($filterEntity);
+      }
     }
     foreach ($filtersData as $key => $filterData) {
       if ($filterData instanceof DynamicSegmentFilterData) {

--- a/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -54,6 +54,9 @@ class ImportExportRepository {
     $this->filterHandler = $filterHandler;
   }
 
+  /**
+   * @return ClassMetadata<object>
+   */
   protected function getClassMetadata(string $className): ClassMetadata {
     return $this->entityManager->getClassMetadata($className);
   }

--- a/lib/Tasks/Subscribers/BatchIterator.php
+++ b/lib/Tasks/Subscribers/BatchIterator.php
@@ -4,6 +4,9 @@ namespace MailPoet\Tasks\Subscribers;
 
 use MailPoet\Models\ScheduledTaskSubscriber;
 
+/**
+ * @implements \Iterator<null, array>
+ */
 class BatchIterator implements \Iterator, \Countable {
   private $taskId;
   private $batchSize;

--- a/lib/Tracy/ApiPanel/ApiPanel.php
+++ b/lib/Tracy/ApiPanel/ApiPanel.php
@@ -20,10 +20,10 @@ class ApiPanel implements IBarPanel {
   /** @var array */
   protected $requestData;
 
-  /** @var ReflectionClass */
+  /** @var ReflectionClass<APIEndpoint> */
   protected $endpointReflection;
 
-  public function __construct($endpoint, $requestMethod, $requestData) {
+  public function __construct(APIEndpoint $endpoint, $requestMethod, $requestData) {
     $this->endpoint = $endpoint;
     $this->requestMethod = $requestMethod;
     $this->requestData = $requestData;

--- a/tasks/phpstan/phpstan-tests.neon
+++ b/tasks/phpstan/phpstan-tests.neon
@@ -32,7 +32,6 @@ parameters:
     maximumNumberOfProcesses: 4
 
   # exclude level 6 errors
-  checkGenericClassInNonGenericObjectType: false
   checkMissingIterableValueType: false
   checkMissingTypehints: false
 

--- a/tasks/phpstan/phpstan-tests.neon
+++ b/tasks/phpstan/phpstan-tests.neon
@@ -33,7 +33,6 @@ parameters:
 
   # exclude level 6 errors
   checkMissingIterableValueType: false
-  checkMissingTypehints: false
 
 includes:
   - vendor/phpstan/phpstan-doctrine/extension.neon

--- a/tasks/phpstan/phpstan-tests.neon
+++ b/tasks/phpstan/phpstan-tests.neon
@@ -34,7 +34,6 @@ parameters:
   # exclude level 6 errors
   checkGenericClassInNonGenericObjectType: false
   checkMissingIterableValueType: false
-  checkMissingVarTagTypehint: false
   checkMissingTypehints: false
 
 includes:

--- a/tasks/phpstan/phpstan.neon
+++ b/tasks/phpstan/phpstan.neon
@@ -28,7 +28,6 @@ parameters:
     objectManagerLoader: create-entity-manager.php
 
   # exclude level 6 errors
-  checkGenericClassInNonGenericObjectType: false
   checkMissingIterableValueType: false
 
   # analysis of templates is extremely slow, let's skip them for now

--- a/tasks/phpstan/phpstan.neon
+++ b/tasks/phpstan/phpstan.neon
@@ -30,7 +30,6 @@ parameters:
   # exclude level 6 errors
   checkGenericClassInNonGenericObjectType: false
   checkMissingIterableValueType: false
-  checkMissingTypehints: false
 
   # analysis of templates is extremely slow, let's skip them for now
   excludes_analyse:

--- a/tasks/phpstan/phpstan.neon
+++ b/tasks/phpstan/phpstan.neon
@@ -30,7 +30,6 @@ parameters:
   # exclude level 6 errors
   checkGenericClassInNonGenericObjectType: false
   checkMissingIterableValueType: false
-  checkMissingVarTagTypehint: false
   checkMissingTypehints: false
 
   # analysis of templates is extremely slow, let's skip them for now

--- a/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartPageVisitTrackerTest.php
+++ b/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartPageVisitTrackerTest.php
@@ -131,6 +131,9 @@ class AbandonedCartPageVisitTrackerTest extends \MailPoetTest {
     return $mock;
   }
 
+  /**
+   * @param class-string<WooCommerce|WC_Session> $className
+   */
   private function mockWooCommerceClass($className, array $methods) {
     // WooCommerce class needs to be mocked without default 'disallowMockingUnknownTypes'
     // since WooCommerce may not be active (would result in error mocking undefined class)

--- a/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -364,6 +364,9 @@ class AbandonedCartTest extends \MailPoetTest {
     return $expectedTime;
   }
 
+  /**
+   * @param class-string<WooCommerce|WC_Cart> $className
+   */
   private function mockWooCommerceClass($className, array $methods) {
     // WooCommerce class needs to be mocked without default 'disallowMockingUnknownTypes'
     // since WooCommerce may not be active (would result in error mocking undefined class)

--- a/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -112,6 +112,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
       return $optionField && $optionField->getName() === 'schedule';
     })->first();
 
+    assert($scheduleOption instanceof NewsletterOptionEntity); // PHPStan
     expect($scheduleOption->getValue())->equals('0 14 * * 1');
 
     // schedule should be recalculated when options change
@@ -123,6 +124,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
       return $optionField && $optionField->getName() === 'schedule';
     })->first();
 
+    assert($scheduleOption instanceof NewsletterOptionEntity); // PHPStan
     expect($scheduleOption->getValue())->equals('* * * * *');
   }
 
@@ -165,6 +167,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
       return $optionField && $optionField->getName() === 'schedule';
     })->first();
     expect($task1->getScheduledAt())->notEquals($currentTime);
+    assert($scheduleOption instanceof NewsletterOptionEntity); // PHPStan
     expect($task1->getScheduledAt())->equals(Scheduler::getNextRunDate($scheduleOption->getValue()));
     expect($task2->getScheduledAt())->null();
   }
@@ -187,7 +190,11 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
 
     $newsletter = $this->saveController->save($newsletterData);
     expect(count($newsletter->getNewsletterSegments()))->equals(1);
-    expect($newsletter->getNewsletterSegments()->first()->getSegment()->getName())->equals('Segment 1');
+    $newsletterSegment = $newsletter->getNewsletterSegments()->first();
+    assert($newsletterSegment instanceof NewsletterSegmentEntity); // PHPStan
+    $segment = $newsletterSegment->getSegment();
+    assert($segment instanceof SegmentEntity); // PHPStan
+    expect($segment->getName())->equals('Segment 1');
   }
 
   public function testItDeletesSendingQueueAndSetsNewsletterStatusToDraftWhenItIsUnscheduled() {

--- a/tests/unit/Form/HtmlParser.php
+++ b/tests/unit/Form/HtmlParser.php
@@ -6,6 +6,9 @@ class HtmlParser {
 
   private $allowedHtml5Tags = ['<figure', '<figcaption'];
 
+  /**
+   * @return \DOMNodeList<\DOMNode>
+   */
   public function findByXpath(string $html, string $xpath): \DOMNodeList {
     $isHtml5 = str_replace($this->allowedHtml5Tags, '', $html) !== $html;
     $dom = new \DOMDocument();


### PR DESCRIPTION
In this PR, I have changed phpstan.neon and phpstan-tests.neon and removed the lines that were added to skip the following checks: checkGenericClassInNonGenericObjectType, checkMissingVarTagTypehint, and checkMissingTypehints. I have also fixed all the errors that PHPStan reported after I changed its configuration files.

Please note that before working on this, I was not familiar with those specific PHPStan checks, so there is a chance that I missed something.

Also, each commit contains all the relevant changes for a specific PHPStan check. It might be easier to review this PR commit by commit.

[MAILPOET-3236]

[MAILPOET-3236]: https://mailpoet.atlassian.net/browse/MAILPOET-3236