### PR TITLE
Prevent deleting a list if attached to a form [MAILPOET-3661] 

### DIFF
--- a/lib/API/JSON/v1/Segments.php
+++ b/lib/API/JSON/v1/Segments.php
@@ -209,7 +209,7 @@ class Segments extends APIEndpoint {
       $this->subscribersRepository->bulkTrash($subscriberIds);
     }
 
-    $this->segmentsRepository->bulkTrash([$segment->getId()], $segment->getType());
+    $this->segmentsRepository->doTrash([$segment->getId()], $segment->getType());
     $this->segmentsRepository->refresh($segment);
     return $this->successResponse(
       $this->segmentsResponseBuilder->build($segment),

--- a/lib/Form/FormsRepository.php
+++ b/lib/Form/FormsRepository.php
@@ -27,6 +27,20 @@ class FormsRepository extends Repository {
       ->getResult();
   }
 
+  public function getNamesOfFormsForSegments(): array {
+    $allNonDeletedForms = $this->findAllNotDeleted();
+
+    $nameMap = [];
+    foreach ($allNonDeletedForms as $form) {
+      $blockSegmentsIds = $form->getSettingsSegmentIds();
+      foreach ($blockSegmentsIds as $blockSegmentId) {
+        $nameMap[(string)$blockSegmentId][] = $form->getName();
+      }
+    }
+
+    return $nameMap;
+  }
+
   public function count(): int {
     return (int)$this->doctrineRepository
       ->createQueryBuilder('f')

--- a/lib/Form/FormsRepository.php
+++ b/lib/Form/FormsRepository.php
@@ -34,7 +34,7 @@ class FormsRepository extends Repository {
     foreach ($allNonDeletedForms as $form) {
       $blockSegmentsIds = $form->getSettingsSegmentIds();
       foreach ($blockSegmentsIds as $blockSegmentId) {
-        $nameMap[(string)$blockSegmentId][] = $form->getName();
+        $nameMap[$blockSegmentId][] = $form->getName();
       }
     }
 

--- a/lib/Segments/SegmentsRepository.php
+++ b/lib/Segments/SegmentsRepository.php
@@ -182,6 +182,10 @@ class SegmentsRepository extends Repository {
     return $this->updateDeletedAt($ids, new Carbon(), $type);
   }
 
+  public function doTrash(array $ids, string $type = SegmentEntity::TYPE_DEFAULT): int {
+    return $this->updateDeletedAt($ids, new Carbon(), $type);
+  }
+
   public function bulkRestore(array $ids, string $type = SegmentEntity::TYPE_DEFAULT): int {
     return $this->updateDeletedAt($ids, null, $type);
   }

--- a/tests/acceptance/Lists/ManageListsCest.php
+++ b/tests/acceptance/Lists/ManageListsCest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\User;
@@ -204,6 +205,32 @@ class ManageListsCest {
     $i->waitForText($listTitle, 5, '[data-automation-id="listing_item_' . $segment->getId() . '"]');
     $i->clickItemRowActionByItemName($listTitle, 'Move to trash');
     $i->waitForText("List cannot be deleted because it’s used for '{$subject}' email");
+    $i->seeNoJSErrors();
+    $i->checkOption('[data-automation-id="listing-row-checkbox-' . $segment->getId() . '"]');
+    $i->waitForText('Move to trash');
+    $i->click('Move to trash');
+    $i->waitForText('0 lists were moved to the trash.');
+  }
+
+  public function cantTrashOrBulkTrashListWithForm(\AcceptanceTester $i) {
+    $listTitle = 'List with form';
+    $segmentFactory = new Segment();
+    $segment = $segmentFactory
+      ->withName($listTitle)
+      ->create();
+    $formName = 'My Form';
+    $formFactory = new Form();
+    $formFactory
+      ->withName($formName)
+      ->withSegments([$segment])
+      ->create();
+
+    $i->wantTo('Check that user can’t delete a list that is assigned to a form');
+    $i->login();
+    $i->amOnMailpoetPage('Lists');
+    $i->waitForText($listTitle, 5, '[data-automation-id="listing_item_' . $segment->getId() . '"]');
+    $i->clickItemRowActionByItemName($listTitle, 'Move to trash');
+    $i->waitForText("List cannot be deleted because it’s used for '{$formName}' form");
     $i->seeNoJSErrors();
     $i->checkOption('[data-automation-id="listing-row-checkbox-' . $segment->getId() . '"]');
     $i->waitForText('Move to trash');

--- a/tests/integration/API/JSON/v1/SegmentsTest.php
+++ b/tests/integration/API/JSON/v1/SegmentsTest.php
@@ -164,12 +164,8 @@ class SegmentsTest extends \MailPoetTest {
   }
 
   public function testItReturnsErrorWhenTrashingSegmentWithActiveForm() {
-    $form = new FormEntity('My Form');
-    $form->setSettings([
-      'segments' => [(string)$this->segment3->getId()],
-    ]);
-    $this->entityManager->persist($form);
-    $this->entityManager->flush();
+    $settings = ['segments' => [(string)$this->segment3->getId()]];
+    $this->createForm('My Form', $settings);
 
     $response = $this->endpoint->trash(['id' => $this->segment3->getId()]);
     $this->entityManager->refresh($this->segment3);
@@ -178,19 +174,9 @@ class SegmentsTest extends \MailPoetTest {
   }
 
   public function testItReturnsPluralErrorWhenTrashingSegmentWithActiveForms() {
-    $form1 = new FormEntity('My Form');
-    $form1->setSettings([
-      'segments' => [(string)$this->segment3->getId()],
-    ]);
-    $this->entityManager->persist($form1);
-    $this->entityManager->flush();
-
-    $form2 = new FormEntity('My other Form');
-    $form2->setSettings([
-      'segments' => [(string)$this->segment3->getId()],
-    ]);
-    $this->entityManager->persist($form2);
-    $this->entityManager->flush();
+    $settings = ['segments' => [(string)$this->segment3->getId()]];
+    $this->createForm('My Form', $settings);
+    $this->createForm('My other Form', $settings);
 
     $response = $this->endpoint->trash(['id' => $this->segment3->getId()]);
     $this->entityManager->refresh($this->segment3);
@@ -199,15 +185,11 @@ class SegmentsTest extends \MailPoetTest {
   }
 
   public function testItCanTrashSegmentWithoutActiveForm() {
-    $form1 = new FormEntity('My Form');
-    $form1->setSettings([
-      'segments' => [(string)$this->segment3->getId()],
-    ]);
-    $this->entityManager->persist($form1);
-    $this->entityManager->flush();
+    $settings = ['segments' => [(string)$this->segment3->getId()]];
+    $this->createForm('My Form', $settings);
 
     $response = $this->endpoint->trash(['id' => $this->segment2->getId()]);
-    $this->entityManager->clear();
+    $this->entityManager->refresh($this->segment2);
     $segment = $this->segmentRepository->findOneById($this->segment2->getId());
     assert($segment instanceof SegmentEntity);
 
@@ -266,6 +248,14 @@ class SegmentsTest extends \MailPoetTest {
 
     $subsribers = $this->subscriberSegmentRepository->findBy(['segment' => $this->segment1]);
     expect($subsribers)->count(0);
+  }
+
+  private function createForm(string $formName, array $settings ) {
+    $form = new FormEntity($formName);
+    $form->setSettings($settings);
+    $this->entityManager->persist($form);
+    $this->entityManager->flush();
+    return $form;
   }
 
   private function createSubscriberSegment(SubscriberEntity $subscriber, SegmentEntity $segment): SubscriberSegmentEntity {


### PR DESCRIPTION
When a user tries to trash a list that is attached to a form, we show a message instead of allowing them to trash the list:
`List cannot be deleted because it’s used for {$formName} form`

Follows the same behavior as when deleting a list if attached to a newsletter.
[MAILPOET-3661] 

[MAILPOET-3661]: https://mailpoet.atlassian.net/browse/MAILPOET-3661