### PR TITLE
Allow import subscribers with empty IP address [MAILPOET-3665]

### DIFF
--- a/lib/Subscribers/ImportExport/Import/Import.php
+++ b/lib/Subscribers/ImportExport/Import/Import.php
@@ -205,9 +205,10 @@ class Import {
       }
       if (in_array($column, ['confirmed_ip', 'subscribed_ip'], true)) {
         $data = array_map(
-          function($index, $ip) use(&$invalidRecords, $validator) {
+          function($index, $ip) use($validator) {
             if (!$validator->validateIPAddress($ip)) {
-              $invalidRecords[] = $index;
+              // if invalid or empty, we allow the import but remove the IP
+              return null;
             }
             return $ip;
           }, array_keys($data), $data

--- a/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -215,23 +215,35 @@ class ImportTest extends \MailPoetTest {
       'adam@smith.com',
       'jane@doe.com',
     ];
-    // invalid confirmed_ip is removed from data object
+    // invalid confirmed_ip is empty in data object
     $data['confirmed_ip'] = [
       '2019-05-31 18:42:35',
       '192.68.69.32',
     ];
     $result = $this->import->validateSubscribersData($data);
-    expect($result['confirmed_ip'])->count(1);
-    expect($result['confirmed_ip'][0])->equals('192.68.69.32');
+    expect($result['confirmed_ip'])->count(2);
+    expect($result['confirmed_ip'][0])->isEmpty();
+    expect($result['confirmed_ip'][1])->equals('192.68.69.32');
 
-    // invalid IPv4 confirmed_ip is removed from data object
+    // invalid IPv4 confirmed_ip is empty in the data object
     $data['confirmed_ip'] = [
       '392.68.69.32',
       '192.68.69.32',
     ];
     $result = $this->import->validateSubscribersData($data);
-    expect($result['confirmed_ip'])->count(1);
-    expect($result['confirmed_ip'][0])->equals('192.68.69.32');
+    expect($result['confirmed_ip'])->count(2);
+    expect($result['confirmed_ip'][0])->isEmpty();
+    expect($result['confirmed_ip'][1])->equals('192.68.69.32');
+
+    // Empty confirmed_ip is empty in the data object
+    $data['confirmed_ip'] = [
+      '',
+      '192.68.69.32',
+    ];
+    $result = $this->import->validateSubscribersData($data);
+    expect($result['confirmed_ip'])->count(2);
+    expect($result['confirmed_ip'][0])->isEmpty();
+    expect($result['confirmed_ip'][1])->equals('192.68.69.32');
 
     // normalize confirmed_at
     $data['confirmed_ip'] = [


### PR DESCRIPTION
Allow import subscribers with empty `confirmed_ip` or `subscribed_ip` when one of the columns is selected in the last step of the import.
Don't allow importing invalid IP addresses - still import the subscriber but remove the invalid IP address.

[MAILPOET-3665]

[MAILPOET-3665]: https://mailpoet.atlassian.net/browse/MAILPOET-3665