### PR TITLE
Protect against fatal error when rendering e-mail styles [MAILPOET-3731]

### DIFF
--- a/lib/Newsletter/Renderer/Renderer.php
+++ b/lib/Newsletter/Renderer/Renderer.php
@@ -175,6 +175,11 @@ class Renderer {
           $selector = '.mailpoet_content-wrapper';
           break;
       }
+
+      if (!is_array($style)) {
+        continue;
+      }
+
       $css .= StylesHelper::setStyle($style, $selector);
     }
     return $css;

--- a/lib/Newsletter/Renderer/StylesHelper.php
+++ b/lib/Newsletter/Renderer/StylesHelper.php
@@ -87,7 +87,7 @@ class StylesHelper {
       $attribute;
   }
 
-  public static function setStyle($style, $selector) {
+  public static function setStyle(array $style, string $selector): string {
     $css = $selector . '{' . PHP_EOL;
     $style = self::applyHeadingMargin($style, $selector);
     $style = self::applyLineHeight($style, $selector);
@@ -138,14 +138,14 @@ class StylesHelper {
         self::$font['Arial'];
   }
 
-  public static function applyHeadingMargin($style, $selector) {
+  public static function applyHeadingMargin(array $style, string $selector): array {
     if (!preg_match('/h[1-4]/i', $selector)) return $style;
     $fontSize = (int)$style['fontSize'];
     $style['margin'] = sprintf('0 0 %spx 0', self::$headingMarginMultiplier * $fontSize);
     return $style;
   }
 
-  public static function applyLineHeight($style, $selector) {
+  public static function applyLineHeight(array $style, string $selector): array {
     if (!preg_match('/mailpoet_paragraph|h[1-4]/i', $selector)) return $style;
     $lineHeight = isset($style['lineHeight']) ? (float)$style['lineHeight'] : self::$defaultLineHeight;
     $fontSize = (int)$style['fontSize'];


### PR DESCRIPTION
This PR protects the code that renders styles for e-mails against a fatal error that could happen if the variable $styles passed to Renderer::renderStyles() is not an array of arrays. To do that, the code will now check if each value of the array is an array. If not, we move on to the next value instead of calling StylesHelper::setStyle(). I also added type hints to StylesHelper::setStyle() and some of the methods that it calls to make it more explicit what it expects to receive and what it returns.

See related Jira ticket for testing instructions.

[MAILPOET-3731]

[MAILPOET-3731]: https://mailpoet.atlassian.net/browse/MAILPOET-3731