### PR TITLE
Refactor lib/Newsletter/ViewInBrowser to Doctrine [MAILPOET-3637]

### DIFF
--- a/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -6,7 +6,6 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer;
@@ -46,7 +45,7 @@ class ViewInBrowserRenderer {
 
   public function render(
     bool $isPreview,
-    Newsletter $newsletter,
+    NewsletterEntity $newsletter,
     SubscriberEntity $subscriber = null,
     SendingQueueEntity $queue = null
   ) {
@@ -104,9 +103,7 @@ class ViewInBrowserRenderer {
     if ($queue instanceof SendingQueueEntity) {
       $this->shortcodes->setQueue($queue);
     }
-    if ($newsletter instanceof Newsletter) {
-      $newsletter = $newsletterRepository->findOneById($newsletter->id);
-    }
+
     if ($newsletter instanceof NewsletterEntity) {
       $this->shortcodes->setNewsletter($newsletter);
     }

--- a/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -2,12 +2,10 @@
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 
-use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links;
-use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
 use MailPoet\Settings\SettingsController;
@@ -97,9 +95,6 @@ class ViewInBrowserRenderer {
 
   /** this is here to prepare entities for the shortcodes library, when this whole file uses doctrine, this can be deleted */
   private function prepareShortcodes($newsletter, $subscriber, $queue, $wpUserPreview) {
-    /** @var NewslettersRepository $newsletterRepository */
-    $newsletterRepository = ContainerWrapper::getInstance()->get(NewslettersRepository::class);
-
     if ($queue instanceof SendingQueueEntity) {
       $this->shortcodes->setQueue($queue);
     }
@@ -109,6 +104,7 @@ class ViewInBrowserRenderer {
     }
 
     $this->shortcodes->setWpUserPreview($wpUserPreview);
+
     if ($subscriber instanceof SubscriberEntity) {
       $this->shortcodes->setSubscriber($subscriber);
     }

--- a/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -93,7 +93,6 @@ class ViewInBrowserRenderer {
     return $renderedNewsletter;
   }
 
-  /** this is here to prepare entities for the shortcodes library, when this whole file uses doctrine, this can be deleted */
   private function prepareShortcodes($newsletter, $subscriber, $queue, $wpUserPreview) {
     if ($queue instanceof SendingQueueEntity) {
       $this->shortcodes->setQueue($queue);

--- a/tests/DataFactories/Newsletter.php
+++ b/tests/DataFactories/Newsletter.php
@@ -58,10 +58,9 @@ class Newsletter {
   }
 
   /**
-   * @param $body
    * @return Newsletter
    */
-  public function withBody($body): Newsletter {
+  public function withBody($body) {
     $this->data['body'] = $body;
     return $this;
   }

--- a/tests/DataFactories/Newsletter.php
+++ b/tests/DataFactories/Newsletter.php
@@ -58,6 +58,15 @@ class Newsletter {
   }
 
   /**
+   * @param $body
+   * @return Newsletter
+   */
+  public function withBody($body): Newsletter {
+    $this->data['body'] = $body;
+    return $this;
+  }
+
+  /**
    * @return Newsletter
    */
   public function withSubject($subject) {

--- a/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\Url;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Util\Security;
 
 class ViewInBrowserControllerTest extends \MailPoetTest {
@@ -56,62 +57,9 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $this->newsletterUrl = $this->diContainer->get(Url::class);
 
     // create newsletter
-    $newsletterData = [
-      'body' => json_decode(
-        '{
-        "content": {
-          "type": "container",
-          "orientation": "vertical",
-          "styles": {
-            "block": {
-              "backgroundColor": "transparent"
-            }
-          },
-          "blocks": [
-            {
-              "type": "container",
-              "orientation": "horizontal",
-              "styles": {
-                "block": {
-                  "backgroundColor": "transparent"
-                }
-              },
-              "blocks": [
-                {
-                  "type": "container",
-                  "orientation": "vertical",
-                  "styles": {
-                    "block": {
-                      "backgroundColor": "transparent"
-                    }
-                  },
-                  "blocks": [
-                    {
-                      "type": "text",
-                      "text": "<p>Rendered newsletter. Hello, [subscriber:firstname | default:reader]. <a href=\"[link:newsletter_view_in_browser_url]\">Unsubscribe</a> or visit <a href=\"http://google.com\">Google</a></p>"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      }', true),
-      'subject' => 'Some subject',
-      'preheader' => 'Some preheader',
-      'type' => 'standard',
-      'status' => 'active',
-    ];
-    // create newsletter
-    $newsletter = new NewsletterEntity();
-    $newsletter->setSubject($newsletterData['subject']);
-    $newsletter->setPreheader($newsletterData['preheader']);
-    $newsletter->setType($newsletterData['type']);
-    $newsletter->setStatus($newsletterData['status']);
-    $newsletter->setBody($newsletterData['body']);
+    $newsletterFactory = new Newsletter();
+    $newsletter = $newsletterFactory->create();
     $newsletter->setHash(Security::generateHash());
-    $this->newslettersRepository->persist($newsletter);
-    $this->newslettersRepository->flush();
     $this->newsletter = $newsletter;
 
     // create subscriber
@@ -129,7 +77,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $sendingTask->setSubscribers([$subscriber->getId()]);
     $sendingTask->updateProcessedSubscribers([$subscriber->getId()]);
     $this->sendingTask = $sendingTask->save();
-    $this->newslettersRepository->refresh($newsletter);
+
     // build browser preview data
     $this->browserPreviewData = [
       'queue_id' => $sendingTask->queue()->id,

--- a/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -8,7 +8,6 @@ use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\NewsletterLink;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer;
@@ -136,21 +135,20 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     $queue->newsletterRenderedBody = $this->queueRenderedNewsletterWithoutTracking;
     $queue->setSubscribers([$subscriber->getId()]);
     $this->sendingTask = $queue->save();
+    $this->newsletterRepository->refresh($newsletter);
+    $this->newsletter = $newsletter;
 
     // create newsletter link associations
-    $newsletterLink1 = NewsletterLink::create();
-    $newsletterLink1->hash = '90e56';
-    $newsletterLink1->url = '[link:newsletter_view_in_browser_url]';
-    $newsletterLink1->newsletterId = $this->newsletter->getId();
-    $newsletterLink1->queueId = $this->sendingTask->id;
-    $newsletterLink1->save();
 
-    $newsletterLink2 = NewsletterLink::create();
-    $newsletterLink2->hash = 'i1893';
-    $newsletterLink2->url = 'http://google.com';
-    $newsletterLink2->newsletterId = $this->newsletter->getId();
-    $newsletterLink2->queueId = $this->sendingTask->id;
-    $newsletterLink2->save();
+    $newsletterLink1 = (new \MailPoet\Test\DataFactories\NewsletterLink($newsletter))
+      ->withUrl('[link:newsletter_view_in_browser_url]')
+      ->withHash('90e56')
+      ->create();
+
+    $newsletterLink2 = (new \MailPoet\Test\DataFactories\NewsletterLink($newsletter))
+      ->withUrl('http://google.com')
+      ->withHash('i1893')
+      ->create();
 
     $this->settings = $this->diContainer->get(SettingsController::class);
     $this->viewInBrowserRenderer = $this->diContainer->get(ViewInBrowserRenderer::class);

--- a/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -17,6 +17,8 @@ use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\WP\Emoji;
 
 class ViewInBrowserRendererTest extends \MailPoetTest {
@@ -54,8 +56,8 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     $this->sendingQueueRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->newsletterRepository = $this->diContainer->get(NewslettersRepository::class);
-    $newsletterData = [
-      'body' => json_decode(
+    $newsletterBody =
+      json_decode(
         '{
         "content": {
           "type": "container",
@@ -94,12 +96,7 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
             }
           ]
         }
-      }', true),
-      'subject' => 'Some subject',
-      'preheader' => 'Some preheader',
-      'type' => 'standard',
-      'status' => 'active',
-    ];
+      }', true);
     $this->queueRenderedNewsletterWithoutTracking = [
       'html' => '<p>Newsletter from queue. Hello, [subscriber:firstname | default:reader]. <a href="[link:newsletter_view_in_browser_url]">Unsubscribe</a> or visit <a href="http://google.com">Google</a></p>',
       'text' => 'test',
@@ -110,14 +107,9 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     ];
 
     // create newsletter
-    $newsletter = new NewsletterEntity();
-    $newsletter->setSubject($newsletterData['subject']);
-    $newsletter->setPreheader($newsletterData['preheader']);
-    $newsletter->setType($newsletterData['type']);
-    $newsletter->setStatus($newsletterData['status']);
-    $newsletter->setBody($newsletterData['body']);
-    $this->newsletterRepository->persist($newsletter);
-    $this->newsletterRepository->flush();
+    $newsletter = (new Newsletter())
+      ->withBody($newsletterBody)
+      ->create();
     $this->newsletter = $newsletter;
 
     // create subscriber
@@ -139,13 +131,12 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     $this->newsletter = $newsletter;
 
     // create newsletter link associations
-
-    $newsletterLink1 = (new \MailPoet\Test\DataFactories\NewsletterLink($newsletter))
+    $newsletterLinkFactory = new NewsletterLink($newsletter);
+    $newsletterLinkFactory
       ->withUrl('[link:newsletter_view_in_browser_url]')
       ->withHash('90e56')
       ->create();
-
-    $newsletterLink2 = (new \MailPoet\Test\DataFactories\NewsletterLink($newsletter))
+    $newsletterLinkFactory
       ->withUrl('http://google.com')
       ->withHash('i1893')
       ->create();


### PR DESCRIPTION
Use `NewsletterEntity` and `NewslettersRepository` instead of `MailPoet\Models\Newsletter`.

To test: Edit a Newsletter and preview in browser. Things should work as before

2 integration tests have been also updated to use the Entities instead of the old models.

Run them on the Docker env with:
`./do --test "test:integration --file=tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php"
`
`./do --test "test:integration --file=tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php"
`

I have a question about a function that has a comment saying the function could be removed after the refactoring. Doesn't look like it, see comment on the file below.

[MAILPOET-3637]

[MAILPOET-3637]: https://mailpoet.atlassian.net/browse/MAILPOET-3637