### PR TITLE
Include open and click user agents in Export Personal Data tool [MAILPOET-3738]

### DIFF
--- a/lib/Config/PersonalDataExporters.php
+++ b/lib/Config/PersonalDataExporters.php
@@ -4,6 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterClicksExporter;
+use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterOpensExporter;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewslettersExporter;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\SegmentsExporter;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\SubscriberExporter;
@@ -15,6 +16,7 @@ class PersonalDataExporters {
     WPFunctions::get()->addFilter('wp_privacy_personal_data_exporters', [$this, 'registerSegmentsExporter']);
     WPFunctions::get()->addFilter('wp_privacy_personal_data_exporters', [$this, 'registerNewslettersExporter']);
     WPFunctions::get()->addFilter('wp_privacy_personal_data_exporters', [$this, 'registerNewsletterClicksExporter']);
+    WPFunctions::get()->addFilter('wp_privacy_personal_data_exporters', [$this, 'registerNewsletterOpensExporter']);
   }
 
   public function registerSegmentsExporter($exporters) {
@@ -46,6 +48,14 @@ class PersonalDataExporters {
     $exporters[] = [
       'exporter_friendly_name' => WPFunctions::get()->__('MailPoet Email Clicks', 'mailpoet'),
       'callback' => [new NewsletterClicksExporter(), 'export'],
+    ];
+    return $exporters;
+  }
+
+  public function registerNewsletterOpensExporter($exporters) {
+    $exporters[] = [
+      'exporter_friendly_name' => WPFunctions::get()->__('MailPoet Email Opens', 'mailpoet'),
+      'callback' => [new NewsletterOpensExporter(), 'export'],
     ];
     return $exporters;
   }

--- a/lib/Config/PersonalDataExporters.php
+++ b/lib/Config/PersonalDataExporters.php
@@ -47,7 +47,7 @@ class PersonalDataExporters {
   public function registerNewsletterClicksExporter($exporters) {
     $exporters[] = [
       'exporter_friendly_name' => WPFunctions::get()->__('MailPoet Email Clicks', 'mailpoet'),
-      'callback' => [new NewsletterClicksExporter(), 'export'],
+      'callback' => [ContainerWrapper::getInstance()->get(NewsletterClicksExporter::class), 'export'],
     ];
     return $exporters;
   }
@@ -55,7 +55,7 @@ class PersonalDataExporters {
   public function registerNewsletterOpensExporter($exporters) {
     $exporters[] = [
       'exporter_friendly_name' => WPFunctions::get()->__('MailPoet Email Opens', 'mailpoet'),
-      'callback' => [new NewsletterOpensExporter(), 'export'],
+      'callback' => [ContainerWrapper::getInstance()->get(NewsletterOpensExporter::class), 'export'],
     ];
     return $exporters;
   }

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -265,6 +265,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\SubscriberSubscribeController::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ImportExport\ImportExportRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewslettersExporter::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterOpensExporter::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterClicksExporter::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\Statistics\SubscriberStatisticsRepository::class);
     $container->autowire(\MailPoet\Subscribers\SubscribersCountsController::class)->setPublic(true);
     // Segments

--- a/lib/Models/StatisticsClicks.php
+++ b/lib/Models/StatisticsClicks.php
@@ -3,6 +3,9 @@
 namespace MailPoet\Models;
 
 use DateTimeInterface;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\UserAgentEntity;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
  * @property int $newsletterId
@@ -15,11 +18,15 @@ class StatisticsClicks extends Model {
   public static $_table = MP_STATISTICS_CLICKS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
 
   public static function getAllForSubscriber(Subscriber $subscriber) {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+    $userAgentsTable = $entityManager->getClassMetadata(UserAgentEntity::class)->getTableName();
+
     return static::tableAlias('clicks')
       ->select('clicks.id', 'id')
       ->select('newsletter_rendered_subject')
       ->select('clicks.created_at', 'created_at')
       ->select('url')
+      ->select('user_agent.user_agent')
       ->join(
        SendingQueue::$_table,
        ['clicks.queue_id', '=', 'queue.id'],
@@ -29,6 +36,11 @@ class StatisticsClicks extends Model {
         NewsletterLink::$_table,
         ['clicks.link_id', '=', 'link.id'],
         'link'
+      )
+      ->leftOuterJoin(
+        $userAgentsTable,
+        ['clicks.user_agent_id', '=', 'user_agent.id'],
+        'user_agent'
       )
       ->where('clicks.subscriber_id', $subscriber->id())
       ->orderByAsc('url');

--- a/lib/Models/StatisticsClicks.php
+++ b/lib/Models/StatisticsClicks.php
@@ -3,9 +3,6 @@
 namespace MailPoet\Models;
 
 use DateTimeInterface;
-use MailPoet\DI\ContainerWrapper;
-use MailPoet\Entities\UserAgentEntity;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
  * @property int $newsletterId
@@ -16,35 +13,6 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
  */
 class StatisticsClicks extends Model {
   public static $_table = MP_STATISTICS_CLICKS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
-
-  public static function getAllForSubscriber(Subscriber $subscriber) {
-    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
-    $userAgentsTable = $entityManager->getClassMetadata(UserAgentEntity::class)->getTableName();
-
-    return static::tableAlias('clicks')
-      ->select('clicks.id', 'id')
-      ->select('newsletter_rendered_subject')
-      ->select('clicks.created_at', 'created_at')
-      ->select('url')
-      ->select('user_agent.user_agent')
-      ->join(
-       SendingQueue::$_table,
-       ['clicks.queue_id', '=', 'queue.id'],
-       'queue'
-      )
-      ->join(
-        NewsletterLink::$_table,
-        ['clicks.link_id', '=', 'link.id'],
-        'link'
-      )
-      ->leftOuterJoin(
-        $userAgentsTable,
-        ['clicks.user_agent_id', '=', 'user_agent.id'],
-        'user_agent'
-      )
-      ->where('clicks.subscriber_id', $subscriber->id())
-      ->orderByAsc('url');
-  }
 
   public static function findLatestPerNewsletterBySubscriber(Subscriber $subscriber, DateTimeInterface $from, DateTimeInterface $to) {
     // subquery to find latest click IDs for each newsletter

--- a/lib/Models/StatisticsOpens.php
+++ b/lib/Models/StatisticsOpens.php
@@ -2,10 +2,6 @@
 
 namespace MailPoet\Models;
 
-use MailPoet\DI\ContainerWrapper;
-use MailPoet\Entities\UserAgentEntity;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
-
 /**
  * @property int $newsletterId
  * @property int $subscriberId
@@ -27,28 +23,5 @@ class StatisticsOpens extends Model {
       $statistics->save();
     }
     return $statistics;
-  }
-
-  public static function getAllForSubscriber(Subscriber $subscriber) {
-    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
-    $userAgentsTable = $entityManager->getClassMetadata(UserAgentEntity::class)->getTableName();
-
-    return static::tableAlias('opens')
-      ->select('opens.id', 'id')
-      ->select('newsletter_rendered_subject')
-      ->select('opens.created_at', 'created_at')
-      ->select('user_agent.user_agent')
-      ->join(
-        SendingQueue::$_table,
-        ['opens.queue_id', '=', 'queue.id'],
-        'queue'
-      )
-      ->leftOuterJoin(
-        $userAgentsTable,
-        ['opens.user_agent_id', '=', 'user_agent.id'],
-        'user_agent'
-      )
-      ->where('opens.subscriber_id', $subscriber->id())
-      ->orderByAsc('newsletter_rendered_subject');
   }
 }

--- a/lib/Statistics/StatisticsClicksRepository.php
+++ b/lib/Statistics/StatisticsClicksRepository.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 /**
  * @extends Repository<StatisticsClickEntity>
@@ -42,5 +43,17 @@ class StatisticsClicksRepository extends Repository {
       $statistics->setCount($statistics->getCount() + 1);
     }
     return $statistics;
+  }
+
+  public function getAllForSubscriber(SubscriberEntity $subscriber): QueryBuilder {
+    return $this->entityManager->createQueryBuilder()
+      ->select('clicks.id id, queue.newsletterRenderedSubject, clicks.createdAt, link.url, userAgent.userAgent')
+      ->from(StatisticsClickEntity::class, 'clicks')
+      ->join('clicks.queue', 'queue')
+      ->join('clicks.link', 'link')
+      ->leftJoin('clicks.userAgent', 'userAgent')
+      ->where('clicks.subscriber = :subscriber')
+      ->orderBy('link.url')
+      ->setParameter('subscriber', $subscriber->getId());
   }
 }

--- a/lib/Statistics/StatisticsOpensRepository.php
+++ b/lib/Statistics/StatisticsOpensRepository.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 /**
  * @extends Repository<StatisticsOpenEntity>
@@ -85,5 +86,16 @@ class StatisticsOpensRepository extends Repository {
       ->set('s.averageEngagementScoreUpdatedAt', ':updatedAt')
       ->setParameter('updatedAt', null)
       ->getQuery()->execute();
+  }
+
+  public function getAllForSubscriber(SubscriberEntity $subscriber): QueryBuilder {
+    return $this->entityManager->createQueryBuilder()
+      ->select('opens.id id, queue.newsletterRenderedSubject, opens.createdAt, userAgent.userAgent')
+      ->from(StatisticsOpenEntity::class, 'opens')
+      ->join('opens.queue', 'queue')
+      ->leftJoin('opens.userAgent', 'userAgent')
+      ->where('opens.subscriber = :subscriber')
+      ->orderBy('queue.newsletterRenderedSubject')
+      ->setParameter('subscriber', $subscriber->getId());
   }
 }

--- a/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporter.php
+++ b/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporter.php
@@ -49,6 +49,18 @@ class NewsletterClicksExporter {
       'name' => WPFunctions::get()->__('URL', 'mailpoet'),
       'value' => $row['url'],
     ];
+
+    if (!is_null($row['user_agent'])) {
+      $userAgent = $row['user_agent'];
+    } else {
+      $userAgent = WPFunctions::get()->__('Unknown', 'mailpoet');
+    }
+
+    $newsletterData[] = [
+      'name' => WPFunctions::get()->__('User-agent', 'mailpoet'),
+      'value' => $userAgent,
+    ];
+
     return [
       'group_id' => 'mailpoet-newsletter-clicks',
       'group_label' => WPFunctions::get()->__('MailPoet Emails Clicks', 'mailpoet'),

--- a/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporter.php
+++ b/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporter.php
@@ -2,29 +2,29 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
-use MailPoet\Models\StatisticsClicks;
+use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class NewsletterClicksExporter extends NewsletterStatsBaseExporter {
-  protected $statsClass = StatisticsClicks::class;
+  protected $statsClassName = StatisticsClicksRepository::class;
 
   protected function getEmailStats(array $row) {
     $newsletterData = [];
     $newsletterData[] = [
       'name' => WPFunctions::get()->__('Email subject', 'mailpoet'),
-      'value' => $row['newsletter_rendered_subject'],
+      'value' => $row['newsletterRenderedSubject'],
     ];
     $newsletterData[] = [
       'name' => WPFunctions::get()->__('Timestamp of the click event', 'mailpoet'),
-      'value' => $row['created_at'],
+      'value' => $row['createdAt']->format("Y-m-d H:i:s"),
     ];
     $newsletterData[] = [
       'name' => WPFunctions::get()->__('URL', 'mailpoet'),
       'value' => $row['url'],
     ];
 
-    if (!is_null($row['user_agent'])) {
-      $userAgent = $row['user_agent'];
+    if (!is_null($row['userAgent'])) {
+      $userAgent = $row['userAgent'];
     } else {
       $userAgent = WPFunctions::get()->__('Unknown', 'mailpoet');
     }

--- a/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporter.php
+++ b/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporter.php
@@ -2,25 +2,25 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
-use MailPoet\Models\StatisticsOpens;
+use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class NewsletterOpensExporter extends NewsletterStatsBaseExporter {
-  protected $statsClass = StatisticsOpens::class;
+  protected $statsClassName = StatisticsOpensRepository::class;
 
   protected function getEmailStats(array $row): array {
     $newsletterData = [];
     $newsletterData[] = [
       'name' => WPFunctions::get()->__('Email subject', 'mailpoet'),
-      'value' => $row['newsletter_rendered_subject'],
+      'value' => $row['newsletterRenderedSubject'],
     ];
     $newsletterData[] = [
       'name' => WPFunctions::get()->__('Timestamp of the open event', 'mailpoet'),
-      'value' => $row['created_at'],
+      'value' => $row['createdAt']->format("Y-m-d H:i:s"),
     ];
 
-    if (!is_null($row['user_agent'])) {
-      $userAgent = $row['user_agent'];
+    if (!is_null($row['userAgent'])) {
+      $userAgent = $row['userAgent'];
     } else {
       $userAgent = WPFunctions::get()->__('Unknown', 'mailpoet');
     }

--- a/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporter.php
+++ b/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporter.php
@@ -2,25 +2,21 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
-use MailPoet\Models\StatisticsClicks;
+use MailPoet\Models\StatisticsOpens;
 use MailPoet\WP\Functions as WPFunctions;
 
-class NewsletterClicksExporter extends NewsletterStatsBaseExporter {
-  protected $statsClass = StatisticsClicks::class;
+class NewsletterOpensExporter extends NewsletterStatsBaseExporter {
+  protected $statsClass = StatisticsOpens::class;
 
-  protected function getEmailStats(array $row) {
+  protected function getEmailStats(array $row): array {
     $newsletterData = [];
     $newsletterData[] = [
       'name' => WPFunctions::get()->__('Email subject', 'mailpoet'),
       'value' => $row['newsletter_rendered_subject'],
     ];
     $newsletterData[] = [
-      'name' => WPFunctions::get()->__('Timestamp of the click event', 'mailpoet'),
+      'name' => WPFunctions::get()->__('Timestamp of the open event', 'mailpoet'),
       'value' => $row['created_at'],
-    ];
-    $newsletterData[] = [
-      'name' => WPFunctions::get()->__('URL', 'mailpoet'),
-      'value' => $row['url'],
     ];
 
     if (!is_null($row['user_agent'])) {
@@ -35,8 +31,8 @@ class NewsletterClicksExporter extends NewsletterStatsBaseExporter {
     ];
 
     return [
-      'group_id' => 'mailpoet-newsletter-clicks',
-      'group_label' => WPFunctions::get()->__('MailPoet Emails Clicks', 'mailpoet'),
+      'group_id' => 'mailpoet-newsletter-opens',
+      'group_label' => WPFunctions::get()->__('MailPoet Emails Opens', 'mailpoet'),
       'item_id' => 'newsletter-' . $row['id'],
       'data' => $newsletterData,
     ];

--- a/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterStatsBaseExporter.php
+++ b/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterStatsBaseExporter.php
@@ -2,33 +2,45 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
-use MailPoet\Models\Subscriber;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
 
 abstract class NewsletterStatsBaseExporter {
 
   const LIMIT = 100;
 
-  protected $statsClass;
+  protected $statsClassName;
 
-  public function export($email, $page = 1) {
-    $data = $this->getSubscriberData(Subscriber::findOne(trim($email)), $page);
+  protected $subscriberRepository;
+
+  public function __construct(SubscribersRepository $subscribersRepository) {
+    $this->subscriberRepository = $subscribersRepository;
+  }
+
+  public function export($email, $page = 1): array {
+    $data = [];
+    $subscriber = $this->subscriberRepository->findOneBy(['email' => trim($email)]);
+
+    if ($subscriber instanceof SubscriberEntity) {
+      $data = $this->getSubscriberData($subscriber, $page);
+    }
+
     return [
       'data' => $data,
       'done' => count($data) < self::LIMIT,
     ];
   }
 
-  private function getSubscriberData($subscriber, $page) {
-    if (!$subscriber) {
-      return [];
-    }
-
+  private function getSubscriberData(SubscriberEntity $subscriber, $page): array {
     $result = [];
 
-    $statistics = $this->statsClass::getAllForSubscriber($subscriber)
-      ->limit(self::LIMIT)
-      ->offset(self::LIMIT * ($page - 1))
-      ->findArray();
+    $statsClass = ContainerWrapper::getInstance()->get($this->statsClassName);
+    $statistics = $statsClass->getAllForSubscriber($subscriber)
+      ->setMaxResults(self::LIMIT)
+      ->setFirstResult(self::LIMIT * ($page - 1))
+      ->getQuery()
+      ->getResult();
 
     foreach ($statistics as $row) {
       $result[] = $this->getEmailStats($row);

--- a/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterStatsBaseExporter.php
+++ b/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterStatsBaseExporter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
+
+use MailPoet\Models\Subscriber;
+
+abstract class NewsletterStatsBaseExporter {
+
+  const LIMIT = 100;
+
+  protected $statsClass;
+
+  public function export($email, $page = 1) {
+    $data = $this->getSubscriberData(Subscriber::findOne(trim($email)), $page);
+    return [
+      'data' => $data,
+      'done' => count($data) < self::LIMIT,
+    ];
+  }
+
+  private function getSubscriberData($subscriber, $page) {
+    if (!$subscriber) {
+      return [];
+    }
+
+    $result = [];
+
+    $statistics = $this->statsClass::getAllForSubscriber($subscriber)
+      ->limit(self::LIMIT)
+      ->offset(self::LIMIT * ($page - 1))
+      ->findArray();
+
+    foreach ($statistics as $row) {
+      $result[] = $this->getEmailStats($row);
+    }
+
+    return $result;
+  }
+
+  protected abstract function getEmailStats(array $row);
+}

--- a/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
+++ b/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
@@ -20,7 +20,7 @@ class NewsletterClicksExporterTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->exporter = new NewsletterClicksExporter();
+    $this->exporter = $this->diContainer->get(NewsletterClicksExporter::class);
   }
 
   public function testExportWorksWhenSubscriberNotFound() {

--- a/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
+++ b/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
@@ -2,11 +2,16 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterLink;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsClicks;
 use MailPoet\Models\Subscriber;
+use MailPoetVendor\Idiorm\ORM;
 
 class NewsletterClicksExporterTest extends \MailPoetTest {
 
@@ -40,8 +45,38 @@ class NewsletterClicksExporterTest extends \MailPoetTest {
   }
 
   public function testExportReturnsData() {
+    $userEmail = 'email@with.clicks';
+    $userAgentName = 'Mozilla/5.0';
+    $this->prepareDataToBeExported($userEmail, $userAgentName);
+
+    $result = $this->exporter->export($userEmail);
+    expect($result['data'])->array();
+    expect($result['data'])->count(1);
+    expect($result['done'])->equals(true);
+    expect($result['data'][0])->hasKey('group_id');
+    expect($result['data'][0])->hasKey('group_label');
+    expect($result['data'][0])->hasKey('item_id');
+    expect($result['data'][0])->hasKey('data');
+    expect($result['data'][0]['data'])->contains(['name' => 'Email subject', 'value' => 'Email Subject']);
+    expect($result['data'][0]['data'])->contains(['name' => 'URL', 'value' => 'Link url']);
+    expect($result['data'][0]['data'])->contains(['name' => 'Timestamp of the click event', 'value' => '2018-01-02 15:16:17']);
+    expect($result['data'][0]['data'])->contains(['name' => 'User-agent', 'value' => $userAgentName]);
+  }
+
+  public function testExportReturnsDataWhenUserAgentIsUnknown() {
+    $userEmail = 'email@with.clicks';
+    $this->prepareDataToBeExported($userEmail);
+
+    $result = $this->exporter->export($userEmail);
+
+    $this->assertIsArray($result['data']);
+    $this->assertCount(1, $result['data']);
+    $this->assertSame($result['data'][0]['data'][3], ['name' => 'User-agent', 'value' => 'Unknown']);
+  }
+
+  protected function prepareDataToBeExported(string $userEmail, string $userAgentName = null) {
     $subscriber = Subscriber::createOrUpdate([
-      'email' => 'email@with.clicks',
+      'email' => $userEmail,
     ]);
     $queue = SendingQueue::createOrUpdate([
       'newsletter_rendered_subject' => 'Email Subject',
@@ -58,6 +93,16 @@ class NewsletterClicksExporterTest extends \MailPoetTest {
       'queue_id' => $queue->id(),
       'hash' => 'xyz',
     ]);
+
+    if ($userAgentName) {
+      $userAgent = new UserAgentEntity($userAgentName);
+      $this->entityManager->persist($userAgent);
+      $this->entityManager->flush();
+      $userAgentId = $userAgent->getId();
+    } else {
+      $userAgentId = null;
+    }
+
     StatisticsClicks::createOrUpdate([
       'newsletter_id' => $newsletter->id(),
       'queue_id' => $queue->id(),
@@ -65,17 +110,16 @@ class NewsletterClicksExporterTest extends \MailPoetTest {
       'link_id' => $link->id(),
       'count' => 1,
       'created_at' => '2018-01-02 15:16:17',
+      'user_agent_id' => $userAgentId,
     ]);
-    $result = $this->exporter->export('email@with.clicks');
-    expect($result['data'])->array();
-    expect($result['data'])->count(1);
-    expect($result['done'])->equals(true);
-    expect($result['data'][0])->hasKey('group_id');
-    expect($result['data'][0])->hasKey('group_label');
-    expect($result['data'][0])->hasKey('item_id');
-    expect($result['data'][0])->hasKey('data');
-    expect($result['data'][0]['data'])->contains(['name' => 'Email subject', 'value' => 'Email Subject']);
-    expect($result['data'][0]['data'])->contains(['name' => 'URL', 'value' => 'Link url']);
-    expect($result['data'][0]['data'])->contains(['name' => 'Timestamp of the click event', 'value' => '2018-01-02 15:16:17']);
+  }
+
+  public function _after() {
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SendingQueueEntity::class);
+    $this->truncateEntity(NewsletterEntity::class);
+    ORM::raw_execute('TRUNCATE ' . NewsletterLink::$_table);
+    $this->truncateEntity(UserAgentEntity::class);
+    ORM::raw_execute('TRUNCATE ' . StatisticsClicks::$_table);
   }
 }

--- a/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
+++ b/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\UserAgentEntity;
+use MailPoet\Models\Newsletter;
+use MailPoet\Models\SendingQueue;
+use MailPoet\Models\StatisticsOpens;
+use MailPoet\Models\Subscriber;
+use MailPoetVendor\Idiorm\ORM;
+
+class NewsletterOpensExporterTest extends \MailPoetTest {
+
+  /** @var NewsletterOpensExporter */
+  private $exporter;
+
+  public function _before() {
+    parent::_before();
+    $this->exporter = new NewsletterOpensExporter();
+  }
+
+  public function testExportWorksWhenSubscriberNotFound() {
+    $result = $this->exporter->export('email.that@doesnt.exists');
+
+    $this->assertIsArray($result);
+    $this->assertArrayHasKey('data', $result);
+    $this->assertEmpty($result['data']);
+    $this->assertArrayHasKey('done', $result);
+    $this->assertTrue($result['done']);
+  }
+
+  public function testExportWorksForSubscriberWithNoNewsletters() {
+    Subscriber::createOrUpdate([
+      'email' => 'email.that@has.no.newsletters',
+    ]);
+
+    $result = $this->exporter->export('email.that@has.no.newsletters');
+
+    $this->assertIsArray($result);
+    $this->assertArrayHasKey('data', $result);
+    $this->assertEmpty($result['data']);
+    $this->assertArrayHasKey('done', $result);
+    $this->assertTrue($result['done']);
+  }
+
+  public function testExportReturnsData() {
+    $userEmail = 'email@with.clicks';
+    $userAgentName = 'Mozilla/5.0';
+    $this->prepareDataToBeExported($userEmail, $userAgentName);
+    $expectedData = [
+      ['name' => 'Email subject', 'value' => 'Email Subject'],
+      ['name' => 'Timestamp of the open event', 'value' => '2018-01-02 15:16:17'],
+      ['name' => 'User-agent', 'value' => $userAgentName],
+    ];
+
+    $result = $this->exporter->export($userEmail);
+
+    $this->assertIsArray($result);
+    $this->assertArrayHasKey('data', $result);
+    $this->assertCount(1, $result['data']);
+    $this->assertTrue($result['done']);
+    $this->assertArrayHasKey('group_id', $result['data'][0]);
+    $this->assertArrayHasKey('group_label', $result['data'][0]);
+    $this->assertArrayHasKey('item_id', $result['data'][0]);
+    $this->assertArrayHasKey('data', $result['data'][0]);
+    $this->assertSame($expectedData, $result['data'][0]['data']);
+  }
+
+  public function testExportReturnsDataWhenUserAgentIsUnknown() {
+    $userEmail = 'email@with.clicks';
+    $this->prepareDataToBeExported($userEmail);
+
+    $result = $this->exporter->export($userEmail);
+
+    $this->assertIsArray($result['data']);
+    $this->assertCount(1, $result['data']);
+    $this->assertSame($result['data'][0]['data'][2], ['name' => 'User-agent', 'value' => 'Unknown']);
+  }
+
+  protected function prepareDataToBeExported(string $userEmail, string $userAgentName = null) {
+    $subscriber = Subscriber::createOrUpdate([
+      'email' => $userEmail,
+    ]);
+
+    $queue = SendingQueue::createOrUpdate([
+      'newsletter_rendered_subject' => 'Email Subject',
+      'task_id' => 1,
+      'newsletter_id' => 8,
+    ]);
+
+    $newsletter = Newsletter::createOrUpdate([
+      'subject' => 'Email Subject1',
+      'type' => Newsletter::TYPE_STANDARD,
+    ]);
+
+    if ($userAgentName) {
+      $userAgent = new UserAgentEntity($userAgentName);
+      $this->entityManager->persist($userAgent);
+      $this->entityManager->flush();
+      $userAgentId = $userAgent->getId();
+    } else {
+      $userAgentId = null;
+    }
+
+    StatisticsOpens::createOrUpdate([
+      'newsletter_id' => $newsletter->id(),
+      'subscriber_id' => $subscriber->id(),
+      'queue_id' => $queue->id(),
+      'created_at' => '2018-01-02 15:16:17',
+      'user_agent_id' => $userAgentId,
+    ]);
+  }
+
+  public function _after() {
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SendingQueueEntity::class);
+    $this->truncateEntity(NewsletterEntity::class);
+    $this->truncateEntity(UserAgentEntity::class);
+    ORM::raw_execute('TRUNCATE ' . StatisticsOpens::$_table);
+  }
+}

--- a/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
+++ b/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
@@ -19,7 +19,7 @@ class NewsletterOpensExporterTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->exporter = new NewsletterOpensExporter();
+    $this->exporter = $this->diContainer->get(NewsletterOpensExporter::class);
   }
 
   public function testExportWorksWhenSubscriberNotFound() {


### PR DESCRIPTION
This PR adds a new "User-Agent" field to e-mail clicks data and it also adds a new section with e-mail opens when the WordPress' Export Personal Data tool is used. I also did some refactoring in the code that generates data for e-mail clicks to avoid duplicating it to add the new e-mail opens section. In the process, since I didn't want to add code that interacts with Paris for e-mail opens, I changed parts of the e-mail clicks code to use Doctrine. I meant to refactor the tests to use Doctrine instead of Paris as well but ran out of time.

[MAILPOET-3738]

[MAILPOET-3738]: https://mailpoet.atlassian.net/browse/MAILPOET-3738