### PR TITLE
Differentiate machine opens and clicks [MAILPOET-3736]

### DIFF
--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -428,7 +428,7 @@ class Migrator {
       'queue_id int(11) unsigned NOT NULL,',
       'link_id int(11) unsigned NOT NULL,',
       'user_agent_id int(11) unsigned NULL,',
-      'user_agent_type varchar(50) NULL,',
+      'user_agent_type tinyint(1) NOT NULL DEFAULT 0,',
       'count int(11) unsigned NOT NULL,',
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
@@ -447,7 +447,7 @@ class Migrator {
       'subscriber_id int(11) unsigned NOT NULL,',
       'queue_id int(11) unsigned NOT NULL,',
       'user_agent_id int(11) unsigned NULL,',
-      'user_agent_type varchar(50) NULL,',
+      'user_agent_type tinyint(1) NOT NULL DEFAULT 0,',
       'created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,',
       'PRIMARY KEY  (id),',
       'KEY newsletter_id_subscriber_id_user_agent_type (newsletter_id, subscriber_id, user_agent_type),',

--- a/lib/Entities/StatisticsClickEntity.php
+++ b/lib/Entities/StatisticsClickEntity.php
@@ -59,10 +59,10 @@ class StatisticsClickEntity {
   private $userAgent;
 
   /**
-   * @ORM\Column(type="string", nullable=true)
-   * @var string|null
+   * @ORM\Column(type="smallint")
+   * @var int
    */
-  private $userAgentType;
+  private $userAgentType = 0;
 
   /**
    * @ORM\Column(type="integer")
@@ -170,11 +170,11 @@ class StatisticsClickEntity {
     $this->userAgent = $userAgent;
   }
 
-  public function getUserAgentType(): ?string {
+  public function getUserAgentType(): int {
     return $this->userAgentType;
   }
 
-  public function setUserAgentType(?string $userAgentType): void {
+  public function setUserAgentType(int $userAgentType): void {
     $this->userAgentType = $userAgentType;
   }
 }

--- a/lib/Entities/StatisticsClickEntity.php
+++ b/lib/Entities/StatisticsClickEntity.php
@@ -59,6 +59,12 @@ class StatisticsClickEntity {
   private $userAgent;
 
   /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $userAgentType;
+
+  /**
    * @ORM\Column(type="integer")
    * @var int
    */
@@ -162,5 +168,13 @@ class StatisticsClickEntity {
 
   public function setUserAgent(?UserAgentEntity $userAgent): void {
     $this->userAgent = $userAgent;
+  }
+
+  public function getUserAgentType(): ?string {
+    return $this->userAgentType;
+  }
+
+  public function setUserAgentType(?string $userAgentType): void {
+    $this->userAgentType = $userAgentType;
   }
 }

--- a/lib/Entities/StatisticsOpenEntity.php
+++ b/lib/Entities/StatisticsOpenEntity.php
@@ -44,10 +44,10 @@ class StatisticsOpenEntity {
   private $userAgent;
 
   /**
-   * @ORM\Column(type="string", nullable=true)
-   * @var string|null
+   * @ORM\Column(type="smallint")
+   * @var int
    */
-  private $userAgentType;
+  private $userAgentType = 0;
 
   public function __construct(
     NewsletterEntity $newsletter,
@@ -104,11 +104,11 @@ class StatisticsOpenEntity {
     $this->userAgent = $userAgent;
   }
 
-  public function getUserAgentType(): ?string {
+  public function getUserAgentType(): int {
     return $this->userAgentType;
   }
 
-  public function setUserAgentType(?string $userAgentType): void {
+  public function setUserAgentType(int $userAgentType): void {
     $this->userAgentType = $userAgentType;
   }
 }

--- a/lib/Entities/StatisticsOpenEntity.php
+++ b/lib/Entities/StatisticsOpenEntity.php
@@ -43,6 +43,12 @@ class StatisticsOpenEntity {
    */
   private $userAgent;
 
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $userAgentType;
+
   public function __construct(
     NewsletterEntity $newsletter,
     SendingQueueEntity $queue,
@@ -96,5 +102,13 @@ class StatisticsOpenEntity {
 
   public function setUserAgent(?UserAgentEntity $userAgent): void {
     $this->userAgent = $userAgent;
+  }
+
+  public function getUserAgentType(): ?string {
+    return $this->userAgentType;
+  }
+
+  public function setUserAgentType(?string $userAgentType): void {
+    $this->userAgentType = $userAgentType;
   }
 }

--- a/lib/Entities/UserAgentEntity.php
+++ b/lib/Entities/UserAgentEntity.php
@@ -16,8 +16,8 @@ class UserAgentEntity {
   use CreatedAtTrait;
   use UpdatedAtTrait;
 
-  public const USER_AGENT_TYPE_HUMAN = 'human';
-  public const USER_AGENT_TYPE_MACHINE = 'machine';
+  public const USER_AGENT_TYPE_HUMAN = 0;
+  public const USER_AGENT_TYPE_MACHINE = 1;
 
   public const MACHINE_USER_AGENTS = [
     'Mozilla/5.0',
@@ -52,7 +52,7 @@ class UserAgentEntity {
     return $this->hash;
   }
 
-  public function getUserAgentType(): string {
+  public function getUserAgentType(): int {
     if (in_array($this->getUserAgent(), self::MACHINE_USER_AGENTS, true)) {
       return self::USER_AGENT_TYPE_MACHINE;
     }

--- a/lib/Entities/UserAgentEntity.php
+++ b/lib/Entities/UserAgentEntity.php
@@ -16,6 +16,13 @@ class UserAgentEntity {
   use CreatedAtTrait;
   use UpdatedAtTrait;
 
+  public const USER_AGENT_TYPE_HUMAN = 'human';
+  public const USER_AGENT_TYPE_MACHINE = 'machine';
+
+  public const MACHINE_USER_AGENTS = [
+    'Mozilla/5.0',
+  ];
+
   /**
    * @ORM\Column(type="string")
    * @var string
@@ -43,5 +50,12 @@ class UserAgentEntity {
 
   public function getHash(): string {
     return $this->hash;
+  }
+
+  public function getUserAgentType(): string {
+    if (in_array($this->getUserAgent(), self::MACHINE_USER_AGENTS, true)) {
+      return self::USER_AGENT_TYPE_MACHINE;
+    }
+    return self::USER_AGENT_TYPE_HUMAN;
   }
 }

--- a/lib/Statistics/StatisticsClicksRepository.php
+++ b/lib/Statistics/StatisticsClicksRepository.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\UserAgentEntity;
 
 /**
  * @extends Repository<StatisticsClickEntity>
@@ -21,7 +22,8 @@ class StatisticsClicksRepository extends Repository {
     NewsletterLinkEntity $link,
     SubscriberEntity $subscriber,
     NewsletterEntity $newsletter,
-    SendingQueueEntity $queue
+    SendingQueueEntity $queue,
+    ?UserAgentEntity $userAgent
   ): StatisticsClickEntity {
     $statistics = $this->findOneBy([
       'link' => $link,
@@ -31,6 +33,10 @@ class StatisticsClicksRepository extends Repository {
     ]);
     if (!$statistics instanceof StatisticsClickEntity) {
       $statistics = new StatisticsClickEntity($newsletter, $queue, $subscriber, $link, 1);
+      if ($userAgent) {
+        $statistics->setUserAgent($userAgent);
+        $statistics->setUserAgentType($userAgent->getUserAgentType());
+      }
       $this->persist($statistics);
     } else {
       $statistics->setCount($statistics->getCount() + 1);

--- a/lib/Statistics/Track/Clicks.php
+++ b/lib/Statistics/Track/Clicks.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Newsletter\Shortcodes\Categories\Link as LinkShortcodeCategory;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
 use MailPoet\Settings\SettingsController;
@@ -88,7 +89,13 @@ class Clicks {
         $queue
       );
       if (!empty($data->userAgent)) {
-        $statisticsClicks->setUserAgent($this->userAgentsRepository->findOrCreate($data->userAgent));
+        $userAgent = $this->userAgentsRepository->findOrCreate($data->userAgent);
+        if ($userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_HUMAN
+          || $statisticsClicks->getUserAgentType() !== UserAgentEntity::USER_AGENT_TYPE_HUMAN
+        ) {
+          $statisticsClicks->setUserAgent($userAgent);
+          $statisticsClicks->setUserAgentType($userAgent->getUserAgentType());
+        }
       }
       $this->statisticsClicksRepository->flush();
       $this->sendRevenueCookie($statisticsClicks);

--- a/lib/Statistics/Track/Opens.php
+++ b/lib/Statistics/Track/Opens.php
@@ -49,7 +49,7 @@ class Opens {
         if (!empty($data->userAgent)) {
           $userAgent = $this->userAgentsRepository->findOrCreate($data->userAgent);
           if ($userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_HUMAN
-            || $oldStatistics->getUserAgentType() !== UserAgentEntity::USER_AGENT_TYPE_HUMAN
+            || $oldStatistics->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_MACHINE
           ) {
             $oldStatistics->setUserAgent($userAgent);
             $oldStatistics->setUserAgentType($userAgent->getUserAgentType());

--- a/tests/integration/Statistics/Track/ClicksTest.php
+++ b/tests/integration/Statistics/Track/ClicksTest.php
@@ -309,7 +309,7 @@ class ClicksTest extends \MailPoetTest {
     expect($trackedClicks)->count(1);
     $click = $trackedClicks[0];
     expect($click->getUserAgent())->null();
-    expect($click->getUserAgentType())->null();
+    expect($click->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     // Track Machine User Agent
     $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $data->userAgent = $machineUserAgentName;
@@ -318,7 +318,7 @@ class ClicksTest extends \MailPoetTest {
     expect($trackedClicks)->count(1);
     $click = $trackedClicks[0];
     expect($click->getUserAgent())->null();
-    expect($click->getUserAgentType())->null();
+    expect($click->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
   }
 
   public function testItOverridesUnknownUserAgentWithHuman(): void {
@@ -342,7 +342,7 @@ class ClicksTest extends \MailPoetTest {
     expect($trackedClicks)->count(1);
     $click = $trackedClicks[0];
     expect($click->getUserAgent())->null();
-    expect($click->getUserAgentType())->null();
+    expect($click->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     // Track Machine User Agent
     $humanUserAgentName = 'User Agent';
     $data->userAgent = $humanUserAgentName;

--- a/tests/integration/Statistics/Track/OpensTest.php
+++ b/tests/integration/Statistics/Track/OpensTest.php
@@ -193,6 +193,76 @@ class OpensTest extends \MailPoetTest {
     expect($userAgent->getUserAgent())->equals('User agent3');
   }
 
+  public function testItDoesNotOverrideHumanUserAgentWithMachine(): void {
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+    // Track Human User Agent
+    $humanUserAgentName = 'Human User Agent';
+    $this->trackData->userAgent = $humanUserAgentName;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    $userAgent = $openEntity->getUserAgent();
+    $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
+    expect($userAgent->getUserAgent())->equals($humanUserAgentName);
+    expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    // Track Machine User Agent
+    $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
+    $this->trackData->userAgent = $machineUserAgentName;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    $userAgent = $openEntity->getUserAgent();
+    $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
+    expect($userAgent->getUserAgent())->equals($humanUserAgentName);
+    expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+  }
+
+  public function testItOverridesMachineUserAgentWithHuman(): void {
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+    // Track Machine User Agent
+    $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
+    $this->trackData->userAgent = $machineUserAgentName;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    $userAgent = $openEntity->getUserAgent();
+    $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
+    expect($userAgent->getUserAgent())->equals($machineUserAgentName);
+    expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_MACHINE);
+    // Track Human User Agent
+    $humanUserAgentName = 'Human User Agent';
+    $this->trackData->userAgent = $humanUserAgentName;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    $userAgent = $openEntity->getUserAgent();
+    $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
+    expect($userAgent->getUserAgent())->equals($humanUserAgentName);
+    expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+  }
+
   public function _after() {
     $this->cleanup();
   }

--- a/tests/integration/Statistics/Track/OpensTest.php
+++ b/tests/integration/Statistics/Track/OpensTest.php
@@ -283,7 +283,7 @@ class OpensTest extends \MailPoetTest {
     $openEntity = reset($openEntities);
     assert($openEntity instanceof StatisticsOpenEntity);
     expect($openEntity->getUserAgent())->null();
-    expect($openEntity->getUserAgentType())->null();
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     // Track Machine User Agent
     $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $this->trackData->userAgent = $machineUserAgentName;
@@ -294,7 +294,7 @@ class OpensTest extends \MailPoetTest {
     $openEntity = reset($openEntities);
     assert($openEntity instanceof StatisticsOpenEntity);
     expect($openEntity->getUserAgent())->null();
-    expect($openEntity->getUserAgentType())->null();
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
   }
 
   public function testItOverridesUnknownUserAgentWithHuman(): void {
@@ -313,7 +313,7 @@ class OpensTest extends \MailPoetTest {
     $openEntity = reset($openEntities);
     assert($openEntity instanceof StatisticsOpenEntity);
     expect($openEntity->getUserAgent())->null();
-    expect($openEntity->getUserAgentType())->null();
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     // Track Human User Agent
     $humanUserAgentName = 'User Agent';
     $this->trackData->userAgent = $humanUserAgentName;

--- a/tests/integration/Statistics/Track/OpensTest.php
+++ b/tests/integration/Statistics/Track/OpensTest.php
@@ -213,6 +213,7 @@ class OpensTest extends \MailPoetTest {
     $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
     expect($userAgent->getUserAgent())->equals($humanUserAgentName);
     expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     // Track Machine User Agent
     $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $this->trackData->userAgent = $machineUserAgentName;
@@ -226,6 +227,7 @@ class OpensTest extends \MailPoetTest {
     $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
     expect($userAgent->getUserAgent())->equals($humanUserAgentName);
     expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
   }
 
   public function testItOverridesMachineUserAgentWithHuman(): void {
@@ -248,6 +250,7 @@ class OpensTest extends \MailPoetTest {
     $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
     expect($userAgent->getUserAgent())->equals($machineUserAgentName);
     expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_MACHINE);
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_MACHINE);
     // Track Human User Agent
     $humanUserAgentName = 'Human User Agent';
     $this->trackData->userAgent = $humanUserAgentName;
@@ -261,6 +264,70 @@ class OpensTest extends \MailPoetTest {
     $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
     expect($userAgent->getUserAgent())->equals($humanUserAgentName);
     expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+  }
+
+  public function testItDoesNotOverrideUnknownUserAgentWithMachine(): void {
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+    // Track Unknown User Agent
+    $this->trackData->userAgent = null;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    expect($openEntity->getUserAgent())->null();
+    expect($openEntity->getUserAgentType())->null();
+    // Track Machine User Agent
+    $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
+    $this->trackData->userAgent = $machineUserAgentName;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    expect($openEntity->getUserAgent())->null();
+    expect($openEntity->getUserAgentType())->null();
+  }
+
+  public function testItOverridesUnknownUserAgentWithHuman(): void {
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+    // Track Unknown User Agent
+    $this->trackData->userAgent = null;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    assert($openEntity instanceof StatisticsOpenEntity);
+    expect($openEntity->getUserAgent())->null();
+    expect($openEntity->getUserAgentType())->null();
+    // Track Human User Agent
+    $humanUserAgentName = 'User Agent';
+    $this->trackData->userAgent = $humanUserAgentName;
+    $opens->track($this->trackData);
+    expect(count(StatisticsOpens::findMany()))->equals(1);
+    $openEntities = $this->statisticsOpensRepository->findAll();
+    expect($openEntities)->count(1);
+    $openEntity = reset($openEntities);
+    $this->assertInstanceOf(StatisticsOpenEntity::class, $openEntity);
+    $userAgent = $openEntity->getUserAgent();
+    $this->assertInstanceOf(UserAgentEntity::class, $userAgent);
+    expect($userAgent->getUserAgent())->equals($humanUserAgentName);
+    expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
   }
 
   public function _after() {


### PR DESCRIPTION
[MAILPOET-3736]

I tried to test the performance on my local with an old mailpoet.com export. It looked fine, but I'm still slightly afraid about recreating indexes in bigger databases. Also, I had to add deleting old indexes because our migration tool doesn't support it.



[MAILPOET-3736]: https://mailpoet.atlassian.net/browse/MAILPOET-3736