### PR TITLE
Fix reply-to address when sending WP e-mails [MAILPOET-3707]

### DIFF
--- a/lib/Mailer/WordPress/WordPressMailer.php
+++ b/lib/Mailer/WordPress/WordPressMailer.php
@@ -51,7 +51,15 @@ class WordPressMailer extends \PHPMailer {
     ];
 
     $sendWithMailer = function ($mailer) use ($email, $address, $extraParams) {
+      // we need to call Mailer::init() for every single WP e-mail to make sure reply-to is set
+      $replyTo = $this->getReplyToAddress();
+      $mailer->init(false, false, $replyTo);
+
       $result = $mailer->send($email, $address, $extraParams);
+
+      // make sure Mailer::init() is called again to clear the reply-to address that was just set if Mailer is used in another context
+      $mailer->mailerInstance = null;
+
       if (!$result['response']) {
         throw new \Exception($result['error']->getMessage());
       }
@@ -102,5 +110,26 @@ class WordPressMailer extends \PHPMailer {
       $result['full_name'] = $data[1];
     }
     return $result;
+  }
+
+  private function getReplyToAddress() {
+    $replyToAddress = false;
+    $addresses = $this->getReplyToAddresses();
+
+    if (!empty($addresses)) {
+      // only one reply-to address supported by \MailPoet\Mailer
+      $address = array_shift($addresses);
+      $replyToAddress = [];
+
+      if ($address[1]) {
+        $replyToAddress['name'] = $address[1];
+      }
+
+      if ($address[0]) {
+        $replyToAddress['address'] = $address[0];
+      }
+    }
+
+    return $replyToAddress;
   }
 }


### PR DESCRIPTION
This PR makes sure that the reply-to set for WP e-mails is preserved when MailPoet is used to send them. Before this change, MailPoet would ignore whatever was set for the reply-to field for WP e-mails and use the same address as the one used for the sender instead.

I'm not super happy with the solution proposed here. I couldn't find an easy way to simply set the reply-to address in the Mailer class, and that is why I'm calling Mailer::init() inside WordPressMailer. There was some discussion in an early PR (#3632) that I created to get feedback, and Pavel proposed using `->setShared(false)` in the ContainerConfigurator to make sure that a new instance of the Mailer class would be created every time we try to get this service. This would solve the problem that I described [here](https://github.com/mailpoet/mailpoet/pull/3632#discussion_r691271344), but I feared that this could have some unwanted consequences as it would mean that we would be creating a new instance of a given Mailer method every time Mailer is instantiated (https://github.com/mailpoet/mailpoet/blob/03400bc4f7e55f1f41139d030d2cb6ddde7dc025/lib/Mailer/Mailer.php#L67). 

In the end, I settled with setting Mailer::mailerInstance to null inside WordPressMailer after sending the e-mail (https://github.com/mailpoet/mailpoet/compare/fix-reply-to-for-wordpress-emails?expand=1#diff-02d6925a03cbe58555aee6dd4eebad337d3e9901408dbd3b3e79ce0642a40d49R61).

I don't particularly like the way that the new tests that I added work. They are sending the e-mails as I didn't find a way to check the reply-to address of the e-mails without actually sending them. There might be a way to achieve this using PHPUnit mocks, but I couldn't find it, and I didn't want to spend too much time on this task. The other problem that I see with the tests is that I had to create a hack using reflection to get the value of a private property to check if the reply-to address is correct, which is an anti-pattern for tests (see WordpressMailerTest::getPrivateProperty()). But again, I opted to leave it as is to not spend too much time on this task. Suggestions here are welcome if you can think of a better way to write those tests.

See the Jira ticket for testing instructions.

[MAILPOET-3707]