### PR TITLE
Save last subscriber's engagement [MAILPOET-3762]

### DIFF
--- a/lib/Config/Hooks.php
+++ b/lib/Config/Hooks.php
@@ -77,6 +77,7 @@ class Hooks {
     $this->setupWPUsers();
     $this->setupWooCommerceUsers();
     $this->setupWooCommercePurchases();
+    $this->setupWooCommerceSubscriberEngagement();
     $this->setupImageSize();
     $this->setupListing();
     $this->setupSubscriptionEvents();
@@ -321,6 +322,14 @@ class Hooks {
         1
       );
     }
+  }
+
+  public function setupWooCommerceSubscriberEngagement() {
+    $this->wp->addAction(
+      'woocommerce_new_order',
+      [$this->hooksWooCommerce, 'updateSubscriberEngagement'],
+      7
+    );
   }
 
   public function setupImageSize() {

--- a/lib/Config/HooksWooCommerce.php
+++ b/lib/Config/HooksWooCommerce.php
@@ -7,6 +7,7 @@ use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\Statistics\Track\WooCommercePurchases;
 use MailPoet\Subscription\Registration;
 use MailPoet\WooCommerce\Settings as WooCommerceSettings;
+use MailPoet\WooCommerce\SubscriberEngagement;
 use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
 
 class HooksWooCommerce {
@@ -28,13 +29,17 @@ class HooksWooCommerce {
   /** @var LoggerFactory */
   private $loggerFactory;
 
+  /** @var SubscriberEngagement */
+  private $subscriberEngagement;
+
   public function __construct(
     WooCommerceSubscription $woocommerceSubscription,
     WooCommerceSegment $woocommerceSegment,
     WooCommerceSettings $woocommerceSettings,
     WooCommercePurchases $woocommercePurchases,
     Registration $subscriberRegistration,
-    LoggerFactory $loggerFactory
+    LoggerFactory $loggerFactory,
+    SubscriberEngagement $subscriberEngagement
   ) {
     $this->woocommerceSubscription = $woocommerceSubscription;
     $this->woocommerceSegment = $woocommerceSegment;
@@ -42,6 +47,7 @@ class HooksWooCommerce {
     $this->woocommercePurchases = $woocommercePurchases;
     $this->loggerFactory = $loggerFactory;
     $this->subscriberRegistration = $subscriberRegistration;
+    $this->subscriberEngagement = $subscriberEngagement;
   }
 
   public function extendWooCommerceCheckoutForm() {
@@ -109,6 +115,14 @@ class HooksWooCommerce {
       $this->logError($e, 'WooCommerce on Register');
     }
     return $errors;
+  }
+
+  public function updateSubscriberEngagement($orderId) {
+    try {
+      $this->subscriberEngagement->updateSubscriberEngagement($orderId);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Update Subscriber Engagement');
+    }
   }
 
   private function logError(\Throwable $e, $name) {

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -224,6 +224,7 @@ class Migrator {
       'link_token char(32) NULL,',
       'engagement_score FLOAT unsigned NULL,',
       'engagement_score_updated_at timestamp NULL,',
+      'last_engagement_at timestamp NULL,',
       'PRIMARY KEY  (id),',
       'UNIQUE KEY email (email),',
       'UNIQUE KEY unsubscribe_token (unsubscribe_token),',

--- a/lib/Cron/Daemon.php
+++ b/lib/Cron/Daemon.php
@@ -74,6 +74,7 @@ class Daemon {
     yield $this->workersFactory->createStatsNotificationsWorkerForAutomatedEmails();
     yield $this->workersFactory->createSubscriberLinkTokensWorker();
     yield $this->workersFactory->createSubscribersEngagementScoreWorker();
+    yield $this->workersFactory->createSubscribersLastEngagementWorker();
     yield $this->workersFactory->createSubscribersCountCacheRecalculationWorker();
   }
 }

--- a/lib/Cron/Triggers/WordPress.php
+++ b/lib/Cron/Triggers/WordPress.php
@@ -17,6 +17,7 @@ use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
 use MailPoet\Cron\Workers\SubscriberLinkTokens;
 use MailPoet\Cron\Workers\SubscribersCountCacheRecalculation;
 use MailPoet\Cron\Workers\SubscribersEngagementScore;
+use MailPoet\Cron\Workers\SubscribersLastEngagement;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Cron\Workers\WooCommercePastOrders;
 use MailPoet\Cron\Workers\WooCommerceSync as WooCommerceSyncWorker;
@@ -214,9 +215,16 @@ class WordPress {
       'status' => ['null', ScheduledTask::STATUS_SCHEDULED],
     ]);
 
-    // subscriber engagement score
+    // subscriber counts cache recalculation
     $subscribersCountCacheRecalculationTasks = $this->getTasksCount([
       'type' => SubscribersCountCacheRecalculation::TASK_TYPE,
+      'scheduled_in' => [self::SCHEDULED_IN_THE_PAST],
+      'status' => ['null', ScheduledTask::STATUS_SCHEDULED],
+    ]);
+
+    // subscriber last engagement
+    $subscribersLastEngagementTasks = $this->getTasksCount([
+      'type' => SubscribersLastEngagement::TASK_TYPE,
       'scheduled_in' => [self::SCHEDULED_IN_THE_PAST],
       'status' => ['null', ScheduledTask::STATUS_SCHEDULED],
     ]);
@@ -246,6 +254,7 @@ class WordPress {
       || $subscriberLinkTokensTasks
       || $subscriberEngagementScoreTasks
       || $subscribersCountCacheRecalculationTasks
+      || $subscribersLastEngagementTasks
     );
   }
 

--- a/lib/Cron/Workers/SubscribersLastEngagement.php
+++ b/lib/Cron/Workers/SubscribersLastEngagement.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Models\ScheduledTask;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class SubscribersLastEngagement extends SimpleWorker {
+  const AUTOMATIC_SCHEDULING = false;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+  const BATCH_SIZE = 60;
+  const TASK_TYPE = 'subscribers_last_engagement';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    parent::__construct();
+    $this->entityManager = $entityManager;
+  }
+
+  public function processTaskStrategy(ScheduledTask $task, $timer) {
+    $statisticsClicksTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
+    $statisticsOpensTable = $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement("
+    UPDATE $subscribersTable as mps
+      LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
+      LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
+    SET mps.last_engagement_at = GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at, 0))
+    WHERE mps.last_engagement_at IS NULL;
+    ");
+  }
+}

--- a/lib/Cron/Workers/SubscribersLastEngagement.php
+++ b/lib/Cron/Workers/SubscribersLastEngagement.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\ScheduledTask;
+use MailPoet\Util\DBCollationChecker;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class SubscribersLastEngagement extends SimpleWorker {
@@ -17,11 +18,19 @@ class SubscribersLastEngagement extends SimpleWorker {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var DBCollationChecker */
+  private $dbCollationChecker;
+
+  /** @var null|string */
+  private $emailCollationCorrection;
+
   public function __construct(
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    DBCollationChecker $dbCollationChecker
   ) {
     parent::__construct();
     $this->entityManager = $entityManager;
+    $this->dbCollationChecker = $dbCollationChecker;
   }
 
   public function processTaskStrategy(ScheduledTask $task, $timer): bool {
@@ -46,11 +55,22 @@ class SubscribersLastEngagement extends SimpleWorker {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $postsTable = $wpdb->posts;
     $postsmetaTable = $wpdb->postmeta;
+
+    if (is_null($this->emailCollationCorrection)) {
+      $this->emailCollationCorrection = $this->dbCollationChecker->getCollateIfNeeded(
+        $subscribersTable,
+        'email',
+        $postsmetaTable,
+        'meta_value'
+      );
+    }
+    $emailCollate = $this->emailCollationCorrection;
+
     $this->entityManager->getConnection()->executeStatement("
     UPDATE $subscribersTable as mps
       LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
       LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
-      LEFT JOIN (SELECT MAX(post_id) AS post_id, meta_value as email FROM $postsmetaTable WHERE meta_key = '_billing_email' GROUP BY email) AS newestOrderIds ON newestOrderIds.email = mps.email
+      LEFT JOIN (SELECT MAX(post_id) AS post_id, meta_value as email FROM $postsmetaTable WHERE meta_key = '_billing_email' GROUP BY email) AS newestOrderIds ON newestOrderIds.email $emailCollate = mps.email
       LEFT JOIN (SELECT ID, post_date FROM $postsTable WHERE post_type = 'shop_order') AS shopOrders ON newestOrderIds.post_id = shopOrders.ID
     SET mps.last_engagement_at = NULLIF(GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at,0), COALESCE(shopOrders.post_date, 0)), 0)
     WHERE mps.last_engagement_at IS NULL AND mps.id >= $minSubscriberId AND  mps.id < $maxSubscriberId;

--- a/lib/Cron/Workers/SubscribersLastEngagement.php
+++ b/lib/Cron/Workers/SubscribersLastEngagement.php
@@ -25,14 +25,19 @@ class SubscribersLastEngagement extends SimpleWorker {
   }
 
   public function processTaskStrategy(ScheduledTask $task, $timer) {
+    global $wpdb;
     $statisticsClicksTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
     $statisticsOpensTable = $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $postsTable = $wpdb->posts;
+    $postsmetaTable = $wpdb->postmeta;
     $this->entityManager->getConnection()->executeStatement("
     UPDATE $subscribersTable as mps
       LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
       LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
-    SET mps.last_engagement_at = GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at, 0))
+      LEFT JOIN (SELECT MAX(post_id) AS post_id, meta_value as email FROM $postsmetaTable WHERE meta_key = '_billing_email' GROUP BY email) AS newestOrderIds ON newestOrderIds.email = mps.email
+      LEFT JOIN (SELECT ID, post_date FROM $postsTable WHERE post_type = 'shop_order') AS shopOrders ON newestOrderIds.post_id = shopOrders.ID
+    SET mps.last_engagement_at = NULLIF(GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at,0), COALESCE(shopOrders.post_date, 0)), 0)
     WHERE mps.last_engagement_at IS NULL;
     ");
   }

--- a/lib/Cron/Workers/SubscribersLastEngagement.php
+++ b/lib/Cron/Workers/SubscribersLastEngagement.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Util\DBCollationChecker;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class SubscribersLastEngagement extends SimpleWorker {
@@ -21,16 +22,21 @@ class SubscribersLastEngagement extends SimpleWorker {
   /** @var DBCollationChecker */
   private $dbCollationChecker;
 
+  /** @var WooCommerceHelper */
+  private $wooCommereHelper;
+
   /** @var null|string */
   private $emailCollationCorrection;
 
   public function __construct(
     EntityManager $entityManager,
-    DBCollationChecker $dbCollationChecker
+    DBCollationChecker $dbCollationChecker,
+    WooCommerceHelper $wooCommereHelper
   ) {
     parent::__construct();
     $this->entityManager = $entityManager;
     $this->dbCollationChecker = $dbCollationChecker;
+    $this->wooCommereHelper = $wooCommereHelper;
   }
 
   public function processTaskStrategy(ScheduledTask $task, $timer): bool {
@@ -66,15 +72,27 @@ class SubscribersLastEngagement extends SimpleWorker {
     }
     $emailCollate = $this->emailCollationCorrection;
 
-    $this->entityManager->getConnection()->executeStatement("
-    UPDATE $subscribersTable as mps
-      LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
-      LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
-      LEFT JOIN (SELECT MAX(post_id) AS post_id, meta_value as email FROM $postsmetaTable WHERE meta_key = '_billing_email' GROUP BY email) AS newestOrderIds ON newestOrderIds.email $emailCollate = mps.email
-      LEFT JOIN (SELECT ID, post_date FROM $postsTable WHERE post_type = 'shop_order') AS shopOrders ON newestOrderIds.post_id = shopOrders.ID
-    SET mps.last_engagement_at = NULLIF(GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at,0), COALESCE(shopOrders.post_date, 0)), 0)
-    WHERE mps.last_engagement_at IS NULL AND mps.id >= $minSubscriberId AND  mps.id < $maxSubscriberId;
-    ");
+    $query = "
+      UPDATE $subscribersTable as mps
+        LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
+        LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
+      SET mps.last_engagement_at = NULLIF(GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at,0)), 0)
+      WHERE mps.last_engagement_at IS NULL AND mps.id >= $minSubscriberId AND  mps.id < $maxSubscriberId;
+    ";
+
+    // Use more complex query that takes into the account also subscriber's latest WooCommerce order
+    if ($this->wooCommereHelper->isWooCommerceActive()) {
+      $query = "
+        UPDATE $subscribersTable as mps
+          LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
+          LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
+          LEFT JOIN (SELECT MAX(post_id) AS post_id, meta_value as email FROM $postsmetaTable WHERE meta_key = '_billing_email' GROUP BY email) AS newestOrderIds ON newestOrderIds.email $emailCollate = mps.email
+          LEFT JOIN (SELECT ID, post_date FROM $postsTable WHERE post_type = 'shop_order') AS shopOrders ON newestOrderIds.post_id = shopOrders.ID
+        SET mps.last_engagement_at = NULLIF(GREATEST(COALESCE(mpso.created_at, 0), COALESCE(mpsc.created_at,0), COALESCE(shopOrders.post_date, 0)), 0)
+        WHERE mps.last_engagement_at IS NULL AND mps.id >= $minSubscriberId AND  mps.id < $maxSubscriberId;
+      ";
+    }
+    $this->entityManager->getConnection()->executeStatement($query);
   }
 
   private function getHighestSubscriberId(): int {

--- a/lib/Cron/Workers/WorkersFactory.php
+++ b/lib/Cron/Workers/WorkersFactory.php
@@ -96,6 +96,11 @@ class WorkersFactory {
     return $this->container->get(SubscribersEngagementScore::class);
   }
 
+  /** @return SubscribersLastEngagement */
+  public function createSubscribersLastEngagementWorker() {
+    return $this->container->get(SubscribersLastEngagement::class);
+  }
+
   /** @return AuthorizedSendingEmailsCheck */
   public function createAuthorizedSendingEmailsCheckWorker() {
     return $this->container->get(AuthorizedSendingEmailsCheck::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -370,6 +370,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\NewsletterTemplates\NewsletterTemplatesRepository::class)->setPublic(true);
     // Util
     $container->autowire(\MailPoet\Util\Cookies::class);
+    $container->autowire(\MailPoet\Util\DBCollationChecker::class);
     $container->autowire(\MailPoet\Util\Url::class)->setPublic(true);
     $container->autowire(\MailPoet\Util\Installation::class);
     $container->autowire(\MailPoet\Util\Security::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -169,6 +169,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\WooCommercePastOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersEngagementScore::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\SubscribersLastEngagement::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersCountCacheRecalculation::class)->setPublic(true);
     // Custom field
     $container->autowire(\MailPoet\CustomFields\ApiDataSanitizer::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -380,6 +380,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // WooCommerce
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\SubscriberEngagement::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmailHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails::class)->setPublic(true);

--- a/lib/Entities/SubscriberEntity.php
+++ b/lib/Entities/SubscriberEntity.php
@@ -448,7 +448,7 @@ class SubscriberEntity {
     return $this->lastEngagementAt;
   }
 
-  public function setLastEngagementAt(?DateTimeInterface $lastEngagementAt): void {
+  public function setLastEngagementAt(DateTimeInterface $lastEngagementAt): void {
     $this->lastEngagementAt = $lastEngagementAt;
   }
 

--- a/lib/Entities/SubscriberEntity.php
+++ b/lib/Entities/SubscriberEntity.php
@@ -139,6 +139,12 @@ class SubscriberEntity {
   private $engagementScoreUpdatedAt;
 
   /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $lastEngagementAt;
+
+  /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\SubscriberSegmentEntity", mappedBy="subscriber", orphanRemoval=true)
    * @var Collection<int, SubscriberSegmentEntity>
    */
@@ -436,6 +442,14 @@ class SubscriberEntity {
    */
   public function setEngagementScoreUpdatedAt(?DateTimeInterface $engagementScoreUpdatedAt): void {
     $this->engagementScoreUpdatedAt = $engagementScoreUpdatedAt;
+  }
+
+  public function getLastEngagementAt(): ?DateTimeInterface {
+    return $this->lastEngagementAt;
+  }
+
+  public function setLastEngagementAt(?DateTimeInterface $lastEngagementAt): void {
+    $this->lastEngagementAt = $lastEngagementAt;
   }
 
   /** @ORM\PreFlush */

--- a/lib/Statistics/Track/Clicks.php
+++ b/lib/Statistics/Track/Clicks.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\Shortcodes\Shortcodes;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\UserAgentsRepository;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\Cookies;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -45,6 +46,9 @@ class Clicks {
   /** @var UserAgentsRepository */
   private $userAgentsRepository;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
   public function __construct(
     SettingsController $settingsController,
     Cookies $cookies,
@@ -52,7 +56,8 @@ class Clicks {
     Opens $opens,
     StatisticsClicksRepository $statisticsClicksRepository,
     UserAgentsRepository $userAgentsRepository,
-    LinkShortcodeCategory $linkShortcodeCategory
+    LinkShortcodeCategory $linkShortcodeCategory,
+    SubscribersRepository $subscribersRepository
   ) {
     $this->settingsController = $settingsController;
     $this->cookies = $cookies;
@@ -61,6 +66,7 @@ class Clicks {
     $this->opens = $opens;
     $this->statisticsClicksRepository = $statisticsClicksRepository;
     $this->userAgentsRepository = $userAgentsRepository;
+    $this->subscribersRepository = $subscribersRepository;
   }
 
   /**
@@ -102,6 +108,8 @@ class Clicks {
       $this->sendAbandonedCartCookie($subscriber);
       // track open event
       $this->opens->track($data, $displayImage = false);
+      // Update engagement date
+      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
     }
     $url = $this->processUrl($link->getUrl(), $newsletter, $subscriber, $queue, $wpUserPreview);
     $this->redirectToUrl($url);

--- a/lib/Statistics/Track/Opens.php
+++ b/lib/Statistics/Track/Opens.php
@@ -10,7 +10,6 @@ use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoetVendor\Carbon\Carbon;
 
 class Opens {
   /** @var StatisticsOpensRepository */
@@ -63,7 +62,7 @@ class Opens {
             $this->statisticsOpensRepository->flush();
           }
         }
-        $this->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
+        $this->subscribersRepository->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
         return $this->returnResponse($displayImage);
       }
       $statistics = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
@@ -74,19 +73,10 @@ class Opens {
       }
       $this->statisticsOpensRepository->persist($statistics);
       $this->statisticsOpensRepository->flush();
-      $this->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
+      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
       $this->statisticsOpensRepository->recalculateSubscriberScore($subscriber);
     }
     return $this->returnResponse($displayImage);
-  }
-
-  private function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity, ?UserAgentEntity $userAgent): void {
-    if ($userAgent instanceof UserAgentEntity && $userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_MACHINE) {
-      return;
-    }
-    // Update last engagement for human (and also unknown) user agent
-    $subscriberEntity->setLastEngagementAt(Carbon::now());
-    $this->subscribersRepository->flush();
   }
 
   public function returnResponse($displayImage) {

--- a/lib/Subscribers/SubscribersRepository.php
+++ b/lib/Subscribers/SubscribersRepository.php
@@ -312,6 +312,10 @@ class SubscribersRepository extends Repository {
     if ($userAgent instanceof UserAgentEntity && $userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_MACHINE) {
       return;
     }
+    // Do not update engagement if was recently updated to avoid unnecessary updates in DB
+    if ($subscriberEntity->getLastEngagementAt() && $subscriberEntity->getLastEngagementAt() > Carbon::now()->subMinute()) {
+      return;
+    }
     // Update last engagement for human (and also unknown) user agent
     $subscriberEntity->setLastEngagementAt(Carbon::now());
     $this->flush();

--- a/lib/Subscribers/SubscribersRepository.php
+++ b/lib/Subscribers/SubscribersRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\UserAgentEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Connection;
@@ -305,5 +306,14 @@ class SubscribersRepository extends Repository {
       ->getQuery()
       ->setMaxResults($limit)
       ->getResult();
+  }
+
+  public function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity, ?UserAgentEntity $userAgent): void {
+    if ($userAgent instanceof UserAgentEntity && $userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_MACHINE) {
+      return;
+    }
+    // Update last engagement for human (and also unknown) user agent
+    $subscriberEntity->setLastEngagementAt(Carbon::now());
+    $this->flush();
   }
 }

--- a/lib/Subscribers/SubscribersRepository.php
+++ b/lib/Subscribers/SubscribersRepository.php
@@ -308,7 +308,7 @@ class SubscribersRepository extends Repository {
       ->getResult();
   }
 
-  public function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity, ?UserAgentEntity $userAgent): void {
+  public function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity, ?UserAgentEntity $userAgent = null): void {
     if ($userAgent instanceof UserAgentEntity && $userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_MACHINE) {
       return;
     }

--- a/lib/Util/DBCollationChecker.php
+++ b/lib/Util/DBCollationChecker.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Util;
 

--- a/lib/Util/DBCollationChecker.php
+++ b/lib/Util/DBCollationChecker.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MailPoet\Util;
+
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class DBCollationChecker {
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    $this->entityManager = $entityManager;
+  }
+
+  /**
+   * If two columns have a different collations returns MySQL's COLLATE command to be used with the target table column.
+   * e.g. WHERE source_table.column = target_table.column COLLATE xyz
+   */
+  public function getCollateIfNeeded(string $sourceTable, string $sourceColumn, string $targetTable, string $targetColumn): string {
+    $connection = $this->entityManager->getConnection();
+    $sourceColumnData = $connection->executeQuery("SHOW FULL COLUMNS FROM $sourceTable WHERE Field = '$sourceColumn';")->fetchAllAssociative();
+    $sourceCollation = $sourceColumnData[0]['Collation'] ?? '';
+    $targetColumnData = $connection->executeQuery("SHOW FULL COLUMNS FROM $targetTable WHERE Field = '$targetColumn';")->fetchAllAssociative();
+    $targetCollation = $targetColumnData[0]['Collation'] ?? '';
+    if ($sourceCollation !== $targetCollation) {
+      return "COLLATE $sourceCollation";
+    }
+    return '';
+  }
+}

--- a/lib/WooCommerce/SubscriberEngagement.php
+++ b/lib/WooCommerce/SubscriberEngagement.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/lib/WooCommerce/SubscriberEngagement.php
+++ b/lib/WooCommerce/SubscriberEngagement.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use WC_Order;
+
+class SubscriberEngagement {
+
+  /** @var Helper */
+  private $woocommerceHelper;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  public function __construct(
+    Helper $woocommerceHelper,
+    SubscribersRepository $subscribersRepository
+  ) {
+    $this->woocommerceHelper = $woocommerceHelper;
+    $this->subscribersRepository = $subscribersRepository;
+  }
+
+  public function updateSubscriberEngagement($orderId): void {
+    $order = $this->woocommerceHelper->wcGetOrder($orderId);
+    if (!$order instanceof WC_Order) {
+      return;
+    }
+
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $order->get_billing_email()]);
+    if (!$subscriber instanceof SubscriberEntity) {
+      return;
+    }
+
+    $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
+  }
+}

--- a/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -303,6 +303,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createUnsubscribeTokensWorker' => $worker,
       'createSubscriberLinkTokensWorker' => $worker,
       'createSubscribersEngagementScoreWorker' => $worker,
+      'createSubscribersLastEngagementWorker' => $worker,
       'createSubscribersCountCacheRecalculationWorker' => $worker,
     ]);
   }

--- a/tests/integration/Cron/DaemonTest.php
+++ b/tests/integration/Cron/DaemonTest.php
@@ -59,6 +59,7 @@ class DaemonTest extends \MailPoetTest {
       'createUnsubscribeTokensWorker' => $this->createSimpleWorkerMock(),
       'createSubscriberLinkTokensWorker' => $this->createSimpleWorkerMock(),
       'createSubscribersEngagementScoreWorker' => $this->createSimpleWorkerMock(),
+      'createSubscribersLastEngagementWorker' => $this->createSimpleWorkerMock(),
       'createSubscribersCountCacheRecalculationWorker' => $this->createSimpleWorkerMock(),
     ]);
   }

--- a/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
+++ b/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Models\ScheduledTask;
+use MailPoetVendor\Carbon\Carbon;
+
+class SubscribersLastEngagementTest extends \MailPoetTest {
+  /** @var SubscribersLastEngagement */
+  private $worker;
+
+  public function _before() {
+    parent::_before();
+    $this->worker = $this->diContainer->get(SubscribersLastEngagement::class);
+  }
+
+  public function testItCanSetLastEngagementFromOpens() {
+    $openTime = new Carbon('2021-08-10 12:13:14');
+    $subscriber = $this->createSubscriber();
+    $newsletter = $this->createSentNewsletter();
+    $this->createOpen(new Carbon($openTime), $newsletter, $subscriber);
+
+    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getLastEngagementAt())->equals($openTime);
+  }
+
+  public function testItCanSetLastEngagementFromClicks() {
+    $clickTime = new Carbon('2021-08-10 13:14:15');
+    $subscriber = $this->createSubscriber();
+    $newsletter = $this->createSentNewsletter();
+    $this->createOpen(new Carbon($clickTime), $newsletter, $subscriber);
+
+    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getLastEngagementAt())->equals($clickTime);
+  }
+
+  public function testItPicksLatestTime() {
+    $openTime = new Carbon('2021-08-10 12:13:14');
+    $clickTime = new Carbon('2021-08-10 13:14:15');
+    $subscriber = $this->createSubscriber();
+    $newsletter = $this->createSentNewsletter();
+    $this->createOpen(new Carbon($openTime), $newsletter, $subscriber);
+    $this->createClick(new Carbon($clickTime), $newsletter, $subscriber);
+
+    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getLastEngagementAt())->equals($clickTime);
+  }
+
+  private function createSubscriber(): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail('last-engagement@test.com');
+    $this->entityManager->persist($subscriber);
+    $this->entityManager->flush();
+    return $subscriber;
+  }
+
+  private function createOpen(Carbon $time, NewsletterEntity $newsletter, SubscriberEntity $subscriber): StatisticsOpenEntity {
+    $open = new StatisticsOpenEntity($newsletter, $newsletter->getLatestQueue(), $subscriber);
+    $open->setCreatedAt($time);
+    $this->entityManager->persist($open);
+    $this->entityManager->flush();
+    return $open;
+  }
+
+  private function createClick(Carbon $time, NewsletterEntity $newsletter, SubscriberEntity $subscriber): StatisticsClickEntity {
+    $link = new NewsletterLinkEntity($newsletter, $newsletter->getLatestQueue(), 'http://example.com', 'hash123');
+    $this->entityManager->persist($link);
+    $click = new StatisticsClickEntity($newsletter, $newsletter->getLatestQueue(), $subscriber, $link, 1);
+    $click->setCreatedAt($time);
+    $this->entityManager->persist($click);
+    $this->entityManager->flush();
+    return $click;
+  }
+
+  private function createSentNewsletter(): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $task = new ScheduledTaskEntity();
+    $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->entityManager->persist($task);
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletterRenderedBody(['html' => 'html', 'text' => 'text']);
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setSubject('subject');
+    $newsletter->setSentAt(Carbon::now()->subMonth());
+    $newsletter->getQueues()->add($queue);
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    return $newsletter;
+  }
+
+  public function _after() {
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(ScheduledTaskEntity::class);
+    $this->truncateEntity(SendingQueueEntity::class);
+    $this->truncateEntity(NewsletterEntity::class);
+    $this->truncateEntity(StatisticsClickEntity::class);
+    $this->truncateEntity(StatisticsOpenEntity::class);
+  }
+}

--- a/tests/integration/Statistics/Track/ClicksTest.php
+++ b/tests/integration/Statistics/Track/ClicksTest.php
@@ -545,6 +545,28 @@ class ClicksTest extends \MailPoetTest {
     expect($this->subscriber->getLastEngagementAt())->null();
   }
 
+  public function testItWontUpdateSubscriberThatWasRecentlyUpdated() {
+    $lastEngagement = Carbon::now()->subSeconds(10);
+    $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
+    $this->subscriber->setLastEngagementAt($lastEngagement);
+    $data = $this->trackData;
+    $data->userAgent = UserAgentEntity::MACHINE_USER_AGENTS[0];
+    $clicks = Stub::construct($this->clicks, [
+      $this->settingsController,
+      new Cookies(),
+      $this->diContainer->get(Shortcodes::class),
+      $this->diContainer->get(Opens::class),
+      $clicksRepository,
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(LinkShortcodeCategory::class),
+      $this->diContainer->get(SubscribersRepository::class),
+    ], [
+      'redirectToUrl' => null,
+    ], $this);
+    $clicks->track($data);
+    expect($this->subscriber->getLastEngagementAt())->equals($lastEngagement);
+  }
+
   public function cleanup() {
     $this->truncateEntity(NewsletterEntity::class);
     $this->truncateEntity(SubscriberEntity::class);

--- a/tests/integration/Statistics/Track/OpensTest.php
+++ b/tests/integration/Statistics/Track/OpensTest.php
@@ -15,13 +15,24 @@ use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\Statistics\Track\Opens;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\LinkTokens;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoetVendor\Carbon\Carbon;
 
 class OpensTest extends \MailPoetTest {
+  /** @var Opens */
   public $opens;
+
+  /** @var \stdClass */
   public $trackData;
+
+  /** @var SendingQueueEntity */
   public $queue;
+
+  /** @var SubscriberEntity */
   public $subscriber;
+
+  /** @var NewsletterEntity */
   public $newsletter;
 
   /** @var StatisticsOpensRepository */
@@ -70,13 +81,18 @@ class OpensTest extends \MailPoetTest {
     ];
     // instantiate class
     $this->statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
-    $this->opens = new Opens($this->statisticsOpensRepository, $this->diContainer->get(UserAgentsRepository::class));
+    $this->opens = new Opens(
+      $this->statisticsOpensRepository,
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class)
+    );
   }
 
   public function testItReturnsImageWhenTrackDataIsEmpty() {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => Expected::exactly(1),
     ], $this);
@@ -91,6 +107,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -106,6 +123,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -117,6 +135,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -130,6 +149,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => Expected::exactly(1),
     ], $this);
@@ -141,6 +161,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -159,6 +180,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -177,6 +199,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -197,6 +220,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -234,6 +258,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -271,6 +296,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -301,6 +327,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -328,6 +355,52 @@ class OpensTest extends \MailPoetTest {
     expect($userAgent->getUserAgent())->equals($humanUserAgentName);
     expect($userAgent->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     expect($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+  }
+
+  public function testItUpdatesSubscriberEngagementForHumanAgent() {
+    Carbon::setTestNow($now = Carbon::now());
+    $this->trackData->userAgent = 'User agent';
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+
+    $opens->track($this->trackData);
+    expect($this->subscriber->getLastEngagementAt())->equals($now);
+    Carbon::setTestNow();
+  }
+
+  public function testItUpdatesSubscriberEngagementFoUnknownAgent() {
+    Carbon::setTestNow($now = Carbon::now());
+    $this->trackData->userAgent = null;
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+
+    $opens->track($this->trackData);
+    expect($this->subscriber->getLastEngagementAt())->equals($now);
+    Carbon::setTestNow();
+  }
+
+  public function testItWontUpdateSubscriberEngagementForMachineAgent() {
+    $this->trackData->userAgent = UserAgentEntity::MACHINE_USER_AGENTS[0];
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+
+    $opens->track($this->trackData);
+    expect($this->subscriber->getLastEngagementAt())->null();
   }
 
   public function _after() {

--- a/tests/integration/WooCommerce/SubscriberEngagementTest.php
+++ b/tests/integration/WooCommerce/SubscriberEngagementTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoetVendor\Carbon\Carbon;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Order;
+
+class SubscriberEngagementTest extends \MailPoetTest {
+
+  /** @var Helper & MockObject */
+  private $wooCommerceHelperMock;
+
+  /** @var SubscriberEngagement */
+  private $subscriberEngagement;
+
+  public function _before() {
+    $this->wooCommerceHelperMock = $this->createMock(Helper::class);
+    $this->subscriberEngagement = new SubscriberEngagement(
+      $this->wooCommerceHelperMock,
+      $this->diContainer->get(SubscribersRepository::class)
+    );
+    $this->truncateEntity(SubscriberEntity::class);
+  }
+
+  public function testItUpdatesLastEngagementForSubscriberWhoCreatedNewOrder() {
+    Carbon::setTestNow($now = new Carbon('2021-08-31 13:13:00'));
+    $subscriber = $this->createSubscriber();
+    $order = $this->createOrderMock($subscriber->getEmail());
+    $this->wooCommerceHelperMock
+      ->expects($this->once())
+      ->method('wcGetOrder')
+      ->willReturn($order);
+    $this->subscriberEngagement->updateSubscriberEngagement(1);
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getLastEngagementAt())->equals($now);
+    Carbon::setTestNow();
+  }
+
+  public function testItDoesntUpdateAnythingForNonExistingOder() {
+    $subscriber = $this->createSubscriber();
+    $this->wooCommerceHelperMock
+      ->expects($this->once())
+      ->method('wcGetOrder')
+      ->willReturn(false);
+    $this->subscriberEngagement->updateSubscriberEngagement(1);
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getLastEngagementAt())->null();
+  }
+
+  public function testItDoesntThrowAnErrorForNonExistingSubscriber() {
+    $order = $this->createOrderMock('some@email.com');
+    $this->wooCommerceHelperMock
+      ->expects($this->once())
+      ->method('wcGetOrder')
+      ->willReturn($order);
+    $this->subscriberEngagement->updateSubscriberEngagement(1);
+  }
+
+  private function createOrderMock($email) {
+    $mock = $this->getMockBuilder(WC_Order::class)
+      ->disableOriginalConstructor()
+      ->disableOriginalClone()
+      ->disableArgumentCloning()
+      ->setMethods(['get_billing_email'])
+      ->getMock();
+
+    $mock->method('get_billing_email')->willReturn($email);
+    return $mock;
+  }
+
+  private function createSubscriber(): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail('subscriber@egagement.com');
+    $this->entityManager->persist($subscriber);
+    $this->entityManager->flush();
+    return $subscriber;
+  }
+}


### PR DESCRIPTION
[MAILPOET-3762]

[MAILPOET-3762]: https://mailpoet.atlassian.net/browse/MAILPOET-3762

**Note for QA**
For testing filling of last engagement dates for existing older subscribers, create some engagement data (opens, clicks, and orders) with the current version of the plugin and then install the zip with this feature. The background job is scheduled during plugin activation/update. The last engagement dates are no visible anywhere in UI. You need to install Adminer or PHPMyAdmin and inspect `wp_mailpoet_subscribers` table.