### PR TITLE
Throttling also for logged-in users [MAILPOET-3790]

### DIFF
--- a/tests/integration/Subscription/ThrottlingTest.php
+++ b/tests/integration/Subscription/ThrottlingTest.php
@@ -40,7 +40,7 @@ class ThrottlingTest extends \MailPoetTest {
     expect($this->throttling->throttle())->greaterThan(0);
   }
 
-  public function testItDoesNotThrottleForLoggedInUsers() {
+  public function testItDoesNotThrottleForExemptRoleUsers() {
     $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
     $wpUsers = get_users();
     wp_set_current_user($wpUsers[0]->ID);
@@ -48,6 +48,17 @@ class ThrottlingTest extends \MailPoetTest {
     expect($this->throttling->throttle())->equals(false);
     wp_set_current_user(0);
     expect($this->throttling->throttle())->greaterThan(0);
+  }
+
+  public function testItThrottlesForNotExemptRoleUsers() {
+    $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+    $wpUsers = get_users();
+    $wpUsers[0]->remove_role('administrator');
+    wp_set_current_user($wpUsers[0]->ID);
+    expect($this->throttling->throttle())->equals(false);
+    expect($this->throttling->throttle())->equals(60);
+    $wpUsers[0]->add_role('administrator');
+    wp_set_current_user(0);
   }
 
   public function testItPurgesOldSubscriberIps() {


### PR DESCRIPTION
Skips IP throttling check only for WordPress users with roles administrator or editor. 
Uses a similar [implementation as for captcha](https://github.com/mailpoet/mailpoet/blob/master/lib/Subscription/Captcha.php#L82-L89).

Adds a filter `mailpoet_subscription_throttling_exclude_roles` allowing to set which roles will be allowed to skip the throttling.

Test with:
`./do --test "test:integration --file=tests/integration/Subscription/ThrottlingTest.php"
`

[MAILPOET-3790]

[MAILPOET-3790]: https://mailpoet.atlassian.net/browse/MAILPOET-3790