### PR TITLE
Fix incorrect counts in dynamic segments form [MAILPOET-3761]

### DIFF
--- a/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -46,7 +46,7 @@ class EmailAction implements Filter {
     $action = $filterData->getParam('action');
     $newsletterId = (int)$filterData->getParam('newsletter_id');
     $linkId = $filterData->getParam('link_id') ? (int)$filterData->getParam('link_id') : null;
-    $parameterSuffix = (string)$filter->getId() ?? Security::generateRandomString();
+    $parameterSuffix = (string)($filter->getId() ?? Security::generateRandomString());
 
     $statsSentTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();

--- a/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
+++ b/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
@@ -25,7 +25,7 @@ class MailPoetCustomFields implements Filter {
     $filterData = $filter->getFilterData();
     $customFieldType = $filterData->getParam('custom_field_type');
     $customFieldId = $filterData->getParam('custom_field_id');
-    $parameterSuffix = (string)$filter->getId() ?? Security::generateRandomString();
+    $parameterSuffix = (string)($filter->getId() ?? Security::generateRandomString());
     $customFieldIdParam = ':customFieldId' . $parameterSuffix;
 
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();


### PR DESCRIPTION
I found that in two filters  the $parameterPrefix for SQL query parameters was not created correctly when called for filter which was not saved.

[MAILPOET-3761]

[MAILPOET-3761]: https://mailpoet.atlassian.net/browse/MAILPOET-3761