### PR TITLE
Add classes to Woo checkout opt-in to match other checkboxes [MAILPOET-3498]

### DIFF
--- a/lib/WooCommerce/Subscription.php
+++ b/lib/WooCommerce/Subscription.php
@@ -82,6 +82,8 @@ class Subscription {
       [
         'type' => 'checkbox',
         'label' => $this->wp->escHtml($labelString),
+        'input_class' => ['woocommerce-form__input', 'woocommerce-form__input-checkbox', 'input-checkbox'],
+        'label_class' => ['woocommerce-form__label', 'woocommerce-form__label-for-checkbox', 'checkbox'],
         'custom_attributes' => ['data-automation-id' => 'woo-commerce-subscription-opt-in'],
         'return' => true,
       ],


### PR DESCRIPTION
I couldn't find some nice way of telling WooCommerce to use "standard" checkbox classes so I'm passing them via related options.
[MAILPOET-3498]

[MAILPOET-3498]: https://mailpoet.atlassian.net/browse/MAILPOET-3498