### PR TITLE
Show CAPTCHA from first signup [MAILPOET-3788]

### DIFF
--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -43,12 +43,16 @@ class Captcha {
   }
 
   public function isRequired($subscriberEmail = null) {
-    if ($this->isUserExemptFromCaptcha()) {
+    if ($this->isUserExemptFromCaptcha() ) {
       return false;
     }
 
-    // Check limits per recipient
-    $subscriptionCaptchaRecipientLimit = $this->wp->applyFilters('mailpoet_subscription_captcha_recipient_limit', 1);
+    $subscriptionCaptchaRecipientLimit = $this->wp->applyFilters('mailpoet_subscription_captcha_recipient_limit', 0);
+    if ($subscriptionCaptchaRecipientLimit === 0) {
+      return true;
+    }
+
+    // Check limits per recipient if enabled
     if ($subscriberEmail) {
       $subscriber = Subscriber::where('email', $subscriberEmail)->findOne();
       if ($subscriber instanceof Subscriber

--- a/lib/Subscription/Captcha.php
+++ b/lib/Subscription/Captcha.php
@@ -43,7 +43,7 @@ class Captcha {
   }
 
   public function isRequired($subscriberEmail = null) {
-    if ($this->isUserExemptFromCaptcha() ) {
+    if ($this->isUserExemptFromCaptcha()) {
       return false;
     }
 


### PR DESCRIPTION
With this PR, subscription forms will always display CAPTCHA, if enabled.
The filter `mailpoet_subscription_captcha_recipient_limit` can be used to enable previous behavior if set to a value > 0.

To test:

1. Enable CAPTCHA
2. Create a signup form that is displayed on the site
3. View the site with a user that is not subscribed, that is not an admin or editor, and verify you see the CAPTCHA.

Integration test:
`./do --test "test:integration --file=tests/integration/Subscription/CaptchaTest.php"
`
[MAILPOET-3788]

[MAILPOET-3788]: https://mailpoet.atlassian.net/browse/MAILPOET-3788