### PR TITLE
Make woocommerce subscription opt-in label translatable

### DIFF
--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -147,6 +147,10 @@ class Functions {
   public function escHtml($text) {
     return esc_html($text);
   }
+  
+  public function esc_html__($text, $domain) {
+    return esc_html__($text, $domain);
+  }
 
   public function escSql($sql) {
     return esc_sql($sql);

--- a/lib/WooCommerce/Subscription.php
+++ b/lib/WooCommerce/Subscription.php
@@ -81,7 +81,7 @@ class Subscription {
       $this->wp->escAttr($inputName),
       [
         'type' => 'checkbox',
-        'label' => $this->wp->escHtml($labelString),
+        'label' => esc_html__($labelString, 'mailpoet'),
         'custom_attributes' => ['data-automation-id' => 'woo-commerce-subscription-opt-in'],
         'return' => true,
       ],

--- a/lib/WooCommerce/Subscription.php
+++ b/lib/WooCommerce/Subscription.php
@@ -81,7 +81,7 @@ class Subscription {
       $this->wp->escAttr($inputName),
       [
         'type' => 'checkbox',
-        'label' => esc_html__($labelString, 'mailpoet'),
+        'label' => $this->wp->esc_html__($labelString, 'mailpoet'),
         'custom_attributes' => ['data-automation-id' => 'woo-commerce-subscription-opt-in'],
         'return' => true,
       ],


### PR DESCRIPTION
By changing to the `esc_html__` method, the checkbox label can be translated by manually creating a translation entry in a translation plugin of choice. If no matching translation is available, the behavior is unchanged.