### PR TITLE
Add comment about deprecation warning for font selection toolbar

### DIFF
--- a/assets/js/src/form_editor/components/font_family_settings.tsx
+++ b/assets/js/src/form_editor/components/font_family_settings.tsx
@@ -87,6 +87,7 @@ const FontFamilySettings: React.FunctionComponent<Props> = ({
     selectedValue = options[0];
   }
   return (
+    // CustomSelectControl generates a warning in the console. See [MAILPOET-3399]
     <CustomSelectControl
       options={options}
       onChange={(selected): void => {


### PR DESCRIPTION
Added a comment for deprecation warning generated by the font selection toolbar when editing a form:
`Using custom components as toolbar controls is deprecated. Please use ToolbarItem or ToolbarButton components instead.`

For now, we are going to keep the warning without modifying the component that extends the toolbar.

[MAILPOET-3399]