### PR TITLE
Display the updated_at field using the site timezone [MAILPOET-3692]

### DIFF
--- a/assets/js/src/help/tasks_list/tasks_list_data_row.jsx
+++ b/assets/js/src/help/tasks_list/tasks_list_data_row.jsx
@@ -8,6 +8,9 @@ const TasksListDataRow = (props) => {
   if (scheduled) {
     scheduled = parseDate(scheduled, 'yyyy-MM-dd HH:mm:ss', new Date());
   }
+
+  const updated = parseDate(props.task.updated_at, 'yyyy-MM-dd HH:mm:ss', new Date());
+
   return (
     <tr>
       <td className="column column-primary">
@@ -38,7 +41,7 @@ const TasksListDataRow = (props) => {
         </td>
       ) : null}
       <td className="column-date">
-        <abbr>{MailPoet.Date.format(props.task.updated_at * 1000)}</abbr>
+        <abbr>{`${MailPoet.Date.short(updated)} ${MailPoet.Date.time(updated)}`}</abbr>
       </td>
     </tr>
   );
@@ -50,7 +53,7 @@ TasksListDataRow.propTypes = {
     id: PropTypes.number.isRequired,
     type: PropTypes.string.isRequired,
     priority: PropTypes.number.isRequired,
-    updated_at: PropTypes.number.isRequired,
+    updated_at: PropTypes.string.isRequired,
     scheduled_at: PropTypes.string,
     status: PropTypes.string,
     newsletter: PropTypes.shape({

--- a/lib/Tasks/State.php
+++ b/lib/Tasks/State.php
@@ -7,7 +7,6 @@ use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Url as NewsletterUrl;
-use MailPoetVendor\Carbon\Carbon;
 
 class State {
   /** @var NewsletterUrl */
@@ -88,7 +87,7 @@ class State {
       'id' => (int)$task->id,
       'type' => $task->type,
       'priority' => (int)$task->priority,
-      'updated_at' => Carbon::createFromTimeString((string)$task->updatedAt)->timestamp,
+      'updated_at' => $task->updatedAt,
       'scheduled_at' => $task->scheduledAt ? $task->scheduledAt : null,
       'status' => $task->status,
       'newsletter' => (($queue instanceof SendingQueue) && ($newsletter instanceof Newsletter)) ? [

--- a/tests/integration/Tasks/StateTest.php
+++ b/tests/integration/Tasks/StateTest.php
@@ -31,7 +31,7 @@ class StateTest extends \MailPoetTest {
     expect($data[1]['id'])->equals(1);
     expect($data[1]['type'])->equals(SendingTask::TASK_TYPE);
     expect(is_int($data[1]['priority']))->true();
-    expect(is_int($data[1]['updated_at']))->true();
+    expect(is_string($data[1]['updated_at']))->true();
     expect($data[1])->hasKey('scheduled_at');
     expect($data[1]['status'])->notEmpty();
     expect($data[1])->hasKey('newsletter');


### PR DESCRIPTION
This PR changes the logic to display the updated_at field for tasks in the system status page to use the site timezone.

[MAILPOET-3692]

[MAILPOET-3692]: https://mailpoet.atlassian.net/browse/MAILPOET-3692