### PR TITLE
Handle recipient related errors from SMTP mailer as soft errors [MAILPOET-3717]

### DIFF
--- a/lib/Mailer/Methods/ErrorMappers/SMTPMapper.php
+++ b/lib/Mailer/Methods/ErrorMappers/SMTPMapper.php
@@ -7,6 +7,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\SubscriberError;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Swift_RfcComplianceException;
+use MailPoetVendor\Swift_TransportException;
 
 class SMTPMapper {
   use BlacklistErrorMapperTrait;
@@ -21,11 +22,17 @@ class SMTPMapper {
   public function getErrorFromException(\Exception $e, $subscriber) {
     // remove redundant information appended by Swift logger to exception messages
     $message = explode(PHP_EOL, $e->getMessage());
+    $code = $e->getCode();
 
     $level = MailerError::LEVEL_HARD;
     if ($e instanceof Swift_RfcComplianceException) {
       $level = MailerError::LEVEL_SOFT;
     }
+
+    if ($e instanceof Swift_TransportException && (($code < 500) || ($code > 504))) {
+      $level = MailerError::LEVEL_SOFT;
+    }
+
     $subscriberErrors = [new SubscriberError($subscriber, null)];
     return new MailerError(MailerError::OPERATION_SEND, $level, $message[0], null, $subscriberErrors);
   }

--- a/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
+++ b/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
@@ -42,6 +42,24 @@ class SMTPMapperTest extends \MailPoetUnitTest {
     expect($error->getLevel())->equals(MailerError::LEVEL_SOFT);
   }
 
+  public function testItCreatesSoftErrorForMostTransportExceptions() {
+    $message = 'Connection could not be established with host localhost [Connection timed out]' . PHP_EOL
+      . 'Log data:' . PHP_EOL
+      . '++ Starting Swift_SmtpTransport' . PHP_EOL
+      . '!! Connection could not be established with host localhost [Connection timed out] (code: 463)';
+    $error = $this->mapper->getErrorFromException(new Swift_RfcComplianceException($message), 'john@rambo.com');
+    expect($error->getLevel())->equals(MailerError::LEVEL_SOFT);
+  }
+
+  public function testItCreatesHardErrorForTransportException500to504() {
+    $message = 'Bad sequence of commands' . PHP_EOL
+      . 'Log data:' . PHP_EOL
+      . '++ Starting Swift_SmtpTransport' . PHP_EOL
+      . '!! Bad sequence of commands (code: 503)';
+    $error = $this->mapper->getErrorFromException(new Swift_RfcComplianceException($message), 'john@rambo.com');
+    expect($error->getLevel())->equals(MailerError::LEVEL_SOFT);
+  }
+
   public function testItCanProcessLogMessageWhenOneExists() {
     $log = '++ Swift_SmtpTransport started' . PHP_EOL
       . '>> MAIL FROM:<moi@mrcasual.com>' . PHP_EOL

--- a/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
+++ b/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
@@ -8,6 +8,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\ErrorMappers\SMTPMapper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Swift_RfcComplianceException;
+use MailPoetVendor\Swift_TransportException;
 
 class SMTPMapperTest extends \MailPoetUnitTest {
 
@@ -47,17 +48,17 @@ class SMTPMapperTest extends \MailPoetUnitTest {
       . 'Log data:' . PHP_EOL
       . '++ Starting Swift_SmtpTransport' . PHP_EOL
       . '!! Connection could not be established with host localhost [Connection timed out] (code: 463)';
-    $error = $this->mapper->getErrorFromException(new Swift_RfcComplianceException($message), 'john@rambo.com');
+    $error = $this->mapper->getErrorFromException(new Swift_TransportException($message, 463), 'john@rambo.com');
     expect($error->getLevel())->equals(MailerError::LEVEL_SOFT);
   }
 
   public function testItCreatesHardErrorForTransportException500to504() {
-    $message = 'Bad sequence of commands' . PHP_EOL
+    $message = 'Connection could not be established with host localhost [Bad sequence of commands]' . PHP_EOL
       . 'Log data:' . PHP_EOL
       . '++ Starting Swift_SmtpTransport' . PHP_EOL
-      . '!! Bad sequence of commands (code: 503)';
-    $error = $this->mapper->getErrorFromException(new Swift_RfcComplianceException($message), 'john@rambo.com');
-    expect($error->getLevel())->equals(MailerError::LEVEL_SOFT);
+      . '!! Connection could not be established with host localhost [Bad sequence of commands] (code: 503)';
+    $error = $this->mapper->getErrorFromException(new Swift_TransportException($message, 503), 'john@rambo.com');
+    expect($error->getLevel())->equals(MailerError::LEVEL_HARD);
   }
 
   public function testItCanProcessLogMessageWhenOneExists() {


### PR DESCRIPTION
Modify SMTP error mapper so that it handles also  `\MailPoetVendor\Swift_TransportException`

Mark an error as soft  if the error code from SMTP is not 500-504.

I was not able to reproduce getting 500-504 messages but it is covered by the unit test.

A soft transport error can be reproduced by entering the SMTP details correctly on _MailPoet > Settings > Send With_ but having a sender address that is not owned by the SMTP account on _MailPoet > Settings > Basic_ , From field.

Note: I used [our own Titan email as outgoing SMTP server](https://support.titan.email/hc/en-us/articles/900000215446-Configure-Titan-on-other-apps-using-IMAP-POP).

[MAILPOET-3717]

[MAILPOET-3717]: https://mailpoet.atlassian.net/browse/MAILPOET-3717