### PR TITLE
Add confirmation before running integration tests on the dev site [MAILPOET-3755]

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -148,6 +148,12 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function testIntegration(array $opts=['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false]) {
+    if (getenv('MAILPOET_DEV_SITE')) {
+      $run = $this->confirm("You are about to run tests on the development site. Your DB data will be erased. \nDo you want to proceed?", false);
+      if (!$run) {
+        return;
+      }
+    }
     $command = 'vendor/bin/codecept run integration -vvv';
 
     if ($opts['multisite']) {


### PR DESCRIPTION
Instead of detecting the test environment, I tried to approach the problem from the other side. The idea is that a developer can mark an environment as "development site" and by doing so the environment will get protection against accidentally running DB cleanup within integration tests. Not everyone uses the MailPoet Dev Environment so I think that this way all developers could set it and use this protection.

There is a related [PR in MailPoet Dev Environment repository that adds the variable for the dev site container](https://github.com/mailpoet/mailpoet-dev-env/pull/43).

[MAILPOET-3755]

[MAILPOET-3755]: https://mailpoet.atlassian.net/browse/MAILPOET-3755