### PR TITLE
Run 'codecept build' before runninng PHPStan checks [MAILPOET-3552]

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -474,6 +474,9 @@ class RoboFile extends \Robo\Tasks {
       $task = "ANALYSIS_PHP_VERSION={$opts['php-version']} $task";
     }
 
+    // make sure Codeception support files are present to avoid invalid errors when running PHPStan
+    $this->_exec('vendor/bin/codecept build');
+
     // PHPStan must be run out of main plugin directory to avoid its autoloading
     // from vendor/autoload.php where some dev dependencies cause conflicts.
     return $this->collectionBuilder()


### PR DESCRIPTION
This PR adds a call to the command 'codecept build' before running PHPStan checks inside the command './do qa:phpstan'. This is needed to make sure that the PHPStan checks don't fail with the error bellow because of missing test support files that are autogenerated by Codeception:

```
Bootstrap file tests/_support/_generated/AcceptanceTesterActions.php does not exist.
```

To test:

- On the master branch, remove the files inside tests/_support/_generated and see the error above when running `./do qa:phpstan`.
- Switch to this branch and run `./do qa:phpstan` again. Check that the deleted files were created again and that the PHPStan checks passed.

[MAILPOET-3552]

[MAILPOET-3552]: https://mailpoet.atlassian.net/browse/MAILPOET-3552