### PR TITLE
Fix flaky tests using  Scheduler::getScheduledTimeWithDelay [MAILPOET-3793]

### DIFF
--- a/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -7,8 +7,18 @@ use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\WP\Functions as WPFunctions;
 
 class AutomaticEmailScheduler {
+  /** @var WPFunctions|null */
+  private $wp;
+
+  public function __construct(
+    ?WPFunctions $wp = null
+  ) {
+    $this->wp = $wp;
+  }
+
   public function scheduleAutomaticEmail($group, $event, $schedulingCondition = false, $subscriberId = false, $meta = false) {
     $newsletters = Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
     if (empty($newsletters)) return false;
@@ -92,7 +102,7 @@ class AutomaticEmailScheduler {
     $sendingTask->status = SendingQueue::STATUS_SCHEDULED;
     $sendingTask->priority = SendingQueue::PRIORITY_MEDIUM;
 
-    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber);
+    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
     return $sendingTask->save();
   }
 
@@ -102,7 +112,7 @@ class AutomaticEmailScheduler {
       $sendingTask->__set('meta', $meta);
     }
     // compute new 'scheduled_at' from now
-    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber);
+    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
     $sendingTask->save();
   }
 }

--- a/lib/Newsletter/Scheduler/Scheduler.php
+++ b/lib/Newsletter/Scheduler/Scheduler.php
@@ -33,8 +33,8 @@ class Scheduler {
     return $previousRunDate;
   }
 
-  public static function getScheduledTimeWithDelay($afterTimeType, $afterTimeNumber) {
-    $wp = WPFunctions::get();
+  public static function getScheduledTimeWithDelay($afterTimeType, $afterTimeNumber, $wp = null): Carbon {
+    $wp = $wp ?? WPFunctions::get();
     $currentTime = Carbon::createFromTimestamp($wp->currentTime('timestamp'));
     switch ($afterTimeType) {
       case 'minutes':

--- a/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -12,6 +12,7 @@ use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\WP\Functions as WPFunctions;
 
 class WelcomeScheduler {
 
@@ -29,16 +30,21 @@ class WelcomeScheduler {
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
 
+  /** @var WPFunctions|null */
+  private $wp;
+
   public function __construct(
     SubscribersRepository $subscribersRepository,
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
-    ScheduledTasksRepository $scheduledTasksRepository
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ?WPFunctions $wp = null
   ) {
     $this->subscribersRepository = $subscribersRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->wp = $wp;
   }
 
   public function scheduleSubscriberWelcomeNotification($subscriberId, $segments) {
@@ -114,7 +120,8 @@ class WelcomeScheduler {
     $sendingTask->priority = SendingQueue::PRIORITY_HIGH;
     $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay(
       $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE),
-      $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER)
+      $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER),
+      $this->wp
     );
     return $sendingTask->save();
   }


### PR DESCRIPTION
If the tests took too long to execute, they would fail because `Scheduler::getScheduledTimeWithDelay` would have a different time than the time set in the test. 

The tests could be made to fail consistently by inserting `sleep(60)` in between the function execution and the time we were setting `currentTime` within the test.

To solve this, I have added `WPFunctions` to the constructor, as an optional argument, so that we can mock `currentTime` inside of the tests.

The issue was originally to fix: `tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php::testItSchedulesAutomaticEmailWhenConditionMatches`

I have also modified `WelcomeScheduler` class and the tests in `tests/integration/Newsletter/Scheduler/WelcomeTest.php`

[MAILPOET-3793]

[MAILPOET-3793]: https://mailpoet.atlassian.net/browse/MAILPOET-3793