### PR TITLE
Change SimpleWorker::prepareTaskStrategy() to use Doctrine [MAILPOET-3842]

### DIFF
--- a/lib/Cron/CronWorkerInterface.php
+++ b/lib/Cron/CronWorkerInterface.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Cron;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\ScheduledTask;
 
 interface CronWorkerInterface {
@@ -20,11 +21,11 @@ interface CronWorkerInterface {
   public function init();
 
   /**
-   * @param ScheduledTask $task
+   * @param ScheduledTaskEntity $task
    * @param float $timer
    * @return bool
    */
-  public function prepareTaskStrategy(ScheduledTask $task, $timer);
+  public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer);
 
   /**
    * @param ScheduledTask $task

--- a/lib/Cron/Workers/Bounce.php
+++ b/lib/Cron/Workers/Bounce.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
-use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
@@ -40,9 +39,6 @@ class Bounce extends SimpleWorker {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
-  /** @var ScheduledTasksRepository */
-  private $scheduledTasksRepository;
-
   /** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
 
@@ -52,7 +48,6 @@ class Bounce extends SimpleWorker {
   public function __construct(
     SettingsController $settings,
     SubscribersRepository $subscribersRepository,
-    ScheduledTasksRepository $scheduledTasksRepository,
     SendingQueuesRepository $sendingQueuesRepository,
     StatisticsBouncesRepository $statisticsBouncesRepository,
     Bridge $bridge
@@ -61,7 +56,6 @@ class Bounce extends SimpleWorker {
     $this->bridge = $bridge;
     parent::__construct();
     $this->subscribersRepository = $subscribersRepository;
-    $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->statisticsBouncesRepository = $statisticsBouncesRepository;
   }

--- a/lib/Cron/Workers/Bounce.php
+++ b/lib/Cron/Workers/Bounce.php
@@ -70,11 +70,11 @@ class Bounce extends SimpleWorker {
     return $this->bridge->isMailpoetSendingServiceEnabled();
   }
 
-  public function prepareTaskStrategy(ScheduledTask $task, $timer) {
+  public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
     BounceTask::prepareSubscribers($task);
 
-    if (!ScheduledTaskSubscriber::getUnprocessedCount($task->id)) {
-      ScheduledTaskSubscriber::where('task_id', $task->id)->deleteMany();
+    if (!ScheduledTaskSubscriber::getUnprocessedCount($task->getId())) {
+      ScheduledTaskSubscriber::where('task_id', $task->getId())->deleteMany();
       return false;
     }
     return true;

--- a/lib/Cron/Workers/SendingQueue/Migration.php
+++ b/lib/Cron/Workers/SendingQueue/Migration.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Cron\Workers\SendingQueue;
 
 use MailPoet\Cron\Workers\SimpleWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
@@ -20,7 +21,7 @@ class Migration extends SimpleWorker {
     return empty($completedTasks);
   }
 
-  public function prepareTaskStrategy(ScheduledTask $task, $timer) {
+  public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $unmigratedColumns = $this->checkUnmigratedColumnsExist();
     $unmigratedQueuesCount = 0;
     $unmigratedQueueSubscribers = [];
@@ -35,9 +36,10 @@ class Migration extends SimpleWorker {
       && count($unmigratedQueueSubscribers) == 0)
     ) {
       // nothing to migrate, complete task
-      $task->processedAt = WPFunctions::get()->currentTime('mysql');
-      $task->status = ScheduledTask::STATUS_COMPLETED;
-      $task->save();
+      $task->setProcessedAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
+      $task->setStatus(ScheduledTask::STATUS_COMPLETED);
+      $this->scheduledTasksRepository->persist($task);
+      $this->scheduledTasksRepository->flush();
       $this->resumeSending();
       return false;
     }

--- a/lib/Cron/Workers/SimpleWorker.php
+++ b/lib/Cron/Workers/SimpleWorker.php
@@ -8,6 +8,7 @@ use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Models\ScheduledTask;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -27,6 +28,9 @@ abstract class SimpleWorker implements CronWorkerInterface {
   /** @var WPFunctions */
   protected $wp;
 
+  /** @var ScheduledTasksRepository */
+  protected $scheduledTasksRepository;
+
   public function __construct(
     WPFunctions $wp = null
   ) {
@@ -38,6 +42,7 @@ abstract class SimpleWorker implements CronWorkerInterface {
     $this->wp = $wp;
     $this->cronHelper = ContainerWrapper::getInstance()->get(CronHelper::class);
     $this->cronWorkerScheduler = ContainerWrapper::getInstance()->get(CronWorkerScheduler::class);
+    $this->scheduledTasksRepository = ContainerWrapper::getInstance()->get(ScheduledTasksRepository::class);
   }
 
   public function getTaskType() {
@@ -88,6 +93,6 @@ abstract class SimpleWorker implements CronWorkerInterface {
   }
 
   protected function getCompletedTasks() {
-    return ScheduledTask::findCompletedByType(static::TASK_TYPE, CronWorkerRunner::TASK_BATCH_SIZE);
+    return $this->scheduledTasksRepository->findCompletedByType(static::TASK_TYPE, CronWorkerRunner::TASK_BATCH_SIZE);
   }
 }

--- a/lib/Cron/Workers/SimpleWorker.php
+++ b/lib/Cron/Workers/SimpleWorker.php
@@ -7,6 +7,7 @@ use MailPoet\Cron\CronWorkerInterface;
 use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\WP\Functions as WPFunctions;
@@ -68,7 +69,7 @@ abstract class SimpleWorker implements CronWorkerInterface {
   public function init() {
   }
 
-  public function prepareTaskStrategy(ScheduledTask $task, $timer) {
+  public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
     return true;
   }
 

--- a/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
+++ b/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
@@ -5,7 +5,6 @@ namespace MailPoet\Cron\Workers;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Models\ScheduledTask;
-use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersCountsController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -26,21 +25,16 @@ class SubscribersCountCacheRecalculation extends SimpleWorker {
   /** @var SubscribersCountsController */
   private $subscribersCountsController;
 
-  /** @var ScheduledTasksRepository */
-  private $scheduledTasksRepository;
-
   public function __construct(
     TransientCache $transientCache,
     SegmentsRepository $segmentsRepository,
     SubscribersCountsController $subscribersCountsController,
-    ScheduledTasksRepository $scheduledTasksRepository,
     WPFunctions $wp
   ) {
     parent::__construct($wp);
     $this->transientCache = $transientCache;
     $this->segmentsRepository = $segmentsRepository;
     $this->subscribersCountsController = $subscribersCountsController;
-    $this->scheduledTasksRepository = $scheduledTasksRepository;
   }
 
   public function processTaskStrategy(ScheduledTask $task, $timer) {

--- a/lib/Models/ScheduledTask.php
+++ b/lib/Models/ScheduledTask.php
@@ -168,10 +168,6 @@ class ScheduledTask extends Model {
     return self::findByTypeAndStatus($type, ScheduledTask::STATUS_SCHEDULED, $limit, true);
   }
 
-  public static function findCompletedByType($type, $limit = null) {
-    return self::findByTypeAndStatus($type, ScheduledTask::STATUS_COMPLETED, $limit);
-  }
-
   private static function findByTypeAndStatus($type, $status, $limit = null, $future = false) {
     $query = ScheduledTask::where('type', $type)
       ->whereNull('deleted_at');

--- a/lib/Models/ScheduledTask.php
+++ b/lib/Models/ScheduledTask.php
@@ -191,4 +191,16 @@ class ScheduledTask extends Model {
 
     return $query->findMany();
   }
+
+  // temporary function to convert an ScheduledTaskEntity object to ScheduledTask while we don't migrate the rest of
+  // the code in this class to use Doctrine entities
+  public static function getFromDoctrineEntity(ScheduledTaskEntity $doctrineTask): ?ScheduledTask {
+    $parisTask = self::findOne($doctrineTask->getId());
+
+    if (!$parisTask instanceof ScheduledTask) {
+      return null;
+    }
+
+    return $parisTask;
+  }
 }

--- a/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -97,6 +97,10 @@ class ScheduledTasksRepository extends Repository {
     return $this->findByTypeAndStatus($type, null, $limit);
   }
 
+  public function findCompletedByType($type, $limit = null) {
+    return $this->findByTypeAndStatus($type, ScheduledTaskEntity::STATUS_COMPLETED, $limit);
+  }
+
   protected function findByTypeAndStatus($type, $status, $limit = null, $future = false) {
     $queryBuilder = $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/lib/Tasks/Bounce.php
+++ b/lib/Tasks/Bounce.php
@@ -2,12 +2,12 @@
 
 namespace MailPoet\Tasks;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\Subscriber;
 
 class Bounce {
-  public static function prepareSubscribers(ScheduledTask $task) {
+  public static function prepareSubscribers(ScheduledTaskEntity $task) {
     // Prepare subscribers on the DB side for performance reasons
     Subscriber::rawExecute(
       'INSERT IGNORE INTO ' . MP_SCHEDULED_TASK_SUBSCRIBERS_TABLE . '
@@ -17,7 +17,7 @@ class Bounce {
        WHERE s.`deleted_at` IS NULL
        AND s.`status` IN (?, ?)',
       [
-        $task->id,
+        $task->getId(),
         ScheduledTaskSubscriber::STATUS_UNPROCESSED,
         Subscriber::STATUS_SUBSCRIBED,
         Subscriber::STATUS_UNCONFIRMED,

--- a/tests/DataFactories/ScheduledTask.php
+++ b/tests/DataFactories/ScheduledTask.php
@@ -15,12 +15,14 @@ use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class ScheduledTask {
-  private $diContainer;
+  /**
+   * @var EntityManager
+   */
   private $entityManager;
 
   public function __construct() {
-    $this->diContainer = ContainerWrapper::getInstance();
-    $this->entityManager = $this->diContainer->get(EntityManager::class);
+    $diContainer = ContainerWrapper::getInstance();
+    $this->entityManager = $diContainer->get(EntityManager::class);
   }
 
   public function deleteAll() {

--- a/tests/integration/Cron/Workers/BounceTest.php
+++ b/tests/integration/Cron/Workers/BounceTest.php
@@ -13,7 +13,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
-use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
@@ -57,7 +56,6 @@ class BounceTest extends \MailPoetTest {
     $this->worker = new Bounce(
       $this->diContainer->get(SettingsController::class),
       $this->subscribersRepository,
-      $this->diContainer->get(ScheduledTasksRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
       $this->diContainer->get(StatisticsBouncesRepository::class),
       $this->diContainer->get(Bridge::class)
@@ -77,7 +75,6 @@ class BounceTest extends \MailPoetTest {
     $worker = new Bounce(
       $this->diContainer->get(SettingsController::class),
       $this->subscribersRepository,
-      $this->diContainer->get(ScheduledTasksRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
       $this->diContainer->get(StatisticsBouncesRepository::class),
       $this->diContainer->get(Bridge::class)

--- a/tests/integration/Models/ScheduledTaskTest.php
+++ b/tests/integration/Models/ScheduledTaskTest.php
@@ -181,40 +181,6 @@ class ScheduledTaskTest extends \MailPoetTest {
     expect($timeout)->equals(ScheduledTask::MAX_RESCHEDULE_TIMEOUT);
   }
 
-  public function testItCanGetCompletedTasks() {
-    // completed (scheduled in past)
-    ScheduledTask::createOrUpdate([
-      'type' => 'test',
-      'status' => ScheduledTask::STATUS_COMPLETED,
-      'scheduled_at' => Carbon::now()->subDay(),
-    ]);
-
-    // deleted (should not be fetched)
-    ScheduledTask::createOrUpdate([
-      'type' => 'test',
-      'status' => ScheduledTask::STATUS_COMPLETED,
-      'scheduled_at' => Carbon::now()->subDay(),
-      'deleted_at' => Carbon::now(),
-    ]);
-
-    // scheduled in future (should not be fetched)
-    ScheduledTask::createOrUpdate([
-      'type' => 'test',
-      'status' => ScheduledTask::STATUS_COMPLETED,
-      'scheduled_at' => Carbon::now()->addDay(),
-    ]);
-
-    // wrong status (should not be fetched)
-    ScheduledTask::createOrUpdate([
-      'type' => 'test',
-      'status' => ScheduledTask::STATUS_SCHEDULED,
-      'scheduled_at' => Carbon::now()->subDay(),
-    ]);
-
-    $tasks = ScheduledTask::findCompletedByType('test', 10);
-    expect($tasks)->count(1);
-  }
-
   public function testItCanGetFutureScheduledTasks() {
     // scheduled (in future)
     ScheduledTask::createOrUpdate([

--- a/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
+++ b/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
@@ -38,6 +38,16 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
     $this->assertSame($expectedResult, $tasks);
   }
 
+  public function testItCanGetCompletedTasks() {
+    $expectedResult[] = $this->createScheduledTask('test', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay()); // completed (scheduled in past)
+    $this->createScheduledTask('test', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay(), Carbon::now()); // deleted (should not be fetched)
+    $this->createScheduledTask('test', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->addDay()); // scheduled in future (should not be fetched)
+    $this->createScheduledTask('test', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->subDay()); // wrong status (should not be fetched)
+
+    $tasks = $this->repository->findCompletedByType('test', 10);
+    $this->assertSame($expectedResult, $tasks);
+  }
+
   public function cleanup() {
     $this->truncateEntity(ScheduledTaskEntity::class);
   }


### PR DESCRIPTION
This PR is a continuation of #3699. It should be reviewed only after #3699 is merged otherwise GitHub will display here all the commits from that PR as well. I decided to create this PR now in case #3699 is merged before I start my day tomorrow.

This PR changes the method prepareTaskStrategy() in SimpleWorker and all its child classes to use ScheduledTaskEntity instead of ScheduledTask. To do that, I also moved the method findCompletedByType() from ScheduledTask to ScheduledTaskEntity (as it is used in one of the modified child classes) and created a helper method for the tests to create ScheduledTaskEntity objects.

[MAILPOET-3842]

[MAILPOET-3842]: https://mailpoet.atlassian.net/browse/MAILPOET-3842