### PR TITLE
Allow reply-to with only address when using MSS [MAILPOET-3812]

### DIFF
--- a/lib/Mailer/Methods/MailPoet.php
+++ b/lib/Mailer/Methods/MailPoet.php
@@ -118,7 +118,7 @@ class MailPoet {
     return $body;
   }
 
-  private function composeBody($newsletter, $subscriber, $unsubscribeUrl, $meta) {
+  private function composeBody($newsletter, $subscriber, $unsubscribeUrl, $meta): array {
     $body = [
       'to' => ([
         'address' => $subscriber['email'],
@@ -130,10 +130,12 @@ class MailPoet {
       ]),
       'reply_to' => ([
         'address' => $this->replyTo['reply_to_email'],
-        'name' => $this->replyTo['reply_to_name'],
       ]),
       'subject' => $newsletter['subject'],
     ];
+    if (!empty($this->replyTo['reply_to_name'])) {
+      $body['reply_to']['name'] = $this->replyTo['reply_to_name'];
+    }
     if (!empty($newsletter['body']['html'])) {
       $body['html'] = $newsletter['body']['html'];
     }

--- a/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -75,6 +75,24 @@ class MailPoetAPITest extends \MailPoetTest {
     expect($body[0]['text'])->equals($this->newsletter['body']['text']);
   }
 
+  public function testItRemovesReplyToNameIfEmpty() {
+    $replyTo = [
+      'reply_to_email' => 'reply-to@mailpoet.com',
+      'reply_to_name_email' => '<reply-to@mailpoet.com>',
+    ];
+    $mailer = new MailPoet(
+      $this->settings['api_key'],
+      $this->sender,
+      $replyTo,
+      new MailPoetMapper(),
+      $this->makeEmpty(AuthorizedEmailsController::class)
+    );
+    $body = $mailer->getBody($this->newsletter, $this->subscriber);
+    expect($body[0]['reply_to'])->equals([
+      'address' => 'reply-to@mailpoet.com',
+    ]);
+  }
+
   public function testItCanGenerateBodyForMultipleMessages() {
     $newsletters = array_fill(0, 10, $this->newsletter);
     $subscribers = array_fill(0, 10, $this->subscriber);


### PR DESCRIPTION
When transactional emails are enabled with MSS, some plugins might create headers that contain a reply-to address but do not have a reply-to name. 

We would then be sending an empty reply-to name and MSS would reply with a Bad request error:

`\"reply_to\":{\"name\":\"name must be a string or name must be boolean\"`

In this PR, we remove the reply-to name from the request to MSS if it is empty.

This is not easy to test from the UI, the plugin where the problem was found is a paid plugin.
I have verified the emails are sent without the reply-to name by manually modifying the code that generates the reply-to data, and sending the emails.
There is also an integration test.

[MAILPOET-3812]

[MAILPOET-3812]: https://mailpoet.atlassian.net/browse/MAILPOET-3812