### PR TITLE
Change SimpleWorker::processTaskStrategy() to use Doctrine [MAILPOET-3843]

### DIFF
--- a/lib/Cron/CronWorkerInterface.php
+++ b/lib/Cron/CronWorkerInterface.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Cron;
 
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Models\ScheduledTask;
 
 interface CronWorkerInterface {
   /** @return string */
@@ -28,11 +27,11 @@ interface CronWorkerInterface {
   public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer);
 
   /**
-   * @param ScheduledTask $task
+   * @param ScheduledTaskEntity $task
    * @param float $timer
    * @return bool
    */
-  public function processTaskStrategy(ScheduledTask $task, $timer);
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer);
 
   /** @return \DateTimeInterface */
   public function getNextRunDate();

--- a/lib/Cron/CronWorkerRunner.php
+++ b/lib/Cron/CronWorkerRunner.php
@@ -127,7 +127,11 @@ class CronWorkerRunner {
     $this->startProgress($task);
 
     try {
-      $completed = $worker->processTaskStrategy($task, $this->timer);
+      $completed = false;
+      $doctrineTask = $this->convertTaskClassToDoctrine($task);
+      if ($doctrineTask) {
+        $completed = $worker->processTaskStrategy($doctrineTask, $this->timer);
+      }
     } catch (\Exception $e) {
       $this->stopProgress($task);
       throw $e;

--- a/lib/Cron/Workers/AuthorizedSendingEmailsCheck.php
+++ b/lib/Cron/Workers/AuthorizedSendingEmailsCheck.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 
@@ -24,7 +24,7 @@ class AuthorizedSendingEmailsCheck extends SimpleWorker {
     return Bridge::isMPSendingServiceEnabled();
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $this->authorizedEmailsController->checkAuthorizedEmailAddresses();
     return true;
   }

--- a/lib/Cron/Workers/Beamer.php
+++ b/lib/Cron/Workers/Beamer.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -23,7 +23,7 @@ class Beamer extends SimpleWorker {
     $this->settings = $settings;
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     return $this->setLastAnnouncementDate();
   }
 

--- a/lib/Cron/Workers/ExportFilesCleanup.php
+++ b/lib/Cron/Workers/ExportFilesCleanup.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Subscribers\ImportExport\Export\Export;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -10,7 +10,7 @@ class ExportFilesCleanup extends SimpleWorker {
   const TASK_TYPE = 'export_files_cleanup';
   const DELETE_FILES_AFTER_X_DAYS = 1;
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $iterator = new \GlobIterator(Export::getExportPath() . '/' . Export::getFilePrefix() . '*.*');
     foreach ($iterator as $file) {
       if (is_string($file)) {

--- a/lib/Cron/Workers/KeyCheck/KeyCheckWorker.php
+++ b/lib/Cron/Workers/KeyCheck/KeyCheckWorker.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Cron\Workers\KeyCheck;
 
 use MailPoet\Cron\Workers\SimpleWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Services\Bridge;
 use MailPoetVendor\Carbon\Carbon;
@@ -16,7 +17,7 @@ abstract class KeyCheckWorker extends SimpleWorker {
     }
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     try {
       $result = $this->checkKey();
     } catch (\Exception $e) {
@@ -24,7 +25,10 @@ abstract class KeyCheckWorker extends SimpleWorker {
     }
 
     if (empty($result['code']) || $result['code'] == Bridge::CHECK_ERROR_UNAVAILABLE) {
-      $task->rescheduleProgressively();
+      $parisTask = ScheduledTask::getFromDoctrineEntity($task);
+      if ($parisTask) {
+        $parisTask->rescheduleProgressively();
+      }
       return false;
     }
 

--- a/lib/Cron/Workers/SendingQueue/Migration.php
+++ b/lib/Cron/Workers/SendingQueue/Migration.php
@@ -5,7 +5,6 @@ namespace MailPoet\Cron\Workers\SendingQueue;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue as SendingQueueModel;
 use MailPoet\WP\Functions as WPFunctions;
@@ -37,7 +36,7 @@ class Migration extends SimpleWorker {
     ) {
       // nothing to migrate, complete task
       $task->setProcessedAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-      $task->setStatus(ScheduledTask::STATUS_COMPLETED);
+      $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
       $this->scheduledTasksRepository->persist($task);
       $this->scheduledTasksRepository->flush();
       $this->resumeSending();
@@ -76,7 +75,7 @@ class Migration extends SimpleWorker {
     }
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $this->migrateSendingQueues($timer);
     $this->migrateSubscribers($timer);
     $this->resumeSending();

--- a/lib/Cron/Workers/SimpleWorker.php
+++ b/lib/Cron/Workers/SimpleWorker.php
@@ -8,7 +8,6 @@ use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -73,7 +72,7 @@ abstract class SimpleWorker implements CronWorkerInterface {
     return true;
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     return true;
   }
 

--- a/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -5,10 +5,10 @@ namespace MailPoet\Cron\Workers\StatsNotifications;
 use MailPoet\Config\Renderer;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
@@ -74,7 +74,7 @@ class AutomatedEmails extends SimpleWorker {
     return (bool)$settings['automated'];
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     try {
       $settings = $this->settings->get(Worker::SETTINGS_KEY);
       $newsletters = $this->getNewsletters();

--- a/lib/Cron/Workers/SubscriberLinkTokens.php
+++ b/lib/Cron/Workers/SubscriberLinkTokens.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\Subscriber;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -15,7 +15,7 @@ class SubscriberLinkTokens extends SimpleWorker {
   const BATCH_SIZE = 10000;
   const AUTOMATIC_SCHEDULING = false;
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $count = Subscriber::whereNull('link_token')->count();
     if ($count) {
       $authKey = defined('AUTH_KEY') ? AUTH_KEY : '';

--- a/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
+++ b/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
@@ -3,8 +3,8 @@
 namespace MailPoet\Cron\Workers;
 
 use MailPoet\Cache\TransientCache;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersCountsController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -37,7 +37,7 @@ class SubscribersCountCacheRecalculation extends SimpleWorker {
     $this->subscribersCountsController = $subscribersCountsController;
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $segments = $this->segmentsRepository->findAll();
     foreach ($segments as $segment) {
       $this->recalculateSegmentCache($timer, (int)$segment->getId(), $segment);

--- a/lib/Cron/Workers/SubscribersEngagementScore.php
+++ b/lib/Cron/Workers/SubscribersEngagementScore.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -33,7 +33,7 @@ class SubscribersEngagementScore extends SimpleWorker {
     $this->subscribersRepository = $subscribersRepository;
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $recalculatedSubscribersCount = $this->recalculateSubscribers();
     if ($recalculatedSubscribersCount > 0) {
       $this->scheduleImmediately();

--- a/lib/Cron/Workers/WooCommerceSync.php
+++ b/lib/Cron/Workers/WooCommerceSync.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 
@@ -30,7 +30,7 @@ class WooCommerceSync extends SimpleWorker {
     return $this->woocommerceHelper->isWooCommerceActive();
   }
 
-  public function processTaskStrategy(ScheduledTask $task, $timer) {
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $this->woocommerceSegment->synchronizeCustomers();
     return true;
   }

--- a/lib/Entities/ScheduledTaskEntity.php
+++ b/lib/Entities/ScheduledTaskEntity.php
@@ -65,6 +65,12 @@ class ScheduledTaskEntity {
   private $meta;
 
   /**
+   * @ORM\Column(type="integer", options={"default" : 0})
+   * @var int
+   */
+  private $rescheduleCount = 0;
+
+  /**
    * @ORM\OneToMany(targetEntity="MailPoet\Entities\ScheduledTaskSubscriberEntity", mappedBy="task", fetch="EXTRA_LAZY")
    */
   public $subscribers;
@@ -151,5 +157,13 @@ class ScheduledTaskEntity {
    */
   public function setMeta($meta) {
     $this->meta = $meta;
+  }
+
+  public function getRescheduleCount(): int {
+    return $this->rescheduleCount;
+  }
+
+  public function setRescheduleCount(int $rescheduleCount) {
+    $this->rescheduleCount = $rescheduleCount;
   }
 }

--- a/tests/integration/Cron/Workers/AuthorizedSendingEmailsCheckTest.php
+++ b/tests/integration/Cron/Workers/AuthorizedSendingEmailsCheckTest.php
@@ -4,19 +4,18 @@ namespace MailPoet\Test\Cron\Workers;
 
 use Codeception\Stub;
 use MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck;
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Services\AuthorizedEmailsController;
-use MailPoetVendor\Idiorm\ORM;
 
 class AuthorizedSendingEmailsCheckTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
+    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 
   public function testItRunsCheckOnBridge() {
     $bridgeMock = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Stub\Expected::once()]);
     $worker = new AuthorizedSendingEmailsCheck($bridgeMock);
-    $worker->processTaskStrategy(ScheduledTask::createOrUpdate([]), microtime(true));
+    $worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
   }
 }

--- a/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
+++ b/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
@@ -3,7 +3,7 @@
 namespace MailPoet\Test\Cron\Workers;
 
 use MailPoet\Cron\Workers\ExportFilesCleanup;
-use MailPoet\Models\ScheduledTask;
+use MailPoet\Entities\ScheduledTaskEntity;
 
 class ExportFilesCleanupTest extends \MailPoetTest {
   public function testItWorks() {
@@ -14,7 +14,7 @@ class ExportFilesCleanupTest extends \MailPoetTest {
     touch($newFilePath);
 
     $cleanup = new ExportFilesCleanup();
-    $cleanup->processTaskStrategy(ScheduledTask::createOrUpdate([]), microtime(true));
+    $cleanup->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
 
     $this->assertFileExists($newFilePath);
     $this->assertFileNotExists($oldFilePath);

--- a/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
+++ b/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\ScheduledTask;
 use MailPoetVendor\Carbon\Carbon;
 
 class SubscribersLastEngagementTest extends \MailPoetTest {
@@ -31,7 +30,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $newsletter = $this->createSentNewsletter();
     $this->createOpen($openTime, $newsletter, $subscriber);
 
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($openTime);
   }
@@ -42,7 +41,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $newsletter = $this->createSentNewsletter();
     $this->createOpen($clickTime, $newsletter, $subscriber);
 
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($clickTime);
   }
@@ -52,7 +51,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $subscriber = $this->createSubscriber();
     $this->createWooOrder($orderTime, $subscriber->getEmail());
 
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($orderTime);
   }
@@ -67,7 +66,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $this->createClick($clickTime, $newsletter, $subscriber);
     $this->createWooOrder($wooOrderTime, $subscriber->getEmail());
 
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($clickTime);
   }
@@ -82,7 +81,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $this->createClick($clickTime, $newsletter, $subscriber);
     $this->createWooOrder($wooOrderTime, $subscriber->getEmail());
 
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($wooOrderTime);
   }
@@ -97,21 +96,21 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $this->createClick($clickTime, $newsletter, $subscriber);
     $this->createWooOrder($wooOrderTime, $subscriber->getEmail());
 
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($openTime);
   }
 
   public function testItKeepsNullIfNoTimeFound() {
     $subscriber = $this->createSubscriber();
-    $this->worker->processTaskStrategy(ScheduledTask::create(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->null();
   }
 
   public function testItReturnsTrueWhenCompleted() {
     $this->createSubscriber();
-    $task = ScheduledTask::create();
+    $task = new ScheduledTaskEntity();
     $result = $this->worker->processTaskStrategy($task, microtime(true));
     expect($result)->true();
   }
@@ -119,7 +118,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
   public function testItInterruptsProcessIfExecutionLimitReachedIsReachedAndFinishesOnSecondRun() {
     $this->createSubscriber();
     $exception = null;
-    $task = ScheduledTask::create();
+    $task = new ScheduledTaskEntity();
     try {
       $this->worker->processTaskStrategy($task, 0);
     } catch (\Exception $e) {
@@ -144,7 +143,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $this->createOpen($firstOpenTime, $newsletter, $subscriberInFirstBatch);
     $this->createOpen($secondOpenTime, $newsletter, $subscriberInSecondBatch);
 
-    $task = ScheduledTask::create();
+    $task = new ScheduledTaskEntity();
     $result = $this->worker->processTaskStrategy($task, microtime(true));
     expect($result)->true();
     $this->entityManager->refresh($subscriberInFirstBatch);

--- a/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
+++ b/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
@@ -4,8 +4,8 @@ namespace MailPoet\Test\Cron\Workers;
 
 use Codeception\Util\Fixtures;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\Subscriber;
 use MailPoetVendor\Idiorm\ORM;
 
@@ -17,7 +17,7 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   private $newsletterWithoutToken;
 
   public function _before() {
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
+    $this->truncateEntity(ScheduledTaskEntity::class);
     ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
     ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
     parent::_before();
@@ -48,7 +48,7 @@ class UnsubscribeTokensTest extends \MailPoetTest {
 
   public function testItAddsTokensToSubscribers() {
     $worker = new UnsubscribeTokens();
-    $worker->processTaskStrategy(ScheduledTask::createOrUpdate(), microtime(true));
+    $worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->subscriberWithToken = Subscriber::findOne($this->subscriberWithToken->id);
     $this->subscriberWithoutToken = Subscriber::findOne($this->subscriberWithoutToken->id);
     expect($this->subscriberWithToken->unsubscribe_token)->equals('aaabbbcccdddeee');
@@ -57,7 +57,7 @@ class UnsubscribeTokensTest extends \MailPoetTest {
 
   public function testItAddsTokensToNewsletters() {
     $worker = new UnsubscribeTokens();
-    $worker->processTaskStrategy(ScheduledTask::createOrUpdate(), microtime(true));
+    $worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->newsletterWithToken = Newsletter::findOne($this->newsletterWithToken->id);
     $this->newsletterWithoutToken = Newsletter::findOne($this->newsletterWithoutToken->id);
     assert($this->newsletterWithToken instanceof Newsletter);
@@ -67,7 +67,7 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   }
 
   public function _after() {
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
+    $this->truncateEntity(ScheduledTaskEntity::class);
     ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
     ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
   }


### PR DESCRIPTION
This PR is a continuation of #3705. It should be reviewed only after #3705 is merged and it will be necessary to rebase it to update the hashes of the commits from #3705.

This PR changes the method processTaskStrategy() in SimpleWorker and all its child classes to use ScheduledTaskEntity instead of ScheduledTask.

[MAILPOET-3843]

[MAILPOET-3843]: https://mailpoet.atlassian.net/browse/MAILPOET-3843