### PR TITLE
Fix "Class 'PHPMailer\PHPMailer\Exception' not found" error [MAILPOET-3836]

### DIFF
--- a/lib/Mailer/WordPress/PHPMailerLoader.php
+++ b/lib/Mailer/WordPress/PHPMailerLoader.php
@@ -21,6 +21,8 @@ class PHPMailerLoader {
       // WordPress 5.5+
       if (!class_exists('PHPMailer\PHPMailer\PHPMailer')) {
         require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+      }
+      if (!class_exists('PHPMailer\PHPMailer\Exception')) {
         require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
       }
       class_alias(\PHPMailer\PHPMailer\PHPMailer::class, 'PHPMailer');


### PR DESCRIPTION
[MAILPOET-3836]

I'm not sure how to reproduce the original problem, but this fix seems to be the most logical solution.

[MAILPOET-3836]: https://mailpoet.atlassian.net/browse/MAILPOET-3836