### PR TITLE
Fix collation detection for subscriber engagement calculation [MAILPOET-3851]

### DIFF
--- a/lib/Segments/WooCommerce.php
+++ b/lib/Segments/WooCommerce.php
@@ -184,6 +184,12 @@ class WooCommerce {
     $this->wpPostmetaValueCollation = $wpPostmetaValueColumn->Collation; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
+  /**
+   * In MySQL, if you have the same charset and collation in joined tables' columns it's perfect;
+   * if you have different charsets, utf8 and utf8mb4, it works too; but if you have the same charset
+   * with different collations, e.g. utf8mb4_unicode_ci and utf8mb4_unicode_520_ci, it will fail
+   * with an 'Illegal mix of collations' error. That's why we need an optional COLLATE clause to fix this.
+   */
   private function needsCollationChange(): bool {
     $this->ensureColumnCollation();
     $collation1 = (string)$this->mailpoetEmailCollation;
@@ -192,11 +198,9 @@ class WooCommerce {
     if ($collation1 === $collation2) {
       return false;
     }
-    $collation1UnderscorePos = strpos($collation1, '_');
-    $collation2UnderscorePos = strpos($collation2, '_');
+    list($charset1) = explode('_', $collation1);
+    list($charset2) = explode('_', $collation2);
 
-    $charset1 = substr($collation1, 0, $collation1UnderscorePos === false ? strlen($collation1) : $collation1UnderscorePos);
-    $charset2 = substr($collation2, 0, $collation2UnderscorePos === false ? strlen($collation2) : $collation2UnderscorePos);
     return $charset1 === $charset2;
   }
 

--- a/lib/Util/DBCollationChecker.php
+++ b/lib/Util/DBCollationChecker.php
@@ -16,8 +16,13 @@ class DBCollationChecker {
   }
 
   /**
-   * If two columns have a different collations returns MySQL's COLLATE command to be used with the target table column.
+   * If two columns have incompatible collations returns MySQL's COLLATE command to be used with the target table column.
    * e.g. WHERE source_table.column = target_table.column COLLATE xyz
+   *
+   * In MySQL, if you have the same charset and collation in joined tables' columns it's perfect;
+   * if you have different charsets, utf8 and utf8mb4, it works too; but if you have the same charset
+   * with different collations, e.g. utf8mb4_unicode_ci and utf8mb4_unicode_520_ci, it will fail
+   * with an 'Illegal mix of collations' error.
    */
   public function getCollateIfNeeded(string $sourceTable, string $sourceColumn, string $targetTable, string $targetColumn): string {
     $connection = $this->entityManager->getConnection();
@@ -25,7 +30,12 @@ class DBCollationChecker {
     $sourceCollation = $sourceColumnData[0]['Collation'] ?? '';
     $targetColumnData = $connection->executeQuery("SHOW FULL COLUMNS FROM $targetTable WHERE Field = '$targetColumn';")->fetchAllAssociative();
     $targetCollation = $targetColumnData[0]['Collation'] ?? '';
-    if ($sourceCollation !== $targetCollation) {
+    if ($sourceCollation === $targetCollation) {
+      return '';
+    }
+    list($sourceCharset) = explode('_', $sourceCollation);
+    list($targetCharset) = explode('_', $targetCollation);
+    if ($sourceCharset === $targetCharset) {
       return "COLLATE $sourceCollation";
     }
     return '';


### PR DESCRIPTION
[MAILPOET-3851]

I have introduced the same logic to the new collation checker as in the old one. 

As for using the `get_col_charset` WP function, I realized that `$wpdb` methods only allow getting a charset of a column, not its collation, which we also need. One way to get column collation from `$wpdb` is by accessing `$wpdb->col_meta` array which is a protected property made readable for backwards compatibility - it's undocumented and thus subject to change, so I'm hesitant to use it. And I don't see much value in using the function in question alone. I just took a line from it which retrieves a charset to make our code more concise. 

If there was a good method to get column collation from `$wpdb`, we could use both functions to shave off a couple queries we use to get collations directly from the DB.


[MAILPOET-3851]: https://mailpoet.atlassian.net/browse/MAILPOET-3851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ