### PR TITLE
Fix removing DI files during build [MAILPOET-3827]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,14 +58,14 @@ echo '[BUILD] Fetching prefixed production libraries'
 rm -rf vendor-prefixed/doctrine/annotations
 
 # Remove DI Container files used for container dump (no need since generated metadata are packed)
-# Should be removed before `dump-autoload` to not include the annotations classes on the autoloader.
+# Should be removed before `dump-autoload` to not include these classes in the autoloader.
 echo '[BUILD] Removing DI Container development dependencies'
-rm -rf $plugin_name/vendor-prefixed/symfony/dependency-injection/Compiler
-rm -rf $plugin_name/vendor-prefixed/symfony/dependency-injection/Config
-rm -rf $plugin_name/vendor-prefixed/symfony/dependency-injection/Dumper
-rm -rf $plugin_name/vendor-prefixed/symfony/dependency-injection/Loader
-rm -rf $plugin_name/vendor-prefixed/symfony/dependency-injection/LazyProxy
-rm -rf $plugin_name/vendor-prefixed/symfony/dependency-injection/Extension
+rm -rf vendor-prefixed/symfony/dependency-injection/Compiler
+rm -rf vendor-prefixed/symfony/dependency-injection/Config
+rm -rf vendor-prefixed/symfony/dependency-injection/Dumper
+rm -rf vendor-prefixed/symfony/dependency-injection/Loader
+rm -rf vendor-prefixed/symfony/dependency-injection/LazyProxy
+rm -rf vendor-prefixed/symfony/dependency-injection/Extension
 
 ./tools/vendor/composer.phar dump-autoload
 


### PR DESCRIPTION
We create a DI container dump during [a release build](https://github.com/mailpoet/mailpoet/blob/master/build.sh#L33). After the container dump is created we don't need a bunch of PHP files from the DI library. This PR fixes the cleanup of those files during the build. It reduces the size of the plugin zip file by 0.13MB.

[MAILPOET-3827]

[MAILPOET-3827]: https://mailpoet.atlassian.net/browse/MAILPOET-3827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ