### PR TITLE
Preselect first form widget [MAILPOET-3847]

### DIFF
--- a/lib/Form/FormsRepository.php
+++ b/lib/Form/FormsRepository.php
@@ -27,22 +27,6 @@ class FormsRepository extends Repository {
       ->getResult();
   }
 
-  /**
-   * @return FormEntity[]
-   */
-  public function findAllActive(): array {
-    return $this->entityManager
-      ->createQueryBuilder()
-      ->select('f')
-      ->from(FormEntity::class, 'f')
-      ->where('f.status = (:enabled)')
-      ->andWhere('f.deletedAt IS NULL')
-      ->setParameter('enabled', FormEntity::STATUS_ENABLED)
-      ->orderBy('f.name', 'asc')
-      ->getQuery()
-      ->getResult();
-  }
-
   public function getNamesOfFormsForSegments(): array {
     $allNonDeletedForms = $this->findAllNotDeleted();
 

--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -137,6 +137,8 @@ class Widget extends \WP_Widget {
     <p>
       <select class="widefat" id="<?php echo $this->get_field_id('form') ?>" name="<?php echo $this->get_field_name('form'); ?>">
         <?php
+        // Select the first one from the list if none selected
+        if ($selectedForm === 0 && !empty($forms)) $selectedForm = $forms[0]->getId();
         foreach ($forms as $form) {
           $isSelected = ($selectedForm === $form->getId()) ? 'selected="selected"' : '';
           $formName = $form->getName() ? $this->wp->escHtml($form->getName()) : "({$this->wp->_x('no name', 'fallback for forms without a name in a form list')})"
@@ -201,8 +203,8 @@ class Widget extends \WP_Widget {
       $form = $this->formsRepository->findOneById($instance['form']);
     } else {
       // Backwards compatibility for MAILPOET-3847
-      // Get first active form
-      $forms = $this->formsRepository->findAllActive();
+      // Get first non deleted form
+      $forms = $this->formsRepository->findBy(['deletedAt' => null], ['name' => 'asc']);
       if (empty($forms)) return '';
       $form = $forms[0];
     }


### PR DESCRIPTION
Preselect the first form of the list displayed in Form Widget.
For backwards compatibility, if the widget was saved without selecting a form, display the first form of the list.

[MAILPOET-3847]

[MAILPOET-3847]: https://mailpoet.atlassian.net/browse/MAILPOET-3847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ