### PR TITLE
Increase default wait time for acceptance tests [MAILPOET-3508]

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -29,7 +29,7 @@ modules:
         port: 4444
         window_size: '1366x980'
         restart: true #  Set to false (default) to use the same browser window for all tests, or set to true to create a new window for each test. In any case, when all tests are finished the browser window is closed.
-        wait: 0 # (default: 0 seconds) - Whenever element is required and is not on page, wait for n seconds to find it before fail.
+        wait: 2 # (default: 2 seconds) - Whenever element is required and is not on page, wait for n seconds to find it before fail.
         connection_timeout: 60 # timeout for opening a connection to remote selenium server (30 seconds by default).
         request_timeout: 60 # timeout for a request to return something from remote selenium server (30 seconds by default).
         adminUsername: admin


### PR DESCRIPTION
I have checked the Codeception documentation, and there is a retry functionality, but we would have to specify it for each test. There is a workaround with the OR operator between more codeception commands(`codecept run || codecept run -g failed`), but this solution didn't work for me with our docker configuration.
So, I increased the default timeout for waiting how you advised me.

[MAILPOET-3508]

[MAILPOET-3508]: https://mailpoet.atlassian.net/browse/MAILPOET-3508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ