### PR TITLE
Refactor saving newsletter template images [MAILPOET-2686]

### DIFF
--- a/assets/js/src/common/thumbnail.ts
+++ b/assets/js/src/common/thumbnail.ts
@@ -11,6 +11,7 @@ import html2canvas from 'html2canvas';
 export const fromDom = async (element) => {
   const canvas = await html2canvas(element, {
     logging: false,
+    scale: 1, // Use a constant scale to prevent generating large images on Retina displays
   });
   return canvas.toDataURL('image/jpeg');
 };

--- a/assets/js/src/newsletter_editor/components/save.js
+++ b/assets/js/src/newsletter_editor/components/save.js
@@ -69,7 +69,7 @@ Module.saveTemplate = function (options) {
   return Thumbnail.fromNewsletter(App.toJSON())
     .then(function (thumbnail) {
       var data = _.extend(options || {}, {
-        thumbnail: thumbnail,
+        thumbnail_data: thumbnail,
         body: JSON.stringify(App.getBody()),
         categories: JSON.stringify([
           'saved',
@@ -90,7 +90,7 @@ Module.exportTemplate = function (options) {
   return Thumbnail.fromNewsletter(App.toJSON())
     .then(function (thumbnail) {
       var data = _.extend(options || {}, {
-        thumbnail: thumbnail,
+        thumbnail_data: thumbnail,
         body: App.getBody(),
         categories: JSON.stringify(['saved', App.getNewsletter().get('type')]),
       });

--- a/assets/js/src/newsletters/send.jsx
+++ b/assets/js/src/newsletters/send.jsx
@@ -211,7 +211,7 @@ class NewsletterSend extends React.Component {
   saveTemplate = (response, done) => {
     const thumbnailPromise = this.getThumbnailPromise(response.meta.preview_url);
     thumbnailPromise
-      .then((thumbnail) => {
+      .then((thumbnailData) => {
         MailPoet.Ajax.post({
           api_version: window.mailpoet_api_version,
           endpoint: 'newsletterTemplates',
@@ -219,7 +219,7 @@ class NewsletterSend extends React.Component {
           data: {
             newsletter_id: response.data.id,
             name: response.data.subject,
-            thumbnail,
+            thumbnail_data: thumbnailData,
             body: JSON.stringify(response.data.body),
             categories: '["recent"]',
           },

--- a/assets/js/src/newsletters/templates/template_box.jsx
+++ b/assets/js/src/newsletters/templates/template_box.jsx
@@ -110,7 +110,7 @@ class TemplateBox extends React.Component {
           }}
         >
           <div className="mailpoet-template-thumbnail">
-            <img src={thumbnail} alt={MailPoet.I18n.t('templatePreview')} loading="lazy" />
+            {thumbnail ? (<img src={thumbnail} alt={MailPoet.I18n.t('templatePreview')} loading="lazy" />) : ''}
           </div>
           <div className="mailpoet-template-preview-overlay">
             <Button>{MailPoet.I18n.t('zoom')}</Button>
@@ -140,12 +140,16 @@ TemplateBox.propTypes = {
   id: PropTypes.number.isRequired,
   newsletterId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  thumbnail: PropTypes.string.isRequired,
+  thumbnail: PropTypes.string,
   readonly: PropTypes.bool.isRequired,
   beforeDelete: PropTypes.func.isRequired,
   afterDelete: PropTypes.func.isRequired,
   beforeSelect: PropTypes.func.isRequired,
   afterSelect: PropTypes.func.isRequired,
+};
+
+TemplateBox.defaultProps = {
+  thumbnail: null,
 };
 
 export default TemplateBox;

--- a/lib/API/JSON/v1/NewsletterTemplates.php
+++ b/lib/API/JSON/v1/NewsletterTemplates.php
@@ -8,6 +8,7 @@ use MailPoet\API\JSON\ResponseBuilders\NewsletterTemplatesResponseBuilder;
 use MailPoet\Config\AccessControl;
 use MailPoet\Newsletter\ApiDataSanitizer;
 use MailPoet\NewsletterTemplates\NewsletterTemplatesRepository;
+use MailPoet\NewsletterTemplates\ThumbnailSaver;
 use MailPoet\WP\Functions as WPFunctions;
 
 class NewsletterTemplates extends APIEndpoint {
@@ -25,16 +26,21 @@ class NewsletterTemplates extends APIEndpoint {
   /** @var NewsletterTemplatesResponseBuilder */
   private $newsletterTemplatesResponseBuilder;
 
+  /** @var ThumbnailSaver */
+  private $thumbnailImageSaver;
+
   /** @var ApiDataSanitizer */
   private $apiDataSanitizer;
 
   public function __construct(
     NewsletterTemplatesRepository $newsletterTemplatesRepository,
     NewsletterTemplatesResponseBuilder $newsletterTemplatesResponseBuilder,
+    ThumbnailSaver $thumbnailImageSaver,
     ApiDataSanitizer $apiDataSanitizer
   ) {
     $this->newsletterTemplatesRepository = $newsletterTemplatesRepository;
     $this->newsletterTemplatesResponseBuilder = $newsletterTemplatesResponseBuilder;
+    $this->thumbnailImageSaver = $thumbnailImageSaver;
     $this->apiDataSanitizer = $apiDataSanitizer;
   }
 
@@ -67,6 +73,7 @@ class NewsletterTemplates extends APIEndpoint {
     }
     try {
       $template = $this->newsletterTemplatesRepository->createOrUpdate($data);
+      $template = $this->thumbnailImageSaver->ensureTemplateThumbnailFile($template);
       if (!empty($data['categories']) && $data['categories'] === NewsletterTemplatesRepository::RECENTLY_SENT_CATEGORIES) {
         $this->newsletterTemplatesRepository->cleanRecentlySent();
       }

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -317,6 +317,7 @@ class Migrator {
       'description varchar(255) NOT NULL DEFAULT "",',
       'body longtext,',
       'thumbnail longtext,',
+      'thumbnail_data longtext,',
       'readonly tinyint(1) DEFAULT 0,',
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -916,7 +916,7 @@ class Populator {
   }
 
   private function moveNewsletterTemplatesThumbnailData() {
-    if (version_compare($this->settings->get('db_version', '3.71.4'), '3.71.3', '>')) {
+    if (version_compare($this->settings->get('db_version', '3.73.1'), '3.73.0', '>')) {
       return;
     }
     $newsletterTemplatesTable = $this->entityManager->getClassMetadata(NewsletterTemplateEntity::class)->getTableName();

--- a/lib/Cron/Daemon.php
+++ b/lib/Cron/Daemon.php
@@ -86,5 +86,6 @@ class Daemon {
     if ($this->featureSwitch->isSupported(FeaturesController::RE_ENGAGEMENT_EMAIL)) {
       yield $this->workersFactory->createReEngagementEmailsSchedulerWorker();
     }
+    yield $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
   }
 }

--- a/lib/Cron/Triggers/WordPress.php
+++ b/lib/Cron/Triggers/WordPress.php
@@ -9,6 +9,7 @@ use MailPoet\Cron\Workers\Bounce as BounceWorker;
 use MailPoet\Cron\Workers\InactiveSubscribers;
 use MailPoet\Cron\Workers\KeyCheck\PremiumKeyCheck as PremiumKeyCheckWorker;
 use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck as SendingServiceKeyCheckWorker;
+use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
 use MailPoet\Cron\Workers\ReEngagementEmailsScheduler;
 use MailPoet\Cron\Workers\Scheduler as SchedulerWorker;
 use MailPoet\Cron\Workers\SendingQueue\Migration as MigrationWorker;
@@ -250,6 +251,13 @@ class WordPress {
       'status' => ['null', ScheduledTask::STATUS_SCHEDULED],
     ]);
 
+    // newsletter template thumbnails
+    $newsletterTemplateThumbnailsTasks = $this->getTasksCount([
+      'type' => NewsletterTemplateThumbnails::TASK_TYPE,
+      'scheduled_in' => [self::SCHEDULED_IN_THE_PAST],
+      'status' => ['null', ScheduledTask::STATUS_SCHEDULED],
+    ]);
+
     // check requirements for each worker
     $sendingQueueActive = (($scheduledQueues || $runningQueues) && !$sendingLimitReached && !$sendingIsPaused);
     $bounceSyncActive = ($mpSendingEnabled && ($bounceDueTasks || !$bounceFutureTasks));
@@ -279,6 +287,7 @@ class WordPress {
       || $subscribersCountCacheRecalculationTasks
       || $subscribersLastEngagementTasks
       || $subscribersReEngagementSchedulingTasks
+      || $newsletterTemplateThumbnailsTasks
     );
   }
 

--- a/lib/Cron/Workers/NewsletterTemplateThumbnails.php
+++ b/lib/Cron/Workers/NewsletterTemplateThumbnails.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\NewsletterTemplates\ThumbnailSaver;
+use MailPoet\WP\Functions as WPFunctions;
+
+class NewsletterTemplateThumbnails extends SimpleWorker {
+  const TASK_TYPE = 'newsletter_templates_thumbnails';
+  const AUTOMATIC_SCHEDULING = false;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+
+  /** @var ThumbnailSaver */
+  private $thumbnailSaver;
+
+  public function __construct(
+    ThumbnailSaver $thumbnailSaver,
+    WPFunctions $wp
+  ) {
+    parent::__construct($wp);
+    $this->thumbnailSaver = $thumbnailSaver;
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    $this->thumbnailSaver->ensureTemplateThumbnailsForAll();
+    return true;
+  }
+}

--- a/lib/Cron/Workers/WorkersFactory.php
+++ b/lib/Cron/Workers/WorkersFactory.php
@@ -127,4 +127,9 @@ class WorkersFactory {
   public function createSubscribersStatsReportWorker() {
     return $this->container->get(SubscribersStatsReport::class);
   }
+
+  /** @return NewsletterTemplateThumbnails */
+  public function createNewsletterTemplateThumbnailsWorker() {
+    return $this->container->get(NewsletterTemplateThumbnails::class);
+  }
 }

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -373,6 +373,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Statistics\GATracking::class)->setPublic(true);
     // Newsletter templates
     $container->autowire(\MailPoet\NewsletterTemplates\NewsletterTemplatesRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\NewsletterTemplates\ThumbnailSaver::class)->setPublic(true);
     // Util
     $container->autowire(\MailPoet\Util\Cookies::class);
     $container->autowire(\MailPoet\Util\DBCollationChecker::class);

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -174,6 +174,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\SubscribersLastEngagement::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersCountCacheRecalculation::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersStatsReport::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\NewsletterTemplateThumbnails::class)->setPublic(true);
     // Custom field
     $container->autowire(\MailPoet\CustomFields\ApiDataSanitizer::class);
     $container->autowire(\MailPoet\CustomFields\CustomFieldsRepository::class)->setPublic(true);

--- a/lib/Doctrine/Repository.php
+++ b/lib/Doctrine/Repository.php
@@ -104,6 +104,13 @@ abstract class Repository {
   }
 
   /**
+   * @param T $entity
+   */
+  public function detach($entity) {
+    $this->entityManager->detach($entity);
+  }
+
+  /**
    * @return class-string<T>
    */
   abstract protected function getEntityClassName();

--- a/lib/Entities/NewsletterTemplateEntity.php
+++ b/lib/Entities/NewsletterTemplateEntity.php
@@ -52,6 +52,12 @@ class NewsletterTemplateEntity {
   private $thumbnail;
 
   /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $thumbnailData;
+
+  /**
    * @ORM\Column(type="boolean")
    * @var bool
    */
@@ -120,6 +126,14 @@ class NewsletterTemplateEntity {
    */
   public function setThumbnail($thumbnail) {
     $this->thumbnail = $thumbnail;
+  }
+
+  public function getThumbnailData(): ?string {
+    return $this->thumbnailData;
+  }
+
+  public function setThumbnailData(string $thumbnailData): void {
+    $this->thumbnailData = $thumbnailData;
   }
 
   public function getReadonly(): bool {

--- a/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
+++ b/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
@@ -98,4 +98,14 @@ class NewsletterTemplatesRepository extends Repository {
       ->getQuery()
       ->getSingleScalarResult();
   }
+
+  public function getIdsOfEditableTemplates(): array {
+    $result = $this->doctrineRepository->createQueryBuilder('nt')
+      ->select('nt.id')
+      ->where('nt.readonly = :readonly')
+      ->setParameter('readonly', false)
+      ->getQuery()
+      ->getArrayResult();
+    return array_column($result, 'id');
+  }
 }

--- a/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
+++ b/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
@@ -49,7 +49,12 @@ class NewsletterTemplatesRepository extends Repository {
     }
 
     if (isset($data['thumbnail'])) {
-      $template->setThumbnail($data['thumbnail']);
+      // Backward compatibility for importing templates exported from older versions
+      if (strpos($data['thumbnail'], 'data:image') === 0) {
+        $data['thumbnail_data'] = $data['thumbnail'];
+      } else {
+        $template->setThumbnail($data['thumbnail']);
+      }
     }
 
     if (isset($data['thumbnail_data'])) {

--- a/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
+++ b/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
@@ -52,6 +52,10 @@ class NewsletterTemplatesRepository extends Repository {
       $template->setThumbnail($data['thumbnail']);
     }
 
+    if (isset($data['thumbnail_data'])) {
+      $template->setThumbnailData($data['thumbnail_data']);
+    }
+
     if (isset($data['body'])) {
       $template->setBody(json_decode($data['body'], true));
     }

--- a/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -32,6 +32,13 @@ class ThumbnailSaver {
     $this->baseUrl = Env::$tempUrl;
   }
 
+  public function ensureTemplateThumbnailsForAll() {
+    $templates = $this->repository->findBy(['readonly' => false]);
+    foreach ($templates as $template) {
+      $this->ensureTemplateThumbnailFile($template);
+    }
+  }
+
   public function ensureTemplateThumbnailFile(NewsletterTemplateEntity $template): NewsletterTemplateEntity {
     if ($template->getReadonly()) {
       return $template;

--- a/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -45,7 +45,12 @@ class ThumbnailSaver {
     if (!$savedFilename || !file_exists($file)) {
       $this->saveTemplateImage($template);
     }
-    // @todo update base url in case it changed e.g. the web was migrated
+
+    // File might exist but domain was changed
+    $thumbnailUrl = $template->getThumbnail();
+    if ($savedBaseUrl && $savedBaseUrl !== $this->baseUrl && $thumbnailUrl) {
+      $template->setThumbnail(str_replace($savedBaseUrl, $this->baseUrl, $thumbnailUrl));
+    }
     return $template;
   }
 

--- a/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -34,9 +34,14 @@ class ThumbnailSaver {
   }
 
   public function ensureTemplateThumbnailsForAll() {
-    $templates = $this->repository->findBy(['readonly' => false]);
-    foreach ($templates as $template) {
+    $templateIds = $this->repository->getIdsOfEditableTemplates();
+    foreach ($templateIds as $templateId) {
+      $template = $this->repository->findOneById((int)$templateId);
+      if (!$template) continue;
       $this->ensureTemplateThumbnailFile($template);
+      // Remove template entity from memory after it was processed
+      $this->repository->detach($template);
+      unset($template);
     }
   }
 

--- a/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MailPoet\NewsletterTemplates;
+
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterTemplateEntity;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ThumbnailSaver {
+  const THUMBNAIL_DIRECTORY = 'newsletter_thumbnails';
+
+  /** @var NewsletterTemplatesRepository */
+  private $repository;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var string */
+  private $baseDirectory;
+
+  /** @var string */
+  private $baseUrl;
+
+  public function __construct(
+    NewsletterTemplatesRepository $repository,
+    WPFunctions $wp
+  ) {
+    $this->repository = $repository;
+    $this->wp = $wp;
+    $this->baseDirectory = Env::$tempPath;
+    $this->baseUrl = Env::$tempUrl;
+  }
+
+  public function ensureTemplateThumbnailFile(NewsletterTemplateEntity $template): NewsletterTemplateEntity {
+    if ($template->getReadonly()) {
+      return $template;
+    }
+    $thumbnailUrl = $template->getThumbnail();
+    $savedFilename = null;
+    $savedBaseUrl = null;
+    if ($thumbnailUrl && strpos($thumbnailUrl, self::THUMBNAIL_DIRECTORY) !== false) {
+      [$savedBaseUrl, $savedFilename] = explode('/' . self::THUMBNAIL_DIRECTORY . '/', $thumbnailUrl ?? '');
+    }
+    $file = $this->baseDirectory . '/' . self::THUMBNAIL_DIRECTORY . '/' . $savedFilename;
+    if (!$savedFilename || !file_exists($file)) {
+      $this->saveTemplateImage($template);
+    }
+    // @todo update base url in case it changed e.g. the web was migrated
+    return $template;
+  }
+
+  private function saveTemplateImage(NewsletterTemplateEntity $template): void {
+    $data = $template->getThumbnailData();
+    if (!$data) {
+      return;
+    }
+    $thumbNailsDirectory = $this->baseDirectory . '/' . self::THUMBNAIL_DIRECTORY;
+    if (!file_exists($thumbNailsDirectory)) {
+      $this->wp->wpMkdirP($thumbNailsDirectory);
+    }
+    $file = $thumbNailsDirectory . '/' . uniqid() . '_template_' . $template->getId() . '.jpg';
+    if (file_put_contents($file, file_get_contents($data))) {
+      $url = str_replace($this->baseDirectory, $this->baseUrl, $file);
+      $template->setThumbnail($url);
+      $this->repository->flush();
+    }
+  }
+}

--- a/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -60,6 +60,10 @@ class ThumbnailSaver {
     if (!$data) {
       return;
     }
+    // Check that data contains Base 64 encoded jpeg
+    if (strpos($data, 'data:image/jpeg;base64') !== 0) {
+      return;
+    }
     $thumbNailsDirectory = $this->baseDirectory . '/' . self::THUMBNAIL_DIRECTORY;
     if (!file_exists($thumbNailsDirectory)) {
       $this->wp->wpMkdirP($thumbNailsDirectory);

--- a/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -4,6 +4,7 @@ namespace MailPoet\NewsletterTemplates;
 
 use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterTemplateEntity;
+use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 
 class ThumbnailSaver {
@@ -75,7 +76,7 @@ class ThumbnailSaver {
     if (!file_exists($thumbNailsDirectory)) {
       $this->wp->wpMkdirP($thumbNailsDirectory);
     }
-    $file = $thumbNailsDirectory . '/' . uniqid() . '_template_' . $template->getId() . '.jpg';
+    $file = $thumbNailsDirectory . '/' . Security::generateHash(16) . '_template_' . $template->getId() . '.jpg';
     if ($this->compressAndSaveFile($file, $data)) {
       $url = str_replace($this->baseDirectory, $this->baseUrl, $file);
       $template->setThumbnail($url);

--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -740,4 +740,8 @@ class Functions {
   public function wpMkdirP(string $dir) {
     return wp_mkdir_p($dir);
   }
+
+  public function wpGetImageEditor(string $path, $args = []) {
+    return wp_get_image_editor($path, $args);
+  }
 }

--- a/lib/WP/Functions.php
+++ b/lib/WP/Functions.php
@@ -736,4 +736,8 @@ class Functions {
   public function hasExcerpt($post = null) {
     return has_excerpt($post);
   }
+
+  public function wpMkdirP(string $dir) {
+    return wp_mkdir_p($dir);
+  }
 }

--- a/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -306,6 +306,8 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createSubscribersEngagementScoreWorker' => $worker,
       'createSubscribersLastEngagementWorker' => $worker,
       'createSubscribersCountCacheRecalculationWorker' => $worker,
+      'createReEngagementEmailsSchedulerWorker' => $worker,
+      'createNewsletterTemplateThumbnailsWorker' => $worker,
     ]);
   }
 }

--- a/tests/integration/Cron/DaemonTest.php
+++ b/tests/integration/Cron/DaemonTest.php
@@ -62,6 +62,8 @@ class DaemonTest extends \MailPoetTest {
       'createSubscribersEngagementScoreWorker' => $this->createSimpleWorkerMock(),
       'createSubscribersLastEngagementWorker' => $this->createSimpleWorkerMock(),
       'createSubscribersCountCacheRecalculationWorker' => $this->createSimpleWorkerMock(),
+      'createReEngagementEmailsSchedulerWorker' => $this->createSimpleWorkerMock(),
+      'createNewsletterTemplateThumbnailsWorker' => $this->createSimpleWorkerMock(),
     ]);
   }
 

--- a/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
+++ b/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
@@ -18,17 +18,21 @@ class NewsletterTemplatesRepositoryTest extends \MailPoetTest {
     $createdTemplate = $this->newsletterTemplatesRepository->createOrUpdate([
       'name' => 'Another template',
       'body' => '{"content": {}, "globalStyles": {}}',
+      'thumbnail_data' => 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
     ]);
     expect($createdTemplate->getName())->equals('Another template');
     expect($createdTemplate->getBody())->equals(['content' => [], 'globalStyles' => []]);
+    expect($createdTemplate->getThumbnailData())->equals('data:image/gif;base64,R0lGODlhAQABAAAAACw=');
 
     $updatedTemplate = $this->newsletterTemplatesRepository->createOrUpdate([
       'id' => $createdTemplate->getId(),
       'name' => 'Another template updated',
       'body' => '{"content": "changed"}',
+      'thumbnail_data' => 'data:image/gif;base64,R0lGO==',
     ]);
     expect($updatedTemplate->getName())->equals('Another template updated');
     expect($updatedTemplate->getBody())->equals(['content' => 'changed']);
+    expect($updatedTemplate->getThumbnailData())->equals('data:image/gif;base64,R0lGO==');
   }
 
   public function testItCleansRecentlySent() {

--- a/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
+++ b/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace MailPoet\Test\API\JSON\v1;
+namespace MailPoet\NewsletterTemplates;
 
 use MailPoet\Entities\NewsletterTemplateEntity;
-use MailPoet\NewsletterTemplates\NewsletterTemplatesRepository;
 
 class NewsletterTemplatesRepositoryTest extends \MailPoetTest {
   /** @var NewsletterTemplatesRepository */

--- a/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
+++ b/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
@@ -54,6 +54,17 @@ class NewsletterTemplatesRepositoryTest extends \MailPoetTest {
     expect($templates[0]->getName())->equals('Testing template 5');
   }
 
+  public function testItCanCreateFromOldDataFormat() {
+    $createdTemplate = $this->newsletterTemplatesRepository->createOrUpdate([
+      'name' => 'Another template',
+      'body' => '{"content": {}, "globalStyles": {}}',
+      'thumbnail' => 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+    ]);
+    expect($createdTemplate->getName())->equals('Another template');
+    expect($createdTemplate->getBody())->equals(['content' => [], 'globalStyles' => []]);
+    expect($createdTemplate->getThumbnailData())->equals('data:image/gif;base64,R0lGODlhAQABAAAAACw=');
+  }
+
   public function _after() {
     $this->truncateEntity(NewsletterTemplateEntity::class);
   }

--- a/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
+++ b/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MailPoet\NewsletterTemplates;
+
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterTemplateEntity;
+
+class ThumbnailSaverTest extends \MailPoetTest {
+  /** @var ThumbnailSaver */
+  private $thumbnailSaver;
+
+  public function _before() {
+    $this->truncateEntity(NewsletterTemplateEntity::class);
+    $this->thumbnailSaver = $this->diContainer->get(ThumbnailSaver::class);
+  }
+
+  public function testItCanSaveThumbnailDataAsFile() {
+    $template = $this->createTemplate();
+    $template = $this->thumbnailSaver->ensureTemplateThumbnailFile($template);
+    $thumbnailUrl = $template->getThumbnail();
+    expect($thumbnailUrl)->notEmpty();
+    expect($thumbnailUrl)->string();
+    expect($thumbnailUrl)->startsWith(Env::$tempUrl);
+    expect($thumbnailUrl)->stringContainsString(ThumbnailSaver::THUMBNAIL_DIRECTORY);
+    [,$fileName] = explode(ThumbnailSaver::THUMBNAIL_DIRECTORY, (string)$thumbnailUrl);
+    $file = Env::$tempPath . '/' . ThumbnailSaver::THUMBNAIL_DIRECTORY . $fileName;
+    expect(file_exists($file))->true();
+    unlink($file); // remove the file after the test
+  }
+
+  private function createTemplate(): NewsletterTemplateEntity {
+    $template = new NewsletterTemplateEntity('Template');
+    $template->setBody([1]);
+    $template->setThumbnailData('data:image/gif;base64,R0lGODlhAQABAAAAACw=');
+    $this->entityManager->persist($template);
+    $this->entityManager->flush();
+    return $template;
+  }
+}

--- a/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
+++ b/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
@@ -28,6 +28,23 @@ class ThumbnailSaverTest extends \MailPoetTest {
     unlink($file); // remove the file after the test
   }
 
+  public function testItUpdatesBaseUrlIfChanged() {
+    $template = $this->createTemplate();
+    $template = $this->thumbnailSaver->ensureTemplateThumbnailFile($template);
+    $thumbnailUrl = $template->getThumbnail();
+    $template->setThumbnail(str_replace(Env::$tempUrl, 'http://example.com', (string)$thumbnailUrl));
+    $template = $this->thumbnailSaver->ensureTemplateThumbnailFile($template);
+    // Base url was updated back to initial value
+    $thumbnailUrl = $template->getThumbnail();
+    expect($thumbnailUrl)->string();
+    expect($thumbnailUrl)->startsWith(Env::$tempUrl);
+    [,$fileName] = explode(ThumbnailSaver::THUMBNAIL_DIRECTORY, (string)$thumbnailUrl);
+    // File is still the same
+    expect($thumbnailUrl)->endsWith($fileName);
+    $file = Env::$tempPath . '/' . ThumbnailSaver::THUMBNAIL_DIRECTORY . $fileName;
+    unlink($file); // remove the file after the test
+  }
+
   private function createTemplate(): NewsletterTemplateEntity {
     $template = new NewsletterTemplateEntity('Template');
     $template->setBody([1]);

--- a/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
+++ b/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
@@ -48,7 +48,7 @@ class ThumbnailSaverTest extends \MailPoetTest {
   private function createTemplate(): NewsletterTemplateEntity {
     $template = new NewsletterTemplateEntity('Template');
     $template->setBody([1]);
-    $template->setThumbnailData('data:image/gif;base64,R0lGODlhAQABAAAAACw=');
+    $template->setThumbnailData('data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////wgALCAABAAEBAREA/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPxA=');
     $this->entityManager->persist($template);
     $this->entityManager->flush();
     return $template;

--- a/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
+++ b/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
@@ -45,6 +45,15 @@ class ThumbnailSaverTest extends \MailPoetTest {
     unlink($file); // remove the file after the test
   }
 
+  public function testItSkipsNotBase64JpegData() {
+    $template = $this->createTemplate();
+    $template->setThumbnailData('Some data');
+    $template = $this->thumbnailSaver->ensureTemplateThumbnailFile($template);
+    $thumbnailUrl = $template->getThumbnail();
+    // Base url was updated back to initial value
+    expect($thumbnailUrl)->null();
+  }
+
   private function createTemplate(): NewsletterTemplateEntity {
     $template = new NewsletterTemplateEntity('Template');
     $template->setBody([1]);


### PR DESCRIPTION
I added comments into commit messages and code. I recommend reviewing by commits. 

### Note for QA
Before updating to this build import a couple of templates and send a couple of newsletters so that you have some template images to migrate after updating to the build.
With the new version, all newsletter templates images should be loaded from image files and the newsletter templates page should display faster.
I also altered how we take screenshots on retina screens so you can try saving a couple of newsletters as templates on a Mac (it is important that the browser window is opened on the retina screen) and check the quality of templates.

[MAILPOET-2686]

[MAILPOET-2686]: https://mailpoet.atlassian.net/browse/MAILPOET-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ