### PR TITLE
Replace PHP8 version of TypedCacheItem class with PHP7 compatible code [MAILPOET-3904]

### DIFF
--- a/prefixer/fix-doctrine.php
+++ b/prefixer/fix-doctrine.php
@@ -19,6 +19,12 @@ foreach ($files as $file) {
   }
 }
 
+// Replace PHP8 version of Doctrine/Common/Cache/Psr6/TypedCacheItem.php with PHP7 version
+// This is needed so that we pass pre-commit checks in the plugin repository.
+$php7CachedItem = file_get_contents(__DIR__ . "/../vendor-prefixed/doctrine/cache/lib/Doctrine/Common/Cache/Psr6/CacheItem.php");
+$php7CachedItem = str_replace('final class CacheItem', 'final class TypedCacheItem', $php7CachedItem);
+file_put_contents(__DIR__ . "/../vendor-prefixed/doctrine/cache/lib/Doctrine/Common/Cache/Psr6/TypedCacheItem.php", $php7CachedItem);
+
 // cleanup file types by extension
 exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name '*.xsd' -delete");
 exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name 'phpstan.neon' -delete");


### PR DESCRIPTION
WordPress plugin repository prevents committing files that contain syntax introduced in PHP8.
[MAILPOET-3904]

[MAILPOET-3904]: https://mailpoet.atlassian.net/browse/MAILPOET-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ