### PR TITLE
Fix Unicode quotes in ALC titles [MAILPOET-3660]

### DIFF
--- a/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -133,7 +133,7 @@ class PostTransformerContentsExtractor {
   }
 
   public function getTitle($post) {
-    $title = $this->sanitizeTitle($post->post_title); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $title = $post->post_title; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
     if (filter_var($this->args['titleIsLink'], FILTER_VALIDATE_BOOLEAN)) {
       $title = '<a href="' . $this->wp->getPermalink($post->ID) . '">' . $title . '</a>';

--- a/tests/integration/Newsletter/RendererTest.php
+++ b/tests/integration/Newsletter/RendererTest.php
@@ -655,7 +655,7 @@ class RendererTest extends \MailPoetTest {
       $this->fail('Error preparing data for test: failed to create post.');
     }
 
-    $filename = 'tests/_data/600x400.jpg';
+    $filename = dirname(__DIR__) . '/../../tests/_data/600x400.jpg';
     $contents = file_get_contents($filename);
     if (!$contents) {
       $this->fail('Error preparing data for test: failed to retrieve file contents.');

--- a/tests/integration/Newsletter/RendererTestALCdata.json
+++ b/tests/integration/Newsletter/RendererTestALCdata.json
@@ -1,0 +1,403 @@
+{
+  "content": {
+    "type": "container",
+    "orientation": "vertical",
+    "styles": {
+      "block": {
+        "backgroundColor": "transparent"
+      }
+    },
+    "blocks": [
+      {
+        "orientation": "horizontal",
+        "type": "container",
+        "styles": {
+          "block": {
+            "backgroundColor": "#999999"
+          }
+        },
+        "blocks": [
+          {
+            "orientation": "vertical",
+            "type": "container",
+            "styles": {
+              "block": {
+                "backgroundColor": "#999999"
+              }
+            },
+            "blocks": [
+            {
+              "type": "automatedLatestContent",
+              "withLayout": true,
+              "amount": "3",
+              "contentType": "post",
+              "terms": [],
+              "inclusionType": "include",
+              "displayType": "excerpt",
+              "titleFormat": "h3",
+              "titleAlignment": "left",
+              "titleIsLink": false,
+              "imageFullWidth": false,
+              "titlePosition": "abovePost",
+              "featuredImagePosition": "alternate",
+              "showAuthor": "no",
+              "authorPrecededBy": "Author:",
+              "showCategories": "no",
+              "categoriesPrecededBy": "Categories:",
+              "readMoreType": "button",
+              "readMoreText": "Read more",
+              "readMoreButton": {
+                "type": "button",
+                "text": "Read the post",
+                "url": "[postLink]",
+                "styles": {
+                  "block": {
+                    "backgroundColor": "#2ea1cd",
+                    "borderColor": "#0074a2",
+                    "borderWidth": "1px",
+                    "borderRadius": "5px",
+                    "borderStyle": "solid",
+                    "width": "160px",
+                    "lineHeight": "30px",
+                    "fontColor": "#ffffff",
+                    "fontFamily": "Verdana",
+                    "fontSize": "16px",
+                    "fontWeight": "normal",
+                    "textAlign": "center"
+                  }
+                }
+              },
+              "sortBy": "newest",
+              "showDivider": true,
+              "divider": {
+                "type": "divider",
+                "styles": {
+                  "block": {
+                    "backgroundColor": "transparent",
+                    "padding": "13px",
+                    "borderStyle": "solid",
+                    "borderWidth": "3px",
+                    "borderColor": "#aaaaaa"
+                  }
+                }
+              },
+              "backgroundColor": "#ffffff",
+              "backgroundColorAlternate": "#eeeeee"
+            }
+          ]
+          }
+        ]
+      }
+    ]
+  },
+  "globalStyles": {
+    "text": {
+      "fontColor": "#000000",
+      "fontFamily": "Arial",
+      "fontSize": "16px"
+    },
+    "h1": {
+      "fontColor": "#111111",
+      "fontFamily": "Trebuchet MS",
+      "fontSize": "30px"
+    },
+    "h2": {
+      "fontColor": "#222222",
+      "fontFamily": "Trebuchet MS",
+      "fontSize": "24px"
+    },
+    "h3": {
+      "fontColor": "#333333",
+      "fontFamily": "Trebuchet MS",
+      "fontSize": "22px"
+    },
+    "link": {
+      "fontColor": "#21759B",
+      "textDecoration": "underline"
+    },
+    "wrapper": {
+      "backgroundColor": "#ffffff"
+    },
+    "body": {
+      "backgroundColor": "#eeeeee"
+    }
+  },
+  "blockDefaults": {
+    "automatedLatestContent": {
+      "amount": "5",
+      "withLayout": false,
+      "contentType": "post",
+      "inclusionType": "include",
+      "displayType": "excerpt",
+      "titleFormat": "h1",
+      "titleAlignment": "left",
+      "titleIsLink": false,
+      "imageFullWidth": false,
+      "titlePosition": "abovePost",
+      "featuredImagePosition": "belowTitle",
+      "showAuthor": "no",
+      "authorPrecededBy": "Author:",
+      "showCategories": "no",
+      "categoriesPrecededBy": "Categories:",
+      "readMoreType": "button",
+      "readMoreText": "Read more",
+      "readMoreButton": {
+        "text": "Read more",
+        "url": "[postLink]",
+        "context": "automatedLatestContent.readMoreButton",
+        "styles": {
+          "block": {
+            "backgroundColor": "#2ea1cd",
+            "borderColor": "#0074a2",
+            "borderWidth": "1px",
+            "borderRadius": "5px",
+            "borderStyle": "solid",
+            "width": "180px",
+            "lineHeight": "40px",
+            "fontColor": "#ffffff",
+            "fontFamily": "Verdana",
+            "fontSize": "18px",
+            "fontWeight": "normal",
+            "textAlign": "center"
+          }
+        }
+      },
+      "sortBy": "newest",
+      "showDivider": true,
+      "divider": {
+        "context": "automatedLatestContent.divider",
+        "styles": {
+          "block": {
+            "backgroundColor": "transparent",
+            "padding": "13px",
+            "borderStyle": "solid",
+            "borderWidth": "3px",
+            "borderColor": "#aaaaaa"
+          }
+        }
+      },
+      "backgroundColor": "#ffffff",
+      "backgroundColorAlternate": "#eeeeee"
+    },
+    "automatedLatestContentLayout": {
+      "amount": "5",
+      "withLayout": true,
+      "contentType": "post",
+      "inclusionType": "include",
+      "displayType": "excerpt",
+      "titleFormat": "h1",
+      "titleAlignment": "left",
+      "titleIsLink": false,
+      "imageFullWidth": false,
+      "titlePosition": "abovePost",
+      "featuredImagePosition": "alternate",
+      "showAuthor": "no",
+      "authorPrecededBy": "Author:",
+      "showCategories": "no",
+      "categoriesPrecededBy": "Categories:",
+      "readMoreType": "button",
+      "readMoreText": "Read more",
+      "readMoreButton": {
+        "text": "Read more",
+        "url": "[postLink]",
+        "context": "automatedLatestContentLayout.readMoreButton",
+        "styles": {
+          "block": {
+            "backgroundColor": "#2ea1cd",
+            "borderColor": "#0074a2",
+            "borderWidth": "1px",
+            "borderRadius": "5px",
+            "borderStyle": "solid",
+            "width": "180px",
+            "lineHeight": "40px",
+            "fontColor": "#ffffff",
+            "fontFamily": "Verdana",
+            "fontSize": "18px",
+            "fontWeight": "normal",
+            "textAlign": "center"
+          }
+        }
+      },
+      "sortBy": "newest",
+      "showDivider": true,
+      "divider": {
+        "context": "automatedLatestContentLayout.divider",
+        "styles": {
+          "block": {
+            "backgroundColor": "transparent",
+            "padding": "13px",
+            "borderStyle": "solid",
+            "borderWidth": "3px",
+            "borderColor": "#aaaaaa"
+          }
+        }
+      },
+      "backgroundColor": "#ffffff",
+      "backgroundColorAlternate": "#eeeeee"
+    },
+    "button": {
+      "text": "Read the post",
+      "url": "[postLink]",
+      "styles": {
+        "block": {
+          "backgroundColor": "#2ea1cd",
+          "borderColor": "#0074a2",
+          "borderWidth": "1px",
+          "borderRadius": "5px",
+          "borderStyle": "solid",
+          "width": "180px",
+          "lineHeight": "40px",
+          "fontColor": "#ffffff",
+          "fontFamily": "Verdana",
+          "fontSize": "18px",
+          "fontWeight": "normal",
+          "textAlign": "center"
+        }
+      },
+      "type": "button"
+    },
+    "container": {
+      "styles": {
+        "block": {
+          "backgroundColor": "transparent"
+        }
+      }
+    },
+    "divider": {
+      "styles": {
+        "block": {
+          "backgroundColor": "transparent",
+          "padding": "13px",
+          "borderStyle": "solid",
+          "borderWidth": "3px",
+          "borderColor": "#aaaaaa"
+        }
+      },
+      "type": "divider"
+    },
+    "footer": {
+      "text": "<p><a href=\"[link:subscription_unsubscribe_url]\">Unsubscribe</a> | <a href=\"[link:subscription_manage_url]\">Manage subscription</a><br />Add your postal address here!</p>",
+      "styles": {
+        "block": {
+          "backgroundColor": "transparent"
+        },
+        "text": {
+          "fontColor": "#222222",
+          "fontFamily": "Arial",
+          "fontSize": "12px",
+          "textAlign": "center"
+        },
+        "link": {
+          "fontColor": "#6cb7d4",
+          "textDecoration": "none"
+        }
+      }
+    },
+    "posts": {
+      "amount": "10",
+      "withLayout": true,
+      "contentType": "post",
+      "postStatus": "publish",
+      "inclusionType": "include",
+      "displayType": "excerpt",
+      "titleFormat": "h1",
+      "titleAlignment": "left",
+      "titleIsLink": false,
+      "imageFullWidth": false,
+      "titlePosition": "abovePost",
+      "featuredImagePosition": "alternate",
+      "showAuthor": "no",
+      "authorPrecededBy": "Author:",
+      "showCategories": "no",
+      "categoriesPrecededBy": "Categories:",
+      "readMoreType": "link",
+      "readMoreText": "Read more",
+      "readMoreButton": {
+        "text": "Read more",
+        "url": "[postLink]",
+        "context": "posts.readMoreButton",
+        "styles": {
+          "block": {
+            "backgroundColor": "#2ea1cd",
+            "borderColor": "#0074a2",
+            "borderWidth": "1px",
+            "borderRadius": "5px",
+            "borderStyle": "solid",
+            "width": "180px",
+            "lineHeight": "40px",
+            "fontColor": "#ffffff",
+            "fontFamily": "Verdana",
+            "fontSize": "18px",
+            "fontWeight": "normal",
+            "textAlign": "center"
+          }
+        }
+      },
+      "sortBy": "newest",
+      "showDivider": true,
+      "divider": {
+        "context": "posts.divider",
+        "styles": {
+          "block": {
+            "backgroundColor": "transparent",
+            "padding": "13px",
+            "borderStyle": "solid",
+            "borderWidth": "3px",
+            "borderColor": "#aaaaaa"
+          }
+        }
+      },
+      "backgroundColor": "#ffffff",
+      "backgroundColorAlternate": "#eeeeee"
+    },
+    "social": {
+      "iconSet": "default",
+      "icons": [
+        {
+          "type": "socialIcon",
+          "iconType": "facebook",
+          "link": "http://www.facebook.com",
+          "image": "http://localhost/wp-content/plugins/mailpoet/assets/img/newsletter_editor/social-icons/01-social/Facebook.png?mailpoet_version=3.7.8",
+          "height": "32px",
+          "width": "32px",
+          "text": "Facebook"
+        },
+        {
+          "type": "socialIcon",
+          "iconType": "twitter",
+          "link": "http://www.twitter.com",
+          "image": "http://localhost/wp-content/plugins/mailpoet/assets/img/newsletter_editor/social-icons/01-social/Twitter.png?mailpoet_version=3.7.8",
+          "height": "32px",
+          "width": "32px",
+          "text": "Twitter"
+        }
+      ]
+    },
+    "spacer": {
+      "styles": {
+        "block": {
+          "backgroundColor": "transparent",
+          "height": "40px"
+        }
+      }
+    },
+    "header": {
+      "text": "<a href=\"[link:newsletter_view_in_browser_url]\">View this in your browser.</a>",
+      "styles": {
+        "block": {
+          "backgroundColor": "transparent"
+        },
+        "text": {
+          "fontColor": "#222222",
+          "fontFamily": "Arial",
+          "fontSize": "12px",
+          "textAlign": "center"
+        },
+        "link": {
+          "fontColor": "#6cb7d4",
+          "textDecoration": "underline"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
With this PR I am removing the function sanitizeTitle that replaces quotes with Unicode quotes on the ALC post titles.

This function was added to fix an issue where the post content would not be rendered in the newsletter sent. The Unicode quotes add spaces to the title.

I have not been able to reproduce the original issue after removing the function from the title.
I have tested with the following titles (and other combinations):
`"This is a 'test"
`
`This "is 'a" test
` -> These are the quotes that were reported to cause issues.
`This "is 'a test
`

I have added a test case for a scenario where a newsletter contains an ALC (Automated Latest Content-Latest posts) block and the post has a title with the quotes, a featured image and content. The test verifies the post content is present in the rendered newsletter.

To test:
* Create a post with a title like this: This "is 'a" test
* Add a featured image
* Add content
* Create a newsletter with an ALC (Automated Latest Content-Latest posts) block
* Send a preview of the newsletter
* Open the newsletter on the email client. 
* Verify the post content is present.
* Verify the post title quotes are not converted to Unicode quotes.

[MAILPOET-3660]

[MAILPOET-3660]: https://mailpoet.atlassian.net/browse/MAILPOET-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ