### PR TITLE
Remove remaining usages of NewsletterLink and deprecate class [MAILPOET-3816]

### DIFF
--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -13,6 +13,7 @@ use MailPoet\Cron\Workers\SubscribersLastEngagement;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterTemplateEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -700,8 +701,8 @@ class Populator {
     $wpdb->query(sprintf(
       $query,
       NewsletterLink::$_table,
-      NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
-      NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE
+      NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
+      NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE
     ));
   }
 

--- a/lib/Config/Populator.php
+++ b/lib/Config/Populator.php
@@ -22,7 +22,6 @@ use MailPoet\Entities\UserFlagEntity;
 use MailPoet\Form\FormsRepository;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\NewsletterLink;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
@@ -700,7 +699,7 @@ class Populator {
     global $wpdb;
     $wpdb->query(sprintf(
       $query,
-      NewsletterLink::$_table,
+      $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName(),
       NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
       NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE
     ));

--- a/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Models\NewsletterLink as NewsletterLinkModel;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Router\Endpoints\Track;
@@ -61,7 +62,7 @@ class Links {
     $settings = SettingsController::getInstance();
     if ((boolean)$settings->get('tracking.enabled') && $subscriber) {
       $linkHash = NewsletterLinkModel::where('queue_id', $queue->id)
-        ->where('url', NewsletterLinkModel::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE)
+        ->where('url', NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE)
         ->findOne();
       if (!$linkHash instanceof NewsletterLinkModel) {
         return '';

--- a/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -11,7 +11,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatsNotificationEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MetaInfo;
-use MailPoet\Models\NewsletterLink;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Settings\SettingsController;
@@ -176,7 +175,7 @@ class Worker {
 
   public static function getShortcodeLinksMapping() {
     return [
-      NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE => __('Unsubscribe link', 'mailpoet'),
+      NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE => __('Unsubscribe link', 'mailpoet'),
       '[link:subscription_manage_url]' => __('Manage subscription link', 'mailpoet'),
       '[link:newsletter_view_in_browser_url]' => __('View in browser link', 'mailpoet'),
     ];

--- a/lib/Doctrine/Repository.php
+++ b/lib/Doctrine/Repository.php
@@ -103,6 +103,10 @@ abstract class Repository {
     $this->entityManager->flush();
   }
 
+  public function getReference($id) {
+    return $this->entityManager->getReference($this->getEntityClassName(), $id);
+  }
+
   /**
    * @param T $entity
    */

--- a/lib/Entities/NewsletterLinkEntity.php
+++ b/lib/Entities/NewsletterLinkEntity.php
@@ -99,4 +99,16 @@ class NewsletterLinkEntity {
   public function getTotalClicksCount() {
     return $this->clicks->count();
   }
+
+  public function toArray(): array {
+    return [
+      'id' => $this->getId(),
+      'newsletter_id' => ($this->getNewsletter() instanceof NewsletterEntity) ? $this->getNewsletter()->getId() : null,
+      'queue_id' => ($this->getQueue() instanceof SendingQueueEntity) ? $this->getQueue()->getId() : null,
+      'url' => $this->getUrl(),
+      'hash' => $this->getHash(),
+      'created_at' => $this->getCreatedAt(),
+      'updated_at' => $this->getUpdatedAt(),
+    ];
+  }
 }

--- a/lib/Entities/NewsletterLinkEntity.php
+++ b/lib/Entities/NewsletterLinkEntity.php
@@ -19,6 +19,9 @@ class NewsletterLinkEntity {
   use UpdatedAtTrait;
   use SafeToOneAssociationLoadTrait;
 
+  public const UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_unsubscribe_url]';
+  public const INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_instant_unsubscribe_url]';
+
   /**
    * @ORM\ManyToOne(targetEntity="MailPoet\Entities\NewsletterEntity")
    * @ORM\JoinColumn(name="newsletter_id", referencedColumnName="id")

--- a/lib/Models/NewsletterLink.php
+++ b/lib/Models/NewsletterLink.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Models;
 
+use MailPoet\Entities\NewsletterLinkEntity;
+
 /**
  * @property int $newsletterId
  * @property int $queueId
@@ -11,6 +13,6 @@ namespace MailPoet\Models;
  */
 class NewsletterLink extends Model {
   public static $_table = MP_NEWSLETTER_LINKS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
-  const UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_unsubscribe_url]';
-  const INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_instant_unsubscribe_url]';
+  const UNSUBSCRIBE_LINK_SHORT_CODE = NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE;
+  const INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE = NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE;
 }

--- a/lib/Models/NewsletterLink.php
+++ b/lib/Models/NewsletterLink.php
@@ -5,14 +5,34 @@ namespace MailPoet\Models;
 use MailPoet\Entities\NewsletterLinkEntity;
 
 /**
- * @property int $newsletterId
- * @property int $queueId
- * @property string $url
- * @property string $hash
- * @property int|null $clicksCount
+ * @deprecated This model is deprecated. Use \MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository and
+ * respective Doctrine entities instead. This class can be removed after 2022-04-27.
  */
 class NewsletterLink extends Model {
   public static $_table = MP_NEWSLETTER_LINKS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
   const UNSUBSCRIBE_LINK_SHORT_CODE = NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE;
   const INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE = NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE;
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for properties.
+   */
+  public function __get($key) {
+    self::deprecationError('property "' . $key . '"');
+    return parent::__get($key);
+  }
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for static calls.
+   */
+  public static function __callStatic($name, $arguments) {
+    self::deprecationError($name);
+    return parent::__callStatic($name, $arguments);
+  }
+
+  private static function deprecationError($methodName) {
+    trigger_error(
+      'Calling ' . $methodName . ' is deprecated and will be removed. Use \MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository and respective Doctrine entities instead.',
+      E_USER_DEPRECATED
+    );
+  }
 }

--- a/lib/Newsletter/Links/Links.php
+++ b/lib/Newsletter/Links/Links.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Links;
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Models\NewsletterLink;
 use MailPoet\Newsletter\Shortcodes\Categories\Link;
@@ -155,13 +156,13 @@ class Links {
 
   public function ensureInstantUnsubscribeLink(array $processedLinks) {
     if (in_array(
-      NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
+      NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
       array_column($processedLinks, 'link'))
     ) {
       return $processedLinks;
     }
     $processedLinks[] = $this->hashLink(
-      NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
+      NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
       Links::LINK_TYPE_SHORTCODE
     );
     return $processedLinks;

--- a/lib/Newsletter/Links/Links.php
+++ b/lib/Newsletter/Links/Links.php
@@ -169,8 +169,8 @@ class Links {
         continue;
       }
 
-      $newsletter = $this->newslettersRepository->findOneById($newsletterId);
-      $sendingQueue = $this->sendingQueueRepository->findOneById($queueId);
+      $newsletter = $this->newslettersRepository->getReference($newsletterId);
+      $sendingQueue = $this->sendingQueueRepository->getReference($queueId);
 
       if (!$newsletter instanceof NewsletterEntity || !$sendingQueue instanceof SendingQueueEntity) {
         continue;

--- a/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -3,7 +3,7 @@
 namespace MailPoet\Newsletter\Shortcodes;
 
 use MailPoet\CustomFields\CustomFieldsRepository;
-use MailPoet\Models\NewsletterLink;
+use MailPoet\Entities\NewsletterLinkEntity;
 
 class ShortcodesHelper {
   /** @var CustomFieldsRepository */
@@ -90,7 +90,7 @@ class ShortcodesHelper {
           'text' => __('Unsubscribe link', 'mailpoet'),
           'shortcode' => sprintf(
             '<a target="_blank" href="%s">%s</a>',
-            NewsletterLink::UNSUBSCRIBE_LINK_SHORT_CODE,
+            NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE,
             __('Unsubscribe', 'mailpoet')
           ),
         ],

--- a/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -4,7 +4,7 @@ namespace MailPoet\Test\DataGenerator\Generators;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Models\NewsletterLink;
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Models\NewsletterSegment;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
@@ -259,6 +259,8 @@ class WooCommercePastRevenues implements Generator {
   }
 
   public function runBefore() {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+
     // Turn off CURRENT_TIMESTAMP to be able to save generated value
     ORM::rawExecute(
       "ALTER TABLE `" . StatisticsClicks::$_table . "`
@@ -272,7 +274,7 @@ class WooCommercePastRevenues implements Generator {
     ORM::rawExecute("ALTER TABLE `{$prefix}postmeta` DISABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . Subscriber::$_table . "` DISABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . SubscriberSegment::$_table . "` DISABLE KEYS");
-    ORM::rawExecute("ALTER TABLE `" . NewsletterLink::$_table . "` DISABLE KEYS");
+    ORM::rawExecute("ALTER TABLE `" . $entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName() . "` DISABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . ScheduledTask::$_table . "` DISABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . ScheduledTaskSubscriber::$_table . "` DISABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . SendingQueue::$_table . "` DISABLE KEYS");
@@ -282,6 +284,8 @@ class WooCommercePastRevenues implements Generator {
   }
 
   public function runAfter() {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+
     ORM::rawExecute(
       "ALTER TABLE `" . StatisticsClicks::$_table . "`
       CHANGE `updated_at` `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;"
@@ -294,7 +298,7 @@ class WooCommercePastRevenues implements Generator {
     ORM::rawExecute("ALTER TABLE `{$prefix}postmeta` DISABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . Subscriber::$_table . "` ENABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . SubscriberSegment::$_table . "` ENABLE KEYS");
-    ORM::rawExecute("ALTER TABLE `" . NewsletterLink::$_table . "` ENABLE KEYS");
+    ORM::rawExecute("ALTER TABLE `" . $entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName() . "` ENABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . ScheduledTask::$_table . "` ENABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . ScheduledTaskSubscriber::$_table . "` ENABLE KEYS");
     ORM::rawExecute("ALTER TABLE `" . SendingQueue::$_table . "` ENABLE KEYS");

--- a/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Links;
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterLink;
 use MailPoetVendor\Idiorm\ORM;
@@ -76,7 +77,7 @@ class LinksTest extends \MailPoetTest {
     $queue = (object)['id' => 2];
     $this->links->process($renderedNewsletter, $newsletter, $queue);
     $unsubscribeCount = NewsletterLink::where('newsletter_id', $newsletter->id)
-      ->where('url', NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE)->count();
+      ->where('url', NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE)->count();
     expect($unsubscribeCount)->equals(1);
   }
 

--- a/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -406,8 +406,10 @@ class NewsletterTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('getErrors')
       ->willReturn([]);
-    $queueMock->id = $queue->id;
-    $queueMock->taskId = $queue->taskId;
+    $queueMock
+      ->expects($this->any())
+      ->method('__get')
+      ->will($this->onConsecutiveCalls($queue->id, $queue->taskId, $queue->id));
 
     $sendingQueue = ORM::forTable(SendingQueue::$_table)->findOne($queue->id);
     assert($sendingQueue instanceof ORM);
@@ -438,8 +440,10 @@ class NewsletterTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('getErrors')
       ->willReturn([]);
-    $queueMock->id = $queue->id;
-    $queueMock->taskId = $queue->taskId;
+    $queueMock
+      ->expects($this->any())
+      ->method('__get')
+      ->will($this->onConsecutiveCalls($queue->id, $queue->taskId, $queue->id, $queue->newsletterRenderedBody));
 
     // properly serialized object
     $sendingQueue = ORM::forTable(SendingQueue::$_table)->findOne($queue->id);

--- a/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -123,6 +123,7 @@ class WorkerTest extends \MailPoetTest {
     ]);
 
     $newsletterEntity = $this->newslettersRepository->findOneById($this->newsletter->id);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $this->newsletterLinkFactory = new NewsletterLinkFactory($newsletterEntity);
 
     $link = $this->newsletterLinkFactory

--- a/tests/integration/Newsletter/Links/LinksTest.php
+++ b/tests/integration/Newsletter/Links/LinksTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Newsletter\Links;
 
 use Codeception\Util\Fixtures;
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Models\NewsletterLink;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\Subscriber;
@@ -255,7 +256,7 @@ class LinksTest extends \MailPoetTest {
     ];
     $links = $this->links->ensureInstantUnsubscribeLink($links);
     expect(count($links))->equals(2);
-    expect($links[1]['link'])->equals(NewsletterLink::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE);
+    expect($links[1]['link'])->equals(NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE);
     expect($links[1]['type'])->equals(Links::LINK_TYPE_SHORTCODE);
     expect($links[1])->hasKey('processed_link');
     expect($links[1])->hasKey('hash');


### PR DESCRIPTION
This is a draft PR to get feedback on an issue before I dive deep into it. In this PR, I replaced the remaining places where NewsletterLink was still used with NewsletterLinkEntity and deprecated the old model class.

The problem is that the integration test `testItLogsErrorWhenNewlyRenderedNewsletterBodyIsInvalid` is failing due to a change in behavior (https://app.circleci.com/pipelines/github/mailpoet/mailpoet/7812/workflows/2eb5dc19-9746-4e5b-80eb-fa21f618a598/jobs/148114/tests#failed-test-0). This test, sets an invalid `newsletter_rendered_body` to make sure that the code in \MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter::preProcessNewsletter() works correctly to detect an invalid body and stop processing the newsletter ([lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php#L187](https://github.com/mailpoet/mailpoet/blob/c9636ebf1b57d53ffd1f94f4224226dcb9aadf26/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php#L187)).

But after replacing NewsletterLink with NewsletterLinkEntity in https://github.com/mailpoet/mailpoet/blame/090974dc6955e54ce4895edd4104181359c59c08/lib/Newsletter/Links/Links.php#L173, it is necessary to get an instance of the SendingQueueEntity instead of just passing the ID of the sending queue. The test now fails when calling `$this->sendingQueueRepository->findOneById()` as Doctrine returns an exception since the body of the newsletter is invalid.

@costasovo, before I dig into the code to understand the best way to approach this problem, I decided to open this PR as a draft to check with you if you have seen similar problems in the past and if you have any suggestions on how to approach it?

Thanks

[MAILPOET-3816]

[MAILPOET-3816]: https://mailpoet.atlassian.net/browse/MAILPOET-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ