### PR TITLE
Fix 'Enable auto-updates' link missing when Premium is up-to-date

### DIFF
--- a/lib/Config/Updater.php
+++ b/lib/Config/Updater.php
@@ -40,6 +40,8 @@ class Updater {
     if (isset($latestVersion->new_version)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       if (version_compare($this->version, $latestVersion->new_version, '<')) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         $updateTransient->response[$this->plugin] = $latestVersion;
+      } else {
+        $updateTransient->no_update[$this->plugin] = $latestVersion; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       }
       $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       $updateTransient->checked[$this->plugin] = $this->version;

--- a/tests/integration/Config/UpdaterTest.php
+++ b/tests/integration/Config/UpdaterTest.php
@@ -74,6 +74,42 @@ class UpdaterTest extends \MailPoetTest {
     expect($result->response[$this->pluginName]->package)->notEmpty();
   }
 
+  public function testItSetsNoupdateKeyIfNoUpdateAvailable() {
+    $updateTransient = new \stdClass;
+    $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'getLatestVersion' => function () {
+          return (object)[
+            'id' => 76630,
+            'slug' => $this->slug,
+            'plugin' => $this->pluginName,
+            'new_version' => $this->version,
+            'url' => 'http://www.mailpoet.com/wordpress-newsletter-plugin-premium/',
+            'package' => home_url() . '/wp-content/uploads/mailpoet-premium.zip',
+          ];
+        },
+      ],
+      $this
+    );
+    $result = $updater->checkForUpdate($updateTransient);
+    expect($result->last_checked)->greaterOrEquals($updateTransient->last_checked); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    expect($result->checked[$this->pluginName])->equals($this->version);
+    expect($result->no_update[$this->pluginName]->slug)->equals($this->slug); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    expect($result->no_update[$this->pluginName]->plugin)->equals($this->pluginName); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    expect(version_compare(
+      $this->version,
+      $result->no_update[$this->pluginName]->new_version, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      '='
+    ))->true();
+  }
+
   public function testItReturnsObjectIfPassedNonObjectWhenCheckingForUpdates() {
     $result = $this->updater->checkForUpdate(null);
     expect($result instanceof \stdClass)->true();


### PR DESCRIPTION
[MAILPOET-3921]

[MAILPOET-3921]: https://mailpoet.atlassian.net/browse/MAILPOET-3921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ