### PR TITLE
Fix/custom select default value on manage page - [MAILPOET-3894]

### DIFF
--- a/assets/js/src/form_editor/blocks/map_custom_field_form_data.jsx
+++ b/assets/js/src/form_editor/blocks/map_custom_field_form_data.jsx
@@ -23,6 +23,8 @@ function mapFormDataToParams(fieldType, data) {
           const mapped = { value: value.name };
           if (value.isChecked) {
             mapped.is_checked = '1';
+          } else {
+            mapped.is_checked = '';
           }
           return mapped;
         }),

--- a/lib/Form/Block/Select.php
+++ b/lib/Form/Block/Select.php
@@ -68,11 +68,15 @@ class Select {
         continue;
       }
 
-      $isSelected = (
-        (isset($option['is_checked']) && $option['is_checked'])
-        ||
-        ($this->rendererHelper->getFieldValue($block) === $option['value'])
-      ) ? ' selected="selected"' : '';
+      $isSelected = '';
+
+      if ($this->rendererHelper->getFieldValue($block) === $option['value']) {
+        // use selected value if it exist
+        $isSelected = ' selected="selected"';
+      } elseif ((isset($option['is_checked']) && $option['is_checked']) && !($this->rendererHelper->getFieldValue($block))) {
+        // use default value otherwise
+        $isSelected = ' selected="selected"';
+      }
 
       $isDisabled = (!empty($option['is_disabled'])) ? ' disabled="disabled"' : '';
 

--- a/tests/unit/Form/Block/SelectTest.php
+++ b/tests/unit/Form/Block/SelectTest.php
@@ -39,7 +39,7 @@ class SelectTest extends \MailPoetUnitTest {
     $this->rendererHelperMock->method('getFieldName')->will($this->returnValue('select'));
     $this->rendererHelperMock->method('renderLabel')->will($this->returnValue('<label></label>'));
     $this->rendererHelperMock->method('getFieldLabel')->will($this->returnValue('Field label'));
-    $this->rendererHelperMock->method('getFieldValue')->will($this->returnValue('1'));
+    $this->rendererHelperMock->method('getFieldValue')->will($this->returnValue(''));
     $this->blockStylesRenderer = $this->createMock(BlockStylesRenderer::class);
     $this->blockStylesRenderer->method('renderForSelect')->willReturn('');
     $this->selectBlock = new Select($this->rendererHelperMock, $this->wrapperMock, $this->blockStylesRenderer, $this->wpMock);


### PR DESCRIPTION
#### Background
See  [MAILPOET-3894](https://mailpoet.atlassian.net/browse/MAILPOET-3894)  for more information


#### Changes proposed in this Pull Request
 * Fixed managed subscription page showing multiple selected option
 * Fixed default select form field uncheck not saving


#### Testing instructions

* From wp-admin, visit the form editor and create a new **Select Custom Field**
* Add a field name and multiple options
* Set **one** of the options as the default by clicking on the checkbox by the side
* Visit the managed subscription page
* Notice the default selected option has been automatically selected.
* From the form editor page, select a new default option, save (Click on _Update custom field_)
* Reload the managed subscription page and notice the default selected option has been automatically updated.
* Select a new option and click on save
* Inspect the page HTML content, validate no other option is selected apart from your new choice


[MAILPOET-3894](https://mailpoet.atlassian.net/browse/MAILPOET-3894)