### PR TITLE
TimestampListener should not use the same time object for different entities [MAILPOET-3870]

### DIFF
--- a/lib/Doctrine/EventListeners/TimestampListener.php
+++ b/lib/Doctrine/EventListeners/TimestampListener.php
@@ -27,11 +27,11 @@ class TimestampListener {
       && method_exists($entity, 'getCreatedAt')
       && !$entity->getCreatedAt()
     ) {
-      $entity->setCreatedAt($this->now);
+      $entity->setCreatedAt($this->now->copy());
     }
 
     if (in_array(UpdatedAtTrait::class, $entityTraits, true) && method_exists($entity, 'setUpdatedAt')) {
-      $entity->setUpdatedAt($this->now);
+      $entity->setUpdatedAt($this->now->copy());
     }
   }
 
@@ -40,7 +40,7 @@ class TimestampListener {
     $entityTraits = $this->getEntityTraits($entity);
 
     if (in_array(UpdatedAtTrait::class, $entityTraits, true) && method_exists($entity, 'setUpdatedAt')) {
-      $entity->setUpdatedAt($this->now);
+      $entity->setUpdatedAt($this->now->copy());
     }
   }
 

--- a/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
+++ b/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
@@ -2,18 +2,9 @@
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 
-use MailPoet\Doctrine\Annotations\AnnotationReaderProvider;
-use MailPoet\Doctrine\ConfigurationFactory;
-use MailPoet\Doctrine\EntityManagerFactory;
-use MailPoet\Doctrine\EventListeners\EmojiEncodingListener;
-use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
-use MailPoet\Doctrine\EventListeners\ValidationListener;
-use MailPoet\Doctrine\Validator\ValidatorFactory;
-use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\Common\Cache\ArrayCache;
 use MailPoetVendor\Doctrine\ORM\Events;
 
 require_once __DIR__ . '/TimestampEntity.php';

--- a/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
+++ b/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
@@ -72,6 +72,26 @@ class TimestampListenerTest extends \MailPoetTest {
     expect($entity->getUpdatedAt())->equals($this->now);
   }
 
+  public function testItUsesDifferentTimesWhenCreatingDifferentEntities() {
+    $entity1 = new TimestampEntity();
+    $entity1->setName('Entity 1');
+
+    $this->entityManager->persist($entity1);
+    $this->entityManager->flush();
+
+    $createdAt1 = $entity1->getCreatedAt();
+    $this->assertInstanceOf(Carbon::class, $createdAt1);
+    $createdAt1->subMonth();
+
+    $entity2 = new TimestampEntity();
+    $entity2->setName('Entity 2');
+
+    $this->entityManager->persist($entity2);
+    $this->entityManager->flush();
+
+    $this->assertEquals($this->now, $entity2->getCreatedAt());
+  }
+
   public function _after() {
     parent::_after();
     $this->connection->executeStatement("DROP TABLE IF EXISTS $this->tableName");


### PR DESCRIPTION
Besides changing TimestampListener to create copies of the Carbon object before passing them to the entities, in a separate, commit I also removed a few unused imports that existed in this class.

[MAILPOET-3870]

[MAILPOET-3870]: https://mailpoet.atlassian.net/browse/MAILPOET-3870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ