### PR TITLE
Attempt to convert dates using d/m/Y on imports [MAILPOET-3747]

### DIFF
--- a/lib/Util/DateConverter.php
+++ b/lib/Util/DateConverter.php
@@ -10,8 +10,11 @@ class DateConverter {
    */
   public function convertDateToDatetime(string $date, string $dateFormat) {
     $datetime = false;
+
     if ($dateFormat === 'datetime') {
       $datetime = $date;
+    } elseif ($dateFormat === 'd/m/Y') {
+      $datetime = str_replace('/', '-', $date);
     } else {
       $parsedDate = explode('/', $date);
       $parsedDateFormat = explode('/', $dateFormat);

--- a/tests/unit/Util/DateConverterTest.php
+++ b/tests/unit/Util/DateConverterTest.php
@@ -66,4 +66,22 @@ class DateConverterTest extends \MailPoetUnitTest {
     expect($this->dateConverter->convertDateToDatetime('0', 'MM'))
       ->equals('');
   }
+
+  public function testItCanConvertCustomFormat() {
+    expect($this->dateConverter->convertDateToDatetime('31/12/2021', 'd/m/Y'))
+      ->equals('2021-12-31 00:00:00');
+    expect($this->dateConverter->convertDateToDatetime('1/12/2021', 'd/m/Y'))
+      ->equals('2021-12-01 00:00:00');
+    expect($this->dateConverter->convertDateToDatetime('12/31/2021', 'd/m/Y'))
+      ->equals(false);
+
+    expect($this->dateConverter->convertDateToDatetime('31/12/2021 10:26', 'd/m/Y'))
+      ->equals('2021-12-31 10:26:00');
+    expect($this->dateConverter->convertDateToDatetime('1/12/2021 17:11', 'd/m/Y'))
+      ->equals('2021-12-01 17:11:00');
+    expect($this->dateConverter->convertDateToDatetime('1/12/2021 1:11', 'd/m/Y'))
+      ->equals('2021-12-01 01:11:00');
+    expect($this->dateConverter->convertDateToDatetime('12/31/2021 11:00', 'd/m/Y'))
+      ->equals(false);
+  }
 }


### PR DESCRIPTION
With this PR, when a site is using the `d/m/Y` format, we will parse `created_at` and `confirmed_at` using `datetime` and `d/m/Y` formats, then select the one with fewer errors.
When no errors parsing with both formats (or same amount of errors) we give preference to `datetime` format, for backwards compatibility.
We assume this will not be accurate in some cases, where dates could be parsed with both formats. For example 01/02/2021 could be first of February with d/m/Y or second of January with datetime. 

To test:
- Set the date on your site to d/m/Y format
- Create a subscribers import file using that format and dates that would be wrong using datetime. For example 31/12/2021
- Import the file, don't forget to select at least one field with dates to be imported as confirmation time (change the dropdown value from `ignore` to confirmation time)
- Check the records are imported properly in the subscribers database table and the dates are correct.

[MAILPOET-3747]

[MAILPOET-3747]: https://mailpoet.atlassian.net/browse/MAILPOET-3747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ