### PR TITLE
Track MailPoet free and premium versions in all events [MAILPOET-3885]

### DIFF
--- a/assets/js/src/analytics_event.js
+++ b/assets/js/src/analytics_event.js
@@ -19,11 +19,22 @@ import _ from 'underscore';
  */
 var eventsCache = [];
 
-function track(name, data) {
+function track(name, data = []) {
+  let trackedData = data;
+
   if (typeof window.mixpanel.track !== 'function') {
     window.mixpanel.init(window.mixpanelTrackingId);
   }
-  window.mixpanel.track(name, data);
+
+  if (typeof window.mailpoet_version !== 'undefined') {
+    trackedData['MailPoet Free version'] = window.mailpoet_version;
+  }
+
+  if (typeof window.mailpoet_premium_version !== 'undefined') {
+    trackedData['MailPoet Premium version'] = window.mailpoet_premium_version;
+  }
+
+  window.mixpanel.track(name, trackedData);
 }
 
 function exportMixpanel() {

--- a/assets/js/src/analytics_event.js
+++ b/assets/js/src/analytics_event.js
@@ -50,7 +50,7 @@ function exportMixpanel() {
 function trackCachedEvents() {
   eventsCache.forEach(function trackIfEnabled(event) {
     if (window.mailpoet_analytics_enabled || event.forced) {
-      window.mixpanel.track(event.name, event.data);
+      track(event.name, event.data);
     }
   });
 }

--- a/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/other_settings.tsx
+++ b/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/other_settings.tsx
@@ -44,7 +44,6 @@ const OtherSettings: React.FunctionComponent = () => {
     event.preventDefault();
     MailPoet.trackEvent('Forms > Embed', {
       'Embed type': type,
-      'MailPoet Free version': MailPoet.version,
     });
     if (type === 'php') {
       return setCopyAreaContent(formExports.php);

--- a/assets/js/src/form_editor/store/controls.jsx
+++ b/assets/js/src/form_editor/store/controls.jsx
@@ -108,7 +108,6 @@ export default {
         const customField = response.data;
         MailPoet.trackEvent('Forms > Add new custom field', {
           'Field type': customField.type,
-          'MailPoet Free version': window.mailpoet_version,
         });
         const blockName = registerCustomFieldBlock(customField);
         const customFieldBlock = createBlock(blockName);
@@ -136,7 +135,6 @@ export default {
       .then(() => {
         MailPoet.trackEvent('Forms > Delete custom field', {
           'Field type': customField.type,
-          'MailPoet Free version': window.mailpoet_version,
         });
         dispatch('mailpoet-form-editor').deleteCustomFieldDone(actionData.customFieldId, actionData.clientId);
         dispatch('core/block-editor').removeBlock(actionData.clientId);

--- a/assets/js/src/form_editor/templates/store/actions.ts
+++ b/assets/js/src/form_editor/templates/store/actions.ts
@@ -12,7 +12,6 @@ export function* selectTemplate(templateId: string, templateName: string): objec
     type: 'TRACK_EVENT',
     name: 'Forms > Template selected',
     data: {
-      'MailPoet Free version': MailPoet.version,
       'Template id': templateId,
       'Template name': templateName,
     },

--- a/assets/js/src/form_editor/templates/store/actions.ts
+++ b/assets/js/src/form_editor/templates/store/actions.ts
@@ -1,5 +1,4 @@
 import { select } from '@wordpress/data';
-import MailPoet from 'mailpoet';
 
 import {
   CategoryActionType,

--- a/assets/js/src/forms/heading.jsx
+++ b/assets/js/src/forms/heading.jsx
@@ -5,9 +5,7 @@ import Button from 'common/button/button';
 import plusIcon from 'common/button/icon/plus';
 
 export const onAddNewForm = () => {
-  MailPoet.trackEvent('Forms > Add New', {
-    'MailPoet Free version': MailPoet.version,
-  });
+  MailPoet.trackEvent('Forms > Add New');
   setTimeout(() => {
     window.location = window.mailpoet_form_template_selection_url;
   }, 200); // leave some time for the event to track

--- a/assets/js/src/newsletter_editor/components/save.js
+++ b/assets/js/src/newsletter_editor/components/save.js
@@ -100,9 +100,7 @@ Module.exportTemplate = function (options) {
       );
 
       FileSaver.saveAs(blob, 'template.json');
-      MailPoet.trackEvent('Editor > Template exported', {
-        'MailPoet Free version': window.mailpoet_version,
-      });
+      MailPoet.trackEvent('Editor > Template exported');
     });
 };
 
@@ -210,9 +208,7 @@ Module.SaveView = Marionette.View.extend({
             scroll: true,
           }
         );
-        MailPoet.trackEvent('Editor > Template saved', {
-          'MailPoet Free version': window.mailpoet_version,
-        });
+        MailPoet.trackEvent('Editor > Template saved');
       }).catch(function () {
         MailPoet.Notice.error(
           MailPoet.I18n.t('templateSaveFailed'),
@@ -288,9 +284,7 @@ Module.SaveView = Marionette.View.extend({
         }.bind(this),
       });
 
-      MailPoet.trackEvent('Editor > Browser Preview', {
-        'MailPoet Free version': window.mailpoet_version,
-      });
+      MailPoet.trackEvent('Editor > Browser Preview');
     }.bind(this)).fail(function (response) {
       if (response.errors.length > 0) {
         MailPoet.Notice.error(
@@ -383,9 +377,7 @@ Module.SaveView = Marionette.View.extend({
       },
     }).done(function () {
       $el.addClass('mailpoet_hidden');
-      MailPoet.trackEvent('Editor > WooCommerce email customizer enabled', {
-        'MailPoet Free version': window.mailpoet_version,
-      });
+      MailPoet.trackEvent('Editor > WooCommerce email customizer enabled');
     }).fail(function (response) {
       MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
     });
@@ -524,7 +516,6 @@ Module.NewsletterPreviewView = Marionette.View.extend({
         that.model.set('sendingPreview', false);
         that.model.set('previewSendingSuccess', true);
         MailPoet.trackEvent('Editor > Preview sent', {
-          'MailPoet Free version': window.mailpoet_version,
           'Domain name': data.subscriber.substring(data.subscriber.indexOf('@') + 1),
         });
       }).fail(function (response) {

--- a/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
+++ b/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
@@ -116,7 +116,6 @@ class EventsConditions extends React.Component {
       },
     }).done((response) => {
       MailPoet.trackEvent('Emails > New Automatic Email Created', {
-        'MailPoet Premium version': window.mailpoet_premium_version,
         'Event type': options.event,
         'Schedule type': options.afterTimeType,
         'Schedule value': options.afterTimeNumber,

--- a/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
+++ b/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
@@ -117,7 +117,6 @@ class EventsConditions extends React.Component {
     }).done((response) => {
       MailPoet.trackEvent('Emails > New Automatic Email Created', {
         'MailPoet Premium version': window.mailpoet_premium_version,
-        'MailPoet Free version': window.mailpoet_version,
         'Event type': options.event,
         'Schedule type': options.afterTimeType,
         'Schedule value': options.afterTimeNumber,

--- a/assets/js/src/newsletters/listings/heading.jsx
+++ b/assets/js/src/newsletters/listings/heading.jsx
@@ -11,10 +11,7 @@ const ListingHeading = () => (
         id="mailpoet-new-email"
         className="mailpoet-button button-secondary"
         to="/new"
-        onClick={() => MailPoet.trackEvent(
-          'Emails > Add New',
-          { 'MailPoet Free version': window.mailpoet_version }
-        )}
+        onClick={() => MailPoet.trackEvent('Emails > Add New')}
         data-automation-id="new_email"
       >
         {plusIcon}

--- a/assets/js/src/newsletters/listings/utils.jsx
+++ b/assets/js/src/newsletters/listings/utils.jsx
@@ -7,10 +7,7 @@ import MailPoet from 'mailpoet';
 import jQuery from 'jquery';
 
 export const trackStatsCTAClicked = () => {
-  MailPoet.trackEvent(
-    'User has clicked a CTA to view detailed stats',
-    { 'MailPoet Free version': window.mailpoet_version }
-  );
+  MailPoet.trackEvent('User has clicked a CTA to view detailed stats');
 };
 
 export const addStatsCTAAction = (actions) => {

--- a/assets/js/src/newsletters/newsletters.jsx
+++ b/assets/js/src/newsletters/newsletters.jsx
@@ -38,10 +38,7 @@ import PropTypes from 'prop-types';
 
 const automaticEmails = window.mailpoet_woocommerce_automatic_emails || [];
 
-const trackTabSwitch = (tabKey) => MailPoet.trackEvent(
-  `Tab Emails > ${tabKey} clicked`,
-  { 'MailPoet Free version': window.mailpoet_version },
-);
+const trackTabSwitch = (tabKey) => MailPoet.trackEvent(`Tab Emails > ${tabKey} clicked`);
 
 const Tabs = withNpsPoll(() => {
   const { parentId } = useParams();

--- a/assets/js/src/newsletters/send.jsx
+++ b/assets/js/src/newsletters/send.jsx
@@ -307,7 +307,6 @@ class NewsletterSend extends React.Component {
         );
         MailPoet.trackEvent('Emails > Newsletter sent', {
           scheduled: true,
-          'MailPoet Free version': window.mailpoet_version,
         });
       } else {
         this.context.notices.success(
@@ -316,7 +315,6 @@ class NewsletterSend extends React.Component {
         );
         MailPoet.trackEvent('Emails > Newsletter sent', {
           scheduled: false,
-          'MailPoet Free version': window.mailpoet_version,
         });
       }
       MailPoet.Modal.loading(false);
@@ -356,7 +354,6 @@ class NewsletterSend extends React.Component {
           <p>{MailPoet.I18n.t('welcomeEmailActivated')}</p>
         );
         MailPoet.trackEvent('Emails > Welcome email activated', {
-          'MailPoet Free version': window.mailpoet_version,
           'List type': opts.event,
           Delay: `${opts.afterTimeNumber} ${opts.afterTimeType}`,
         });
@@ -365,7 +362,6 @@ class NewsletterSend extends React.Component {
           <p>{MailPoet.I18n.t('postNotificationActivated')}</p>
         );
         MailPoet.trackEvent('Emails > Post notifications activated', {
-          'MailPoet Free version': window.mailpoet_version,
           Frequency: opts.intervalType,
         });
       }

--- a/assets/js/src/newsletters/send/ga_tracking.jsx
+++ b/assets/js/src/newsletters/send/ga_tracking.jsx
@@ -4,10 +4,7 @@ import MailPoet from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
 
 // Track once per page load
-const trackCampaignNameTyped = _.once(() => MailPoet.trackEvent(
-  'User has typed a GA campaign name',
-  { 'MailPoet Premium version': window.mailpoet_premium_version }
-));
+const trackCampaignNameTyped = _.once(() => MailPoet.trackEvent('User has typed a GA campaign name'));
 const tipLink = 'https://kb.mailpoet.com/article/187-track-your-newsletters-subscribers-in-google-analytics';
 const tip = ReactStringReplace(
   MailPoet.I18n.t('gaCampaignTip'),

--- a/assets/js/src/newsletters/templates/import_template.jsx
+++ b/assets/js/src/newsletters/templates/import_template.jsx
@@ -25,9 +25,7 @@ class ImportTemplate extends React.Component {
     reader.onload = (evt) => {
       try {
         this.saveTemplate(JSON.parse(evt.target.result));
-        MailPoet.trackEvent('Emails > Template imported', {
-          'MailPoet Free version': window.mailpoet_version,
-        });
+        MailPoet.trackEvent('Emails > Template imported');
       } catch (err) {
         this.context.notices.error(<p>{MailPoet.I18n.t('templateFileMalformedError')}</p>);
       }

--- a/assets/js/src/newsletters/templates/template_box.jsx
+++ b/assets/js/src/newsletters/templates/template_box.jsx
@@ -68,7 +68,6 @@ class TemplateBox extends React.Component {
     beforeSelect();
 
     MailPoet.trackEvent('Emails > Template selected', {
-      'MailPoet Free version': window.mailpoet_version,
       'Email name': name,
     });
 

--- a/assets/js/src/newsletters/types.tsx
+++ b/assets/js/src/newsletters/types.tsx
@@ -44,7 +44,6 @@ const NewsletterTypes: React.FunctionComponent<Props> = ({
     if (type !== undefined) {
       history.push(`/new/${type}`);
       MailPoet.trackEvent('Emails > Type selected', {
-        'MailPoet Free version': MailPoet.version,
         'Email type': type,
       });
     }
@@ -52,7 +51,6 @@ const NewsletterTypes: React.FunctionComponent<Props> = ({
 
   const openWooCommerceCustomizer = async (): Promise<JSX.Element> => {
     MailPoet.trackEvent('Emails > Type selected', {
-      'MailPoet Free version': MailPoet.version,
       'Email type': 'wc_transactional',
     });
     let emailId = window.mailpoet_woocommerce_transactional_email_id;
@@ -67,9 +65,7 @@ const NewsletterTypes: React.FunctionComponent<Props> = ({
           },
         });
         emailId = response.data.woocommerce.transactional_email_id;
-        MailPoet.trackEvent('Emails > WooCommerce email customizer enabled', {
-          'MailPoet Free version': MailPoet.version,
-        });
+        MailPoet.trackEvent('Emails > WooCommerce email customizer enabled');
       } catch (response) {
         if (response.errors.length > 0) {
           return (<APIErrorsNotice errors={response.errors} />);
@@ -174,7 +170,6 @@ const NewsletterTypes: React.FunctionComponent<Props> = ({
   const createNewsletter = (type): void => {
     setIsCreating(true);
     MailPoet.trackEvent('Emails > Type selected', {
-      'MailPoet Free version': MailPoet.version,
       'Email type': type,
     });
     MailPoet.Ajax.post({

--- a/assets/js/src/newsletters/types/automatic_emails/events_list.jsx
+++ b/assets/js/src/newsletters/types/automatic_emails/events_list.jsx
@@ -15,7 +15,6 @@ class AutomaticEmailEventsList extends React.Component {
 
   eventsConfigurator(eventSlug) {
     MailPoet.trackEvent('Emails > Automatic Type selected', {
-      'MailPoet Premium version': window.mailpoet_premium_version,
       'Email type': eventSlug,
     });
     this.props.history.push(`/new/${this.email.slug}/${eventSlug}/conditions`);

--- a/assets/js/src/newsletters/types/automatic_emails/events_list.jsx
+++ b/assets/js/src/newsletters/types/automatic_emails/events_list.jsx
@@ -15,7 +15,6 @@ class AutomaticEmailEventsList extends React.Component {
 
   eventsConfigurator(eventSlug) {
     MailPoet.trackEvent('Emails > Automatic Type selected', {
-      'MailPoet Free version': window.mailpoet_version,
       'MailPoet Premium version': window.mailpoet_premium_version,
       'Email type': eventSlug,
     });

--- a/assets/js/src/segments/dynamic/store/actions.ts
+++ b/assets/js/src/segments/dynamic/store/actions.ts
@@ -102,7 +102,6 @@ const messages = {
   onCreate: (data): void => {
     MailPoet.Notice.success(MailPoet.I18n.t('dynamicSegmentAdded'));
     MailPoet.trackEvent('Segments > Add new', {
-      'MailPoet Free version': MailPoet.version,
       type: data.segmentType || 'unknown type',
       subtype: data.action || data.wordpressRole || 'unknown subtype',
     });

--- a/assets/js/src/segments/form.jsx
+++ b/assets/js/src/segments/form.jsx
@@ -28,9 +28,7 @@ const messages = {
   },
   onCreate: function onCreate() {
     MailPoet.Notice.success(MailPoet.I18n.t('segmentAdded'));
-    MailPoet.trackEvent('Lists > Add new', {
-      'MailPoet Free version': window.mailpoet_version,
-    });
+    MailPoet.trackEvent('Lists > Add new');
   },
 };
 

--- a/assets/js/src/settings/settings.tsx
+++ b/assets/js/src/settings/settings.tsx
@@ -18,7 +18,6 @@ import { useSelector } from './store/hooks';
 
 const trackTabSwitched = (tabKey: string) => {
   MailPoet.trackEvent('User has clicked a tab in Settings', {
-    'MailPoet Free version': MailPoet.version,
     'Tab ID': tabKey,
   });
 };

--- a/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -60,7 +60,6 @@ export function* verifyPremiumKey(key: string) {
     MailPoet.trackEvent(
       'User has failed to validate a Premium key',
       {
-        'MailPoet Free version': MailPoet.version,
         'Premium plugin is active': !!MailPoet.premiumVersion,
       }
     );
@@ -90,12 +89,7 @@ export function* verifyPremiumKey(key: string) {
     downloadUrl: res?.meta?.premium_plugin_info?.download_link,
   });
 
-  MailPoet.trackEvent(
-    'User has validated a Premium key',
-    {
-      'MailPoet Free version': MailPoet.version,
-    }
-  );
+  MailPoet.trackEvent('User has validated a Premium key');
 
   return null;
 }

--- a/assets/js/src/settings/store/controls.ts
+++ b/assets/js/src/settings/store/controls.ts
@@ -7,7 +7,6 @@ export { default as CALL_API } from 'common/controls/call_api';
 export function TRACK_SETTINGS_SAVED() {
   const settings = select(STORE_NAME).getSettings();
   const data = {
-    'MailPoet Free version': MailPoet.version,
     'Sending method type': settings.mta_group || null,
     'Sending frequency (emails)': (
       settings.mta_group !== 'mailpoet'
@@ -33,10 +32,7 @@ export function TRACK_SETTINGS_SAVED() {
 }
 
 export function TRACK_REINSTALLED() {
-  MailPoet.trackEvent(
-    'User has reinstalled MailPoet via Settings',
-    { 'MailPoet Free version': MailPoet.version }
-  );
+  MailPoet.trackEvent('User has reinstalled MailPoet via Settings');
 }
 
 export function TRACK_TEST_EMAIL_SENT({ success, method }) {
@@ -45,7 +41,6 @@ export function TRACK_TEST_EMAIL_SENT({ success, method }) {
     {
       'Sending was successful': !!success,
       'Sending method type': method,
-      'MailPoet Free version': MailPoet.version,
     }
   );
 }

--- a/assets/js/src/subscribers/form.jsx
+++ b/assets/js/src/subscribers/form.jsx
@@ -142,9 +142,7 @@ const messages = {
   },
   onCreate: function onCreate() {
     MailPoet.Notice.success(MailPoet.I18n.t('subscriberAdded'));
-    MailPoet.trackEvent('Subscribers > Add new', {
-      'MailPoet Free version': window.mailpoet_version,
-    });
+    MailPoet.trackEvent('Subscribers > Add new');
   },
 };
 

--- a/assets/js/src/subscribers/importExport/export.ts
+++ b/assets/js/src/subscribers/importExport/export.ts
@@ -166,7 +166,6 @@ jQuery(document).ready(() => {
       MailPoet.trackEvent('Subscribers export completed', {
         'Total exported': response.data.totalExported,
         'File Format': exportFormat,
-        'MailPoet Free version': MailPoet.version,
       });
     }).fail((response) => {
       if (response.errors.length > 0) {

--- a/assets/js/src/subscribers/importExport/import/step_method_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_method_selection.jsx
@@ -48,7 +48,6 @@ function StepMethodSelection({
     processCsv(data, (sanitizedData) => {
       MailPoet.trackEvent('Subscribers import started', {
         source: method === 'file-method' ? 'file upload' : 'pasted data',
-        'MailPoet Free version': window.mailpoet_version,
       });
       finish(sanitizedData);
     });
@@ -84,7 +83,6 @@ function StepMethodSelection({
           onFinish={(data) => {
             MailPoet.trackEvent('Subscribers import started', {
               source: 'MailChimp',
-              'MailPoet Free version': window.mailpoet_version,
             });
             finish(data);
           }}

--- a/views/forms.html
+++ b/views/forms.html
@@ -106,9 +106,7 @@
 <% block after_javascript %>
 <script type="text/javascript">
   jQuery('#mailpoet_helper_link').on('click', function() {
-    MailPoet.trackEvent('Forms page > link to doc page', {
-      'MailPoet Free version': window.mailpoet_version
-    });
+    MailPoet.trackEvent('Forms page > link to doc page');
   });
 </script>
 <% endblock %>

--- a/views/premium.html
+++ b/views/premium.html
@@ -393,8 +393,6 @@
 
 <% block after_javascript %>
 <script type="text/javascript">
-  MailPoet.trackEvent('Premium page viewed', {
-    'MailPoet Free version': window.mailpoet_version
-  });
+  MailPoet.trackEvent('Premium page viewed');
 </script>
 <% endblock %>


### PR DESCRIPTION
To make it easier to test, you can enable the Mixpanel debug mode (https://developer.mixpanel.com/docs/javascript#debug-mode) by changing the code in the place where we initialize it: https://github.com/mailpoet/mailpoet/blob/master/assets/js/lib/analytics.js#L9

[MAILPOET-3885]

[MAILPOET-3885]: https://mailpoet.atlassian.net/browse/MAILPOET-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ