### PR TITLE
Fixed CSS is not applied when using form iframe - [MAILPOET-3871]

### DIFF
--- a/assets/css/src/components-public/_resets.scss
+++ b/assets/css/src/components-public/_resets.scss
@@ -1,0 +1,82 @@
+// basic default styling
+// to allow for consistent styling between mailpoet plugin and user's theme
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  color: rgb(40, 48, 61);
+  font-size: 16px;
+  font-weight: normal;
+  text-align: left;
+}
+
+html,
+body,
+p,
+ol,
+ul,
+li,
+dl,
+dt,
+dd,
+blockquote,
+figure,
+fieldset,
+form,
+legend,
+textarea,
+pre,
+iframe,
+hr,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3,
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
+  font-weight: normal;
+  letter-spacing: normal;
+}
+
+ul,
+ol {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+label {
+  font-family: Arial, Helvetica, sans-serif;
+  margin-bottom: 10px;
+}
+
+a {
+  background-color: transparent;
+  color: rgb(40, 48, 61);
+  cursor: pointer;
+  text-decoration-skip-ink: all;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}

--- a/assets/css/src/components-public/_resets.scss
+++ b/assets/css/src/components-public/_resets.scss
@@ -11,72 +11,94 @@ html {
   box-sizing: inherit;
 }
 
-body {
-  color: rgb(40, 48, 61);
-  font-size: 16px;
-  font-weight: normal;
-  text-align: left;
-}
+.mailpoet_form {
+  body {
+    color: rgb(40, 48, 61);
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 16px;
+    font-weight: normal;
+    text-align: left;
+  }
 
-html,
-body,
-p,
-ol,
-ul,
-li,
-dl,
-dt,
-dd,
-blockquote,
-figure,
-fieldset,
-form,
-legend,
-textarea,
-pre,
-iframe,
-hr,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
+  html,
+  body,
+  p,
+  ol,
+  ul,
+  li,
+  dl,
+  dt,
+  dd,
+  blockquote,
+  figure,
+  fieldset,
+  form,
+  legend,
+  textarea,
+  pre,
+  iframe,
+  hr,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: rgb(40, 48, 61);
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 16px;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    font-synthesis: none;
+    font-weight: normal;
+    letter-spacing: normal;
+    text-align: left;
+  }
 
-h1,
-.h1,
-h2,
-.h2,
-h3,
-.h3,
-h4,
-.h4,
-h5,
-.h5,
-h6,
-.h6 {
-  font-weight: normal;
-  letter-spacing: normal;
-}
+  h1,
+  .h1,
+  h2,
+  .h2,
+  h3,
+  .h3,
+  h4,
+  .h4,
+  h5,
+  .h5,
+  h6,
+  .h6 {
+    font-weight: normal;
+    letter-spacing: normal;
+    padding-top: 0;
+  }
 
-ul,
-ol {
-  font-family: Arial, Helvetica, sans-serif;
-}
+  ul,
+  ol {
+    font-family: Arial, Helvetica, sans-serif;
+  }
 
-label {
-  font-family: Arial, Helvetica, sans-serif;
-  margin-bottom: 10px;
-}
+  label {
+    font-family: Arial, Helvetica, sans-serif;
+    margin-bottom: 10px;
+  }
 
-a {
-  background-color: transparent;
-  color: rgb(40, 48, 61);
-  cursor: pointer;
-  text-decoration-skip-ink: all;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
+  input {
+    font-family: Arial, Helvetica, sans-serif;
+  }
+
+  a {
+    background-color: transparent;
+    color: rgb(40, 48, 61);
+    cursor: pointer;
+    text-decoration-skip-ink: all;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  button,
+  input[type='button'],
+  input[type='reset'],
+  input[type='submit'] {
+    text-transform: none;
+  }
 }

--- a/assets/css/src/components-public/_resets.scss
+++ b/assets/css/src/components-public/_resets.scss
@@ -1,25 +1,8 @@
 // basic default styling
 // to allow for consistent styling between mailpoet plugin and user's theme
 
-html {
-  box-sizing: border-box;
-}
-
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
-
-.mailpoet_form {
-  body {
-    color: rgb(40, 48, 61);
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 16px;
-    font-weight: normal;
-    text-align: left;
-  }
-
+.mailpoet_form_html,
+.mailpoet_form_iframe {
   html,
   body,
   p,
@@ -44,7 +27,6 @@ html {
   h4,
   h5,
   h6 {
-    color: rgb(40, 48, 61);
     font-family: Arial, Helvetica, sans-serif;
     font-size: 16px;
     -moz-osx-font-smoothing: grayscale;
@@ -67,7 +49,7 @@ html {
   .h5,
   h6,
   .h6 {
-    font-weight: normal;
+    font-weight: 700;
     letter-spacing: normal;
     padding-top: 0;
   }

--- a/assets/css/src/components-public/_resets.scss
+++ b/assets/css/src/components-public/_resets.scss
@@ -3,8 +3,6 @@
 
 .mailpoet_form_html,
 .mailpoet_form_iframe {
-  html,
-  body,
   p,
   ol,
   ul,
@@ -34,7 +32,6 @@
     font-synthesis: none;
     font-weight: normal;
     letter-spacing: normal;
-    text-align: left;
   }
 
   h1,

--- a/assets/css/src/mailpoet-public.scss
+++ b/assets/css/src/mailpoet-public.scss
@@ -14,6 +14,7 @@
 // Components
 // Actual UI components.
 
+@import 'components-public/resets';
 @import 'components/parsley';
 @import 'components-public/public';
 @import 'components-public/animation';

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -215,7 +215,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Form\PreviewPage::class);
     $container->autowire(\MailPoet\Form\Templates\TemplateRepository::class);
     $container->autowire(\MailPoet\Form\Util\Styles::class);
-    $container->autowire(\MailPoet\Form\Util\CustomFonts::class);
+    $container->autowire(\MailPoet\Form\Util\CustomFonts::class)->setPublic(true);
     // Helpscout
     $container->autowire(\MailPoet\Helpscout\Beacon::class)->setPublic(true);
     // Listing

--- a/lib/Form/Util/CustomFonts.php
+++ b/lib/Form/Util/CustomFonts.php
@@ -87,26 +87,22 @@ class CustomFonts {
       // When we load all custom fonts in one request, a form from WC Payments isn't displayed correctly.
       // It looks that the larger file size overloads the Stripe SDK.
       foreach (array_chunk(self::FONTS, self::FONT_CHUNK_SIZE) as $key => $fonts) {
-        $this->wp->wpEnqueueStyle('mailpoet_custom_fonts_' . $key, self::generateLink($fonts));
+        $this->wp->wpEnqueueStyle('mailpoet_custom_fonts_' . $key, $this->generateLink($fonts));
       }
     }
   }
 
-  public static function getCustomFontLink() {
+  public function generateHtmlCustomFontLink() {
     $output = '';
 
     foreach (array_chunk(self::FONTS, self::FONT_CHUNK_SIZE) as $key => $fonts) {
-      $output .= self::generateLink($fonts);
+      $output .= sprintf('<link href="%s" rel="stylesheet">', $this->generateLink($fonts));
     }
 
     return $output;
   }
 
-  public static function generateHtmlCustomFontLink() {
-      return sprintf('<link href="%s" rel="stylesheet">', self::getCustomFontLink());
-  }
-
-  private static function generateLink(array $fonts): string {
+  private function generateLink(array $fonts): string {
     $fonts = array_map(function ($fontName) {
       return urlencode($fontName) . ':400,400i,700,700i';
     }, $fonts);

--- a/lib/Form/Util/CustomFonts.php
+++ b/lib/Form/Util/CustomFonts.php
@@ -87,12 +87,26 @@ class CustomFonts {
       // When we load all custom fonts in one request, a form from WC Payments isn't displayed correctly.
       // It looks that the larger file size overloads the Stripe SDK.
       foreach (array_chunk(self::FONTS, self::FONT_CHUNK_SIZE) as $key => $fonts) {
-        $this->wp->wpEnqueueStyle('mailpoet_custom_fonts_' . $key, $this->generateLink($fonts));
+        $this->wp->wpEnqueueStyle('mailpoet_custom_fonts_' . $key, self::generateLink($fonts));
       }
     }
   }
 
-  private function generateLink(array $fonts): string {
+  public static function getCustomFontLink() {
+    $output = '';
+
+    foreach (array_chunk(self::FONTS, self::FONT_CHUNK_SIZE) as $key => $fonts) {
+      $output .= self::generateLink($fonts);
+    }
+
+    return $output;
+  }
+
+  public static function generateHtmlCustomFontLink() {
+      return sprintf('<link href="%s" rel="stylesheet">', self::getCustomFontLink());
+  }
+
+  private static function generateLink(array $fonts): string {
     $fonts = array_map(function ($fontName) {
       return urlencode($fontName) . ':400,400i,700,700i';
     }, $fonts);

--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -7,6 +7,7 @@ use MailPoet\Config\Renderer as ConfigRenderer;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Form\Renderer as FormRenderer;
+use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
@@ -82,6 +83,7 @@ class Widget extends \WP_Widget {
         'ajax_url' => WPFunctions::get()->adminUrl('admin-ajax.php', 'absolute'),
         'is_rtl' => $isRtl,
       ],
+      'fonts_link' => CustomFonts::generateHtmlCustomFontLink(),
     ];
 
     try {

--- a/lib/Form/Widget.php
+++ b/lib/Form/Widget.php
@@ -25,6 +25,9 @@ class Widget extends \WP_Widget {
   /** @var FormsRepository */
   private $formsRepository;
 
+  /** @var CustomFonts */
+  private $customFonts;
+
   public function __construct() {
     parent::__construct(
       'mailpoet_form',
@@ -36,6 +39,8 @@ class Widget extends \WP_Widget {
     $this->assetsController = new AssetsController($this->wp, $this->renderer, SettingsController::getInstance());
     $this->formRenderer = ContainerWrapper::getInstance()->get(FormRenderer::class);
     $this->formsRepository = ContainerWrapper::getInstance()->get(FormsRepository::class);
+    $this->customFonts = ContainerWrapper::getInstance()->get(CustomFonts::class);
+
     if (!is_admin()) {
       $this->setupIframe();
     } else {
@@ -83,7 +88,7 @@ class Widget extends \WP_Widget {
         'ajax_url' => WPFunctions::get()->adminUrl('admin-ajax.php', 'absolute'),
         'is_rtl' => $isRtl,
       ],
-      'fonts_link' => CustomFonts::generateHtmlCustomFontLink(),
+      'fonts_link' => $this->customFonts->generateHtmlCustomFontLink(),
     ];
 
     try {

--- a/views/form/iframe.html
+++ b/views/form/iframe.html
@@ -13,6 +13,23 @@
     <meta name="viewport" content="width=device-width">
     <meta name="robots" content="noindex, nofollow">
     <title><%= __('MailPoet Subscription Form') %></title>
+    <style>
+      html {
+        box-sizing: border-box;
+      }
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+      body {
+        color: rgb(40, 48, 61);
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 16px;
+        font-weight: normal;
+        text-align: left;
+      }
+    </style>
     <%= fonts_link | raw %>
     <%= stylesheet('mailpoet-public.css') %>
     <%= scripts | raw %>

--- a/views/form/iframe.html
+++ b/views/form/iframe.html
@@ -13,6 +13,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="robots" content="noindex, nofollow">
     <title><%= __('MailPoet Subscription Form') %></title>
+    <%= fonts_link | raw %>
     <%= stylesheet('mailpoet-public.css') %>
     <%= scripts | raw %>
   </head>


### PR DESCRIPTION

#### Background
See  [MAILPOET-3871](https://mailpoet.atlassian.net/browse/MAILPOET-3871)  for more information


#### Changes proposed in this Pull Request
 * Added default styles
 * Added support for custom fonts
 * Fixed iframe styling errors

**Before:**
<img width="681" alt="Screenshot 2021-11-11 at 8 29 52 AM" src="https://user-images.githubusercontent.com/30554163/141256737-154b8714-7c16-4c09-b001-20838a3ea499.png">


<img width="745" alt="Screenshot 2021-11-11 at 8 30 02 AM" src="https://user-images.githubusercontent.com/30554163/141256757-d98e5a34-9c0f-4ebe-be8d-e7ad74fa2051.png">



**After:**

<img width="666" alt="Screenshot 2021-11-11 at 8 28 26 AM" src="https://user-images.githubusercontent.com/30554163/141256642-43bf543d-dab1-48bf-8e15-eaac5ba88fb1.png">

<img width="693" alt="Screenshot 2021-11-11 at 8 28 58 AM" src="https://user-images.githubusercontent.com/30554163/141256663-fc6f6f80-175d-4cb3-aeb3-913ab0c27312.png">


#### Testing instructions

* Create a form using any of the available form templates
* Save the form and copy iframe code
* Place the iframe to some other site. (Note you might need to update with or height attributes)
* Observe the fonts and other styles 


[MAILPOET-3871](https://mailpoet.atlassian.net/browse/MAILPOET-3871)