### PR TITLE
LastSubscribedAtListener should not use the same time object for different entities [MAILPOET-3946]

### DIFF
--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -127,7 +127,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setFactory([new Reference(\MailPoet\Doctrine\EntityManagerFactory::class), 'createEntityManager'])
       ->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\EmojiEncodingListener::class)->setPublic(true);
-    $container->autowire(\MailPoet\Doctrine\EventListeners\LastSubscribedAtListener::class);
+    $container->autowire(\MailPoet\Doctrine\EventListeners\LastSubscribedAtListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\TimestampListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\ValidationListener::class);
     $container->autowire(\MailPoet\Doctrine\Validator\ValidatorFactory::class);

--- a/lib/Doctrine/EventListeners/LastSubscribedAtListener.php
+++ b/lib/Doctrine/EventListeners/LastSubscribedAtListener.php
@@ -19,7 +19,7 @@ class LastSubscribedAtListener {
     $entity = $eventArgs->getEntity();
 
     if ($entity instanceof SubscriberEntity && $entity->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED) {
-      $entity->setLastSubscribedAt($this->now);
+      $entity->setLastSubscribedAt($this->now->copy());
     }
   }
 
@@ -38,7 +38,7 @@ class LastSubscribedAtListener {
     [$oldStatus, $newStatus] = $changeSet['status'];
     // Update last_subscribed_at when status changes to subscribed
     if ($oldStatus !== SubscriberEntity::STATUS_SUBSCRIBED && $newStatus === SubscriberEntity::STATUS_SUBSCRIBED) {
-      $entity->setLastSubscribedAt($this->now);
+      $entity->setLastSubscribedAt($this->now->copy());
     }
   }
 }

--- a/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
+++ b/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MailPoet\Test\Doctrine\EventListeners;
+
+use MailPoetVendor\Doctrine\ORM\Events;
+
+class EventListenersBaseTest extends \MailPoetTest {
+  /**
+   * Replaces event listeners. Needed to test them since EventManager
+   * is shared for all entity managers using same DB connection.
+   */
+  protected function replaceListeners($original, $replacement) {
+    $this->entityManager->getEventManager()->removeEventListener(
+      [Events::prePersist, Events::preUpdate],
+      $original
+    );
+
+    $this->entityManager->getEventManager()->addEventListener(
+      [Events::prePersist, Events::preUpdate],
+      $replacement
+    );
+  }
+}

--- a/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
+++ b/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
@@ -86,6 +86,28 @@ class LastSubscribedAtTest extends EventListenersBaseTest {
     $this->assertEquals($pastDate, $entity->getLastSubscribedAt());
   }
 
+  public function testItUsesDifferentTimeObjectsWhenCreatingDifferentEntities() {
+    $entity1 = new SubscriberEntity();
+    $entity1->setEmail('test@test.com');
+    $entity1->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+
+    $this->entityManager->persist($entity1);
+    $this->entityManager->flush();
+
+    $lastSubscribedAt = $entity1->getLastSubscribedAt();
+    $this->assertInstanceOf(Carbon::class, $lastSubscribedAt);
+    $lastSubscribedAt->subMonth();
+
+    $entity2 = new SubscriberEntity();
+    $entity2->setEmail('test2@test.com');
+    $entity2->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+
+    $this->entityManager->persist($entity2);
+    $this->entityManager->flush();
+
+    $this->assertEquals($this->now, $entity2->getLastSubscribedAt());
+  }
+
   public function _after() {
     parent::_after();
     $this->truncateEntity(SubscriberEntity::class);

--- a/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
+++ b/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace MailPoet\Test\Doctrine\EventListeners;
+
+use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
+
+require_once __DIR__ . '/EventListenersBaseTest.php';
+
+class LastSubscribedAtTest extends EventListenersBaseTest {
+  /** @var Carbon */
+  private $now;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function _before() {
+    $timestamp = time();
+    $this->now = Carbon::createFromTimestamp($timestamp);
+    $this->wp = $this->make(WPFunctions::class, [
+      'currentTime' => $timestamp,
+    ]);
+
+    $newTimestampListener = new LastSubscribedAtListener($this->wp);
+    $originalListener = $this->diContainer->get(LastSubscribedAtListener::class);
+    $this->replaceListeners($originalListener, $newTimestampListener);
+  }
+
+  public function testItSetsLastSubscribedAtOnCreate() {
+    $entity = new SubscriberEntity();
+    $entity->setEmail('test@test.com');
+    $entity->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+
+    $this->entityManager->persist($entity);
+    $this->entityManager->flush();
+
+    $this->assertEquals($this->now, $entity->getLastSubscribedAt());
+  }
+
+  public function testItDoesntSetLastSubscribedAtOnCreateWhenStatusIsNotSubscribed() {
+    $entity = new SubscriberEntity();
+    $entity->setEmail('test@test.com');
+    $entity->setStatus(SubscriberEntity::STATUS_INACTIVE);
+
+    $this->entityManager->persist($entity);
+    $this->entityManager->flush();
+
+    $this->assertNull($entity->getLastSubscribedAt());
+  }
+
+  public function testItSetsLastSubscribedAtOnUpdate() {
+    $pastDate = new Carbon('2000-01-01 12:00:00');
+    $entity = new SubscriberEntity();
+    $entity->setEmail('test@test.com');
+    $entity->setStatus(SubscriberEntity::STATUS_INACTIVE);
+    $entity->setLastSubscribedAt($pastDate);
+
+    $this->entityManager->persist($entity);
+    $this->entityManager->flush();
+
+    $this->assertEquals($pastDate, $entity->getLastSubscribedAt());
+
+    $entity->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->entityManager->flush();
+
+    $this->assertEquals($this->now, $entity->getLastSubscribedAt());
+  }
+
+  public function testItDoesntChangeLastSubscribedAtOnUpdateIfStatusIsNotSubscribed() {
+    $pastDate = new Carbon('2000-01-01 12:00:00');
+    $entity = new SubscriberEntity();
+    $entity->setEmail('test@test.com');
+    $entity->setStatus(SubscriberEntity::STATUS_INACTIVE);
+    $entity->setLastSubscribedAt($pastDate);
+
+    $this->entityManager->persist($entity);
+    $this->entityManager->flush();
+
+    $this->assertEquals($pastDate, $entity->getLastSubscribedAt());
+
+    $entity->setEmail('test2@test.com');
+    $this->entityManager->flush();
+
+    $this->assertEquals($pastDate, $entity->getLastSubscribedAt());
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->truncateEntity(SubscriberEntity::class);
+  }
+}

--- a/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
+++ b/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
@@ -16,9 +16,10 @@ use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\Common\Cache\ArrayCache;
 use MailPoetVendor\Doctrine\ORM\Events;
 
+require_once __DIR__ . '/EventListenersBaseTest.php';
 require_once __DIR__ . '/TimestampEntity.php';
 
-class TimestampListenerTest extends \MailPoetTest {
+class TimestampListenerTest extends EventListenersBaseTest {
   /** @var Carbon */
   private $now;
 
@@ -84,21 +85,5 @@ class TimestampListenerTest extends \MailPoetTest {
   public function _after() {
     parent::_after();
     $this->connection->executeStatement("DROP TABLE IF EXISTS $this->tableName");
-  }
-
-  /**
-   * We have to replace event listeners since EventManager
-   * is shared for all entity managers using same DB connection
-   */
-  private function replaceListeners($original, $replacement) {
-    $this->entityManager->getEventManager()->removeEventListener(
-      [Events::prePersist, Events::preUpdate],
-      $original
-    );
-
-    $this->entityManager->getEventManager()->addEventListener(
-      [Events::prePersist, Events::preUpdate],
-      $replacement
-    );
   }
 }


### PR DESCRIPTION
This PR is similar to #3793 in that it applies the same change but to LastSubscribedAtListener instead of TimestampListener. On a separate commit, I created some basic integration tests for LastSubscribedAtListener as there were none.

[MAILPOET-3946]

[MAILPOET-3946]: https://mailpoet.atlassian.net/browse/MAILPOET-3946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ