### PR TITLE
Fix query to get subscribers of the "has WC subscription" segment [MAILPOET-3898]

### DIFF
--- a/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
@@ -40,7 +40,7 @@ class WooCommerceSubscription implements Filter {
       'postmeta',
       $wpdb->prefix . 'woocommerce_order_items',
       'items',
-      'postmeta.post_id = items.order_id'
+      'postmeta.post_id = items.order_id AND order_item_type = "line_item"'
     )->innerJoin(
       'items',
       $wpdb->prefix . 'woocommerce_order_itemmeta',


### PR DESCRIPTION
There was an issue in the old query used to get subscribers of the "has WooCommerce subscription" segment. When getting the IDs of the users that purchased a given subscription, it would get all the entries from wp_woocommerce_order_items without checking the value of ordem_item_type.

The problem is that wp_woocommerce_order_items contains entries for the purchased product, but also other things like shipping and tax information. The WooCommerce Subscriptions extension uses wp_woocommerce_order_items to store data when a user switches from one subscription to another. This was causing users to be included in the "has WooCommerce subscription" segment even after they had switched from the subscription that belonged to the segment to another one.

This problem was fixed by adding another condition to the part of the query that joins with wp_woocommerce_order_items to get only entries that have the value 'line_item' for the field 'order_item_type'. This excludes entries where the value of order_item_type' is 'line_item_switched', which is what WC Subscriptions uses to track subscriptions that a user used to have before switching to something else.

Kudos to @brezocordero for proposing the solution that I implemented in this PR.

[MAILPOET-3898]

[MAILPOET-3898]: https://mailpoet.atlassian.net/browse/MAILPOET-3898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ