### PR TITLE
Add code to process the new link:subscription_re_engage_url shortcode [MAILPOET-3976]

### DIFF
--- a/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -82,6 +82,10 @@ class Link implements CategoryInterface {
         );
         return self::processUrl($shortcodeDetails['action'], $url, $queue, $wpUserPreview);
 
+      case 'subscription_re_engage_url':
+        $url = $subscriptionUrlFactory->getReEngagementUrl($wpUserPreview ? null : $subscriber);
+        return self::processUrl($shortcodeDetails['action'], $url, $queue, $wpUserPreview);
+
       default:
         $shortcode = self::getFullShortcode($shortcodeDetails['action']);
         $url = $this->wp->applyFilters(
@@ -135,6 +139,9 @@ class Link implements CategoryInterface {
           $queueModel,
           false
         );
+        break;
+      case 'subscription_re_engage_url':
+        $url = $subscriptionUrlFactory->getReEngagementUrl($subscriber);
         break;
       default:
         $shortcode = self::getFullShortcode($shortcodeAction);

--- a/lib/Subscription/SubscriptionUrlFactory.php
+++ b/lib/Subscription/SubscriptionUrlFactory.php
@@ -72,6 +72,14 @@ class SubscriptionUrlFactory {
     return $this->getSubscriptionUrl($post, 'unsubscribe', $subscriber, $data);
   }
 
+  public function getReEngagementUrl(SubscriberEntity $subscriber = null) {
+    $reEngagementSetting = $this->settings->get('reEngagement');
+    $postId = $reEngagementSetting['page'] ?? null;
+
+    $post = $this->getPost($postId);
+    return $this->getSubscriptionUrl($post, 're_engagement', $subscriber);
+  }
+
   public function getSubscriptionUrl(
     $post = null,
     $action = null,

--- a/tests/integration/Newsletter/ShortcodesTest.php
+++ b/tests/integration/Newsletter/ShortcodesTest.php
@@ -296,6 +296,12 @@ class ShortcodesTest extends \MailPoetTest {
     expect($linkData['newsletter_hash'])->equals($this->newsletter->getHash());
     expect($linkData['subscriber_token'])->equals($this->subscriber->getLinkToken());
     expect($linkData['subscriber_id'])->equals($this->subscriber->getId());
+
+    $result = $shortcodesObject->process(['[link:subscription_re_engage_url]']);
+    expect($result['0'])->regExp('/^http.*?endpoint=subscription&action=re_engagement/');
+    $linkData = $this->getLinkData($result['0']);
+    expect($linkData['email'])->equals($this->subscriber->getEmail());
+    expect($linkData['token'])->equals($this->subscriber->getLinkToken());
   }
 
   private function getLinkData(string $link): array {

--- a/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
+++ b/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MailPoet\Test\Subscription;
+
+use MailPoet\Entities\SettingEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\SubscriptionUrlFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class SubscriptionUrlFactoryTest extends \MailPoetTest {
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var SubscriptionUrlFactory */
+  private $subscriptionUrlFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->subscriptionUrlFactory = $this->diContainer->get(SubscriptionUrlFactory::class);
+    $subscriberFactory = new SubscriberFactory();
+    $this->subscriber = $subscriberFactory->create();
+  }
+
+  public function testGetReEngagementUrlReturnsDefaultUrl() {
+    $expectedUrl = '/?mailpoet_page=subscriptions&mailpoet_router&endpoint=subscription&action=re_engagement&data=';
+    $this->assertContains($expectedUrl, $this->subscriptionUrlFactory->getReEngagementUrl($this->subscriber));
+  }
+
+  public function testGetReEngagementUrlReturnsUrlToUserSelectedPage() {
+    global $wp_rewrite;
+
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set('reEngagement', ['page' => 2]);
+
+    $pagePermaStructure = $wp_rewrite->get_page_permastruct();
+
+    // this check is needed because on CircleCI permalinks are enabled and on the local environments not necessarily.
+    if ($pagePermaStructure) {
+      $expectedUrl = '/sample-page/';
+    } else {
+      $expectedUrl = '/?page_id=2';
+    }
+
+    $this->assertContains($expectedUrl, $this->subscriptionUrlFactory->getReEngagementUrl($this->subscriber));
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->truncateEntity(SettingEntity::class);
+  }
+}


### PR DESCRIPTION
There is an acceptance test failing but it doesn't seem to be related to this change.

[MAILPOET-3976]

[MAILPOET-3976]: https://mailpoet.atlassian.net/browse/MAILPOET-3976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ