### PR TITLE
Add retry for pulling docker images on CI [MAILPOET-3991]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
   acceptance_tests:
     working_directory: /home/circleci/mailpoet
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202111-01
     parameters:
       group_arg:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,10 @@ jobs:
       - run:
           name: "Set up virtual host"
           command: echo 127.0.0.1 mailpoet.loc | sudo tee -a /etc/hosts
+      - run:
+          name: "Pull acceptance test docker images"
+          # Pull docker images with 3 retries
+          command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - when:
           condition: << parameters.woo_core_version >>
           steps:


### PR DESCRIPTION
I added a step in which CI only pulls docker images for acceptance tests and added 3 retries for this step.
I also updated the machine image to the latest available Ubuntu 20.04
[MAILPOET-3991]

[MAILPOET-3991]: https://mailpoet.atlassian.net/browse/MAILPOET-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ