### PR TITLE
Refactor ConfirmationEmailMailer to Doctrine

### DIFF
--- a/lib/API/JSON/v1/Subscribers.php
+++ b/lib/API/JSON/v1/Subscribers.php
@@ -197,8 +197,8 @@ class Subscribers extends APIEndpoint {
 
   public function sendConfirmationEmail($data = []) {
     $id = (isset($data['id']) ? (int)$data['id'] : false);
-    $subscriber = Subscriber::findOne($id);
-    if ($subscriber instanceof Subscriber) {
+    $subscriber = $this->subscribersRepository->findOneById($id);
+    if ($subscriber instanceof SubscriberEntity) {
       if ($this->confirmationEmailMailer->sendConfirmationEmail($subscriber)) {
         return $this->successResponse();
       }

--- a/lib/API/JSON/v1/Subscribers.php
+++ b/lib/API/JSON/v1/Subscribers.php
@@ -199,12 +199,19 @@ class Subscribers extends APIEndpoint {
     $id = (isset($data['id']) ? (int)$data['id'] : false);
     $subscriber = $this->subscribersRepository->findOneById($id);
     if ($subscriber instanceof SubscriberEntity) {
-      if ($this->confirmationEmailMailer->sendConfirmationEmail($subscriber)) {
-        return $this->successResponse();
+      try {
+        if ($this->confirmationEmailMailer->sendConfirmationEmail($subscriber)) {
+          return $this->successResponse();
+        } else {
+          return $this->errorResponse([
+            APIError::UNKNOWN => __('There was a problem with your sending method. Please check if your sending method is properly configured.', 'mailpoet'),
+          ]);
+        }
+      } catch (\Exception $e) {
+        return $this->errorResponse([
+          APIError::UNKNOWN => __('There was a problem with your sending method. Please check if your sending method is properly configured.', 'mailpoet'),
+        ]);
       }
-      return $this->errorResponse([
-        APIError::UNKNOWN => __('There was a problem with your sending method. Please check if your sending method is properly configured.', 'mailpoet'),
-      ]);
     } else {
       return $this->errorResponse([
         APIError::NOT_FOUND => WPFunctions::get()->__('This subscriber does not exist.', 'mailpoet'),

--- a/lib/API/MP/v1/API.php
+++ b/lib/API/MP/v1/API.php
@@ -148,11 +148,13 @@ class API {
 
     // send confirmation email
     if ($sendConfirmationEmail) {
-      $result = $this->_sendConfirmationEmail($subscriber);
-      if (!$result && $subscriber->getErrors()) {
+      try {
+        $this->_sendConfirmationEmail($subscriber);
+      } catch (\Exception $e) {
         throw new APIException(
-          __(sprintf('Subscriber added to lists, but confirmation email failed to send: %s', strtolower(implode(', ', $subscriber->getErrors()))), 'mailpoet'),
-        APIException::CONFIRMATION_FAILED_TO_SEND);
+          __(sprintf('Subscriber added to lists, but confirmation email failed to send: %s', strtolower($e->getMessage())), 'mailpoet'),
+          APIException::CONFIRMATION_FAILED_TO_SEND
+        );
       }
     }
 

--- a/lib/Mailer/Mailer.php
+++ b/lib/Mailer/Mailer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Mailer;
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Methods\AmazonSES;
 use MailPoet\Mailer\Methods\ErrorMappers\AmazonSESMapper;
 use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
@@ -13,6 +14,7 @@ use MailPoet\Mailer\Methods\MailPoet;
 use MailPoet\Mailer\Methods\PHPMail;
 use MailPoet\Mailer\Methods\SendGrid;
 use MailPoet\Mailer\Methods\SMTP;
+use MailPoet\Models\Subscriber;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -60,6 +62,11 @@ class Mailer {
   }
 
   public function send($newsletter, $subscriber, $extraParams = []) {
+    // This if adds support for code that calls this method to use SubscriberEntity while the Mailer class is still using the old model.
+    // Once we add support for SubscriberEntity in the Mailer class, this if can be removed.
+    if ($subscriber instanceof SubscriberEntity) {
+      $subscriber = Subscriber::findOne($subscriber->getId());
+    }
     if (!$this->mailerInstance) {
       $this->init();
     }

--- a/lib/Mailer/MetaInfo.php
+++ b/lib/Mailer/MetaInfo.php
@@ -27,8 +27,8 @@ class MetaInfo {
     );
   }
 
-  public function getConfirmationMetaInfo(Subscriber $subscriber) {
-    return $this->makeMetaInfo('confirmation', $subscriber->status, $subscriber->source);
+  public function getConfirmationMetaInfo(SubscriberEntity $subscriber) {
+    return $this->makeMetaInfo('confirmation', $subscriber->getStatus(), $subscriber->getSource());
   }
 
   public function getNewSubscriberNotificationMetaInfo() {

--- a/lib/Segments/WP.php
+++ b/lib/Segments/WP.php
@@ -151,7 +151,11 @@ class WP {
         $confirmationEmailMailer = ContainerWrapper::getInstance()->get(ConfirmationEmailMailer::class);
         $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
         if ($subscriberEntity instanceof SubscriberEntity) {
-          $confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+          try {
+            $confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+          } catch (\Exception $e) {
+            // ignore errors
+          }
         }
       }
 

--- a/lib/Segments/WP.php
+++ b/lib/Segments/WP.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\Source;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
 use MailPoet\WP\Functions as WPFunctions;
@@ -30,14 +31,19 @@ class WP {
   /** @var WooCommerceHelper */
   private $wooHelper;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
   public function __construct(
     WPFunctions $wp,
     WelcomeScheduler $welcomeScheduler,
-    WooCommerceHelper $wooHelper
+    WooCommerceHelper $wooHelper,
+    SubscribersRepository $subscribersRepository
   ) {
     $this->wp = $wp;
     $this->welcomeScheduler = $welcomeScheduler;
     $this->wooHelper = $wooHelper;
+    $this->subscribersRepository = $subscribersRepository;
   }
 
   public function synchronizeUser($wpUserId, $oldWpUserData = false) {
@@ -143,7 +149,10 @@ class WP {
       if ($sendConfirmationEmail && ($subscriber->status === Subscriber::STATUS_UNCONFIRMED)) {
         /** @var ConfirmationEmailMailer $confirmationEmailMailer */
         $confirmationEmailMailer = ContainerWrapper::getInstance()->get(ConfirmationEmailMailer::class);
-        $confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
+        $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
+        if ($subscriberEntity instanceof SubscriberEntity) {
+          $confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+        }
       }
 
       // welcome email

--- a/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/lib/Subscribers/ConfirmationEmailMailer.php
@@ -121,7 +121,7 @@ class ConfirmationEmailMailer {
     // send email
     try {
       $extraParams = [
-        'meta' => $this->mailerMetaInfo->getConfirmationMetaInfo($subscriber),
+        'meta' => $this->mailerMetaInfo->getConfirmationMetaInfo($subscriberEntity),
       ];
       $result = $this->mailer->send($email, $subscriber, $extraParams);
       if ($result['response'] === false) {

--- a/lib/Subscribers/SubscriberActions.php
+++ b/lib/Subscribers/SubscriberActions.php
@@ -103,7 +103,12 @@ class SubscriberActions {
     // link subscriber to segments
     $segments = $this->segmentsRepository->findBy(['id' => $segmentIds]);
     $this->subscriberSegmentRepository->subscribeToSegments($subscriber, $segments);
-    $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
+
+    try {
+      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
+    } catch (\Exception $e) {
+      // ignore errors
+    }
 
     $subscriberModel = Subscriber::findOne($subscriber->getId());
 

--- a/lib/Subscribers/SubscriberActions.php
+++ b/lib/Subscribers/SubscriberActions.php
@@ -103,11 +103,9 @@ class SubscriberActions {
     // link subscriber to segments
     $segments = $this->segmentsRepository->findBy(['id' => $segmentIds]);
     $this->subscriberSegmentRepository->subscribeToSegments($subscriber, $segments);
+    $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
 
     $subscriberModel = Subscriber::findOne($subscriber->getId());
-    if ($subscriberModel) {
-      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberModel);
-    }
 
     // We want to send the notification on subscribe only when signupConfirmation is disabled
     if ($signupConfirmationEnabled === false && $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED && $subscriberModel) {

--- a/lib/WooCommerce/Subscription.php
+++ b/lib/WooCommerce/Subscription.php
@@ -225,7 +225,11 @@ class Subscription {
       $this->subscribersRepository->persist($subscriberEntity);
       $this->subscribersRepository->flush();
 
-      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+      try {
+        $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+      } catch (\Exception $e) {
+        // ignore errors
+      }
     }
   }
 

--- a/tests/DataFactories/Subscriber.php
+++ b/tests/DataFactories/Subscriber.php
@@ -60,6 +60,11 @@ class Subscriber {
     return $this;
   }
 
+  public function withSource(string $source): self {
+    $this->data['source'] = $source;
+    return $this;
+  }
+
   /**
    * @param int $count
    * @return $this
@@ -101,6 +106,9 @@ class Subscriber {
     if (isset($this->data['last_name'])) $subscriber->setLastName($this->data['last_name']);
     if (isset($this->data['first_name'])) $subscriber->setFirstName($this->data['first_name']);
     if (isset($this->data['is_woocommerce_user'])) $subscriber->setIsWoocommerceUser($this->data['is_woocommerce_user']);
+    if (isset($this->data['source'])) {
+      $subscriber->setSource($this->data['source']);
+    }
     $entityManager->persist($subscriber);
 
     foreach ($this->segments as $segment) {

--- a/tests/integration/API/MP/APITest.php
+++ b/tests/integration/API/MP/APITest.php
@@ -576,9 +576,8 @@ class APITest extends \MailPoetTest {
     $confirmationMailer = $this->createMock(ConfirmationEmailMailer::class);
     $confirmationMailer->expects($this->once())
       ->method('sendConfirmationEmailOnce')
-      ->willReturnCallback(function (Subscriber $subscriber) {
-        $subscriber->setError('Big Error');
-        return false;
+      ->willReturnCallback(function () {
+        throw new \Exception('Big Error');
       });
 
     $API = Stub::copy($this->getApi(), [

--- a/tests/integration/API/MP/APITest.php
+++ b/tests/integration/API/MP/APITest.php
@@ -17,6 +17,7 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\RequiredCustomFieldValidator;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending;
 use MailPoetVendor\Idiorm\ORM;
 
@@ -40,7 +41,8 @@ class APITest extends \MailPoetTest {
       $this->diContainer->get(RequiredCustomFieldValidator::class),
       Stub::makeEmpty(WelcomeScheduler::class),
       $this->diContainer->get(CustomFields::class),
-      SettingsController::getInstance()
+      SettingsController::getInstance(),
+      $this->diContainer->get(SubscribersRepository::class)
     );
   }
 
@@ -228,7 +230,8 @@ class APITest extends \MailPoetTest {
       $this->makeEmpty(RequiredCustomFieldValidator::class),
       Stub::makeEmpty(WelcomeScheduler::class),
       $this->diContainer->get(CustomFields::class),
-      SettingsController::getInstance()
+      SettingsController::getInstance(),
+      $this->diContainer->get(SubscribersRepository::class)
     );
     $API->subscribeToLists($subscriber->email, $segments, ['send_confirmation_email' => false, 'skip_subscriber_notification' => true]);
 
@@ -241,7 +244,8 @@ class APITest extends \MailPoetTest {
       $this->makeEmpty(RequiredCustomFieldValidator::class),
       Stub::makeEmpty(WelcomeScheduler::class),
       $this->diContainer->get(CustomFields::class),
-      SettingsController::getInstance()
+      SettingsController::getInstance(),
+      $this->diContainer->get(SubscribersRepository::class)
     );
     $API->subscribeToLists($subscriber->email, $segments, ['send_confirmation_email' => false, 'skip_subscriber_notification' => false]);
   }
@@ -468,6 +472,7 @@ class APITest extends \MailPoetTest {
         'confirmationEmailMailer' => Stub::makeEmpty(ConfirmationEmailMailer::class),
         '_scheduleWelcomeNotification' => Expected::once(),
         'settings' => $settings,
+        'subscribersRepository' => Stub::makeEmpty(SubscribersRepository::class),
       ],
       $this
     );
@@ -500,7 +505,8 @@ class APITest extends \MailPoetTest {
       $this->diContainer->get(RequiredCustomFieldValidator::class),
       $welcomeScheduler,
       $this->diContainer->get(CustomFields::class),
-      Stub::makeEmpty(SettingsController::class)
+      Stub::makeEmpty(SettingsController::class),
+      $this->diContainer->get(SubscribersRepository::class)
     );
     $subscriber = [
       'email' => 'test@example.com',

--- a/tests/integration/Mailer/MailerTest.php
+++ b/tests/integration/Mailer/MailerTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Mailer;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
 class MailerTest extends \MailPoetTest {
   public $newsletter;
@@ -198,6 +199,20 @@ class MailerTest extends \MailPoetTest {
     $mailer = new Mailer();
     $mailer->init($this->mailer, $this->sender, $this->replyTo);
     $result = $mailer->send($this->newsletter, $this->subscriber);
+    expect($result['response'])->true();
+  }
+
+  public function testItCanSendWhenSubscriberEntityIsPassed() {
+    if (getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') {
+      $this->markTestSkipped();
+    }
+
+    $subscriberFactory = new SubscriberFactory();
+    $subscriber = $subscriberFactory->withFirstName('Recipient')->create();
+    $this->sender['address'] = 'staff@mailpoet.com';
+    $mailer = new Mailer();
+    $mailer->init($this->mailer, $this->sender, $this->replyTo);
+    $result = $mailer->send($this->newsletter, $subscriber);
     expect($result['response'])->true();
   }
 

--- a/tests/integration/Mailer/MetaInfoTest.php
+++ b/tests/integration/Mailer/MetaInfoTest.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\Subscriber;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
 class MetaInfoTest extends \MailPoetTest {
   /** @var MetaInfo */
@@ -59,11 +60,9 @@ class MetaInfoTest extends \MailPoetTest {
   }
 
   public function testItGetsMetaInfoForConfirmationEmails() {
-    $subscriber = Subscriber::create();
-    $subscriber->hydrate([
-      'status' => 'unconfirmed',
-      'source' => 'form',
-    ]);
+    $subscriberFactory = new SubscriberFactory();
+    $subscriber = $subscriberFactory->withStatus('unconfirmed')->withSource('form')->create();
+
     expect($this->meta->getConfirmationMetaInfo($subscriber))->equals([
       'email_type' => 'confirmation',
       'subscriber_status' => 'unconfirmed',

--- a/tests/integration/Segments/WPTest.php
+++ b/tests/integration/Segments/WPTest.php
@@ -12,6 +12,7 @@ use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\WP;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Registration;
 use MailPoet\WooCommerce\Helper;
 use MailPoet\WooCommerce\Subscription;
@@ -420,7 +421,12 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP($wp, $this->diContainer->get(WelcomeScheduler::class), $this->diContainer->get(Helper::class));
+    $wpSegment = new WP(
+      $wp,
+      $this->diContainer->get(WelcomeScheduler::class),
+      $this->diContainer->get(Helper::class),
+      $this->diContainer->get(SubscribersRepository::class)
+    );
     $wpSegment->synchronizeUser($id);
     $subscriber = Subscriber::where("wp_user_id", $id)->findOne();
     $deletedAt = Carbon::createFromFormat('Y-m-d H:i:s', $subscriber->deletedAt);
@@ -438,7 +444,12 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP($wp, $this->diContainer->get(WelcomeScheduler::class), $this->diContainer->get(Helper::class));
+    $wpSegment = new WP(
+      $wp,
+      $this->diContainer->get(WelcomeScheduler::class),
+      $this->diContainer->get(Helper::class),
+      $this->diContainer->get(SubscribersRepository::class)
+    );
     $_POST[Subscription::CHECKOUT_OPTIN_PRESENCE_CHECK_INPUT_NAME] = 1;
     $wpSegment->synchronizeUser($id);
     $subscriber = Subscriber::where("wp_user_id", $id)->findOne();
@@ -463,7 +474,12 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP($wp, $this->diContainer->get(WelcomeScheduler::class), $this->diContainer->get(Helper::class));
+    $wpSegment = new WP(
+      $wp,
+      $this->diContainer->get(WelcomeScheduler::class),
+      $this->diContainer->get(Helper::class),
+      $this->diContainer->get(SubscribersRepository::class)
+    );
     $wpSegment->synchronizeUser($id);
     $wpSubscriber = Segment::getWPSegment()->subscribers()->where('wp_user_id', $id)->findOne();
     expect($wpSubscriber->countConfirmations)->equals(0);
@@ -491,7 +507,12 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP($wp, $this->diContainer->get(WelcomeScheduler::class), $this->diContainer->get(Helper::class));
+    $wpSegment = new WP(
+      $wp,
+      $this->diContainer->get(WelcomeScheduler::class),
+      $this->diContainer->get(Helper::class),
+      $this->diContainer->get(SubscribersRepository::class)
+    );
     $wpSegment->synchronizeUser($id);
     $subscriber1 = Subscriber::where("wp_user_id", $id)->findOne();
     expect($subscriber1->status)->equals(SubscriberEntity::STATUS_SUBSCRIBED);
@@ -521,7 +542,12 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP($wp, $this->diContainer->get(WelcomeScheduler::class), $wooHelper);
+    $wpSegment = new WP(
+      $wp,
+      $this->diContainer->get(WelcomeScheduler::class),
+      $wooHelper,
+      $this->diContainer->get(SubscribersRepository::class)
+    );
     $wpSegment->synchronizeUser($id);
     $subscriber1 = Subscriber::where("wp_user_id", $id)->findOne();
     expect($subscriber1->status)->equals(SubscriberEntity::STATUS_UNCONFIRMED);

--- a/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -15,8 +15,8 @@ use MailPoetVendor\Idiorm\ORM;
 
 class ConfirmationEmailMailerTest extends \MailPoetTest {
   public function testItSendsConfirmationEmail() {
-    $subcriptionUrlFacroryMock = $this->createMock(SubscriptionUrlFactory::class);
-    $subcriptionUrlFacroryMock->method('getConfirmationUrl')->willReturn('http://example.com');
+    $subcriptionUrlFactoryMock = $this->createMock(SubscriptionUrlFactory::class);
+    $subcriptionUrlFactoryMock->method('getConfirmationUrl')->willReturn('http://example.com');
 
     $settings = $this->diContainer->get(SettingsController::class);
     $settings->set(
@@ -53,7 +53,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
-      $subcriptionUrlFacroryMock
+      $subcriptionUrlFactoryMock
     );
 
 


### PR DESCRIPTION
@brezocordero, I'm assigning this PR to you as you mentioned that you were working on another task to refactor API::subscribeToLists() to Doctrine. I believe I might need to make some adjustments to the changes that I made to this method depending on what you did.

The code changed here is used in a few places to send a confirmation email to a subscriber (not an exhaustive list):

- When an admin clicks on the link to resend the confirmation email on the page that lists all subscribers of a given list.
- When a WC customer purchase a new product and select the checkbox to subscribe to the WC list.
- When a new WP user is created.

When removing Subscriber::setError() as we discussed in the Slack channel, I opted to replace it with a call to `throw`. There are some disadvantages to this approach that I mentioned in more detail in the corresponding [commit message](https://github.com/mailpoet/mailpoet/commit/92185074428d7bde2afc78d1cb46a9dfcf5394bf). But settled with it as I felt it wasn't worth investing more time improving the solution.

[MAILPOET-3815]

[MAILPOET-3815]: https://mailpoet.atlassian.net/browse/MAILPOET-3815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ