### PR TITLE
Refactor MPAPI subscribeToLists to Doctrine [MAILPOET-3813]

### DIFF
--- a/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -69,12 +69,12 @@ class SubscribersResponseBuilder {
     ];
   }
 
-  public function build(SubscriberEntity $subscriberEntity, bool $isMPAPI = false): array {
+  public function build(SubscriberEntity $subscriberEntity): array {
     $data = [
       'id' => (string)$subscriberEntity->getId(),
       'wp_user_id' => $subscriberEntity->getWpUserId(),
       'is_woocommerce_user' => $subscriberEntity->getIsWoocommerceUser(),
-      'subscriptions' => $this->buildSubscriptions($subscriberEntity, $isMPAPI),
+      'subscriptions' => $this->buildSubscriptions($subscriberEntity),
       'unsubscribes' => $this->buildUnsubscribes($subscriberEntity),
       'status' => $subscriberEntity->getStatus(),
       'last_name' => $subscriberEntity->getLastName(),
@@ -97,27 +97,20 @@ class SubscribersResponseBuilder {
     return $this->buildCustomFields($subscriberEntity, $data);
   }
 
-  private function buildSubscriptions(SubscriberEntity $subscriberEntity, bool $isMPAPI = false): array {
+  private function buildSubscriptions(SubscriberEntity $subscriberEntity): array {
     $result = [];
     $subscriptions = $this->subscriberSegmentRepository->findBy(['subscriber' => $subscriberEntity]);
     foreach ($subscriptions as $subscription) {
       $segment = $subscription->getSegment();
       if ($segment instanceof SegmentEntity) {
-        $extraData = [];
-        if ( $isMPAPI ) {
-          $extraData = [
-            'id' => $subscription->getId(),
-            'subscriber_id' => (string)$subscriberEntity->getId(),
-            'created_at' => $subscription->getCreatedAt()->format(self::DATE_FORMAT),
-          ];
-        }
-        $result[] = array_merge(
-          $extraData,
-          [
+        $result[] = [
+          'id' => $subscription->getId(),
+          'subscriber_id' => (string)$subscriberEntity->getId(),
+          'created_at' => $subscription->getCreatedAt()->format(self::DATE_FORMAT),
           'segment_id' => (string)$segment->getId(),
           'status' => $subscription->getStatus(),
           'updated_at' => $subscription->getUpdatedAt()->format(self::DATE_FORMAT),
-          ]);
+        ];
       }
     }
     return $result;

--- a/lib/API/MP/v1/API.php
+++ b/lib/API/MP/v1/API.php
@@ -2,60 +2,33 @@
 
 namespace MailPoet\API\MP\v1;
 
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
-use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
-use MailPoet\Settings\SettingsController;
-use MailPoet\Subscribers\ConfirmationEmailMailer;
-use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\RequiredCustomFieldValidator;
 use MailPoet\Subscribers\Source;
-use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 
 class API {
 
-  /** @var NewSubscriberNotificationMailer */
-  private $newSubscriberNotificationMailer;
-
-  /** @var ConfirmationEmailMailer */
-  private $confirmationEmailMailer;
-
   /** @var RequiredCustomFieldValidator */
   private $requiredCustomFieldValidator;
-
-  /** @var WelcomeScheduler */
-  private $welcomeScheduler;
-
-  /** @var SettingsController */
-  private $settings;
 
   /** @var CustomFields */
   private $customFields;
 
-  /** @var SubscribersRepository */
-  private $subscribersRepository;
+  /** @var Subscribers */
+  private $subscribers;
 
   public function __construct(
-    NewSubscriberNotificationMailer $newSubscriberNotificationMailer,
-    ConfirmationEmailMailer $confirmationEmailMailer,
     RequiredCustomFieldValidator $requiredCustomFieldValidator,
-    WelcomeScheduler $welcomeScheduler,
     CustomFields $customFields,
-    SettingsController $settings,
-    SubscribersRepository $subscribersRepository
+    Subscribers $subscribers
   ) {
-    $this->newSubscriberNotificationMailer = $newSubscriberNotificationMailer;
-    $this->confirmationEmailMailer = $confirmationEmailMailer;
     $this->requiredCustomFieldValidator = $requiredCustomFieldValidator;
-    $this->welcomeScheduler = $welcomeScheduler;
-    $this->settings = $settings;
     $this->customFields = $customFields;
-    $this->subscribersRepository = $subscribersRepository;
+    $this->subscribers = $subscribers;
   }
 
   public function getSubscriberFields() {
@@ -70,99 +43,18 @@ class API {
     }
   }
 
-  public function subscribeToList($subscriberId, $listId, $options = []) {
+  /**
+   * @throws APIException
+   */
+  public function subscribeToList($subscriberId, $listId, $options = []): array {
     return $this->subscribeToLists($subscriberId, [$listId], $options);
   }
 
+  /**
+   * @throws APIException
+   */
   public function subscribeToLists($subscriberId, array $listIds, $options = []) {
-    $scheduleWelcomeEmail = (isset($options['schedule_welcome_email']) && $options['schedule_welcome_email'] === false) ? false : true;
-    $sendConfirmationEmail = (isset($options['send_confirmation_email']) && $options['send_confirmation_email'] === false) ? false : true;
-    $skipSubscriberNotification = (isset($options['skip_subscriber_notification']) && $options['skip_subscriber_notification'] === true) ? true : false;
-    $signupConfirmationEnabled = (bool)$this->settings->get('signup_confirmation.enabled');
-
-    if (empty($listIds)) {
-      throw new APIException(__('At least one segment ID is required.', 'mailpoet'), APIException::SEGMENT_REQUIRED);
-    }
-
-    // throw exception when subscriber does not exist
-    $subscriber = Subscriber::findOne($subscriberId);
-    if (!$subscriber) {
-      throw new APIException(__('This subscriber does not exist.', 'mailpoet'), APIException::SUBSCRIBER_NOT_EXISTS);
-    }
-
-    // throw exception when none of the segments exist
-    $foundSegments = Segment::whereIn('id', $listIds)->findMany();
-    if (!$foundSegments) {
-      $exception = WPFunctions::get()->_n('This list does not exist.', 'These lists do not exist.', count($listIds), 'mailpoet');
-      throw new APIException($exception, APIException::LIST_NOT_EXISTS);
-    }
-
-    // throw exception when trying to subscribe to WP Users or WooCommerce Customers segments
-    $foundSegmentsIds = [];
-    foreach ($foundSegments as $foundSegment) {
-      if ($foundSegment->type === Segment::TYPE_WP_USERS) {
-        throw new APIException(__(sprintf("Can't subscribe to a WordPress Users list with ID %d.", $foundSegment->id), 'mailpoet'), APIException::SUBSCRIBING_TO_WP_LIST_NOT_ALLOWED);
-      }
-      if ($foundSegment->type === Segment::TYPE_WC_USERS) {
-        throw new APIException(__(sprintf("Can't subscribe to a WooCommerce Customers list with ID %d.", $foundSegment->id), 'mailpoet'), APIException::SUBSCRIBING_TO_WC_LIST_NOT_ALLOWED);
-      }
-      if ($foundSegment->type !== Segment::TYPE_DEFAULT) {
-        throw new APIException(__(sprintf("Can't subscribe to a list with ID %d.", $foundSegment->id), 'mailpoet'), APIException::SUBSCRIBING_TO_LIST_NOT_ALLOWED);
-      }
-      $foundSegmentsIds[] = $foundSegment->id;
-    }
-
-    // throw an exception when one or more segments do not exist
-    if (count($foundSegmentsIds) !== count($listIds)) {
-      $missingIds = array_values(array_diff($listIds, $foundSegmentsIds));
-      $exception = sprintf(
-        WPFunctions::get()->_n('List with ID %s does not exist.', 'Lists with IDs %s do not exist.', count($missingIds), 'mailpoet'),
-        implode(', ', $missingIds)
-      );
-      throw new APIException(sprintf($exception, implode(', ', $missingIds)), APIException::LIST_NOT_EXISTS);
-    }
-
-    SubscriberSegment::subscribeToSegments($subscriber, $foundSegmentsIds);
-
-    // set status depending on signup confirmation setting
-    if ($subscriber->status !== Subscriber::STATUS_SUBSCRIBED) {
-      if ($signupConfirmationEnabled === true) {
-        $subscriber->set('status', Subscriber::STATUS_UNCONFIRMED);
-      } else {
-        $subscriber->set('status', Subscriber::STATUS_SUBSCRIBED);
-      }
-
-      $subscriber->save();
-      if ($subscriber->getErrors() !== false) {
-        throw new APIException(
-          __(sprintf('Failed to save a status of a subscriber : %s', strtolower(implode(', ', $subscriber->getErrors()))), 'mailpoet'),
-          APIException::FAILED_TO_SAVE_SUBSCRIBER
-        );
-      }
-    }
-
-    // schedule welcome email
-    if ($scheduleWelcomeEmail && $subscriber->status === Subscriber::STATUS_SUBSCRIBED) {
-      $this->_scheduleWelcomeNotification($subscriber, $foundSegmentsIds);
-    }
-
-    // send confirmation email
-    if ($sendConfirmationEmail) {
-      try {
-        $this->_sendConfirmationEmail($subscriber);
-      } catch (\Exception $e) {
-        throw new APIException(
-          __(sprintf('Subscriber added to lists, but confirmation email failed to send: %s', strtolower($e->getMessage())), 'mailpoet'),
-          APIException::CONFIRMATION_FAILED_TO_SEND
-        );
-      }
-    }
-
-    if (!$skipSubscriberNotification && ($subscriber->status === Subscriber::STATUS_SUBSCRIBED)) {
-      $this->sendSubscriberNotification($subscriber, $foundSegmentsIds);
-    }
-
-    return $subscriber->withCustomFields()->withSubscriptions()->asArray();
+      return $this->subscribers->subscribeToLists($subscriberId, $listIds, $options);
   }
 
   public function unsubscribeFromList($subscriberId, $listId) {
@@ -330,31 +222,5 @@ class API {
       throw new APIException(__('This subscriber does not exist.', 'mailpoet'), APIException::SUBSCRIBER_NOT_EXISTS);
     }
     return $subscriber->withCustomFields()->withSubscriptions()->asArray();
-  }
-
-  protected function _sendConfirmationEmail(Subscriber $subscriber) {
-    $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
-    if ($subscriberEntity instanceof SubscriberEntity) {
-      return $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
-    }
-  }
-
-  protected function _scheduleWelcomeNotification(Subscriber $subscriber, array $segments) {
-    $result = $this->welcomeScheduler->scheduleSubscriberWelcomeNotification($subscriber->id, $segments);
-    if (is_array($result)) {
-      foreach ($result as $queue) {
-        if ($queue instanceof Sending && $queue->getErrors()) {
-          throw new APIException(
-            __(sprintf('Subscriber added, but welcome email failed to send: %s', strtolower(implode(', ', $queue->getErrors()))), 'mailpoet'),
-            APIException::WELCOME_FAILED_TO_SEND
-          );
-        }
-      }
-    }
-    return $result;
-  }
-
-  private function sendSubscriberNotification(Subscriber $subscriber, array $segmentIds) {
-    $this->newSubscriberNotificationMailer->send($subscriber, Segment::whereIn('id', $segmentIds)->findMany());
   }
 }

--- a/lib/API/MP/v1/Subscribers.php
+++ b/lib/API/MP/v1/Subscribers.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace MailPoet\API\MP\v1;
+
+use MailPoet\API\JSON\ResponseBuilders\SubscribersResponseBuilder;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Models\Segment;
+use MailPoet\Models\Subscriber;
+use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\NewSubscriberNotificationMailer;
+use MailPoet\Subscribers\SubscriberSegmentRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Tasks\Sending;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Subscribers {
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var SubscriberSegmentRepository */
+  private $subscribersSegmentRepository;
+
+  /** @var ConfirmationEmailMailer */
+  private $confirmationEmailMailer;
+
+  /** @var WelcomeScheduler */
+  private $welcomeScheduler;
+
+  /** @var SubscribersResponseBuilder */
+  private $subscribersResponseBuilder;
+
+  /** @var NewSubscriberNotificationMailer */
+  private $newSubscriberNotificationMailer;
+
+  public function __construct (
+    ConfirmationEmailMailer $confirmationEmailMailer,
+    NewSubscriberNotificationMailer $newSubscriberNotificationMailer,
+    SegmentsRepository $segmentsRepository,
+    SettingsController $settings,
+    SubscriberSegmentRepository $subscriberSegmentRepository,
+    SubscribersRepository $subscribersRepository,
+    SubscribersResponseBuilder $subscribersResponseBuilder,
+    WelcomeScheduler $welcomeScheduler
+  ) {
+    $this->confirmationEmailMailer = $confirmationEmailMailer;
+    $this->newSubscriberNotificationMailer = $newSubscriberNotificationMailer;
+    $this->segmentsRepository = $segmentsRepository;
+    $this->settings = $settings;
+    $this->subscribersSegmentRepository = $subscriberSegmentRepository;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->subscribersResponseBuilder = $subscribersResponseBuilder;
+    $this->welcomeScheduler = $welcomeScheduler;
+  }
+
+  /**
+   * @throws APIException
+   */
+  public function subscribeToLists(
+    $subscriberId,
+    array $listIds,
+    array $options = []
+  ): array {
+    $scheduleWelcomeEmail = !((isset($options['schedule_welcome_email']) && $options['schedule_welcome_email'] === false));
+    $sendConfirmationEmail = !((isset($options['send_confirmation_email']) && $options['send_confirmation_email'] === false));
+    $skipSubscriberNotification = isset($options['skip_subscriber_notification']) && $options['skip_subscriber_notification'] === true;
+    $signupConfirmationEnabled = (bool)$this->settings->get('signup_confirmation.enabled');
+
+    if (empty($listIds)) {
+      throw new APIException(__('At least one segment ID is required.', 'mailpoet'), APIException::SEGMENT_REQUIRED);
+    }
+
+    if (empty($subscriberId)) {
+      throw new APIException(__('A subscriber is required.', 'mailpoet'), APIException::SUBSCRIBER_NOT_EXISTS);
+    }
+
+    // throw exception when subscriber does not exist
+    $subscriber = null;
+    if (is_int($subscriberId) || (string)(int)$subscriberId === $subscriberId) {
+      $subscriber = $this->subscribersRepository->findOneById($subscriberId);
+    } else if (strlen(trim($subscriberId)) > 0) {
+      $subscriber = $this->subscribersRepository->findOneBy(['email' => $subscriberId]);
+    }
+
+    if (!$subscriber) {
+      throw new APIException(__('This subscriber does not exist.', 'mailpoet'), APIException::SUBSCRIBER_NOT_EXISTS);
+    }
+
+    // throw exception when none of the segments exist
+    $foundSegments = $this->segmentsRepository->findBy(['id' => $listIds]);
+    if (!$foundSegments) {
+      $exception = WPFunctions::get()->_n('This list does not exist.', 'These lists do not exist.', count($listIds), 'mailpoet');
+      throw new APIException($exception, APIException::LIST_NOT_EXISTS);
+    }
+
+    // throw exception when trying to subscribe to WP Users or WooCommerce Customers segments
+    $foundSegmentsIds = [];
+    foreach ($foundSegments as $foundSegment) {
+      if ($foundSegment->getType() === SegmentEntity::TYPE_WP_USERS) {
+        throw new APIException(__(sprintf("Can't subscribe to a WordPress Users list with ID %d.", $foundSegment->getId()), 'mailpoet'), APIException::SUBSCRIBING_TO_WP_LIST_NOT_ALLOWED);
+      }
+      if ($foundSegment->getType() === SegmentEntity::TYPE_WC_USERS) {
+        throw new APIException(__(sprintf("Can't subscribe to a WooCommerce Customers list with ID %d.", $foundSegment->getId()), 'mailpoet'), APIException::SUBSCRIBING_TO_WC_LIST_NOT_ALLOWED);
+      }
+      if ($foundSegment->getType() !== SegmentEntity::TYPE_DEFAULT) {
+        throw new APIException(__(sprintf("Can't subscribe to a list with ID %d.", $foundSegment->getId()), 'mailpoet'), APIException::SUBSCRIBING_TO_LIST_NOT_ALLOWED);
+      }
+      $foundSegmentsIds[] = $foundSegment->getId();
+    }
+
+    // throw an exception when one or more segments do not exist
+    if (count($foundSegmentsIds) !== count($listIds)) {
+      $missingIds = array_values(array_diff($listIds, $foundSegmentsIds));
+      $exception = sprintf(
+        WPFunctions::get()->_n('List with ID %s does not exist.', 'Lists with IDs %s do not exist.', count($missingIds), 'mailpoet'),
+        implode(', ', $missingIds)
+      );
+      throw new APIException(sprintf($exception, implode(', ', $missingIds)), APIException::LIST_NOT_EXISTS);
+    }
+
+    $this->subscribersSegmentRepository->subscribeToSegments($subscriber, $foundSegments);
+
+    // set status depending on signup confirmation setting
+    if ($subscriber->getStatus() !== SubscriberEntity::STATUS_SUBSCRIBED) {
+      if ($signupConfirmationEnabled === true) {
+        $subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+      } else {
+        $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+      }
+      try {
+        $this->subscribersRepository->flush();
+      } catch (\Exception $e) {
+        throw new APIException(
+          __(sprintf('Failed to save a status of a subscriber : %s', $e->getMessage()), 'mailpoet'),
+          APIException::FAILED_TO_SAVE_SUBSCRIBER
+        );
+      }
+    }
+
+    // schedule welcome email
+    if ($scheduleWelcomeEmail && $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED) {
+      $this->_scheduleWelcomeNotification($subscriber, $foundSegmentsIds);
+    }
+
+    // send confirmation email
+    if ($sendConfirmationEmail) {
+      $this->_sendConfirmationEmail($subscriber);
+    }
+
+    if (!$skipSubscriberNotification && ($subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED)) {
+      $this->sendSubscriberNotification($subscriber, $foundSegmentsIds);
+    }
+
+    $this->subscribersRepository->refresh($subscriber);
+    return $this->subscribersResponseBuilder->build($subscriber, true );
+  }
+
+  /**
+   * @throws APIException
+   */
+  protected function _scheduleWelcomeNotification(SubscriberEntity $subscriber, array $segments) {
+    $result = $this->welcomeScheduler->scheduleSubscriberWelcomeNotification($subscriber->getId(), $segments);
+    if (is_array($result)) {
+      foreach ($result as $queue) {
+        if ($queue instanceof Sending && $queue->getErrors()) {
+          throw new APIException(
+            __(sprintf('Subscriber added, but welcome email failed to send: %s', strtolower(implode(', ', $queue->getErrors()))), 'mailpoet'),
+            APIException::WELCOME_FAILED_TO_SEND
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * @throws APIException
+   */
+  protected function _sendConfirmationEmail(SubscriberEntity $subscriberEntity) {
+    try {
+      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+    } catch (\Exception $e) {
+      throw new APIException(
+        __(sprintf('Subscriber added to lists, but confirmation email failed to send: %s', strtolower($e->getMessage())), 'mailpoet'),
+        APIException::CONFIRMATION_FAILED_TO_SEND
+      );
+    }
+  }
+
+  /**
+   * @throws APIException
+   */
+  private function sendSubscriberNotification(SubscriberEntity $subscriberEntity, array $segmentIds) {
+    $subscriber = Subscriber::findOne($subscriberEntity->getId());
+    if (!$subscriber) {
+      throw new APIException(__('This subscriber does not exist.', 'mailpoet'), APIException::SUBSCRIBER_NOT_EXISTS);
+    }
+
+    $this->newSubscriberNotificationMailer->send($subscriber, Segment::whereIn('id', $segmentIds)->findMany());
+  }
+}

--- a/lib/API/MP/v1/Subscribers.php
+++ b/lib/API/MP/v1/Subscribers.php
@@ -161,7 +161,7 @@ class Subscribers {
     }
 
     $this->subscribersRepository->refresh($subscriber);
-    return $this->subscribersResponseBuilder->build($subscriber, true );
+    return $this->subscribersResponseBuilder->build($subscriber);
   }
 
   /**

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -57,6 +57,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\API\JSON\ErrorHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\API\MP\v1\CustomFields::class)->setPublic(true);
     $container->autowire(\MailPoet\API\MP\v1\API::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\MP\v1\Subscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Analytics::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\AutomatedLatestContent::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\AutomaticEmails::class)->setPublic(true);

--- a/tests/integration/API/MP/APITest.php
+++ b/tests/integration/API/MP/APITest.php
@@ -14,7 +14,6 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
-use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -356,10 +355,7 @@ class APITest extends \MailPoetTest {
     $confirmationMailer = $this->createMock(ConfirmationEmailMailer::class);
     $confirmationMailer->expects($this->once())
       ->method('sendConfirmationEmailOnce')
-      ->willReturnCallback(function (Subscriber $subscriber) {
-        $subscriber->setError('Big Error');
-        return false;
-      });
+      ->willThrowException(new \Exception('Something went wrong with your subscription. Please contact the website owner.'));
 
     $subscribers = Stub::copy($this->getSubscribers(), [
       'confirmationEmailMailer' => $confirmationMailer,
@@ -372,7 +368,7 @@ class APITest extends \MailPoetTest {
       'email' => 'test@example.com',
     ];
     $this->expectException('\Exception');
-    $this->expectExceptionMessage('Subscriber added to lists, but confirmation email failed to send: big error');
+    $this->expectExceptionMessage('Subscriber added to lists, but confirmation email failed to send: something went wrong with your subscription. please contact the website owner.');
     $API->addSubscriber($subscriber, [$segment->getId()], ['send_confirmation_email' => true]);
   }
 

--- a/tests/integration/API/MP/SubscribersTest.php
+++ b/tests/integration/API/MP/SubscribersTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace MailPoet\Test\API\MP;
+
+use Codeception\Stub;
+use Codeception\Stub\Expected;
+use MailPoet\API\JSON\ResponseBuilders\SubscribersResponseBuilder;
+use MailPoet\API\MP\v1\API;
+use MailPoet\API\MP\v1\CustomFields;
+use MailPoet\API\MP\v1\Subscribers;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\NewSubscriberNotificationMailer;
+use MailPoet\Subscribers\RequiredCustomFieldValidator;
+use MailPoet\Subscribers\SubscriberSegmentRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class SubscribersTest extends \MailPoetTest {
+
+
+  /**  @var SubscriberFactory */
+  private $subscriberFactory;
+
+  /** @var SegmentsRepository */
+  private $segmentRepository;
+
+  public function _before() {
+    parent::_before();
+    $settings = SettingsController::getInstance();
+    $settings->set('signup_confirmation.enabled', true);
+    $this->subscriberFactory = new SubscriberFactory();
+    $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
+  }
+
+  private function getSubscribers() {
+    return new Subscribers(
+      Stub::makeEmpty(ConfirmationEmailMailer::class, ['sendConfirmationEmail']),
+      Stub::makeEmpty(NewSubscriberNotificationMailer::class, ['send']),
+      $this->diContainer->get(SegmentsRepository::class),
+      SettingsController::getInstance(),
+      $this->diContainer->get(SubscriberSegmentRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(SubscribersResponseBuilder::class),
+      Stub::makeEmpty(WelcomeScheduler::class)
+    );
+  }
+
+  private function getApi($subscriberActions = null) {
+    if (!$subscriberActions) {
+      $subscriberActions = $this->getSubscribers();
+    }
+    return new API(
+      $this->makeEmpty(RequiredCustomFieldValidator::class),
+      $this->diContainer->get(CustomFields::class),
+      $subscriberActions
+    );
+  }
+
+  private function getSegment($name = 'Default', $type = SegmentEntity::TYPE_DEFAULT) {
+    $segment = $this->segmentRepository->createOrUpdate($name);
+    $segment->setType($type);
+    $this->segmentRepository->flush();
+    return $segment;
+  }
+
+  public function testItDoesNotSubscribeMissingSubscriberToLists() {
+    try {
+      $this->getApi()->subscribeToLists(false, [1,2,3]);
+      $this->fail('Subscriber does not exist exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('A subscriber is required.');
+    }
+  }
+
+  public function testItDoesNotSubscribeSubscriberToMissingLists() {
+    $subscriber = $this->subscriberFactory->create();
+    // multiple lists error message
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), [1,2,3]);
+      $this->fail('Missing segments exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('These lists do not exist.');
+    }
+    // single list error message
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), [1]);
+      $this->fail('Missing segments exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('This list does not exist.');
+    }
+  }
+
+  public function testItDoesNotSubscribeSubscriberToWPUsersList() {
+    $subscriber = $this->subscriberFactory->create();
+    $segment = $this->getSegment('WordPress', SegmentEntity::TYPE_WP_USERS);
+
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), [$segment->getId()]);
+      $this->fail('WP Users segment exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals("Can't subscribe to a WordPress Users list with ID {$segment->getId()}.");
+    }
+  }
+
+  public function testItDoesNotSubscribeSubscriberToWooCommerceCustomersList() {
+    $subscriber = $this->subscriberFactory->create();
+    $segment = $this->getSegment('WooCommerce', SegmentEntity::TYPE_WC_USERS);
+
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), [$segment->getId()]);
+      $this->fail('WooCommerce Customers segment exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals("Can't subscribe to a WooCommerce Customers list with ID {$segment->getId()}.");
+    }
+  }
+
+  public function testItDoesNotSubscribeSubscriberToListsWhenOneOrMoreListsAreMissing() {
+    $subscriber = $this->subscriberFactory->create();
+    $segment = $this->getSegment();
+
+    // multiple lists error message
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), [$segment->getId(), 90, 100]);
+      $this->fail('Missing segments with IDs exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('Lists with IDs 90, 100 do not exist.');
+    }
+    // single list error message
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), [$segment->getId(), 90]);
+      $this->fail('Missing segments with IDs exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('List with ID 90 does not exist.');
+    }
+  }
+
+  public function testItSubscribesSubscriberToMultipleLists() {
+    $subscriber = $this->subscriberFactory->create();
+    $segment = $this->getSegment();
+
+    // test if segments are specified
+    try {
+      $this->getApi()->subscribeToLists($subscriber->getId(), []);
+      $this->fail('Segments are required exception should have been thrown.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('At least one segment ID is required.');
+    }
+
+    $result = $this->getApi()->subscribeToLists($subscriber->getId(), [$segment->getId()]);
+    expect($result['id'])->equals($subscriber->getId());
+    expect($result['subscriptions'][0]['segment_id'])->equals($segment->getId());
+  }
+
+  public function testItSendsConfirmationEmailToASubscriberWhenBeingAddedToList() {
+    $subscriber = $this->subscriberFactory
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    $segment = $this->getSegment();
+    $segments = [$segment->getId()];
+
+    $sent = false;
+    $subscribers = $this->makeEmptyExcept(
+      Subscribers::class,
+      'subscribeToLists',
+      [
+        '_sendConfirmationEmail' => function () use (&$sent) {
+          $sent = true;
+        },
+        'segmentsRepository' => $this->diContainer->get(SegmentsRepository::class),
+        'subscribersRepository' => $this->diContainer->get(SubscribersRepository::class),
+        'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
+        'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
+        'settings' => SettingsController::getInstance(),
+      ]
+    );
+
+    $API = $this->getApi($subscribers);
+
+    $API->subscribeToLists($subscriber->getEmail(), $segments, ['send_confirmation_email' => false, 'skip_subscriber_notification' => true]);
+    expect($sent)->equals(false);
+    // should send
+    $API->subscribeToLists($subscriber->getEmail(), $segments, ['skip_subscriber_notification' => true]);
+    expect($sent)->equals(true);
+  }
+
+  public function testItSendsNotificationEmailWhenBeingAddedToList() {
+    $subscriber = $this->subscriberFactory
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $segment = $this->getSegment();
+    $segments = [$segment->getId()];
+
+    $subscriberActions = Stub::copy($this->getSubscribers(), [
+      '$newSubscriberNotificationMailer' => $this->make(NewSubscriberNotificationMailer::class, ['send' => Expected::never()]),
+    ]);
+    $API = $this->getApi($subscriberActions);
+
+    $API->subscribeToLists($subscriber->getEmail(), $segments, ['send_confirmation_email' => false, 'skip_subscriber_notification' => true]);
+
+    // should send
+    $subscribers = Stub::copy($this->getSubscribers(), [
+      'newSubscriberNotificationMailer' => $this->make(NewSubscriberNotificationMailer::class, ['send' => Expected::once()]),
+    ]);
+    $API = $this->getApi($subscribers);
+
+    $API->subscribeToLists($subscriber->getEmail(), $segments, ['send_confirmation_email' => false, 'skip_subscriber_notification' => false]);
+  }
+
+  public function testItSubscribesSubscriberWithEmailIdentifier() {
+    $subscriber = $this->subscriberFactory->create();
+    $segment = $this->getSegment();
+
+    $result = $this->getApi()->subscribeToList($subscriber->getEmail(), $segment->getId());
+    expect($result['id'])->equals($subscriber->getId());
+    expect($result['subscriptions'])->notEmpty();
+    expect($result['subscriptions'][0]['segment_id'])->equals($segment->getId());
+  }
+
+  public function testItSchedulesWelcomeNotificationByDefaultAfterSubscriberSubscriberToLists() {
+    $subscriber = $this->subscriberFactory
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $segment = $this->getSegment();
+
+    $subscribers = Stub::makeEmptyExcept(
+      Subscribers::class,
+      'subscribeToLists',
+      [
+        '_scheduleWelcomeNotification' => Expected::once(),
+        'segmentsRepository' => $this->diContainer->get(SegmentsRepository::class),
+        'subscribersRepository' => $this->diContainer->get(SubscribersRepository::class),
+        'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
+        'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
+        'settings' => SettingsController::getInstance(),
+      ],
+      $this);
+    $API = $this->getApi($subscribers);
+
+    $API->subscribeToLists($subscriber->getId(), [$segment->getId()], ['skip_subscriber_notification' => true]);
+  }
+
+  public function testItDoesNotScheduleWelcomeNotificationAfterSubscribingSubscriberToListsWhenDisabledByOption() {
+    $subscriber = $this->subscriberFactory
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $segment = $this->getSegment();
+    $options = ['schedule_welcome_email' => false, 'skip_subscriber_notification' => true];
+
+    $subscribers = Stub::makeEmptyExcept(
+      Subscribers::class,
+      'subscribeToLists',
+      [
+        '_scheduleWelcomeNotification' => Expected::never(),
+        'segmentsRepository' => $this->diContainer->get(SegmentsRepository::class),
+        'subscribersRepository' => $this->diContainer->get(SubscribersRepository::class),
+        'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
+        'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
+        'settings' => SettingsController::getInstance(),
+      ],
+      $this);
+    $API = $this->getApi($subscribers);
+
+
+    $API->subscribeToLists($subscriber->getId(), [$segment->getId()], $options);
+  }
+
+  public function _after() {
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SegmentEntity::class);
+  }
+}


### PR DESCRIPTION
This PR refactors 

- \MailPoet\API\MP\v1\API::subscribeToList 
- \MailPoet\API\MP\v1\API::subscribeToLists 

The methods are now in a new class `lib/API/MP/v1/Subscribers.php`
Tests have been moved and refactored from `tests/integration/API/MP/APITest.php` to `tests/integration/API/MP/SubscribersTest.php`

I have reused the class `lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php` to build the response replacing 
`->withCustomFields()->withSubscriptions()->asArray();`
I have added a parameter to the function 'build' to add more data on subscriptions if we are calling it from MPAPI. 
This information is redundant but I wanted to avoid modifying current MPAPI response, [as documented here](https://github.com/mailpoet/mailpoet/blob/master/doc/api_methods/GetSubscriber.md).

There are two functions where the old models are still present that require refactoring other components.
* sendSubscriberNotification
* _sendConfirmationEmail : The old models on this function can be refactored with this PR: https://github.com/mailpoet/mailpoet/pull/3834

I have also replaced many of the fixtures for Subscribers and Segments on APITest.php with the Doctrine version.

To test:
```
./do --test "test:integration --file=tests/integration/API/MP/APITest.php"
./do --test "test:integration --file=tests/integration/API/MP/SubscribersTest.php"
```
You can also check that the response structure has not changed after the refactoring.
I haven't tested the integration with a 3rd party plugin but if you know of a good candidate, I wouldn't mind doing it.

[MAILPOET-3813]

[MAILPOET-3820]: https://mailpoet.atlassian.net/browse/MAILPOET-3820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-3813]: https://mailpoet.atlassian.net/browse/MAILPOET-3813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ