### PR TITLE
Make form error containers unique by form id [MAILPOET-3875]

### DIFF
--- a/lib/Form/Block/BlockRendererHelper.php
+++ b/lib/Form/Block/BlockRendererHelper.php
@@ -26,7 +26,7 @@ class BlockRendererHelper {
     $this->wp = $wp;
   }
 
-  public function getInputValidation(array $block, array $extraRules = []): string {
+  public function getInputValidation(array $block, array $extraRules = [], ?int $formId = null): string {
     $rules = [];
     $blockId = $this->wp->escAttr($block['id']);
 
@@ -51,7 +51,7 @@ class BlockRendererHelper {
       $rules['required'] = true;
       $rules['mincheck'] = 1;
       $rules['group'] = $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId;
+      $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
       $rules['required-message'] = __('Please select a list.', 'mailpoet');
     }
 
@@ -71,13 +71,13 @@ class BlockRendererHelper {
 
     if (in_array($block['type'], ['radio', 'checkbox'])) {
       $rules['group'] = 'custom_field_' . $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId;
+      $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
       $rules['required-message'] = __('Please select at least one option.', 'mailpoet');
     }
 
     if ($block['type'] === 'date') {
       $rules['group'] = 'custom_field_' . $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId;
+      $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
     }
 
     $validation = [];

--- a/lib/Form/Block/Checkbox.php
+++ b/lib/Form/Block/Checkbox.php
@@ -26,11 +26,11 @@ class Checkbox {
     $this->wp = $wp;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $html = '';
 
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
-    $fieldValidation = $this->rendererHelper->getInputValidation($block);
+    $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
     $html .= $this->rendererHelper->renderLabel($block, $formSettings);
 
@@ -70,7 +70,7 @@ class Checkbox {
       $html .= '</label>';
     }
 
-    $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . '"></span>';
+    $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . ($formId ? '_' . $formId : '') . '"></span>';
 
     return $this->wrapper->render($block, $html);
   }

--- a/lib/Form/Block/Date.php
+++ b/lib/Form/Block/Date.php
@@ -33,14 +33,14 @@ class Date {
     $this->wp = $wp;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $html = '';
     $html .= $this->rendererHelper->renderLabel($block, $formSettings);
-    $html .= $this->renderDateSelect($block, $formSettings);
+    $html .= $this->renderDateSelect($formId, $block, $formSettings);
     return $this->wrapper->render($block, $html);
   }
 
-  private function renderDateSelect(array $block = [], $formSettings = []): string {
+  private function renderDateSelect(?int $formId, array $block = [], $formSettings = []): string {
     $html = '';
 
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
@@ -65,7 +65,7 @@ class Date {
         $html .= ' style="' . $this->wp->escAttr($this->blockStylesRenderer->renderForSelect([], $formSettings)) . '"';
         $html .= $this->rendererHelper->getInputValidation($block, [
           'required-message' => __('Please select a day', 'mailpoet'),
-        ]);
+        ], $formId);
         $html .= 'name="' . $fieldName . '[day]" placeholder="' . __('Day', 'mailpoet') . '">';
         $html .= $this->getDays($block);
         $html .= '</select>';
@@ -74,7 +74,7 @@ class Date {
         $html .= ' style="' . $this->wp->escAttr($this->blockStylesRenderer->renderForSelect([], $formSettings)) . '"';
         $html .= $this->rendererHelper->getInputValidation($block, [
           'required-message' => __('Please select a month', 'mailpoet'),
-        ]);
+        ], $formId);
         $html .= 'name="' . $fieldName . '[month]" placeholder="' . __('Month', 'mailpoet') . '">';
         $html .= $this->getMonths($block);
         $html .= '</select>';
@@ -83,14 +83,14 @@ class Date {
         $html .= ' style="' . $this->wp->escAttr($this->blockStylesRenderer->renderForSelect([], $formSettings)) . '"';
         $html .= $this->rendererHelper->getInputValidation($block, [
           'required-message' => __('Please select a year', 'mailpoet'),
-        ]);
+        ], $formId);
         $html .= 'name="' . $fieldName . '[year]" placeholder="' . __('Year', 'mailpoet') . '">';
         $html .= $this->getYears($block);
         $html .= '</select>';
       }
     }
 
-    $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . '"></span>';
+    $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . ($formId ? '_' . $formId : '') . '"></span>';
 
     return $html;
   }

--- a/lib/Form/Block/Radio.php
+++ b/lib/Form/Block/Radio.php
@@ -26,11 +26,11 @@ class Radio {
     $this->wp = $wp;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $html = '';
 
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
-    $fieldValidation = $this->rendererHelper->getInputValidation($block);
+    $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
     $html .= $this->rendererHelper->renderLabel($block, $formSettings);
 
@@ -73,7 +73,7 @@ class Radio {
       $html .= '</label>';
     }
 
-    $html .= '<span class="mailpoet_error_' . $block['id'] . '"></span>';
+    $html .= '<span class="mailpoet_error_' . $block['id'] . ($formId ? '_' . $formId : '') . '"></span>';
 
     return $this->wrapper->render($block, $html);
   }

--- a/lib/Form/Block/Segment.php
+++ b/lib/Form/Block/Segment.php
@@ -32,11 +32,11 @@ class Segment {
     $this->segmentsRepository = $segmentsRepository;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $html = '';
 
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
-    $fieldValidation = $this->rendererHelper->getInputValidation($block);
+    $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
     $html .= $this->rendererHelper->renderLabel($block, $formSettings);
 
@@ -67,7 +67,7 @@ class Segment {
       $html .= '</label>';
     }
 
-    $html .= '<span class="mailpoet_error_' . $block['id'] . '"></span>';
+    $html .= '<span class="mailpoet_error_' . $block['id'] . ($formId ? '_' . $formId : '') . '"></span>';
 
     return $this->wrapper->render($block, $html);
   }

--- a/lib/Form/BlocksRenderer.php
+++ b/lib/Form/BlocksRenderer.php
@@ -99,7 +99,7 @@ class BlocksRenderer {
     $this->paragraph = $paragraph;
   }
 
-  public function renderBlock(array $block, array $formSettings): string {
+  public function renderBlock(array $block, array $formSettings, ?int $formId): string {
     $html = '';
     switch ($block['type']) {
       case FormEntity::HTML_BLOCK_TYPE:
@@ -123,19 +123,19 @@ class BlocksRenderer {
         break;
 
       case FormEntity::CHECKBOX_BLOCK_TYPE:
-        $html .= $this->checkbox->render($block, $formSettings);
+        $html .= $this->checkbox->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::RADIO_BLOCK_TYPE:
-        $html .= $this->radio->render($block, $formSettings);
+        $html .= $this->radio->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::SEGMENT_SELECTION_BLOCK_TYPE:
-        $html .= $this->segment->render($block, $formSettings);
+        $html .= $this->segment->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::DATE_BLOCK_TYPE:
-        $html .= $this->date->render($block, $formSettings);
+        $html .= $this->date->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::SELECT_BLOCK_TYPE:

--- a/lib/Form/Renderer.php
+++ b/lib/Form/Renderer.php
@@ -44,7 +44,7 @@ class Renderer {
 
   public function renderHTML(FormEntity $form = null): string {
     if (($form instanceof FormEntity) && !empty($form->getBody()) && is_array($form->getSettings())) {
-      return $this->renderBlocks($form->getBody(), $form->getSettings() ?? []);
+      return $this->renderBlocks($form->getBody(), $form->getSettings() ?? [], $form->getId());
     }
     return '';
   }
@@ -57,7 +57,13 @@ class Renderer {
     }
   }
 
-  public function renderBlocks(array $blocks = [], array $formSettings = [], bool $honeypotEnabled = true, bool $captchaEnabled = true): string {
+  public function renderBlocks(
+    array $blocks = [],
+    array $formSettings = [],
+    ?int $formId = null,
+    bool $honeypotEnabled = true,
+    bool $captchaEnabled = true
+  ): string {
     // add honeypot for spambots
     $html = ($honeypotEnabled) ? $this->renderHoneypot() : '';
     foreach ($blocks as $key => $block) {
@@ -69,9 +75,9 @@ class Renderer {
       }
       if (in_array($block['type'], [FormEntity::COLUMN_BLOCK_TYPE, FormEntity::COLUMNS_BLOCK_TYPE])) {
         $blocks = $block['body'] ?? [];
-        $html .= $this->blocksRenderer->renderContainerBlock($block, $this->renderBlocks($blocks, $formSettings, false)) . PHP_EOL;
+        $html .= $this->blocksRenderer->renderContainerBlock($block, $this->renderBlocks($blocks, $formSettings, $formId, false)) . PHP_EOL;
       } else {
-        $html .= $this->blocksRenderer->renderBlock($block, $formSettings) . PHP_EOL;
+        $html .= $this->blocksRenderer->renderBlock($block, $formSettings, $formId) . PHP_EOL;
       }
     }
     return $html;

--- a/lib/Subscription/CaptchaRenderer.php
+++ b/lib/Subscription/CaptchaRenderer.php
@@ -120,7 +120,7 @@ class CaptchaRenderer {
     $formHtml .= '</p>';
 
     // subscription form
-    $formHtml .= $this->formRenderer->renderBlocks($form, [], $honeypot = false);
+    $formHtml .= $this->formRenderer->renderBlocks($form, [], null, $honeypot = false);
     $formHtml .= '</div>';
     $formHtml .= $this->renderFormMessages($formModel, $showSuccessMessage, $showErrorMessage);
     $formHtml .= '</form>';

--- a/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -106,7 +106,7 @@ class ManageSubscriptionFormRenderer {
       'email' => $subscriber->email,
       'token' => $this->linkTokens->getToken($subscriberEntity),
       'editEmailInfo' => __('Need to change your email address? Unsubscribe here, then simply sign up again.', 'mailpoet'),
-      'formHtml' => $this->formRenderer->renderBlocks($form, [], $honeypot = false, $captcha = false),
+      'formHtml' => $this->formRenderer->renderBlocks($form, [], null, $honeypot = false, $captcha = false),
       'formState' => $formState,
     ];
 

--- a/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -108,6 +108,28 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
     expect($validation)->equals('data-parsley-0="custom"');
   }
 
+  public function testItShouldRenderInputValidationsWithFormId(): void {
+    $block = $this->block;
+    $block['type'] = 'radio';
+    $validation = $this->rendererHelper->getInputValidation($block, [], 1);
+    expect($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_1" data-parsley-required-message="Please select at least one option."');
+
+    $block = $this->block;
+    $block['type'] = 'checkbox';
+    $validation = $this->rendererHelper->getInputValidation($block, [], 2);
+    expect($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required-message="Please select at least one option."');
+
+    $block = $this->block;
+    $block['type'] = 'date';
+    $validation = $this->rendererHelper->getInputValidation($block, [], 3);
+    expect($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_3"');
+
+    $block = $this->block;
+    $block['id'] = 'segments';
+    $validation = $this->rendererHelper->getInputValidation($block, [], 4);
+    expect($validation)->equals('data-parsley-required="true" data-parsley-group="segments" data-parsley-errors-container=".mailpoet_error_segments_4" data-parsley-required-message="Please select a list."');
+  }
+
   public function testItShouldObfuscateFieldNameIfNeeded() {
     $block = $this->block;
     $fieldName = $this->rendererHelper->getFieldName($block);

--- a/tests/unit/Form/Block/CheckboxTest.php
+++ b/tests/unit/Form/Block/CheckboxTest.php
@@ -66,4 +66,17 @@ class CheckboxTest extends \MailPoetUnitTest {
     $checked = $this->htmlParser->getAttribute($checkbox, 'checked');
     expect($checked->value)->equals('checked');
   }
+
+  public function testItShouldRenderErrorContainerWithFormId() {
+    $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
+    $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
+    $this->rendererHelperMock->expects($this->once())->method('getFieldValue')->willReturn('1');
+
+    $html = $this->checkbox->render($this->block, [], 213);
+
+    $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_1_213']");
+    expect($errorContainer)->notEmpty();
+    expect($errorContainer->nodeName)->equals('span');
+  }
 }

--- a/tests/unit/Form/Block/DateTest.php
+++ b/tests/unit/Form/Block/DateTest.php
@@ -129,4 +129,16 @@ class DateTest extends \MailPoetUnitTest {
     $selectedYear = $this->htmlParser->getElementByXpath($html, "//option[@selected='selected']", 2);
     expect($selectedYear->textContent)->equals('2009');
   }
+
+  public function testItShouldRenderErrorContainerWithFormId() {
+    $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
+    $this->baseMock->expects($this->any())->method('getInputValidation')->willReturn(' validation="1" ');
+
+    $html = $this->date->render($this->block, [], 44);
+
+    $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_1_44']");
+    expect($errorContainer)->notEmpty();
+    expect($errorContainer->nodeName)->equals('span');
+  }
 }

--- a/tests/unit/Form/Block/RadioTest.php
+++ b/tests/unit/Form/Block/RadioTest.php
@@ -79,4 +79,17 @@ class RadioTest extends \MailPoetUnitTest {
 
     expect($this->htmlParser->getAttribute($radio2Input, 'checked')->value)->equals('checked');
   }
+
+  public function testItShouldRenderErrorContainerWithFormId() {
+    $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
+    $this->baseMock->expects($this->once())->method('getInputValidation')->willReturn(' validation="1" ');
+    $this->baseMock->expects($this->once())->method('getFieldValue')->willReturn('Radio 2');
+
+    $html = $this->radio->render($this->block, [], 31);
+
+    $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_1_31']");
+    expect($errorContainer)->notEmpty();
+    expect($errorContainer->nodeName)->equals('span');
+  }
 }

--- a/tests/unit/Form/Block/SegmentTest.php
+++ b/tests/unit/Form/Block/SegmentTest.php
@@ -63,7 +63,7 @@ class SegmentTest extends \MailPoetUnitTest {
     $this->htmlParser = new HtmlParser();
   }
 
-  public function testItShouldRenderSegmets() {
+  public function testItShouldRenderSegments() {
     $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
     $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Segments');
@@ -86,6 +86,22 @@ class SegmentTest extends \MailPoetUnitTest {
     expect($this->htmlParser->getAttribute($checkbox1Input, 'name')->value)->equals('data[Segments][]');
     expect($this->htmlParser->getAttribute($checkbox2Input, 'name')->value)->equals('data[Segments][]');
     expect($this->htmlParser->getAttribute($checkbox1Input, 'checked')->value)->equals('checked');
+  }
+
+  public function testItShouldRenderErrorContainerWithFormId(): void {
+    $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
+    $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Segments');
+    $this->segmentsRepositoryMock->expects($this->once())->method('findBy')->willReturn([
+      $this->createSegmentMock(1, 'List 1'),
+      $this->createSegmentMock(2, 'List 2'),
+    ]);
+
+    $html = $this->segment->render($this->block, [], 1);
+
+    $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_segment_1']");
+    expect($errorContainer)->notEmpty();
+    expect($errorContainer->nodeName)->equals('span');
   }
 
   /**

--- a/tests/unit/Form/RendererTest.php
+++ b/tests/unit/Form/RendererTest.php
@@ -97,7 +97,7 @@ class RendererTest extends \MailPoetUnitTest {
       ->method('get')
       ->with('captcha.type')
       ->willReturn(Captcha::TYPE_DISABLED);
-    $html = $this->renderer->renderBlocks(Fixtures::get('simple_form_body'), [], false);
+    $html = $this->renderer->renderBlocks(Fixtures::get('simple_form_body'), [], null, false);
     $hpLabel = $this->htmlParser->findByXpath($html, "//label[@class='mailpoet_hp_email_label']");
     expect($hpLabel->length)->equals(0);
     $recaptcha = $this->htmlParser->findByXpath($html, "//div[@class='mailpoet_recaptcha']");


### PR DESCRIPTION
[MAILPOET-3875]

[MAILPOET-3875]: https://mailpoet.atlassian.net/browse/MAILPOET-3875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing Instructions:
1. Go to WP Admin > MailPoet > Forms
2. Click to Add New Form
3. Click `Skip, start with a blank form` button
4. Click Plus (black) button and search for `List Selection` block to insert it
5. On the right sidebar, insert a few available lists under `Select the segment that you want to add` dropdown
6. Click to `Form`, then `Form Placements` tab
7. Then click Popup and then click Enable switcher
8. Click the switcher for `Display on all pages`
9. Change the `Display with a delay of` time from 15sec to 0sec
10. Click Save to save the form
11. Now, go back to Forms page
12. Click to duplicate created form (hover it and you'll see Duplicate link)
13. Edit duplicated form now
14. Click `Form Placement` in the right sidebar
15. Turn off the switcher Enable for showing in Popup type
16. Save the form
17. Go to WP Admin > Appearance > Widgets
18. Click Plus button to add a new widget form in the sidebar
19. Search for MailPoet 3 Form widget
20. When added, select to be shown your duplicated form you have created recently
21. Click Update button to update all widgets
22. Go to the site front-end and open any page like /about-us/ page
23. Make sure you see a popup form present, fill data like email address and just click Subscrube button without checking the lists below
24. Make sure you see a warning within the popup "Please select a list."
25. That's it.