### PR TITLE
Allow multiple values in "WordPress user role" segment [MAILPOET-3955]

### DIFF
--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -15,7 +15,7 @@ import { SubscribedToList, validateSubscribedToList } from './subscriber_subscri
 
 export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
   if ((!formItems.action) || (formItems.action === SubscriberActionTypes.WORDPRESS_ROLE)) {
-    return !!formItems.wordpressRole;
+    return Array.isArray(formItems.wordpressRole) && (formItems.wordpressRole.length > 0);
   }
   if (formItems.action === SubscriberActionTypes.MAILPOET_CUSTOM_FIELD) {
     return validateMailPoetCustomField(formItems);

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_wordpress_role.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_wordpress_role.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { find } from 'lodash/fp';
+import { filter, map } from 'lodash/fp';
 import MailPoet from 'mailpoet';
 import { useSelect, useDispatch } from '@wordpress/data';
 
-import Select from 'common/form/react_select/react_select';
+import ReactSelect from 'common/form/react_select/react_select';
+import { Grid } from 'common/grid';
 
 import {
   WordpressRoleFormItem,
@@ -33,25 +34,32 @@ export const WordpressRoleFields: React.FunctionComponent<Props> = ({ filterInde
   }));
 
   return (
-    <div>
-      <Select
-        isFullWidth
-        placeholder={MailPoet.I18n.t('selectUserRolePlaceholder')}
-        options={options}
-        value={
-          find(
-            (option) => {
-              if (!segment.wordpressRole) return undefined;
-              return segment.wordpressRole.toLowerCase() === option.value.toLowerCase();
-            },
-            options
-          )
-        }
-        onChange={(option: SelectOption): void => {
-          updateSegmentFilter({ wordpressRole: option.value }, filterIndex);
-        }}
-        automationId="segment-wordpress-role"
-      />
-    </div>
+    <>
+      <Grid.CenteredRow>
+        <ReactSelect
+          dimension="small"
+          isFullWidth
+          isMulti
+          automationId="segment-wordpress-role"
+          placeholder={MailPoet.I18n.t('selectUserRolePlaceholder')}
+          options={options}
+          value={
+            filter(
+              (option) => {
+                if (!segment.wordpressRole) return undefined;
+                return segment.wordpressRole.indexOf(option.value) !== -1;
+              },
+              options
+            )
+          }
+          onChange={(options: SelectOption[]): void => {
+            updateSegmentFilter(
+              { wordpressRole: map('value', options) },
+              filterIndex
+            );
+          }}
+        />
+      </Grid.CenteredRow>
+    </>
   );
 };

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_wordpress_role.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_wordpress_role.tsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { filter, map } from 'lodash/fp';
 import MailPoet from 'mailpoet';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 import ReactSelect from 'common/form/react_select/react_select';
+import Select from 'common/form/select/select';
 import { Grid } from 'common/grid';
 
 import {
   WordpressRoleFormItem,
   SelectOption,
   WindowEditableRoles,
+  AnyValueTypes,
+  SubscriberActionTypes,
 } from '../types';
 
 type Props = {
@@ -22,7 +25,18 @@ export const WordpressRoleFields: React.FunctionComponent<Props> = ({ filterInde
     [filterIndex]
   );
 
-  const { updateSegmentFilter } = useDispatch('mailpoet-dynamic-segments-form');
+  const { updateSegmentFilter, updateSegmentFilterFromEvent } = useDispatch('mailpoet-dynamic-segments-form');
+
+  useEffect(() => {
+    if (
+      (segment.action === SubscriberActionTypes.WORDPRESS_ROLE)
+      && (segment.operator !== AnyValueTypes.ANY)
+      && (segment.operator !== AnyValueTypes.ALL)
+      && (segment.operator !== AnyValueTypes.NONE)
+    ) {
+      updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
 
   const wordpressRoles: WindowEditableRoles = useSelect(
     (select) => select('mailpoet-dynamic-segments-form').getWordpressRoles(),
@@ -35,6 +49,20 @@ export const WordpressRoleFields: React.FunctionComponent<Props> = ({ filterInde
 
   return (
     <>
+      <Grid.CenteredRow>
+        <Select
+          key="select"
+          isFullWidth
+          value={segment.operator}
+          onChange={(e) => {
+            updateSegmentFilterFromEvent('operator', filterIndex, e);
+          }}
+        >
+          <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+          <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+          <option value={AnyValueTypes.NONE}>{MailPoet.I18n.t('noneOf')}</option>
+        </Select>
+      </Grid.CenteredRow>
       <Grid.CenteredRow>
         <ReactSelect
           dimension="small"

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -62,7 +62,7 @@ export interface FormItem {
 }
 
 export interface WordpressRoleFormItem extends FormItem {
-  wordpressRole?: string;
+  wordpressRole?: string[];
   operator?: string;
   value?: string;
   custom_field_id?: string;

--- a/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
+++ b/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
@@ -51,6 +51,10 @@ class DynamicSegmentsResponseBuilder {
       $filter['id'] = $dynamicFilter->getId();
       $filter['segmentType'] = $dynamicFilter->getFilterData()->getFilterType(); // We need to add filterType with key segmentType due to BC
       $filter['action'] = $dynamicFilter->getFilterData()->getAction();
+      if (isset($filter['wordpressRole']) && !is_array($filter['wordpressRole'])) {
+        // new filters are always array, they support multiple values, the old didn't convert old filters to new format
+        $filter['wordpressRole'] = [$filter['wordpressRole']];
+      }
       $filters[] = $filter;
     }
     $data['filters'] = $filters;

--- a/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -106,6 +106,7 @@ class FilterDataMapper {
     if (empty($data['wordpressRole'])) throw new InvalidFilterException('Missing role', InvalidFilterException::MISSING_ROLE);
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
       'wordpressRole' => $data['wordpressRole'],
+      'operator' => $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => $data['connect'],
     ]);
   }

--- a/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -60,7 +60,14 @@ class UserRole implements Filter {
   private function createCondition(array $roles, string $operator, $parameterSuffix): string {
     $sqlParts = [];
     foreach ($roles as $key => $role) {
-      $sqlParts[] = '(wpusermeta.meta_value LIKE :role' . $key . $parameterSuffix . ')';
+      if ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+        $sqlParts[] = '(wpusermeta.meta_value NOT LIKE :role' . $key . $parameterSuffix . ')';
+      } else {
+        $sqlParts[] = '(wpusermeta.meta_value LIKE :role' . $key . $parameterSuffix . ')';
+      }
+    }
+    if ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+      return join(' AND ', $sqlParts);
     }
     return join(' OR ', $sqlParts);
   }

--- a/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
@@ -25,8 +26,16 @@ class UserRole implements Filter {
     global $wpdb;
     $filterData = $filter->getFilterData();
     $role = $filterData->getParam('wordpressRole');
+    $operator = $filterData->getParam('operator');
     if (!$role) {
       throw new InvalidFilterException('Missing role', InvalidFilterException::MISSING_ROLE);
+    }
+    if (!is_array($role)) {
+      // compatibility with the older segment before multiple roles were added
+      $role = [$role];
+    }
+    if (!$operator) {
+      $operator = DynamicSegmentFilterData::OPERATOR_ANY;
     }
 
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
@@ -34,6 +43,7 @@ class UserRole implements Filter {
     return $queryBuilder->join($subscribersTable, $wpdb->users, 'wpusers', "$subscribersTable.wp_user_id = wpusers.id")
       ->join('wpusers', $wpdb->usermeta, 'wpusermeta', 'wpusers.id = wpusermeta.user_id')
       ->andWhere("wpusermeta.meta_key = '{$wpdb->prefix}capabilities' AND wpusermeta.meta_value LIKE :role" . $parameterSuffix)
-      ->setParameter(':role' . $parameterSuffix, '%"' . $role . '"%');
+      ->setParameter(':role' . $parameterSuffix, '%"' . $role[0] . '"%');
   }
+
 }

--- a/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -39,7 +39,7 @@ class UserRole implements Filter {
     }
 
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $parameterSuffix = (string)$filter->getId() ?? Security::generateRandomString();
+    $parameterSuffix = ((string)$filter->getId()) . Security::generateRandomString();
     $condition = $this->createCondition($role, $operator, $parameterSuffix);
     $qb = $queryBuilder->join($subscribersTable, $wpdb->users, 'wpusers', "$subscribersTable.wp_user_id = wpusers.id")
       ->join('wpusers', $wpdb->usermeta, 'wpusermeta', 'wpusers.id = wpusermeta.user_id')

--- a/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -50,7 +50,6 @@ class UserRole implements Filter {
     return $qb;
   }
 
-
   /**
    * @param string[] $roles
    * @param string $operator
@@ -66,7 +65,7 @@ class UserRole implements Filter {
         $sqlParts[] = '(wpusermeta.meta_value LIKE :role' . $key . $parameterSuffix . ')';
       }
     }
-    if ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+    if (($operator === DynamicSegmentFilterData::OPERATOR_NONE) || ($operator === DynamicSegmentFilterData::OPERATOR_ALL)) {
       return join(' AND ', $sqlParts);
     }
     return join(' OR ', $sqlParts);

--- a/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -619,6 +619,7 @@ class ManageSegmentsCest {
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], $segmentDesc);
     $i->see('WordPress user role', "{$filterRowOne} {$actionSelectElement}");
+    $i->waitForText('Admin', 10, "{$filterRowOne} {$roleSelectElement}");
     $i->see('Admin', "{$filterRowOne} {$roleSelectElement}");
     $i->see('WordPress user role', "{$filterRowTwo} {$actionSelectElement}");
     $i->see('Editor', "{$filterRowTwo} {$roleSelectElement}");

--- a/tests/integration/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilderTest.php
+++ b/tests/integration/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilderTest.php
@@ -37,7 +37,7 @@ class DynamicSegmentsResponseBuilderTest extends \MailPoetTest {
     expect($response['filters'])->array();
     expect($response['filters'])->count(1);
     expect($response['filters'][0]['segmentType'])->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
-    expect($response['filters'][0]['wordpressRole'])->equals('editor');
+    expect($response['filters'][0]['wordpressRole'])->equals(['editor']);
     expect($response['filters'][0]['action'])->equals(UserRole::TYPE);
   }
 
@@ -64,11 +64,11 @@ class DynamicSegmentsResponseBuilderTest extends \MailPoetTest {
     expect($response['filters'])->array();
     expect($response['filters'])->count(2);
     expect($response['filters'][0]['segmentType'])->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
-    expect($response['filters'][0]['wordpressRole'])->equals('editor');
+    expect($response['filters'][0]['wordpressRole'])->equals(['editor']);
     expect($response['filters'][0]['action'])->equals(UserRole::TYPE);
     expect($response['filters'][0]['connect'])->equals(DynamicSegmentFilterData::CONNECT_TYPE_AND);
     expect($response['filters'][1]['segmentType'])->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
-    expect($response['filters'][1]['wordpressRole'])->equals('administrator');
+    expect($response['filters'][1]['wordpressRole'])->equals(['administrator']);
     expect($response['filters'][1]['action'])->equals(UserRole::TYPE);
     expect($response['filters'][1]['connect'])->equals(DynamicSegmentFilterData::CONNECT_TYPE_AND);
   }

--- a/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -34,6 +34,22 @@ class UserRoleTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
   }
 
+  public function testItAppliesFilterAny() {
+    $segmentFilter = $this->getSegmentFilter(['editor', 'author']);
+    $queryBuilder = $this->userRole->apply($this->getQueryBuilder(), $segmentFilter);
+    $result = $queryBuilder->execute()->fetchAll();
+    expect(count($result))->equals(3);
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    assert($subscriber1 instanceof SubscriberEntity);
+    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
+    assert($subscriber2 instanceof SubscriberEntity);
+    $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
+    assert($subscriber3 instanceof SubscriberEntity);
+    expect($subscriber1->getEmail())->equals('user-role-test1@example.com');
+    expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
+    expect($subscriber3->getEmail())->equals('user-role-test4@example.com');
+  }
+
   public function testItDoesntGetSubString() {
     $segmentFilter = $this->getSegmentFilter('edit');
     $queryBuilder = $this->userRole->apply($this->getQueryBuilder(), $segmentFilter);
@@ -46,11 +62,16 @@ class UserRoleTest extends \MailPoetTest {
     return $this->entityManager
       ->getConnection()
       ->createQueryBuilder()
+      ->orderBy('email')
       ->select("$subscribersTable.id")
       ->from($subscribersTable);
   }
 
-  private function getSegmentFilter(string $role): DynamicSegmentFilterEntity {
+  /**
+   * @param string[]|string $role
+   * @return DynamicSegmentFilterEntity
+   */
+  private function getSegmentFilter($role): DynamicSegmentFilterEntity {
     $data = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, [
       'wordpressRole' => $role,
     ]);
@@ -73,7 +94,7 @@ class UserRoleTest extends \MailPoetTest {
   }
 
   private function cleanWpUsers() {
-    $emails = ['user-role-test1@example.com', 'user-role-test2@example.com', 'user-role-test3@example.com'];
+    $emails = ['user-role-test1@example.com', 'user-role-test2@example.com', 'user-role-test3@example.com', 'user-role-test4@example.com'];
     foreach ($emails as $email) {
       $this->tester->deleteWordPressUser($email);
     }

--- a/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -27,9 +27,9 @@ class UserRoleTest extends \MailPoetTest {
     $result = $queryBuilder->execute()->fetchAll();
     expect(count($result))->equals(2);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    assert($subscriber2 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     expect($subscriber1->getEmail())->equals('user-role-test1@example.com');
     expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
   }
@@ -40,11 +40,11 @@ class UserRoleTest extends \MailPoetTest {
     $result = $queryBuilder->execute()->fetchAll();
     expect(count($result))->equals(3);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    assert($subscriber2 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    assert($subscriber3 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
     expect($subscriber1->getEmail())->equals('user-role-test1@example.com');
     expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
     expect($subscriber3->getEmail())->equals('user-role-test4@example.com');

--- a/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -13,11 +13,12 @@ class UserRoleTest extends \MailPoetTest {
 
   public function _before() {
     $this->userRole = $this->diContainer->get(UserRole::class);
-    $this->cleanWpUsers();
+    $this->cleanup();
     // Insert WP users and subscribers are created automatically
     $this->tester->createWordPressUser('user-role-test1@example.com', 'editor');
     $this->tester->createWordPressUser('user-role-test2@example.com', 'administrator');
     $this->tester->createWordPressUser('user-role-test3@example.com', 'editor');
+    $this->tester->createWordPressUser('user-role-test4@example.com', 'author');
   }
 
   public function testItAppliesFilter() {
@@ -62,6 +63,11 @@ class UserRoleTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
+    $this->cleanup();
+  }
+
+  private function cleanup() {
     $this->cleanWpUsers();
     $this->truncateEntity(SubscriberEntity::class);
   }

--- a/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
+++ b/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
@@ -40,6 +40,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     expect($filter->getFilterData()->getAction())->equals(UserRole::TYPE);
     expect($filter->getFilterData()->getData())->equals([
       'wordpressRole' => 'editor',
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }
@@ -52,12 +53,12 @@ class SegmentSaveControllerTest extends \MailPoetTest {
       'filters' => [
         [
           'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
-          'wordpressRole' => 'administrator',
+          'wordpressRole' => ['administrator'],
           'action' => UserRole::TYPE,
         ],
         [
           'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
-          'wordpressRole' => 'editor',
+          'wordpressRole' => ['editor'],
           'action' => UserRole::TYPE,
         ],
       ],
@@ -73,7 +74,8 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     expect($filter->getFilterData()->getFilterType())->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
     expect($filter->getFilterData()->getAction())->equals(UserRole::TYPE);
     expect($filter->getFilterData()->getData())->equals([
-      'wordpressRole' => 'administrator',
+      'wordpressRole' => ['administrator'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
     ]);
     $filter = $segment->getDynamicFilters()->next();
@@ -81,15 +83,16 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     expect($filter->getFilterData()->getFilterType())->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
     expect($filter->getFilterData()->getAction())->equals(UserRole::TYPE);
     expect($filter->getFilterData()->getData())->equals([
-      'wordpressRole' => 'editor',
+      'wordpressRole' => ['editor'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
     ]);
   }
 
   public function testItCanRemoveRedundantFilter() {
     $segment = $this->createSegment('Test Segment');
-    $this->addDynamicFilter($segment, 'editor');
-    $this->addDynamicFilter($segment, 'administrator');
+    $this->addDynamicFilter($segment, ['editor']);
+    $this->addDynamicFilter($segment, ['administrator']);
     $segmentData = [
       'id' => $segment->getId(),
       'name' => 'Test Segment Edited',
@@ -97,8 +100,9 @@ class SegmentSaveControllerTest extends \MailPoetTest {
       'filters_connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
       'filters' => [[
         'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
-        'wordpressRole' => 'subscriber',
+        'wordpressRole' => ['subscriber'],
         'action' => UserRole::TYPE,
+        'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
         'connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
       ]],
     ];
@@ -113,7 +117,8 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     expect($filter->getFilterData()->getFilterType())->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
     expect($filter->getFilterData()->getAction())->equals(UserRole::TYPE);
     expect($filter->getFilterData()->getData())->equals([
-      'wordpressRole' => 'subscriber',
+      'wordpressRole' => ['subscriber'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
     ]);
   }
@@ -158,7 +163,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     return $segment;
   }
 
-  private function addDynamicFilter(SegmentEntity $segment, string $wordpressRole): DynamicSegmentFilterEntity {
+  private function addDynamicFilter(SegmentEntity $segment, array $wordpressRole): DynamicSegmentFilterEntity {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, [
       'wordpressRole' => $wordpressRole,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,

--- a/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -99,7 +99,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
   public function testItMapsUserRoleFilter() {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
-      'wordpressRole' => 'editor',
+      'wordpressRole' => ['editor'],
       'some_mess' => 'mess',
     ]]];
     $filters = $this->mapper->map($data);
@@ -111,7 +111,8 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_USER_ROLE);
     expect($filter->getAction())->equals('userRole');
     expect($filter->getData())->equals([
-      'wordpressRole' => 'editor',
+      'wordpressRole' => ['editor'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }

--- a/views/segments.html
+++ b/views/segments.html
@@ -138,7 +138,7 @@
     'selectLinkPlaceholder': __('Select link'),
     'selectNewsletterPlaceholder': __('Select email'),
     'selectActionPlaceholder': __('Select action'),
-    'selectUserRolePlaceholder': __('Select user role'),
+    'selectUserRolePlaceholder': __('Search user roles'),
     'selectCustomFieldPlaceholder': __('Select custom field'),
     'emailActionOpened': _x('opened', 'Dynamic segment creation: when newsletter was opened'),
     'emailActionMachineOpened': _x('machine-opened', 'Dynamic segment creation: list of all subscribers that opened the newsletter automatically in the background'),


### PR DESCRIPTION
[MAILPOET-3955]

[MAILPOET-3955]: https://mailpoet.atlassian.net/browse/MAILPOET-3955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:

1. Go to WP Admin > MailPoet > Lists
2. Click on Segments tab
3. Click to `+ New Segment` button at the top
4. From there, test the segment creation and modification according to [MAILPOET-3955](https://mailpoet.atlassian.net/browse/MAILPOET-3955) specs in Jira ticket.
5. Make sure you follow the specs and that it behaves according to the specification.