### PR TITLE
Fix WooCommerce block's checkout error when opt-in is disabled [MAILPOET-4004]

### DIFF
--- a/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -83,6 +83,9 @@ class WooCommerceBlocksIntegration {
   }
 
   public function extendRestApi() {
+    if (!$this->settings->get('woocommerce.optin_on_checkout.enabled', false)) {
+      return;
+    }
     $extend = Package::container()->get(ExtendRestApi::class);
     $extend->register_endpoint_data(
       [


### PR DESCRIPTION
When opt-in is disabled it fails to validate checkout data, because it expects
`mailpoet.optin` to be present. In this PR I added a condition so that it skips extending checkout data schema in case
the opt-in is disabled.

[MAILPOET-4004]

[MAILPOET-4004]: https://mailpoet.atlassian.net/browse/MAILPOET-4004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ