### PR TITLE
Fix flaky TimestampListenerTest [MAILPOET-3983]

### DIFF
--- a/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
+++ b/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
@@ -20,16 +20,18 @@ class TimestampListenerTest extends EventListenersBaseTest {
   /** @var string */
   private $tableName;
 
+  /** @var TimestampListener */
+  private $timestampListener;
+
   public function _before() {
     $timestamp = time();
     $this->now = Carbon::createFromTimestamp($timestamp);
     $this->wp = $this->make(WPFunctions::class, [
       'currentTime' => $timestamp,
     ]);
-
-    $newTimestampListener = new TimestampListener($this->wp);
+    $this->timestampListener = new TimestampListener($this->wp);
     $originalListener = $this->diContainer->get(TimestampListener::class);
-    $this->replaceListeners($originalListener, $newTimestampListener);
+    $this->replaceListeners($originalListener, $this->timestampListener);
 
     $this->tableName = $this->entityManager->getClassMetadata(TimestampEntity::class)->getTableName();
     $this->connection->executeStatement("DROP TABLE IF EXISTS $this->tableName");
@@ -95,6 +97,8 @@ class TimestampListenerTest extends EventListenersBaseTest {
 
   public function _after() {
     parent::_after();
+    $originalListener = $this->diContainer->get(TimestampListener::class);
+    $this->replaceListeners($this->timestampListener, $originalListener);
     $this->connection->executeStatement("DROP TABLE IF EXISTS $this->tableName");
   }
 }


### PR DESCRIPTION
The problem was that the listener was replaced in the EntityManager only
in the first test case. For other test cases, replaceListeners didn't replace
anything because the original listener was not set.
[MAILPOET-3983]

[MAILPOET-3983]: https://mailpoet.atlassian.net/browse/MAILPOET-3983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ