### PR TITLE
Allow multiple values in "opened" segment [MAILPOET-3950]

### DIFF
--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
@@ -38,7 +38,11 @@ export function validateEmail(formItems: EmailFormItem): boolean {
     (formItems.action !== EmailActionTypes.OPENS_ABSOLUTE_COUNT)
     && (formItems.action !== EmailActionTypes.MACHINE_OPENS_ABSOLUTE_COUNT)
   ) {
-    return !!formItems.newsletter_id;
+    return (!!formItems.newsletter_id) // old segments this can be removed after MAILPOET-3951
+      || (
+        Array.isArray(formItems.newsletters)
+        && formItems.newsletters.length > 0
+      );
   }
 
   return (

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
@@ -16,7 +16,6 @@ export const EmailSegmentOptions = [
   { value: EmailActionTypes.MACHINE_OPENS_ABSOLUTE_COUNT, label: MailPoet.I18n.t('emailActionMachineOpensAbsoluteCount'), group: SegmentTypes.Email },
   { value: EmailActionTypes.OPENED, label: MailPoet.I18n.t('emailActionOpened'), group: SegmentTypes.Email },
   { value: EmailActionTypes.MACHINE_OPENED, label: MailPoet.I18n.t('emailActionMachineOpened'), group: SegmentTypes.Email },
-  { value: EmailActionTypes.NOT_OPENED, label: MailPoet.I18n.t('emailActionNotOpened'), group: SegmentTypes.Email },
   { value: EmailActionTypes.CLICKED, label: MailPoet.I18n.t('emailActionClicked'), group: SegmentTypes.Email },
   { value: EmailActionTypes.CLICKED_ANY, label: MailPoet.I18n.t('emailActionClickedAnyEmail'), group: SegmentTypes.Email },
   { value: EmailActionTypes.NOT_CLICKED, label: MailPoet.I18n.t('emailActionNotClicked'), group: SegmentTypes.Email },
@@ -59,7 +58,6 @@ const componentsMap = {
   [EmailActionTypes.NOT_CLICKED]: EmailStatisticsFields,
   [EmailActionTypes.OPENED]: EmailStatisticsFields,
   [EmailActionTypes.MACHINE_OPENED]: EmailStatisticsFields,
-  [EmailActionTypes.NOT_OPENED]: EmailStatisticsFields,
   [EmailActionTypes.CLICKED_ANY]: null,
 };
 

--- a/assets/js/src/segments/dynamic/privacy_protection_notice.tsx
+++ b/assets/js/src/segments/dynamic/privacy_protection_notice.tsx
@@ -15,7 +15,6 @@ const PrivacyProtectionNotice: React.FunctionComponent = () => {
     EmailActionTypes.OPENS_ABSOLUTE_COUNT,
     EmailActionTypes.MACHINE_OPENED,
     EmailActionTypes.MACHINE_OPENS_ABSOLUTE_COUNT,
-    EmailActionTypes.NOT_OPENED,
   ];
 
   let containsOpensFilter = false;

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -11,7 +11,6 @@ export enum EmailActionTypes {
   MACHINE_OPENS_ABSOLUTE_COUNT = 'machineOpensAbsoluteCount',
   OPENED = 'opened',
   MACHINE_OPENED = 'machineOpened',
-  NOT_OPENED = 'notOpened',
   CLICKED = 'clicked',
   CLICKED_ANY = 'clickedAny',
   NOT_CLICKED = 'notClicked',

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -90,6 +90,7 @@ export interface WooCommerceSubscriptionFormItem extends FormItem {
 
 export interface EmailFormItem extends FormItem {
   newsletter_id?: string;
+  newsletters: number[]
   link_id?: string;
   operator?: string;
   opens?: string;

--- a/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
+++ b/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\SegmentDependencyValidator;
@@ -54,6 +55,11 @@ class DynamicSegmentsResponseBuilder {
       if (isset($filter['wordpressRole']) && !is_array($filter['wordpressRole'])) {
         // new filters are always array, they support multiple values, the old didn't convert old filters to new format
         $filter['wordpressRole'] = [$filter['wordpressRole']];
+      }
+      if (($filter['segmentType'] === DynamicSegmentFilterData::TYPE_EMAIL) && isset($filter['newsletter_id']) && !isset($filter['newsletters'])) {
+        // compatibility with older filters
+        $filter['newsletters'] = [intval($filter['newsletter_id'])];
+        unset($filter['newsletter_id']);
       }
       $filters[] = $filter;
     }

--- a/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
+++ b/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
@@ -5,6 +5,7 @@ namespace MailPoet\API\JSON\ResponseBuilders;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
 use MailPoet\Segments\SegmentDependencyValidator;
 use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Subscribers\SubscribersCountsController;
@@ -56,10 +57,18 @@ class DynamicSegmentsResponseBuilder {
         // new filters are always array, they support multiple values, the old didn't convert old filters to new format
         $filter['wordpressRole'] = [$filter['wordpressRole']];
       }
-      if (($filter['segmentType'] === DynamicSegmentFilterData::TYPE_EMAIL) && isset($filter['newsletter_id']) && !isset($filter['newsletters'])) {
+      if (($filter['segmentType'] === DynamicSegmentFilterData::TYPE_EMAIL)) {
         // compatibility with older filters
-        $filter['newsletters'] = [intval($filter['newsletter_id'])];
-        unset($filter['newsletter_id']);
+        if (isset($filter['newsletter_id']) && !isset($filter['newsletters'])) {
+          // make sure the newsletters are an array
+          $filter['newsletters'] = [intval($filter['newsletter_id'])];
+          unset($filter['newsletter_id']);
+        }
+        if ($filter['action'] === EmailAction::ACTION_NOT_OPENED) {
+          // convert not opened
+          $filter['action'] = EmailAction::ACTION_OPENED;
+          $filter['operator'] = DynamicSegmentFilterData::OPERATOR_NONE;
+        }
       }
       $filters[] = $filter;
     }

--- a/lib/Analytics/Reporter.php
+++ b/lib/Analytics/Reporter.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
+use MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny;
 use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
 use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
@@ -151,7 +152,7 @@ class Reporter {
       'Segment > # of opens' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailOpensAbsoluteCountAction::TYPE),
       'Segment > # of orders' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS),
       'Segment > clicked' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_CLICKED),
-      'Segment > clicked any email' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_CLICKED_ANY),
+      'Segment > clicked any email' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailActionClickAny::TYPE),
       'Segment > not clicked' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_NOT_CLICKED),
       'Segment > not opened' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_NOT_OPENED),
       'Segment > opened' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_OPENED),

--- a/lib/DI/ContainerConfigurator.php
+++ b/lib/DI/ContainerConfigurator.php
@@ -289,6 +289,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailAction::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberScore::class)->setPublic(true);

--- a/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -129,10 +129,13 @@ class FilterDataMapper {
           'connect' => $data['connect'],
         ]);
     }
-    if (empty($data['newsletter_id'])) throw new InvalidFilterException('Missing newsletter id', InvalidFilterException::MISSING_NEWSLETTER_ID);
+    if (empty($data['newsletters']) || !is_array($data['newsletters'])) throw new InvalidFilterException('Missing newsletter', InvalidFilterException::MISSING_NEWSLETTER_ID);
     $filterData = [
-      'newsletter_id' => $data['newsletter_id'],
+      'newsletters' => array_map(function ($segmentId) {
+        return intval($segmentId);
+      }, $data['newsletters']),
       'connect' => $data['connect'],
+      'operator' => $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY,
     ];
     $filterType = DynamicSegmentFilterData::TYPE_EMAIL;
     $action = $data['action'];

--- a/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -5,6 +5,7 @@ namespace MailPoet\Segments\DynamicSegments;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
+use MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny;
 use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
 use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberScore;
@@ -123,7 +124,7 @@ class FilterDataMapper {
     ) {
       return $this->createEmailOpensAbsoluteCount($data);
     }
-    if ($data['action'] === EmailAction::ACTION_CLICKED_ANY) {
+    if ($data['action'] === EmailActionClickAny::TYPE) {
         return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $data['action'], [
           'connect' => $data['connect'],
         ]);

--- a/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/lib/Segments/DynamicSegments/FilterFactory.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
+use MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny;
 use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
 use MailPoet\Segments\DynamicSegments\Filters\Filter;
 use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
@@ -57,13 +58,15 @@ class FilterFactory {
   /** @var MailPoetCustomFields */
   private $mailPoetCustomFields;
 
-  /**
-   * @var SubscriberSegment
-   */
+  /** @var SubscriberSegment */
   private $subscriberSegment;
+
+  /** @var EmailActionClickAny */
+  private $emailActionClickAny;
 
   public function __construct(
     EmailAction $emailAction,
+    EmailActionClickAny $emailActionClickAny,
     UserRole $userRole,
     MailPoetCustomFields $mailPoetCustomFields,
     WooCommerceProduct $wooCommerceProduct,
@@ -90,6 +93,7 @@ class FilterFactory {
     $this->subscriberScore = $subscriberScore;
     $this->mailPoetCustomFields = $mailPoetCustomFields;
     $this->subscriberSegment = $subscriberSegment;
+    $this->emailActionClickAny = $emailActionClickAny;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -127,6 +131,8 @@ class FilterFactory {
     $countActions = [EmailOpensAbsoluteCountAction::TYPE, EmailOpensAbsoluteCountAction::MACHINE_TYPE];
     if (in_array($action, $countActions)) {
       return $this->emailOpensAbsoluteCount;
+    } elseif ($action === EmailActionClickAny::TYPE) {
+      return $this->emailActionClickAny;
     }
     return $this->emailAction;
   }

--- a/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -103,7 +103,7 @@ class EmailAction implements Filter {
         'statssent',
         $statsTable,
         'stats',
-        "statssent.subscriber_id = stats.subscriber_id AND stats.newsletter_id = (:newsletters" . $parameterSuffix . ')'
+        "statssent.subscriber_id = stats.subscriber_id AND stats.newsletter_id IN (:newsletters" . $parameterSuffix . ')'
       )->setParameter('newsletters' . $parameterSuffix, $newsletters, Connection::PARAM_INT_ARRAY);
       $where .= ' AND stats.id IS NULL';
     } elseif ($action === EmailAction::ACTION_OPENED) {

--- a/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
@@ -54,6 +55,7 @@ class EmailAction implements Filter {
     } else {
       $newsletters = $filterData->getParam('newsletters');
     }
+    $operator = $filterData->getParam('operator');
     $linkId = $filterData->getParam('link_id') ? (int)$filterData->getParam('link_id') : null;
     $parameterSuffix = (string)($filter->getId() ?? Security::generateRandomString());
 
@@ -87,6 +89,12 @@ class EmailAction implements Filter {
         'stats',
         "stats.subscriber_id = $subscribersTable.id AND stats.newsletter_id IN (:newsletters" . $parameterSuffix . ')'
       )->setParameter('newsletters' . $parameterSuffix, $newsletters, Connection::PARAM_INT_ARRAY);
+
+      if ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
+        $queryBuilder->groupBy('subscriber_id');
+        $queryBuilder->having('COUNT(1) = ' . count($newsletters));
+      }
+
     } else {
       $queryBuilder = $queryBuilder->innerJoin(
         $subscribersTable,

--- a/lib/Segments/DynamicSegments/Filters/EmailActionClickAny.php
+++ b/lib/Segments/DynamicSegments/Filters/EmailActionClickAny.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class EmailActionClickAny implements Filter {
+  const TYPE = 'clickedAny';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    $this->entityManager = $entityManager;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $newsletterLinksTable = $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName();
+
+    $statsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
+
+    $excludedLinks = [
+      '[link:subscription_unsubscribe_url]',
+      '[link:subscription_instant_unsubscribe_url]',
+      '[link:newsletter_view_in_browser_url]',
+      '[link:subscription_manage_url]',
+    ];
+    $queryBuilder = $queryBuilder->innerJoin(
+      $subscribersTable,
+      $statsTable,
+      'stats',
+      "stats.subscriber_id = $subscribersTable.id"
+    )->innerJoin(
+      'stats',
+      $newsletterLinksTable,
+      'newsletterLinks',
+      "stats.link_id = newsletterLinks.id AND newsletterLinks.URL NOT IN ('" . join("', '", $excludedLinks) . "')"
+    );
+
+    return $queryBuilder;
+  }
+}

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsNewsletterEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\UserAgentEntity;
+use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+
+class EmailActionClickAnyTest extends \MailPoetTest {
+  /** @var EmailActionClickAny */
+  private $emailAction;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+  public $subscriberOpenedNotClicked;
+  public $subscriberNotSent;
+  public $subscriberNotOpened;
+  public $subscriberOpenedClicked;
+
+  public function _before() {
+    $this->cleanData();
+    $this->emailAction = $this->diContainer->get(EmailActionClickAny::class);
+    $this->newsletter = new NewsletterEntity();
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->persist($task);
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($this->newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $this->newsletter->getQueues()->add($queue);
+    $this->newsletter->setSubject('newsletter 1');
+    $this->newsletter->setStatus('sent');
+    $this->newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $this->entityManager->persist($this->newsletter);
+    $this->entityManager->flush();
+
+    $this->subscriberOpenedClicked = $this->createSubscriber('opened_clicked@example.com');
+    $this->subscriberOpenedNotClicked = $this->createSubscriber('opened_not_clicked@example.com');
+    $this->subscriberNotOpened = $this->createSubscriber('not_opened@example.com');
+    $this->subscriberNotSent = $this->createSubscriber('not_sent@example.com');
+
+    $this->createStatsNewsletter($this->subscriberOpenedClicked);
+    $this->createStatsNewsletter($this->subscriberOpenedNotClicked);
+    $this->createStatsNewsletter($this->subscriberNotOpened);
+
+    $this->createStatisticsOpens($this->subscriberOpenedClicked);
+    $this->createStatisticsOpens($this->subscriberOpenedNotClicked);
+
+    $this->addClickedToLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
+  }
+
+  public function testGetClickedAnyLink() {
+    $subscriberClickedExcludedLinks = $this->createSubscriber('opened_clicked_excluded@example.com');
+    $this->createStatsNewsletter($subscriberClickedExcludedLinks);
+    $this->createStatisticsOpens($subscriberClickedExcludedLinks);
+    $this->addClickedToLink('[link:subscription_unsubscribe_url]', $this->newsletter, $subscriberClickedExcludedLinks);
+    $this->addClickedToLink('[link:subscription_instant_unsubscribe_url]', $this->newsletter, $subscriberClickedExcludedLinks);
+    $this->addClickedToLink('[link:newsletter_view_in_browser_url]', $this->newsletter, $subscriberClickedExcludedLinks);
+    $this->addClickedToLink('[link:subscription_manage_url]', $this->newsletter, $subscriberClickedExcludedLinks);
+
+    $segmentFilter = $this->getSegmentFilter(EmailActionClickAny::TYPE);
+    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+    expect(count($result))->equals(1);
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
+  }
+
+  private function getQueryBuilder() {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select("$subscribersTable.id")
+      ->from($subscribersTable);
+  }
+
+  private function getSegmentFilter(string $action, int $newsletterId = null, int $linkId = null): DynamicSegmentFilterEntity {
+    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
+      'newsletter_id' => $newsletterId,
+      'link_id' => $linkId,
+    ]);
+    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
+    $this->entityManager->persist($segment);
+    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
+    $this->entityManager->persist($dynamicSegmentFilter);
+    $segment->addDynamicFilter($dynamicSegmentFilter);
+    return $dynamicSegmentFilter;
+  }
+
+  private function createSubscriber(string $email) {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail($email);
+    $subscriber->setLastName('Last');
+    $subscriber->setFirstName('First');
+    $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->entityManager->persist($subscriber);
+    $this->entityManager->flush();
+    return $subscriber;
+  }
+
+  private function createStatsNewsletter(SubscriberEntity $subscriber) {
+    $queue = $this->newsletter->getLatestQueue();
+    assert($queue instanceof SendingQueueEntity);
+    $stats = new StatisticsNewsletterEntity($this->newsletter, $queue, $subscriber);
+    $this->entityManager->persist($stats);
+    $this->entityManager->flush();
+    return $stats;
+  }
+
+  private function createStatisticsOpens(SubscriberEntity $subscriber) {
+    $queue = $this->newsletter->getLatestQueue();
+    assert($queue instanceof SendingQueueEntity);
+    $open = new StatisticsOpenEntity($this->newsletter, $queue, $subscriber);
+    $this->entityManager->persist($open);
+    $this->entityManager->flush();
+    return $open;
+  }
+
+  private function addClickedToLink(string $link, NewsletterEntity $newsletter, SubscriberEntity $subscriber) {
+    $queue = $newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $link = new NewsletterLinkEntity($this->newsletter, $queue, $link, uniqid());
+    $this->entityManager->persist($link);
+    $this->entityManager->flush();
+    $click = new StatisticsClickEntity(
+      $newsletter,
+      $queue,
+      $subscriber,
+      $link,
+      1
+    );
+    $this->entityManager->persist($click);
+    $this->entityManager->flush();
+  }
+
+  public function _after() {
+    $this->cleanData();
+  }
+
+  private function cleanData() {
+    $this->truncateEntity(NewsletterEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(StatisticsOpenEntity::class);
+    $this->truncateEntity(StatisticsClickEntity::class);
+    $this->truncateEntity(StatisticsNewsletterEntity::class);
+    $this->truncateEntity(NewsletterLinkEntity::class);
+    $this->truncateEntity(UserAgentEntity::class);
+  }
+}

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -173,6 +173,23 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_not_clicked4@example.com');
   }
 
+  public function testGetOpenedOperatorNone() {
+    $segmentFilter = $this->getSegmentFilter(
+      EmailAction::ACTION_OPENED,
+      [
+        'newsletters' => [(int)$this->newsletter->getId()],
+        'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
+      ]
+    );
+    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+    expect(count($result))->equals(1);
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    expect($subscriber1->getEmail())->equals('not_opened@example.com');
+  }
+
   public function testGetClickedWithoutLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -97,7 +97,9 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetOpened() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, (int)$this->newsletter->getId());
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -111,7 +113,9 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testNotOpened() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_OPENED, (int)$this->newsletter->getId());
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_OPENED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -122,7 +126,9 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetClickedWithoutLink() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, (int)$this->newsletter->getId());
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -133,7 +139,10 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetClickedWithLink() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, (int)$this->newsletter->getId(), 1);
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+      'link_id' => 1,
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -144,7 +153,10 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetClickedWrongLink() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, (int)$this->newsletter->getId(), 2);
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+      'link_id' => 2,
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -152,7 +164,10 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetNotClickedWithLink() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId(), 1);
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+      'link_id' => 1,
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -166,7 +181,10 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetNotClickedWithWrongLink() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId(), 2);
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+      'link_id' => 2,
+    ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -183,7 +201,7 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetNotClickedWithoutLink() {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId());
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, ['newsletter_id' => (int)$this->newsletter->getId()]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
@@ -206,7 +224,7 @@ class EmailActionTest extends \MailPoetTest {
     $open->setUserAgent($userAgent);
     $this->entityManager->flush();
 
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, (int)$this->newsletter->getId());
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, ['newsletter_id' => (int)$this->newsletter->getId()]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->rowCount();
@@ -223,7 +241,7 @@ class EmailActionTest extends \MailPoetTest {
     $open->setUserAgent($userAgent);
     $this->entityManager->flush();
 
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_MACHINE_OPENED, (int)$this->newsletter->getId());
+    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_MACHINE_OPENED, ['newsletter_id' => (int)$this->newsletter->getId()]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->rowCount();
@@ -239,21 +257,7 @@ class EmailActionTest extends \MailPoetTest {
       ->from($subscribersTable);
   }
 
-  /**
-   * @param string $action
-   * @param int|int[] $newsletterId
-   * @param int|null $linkId
-   * @param string|null $operator
-   * @return DynamicSegmentFilterEntity
-   */
-  private function getSegmentFilter(string $action, $newsletterId = null, int $linkId = null, string $operator = null): DynamicSegmentFilterEntity {
-    $data = [
-      'newsletter_id' => $newsletterId,
-      'link_id' => $linkId,
-    ];
-    if ($operator) {
-      $data['operator'] = $operator;
-    }
+  private function getSegmentFilter(string $action, array $data): DynamicSegmentFilterEntity {
     $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, $data);
     $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
     $this->entityManager->persist($segment);

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -156,6 +156,23 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber4->getEmail())->equals('opened_not_clicked4@example.com');
   }
 
+  public function testGetOpenedOperatorAll() {
+    $segmentFilter = $this->getSegmentFilter(
+      EmailAction::ACTION_OPENED,
+      [
+        'newsletters' => [(int)$this->newsletter2->getId(), (int)$this->newsletter3->getId()],
+        'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
+      ]
+    );
+    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+    expect(count($result))->equals(1);
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    expect($subscriber1->getEmail())->equals('opened_not_clicked4@example.com');
+  }
+
   public function testGetClickedWithoutLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -99,13 +99,13 @@ class EmailActionTest extends \MailPoetTest {
   public function testGetOpened() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, (int)$this->newsletter->getId());
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(2);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    assert($subscriber2 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
     expect($subscriber2->getEmail())->equals('opened_not_clicked@example.com');
   }
@@ -113,40 +113,40 @@ class EmailActionTest extends \MailPoetTest {
   public function testNotOpened() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_OPENED, (int)$this->newsletter->getId());
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(1);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     expect($subscriber1->getEmail())->equals('not_opened@example.com');
   }
 
   public function testGetClickedWithoutLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, (int)$this->newsletter->getId());
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(1);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
   public function testGetClickedWithLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, (int)$this->newsletter->getId(), 1);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(1);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
   public function testGetClickedWrongLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, (int)$this->newsletter->getId(), 2);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(0);
   }
@@ -154,13 +154,13 @@ class EmailActionTest extends \MailPoetTest {
   public function testGetNotClickedWithLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId(), 1);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(2);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    assert($subscriber2 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     expect($subscriber1->getEmail())->equals('opened_not_clicked@example.com');
     expect($subscriber2->getEmail())->equals('not_opened@example.com');
   }
@@ -168,15 +168,15 @@ class EmailActionTest extends \MailPoetTest {
   public function testGetNotClickedWithWrongLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId(), 2);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(3);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    assert($subscriber2 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    assert($subscriber3 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
     expect($subscriber2->getEmail())->equals('opened_not_clicked@example.com');
     expect($subscriber3->getEmail())->equals('not_opened@example.com');
@@ -185,13 +185,13 @@ class EmailActionTest extends \MailPoetTest {
   public function testGetNotClickedWithoutLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId());
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
     expect(count($result))->equals(2);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    assert($subscriber1 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    assert($subscriber2 instanceof SubscriberEntity);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     expect($subscriber1->getEmail())->equals('opened_not_clicked@example.com');
     expect($subscriber2->getEmail())->equals('not_opened@example.com');
   }
@@ -208,7 +208,7 @@ class EmailActionTest extends \MailPoetTest {
 
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, (int)$this->newsletter->getId());
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->rowCount();
     expect($result)->equals(2);
   }
@@ -225,7 +225,7 @@ class EmailActionTest extends \MailPoetTest {
 
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_MACHINE_OPENED, (int)$this->newsletter->getId());
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    assert($statement instanceof Statement);
+    $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->rowCount();
     expect($result)->equals(1);
   }
@@ -276,7 +276,7 @@ class EmailActionTest extends \MailPoetTest {
 
   private function createStatsNewsletter(SubscriberEntity $subscriber, NewsletterEntity $newsletter) {
     $queue = $this->newsletter->getLatestQueue();
-    assert($queue instanceof SendingQueueEntity);
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $stats = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
     $this->entityManager->persist($stats);
     $this->entityManager->flush();
@@ -285,7 +285,7 @@ class EmailActionTest extends \MailPoetTest {
 
   private function createStatisticsOpens(SubscriberEntity $subscriber, NewsletterEntity $newsletter) {
     $queue = $newsletter->getLatestQueue();
-    assert($queue instanceof SendingQueueEntity);
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $open = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
     $this->entityManager->persist($open);
     $this->entityManager->flush();

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -128,25 +128,6 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('not_opened@example.com');
   }
 
-  public function testGetClickedAnyLink() {
-    $subscriberClickedExcludedLinks = $this->createSubscriber('opened_clicked_excluded@example.com');
-    $this->createStatsNewsletter($subscriberClickedExcludedLinks);
-    $this->createStatisticsOpens($subscriberClickedExcludedLinks);
-    $this->addClickedToLink('[link:subscription_unsubscribe_url]', $this->newsletter, $subscriberClickedExcludedLinks);
-    $this->addClickedToLink('[link:subscription_instant_unsubscribe_url]', $this->newsletter, $subscriberClickedExcludedLinks);
-    $this->addClickedToLink('[link:newsletter_view_in_browser_url]', $this->newsletter, $subscriberClickedExcludedLinks);
-    $this->addClickedToLink('[link:subscription_manage_url]', $this->newsletter, $subscriberClickedExcludedLinks);
-
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED_ANY);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
-  }
-
   public function testGetNotClickedWithWrongLink() {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_NOT_CLICKED, (int)$this->newsletter->getId(), 2);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();

--- a/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Segments\DynamicSegments;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
+use MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny;
 use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
@@ -47,7 +48,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $data = ['filters' => [[
         'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
         'action' => EmailAction::ACTION_OPENED,
-        'newsletter_id' => 1,
+        'newsletters' => [1],
       ]],
       'some_mess' => 'mess',
     ];
@@ -60,7 +61,8 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_EMAIL);
     expect($filter->getAction())->equals(EmailAction::ACTION_OPENED);
     expect($filter->getData())->equals([
-      'newsletter_id' => 1,
+      'newsletters' => [1],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }
@@ -71,13 +73,13 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
-      'newsletter_id' => 1,
+      'newsletters' => [1],
     ]]]);
   }
 
   public function testItChecksFilterEmailNewsletter() {
     $this->expectException(InvalidFilterException::class);
-    $this->expectExceptionMessage('Missing newsletter id');
+    $this->expectExceptionMessage('Missing newsletter');
     $this->expectExceptionCode(InvalidFilterException::MISSING_NEWSLETTER_ID);
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
@@ -256,7 +258,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
   public function testItMapsLinkClicksAny() {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
-      'action' => EmailAction::ACTION_CLICKED_ANY,
+      'action' => EmailActionClickAny::TYPE,
       'uselessParam' => 1,
     ]]];
     $filters = $this->mapper->map($data);
@@ -266,7 +268,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     assert($filter instanceof DynamicSegmentFilterData);
     expect($filter)->isInstanceOf(DynamicSegmentFilterData::class);
     expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_EMAIL);
-    expect($filter->getAction())->equals(EmailAction::ACTION_CLICKED_ANY);
+    expect($filter->getAction())->equals(EmailActionClickAny::TYPE);
     expect($filter->getData())->equals([
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);

--- a/views/segments.html
+++ b/views/segments.html
@@ -137,7 +137,7 @@
     'pageOutOf': _x('of', 'Page X of Y'),
     'notSentYet': __('Not sent yet'),
     'selectLinkPlaceholder': __('Select link'),
-    'selectNewsletterPlaceholder': __('Select email'),
+    'selectNewsletterPlaceholder': __('Search emails'),
     'selectActionPlaceholder': __('Select action'),
     'selectUserRolePlaceholder': __('Search user roles'),
     'selectCustomFieldPlaceholder': __('Select custom field'),


### PR DESCRIPTION
There is a lot of code shared with the "clicked" segment. But that is in a different [ticket](https://mailpoet.atlassian.net/browse/MAILPOET-3951). So I left some code in which will be deleted/refactored in an upcoming ticket.

[MAILPOET-3950]

[MAILPOET-3950]: https://mailpoet.atlassian.net/browse/MAILPOET-3950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to WP Admin > MailPoet > Lists
2. Click to Add New Segment
3. Select `opened` segment type
4. Compare results from your testing with the specification from Jira ticket above (MAILPOET-3950)
5. Verify you see all the new improvements and that creating such segmentation works