### PR TITLE
Feat/deactivate automatic emails on edit - MAILPOET-3960

### DIFF
--- a/assets/js/src/newsletter_editor/initializer.jsx
+++ b/assets/js/src/newsletter_editor/initializer.jsx
@@ -74,6 +74,25 @@ const initializeEditor = (config) => {
               );
             }
           });
+      } else if (newsletter.type === 'automatic' && newsletter.status === 'active') {
+        MailPoet.Ajax.post({
+          api_version: window.mailpoet_api_version,
+          endpoint: 'newsletters',
+          action: 'setStatus',
+          data: {
+            id: newsletter.id,
+            status: 'draft',
+          },
+        }).done((setStatusResponse) => {
+          if (setStatusResponse.data.status === 'draft') {
+            MailPoet.Notice.success(MailPoet.I18n.t('emailWasDeactivated'));
+          }
+        }).fail((pauseFailResponse) => {
+          MailPoet.Notice.error(
+            pauseFailResponse.errors.map((error) => error.message),
+            { scroll: true, static: true }
+          );
+        });
       }
     })
     .fail((response) => {

--- a/assets/js/src/newsletter_editor/initializer.jsx
+++ b/assets/js/src/newsletter_editor/initializer.jsx
@@ -3,6 +3,7 @@ import MailPoet from 'mailpoet';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ListingHeadingSteps from 'newsletters/listings/heading_steps';
+import { newsletterTypesWithActivation } from 'newsletters/listings/utils';
 import fetchAutomaticEmailShortcodes from 'newsletters/automatic_emails/fetch_editor_shortcodes.jsx';
 import displayTutorial from './tutorial.jsx';
 
@@ -74,7 +75,7 @@ const initializeEditor = (config) => {
               );
             }
           });
-      } else if (newsletter.type === 'automatic' && newsletter.status === 'active') {
+      } else if (newsletterTypesWithActivation.includes(newsletter.type) && newsletter.status === 'active') {
         MailPoet.Ajax.post({
           api_version: window.mailpoet_api_version,
           endpoint: 'newsletters',

--- a/assets/js/src/newsletters/automatic_emails/listings.jsx
+++ b/assets/js/src/newsletters/automatic_emails/listings.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactStringReplace from 'react-string-replace';
 
 import Listing from 'listing/listing.jsx';
+import confirmAlert from 'common/confirm_alert.jsx';
 import Tags from 'common/tag/tags';
 import Toggle from 'common/form/toggle/toggle';
 import { ScheduledIcon } from 'common/listings/newsletter_status';
@@ -100,6 +101,21 @@ const bulkActions = [
   },
 ];
 
+const confirmEdit = (newsletter) => {
+  const redirectToEditing = () => {
+    window.location.href = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
+  };
+
+  if (newsletter.type === 'automatic' && newsletter.status === 'active') {
+    confirmAlert({
+      message: MailPoet.I18n.t('confirmAutomaticNewsletterEdit'),
+      onConfirm: redirectToEditing,
+    });
+  } else {
+    redirectToEditing();
+  }
+};
+
 let newsletterActions = [
   {
     name: 'view',
@@ -114,13 +130,8 @@ let newsletterActions = [
   {
     name: 'edit',
     className: 'mailpoet-hide-on-mobile',
-    link: function link(newsletter) {
-      return (
-        <a href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}>
-          {MailPoet.I18n.t('edit')}
-        </a>
-      );
-    },
+    label: MailPoet.I18n.t('edit'),
+    onClick: confirmEdit,
   },
   {
     name: 'duplicate',

--- a/assets/js/src/newsletters/automatic_emails/listings.jsx
+++ b/assets/js/src/newsletters/automatic_emails/listings.jsx
@@ -2,11 +2,10 @@ import React from 'react';
 import ReactStringReplace from 'react-string-replace';
 
 import Listing from 'listing/listing.jsx';
-import confirmAlert from 'common/confirm_alert.jsx';
 import Tags from 'common/tag/tags';
 import Toggle from 'common/form/toggle/toggle';
 import { ScheduledIcon } from 'common/listings/newsletter_status';
-import { checkMailerStatus, addStatsCTAAction } from 'newsletters/listings/utils.jsx';
+import { checkMailerStatus, addStatsCTAAction, confirmEdit } from 'newsletters/listings/utils.jsx';
 import Statistics from 'newsletters/listings/statistics.jsx';
 import NewsletterTypes from 'newsletters/types';
 import classNames from 'classnames';
@@ -100,21 +99,6 @@ const bulkActions = [
     onSuccess: messages.onTrash,
   },
 ];
-
-const confirmEdit = (newsletter) => {
-  const redirectToEditing = () => {
-    window.location.href = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  };
-
-  if (newsletter.type === 'automatic' && newsletter.status === 'active') {
-    confirmAlert({
-      message: MailPoet.I18n.t('confirmAutomaticNewsletterEdit'),
-      onConfirm: redirectToEditing,
-    });
-  } else {
-    redirectToEditing();
-  }
-};
 
 let newsletterActions = [
   {

--- a/assets/js/src/newsletters/listings/notification.jsx
+++ b/assets/js/src/newsletters/listings/notification.jsx
@@ -12,6 +12,7 @@ import Listing from 'listing/listing.jsx';
 import {
   checkCronStatus,
   checkMailerStatus,
+  confirmEdit,
 } from 'newsletters/listings/utils.jsx';
 import NewsletterTypes from 'newsletters/types';
 
@@ -123,13 +124,8 @@ const newsletterActions = [
   {
     name: 'edit',
     className: 'mailpoet-hide-on-mobile',
-    link: function link(newsletter) {
-      return (
-        <a href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}>
-          {MailPoet.I18n.t('edit')}
-        </a>
-      );
-    },
+    label: MailPoet.I18n.t('edit'),
+    onClick: confirmEdit,
   },
   {
     name: 'duplicate',

--- a/assets/js/src/newsletters/listings/re_engagement.jsx
+++ b/assets/js/src/newsletters/listings/re_engagement.jsx
@@ -14,6 +14,7 @@ import {
   addStatsCTAAction,
   checkCronStatus,
   checkMailerStatus,
+  confirmEdit,
 } from 'newsletters/listings/utils.jsx';
 import NewsletterTypes from 'newsletters/types';
 
@@ -140,13 +141,8 @@ let newsletterActions = [
   {
     name: 'edit',
     className: 'mailpoet-hide-on-mobile',
-    link: function link(newsletter) {
-      return (
-        <a href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}>
-          {MailPoet.I18n.t('edit')}
-        </a>
-      );
-    },
+    label: MailPoet.I18n.t('edit'),
+    onClick: confirmEdit,
   },
   {
     name: 'trash',

--- a/assets/js/src/newsletters/listings/utils.jsx
+++ b/assets/js/src/newsletters/listings/utils.jsx
@@ -5,6 +5,7 @@ import ReactStringReplace from 'react-string-replace';
 import Hooks from 'wp-js-hooks';
 import MailPoet from 'mailpoet';
 import jQuery from 'jquery';
+import confirmAlert from 'common/confirm_alert.jsx';
 
 export const trackStatsCTAClicked = () => {
   MailPoet.trackEvent('User has clicked a CTA to view detailed stats');
@@ -80,4 +81,21 @@ export const checkCronStatus = (state) => {
     ),
     jQuery('[data-id="mailpoet_cron_error"]')[0]
   );
+};
+
+export const newsletterTypesWithActivation = ['automatic', 'welcome', 'notification', 're_engagement'];
+
+export const confirmEdit = (newsletter) => {
+  const redirectToEditing = () => {
+    window.location.href = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
+  };
+
+  if (newsletterTypesWithActivation.includes(newsletter.type) && newsletter.status === 'active') {
+    confirmAlert({
+      message: MailPoet.I18n.t('confirmAutomaticNewsletterEdit'),
+      onConfirm: redirectToEditing,
+    });
+  } else {
+    redirectToEditing();
+  }
 };

--- a/assets/js/src/newsletters/listings/welcome.jsx
+++ b/assets/js/src/newsletters/listings/welcome.jsx
@@ -12,6 +12,7 @@ import {
   addStatsCTAAction,
   checkCronStatus,
   checkMailerStatus,
+  confirmEdit,
 } from 'newsletters/listings/utils.jsx';
 import NewsletterTypes from 'newsletters/types';
 
@@ -144,13 +145,8 @@ let newsletterActions = [
   {
     name: 'edit',
     className: 'mailpoet-hide-on-mobile',
-    link: function link(newsletter) {
-      return (
-        <a href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}>
-          {MailPoet.I18n.t('edit')}
-        </a>
-      );
-    },
+    label: MailPoet.I18n.t('edit'),
+    onClick: confirmEdit,
   },
   {
     name: 'trash',

--- a/views/newsletter/editor.html
+++ b/views/newsletter/editor.html
@@ -407,6 +407,7 @@
     'selectColor': _x('Select', 'select color'),
     'cancelColorSelection': _x('Cancel', 'cancel color selection'),
     'newsletterIsPaused': __('Email sending has been paused.'),
+    'emailWasDeactivated': __('This email was deactivated.'),
     'tutorialVideoTitle': __('Before you start, this is how you drag and drop in MailPoet'),
     'selectType': __('Select type'),
     'events': __('Events'),

--- a/views/newsletters.html
+++ b/views/newsletters.html
@@ -354,6 +354,7 @@
     'confirmTitle': __('Confirm to proceed'),
     'confirmLabel': __('Confirm'),
     'cancelLabel': __('Cancel'),
+    'confirmAutomaticNewsletterEdit': __('To edit this email, it needs to be deactivated. You can activate it again after you make the changes.'),
 
     'recentlySent': __('Recently sent'),
     'savedTemplates': __('Your saved templates'),


### PR DESCRIPTION
[MAILPOET-3960](https://mailpoet.atlassian.net/browse/MAILPOET-3960)

Testing instructions:
1. Go to WP Admin > MailPoet > Emails
2. Click to Add New Newsletter
3. Select First Purchase for example
4. Proceed further and activate it at the end (feel free to chose any data, options etc)
5. Once activated, from that point, hover over it and click Edit link
6. Check the specification in Jira ticket above (MAILPOET-3960) and verify you see proper dialog with text etc)