### PR TITLE
Fix segment with multiple purchased product conditions with all of [MAILPOET-4010]

### DIFF
--- a/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -43,8 +43,8 @@ class WooCommerceProduct implements Filter {
       $this->applyOrderItemmetaJoin($queryBuilder);
       $queryBuilder->where("itemmeta.meta_value IN (:products_{$parameterSuffix})")
         ->groupBy("{$subscribersTable}.id, items.order_id")
-        ->having('COUNT(items.order_id) = :count')
-        ->setParameter('count', count($productIds));
+        ->having('COUNT(items.order_id) = :count' . $parameterSuffix)
+        ->setParameter('count' . $parameterSuffix, count($productIds));
 
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
       $this->applyPostmetaJoin($queryBuilder);


### PR DESCRIPTION
The non-unique count parameter name was causing that when more conditions
used "all of" operands the count parameter was overrode in the final combined query.
[MAILPOET-4010]

[MAILPOET-4010]: https://mailpoet.atlassian.net/browse/MAILPOET-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Lists
2. Click to add New Segment
3. Select `purchased product` as the segment type
4. Select All of from the second dropdown
5. and Select `1 month subscription` product from the third dropdown
6. You should see 1 subscriber as the result of the calculation
7. Click to add new additional segment by clicking `Add a condition` link
8. Select again `purchased product` type and then `All of` and then select a few products except `1 month subscription`
9. Make sure you see 0 subscribers now as the result of the calculation
10. Set some title for the segment and save it
11. Click to `Recalculate now` button to refresh the results of the calculations
12. Make sure your segment contains `0 subscribers`
13. Click on `View Subscribers` of your segment
14. Make sure you don't see any subscribers on the list