### PR TITLE
Fix "# number of machine opens" segment [MAILPOET-4011]

### DIFF
--- a/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/lib/Segments/DynamicSegments/FilterFactory.php
@@ -124,7 +124,8 @@ class FilterFactory {
   }
 
   private function email($action) {
-    if ($action === EmailOpensAbsoluteCountAction::TYPE) {
+    $countActions = [EmailOpensAbsoluteCountAction::TYPE, EmailOpensAbsoluteCountAction::MACHINE_TYPE];
+    if (in_array($action, $countActions)) {
       return $this->emailOpensAbsoluteCount;
     }
     return $this->emailAction;


### PR DESCRIPTION
There was a bug that was making the code use the wrong filter and thus the wrong SQL query for the "# number of machine opens" segment. Resulting in the wrong subscribers being associated with this segment.

The email() method of the FilterFactory was using the wrong check to decide which filter to use for this segment (the filter should be EmailOpensAbsoluteCountAction and the factory was using EmailAction).

[MAILPOET-4011]

[MAILPOET-4011]: https://mailpoet.atlassian.net/browse/MAILPOET-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ