### PR TITLE
Add more comparison options for WooCommerce segments [MAILPOET-4007]

### DIFF
--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -209,7 +209,8 @@ export const WooCommerceFields: React.FunctionComponent<Props> = ({ filterIndex 
             }}
             automationId="select-number-of-orders-type"
           >
-            <option value="=">{MailPoet.I18n.t('equal')}</option>
+            <option value="=">{MailPoet.I18n.t('equals')}</option>
+            <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
             <option value=">">{MailPoet.I18n.t('moreThan')}</option>
             <option value="<">{MailPoet.I18n.t('lessThan')}</option>
           </Select>
@@ -253,6 +254,8 @@ export const WooCommerceFields: React.FunctionComponent<Props> = ({ filterIndex 
             }}
             automationId="select-total-spent-type"
           >
+            <option value="=">{MailPoet.I18n.t('equals')}</option>
+            <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
             <option value=">">{MailPoet.I18n.t('moreThan')}</option>
             <option value="<">{MailPoet.I18n.t('lessThan')}</option>
           </Select>

--- a/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -50,6 +50,8 @@ class WooCommerceNumberOfOrders implements Filter {
 
     if ($type === '=') {
       $queryBuilder->having('COUNT(posts.ID) = :count' . $parameterSuffix);
+    } elseif ($type === '!=') {
+      $queryBuilder->having('COUNT(posts.ID) != :count' . $parameterSuffix);
     } elseif ($type === '>') {
       $queryBuilder->having('COUNT(posts.ID) > :count' . $parameterSuffix);
     } elseif ($type === '<') {

--- a/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -53,7 +53,11 @@ class WooCommerceTotalSpent implements Filter {
       'inner_subscriber_id'
     );
 
-    if ($type === '>') {
+    if ($type === '=') {
+      $queryBuilder->having('SUM(order_total.meta_value) = :amount' . $parameterSuffix);
+    } elseif ($type === '!=') {
+      $queryBuilder->having('SUM(order_total.meta_value) != :amount' . $parameterSuffix);
+    } elseif ($type === '>') {
       $queryBuilder->having('SUM(order_total.meta_value) > :amount' . $parameterSuffix);
     } elseif ($type === '<') {
       $queryBuilder->having('SUM(order_total.meta_value) < :amount' . $parameterSuffix);

--- a/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -504,7 +504,7 @@ class ManageSegmentsCest {
     $i->seeInField(['name' => 'name'], $editedTitle);
     $i->seeInField(['name' => 'description'], $editedDesc);
     $i->see('# of orders', $actionSelectElement);
-    $i->see('equal', $numberOfOrdersTypeElement);
+    $i->see('equals', $numberOfOrdersTypeElement);
     $i->seeInField($numberOfOrdersCountElement, '4');
     $i->seeInField($numberOfOrdersDaysElement, '20');
   }

--- a/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -48,7 +48,20 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     $this->assertSame('customer1@example.com', $subscriber1->getEmail());
   }
 
-  public function testItGestCustomersThatPlacedAtLeastOneOrderInTheLastWeek() {
+  public function testItGetsCustomersThatDidNotPlaceTwoOrdersInTheLastWeek() {
+    $segmentFilter = $this->getSegmentFilter('!=', 2, 7);
+    $queryBuilder = $this->numberOfOrders->apply($this->getQueryBuilder(), $segmentFilter);
+    $result = $queryBuilder->execute()->fetchAll();
+    $this->assertSame(2, count($result));
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['inner_subscriber_id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    $this->assertSame('customer1@example.com', $subscriber1->getEmail());
+    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['inner_subscriber_id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
+    $this->assertSame('customer3@example.com', $subscriber2->getEmail());
+  }
+
+  public function testItGetsCustomersThatPlacedAtLeastOneOrderInTheLastWeek() {
     $segmentFilter = $this->getSegmentFilter('>', 0, 7);
     $queryBuilder = $this->numberOfOrders->apply($this->getQueryBuilder(), $segmentFilter);
     $result = $queryBuilder->execute()->fetchAll();

--- a/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -45,6 +45,50 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
     $this->orders[] = $this->createOrder(['user_id' => $userId3, 'order_total' => 25]);
   }
 
+  public function testItGetsCustomersThatSpentFifteenInTheLastDay(): void {
+    $segmentFilter = $this->getSegmentFilter('=', 15, 1);
+    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
+    $statement = $queryBuilder->execute();
+    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
+    expect($result)->count(1);
+    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
+    assert($subscriber1 instanceof SubscriberEntity);
+    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
+    expect($subscriber1->getEmail())->equals('customer2@example.com');
+  }
+
+  public function testItGetsCustomersThatSpentFifteenInTheLastWeek(): void {
+    $segmentFilter = $this->getSegmentFilter('=', 15, 7);
+    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
+    $statement = $queryBuilder->execute();
+    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
+    expect($result)->count(2);
+    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
+    assert($subscriber1 instanceof SubscriberEntity);
+    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
+    expect($subscriber1->getEmail())->equals('customer1@example.com');
+    $subscriber2 = $this->subscribersRepository->findOneById($result[1]['inner_subscriber_id']);
+    assert($subscriber2 instanceof SubscriberEntity);
+    expect($subscriber2)->isInstanceOf(SubscriberEntity::class);
+    expect($subscriber2->getEmail())->equals('customer2@example.com');
+  }
+
+  public function testItGetsCustomersThatDidNotSpendFifteenInTheLastDay(): void {
+    $segmentFilter = $this->getSegmentFilter('!=', 15, 1);
+    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
+    $statement = $queryBuilder->execute();
+    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
+    expect($result)->count(2);
+    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
+    assert($subscriber1 instanceof SubscriberEntity);
+    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
+    expect($subscriber1->getEmail())->equals('customer1@example.com');
+    $subscriber2 = $this->subscribersRepository->findOneById($result[1]['inner_subscriber_id']);
+    assert($subscriber2 instanceof SubscriberEntity);
+    expect($subscriber2)->isInstanceOf(SubscriberEntity::class);
+    expect($subscriber2->getEmail())->equals('customer3@example.com');
+  }
+
   public function testItGetsCustomersThatSpentMoreThanTwentyInTheLastDay(): void {
     $segmentFilter = $this->getSegmentFilter('>', 20, 1);
     $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);

--- a/views/segments.html
+++ b/views/segments.html
@@ -204,7 +204,6 @@
     'oneDynamicSegmentDeleted': __('1 segment was permanently deleted.'),
 
     'wooNumberOfOrders': __('# of orders'),
-    'equal': __('equal'),
     'moreThan': __('more than'),
     'lessThan': __('less than'),
     'wooNumberOfOrdersCount': __('count'),


### PR DESCRIPTION
[MAILPOET-4007]

[MAILPOET-4007]: https://mailpoet.atlassian.net/browse/MAILPOET-4007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Lists > Segments tab
2. Click to add New Segment
3. Select `# of orders` segment type
4. Make sure you see a new option and renamed existing option (check Jira specification on what has been changed)
4. Then select `total spent` segment type
5. Make sure you see new options there (check Jira specification to see what new options were added)
6. Make sure they are calculating properly. If you want to add new data, you will need to buy some items in order to see new data. Also consider creating a new customer user and then purchasing some items, that's another way to add new data to calculations results.