### PR TITLE
Add more comparison options to three different segments [MAILPOET-3614]

### DIFF
--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/email_opens_absolute_count.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/email_opens_absolute_count.tsx
@@ -55,6 +55,8 @@ export const EmailOpensAbsoluteCountFields: React.FunctionComponent<Props> = ({ 
                 >
                   <option value="more">{MailPoet.I18n.t('moreThan')}</option>
                   <option value="less">{MailPoet.I18n.t('lessThan')}</option>
+                  <option value="equals">{MailPoet.I18n.t('equals')}</option>
+                  <option value="not_equals">{MailPoet.I18n.t('notEquals')}</option>
                 </Select>
               );
             }

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -32,6 +32,8 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
   if (
     formItems.operator === SubscribedDateOperator.BEFORE
     || formItems.operator === SubscribedDateOperator.AFTER
+    || formItems.operator === SubscribedDateOperator.ON
+    || formItems.operator === SubscribedDateOperator.NOT_ON
   ) {
     const re = new RegExp(/^\d+-\d+-\d+$/);
     return re.test(formItems.value);

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_subscribed_date.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_subscribed_date.tsx
@@ -15,6 +15,8 @@ import {
 export enum SubscribedDateOperator {
   BEFORE = 'before',
   AFTER = 'after',
+  ON = 'on',
+  NOT_ON = 'notOn',
   IN_THE_LAST = 'inTheLast',
   NOT_IN_THE_LAST = 'notInTheLast',
 }
@@ -22,6 +24,8 @@ export enum SubscribedDateOperator {
 const availableOperators = [
   SubscribedDateOperator.BEFORE,
   SubscribedDateOperator.AFTER,
+  SubscribedDateOperator.ON,
+  SubscribedDateOperator.NOT_ON,
   SubscribedDateOperator.IN_THE_LAST,
   SubscribedDateOperator.NOT_IN_THE_LAST,
 ];
@@ -62,6 +66,8 @@ export const SubscribedDateFields: React.FunctionComponent<Props> = ({ filterInd
       (
         segment.operator === SubscribedDateOperator.BEFORE
         || segment.operator === SubscribedDateOperator.AFTER
+        || segment.operator === SubscribedDateOperator.ON
+        || segment.operator === SubscribedDateOperator.NOT_ON
       )
       && ((parseDate(segment.value) === undefined) || !new RegExp(/^\d+-\d+-\d+$/).test(segment.value))
     ) {
@@ -90,12 +96,16 @@ export const SubscribedDateFields: React.FunctionComponent<Props> = ({ filterInd
         >
           <option value={SubscribedDateOperator.BEFORE}>{MailPoet.I18n.t('before')}</option>
           <option value={SubscribedDateOperator.AFTER}>{MailPoet.I18n.t('after')}</option>
+          <option value={SubscribedDateOperator.ON}>{MailPoet.I18n.t('on')}</option>
+          <option value={SubscribedDateOperator.NOT_ON}>{MailPoet.I18n.t('notOn')}</option>
           <option value={SubscribedDateOperator.IN_THE_LAST}>{MailPoet.I18n.t('inTheLast')}</option>
           <option value={SubscribedDateOperator.NOT_IN_THE_LAST}>{MailPoet.I18n.t('notInTheLast')}</option>
         </Select>
         {(
           segment.operator === SubscribedDateOperator.BEFORE
           || segment.operator === SubscribedDateOperator.AFTER
+          || segment.operator === SubscribedDateOperator.ON
+          || segment.operator === SubscribedDateOperator.NOT_ON
         ) && (
           <Datepicker
             dateFormat="MMMM d, yyyy"

--- a/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
+++ b/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
@@ -40,7 +40,11 @@ class EmailOpensAbsoluteCountAction implements Filter {
     );
     $queryBuilder->setParameter('newer' . $parameterSuffix, CarbonImmutable::now()->subDays($days)->startOfDay());
     $queryBuilder->groupBy("$subscribersTable.id");
-    if ($operator === 'less') {
+    if ($operator === 'equals') {
+      $queryBuilder->having("count(opens.id) = :opens" . $parameterSuffix);
+    } else if ($operator === 'not_equals') {
+      $queryBuilder->having("count(opens.id) != :opens" . $parameterSuffix);
+    } else if ($operator === 'less') {
       $queryBuilder->having("count(opens.id) < :opens" . $parameterSuffix);
     } else {
       $queryBuilder->having("count(opens.id) > :opens" . $parameterSuffix);

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -144,6 +144,37 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('opened-old-opens@example.com');
   }
 
+  public function testGetOpenedEquals() {
+    $segmentFilter = $this->getSegmentFilter(1, 'equals', 3);
+    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
+      ->orderBy('email')
+      ->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+
+    $this->assertCount(1, $result);
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    $this->assertSame('opened-old-opens@example.com', $subscriber1->getEmail());
+  }
+
+  public function testGetOpenedNotEquals() {
+    $segmentFilter = $this->getSegmentFilter(2, 'not_equals', 3);
+    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
+      ->orderBy('email')
+      ->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+
+    $this->assertCount(2, $result);
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    $this->assertSame('opened-3-newsletters@example.com', $subscriber1->getEmail());
+    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
+    $this->assertSame('opened-old-opens@example.com', $subscriber2->getEmail());
+  }
+
   private function getQueryBuilder() {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager

--- a/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -86,6 +86,8 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     $open->setCreatedAt(CarbonImmutable::now()->subDays(1));
     $open->setUserAgentType(UserAgentEntity::USER_AGENT_TYPE_MACHINE);
     $open->setUserAgent($userAgent);
+    $this->entityManager->persist($open);
+    $this->entityManager->flush();
   }
 
   public function testGetOpened() {
@@ -133,16 +135,13 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
       ->execute();
     $this->assertInstanceOf(Statement::class, $statement);
     $result = $statement->fetchAll();
-    expect(count($result))->equals(3);
+    expect(count($result))->equals(2);
     $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
     expect($subscriber1->getEmail())->equals('opened-less-opens@example.com');
     $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber2->getEmail())->equals('opened-no-opens@example.com');
-    $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
-    expect($subscriber3->getEmail())->equals('opened-old-opens@example.com');
+    expect($subscriber2->getEmail())->equals('opened-old-opens@example.com');
   }
 
   private function getQueryBuilder() {

--- a/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -76,6 +76,48 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12@example.com');
   }
 
+  public function testGetOn() {
+    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::ON, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
+      ->orderBy('email')
+      ->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+
+    $this->assertCount(1, $result);
+
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame('e123@example.com', $subscriber->getEmail());
+  }
+
+  public function testGetNotOn() {
+    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::NOT_ON, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
+      ->orderBy('email')
+      ->execute();
+    $this->assertInstanceOf(Statement::class, $statement);
+    $result = $statement->fetchAll();
+
+    $this->assertCount(4, $result);
+
+    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    $this->assertSame('e1@example.com', $subscriber1->getEmail());
+
+    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
+    $this->assertSame('e12@example.com', $subscriber2->getEmail());
+
+    $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
+    $this->assertSame('e1234@example.com', $subscriber3->getEmail());
+
+    $subscriber4 = $this->entityManager->find(SubscriberEntity::class, $result[3]['id']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber4);
+    $this->assertSame('e12345@example.com', $subscriber4->getEmail());
+  }
+
   public function testGetInTheLast() {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::IN_THE_LAST, '2');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)

--- a/views/segments.html
+++ b/views/segments.html
@@ -165,7 +165,7 @@
     'unknown': __('unknown'),
     'notUnknown': __('not unknown'),
 
-    'before': _x('before', 'Meaning: "Subscriber subscribed before Aprile"'),
+    'before': _x('before', 'Meaning: "Subscriber subscribed before April"'),
     'after': _x('after', 'Meaning: "Subscriber subscribed after April'),
     'inTheLast': _x('in the last', 'Meaning: "Subscriber subscribed in the last 3 days"'),
     'notInTheLast': _x('not in the last', 'Meaning: "Subscriber subscribed not in the last 3 days"'),

--- a/views/segments.html
+++ b/views/segments.html
@@ -167,6 +167,8 @@
 
     'before': _x('before', 'Meaning: "Subscriber subscribed before April"'),
     'after': _x('after', 'Meaning: "Subscriber subscribed after April'),
+    'on': _x('on', 'Meaning: "Subscriber subscribed on a given date"'),
+    'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
     'inTheLast': _x('in the last', 'Meaning: "Subscriber subscribed in the last 3 days"'),
     'notInTheLast': _x('not in the last', 'Meaning: "Subscriber subscribed not in the last 3 days"'),
 


### PR DESCRIPTION
Noting that it won't be possible to test the changes to the "# of machine-opens" segment until #3853 is merged. #3853 fixes a bug in this segment that is preventing it from working properly.

[MAILPOET-3614]

[MAILPOET-3614]: https://mailpoet.atlassian.net/browse/MAILPOET-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Lists
2. Click to add New Segment
3. Select appropriate segment from the Jira Specification in order to test the new options
4. Make sure calculation is working along with date selector