### PR TITLE
Add the “Learn more” link when calculating size times out. - MAILPOET-3493

### DIFF
--- a/assets/js/src/segments/dynamic/subscribers_counter.tsx
+++ b/assets/js/src/segments/dynamic/subscribers_counter.tsx
@@ -65,6 +65,16 @@ const SubscribersCounter: React.FunctionComponent = () => {
       <div className="mailpoet-form-field">
         <span className="mailpoet-form-error-message">
           {MailPoet.I18n.t('dynamicSegmentSizeCalculatingTimeout')}
+          {' '}
+          <a
+            href="https://kb.mailpoet.com/article/237-guide-to-subscriber-segmentation?utm_source=plugin&utm_medium=segments"
+            data-beacon-article="5a574bd92c7d3a194368233e"
+            target="_blank"
+            className="mailpoet-form-error-message"
+            rel="noopener noreferrer"
+          >
+            {MailPoet.I18n.t('learnMore')}
+          </a>
         </span>
       </div>
     );

--- a/views/segments.html
+++ b/views/segments.html
@@ -225,6 +225,7 @@
     'dynamicSegmentSizeIsCalculated': __('Calculating segment size…'),
     'dynamicSegmentSizeCalculatingTimeout': __("It's taking longer than usual to generate the segment, which may be due to a complex configuration. Try using fewer or simpler conditions."),
     'dynamicSegmentSize': __('This segment has %1$d subscribers.'),
+    'learnMore': __('Learn more.'),
 
     'unknownBadgeName': __('Unknown'),
     'unknownBadgeTooltip': __('Not enough data.'),


### PR DESCRIPTION
[MAILPOET-3493](https://mailpoet.atlassian.net/browse/MAILPOET-3493)

Testing instructions:
1. Go to WP Admin > MailPoet > Lists
2. Click on Add New Segment button
3. Try to add as much as possible segment variations with AND and AND and AND... until you see message at the bottom saying "Calculating segment size..." taking for more than 15 seconds. Then you'll see this warning that it taking too long to display... If you don't see it but you see calculating segment size.. try adding more segment variations and you'll see it.
4. Verify that the link Learn more is present and it leads to opening a Beacon article on the bottom-right corner. Verify the proper article is shown.