### PR TITLE
Add/multiple woo subscription segment [MAILPOET-3956]

### DIFF
--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
@@ -66,10 +66,6 @@ export const WooCommerceSubscriptionFields: React.FunctionComponent<Props> = ({ 
     ) {
       updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
     }
-    // Temporary BC fix
-    if (segment.product_id && !segment.product_ids) {
-      updateSegmentFilter({ product_ids: [segment.product_id] }, filterIndex);
-    }
   }, [updateSegmentFilter, segment, filterIndex]);
 
   return (

--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_subscription.tsx
@@ -61,6 +61,8 @@ export const WooCommerceSubscriptionFields: React.FunctionComponent<Props> = ({ 
     if (
       (segment.action === WooCommerceSubscriptionsActionTypes.ACTIVE_SUBSCRIPTIONS)
       && (segment.operator !== AnyValueTypes.ANY)
+      && (segment.operator !== AnyValueTypes.ALL)
+      && (segment.operator !== AnyValueTypes.NONE)
     ) {
       updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
     }
@@ -84,6 +86,8 @@ export const WooCommerceSubscriptionFields: React.FunctionComponent<Props> = ({ 
           automationId="select-operator"
         >
           <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+          <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+          <option value={AnyValueTypes.NONE}>{MailPoet.I18n.t('noneOf')}</option>
         </Select>
       </Grid.CenteredRow>
       <Grid.CenteredRow>

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -84,7 +84,6 @@ export interface WooCommerceFormItem extends FormItem {
 }
 
 export interface WooCommerceSubscriptionFormItem extends FormItem {
-  product_id?: string;
   product_ids?: string[];
   operator?: AnyValueTypes;
 }

--- a/assets/js/src/segments/dynamic/types.ts
+++ b/assets/js/src/segments/dynamic/types.ts
@@ -85,6 +85,8 @@ export interface WooCommerceFormItem extends FormItem {
 
 export interface WooCommerceSubscriptionFormItem extends FormItem {
   product_id?: string;
+  product_ids?: string[];
+  operator?: AnyValueTypes;
 }
 
 export interface EmailFormItem extends FormItem {

--- a/lib/Config/Migrator.php
+++ b/lib/Config/Migrator.php
@@ -820,8 +820,8 @@ class Migrator {
 
   private function migrateWooSubscriptionsDynamicFilters(): bool {
     global $wpdb;
-    // skip the migration if the DB version is higher than 3.74.3 or is not set (a new installation)
-    if (version_compare($this->settings->get('db_version', '3.74.4'), '3.74.3', '>')) {
+    // skip the migration if the DB version is higher than 3.75.1 or is not set (a new installation)
+    if (version_compare($this->settings->get('db_version', '3.75.2'), '3.75.1', '>')) {
       return false;
     }
 

--- a/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -223,8 +223,10 @@ class FilterDataMapper {
     $filterType = DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION;
     $action = $data['action'];
     if ($data['action'] === WooCommerceSubscription::ACTION_HAS_ACTIVE) {
-      if (!isset($data['product_id'])) throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
-      $filterData['product_id'] = $data['product_id'];
+      if (!isset($data['product_ids']) || !is_array($data['product_ids'])) throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
+      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      $filterData['operator'] = $data['operator'];
+      $filterData['product_ids'] = $data['product_ids'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
+++ b/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
@@ -25,10 +25,6 @@ class WooCommerceSubscription implements Filter {
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $filterData = $filter->getFilterData();
     $productIds = $filterData->getParam('product_ids');
-    // Temporary BC fix
-    if (!$productIds) {
-      $productIds = [(int)$filterData->getParam('product_id')];
-    }
     $operator = $filterData->getParam('operator');
     $parameterSuffix = $filter->getId() ?: Security::generateRandomString();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();

--- a/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -60,7 +60,7 @@ class WooCommerceSubscriptionsSegmentCest {
     $i->click('[data-automation-id="new-segment"]');
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], 'Desc ' . $segmentTitle);
-    $i->selectOptionInReactSelect('has an active subscription', $segmentActionSelectElement);
+    $i->selectOptionInReactSelect('has active subscription', $segmentActionSelectElement);
     $i->selectOptionInReactSelect('Subscription 1', '[data-automation-id="select-segment-products"]');
     $i->selectOptionInReactSelect('Subscription 2', '[data-automation-id="select-segment-products"]');
     $i->waitForText('This segment has');
@@ -98,7 +98,7 @@ class WooCommerceSubscriptionsSegmentCest {
     $i->wantTo('Check that admin can‘t add new subscriptions segment when WooCommerce Subscriptions is not active');
     $i->click('[data-automation-id="new-segment"]');
     $i->waitForElement($segmentActionSelectElement);
-    $i->fillField("$segmentActionSelectElement input", 'has an active subscription');
+    $i->fillField("$segmentActionSelectElement input", 'has active subscription');
     $i->canSee('No options', $segmentActionSelectElement);
   }
 }

--- a/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -51,7 +51,7 @@ class WooCommerceSubscriptionsSegmentCest {
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], 'Desc ' . $segmentTitle);
     $i->selectOptionInReactSelect('has an active subscription', $segmentActionSelectElement);
-    $i->selectOptionInReactSelect('Subscription 1', '[data-automation-id="segment-woo-subscription-action"]');
+    $i->selectOptionInReactSelect('Subscription 1', '[data-automation-id="select-segment-products"]');
     $i->waitForText('Calculating segment size…');
     $i->waitForText('This segment has 2 subscribers.');
     $i->seeNoJSErrors();

--- a/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -373,7 +373,8 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
       'action' => WooCommerceSubscription::ACTION_HAS_ACTIVE,
-      'product_id' => '10',
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'product_ids' => ['10'],
       'some_mess' => 'mess',
     ]]];
     $filters = $this->mapper->map($data);
@@ -385,7 +386,8 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION);
     expect($filter->getAction())->equals(WooCommerceSubscription::ACTION_HAS_ACTIVE);
     expect($filter->getData())->equals([
-      'product_id' => '10',
+      'product_ids' => ['10'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }
@@ -396,12 +398,25 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
-      'product_id' => '10',
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'product_ids' => ['10'],
     ]]];
     $this->mapper->map($data);
   }
 
-  public function testItChecksWooCommerceSubscriptionProductId() {
+  public function testItChecksWooCommerceSubscriptionProductIds() {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing product');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_PRODUCT_ID);
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
+      'action' => WooCommerceSubscription::ACTION_HAS_ACTIVE,
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+    ]]];
+    $this->mapper->map($data);
+  }
+
+  public function testItChecksWooCommerceSubscriptionMissingOperator() {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing product');
     $this->expectExceptionCode(InvalidFilterException::MISSING_PRODUCT_ID);

--- a/views/segments.html
+++ b/views/segments.html
@@ -183,7 +183,7 @@
     'subscribedToList': __('subscribed to list'),
     'segmentsSubscriber': __('WordPress user role'),
     'mailpoetCustomField': __('MailPoet custom field'),
-    'segmentsActiveSubscription': __('has an active subscription'),
+    'segmentsActiveSubscription': __('has active subscription'),
     'woocommerceSubscriptions': _x('WooCommerce Subscriptions', 'Dynamic segment creation: User selects this to use any WooCommerce Subscriptions filters'),
     'selectWooSubscription': __('Search subscriptions'),
     'searchLists': __('Search lists'),


### PR DESCRIPTION
[MAILPOET-3956]



[MAILPOET-3956]: https://mailpoet.atlassian.net/browse/MAILPOET-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Lists
2. Click to add a New Segment
3. Select `has an active subscription segment` from the first dropdown
4. Follow the specs from the Jira ticket above and make sure everything is made according to Specification
5. After everything's tested and verified, try to disable `WooCommerce Subscription` plugin in My Plugins section and then to go back to MailPoet > Lists > Segments Tab... to check if you see this message "Activate the WooCommerce Subscriptions plugin to see the number of subscribers and enable the editing of this segment.". Because this message should be present for segments that contains "has an active subscription" segment type but the required plugin is not active. Please activate the subscription plugin at the end of testing.