### PR TITLE
Fix slide-in animation value displayed in editor on form load [MAILPOET-3263]

### DIFF
--- a/assets/js/src/form_editor/store/map_form_data_after_loading.jsx
+++ b/assets/js/src/form_editor/store/map_form_data_after_loading.jsx
@@ -89,7 +89,7 @@ export default function mapFormDataAfterLoading(data) {
             : defaults.slideInForm.formDelay,
           position: data.settings.form_placement?.slide_in?.position
             ?? defaults.slideInForm.position,
-          animation: data.settings.form_placement?.slide_in?.position
+          animation: data.settings.form_placement?.slide_in?.animation
             ?? defaults.slideInForm.animation,
           styles: {
             ...defaults.slideInForm.styles,

--- a/tests/javascript/form_editor/store/map_form_data_after_loading.spec.js
+++ b/tests/javascript/form_editor/store/map_form_data_after_loading.spec.js
@@ -24,6 +24,9 @@ const data = {
       fixed_bar: {
         animation: 'slideright',
       },
+      slide_in: {
+        animation: 'flip',
+      },
       popup: {},
     },
   },
@@ -154,6 +157,7 @@ describe('Form Data Load Mapper', () => {
     it('Maps animation', () => {
       expect(map(data).settings.formPlacement.fixedBar).to.have.property('animation').that.eq('slideright');
       expect(map(data).settings.formPlacement.popup).to.have.property('animation').that.eq('slideup');// default
+      expect(map(data).settings.formPlacement.slideIn).to.have.property('animation').that.eq('flip');
       expect(map(data).settings.formPlacement.belowPosts).to.not.have.property('animation');
     });
 


### PR DESCRIPTION
[MAILPOET-3263] (testing instructions are inside the ticket)

This fixes a bug where the animation setting ("Show animation on display") was not being displayed properly for previously-saved slide-in forms immediately after loading the form in the editor.

<img width="280" alt="image" src="https://user-images.githubusercontent.com/8656640/145867564-deacbfe8-ec46-4287-8eac-956daebd212c.png">

The value was coming through as either 'right' or 'left' because the `position` value was being referenced instead of `animation`.

Because 'right' and 'left' don't correspond to a slide-in animation value, it always looked like the "Show animation on display" setting was "No Animation" even if a different value was saved in the database.

This bug only affected the editor and only affected the display of the value, not the ability to save a setting (the `animation` property was always correctly referenced in map_form_data_before_saving.jsx)

[MAILPOET-3263]: https://mailpoet.atlassian.net/browse/MAILPOET-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ