### PR TITLE
Fix import subscribers column header search [MAILPOET-3958]

### DIFF
--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
@@ -2,48 +2,47 @@ import jQuery from 'jquery';
 import MailPoet from 'mailpoet';
 
 export default () => {
-  // A custom matcher is required because we are using optgroups instead of single values.
-  // See https://select2.org/searching
-  const columnSearchMatcher = (params, data) => {
-    if (data.children === undefined) {
-      return null;
-    }
-    const searchTerm = (params.term ?? '').trim().toLowerCase();
-    if (searchTerm === '') {
-      return data;
-    }
-    // "children" are objects representing the individual options within an optgroup
-    // `name` is the label displayed to users
-    const matchedChildren = data.children.filter((child) => {
-      const label = child.name.toLowerCase();
-      return label.includes(searchTerm);
-    });
-    if (matchedChildren.length === 0) {
-      // Returning null prevent the entire optgroup from being displayed
-      return null;
-    }
-    // We can't change the original `data` object because select2 continues use it as the basis for
-    // future searches. In other words, if we simply modified `data`, it could prevent options
-    // that were previously filtered out from reappearing if the search term changes or gets
-    // cleared out.
-    const modifiedData = jQuery.extend(true, {}, data);
-    modifiedData.children = matchedChildren;
+  const select2Config = {
+    data: window.mailpoetColumnsSelect2,
+    width: '15em',
+    templateResult(item) {
+      return item.name;
+    },
+    templateSelection(item) {
+      return item.name;
+    },
+    // A custom matcher is required because we are using optgroups instead of single values.
+    // See https://select2.org/searching
+    matcher: (params, data) => {
+      if (data.children === undefined) {
+        return null;
+      }
+      const searchTerm = (params.term ?? '').trim().toLowerCase();
+      if (searchTerm === '') {
+        return data;
+      }
+      // "children" are objects representing the individual options within an optgroup
+      // `name` is the label displayed to users
+      const matchedChildren = data.children.filter((child) => {
+        const label = child.name.toLowerCase();
+        return label.includes(searchTerm);
+      });
+      if (matchedChildren.length === 0) {
+        // Returning null prevent the entire optgroup from being displayed
+        return null;
+      }
+      // We can't change the original `data` object because select2 continues use it as the
+      // basis for future searches. In other words, if we simply modified `data`, it could
+      // prevent options that were previously filtered out from reappearing if the search term
+      // changes or gets cleared out.
+      const modifiedData = jQuery.extend(true, {}, data);
+      modifiedData.children = matchedChildren;
 
-    return modifiedData;
+      return modifiedData;
+    },
   };
-
   jQuery('select.mailpoet_subscribers_column_data_match')
-    .select2({
-      data: window.mailpoetColumnsSelect2,
-      width: '15em',
-      templateResult(item) {
-        return item.name;
-      },
-      templateSelection(item) {
-        return item.name;
-      },
-      matcher: columnSearchMatcher,
-    })
+    .select2(select2Config)
     .on('select2:selecting', (selectEvent) => {
       const selectElement = selectEvent.currentTarget;
       const selectedOptionId = selectEvent.params.args.data.id;
@@ -87,17 +86,7 @@ export default () => {
                 jQuery(selectElement)
                   .html('')
                   .select2('destroy')
-                  .select2({
-                    data: window.mailpoetColumnsSelect2,
-                    width: '15em',
-                    templateResult(item) {
-                      return item.name;
-                    },
-                    templateSelection(item) {
-                      return item.name;
-                    },
-                    matcher: columnSearchMatcher,
-                  });
+                  .select2(select2Config);
               });
             jQuery(selectElement).data('column-id', newColumnData.id);
             // close popup

--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
@@ -25,7 +25,8 @@ export default () => {
       // `name` is the label displayed to users
       const matchedChildren = data.children.filter((child) => {
         const label = child.name.toLowerCase();
-        return label.includes(searchTerm);
+        const words = label.split(' ');
+        return words.some((word) => word.startsWith(searchTerm));
       });
       if (matchedChildren.length === 0) {
         // Returning null prevent the entire optgroup from being displayed

--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
@@ -5,42 +5,6 @@ export default () => {
   const select2Config = {
     data: window.mailpoetColumnsSelect2,
     width: '15em',
-    templateResult(item) {
-      return item.name;
-    },
-    templateSelection(item) {
-      return item.name;
-    },
-    // A custom matcher is required because we are using optgroups instead of single values.
-    // See https://select2.org/searching
-    matcher: (params, data) => {
-      if (data.children === undefined) {
-        return null;
-      }
-      const searchTerm = (params.term ?? '').trim().toLowerCase();
-      if (searchTerm === '') {
-        return data;
-      }
-      // "children" are objects representing the individual options within an optgroup
-      // `name` is the label displayed to users
-      const matchedChildren = data.children.filter((child) => {
-        const label = child.name.toLowerCase();
-        const words = label.split(' ');
-        return words.some((word) => word.startsWith(searchTerm));
-      });
-      if (matchedChildren.length === 0) {
-        // Returning null prevent the entire optgroup from being displayed
-        return null;
-      }
-      // We can't change the original `data` object because select2 continues use it as the
-      // basis for future searches. In other words, if we simply modified `data`, it could
-      // prevent options that were previously filtered out from reappearing if the search term
-      // changes or gets cleared out.
-      const modifiedData = jQuery.extend(true, {}, data);
-      modifiedData.children = matchedChildren;
-
-      return modifiedData;
-    },
   };
   jQuery('select.mailpoet_subscribers_column_data_match')
     .select2(select2Config)
@@ -69,6 +33,7 @@ export default () => {
             const newColumnData = {
               id: response.data.id,
               name: response.data.name,
+              text: response.data.name, // Required for select2 default functionality
               type: response.data.type,
               params: response.data.params,
               custom: true,

--- a/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
+++ b/assets/js/src/subscribers/importExport/import/step_data_manipulation/generate_column_selection.jsx
@@ -126,6 +126,19 @@ export default () => {
       const selectElement = selectEvent.currentTarget;
       const selectedOptionId = selectEvent.params.data.id;
       jQuery(selectElement).data('column-id', selectedOptionId);
+    })
+    // Temporary fix for search inputs not getting focus when clicked due to jQuery 3.6.0
+    // see: https://github.com/select2/select2/issues/5993 and feel free to remove if the bug
+    // has been fixed and our select2/jQuery libraries have been updated.
+    .on('select2:open', () => {
+      const inputs = document.querySelectorAll('.select2-search__field[aria-controls]');
+      if (inputs.length === 0) {
+        return;
+      }
+      // Allow focus to transfer from already-open select to another one that was just clicked
+      // on, when there are temporarily two in the DOM
+      const mostRecentlyOpenedInput = inputs[inputs.length - 1];
+      mostRecentlyOpenedInput.focus();
     });
   jQuery.map(
     jQuery('.mailpoet_subscribers_column_data_match'), (element) => {

--- a/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -72,6 +72,7 @@ class ImportExportFactory {
       return [
         'id' => $fieldId,
         'name' => $fieldName,
+        'text' => $fieldName, // Required for select2 default functionality
         'type' => ($fieldId === 'confirmed_at' || $fieldId === 'created_at') ? 'date' : null,
         'custom' => false,
       ];
@@ -87,6 +88,7 @@ class ImportExportFactory {
       return [
         'id' => $field['id'],
         'name' => $field['name'],
+        'text' => $field['name'], // Required for select2 default functionality
         'type' => $field['type'],
         'params' => unserialize($field['params']),
         'custom' => true,
@@ -103,35 +105,42 @@ class ImportExportFactory {
         [
           'id' => 'ignore',
           'name' => __('Ignore field...', 'mailpoet'),
+          'text' => __('Ignore field...', 'mailpoet'), // Required for select2 default functionality
         ],
         [
           'id' => 'create',
           'name' => __('Create new field...', 'mailpoet'),
+          'text' => __('Create new field...', 'mailpoet'), // Required for select2 default functionality
         ],
       ] :
       [
         [
           'id' => 'select',
           'name' => __('Select all...', 'mailpoet'),
+          'text' => __('Select all...', 'mailpoet'), // Required for select2 default functionality
         ],
         [
           'id' => 'deselect',
           'name' => __('Deselect all...', 'mailpoet'),
+          'text' => __('Deselect all...', 'mailpoet'), // Required for select2 default functionality
         ],
       ];
     $select2Fields = [
       [
         'name' => __('Actions', 'mailpoet'),
+        'text' => __('Actions', 'mailpoet'), // Required for select2 default functionality
         'children' => $actions,
       ],
       [
         'name' => __('System fields', 'mailpoet'),
+        'text' => __('System fields', 'mailpoet'), // Required for select2 default functionality
         'children' => $this->formatSubscriberFields($subscriberFields),
       ],
     ];
     if ($subscriberCustomFields) {
       array_push($select2Fields, [
         'name' => __('User fields', 'mailpoet'),
+        'text' => __('User fields', 'mailpoet'), // Required for select2 default functionality
         'children' => $this->formatSubscriberCustomFields(
           $subscriberCustomFields
         ),

--- a/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -178,19 +178,23 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $select2FieldsWithoutCustomFields = [
       [
         'name' => 'Actions',
+        'text' => 'Actions',
         'children' => [
           [
             'id' => 'ignore',
             'name' => 'Ignore field...',
+            'text' => 'Ignore field...',
           ],
           [
             'id' => 'create',
             'name' => 'Create new field...',
+            'text' => 'Create new field...',
           ],
         ],
       ],
       [
         'name' => 'System fields',
+        'text' => 'System fields',
         'children' => $importExportFactory->formatSubscriberFields(
           $importExportFactory->getSubscriberFields()
         ),
@@ -201,6 +205,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
       [
         [
           'name' => 'User fields',
+          'text' => 'User fields',
           'children' => $importExportFactory->formatSubscriberCustomFields(
             $importExportFactory->getSubscriberCustomFields()
           ),
@@ -223,19 +228,23 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $select2FieldsWithoutCustomFields = [
       [
         'name' => 'Actions',
+        'text' => 'Actions',
         'children' => [
           [
             'id' => 'select',
             'name' => 'Select all...',
+            'text' => 'Select all...',
           ],
           [
             'id' => 'deselect',
             'name' => 'Deselect all...',
+            'text' => 'Deselect all...',
           ],
         ],
       ],
       [
         'name' => 'System fields',
+        'text' => 'System fields',
         'children' => $importExportFactory->formatSubscriberFields(
           $importExportFactory->getSubscriberFields()
         ),
@@ -246,6 +255,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
       [
         [
           'name' => 'User fields',
+          'text' => 'User fields',
           'children' => $importExportFactory->formatSubscriberCustomFields(
             $importExportFactory->getSubscriberCustomFields()
           ),


### PR DESCRIPTION
[MAILPOET-3958](https://mailpoet.atlassian.net/browse/MAILPOET-3958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

Check the testing instructions inside Jira ticket.

This fixes a bug where the search at the top of columns on the subscriber import page weren't doing anything.

It also includes a fix for a [bug with the latest version of select2 and jQuery](https://github.com/select2/select2/issues/5993) where the search inputs weren't receiving focus when clicked.

Before:

https://user-images.githubusercontent.com/8656640/146259444-9aac664b-b094-4932-bdf8-3103963b6e16.mov

After:

https://user-images.githubusercontent.com/8656640/146259461-4e200002-74be-429c-b936-8630235a0436.mov

I believe this issue may have originally been caused by removing the `text` property from the data we supply to select2 (see 4045fba527a9acdafdcb08e346b80d0b85e2ed70), which means we're not complying with [select2's "required" data format](https://select2.org/data-sources/formats). Restoring those properties seems to have fixed the issue.

Sidenote: because I was testing this in the browser a lot, I ended up writing a little tempermonkey script so I didn't have to copy/paste my CSV data every time. Note that you still have to type something in the textarea to trigger the callback that activates the "Next step" button.

```javascript
// ==UserScript==
// @name         Fill Paste Method Input
// @namespace    http://tampermonkey.net/
// @version      0.1
// @description  try to take over the world!
// @author       You
// @match        http://localhost:8002/wp-admin/admin.php?page=mailpoet-import
// @icon         https://www.google.com/s2/favicons?domain=undefined.localhost
// @grant        none
// ==/UserScript==

(function() {
    'use strict';
    const pasteMethodOption = document.getElementById('import-paste-method');
    if (!pasteMethodOption) {
        return;
    }
    pasteMethodOption.click();
    const textarea = document.getElementById('paste_input');
    const content = "Email, First Name, Last Name\njohn@example.com, John, Olek";
    textarea.value = content;
    textarea.focus();
})();
```