### PR TITLE
Ensure plugin activated before running tests

### DIFF
--- a/tests/integration/_bootstrap.php
+++ b/tests/integration/_bootstrap.php
@@ -16,6 +16,10 @@ if ((boolean)getenv('MULTISITE') === true) {
 }
 require_once($wpLoadFile);
 
+// Ensure that the plugin is activated
+require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+activate_plugin('mailpoet/mailpoet.php');
+
 $console = new \Codeception\Lib\Console\Output([]);
 $console->writeln('Loading WP core... (' . $wpLoadFile . ')');
 


### PR DESCRIPTION
This PR ensures that the test environment's MailPoet plugin is activated before proceeding with any tests.

This might not be necessary, in which case I'm happy to close it out.