### PR TITLE
Remove unused import from WooCommerce component

### DIFF
--- a/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import MailPoet from 'mailpoet';
-import { find, filter } from 'lodash/fp';
+import { filter } from 'lodash/fp';
 import ReactSelect from 'common/form/react_select/react_select';
 import Select from 'common/form/select/select';
 import { useSelect, useDispatch } from '@wordpress/data';


### PR DESCRIPTION
The QA JS job is failing on master because we have an unused import in the WooCommerce component.