### PR TITLE
Add check for unique name when creating segment [MAILPOET-3998]

### DIFF
--- a/lib/API/JSON/v1/DynamicSegments.php
+++ b/lib/API/JSON/v1/DynamicSegments.php
@@ -2,12 +2,12 @@
 
 namespace MailPoet\API\JSON\v1;
 
-use InvalidArgumentException;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error;
 use MailPoet\API\JSON\Response;
 use MailPoet\API\JSON\ResponseBuilders\DynamicSegmentsResponseBuilder;
 use MailPoet\Config\AccessControl;
+use MailPoet\ConflictException;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\Handler;
@@ -112,7 +112,7 @@ class DynamicSegments extends APIEndpoint {
       return $this->errorResponse([
         Error::BAD_REQUEST => $this->getErrorString($e),
       ], [], Response::STATUS_BAD_REQUEST);
-    } catch (InvalidArgumentException $e) {
+    } catch (ConflictException $e) {
       return $this->badRequest([
         Error::BAD_REQUEST => __('Another record already exists. Please specify a different "name".', 'mailpoet'),
       ]);

--- a/lib/API/JSON/v1/Segments.php
+++ b/lib/API/JSON/v1/Segments.php
@@ -3,12 +3,12 @@
 namespace MailPoet\API\JSON\v1;
 
 use Exception;
-use InvalidArgumentException;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\Response;
 use MailPoet\API\JSON\ResponseBuilders\SegmentsResponseBuilder;
 use MailPoet\Config\AccessControl;
+use MailPoet\ConflictException;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Cron\Workers\WooCommerceSync;
 use MailPoet\Doctrine\Validator\ValidationException;
@@ -125,7 +125,7 @@ class Segments extends APIEndpoint {
       return $this->badRequest([
         APIError::BAD_REQUEST  => __('Please specify a name.', 'mailpoet'),
       ]);
-    } catch (InvalidArgumentException $exception) {
+    } catch (ConflictException $exception) {
       return $this->badRequest([
         APIError::BAD_REQUEST  => __('Another record already exists. Please specify a different "name".', 'mailpoet'),
       ]);

--- a/lib/Segments/DynamicSegments/SegmentSaveController.php
+++ b/lib/Segments/DynamicSegments/SegmentSaveController.php
@@ -2,9 +2,11 @@
 
 namespace MailPoet\Segments\DynamicSegments;
 
-use InvalidArgumentException;
+use MailPoet\ConflictException;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\NotFoundException;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoetVendor\Doctrine\ORM\ORMException;
 
 class SegmentSaveController {
   /** @var SegmentsRepository */
@@ -21,20 +23,18 @@ class SegmentSaveController {
     $this->filterDataMapper = $filterDataMapper;
   }
 
+  /**
+   * @throws ConflictException
+   * @throws NotFoundException
+   * @throws Exceptions\InvalidFilterException
+   * @throws ORMException
+   */
   public function save(array $data = []): SegmentEntity {
     $id = isset($data['id']) ? (int)$data['id'] : null;
     $name = $data['name'] ?? '';
     $description = $data['description'] ?? '';
     $filtersData = $this->filterDataMapper->map($data);
 
-    $this->checkSegmentUniqueName($name, $id);
-
     return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DYNAMIC, $filtersData, $id);
-  }
-
-  private function checkSegmentUniqueName(string $name, ?int $id): void {
-    if (!$this->segmentsRepository->isNameUnique($name, $id)) {
-      throw new InvalidArgumentException("Segment with name: '{$name}' already exists.");
-    }
   }
 }

--- a/lib/Segments/SegmentsRepository.php
+++ b/lib/Segments/SegmentsRepository.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Segments;
 
 use DateTime;
+use MailPoet\ConflictException;
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
@@ -94,6 +95,8 @@ class SegmentsRepository extends Repository {
 
   /**
    * @param DynamicSegmentFilterData[] $filtersData
+   * @throws ConflictException
+   * @throws NotFoundException
    */
   public function createOrUpdate(
     string $name,
@@ -110,6 +113,9 @@ class SegmentsRepository extends Repository {
       $segment->setName($name);
       $segment->setDescription($description);
     } else {
+      if (!$this->isNameUnique($name, $id)) {
+        throw new ConflictException("Could not create new segment with name [{$name}] because a segment with that name already exists.");
+      }
       $segment = new SegmentEntity($name, $type, $description);
       $this->persist($segment);
     }

--- a/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
+++ b/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments;
 
+use MailPoet\ConflictException;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -135,8 +136,8 @@ class SegmentSaveControllerTest extends \MailPoetTest {
         'action' => UserRole::TYPE,
       ]],
     ];
-    $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage("Segment with name: 'Test name' already exists.");
+    $this->expectException(ConflictException::class);
+    $this->expectExceptionMessage("Could not create new segment with name [Test name] because a segment with that name already exists.");
     $this->saveController->save($segmentData);
   }
 

--- a/tests/integration/Segments/SegmentsRepositoryTest.php
+++ b/tests/integration/Segments/SegmentsRepositoryTest.php
@@ -108,6 +108,27 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     expect($count)->equals(2);
   }
 
+  public function testItCanCheckForUniqueNames() {
+    $this->createDefaultSegment('Test');
+    $this->segmentsRepository->flush();
+    expect($this->segmentsRepository->isNameUnique('Test', null))->false();
+    expect($this->segmentsRepository->isNameUnique('Unique Name', null))->true();
+  }
+
+  public function testItCanForcefullyVerifyUniquenessOfName() {
+    $this->createDefaultSegment('Test');
+    $this->segmentsRepository->flush();
+    try {
+      $this->segmentsRepository->verifyNameIsUnique('Unique', null);
+      $this->addToAssertionCount(1);
+    } catch (ConflictException $exception) {
+      $this->fail();
+    }
+    $this->expectException(ConflictException::class);
+    $this->expectExceptionMessage('Could not create new segment with name [Test] because a segment with that name already exists.');
+    $this->segmentsRepository->verifyNameIsUnique('Test', null);
+  }
+
   public function testItChecksForDuplicateNameWhenCreatingNewSegment() {
     $this->createDefaultSegment('Existing Segment');
     $this->segmentsRepository->flush();

--- a/tests/integration/Segments/SegmentsRepositoryTest.php
+++ b/tests/integration/Segments/SegmentsRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments;
 
+use MailPoet\ConflictException;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\NewsletterEntity;
@@ -105,6 +106,14 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     $this->segmentsRepository->flush();
     $count = $this->segmentsRepository->getSegmentCountWithMultipleFilters();
     expect($count)->equals(2);
+  }
+
+  public function testItChecksForDuplicateNameWhenCreatingNewSegment() {
+    $this->createDefaultSegment('Existing Segment');
+    $this->segmentsRepository->flush();
+    $this->expectException(ConflictException::class);
+    $this->expectExceptionMessage("Could not create new segment with name [Existing Segment] because a segment with that name already exists.");
+    $this->segmentsRepository->createOrUpdate('Existing Segment');
   }
 
   private function createDefaultSegment(string $name): SegmentEntity {


### PR DESCRIPTION
This PR adds a check directly in [SegmentRepository](https://github.com/mailpoet/mailpoet/blob/90d479fdc7e25c42da3e15264c48f1f488ac8e2b/lib/Segments/SegmentsRepository.php) to verify that a given segment name is unique before attempting to persist a new segment to the database. It's important to have this check because the `mailpoet_segments` table has a [unique key constraint](https://github.com/mailpoet/mailpoet/blob/158d70dc7a43d5185c84db4493a66fa53cccd087/lib/Config/Migrator.php#L107) on the `name` column.

We were previously checking for uniqueness through the save controllers ([regular](https://github.com/mailpoet/mailpoet/blob/90d479fdc7e25c42da3e15264c48f1f488ac8e2b/lib/Segments/SegmentSaveController.php#L30) and [dynamic](https://github.com/mailpoet/mailpoet/blob/90d479fdc7e25c42da3e15264c48f1f488ac8e2b/lib/Segments/DynamicSegments/SegmentSaveController.php#L30)), which I believe are the only places where `createOrUpdate` is being called other than tests, so it's unlikely that this bug is something that could have been encountered in the wild.

I decided to refactor the handful of uniqueness checks we have in the codebase to all use the same code. This cuts down on a bit of duplication and allows us to eliminate some code in the controllers that can be handled through the repository instead. This may or may not be a good idea and I would very much like to get the reviewer's opinion on that.

I believe the biggest difference is that I changed the `InvalidArgumentException` to a `ConflictException` because it seemed more accurate [based on its description](https://github.com/mailpoet/mailpoet/blob/bf882e3c921a12a0f91f574e4d56969a1153a0c1/lib/exceptions.php#L91). I believe I updated all the places that were referencing the `InvalidArgumentException` but the reviewer may want to double check.

[MAILPOET-3998]


[MAILPOET-3998]: https://mailpoet.atlassian.net/browse/MAILPOET-3998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ