### PR TITLE
Opt out on WC checkout from configured segments [MAILPOET-4026]

### DIFF
--- a/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -104,7 +104,8 @@ class WooCommerceBlocksIntegration {
   }
 
   public function processCheckoutBlockOptin(\WC_Order $order, $request) {
-    if (!$this->settings->get('woocommerce.optin_on_checkout.enabled', false)) {
+    $checkoutOptinEnabled = $this->settings->get(WooCommerceSubscription::OPTIN_ENABLED_SETTING_NAME, false);
+    if (!$checkoutOptinEnabled) {
       return;
     }
 
@@ -135,6 +136,6 @@ class WooCommerceBlocksIntegration {
       return null;
     }
 
-    $this->woocommerceSubscription->handleSubscriberOptin($subscriberOldModel, (bool)$request['extensions']['mailpoet']['optin']);
+    $this->woocommerceSubscription->handleSubscriberOptin($subscriberOldModel, $checkoutOptinEnabled, (bool)$request['extensions']['mailpoet']['optin']);
   }
 }


### PR DESCRIPTION
[MAILPOET-4026]

[MAILPOET-4026]: https://mailpoet.atlassian.net/browse/MAILPOET-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Settings > WooCommerce tab
2. Make sure to select at least 2 lists from the select lists dropdown
3. Remember what lists you selected
4. Go to the shop (front-end) and purchase some product/s (but make sure to also check the checkbox in the checkout for opting-in for these lists)
5. Confirm subscription when received email (with the email entered during checkout)
6. Go to MailPoet > Subscribers
7. Make sure the new subscriber is subscribed to all necessary lists
8. Perform again checkout using the same email address and this time unchecking the checkbox during checkout
9. Go to MailPoet > Subscribers and make sure the new subscriber is now unsubscribed from all the lists
10. After this we can say it is working, but, make another test using existing subscriber with multiple lists and make sure when performing checkout and unchecking the checkbox, that the subscriber remain subscriber to all other lists not included in MailPoet > Settings > WooCommerce tab (selected lists for _Opt-in on checkout_)

Note: The idea with this implementation is that when subscriber make a purchase and uncheck the checkbox, he will be unsubscribed from _WooCommerce Customers_ list but also all other lists entered in MailPoet > Settings > WooCommerce tab.