### PR TITLE
Create API endpoint to check if MailPoet welcome wizard is finished [MAILPOET-4042]

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -26,6 +26,7 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 * [Get Lists (getLists)](api_methods/GetLists.md)
 * [Get Subscriber (getSubscriber)](api_methods/GetSubscriber.md)
 * [Get Subscriber Fields (getSubscriberFields)](api_methods/GetSubscriberFields.md)
+* [Is Setup Complete (isSetupComplete)](api_methods/IsSetupComplete.md)
 * [Subscribe to List (subscribeToList)](api_methods/SubscribeToList.md)
 * [Subscribe to List (subscribeToLists)](api_methods/SubscribeToLists.md)
 * [Unsubscribe from List (unsubscribeFromList)](api_methods/UnsubscribeFromList.md)

--- a/doc/api_methods/IsSetupComplete.md
+++ b/doc/api_methods/IsSetupComplete.md
@@ -1,0 +1,9 @@
+[back to list](../Readme.md)
+
+# Is setup complete
+
+## `bool isSetupComplete()`
+
+This method checks if the MailPoet is set up.
+
+It returns `false` if either Welcome Wizard, or WooCommerce setup, or MailPoet 2 migration is shown on the next MailPoet page visit. Otherwise it returns `true`.

--- a/lib/API/MP/v1/API.php
+++ b/lib/API/MP/v1/API.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\API\MP\v1;
 
+use MailPoet\Config\Changelog;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
@@ -21,14 +22,19 @@ class API {
   /** @var Subscribers */
   private $subscribers;
 
+  /** @var Changelog */
+  private $changelog;
+
   public function __construct(
     RequiredCustomFieldValidator $requiredCustomFieldValidator,
     CustomFields $customFields,
-    Subscribers $subscribers
+    Subscribers $subscribers,
+    Changelog $changelog
   ) {
     $this->requiredCustomFieldValidator = $requiredCustomFieldValidator;
     $this->customFields = $customFields;
     $this->subscribers = $subscribers;
+    $this->changelog = $changelog;
   }
 
   public function getSubscriberFields() {
@@ -222,5 +228,15 @@ class API {
       throw new APIException(__('This subscriber does not exist.', 'mailpoet'), APIException::SUBSCRIBER_NOT_EXISTS);
     }
     return $subscriber->withCustomFields()->withSubscriptions()->asArray();
+  }
+
+  public function isSetupComplete() {
+    return !(
+      $this->changelog->shouldShowWelcomeWizard()
+      || $this->changelog->shouldShowWooCommerceListImportPage()
+      || $this->changelog->shouldShowRevenueTrackingPermissionPage()
+      || $this->changelog->isMp2MigrationInProgress()
+      || $this->changelog->shouldShowMp2Migration()
+    );
   }
 }

--- a/lib/Config/Changelog.php
+++ b/lib/Config/Changelog.php
@@ -94,6 +94,13 @@ class Changelog {
       && $this->wp->currentUserCan('administrator');
   }
 
+  public function shouldShowRevenueTrackingPermissionPage() {
+    return ($this->settings->get('woocommerce.accept_cookie_revenue_tracking.set') === null)
+      && $this->trackingConfig->isEmailTrackingEnabled()
+      && $this->wooCommerceHelper->isWooCommerceActive()
+      && $this->wp->currentUserCan('administrator');
+  }
+
   public function isMp2MigrationInProgress() {
     return $this->mp2Migrator->isMigrationStartedAndNotCompleted();
   }
@@ -135,10 +142,7 @@ class Changelog {
   private function checkRevenueTrackingPermissionPage() {
     if (
       !in_array($_GET['page'], ['mailpoet-woocommerce-setup', 'mailpoet-welcome-wizard', 'mailpoet-migration'])
-      && ($this->settings->get('woocommerce.accept_cookie_revenue_tracking.set') === null)
-      && $this->trackingConfig->isEmailTrackingEnabled()
-      && $this->wooCommerceHelper->isWooCommerceActive()
-      && $this->wp->currentUserCan('administrator')
+      && $this->shouldShowRevenueTrackingPermissionPage()
     ) {
       $this->urlHelper->redirectTo($this->wp->adminUrl('admin.php?page=mailpoet-woocommerce-setup'));
     }

--- a/lib/Config/Changelog.php
+++ b/lib/Config/Changelog.php
@@ -84,6 +84,16 @@ class Changelog {
     return $this->settings->get('version') === null;
   }
 
+  public function shouldShowWooCommerceListImportPage() {
+    if ($this->wp->applyFilters('mailpoet_skip_woocommerce_import_page', false)) {
+      return false;
+    }
+    return !$this->settings->get('woocommerce_import_screen_displayed')
+      && $this->wooCommerceHelper->isWooCommerceActive()
+      && $this->wooCommerceHelper->getOrdersCountCreatedBefore($this->settings->get('installed_at')) > 0
+      && $this->wp->currentUserCan('administrator');
+  }
+
   public function isMp2MigrationInProgress() {
     return $this->mp2Migrator->isMigrationStartedAndNotCompleted();
   }
@@ -114,15 +124,9 @@ class Changelog {
   }
 
   private function checkWooCommerceListImportPage() {
-    if ($this->wp->applyFilters('mailpoet_skip_woocommerce_import_page', false)) {
-      return;
-    }
     if (
       !in_array($_GET['page'], ['mailpoet-woocommerce-setup', 'mailpoet-welcome-wizard', 'mailpoet-migration'])
-      && !$this->settings->get('woocommerce_import_screen_displayed')
-      && $this->wooCommerceHelper->isWooCommerceActive()
-      && $this->wooCommerceHelper->getOrdersCountCreatedBefore($this->settings->get('installed_at')) > 0
-      && $this->wp->currentUserCan('administrator')
+      && $this->shouldShowWooCommerceListImportPage()
     ) {
       $this->urlHelper->redirectTo($this->wp->adminUrl('admin.php?page=mailpoet-woocommerce-setup'));
     }

--- a/lib/Config/Changelog.php
+++ b/lib/Config/Changelog.php
@@ -77,6 +77,13 @@ class Changelog {
     $this->checkRevenueTrackingPermissionPage();
   }
 
+  public function shouldShowWelcomeWizard() {
+    if ($this->wp->applyFilters('mailpoet_skip_welcome_wizard', false)) {
+      return false;
+    }
+    return $this->settings->get('version') === null;
+  }
+
   public function isMp2MigrationInProgress() {
     return $this->mp2Migrator->isMigrationStartedAndNotCompleted();
   }
@@ -101,8 +108,7 @@ class Changelog {
   }
 
   private function checkWelcomeWizard() {
-    $skipWizard = $this->wp->applyFilters('mailpoet_skip_welcome_wizard', false);
-    if (!$skipWizard) {
+    if ($this->shouldShowWelcomeWizard()) {
       $this->terminateWithRedirect($this->wp->adminUrl('admin.php?page=mailpoet-welcome-wizard'));
     }
   }

--- a/tests/integration/API/MP/APITest.php
+++ b/tests/integration/API/MP/APITest.php
@@ -8,6 +8,7 @@ use MailPoet\API\JSON\ResponseBuilders\SubscribersResponseBuilder;
 use MailPoet\API\MP\v1\API;
 use MailPoet\API\MP\v1\CustomFields;
 use MailPoet\API\MP\v1\Subscribers;
+use MailPoet\Config\Changelog;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -67,7 +68,8 @@ class APITest extends \MailPoetTest {
     return new API(
       $this->diContainer->get(RequiredCustomFieldValidator::class),
       $this->diContainer->get(CustomFields::class),
-      $subscriberActions
+      $subscriberActions,
+      $this->diContainer->get(Changelog::class)
     );
   }
 

--- a/tests/integration/API/MP/SubscribersTest.php
+++ b/tests/integration/API/MP/SubscribersTest.php
@@ -8,6 +8,7 @@ use MailPoet\API\JSON\ResponseBuilders\SubscribersResponseBuilder;
 use MailPoet\API\MP\v1\API;
 use MailPoet\API\MP\v1\CustomFields;
 use MailPoet\API\MP\v1\Subscribers;
+use MailPoet\Config\Changelog;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
@@ -57,7 +58,8 @@ class SubscribersTest extends \MailPoetTest {
     return new API(
       $this->makeEmpty(RequiredCustomFieldValidator::class),
       $this->diContainer->get(CustomFields::class),
-      $subscriberActions
+      $subscriberActions,
+      $this->diContainer->get(Changelog::class)
     );
   }
 


### PR DESCRIPTION
[MAILPOET-4042]

@costasovo I didn't add the new endpoint to public API docs because I don't think this is something other plugins should use. But I don't have a strong opinion on this, so if you think we should document it, I can do that.

For QA - this PR also includes a slight refactor for showing the welcome wizard, WooCommerce setup (when someone installs WC after MP is already set up), and MP2 migration step, so please make sure all are still working as they should.

[MAILPOET-4042]: https://mailpoet.atlassian.net/browse/MAILPOET-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ