### PR TITLE
Use "today" or "tomorrow" status when applicable [MAILPOET-3560]

### DIFF
--- a/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import MailPoet from 'mailpoet';
 import classNames from 'classnames';
 import {
-  isFuture, isPast, differenceInMinutes,
+  addDays, differenceInMinutes, isFuture, isPast,
 } from 'date-fns';
 import t from 'common/functions/t';
+import Tooltip from '../tooltip/tooltip';
 
 type NewsletterStatusProps = {
   scheduledFor?: Date;
@@ -29,15 +30,38 @@ const NewsletterStatus = ({
   let percentage = 0;
   let label = (<>{t('notSentYet')}</>);
   if (scheduled) {
+    const scheduledDate = MailPoet.Date.short(scheduledFor);
+    const scheduledTime = MailPoet.Date.time(scheduledFor);
+    const now = new Date();
+    const tomorrow = addDays(now, 1);
+    const isScheduledForToday = MailPoet.Date.short(now) === scheduledDate;
+    const isScheduledForTomorrow = MailPoet.Date.short(tomorrow) === scheduledDate;
+    if (isScheduledForToday || isScheduledForTomorrow) {
+      const randomId = Math.random().toString(36).substring(2, 15);
+      const dateWord = isScheduledForToday ? t('today') : t('tomorrow');
+      label = (
+        <>
+          <span data-tip data-for={randomId}>
+            {dateWord}
+          </span>
+          <Tooltip place="right" id={randomId}>
+            {scheduledDate}
+          </Tooltip>
+          <br />
+          {scheduledTime}
+        </>
+      );
+    } else {
+      label = (
+        <>
+          {scheduledDate}
+          <br />
+          {scheduledTime}
+        </>
+      );
+    }
     const minutesIn12Hours = 720;
-    const minutesLeft = differenceInMinutes(scheduledFor, new Date());
-    label = (
-      <>
-        {MailPoet.Date.short(scheduledFor)}
-        <br />
-        {MailPoet.Date.time(scheduledFor)}
-      </>
-    );
+    const minutesLeft = differenceInMinutes(scheduledFor, now);
     if (minutesLeft < minutesIn12Hours) {
       percentage = 100 * (minutesLeft / minutesIn12Hours);
     } else {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -123,6 +123,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
 
   'close': __('Close'),
   'today': __('Today'),
+  'tomorrow': __('Tomorrow'),
   'january': __('January'),
   'february': __('February'),
   'march': __('March'),

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -123,7 +123,6 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
 
   'close': __('Close'),
   'today': __('Today'),
-  'tomorrow': __('Tomorrow'),
   'january': __('January'),
   'february': __('February'),
   'march': __('March'),

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -251,6 +251,7 @@
     'thursday': __('Thursday'),
     'friday': __('Friday'),
     'saturday': __('Saturday'),
+    'tomorrow': __('Tomorrow'),
     'first': __('1st'),
     'second': __('2nd'),
     'third': __('3rd'),


### PR DESCRIPTION
[MAILPOET-3560]

On the Emails listing page, if the newsletter is scheduled to send
either today or tomorrow, the status column will now display "Today" or
"Tomorrow" respectively.

A user may still see the full date if desired by hovering their mouse
over the text, which will show the full date as a tooltip.

Testing Instructions:
1. Go to MailPoet > Emails
2. Create a new newsletter and schedule it for sending tomorrow (anytime tomorrow)
3. Create another new newsletter and schedule it for sending today (anytime but today)
4. Make sure you're on MailPoet > Emails page
5. Observe that you see Tomorrow and Today labels for those 2 scheduled newsletters
6. Hover over them and make sure you see dates as in the below video example


https://user-images.githubusercontent.com/8656640/147689762-20026445-5469-41d8-a349-31a3e8ac7152.mov




[MAILPOET-3560]: https://mailpoet.atlassian.net/browse/MAILPOET-3560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ