### PR TITLE
Add more form delay options [MAILPOET-3575]

### DIFF
--- a/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/fixed_bar_settings.tsx
+++ b/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/fixed_bar_settings.tsx
@@ -7,7 +7,7 @@ import { SizeSettings } from 'form_editor/components/size_settings';
 import AnimationSettings from './animation_settings';
 import PlacementSettings from './placement_settings';
 
-const delayValues = [0, 15, 30, 60, 120, 180, 240];
+const delayValues = [0, 2, 5, 10, 15, 30, 45, 60, 120, 180, 240];
 
 const FixedBarSettings: React.FunctionComponent = () => {
   const formSettings = useSelect(

--- a/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/popup_settings.tsx
+++ b/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/popup_settings.tsx
@@ -7,7 +7,7 @@ import { SizeSettings } from 'form_editor/components/size_settings';
 import AnimationSettings from './animation_settings';
 import PlacementSettings from './placement_settings';
 
-const delayValues = [0, 15, 30, 60, 120, 180, 240];
+const delayValues = [0, 2, 5, 10, 15, 30, 45, 60, 120, 180, 240];
 
 const PopUpSettings: React.FunctionComponent = () => {
   const formSettings = useSelect(

--- a/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/slide_in_settings.tsx
+++ b/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/slide_in_settings.tsx
@@ -7,7 +7,7 @@ import { SizeSettings } from 'form_editor/components/size_settings';
 import AnimationSettings from './animation_settings';
 import PlacementSettings from './placement_settings';
 
-const delayValues = [0, 15, 30, 60, 120, 180, 240];
+const delayValues = [0, 2, 5, 10, 15, 30, 45, 60, 120, 180, 240];
 
 const SlideInSettings: React.FunctionComponent = () => {
   const formSettings = useSelect(


### PR DESCRIPTION
[MAILPOET-3575]

I believe this is a pretty straightforward change unless I've missed some tests that should be updated.

When configuring fixed bar, popup, or slide in form placement settings, the options `2` `5` `10` and `45` should now be available for the `Display with a delay of` setting.

[MAILPOET-3575]: https://mailpoet.atlassian.net/browse/MAILPOET-3575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing Instructions:
1. Go to MailPoet > Forms
2. Edit existing or add a new form
3. In the form editor, collapse Form Placement tab from the right sidebar
4. Click on any form placement like Pop-up, make sure it is enabled/activated properly
5. Check if you see the new delay options 2s, 5s, 10s and 45s as available options under "Display with a delay of"
6. Make sure to test the form on the front end to see if it is loading after mentioned seconds (according to what you set in your test, test 2s, 5s..)