### PR TITLE
Prevent unintended re-use of preview settings [MAILPOET-3877]

### DIFF
--- a/mailpoet/assets/js/src/form_editor/store/actions.ts
+++ b/mailpoet/assets/js/src/form_editor/store/actions.ts
@@ -182,11 +182,15 @@ export function changeActiveSidebar(
 
 export function* changePreviewSettings(settings) {
   const formData = select('mailpoet-form-editor').getFormData();
-  yield {
-    type: 'STORE_LOCALLY',
-    key: `mailpoet_form_preview_settings${formData.id}`,
-    value: settings,
-  };
+  // We don't need or want to save preview settings for unsaved forms. These stored settings
+  // are only ever used when reloading previously-edited forms.
+  if (formData.id !== null) {
+    yield {
+      type: 'STORE_LOCALLY',
+      key: `mailpoet_form_preview_settings${formData.id}`,
+      value: settings,
+    };
+  }
   yield {
     type: 'CHANGE_PREVIEW_SETTINGS',
     settings,

--- a/mailpoet/assets/js/src/form_editor/store/store.jsx
+++ b/mailpoet/assets/js/src/form_editor/store/store.jsx
@@ -36,10 +36,13 @@ export default () => {
   formData.settings.segments = formData.settings.segments ? formData.settings.segments : [];
 
   let previewSettings = null;
-  try {
-    previewSettings = JSON.parse(window.localStorage.getItem(`mailpoet_form_preview_settings${formData.id}`));
-  } catch (e) {
-    // We just keep it null
+  // We don't want to try to load saved settings for forms that are brand new
+  if (formData.id !== null) {
+    try {
+      previewSettings = JSON.parse(window.localStorage.getItem(`mailpoet_form_preview_settings${formData.id}`));
+    } catch (e) {
+      // We just keep it null
+    }
   }
 
   let fullscreenStatus = null;


### PR DESCRIPTION
[MAILPOET-3877]
⏫ Testing Instructions are inside this Jira ticket, please open it and test it.

[MAILPOET-3877]: https://mailpoet.atlassian.net/browse/MAILPOET-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Information

This PR prevents newly-created forms from inheriting preview settings of the last unsaved form that was previewed. 

The bug was occurring because we use local storage to remember the preview settings for previously-previewed forms, and those settings are saved using a key based on the ID of the form. In the case of new, unsaved forms, these settings were always being saved and loaded with the key `mailpoet_form_preview_settingsnull`. 

That meant that whatever preview settings were stored for the last unsaved form a user was working on would always be applied to newly created forms.

There is one case that this PR doesn't address, and I'm interested to hear from the reviewer(s) if it's something that seems worth addressing: preview settings won't necessarily be retained for newly saved forms. There are two methods I'm seeing in the code for storing preview settings in local storage, neither of which fires when a form is saved:

1. Preview the form and change the form placement in the preview.
<img width="442" alt="image" src="https://user-images.githubusercontent.com/8656640/148994440-190ccc62-8138-431e-9e14-86bae6ca5ef4.png">

2. Click on any one of the "Form Placement" options
<img width="287" alt="image" src="https://user-images.githubusercontent.com/8656640/148994475-380382a6-ad51-402a-89ba-6831d9e22d15.png">

This means the following can still happen (the specific form types in this example aren't important other than the fact that they're different):

1. Create a new Pop-up form
2. Previews the form and change the form placement to fixed bar (settings don't get saved because the form doesn't have an ID yet) but don't enable that form type
3. Save the form
4. Reload the editor, or navigate away and come back
5. Click preview

Expected result:  form is previewed as a fixed bar, the last-used setting
Actual result: form is displayed as a Pop-up

Personally I think the "actual result' makes a little more sense, especially if it's been a while since editing the form. Because there aren't any stored settings for the form, the following code will determine the previewSetting's formType, which must be one of the options that's actually enabled for the form:

```js
  getPreviewSettings(state) {
    // Use previously used value
    if (state.previewSettings) {
      return state.previewSettings;
    }
    // Otherwise create one based on settings
    const previewSettings = {
      displayType: 'desktop',
      formType: 'others',
    };
    const settings = state.formData.settings;
    if (settings.formPlacement.belowPosts.enabled) {
      previewSettings.formType = 'below_post';
    }
    if (settings.formPlacement.popup.enabled) {
      previewSettings.formType = 'popup';
    }
    if (settings.formPlacement.fixedBar.enabled) {
      previewSettings.formType = 'fixed_bar';
    }
    if (settings.formPlacement.slideIn.enabled) {
      previewSettings.formType = 'slide_in';
    }
    return previewSettings;
  },
```

This is probably outside the scope of this ticket, and the fact remains that there could be a discrepancy in behavior for this case, which I imagine is probably an edge case. If we want to always retain the last-used preview form type setting we would need to also update the local storage immediately after saving a form (i.e. once the form gets an ID).
