### PR TITLE
Count non-customers in "none of" option of purchased product/in category segments [MAILPOET-4021]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -51,8 +51,6 @@ class WooCommerceProduct implements Filter {
         ->setParameter('count' . $parameterSuffix, count($productIds));
 
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
-      $this->applyCustomerJoin($queryBuilder);
-      $this->applyOrderJoin($queryBuilder);
       // subQuery with subscriber ids that bought products
       $subQuery = $this->createQueryBuilder($subscribersTable);
       $subQuery->select("DISTINCT $subscribersTable.id");

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use Helper\Database;
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooCommerceProductTest extends \MailPoetTest {
+  /** @var WooCommerceProduct */
+  private $wooCommerceProduct;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var int[] */
+  private $productIds;
+
+  /** @var int[] */
+  private $orderIds;
+
+  public function _before() {
+    $this->wooCommerceProduct = $this->diContainer->get(WooCommerceProduct::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+
+    Database::loadSQL('createWCLookupTables');
+    $this->cleanUp();
+
+    $customerId1 = $this->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->createCustomer('customer2@example.com', 'customer');
+
+    $this->createSubscriber('a1@example.com');
+    $this->createSubscriber('a2@example.com');
+
+    $this->productIds[] = $this->createProduct('testProduct1');
+    $this->productIds[] = $this->createProduct('testProduct2');
+
+    $this->orderIds[] = $this->createOrder($customerId1, Carbon::now());
+    $this->addToOrder(1, $this->orderIds[0], $this->productIds[0], $customerId1);
+    $this->orderIds[] = $this->createOrder($customerId2, Carbon::now());
+    $this->addToOrder(2, $this->orderIds[1], $this->productIds[1], $customerId2);
+  }
+
+  public function testItGetsSubscribersThatPurchasedAnyProducts() {
+    $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
+    $segmentFilter = $this->getSegmentFilter($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
+    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
+    $result = $queryBuilder->execute()->fetchAll();
+    $this->assertSame(2, count($result));
+    $emails = array_map([$this, 'getSubscriberEmail'], $result);
+    sort($emails, SORT_STRING);
+    $this->assertSame($expectedEmails, $emails);
+  }
+
+  public function testItGetsSubscribersThatDidNotPurchasedProducts() {
+    $expectedEmails = ['a1@example.com','a2@example.com', 'customer2@example.com'];
+    $segmentFilter = $this->getSegmentFilter([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_NONE);
+    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
+    $result = $queryBuilder->execute()->fetchAll();
+    $this->assertSame(3, count($result));
+    $emails = array_map([$this, 'getSubscriberEmail'], $result);
+    sort($emails, SORT_STRING);
+    $this->assertSame($expectedEmails, $emails);
+  }
+
+  public function testItGetsSubscribersThatPurchasedAllProducts() {
+    $segmentFilter = $this->getSegmentFilter($this->productIds, DynamicSegmentFilterData::OPERATOR_ALL);
+    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
+    $result = $queryBuilder->execute()->fetchAll();
+    $this->assertSame(0, count($result));
+
+    $expectedEmails = ['customer1@example.com'];
+    $segmentFilter = $this->getSegmentFilter([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
+    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
+    $result = $queryBuilder->execute()->fetchAll();
+    $this->assertSame(1, count($result));
+    $emails = array_map([$this, 'getSubscriberEmail'], $result);
+    $this->assertSame($expectedEmails, $emails);
+  }
+
+  private function getSubscriberEmail(array $value): string {
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $value['inner_subscriber_id']);
+    return $subscriber->getEmail();
+  }
+
+  private function getQueryBuilder(): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select("$subscribersTable.id as inner_subscriber_id")
+      ->from($subscribersTable);
+  }
+
+  private function getSegmentFilter(array $productIds, string $operator): DynamicSegmentFilterEntity {
+    $filterData = [
+      'product_ids' => $productIds,
+      'operator' => $operator,
+    ];
+
+    $data = new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceProduct::ACTION_PRODUCT,
+      $filterData
+    );
+    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
+    $this->entityManager->persist($segment);
+    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
+    $this->entityManager->persist($dynamicSegmentFilter);
+    $segment->addDynamicFilter($dynamicSegmentFilter);
+    return $dynamicSegmentFilter;
+  }
+
+  private function createCustomer(string $email, string $role): int {
+    global $wpdb;
+    $userId = $this->tester->createWordPressUser($email, $role);
+    $this->connection->executeQuery("
+      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
+      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
+    ");
+    return $userId;
+  }
+
+  private function createOrder(int $customerId, Carbon $createdAt): int {
+    global $wpdb;
+    $orderData = [
+      'post_type' => 'shop_order',
+      'post_status' => 'wc-completed',
+      'post_date' => $createdAt->toDateTimeString(),
+    ];
+
+    $orderId = wp_insert_post($orderData);
+    assert(is_integer($orderId));
+    $this->connection->executeQuery("
+      INSERT INTO {$wpdb->prefix}wc_order_stats (order_id, customer_id, status, date_created, date_created_gmt)
+      VALUES ({$orderId}, {$customerId}, 'wc-completed', '{$createdAt->toDateTimeString()}', '{$createdAt->toDateTimeString()}')
+    ");
+    return $orderId;
+  }
+
+  private function createProduct(string $name) {
+    $productData = [
+      'post_type' => 'product',
+      'post_status' => 'publish',
+      'post_title' => $name,
+    ];
+    return wp_insert_post($productData);
+  }
+
+  private function addToOrder(int $orderItemId, int $orderId, int $productId, int $customerId) {
+    global $wpdb;
+    $this->connection->executeQuery("
+      INSERT INTO {$wpdb->prefix}wc_order_product_lookup (order_item_id, order_id, product_id, customer_id, variation_id, product_qty)
+      VALUES ({$orderItemId}, {$orderId}, {$productId}, {$customerId}, 0, 1)
+    ");
+  }
+
+  private function createSubscriber(string $email): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail($email);
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+    return $subscriber;
+  }
+
+  public function _after() {
+    $this->cleanUp();
+  }
+
+  private function cleanUp() {
+    global $wpdb;
+    $this->truncateEntity(SegmentEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com'];
+    foreach ($emails as $email) {
+      $this->tester->deleteWordPressUser($email);
+    }
+
+    if (!empty($this->orders)) {
+      foreach ($this->orders as $orderId) {
+        wp_delete_post($orderId);
+      }
+    }
+
+    if (!empty($this->products)) {
+      foreach ($this->products as $productId) {
+        wp_delete_post($productId);
+      }
+    }
+
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_product_lookup");
+  }
+}


### PR DESCRIPTION
With this PR, when 'none' is selected, subscribers that never placed an order are also included on segments Purchased Products or Purchased in Category.

To test:
1. Go to MailPoet > Lists > Segment tab
2. Create a new segment
3. Select "purchased product", "none of" and a product (select one from your wish)
4. Save the segment
5. Create another segment
6. Select "purchased in category", "none of" and a category (any but remember which one you selected)
7. Save the segment
8. Now you have 2 segments that counts all subscribers who didn't purchase specific product or in specific category
9. Go and purchase some product (the one you selected) and make sure the subscriber is not counted in the segment list
10. Go and purchase some product (the one in category you selected) and make sure the subscriber isn't counted in the segment list
11. You could create also a segment with "purchased product" and "any of" type selecting the product which is in one of your lists, that will make sure that purchasing such product would add subscriber into that list and reducing it from one of your lists (that you previously created above)

Explanation: This test should ensure that segmentation can divide subscribers who have purchased specific products from those who never purchased it. Make sure to always press `Recalculate Now` button when you want to see the real standing of segments lists, e.g. after you place an order as a guest, registered user.. Lists need recalculation in order to show real results.


Note for developers: Integration tests for both segments:
```
./do --test "test:integration --file=tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedTest.php"
./do --test "test:integration --file=tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php"
```

[MAILPOET-4021]

[MAILPOET-4021]: https://mailpoet.atlassian.net/browse/MAILPOET-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ