### PR TITLE
Use WP plugins repo for downloading WooCommerce plugin - [MAILPOET-4046]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 5.2.2
+            ./do download:woo-commerce-zip 6.0.0
             ./do download:woo-commerce-subscriptions-zip 3.0.14
       - run:
           name: Dump tests ENV variables for acceptance tests

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -926,8 +926,8 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function downloadWooCommerceZip($tag = null) {
-    $this->createGithubClient('woocommerce/woocommerce')
-      ->downloadReleaseZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
+    $this->createWpOrgDownloader('woocommerce')
+    ->downloadPluginZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
   public function generateData($generatorName = null, $threads = 1) {
@@ -1065,6 +1065,11 @@ class RoboFile extends \Robo\Tasks {
       getenv('WP_GITHUB_USERNAME') ?: null,
       getenv('WP_GITHUB_TOKEN') ?: null
     );
+  }
+
+  private function createWpOrgDownloader($pluginSlug) {
+    require_once __DIR__ . '/tasks/WPOrgPluginDownloader.php';
+    return new \MailPoetTasks\WPOrgPluginDownloader($pluginSlug);
   }
 
   private function createDoctrineEntityManager() {

--- a/tasks/WPOrgPluginDownloader.php
+++ b/tasks/WPOrgPluginDownloader.php
@@ -50,7 +50,7 @@ class WPOrgPluginDownloader {
     }
 
     $recentVersion = $pluginInfo['version'];
-    if (! array_key_exists($tag, $pluginInfo['versions'])) {
+    if (!array_key_exists($tag, $pluginInfo['versions'])) {
       throw new \Exception("Plugin zip for version $tag not found. Most recent version is $recentVersion");
     }
 

--- a/tasks/WPOrgPluginDownloader.php
+++ b/tasks/WPOrgPluginDownloader.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MailPoetTasks;
+
+use GuzzleHttp\Client;
+
+class WPOrgPluginDownloader {
+  /** @var Client */
+  private $httpClient;
+
+  private const API_BASE_URI = 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information';
+
+  private $pluginSlug;
+
+  private $apiUrl;
+
+  public function __construct(
+    $pluginSlug
+  ) {
+    $this->pluginSlug = $pluginSlug;
+    $this->apiUrl = self::API_BASE_URI . "&request[slug]=$pluginSlug";
+    $this->httpClient = new Client();
+  }
+
+  public function downloadPluginZip($zip, $downloadDir, $tag = null) {
+    $downloadLink = $this->getDownloadLink($tag);
+
+    if (!is_dir($downloadDir)) {
+      mkdir($downloadDir, 0777, true);
+    }
+
+    $this->httpClient->get($downloadLink, ['sink' => $downloadDir . $zip, 'headers' => ['Accept' => 'application/octet-stream']]);
+    file_put_contents($downloadDir . '/' . $zip . '-info', $downloadLink);
+  }
+
+  private function getDownloadLink($tag = null) {
+    $pluginInfo = $this->getPluginInformation();
+
+    if (!$pluginInfo) {
+      throw new \Exception("Plugin {$this->pluginSlug} not found");
+    }
+
+    if ($pluginInfo['slug'] !== $this->pluginSlug) {
+      throw new \Exception("Error with data gotten from WordPress.org");
+    }
+
+    // use the latest version if tag is not specified
+    if (empty($tag) || $tag === 'latest') {
+      return $pluginInfo['download_link'];
+    }
+
+    $recentVersion = $pluginInfo['version'];
+    if (! array_key_exists($tag, $pluginInfo['versions'])) {
+      throw new \Exception("Plugin zip for version $tag not found. Most recent version is $recentVersion");
+    }
+
+    return $pluginInfo['versions'][$tag];
+  }
+
+  private function getPluginInformation() {
+    $response = $this->httpClient->get($this->apiUrl);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+}


### PR DESCRIPTION
We updated the command (`./do download:woo-commerce-zip`) to download the WooCommerce plugin from the WordPress.org directory instead of pulling it from Github.

We updated the WooCommerce plugin version used for acceptance tests on CircleCI from **5.2.2** to **6.0.0**

Testing
* Run the command: `./do download:woo-commerce-zip 4.0.0` (this would download WooCommerce version 4.0.0)
* Check the content of _tests/plugins/woocommerce.zip-info_. it should contain ***/woocommerce.4.0.0.zip
* You may choose to reconfirm this by unzipping _tests/plugins/woocommerce.zip_ and checking the plugin version

[MAILPOET-4046](https://mailpoet.atlassian.net/browse/MAILPOET-4046)