### PR TITLE
Updated baseline files [MAILPOET-3932]

### DIFF
--- a/tasks/phpstan/fix-WPStubs-for-PHP-8_1.php
+++ b/tasks/phpstan/fix-WPStubs-for-PHP-8_1.php
@@ -11,7 +11,7 @@ $data = file_get_contents($file);
 
 $search_term = 'function readonly';
 
-if (! strpos($data, $search_term)) {
+if (!strpos($data, $search_term)) {
   return;
 }
 

--- a/tasks/phpstan/phpstan-7-baseline.neon
+++ b/tasks/phpstan/phpstan-7-baseline.neon
@@ -1091,6 +1091,11 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
 
 		-
+			message: "#^Parameter \\#1 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+
+		-
 			message: "#^Parameter \\#2 \\$value of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -1872,7 +1877,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 7
+			count: 9
 			path: ../../tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
 
 		-
@@ -1892,7 +1897,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 7
+			count: 12
 			path: ../../tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
 
 		-

--- a/tasks/phpstan/phpstan-8-baseline.neon
+++ b/tasks/phpstan/phpstan-8-baseline.neon
@@ -1091,6 +1091,11 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
 
 		-
+			message: "#^Parameter \\#1 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+
+		-
 			message: "#^Parameter \\#2 \\$value of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -1877,7 +1882,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 7
+			count: 9
 			path: ../../tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
 
 		-
@@ -1897,7 +1902,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 7
+			count: 12
 			path: ../../tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
 
 		-

--- a/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -1091,6 +1091,11 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
 
 		-
+			message: "#^Parameter \\#1 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+
+		-
 			message: "#^Parameter \\#2 \\$value of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -1877,7 +1882,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 7
+			count: 9
 			path: ../../tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
 
 		-
@@ -1897,7 +1902,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 7
+			count: 12
 			path: ../../tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
 
 		-


### PR DESCRIPTION
We updated PHPStan to use a new Error level (Level 9).
Fixing current static analysis errors on master