### PR TITLE
Mask the API key when displayed in the info page

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
@@ -136,10 +136,10 @@ export default function KeyActivation() {
       />
       <Inputs>
         <Input
-          type="password"
+          type="text"
           id="mailpoet_premium_key"
           name="premium[premium_key]"
-          value={state.key ? 'premium_key' : ''}
+          value={state.key || ''}
           onChange={(event) => setState({
             mssStatus: null,
             premiumStatus: null,

--- a/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
@@ -139,7 +139,7 @@ export default function KeyActivation() {
           type="password"
           id="mailpoet_premium_key"
           name="premium[premium_key]"
-          value={state.key || ''}
+          value={state.key ? 'premium_key' : ''}
           onChange={(event) => setState({
             mssStatus: null,
             premiumStatus: null,

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -37,7 +37,7 @@ class Help {
   }
 
   public function render() {
-    $systemInfoData = $this->helpscoutBeacon->getData();
+    $systemInfoData = $this->helpscoutBeacon->getData(true);
     $cronPingResponse = $this->cronHelper->pingDaemon();
     $systemStatusData = [
       'cron' => [

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -156,40 +156,6 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   /**
-   * Wrapper around fillField, emit change event
-   *
-   * useful for emiting change events in react input components
-   *
-   * @param string $element - selectable by document.querySelector
-   * @param string $value
-   */
-  public function fillFieldWithOnChangeEvent($element, $value) {
-    $i = $this;
-    $i->waitForElement($element);
-    $i->executeJS("(() => {
-      const node = document.querySelector(arguments[0]);
-      const inputValue = arguments[1];
-
-      const descriptor = Object.getOwnPropertyDescriptor(node, 'value');
-
-      node.value = inputValue + '#';
-
-      if (descriptor && descriptor.configurable) {
-        delete node.value;
-      }
-      node.value = inputValue;
-
-      const e = document.createEvent('HTMLEvents');
-      e.initEvent('change', true, false);
-      node.dispatchEvent(e);
-
-      if (descriptor) {
-        Object.defineProperty(node, 'value', descriptor);
-      }
-    })()", [$element, $value]);
-  }
-
-  /**
    * Navigate to the editor for a newsletter.
    *
    * @param int|null $id

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -163,7 +163,7 @@ class AcceptanceTester extends \Codeception\Actor {
    * @param string $element - selectable by document.querySelector
    * @param string $value
    */
-  public function fillFieldWithOnChangeEvent(string $element, string $value = '') {
+  public function fillFieldWithOnChangeEvent($element, $value) {
     $i = $this;
     $i->waitForElement($element);
     $i->executeJS("(() => {

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -19,9 +19,7 @@ class AddSendingKeyCest {
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->click($keyActivationTab);
-
-    $selector = '[name="premium[premium_key]"]';
-    $i->fillFieldWithOnChangeEvent($selector, $mailPoetSendingKey);
+    $i->fillField('premium[premium_key]', $mailPoetSendingKey);
     $i->click('Verify');
 
     // validate key, activate MSS, install & activate Premium plugin
@@ -63,8 +61,7 @@ class AddSendingKeyCest {
     $i->dontSee('A test email was sent to');
 
     // try invalid key
-    $selector = '[name="premium[premium_key]"]';
-    $i->fillFieldWithOnChangeEvent($selector, 'invalid-key');
+    $i->fillField(['name' => 'premium[premium_key]'], 'invalid-key');
     $i->click('Verify');
     $i->waitForText('Your key is not valid for the MailPoet Sending Service');
     $i->waitForText('Your key is not valid for MailPoet Premium');

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -19,7 +19,7 @@ class AddSendingKeyCest {
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->click($keyActivationTab);
-    $i->fillField('premium[premium_key]', $mailPoetSendingKey);
+    $i->fillField(['name' => 'premium[premium_key]'], $mailPoetSendingKey);
     $i->click('Verify');
 
     // validate key, activate MSS, install & activate Premium plugin

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -21,7 +21,7 @@ class AddSendingKeyCest {
     $i->click($keyActivationTab);
 
     $selector = '[name="premium[premium_key]"]';
-    $i->fillFieldWithOnChangeEvent($selector, (string)$mailPoetSendingKey);
+    $i->fillFieldWithOnChangeEvent($selector, $mailPoetSendingKey);
     $i->click('Verify');
 
     // validate key, activate MSS, install & activate Premium plugin

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -5,9 +5,9 @@ namespace MailPoet\Test\Helpscout;
 use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Helpscout\Beacon;
-use MailPoet\Models\Subscriber;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
 class BeaconTest extends \MailPoetTest {
@@ -18,22 +18,22 @@ class BeaconTest extends \MailPoetTest {
     parent::_before();
     $this->cleanup();
     // create 4 users (1 confirmed, 1 subscribed, 1 unsubscribed, 1 bounced)
-    Subscriber::createOrUpdate([
-      'email' => 'user1@mailpoet.com',
-      'status' => Subscriber::STATUS_SUBSCRIBED,
-    ]);
-    Subscriber::createOrUpdate([
-      'email' => 'user2@mailpoet.com',
-      'status' => Subscriber::STATUS_UNCONFIRMED,
-    ]);
-    Subscriber::createOrUpdate([
-      'email' => 'user3@mailpoet.com',
-      'status' => Subscriber::STATUS_UNSUBSCRIBED,
-    ]);
-    Subscriber::createOrUpdate([
-      'email' => 'user4@mailpoet.com',
-      'status' => Subscriber::STATUS_BOUNCED,
-    ]);
+    $subscriberFactory = new SubscriberFactory();
+    $subscriberFactory
+      ->withEmail('user1@mailpoet.com')
+      ->create();
+    $subscriberFactory
+      ->withEmail('user2@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    $subscriberFactory
+      ->withEmail('user3@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->create();
+    $subscriberFactory
+      ->withEmail('user4@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_BOUNCED)
+      ->create();
 
     $this->beaconData = $this->diContainer->get(Beacon::class)->getData();
     $this->settings = SettingsController::getInstance();

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Helpscout;
 
+use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Helpscout\Beacon;
 use MailPoet\Models\Subscriber;
@@ -162,7 +163,16 @@ class BeaconTest extends \MailPoetTest {
     );
   }
 
+  public function testItMasksPremiumKey() {
+    $this->settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, 'f5c08f56464665c99fb462fa584398b5');
+    $expectedResult = 'f5c08f56464665c9****************';
+    $beaconData = $this->diContainer->get(Beacon::class)->getData(true);
+
+    $this->assertSame($expectedResult, $beaconData['MailPoet Premium/MSS key']);
+  }
+
   private function cleanup() {
     $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SettingEntity::class);
   }
 }


### PR DESCRIPTION
This PR reverts the commits from #3804 and implements logic to mask half of the API key when it is displayed on the System Info page. There is also a bonus commit replacing the old Subscriber model used in an updated integration tests file with the Doctrine equivalent.

[MAILPOET-4009]

[MAILPOET-4009]: https://mailpoet.atlassian.net/browse/MAILPOET-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Settings
2. Click on Key Activation tab
3. Verify the key is visible in full (without ***)
4. Then, go to MailPoet > Help
5. Click on System Info tab
6. Verify you see your key in half visible and half *** such as: `MailPoet Premium/MSS key: 12345678910111213****************`