### PR TITLE
Prevent tests from emailing [randomhex]@example.com [MAILPOET-4064]

### DIFF
--- a/mailpoet/tests/integration/Mailer/MailerTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerTest.php
@@ -64,7 +64,7 @@ class MailerTest extends \MailPoetTest {
         getenv('WP_TEST_MAILER_MAILPOET_API') :
         '1234567890',
     ];
-    $this->subscriber = 'Recipient <mailpoet-phoenix-test@mailinator.com>';
+    $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing Mailer',
       'body' => [
@@ -209,7 +209,7 @@ class MailerTest extends \MailPoetTest {
 
     $subscriberFactory = new SubscriberFactory();
     $subscriber = $subscriberFactory
-      ->withEmail('mailpoet-phoenix-test@mailinator.com')
+      ->withEmail('blackhole@mailpoet.com')
       ->withFirstName('Recipient')
       ->create();
     $this->sender['address'] = 'staff@mailpoet.com';

--- a/mailpoet/tests/integration/Mailer/MailerTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerTest.php
@@ -208,7 +208,10 @@ class MailerTest extends \MailPoetTest {
     }
 
     $subscriberFactory = new SubscriberFactory();
-    $subscriber = $subscriberFactory->withFirstName('Recipient')->create();
+    $subscriber = $subscriberFactory
+      ->withEmail('mailpoet-phoenix-test@mailinator.com')
+      ->withFirstName('Recipient')
+      ->create();
     $this->sender['address'] = 'staff@mailpoet.com';
     $mailer = new Mailer();
     $mailer->init($this->mailer, $this->sender, $this->replyTo);

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -53,7 +53,7 @@ class AmazonSESTest extends \MailPoetTest {
       $this->returnPath,
       new AmazonSESMapper()
     );
-    $this->subscriber = 'Recipient <mailpoet-phoenix-test@mailinator.com>';
+    $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing AmazonSES … © & ěščřžýáíéůėę€żąß∂ 😊👨‍👩‍👧‍👧', // try some special chars
       'body' => [
@@ -122,7 +122,7 @@ class AmazonSESTest extends \MailPoetTest {
     $message = $this->mailer
       ->createMessage($this->newsletter, $this->subscriber, $this->extraParams);
     expect($message->getTo())
-      ->equals(['mailpoet-phoenix-test@mailinator.com' => 'Recipient']);
+      ->equals(['blackhole@mailpoet.com' => 'Recipient']);
     expect($message->getFrom())
       ->equals([$this->sender['from_email'] => $this->sender['from_name']]);
     expect($message->getSender())

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -47,7 +47,7 @@ class MailPoetAPITest extends \MailPoetTest {
       new MailPoetMapper(),
       $this->makeEmpty(AuthorizedEmailsController::class)
     );
-    $this->subscriber = 'Recipient <mailpoet-phoenix-test@mailinator.com>';
+    $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing MailPoet … © & ěščřžýáíéůėę€żąß∂ 😊👨‍👩‍👧‍👧', // try some special chars
       'body' => [

--- a/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -37,7 +37,7 @@ class PHPMailTest extends \MailPoetTest {
       $this->returnPath,
       new PHPMailMapper()
     );
-    $this->subscriber = 'Recipient <mailpoet-phoenix-test@mailinator.com>';
+    $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing local method (PHP mail) … © & ěščřžýáíéůėę€żąß∂ 😊👨‍👩‍👧‍👧', // try some special chars
       'body' => [
@@ -75,13 +75,13 @@ class PHPMailTest extends \MailPoetTest {
     expect($mailer->getToAddresses())->equals(
       [
         [
-          'mailpoet-phoenix-test@mailinator.com',
+          'blackhole@mailpoet.com',
           'Recipient',
         ],
       ]
     );
     expect($mailer->getAllRecipientAddresses())
-      ->equals(['mailpoet-phoenix-test@mailinator.com' => true]);
+      ->equals(['blackhole@mailpoet.com' => true]);
     expect($mailer->From)->equals($this->sender['from_email']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     expect($mailer->FromName)->equals($this->sender['from_name']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     expect($mailer->getReplyToAddresses())->equals(

--- a/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
@@ -60,7 +60,7 @@ class SMTPTest extends \MailPoetTest {
       $this->settings['login'],
       $this->settings['password']
     );
-    $this->subscriber = 'Recipient <mailpoet-phoenix-test@mailinator.com>';
+    $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing SMTP … © & ěščřžýáíéůėę€żąß∂ 😊👨‍👩‍👧‍👧', // try some special chars
       'body' => [
@@ -107,7 +107,7 @@ class SMTPTest extends \MailPoetTest {
     $message = $this->mailer
       ->createMessage($this->newsletter, $this->subscriber, $this->extraParams);
     expect($message->getTo())
-      ->equals(['mailpoet-phoenix-test@mailinator.com' => 'Recipient']);
+      ->equals(['blackhole@mailpoet.com' => 'Recipient']);
     expect($message->getFrom())
       ->equals([$this->sender['from_email'] => $this->sender['from_name']]);
     expect($message->getSender())

--- a/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
@@ -42,7 +42,7 @@ class SendGridTest extends \MailPoetTest {
       $this->replyTo,
       new SendGridMapper()
     );
-    $this->subscriber = 'Recipient <mailpoet-phoenix-test@mailinator.com>';
+    $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing SendGrid … © & ěščřžýáíéůėę€żąß∂ 😊👨‍👩‍👧‍👧', // try some special chars
       'body' => [


### PR DESCRIPTION
Previously this test was using random email addresses in the form of
`bin2hex(random_bytes(7)) . '@example.com'`, the default address
generated by `\MailPoet\Test\DataFactories\Subscriber`. This was causing
the staff@mailpoet.com account to get banned by the MSS due to
`bad-domain-discard`s. Using the mailinator email address instead, like
the other sending tests, should prevent this from occurring.

[MAILPOET-4064]

[MAILPOET-4064]: https://mailpoet.atlassian.net/browse/MAILPOET-4064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ