### PR TITLE
Remove exact comparison with last order id in WooCommerce sync [MAILPOET-4065]

### DIFF
--- a/lib/Cron/Workers/WooCommerceSync.php
+++ b/lib/Cron/Workers/WooCommerceSync.php
@@ -41,21 +41,21 @@ class WooCommerceSync extends SimpleWorker {
     $meta = $task->getMeta();
     $highestOrderId = $this->getHighestOrderId();
 
-    if (!isset($meta['last_processed_order_id'])) {
-      $meta['last_processed_order_id'] = 0;
+    if (!isset($meta['last_checked_order_id'])) {
+      $meta['last_checked_order_id'] = 0;
     }
 
     do {
       $this->cronHelper->enforceExecutionLimit($timer);
-      $meta['last_processed_order_id'] = $this->woocommerceSegment->synchronizeCustomers(
-        $meta['last_processed_order_id'],
+      $meta['last_checked_order_id'] = $this->woocommerceSegment->synchronizeCustomers(
+        $meta['last_checked_order_id'],
         $highestOrderId,
         self::BATCH_SIZE
       );
       $task->setMeta($meta);
       $this->scheduledTasksRepository->persist($task);
       $this->scheduledTasksRepository->flush();
-    } while ($meta['last_processed_order_id'] !== $highestOrderId);
+    } while ($meta['last_checked_order_id'] < $highestOrderId);
 
     return true;
   }

--- a/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -41,7 +41,8 @@ class WooCommerceSyncTest extends \MailPoetTest {
 
   public function testItCallsWooCommerceSync() {
     $this->woocommerceSegment->expects($this->once())
-      ->method('synchronizeCustomers');
+      ->method('synchronizeCustomers')
+      ->willReturn(1000);
     $task = $this->scheduledTaskFactory->create(
       WooCommerceSync::TASK_TYPE,
       null,


### PR DESCRIPTION
[MAILPOET-4065]

[MAILPOET-4065]: https://mailpoet.atlassian.net/browse/MAILPOET-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ