### PR TITLE
Add a check of production vendor packages for PHP 7 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,11 @@ executors:
     docker:
     - image: mailpoet/wordpress:7.2_20211213.1
 
+  wpcli_php_max_wporg:
+    <<: *default_job_config
+    docker:
+      - image: mailpoet/wordpress:7.4_20210122.1
+
   wpcli_php_latest:
     <<: *default_job_config
     docker:
@@ -255,6 +260,14 @@ jobs:
   qa_php_oldest:
     executor: wpcli_php_oldest
     working_directory: /home/circleci/mailpoet/mailpoet
+    steps:
+      - attach_workspace:
+          at: /home/circleci/mailpoet
+      - run:
+          name: "QA PHP"
+          command: ./do qa:php
+  qa_php_max_wporg:
+    executor: wpcli_php_max_wporg
     steps:
       - attach_workspace:
           at: /home/circleci/mailpoet
@@ -485,6 +498,10 @@ workflows:
           requires:
             - build
       - qa_php_oldest:
+          <<: *slack-fail-post-step
+          requires:
+            - build
+      - qa_php_max_wporg:
           <<: *slack-fail-post-step
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ jobs:
           at: /home/circleci/mailpoet
       - run:
           name: "QA PHP"
-          command: ./do qa:php
+          command: ./do qa:php-max-wporg
   js_tests:
     executor: wpcli_php_latest
     working_directory: /home/circleci/mailpoet/mailpoet

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -347,6 +347,12 @@ class RoboFile extends \Robo\Tasks {
     return $collection->run();
   }
 
+  public function qaPhpMaxWPOrg() {
+    $collection = $this->collectionBuilder();
+    $collection->addCode([$this, 'qaLintBuild']);
+    return $collection->run();
+  }
+
   public function qaFrontendAssets() {
     $collection = $this->collectionBuilder();
     $collection->addCode([$this, 'qaLintJavascript']);
@@ -356,6 +362,46 @@ class RoboFile extends \Robo\Tasks {
 
   public function qaLint() {
     return $this->_exec('./tasks/code_sniffer/vendor/bin/parallel-lint lib/ tests/ mailpoet.php');
+  }
+
+  public function qaLintBuild() {
+    $task = './tasks/code_sniffer/vendor/bin/parallel-lint';
+    $filesToCheckString = implode(' ', [
+      'lib/',
+      'lib-3rd-party/',
+      'vendor/composer',
+      'vendor/mtdowling',
+      'vendor/soundasleep',
+      'vendor-prefixed/',
+      'mailpoet.php',
+    ]);
+    $filesToExcludeString = '--exclude ' . implode(' --exclude ', [
+      'vendor-prefixed/symfony/dependency-injection/Compiler',
+      'vendor-prefixed/symfony/dependency-injection/Config',
+      'vendor-prefixed/symfony/dependency-injection/Dumper',
+      'vendor-prefixed/symfony/dependency-injection/Loader',
+      'vendor-prefixed/symfony/dependency-injection/LazyProxy',
+      'vendor-prefixed/symfony/dependency-injection/Extension',
+      'vendor-prefixed/cerdic/css-tidy/COPYING',
+      'vendor-prefixed/cerdic/css-tidy/NEWS',
+      'vendor-prefixed/cerdic/css-tidy/testing',
+      'vendor/mtdowling/cron-expression/tests',
+      'vendor/phpmailer/phpmailer/test',
+      'vendor-prefixed/psr/log/Psr/Log/Test',
+      'vendor-prefixed/sabberworm/php-css-parser/tests',
+      'vendor/soundasleep/html2text/tests',
+      'vendor-prefixed/swiftmailer/swiftmailer/tests',
+      'vendor-prefixed/symfony/service-contracts/Tests',
+      'vendor-prefixed/symfony/translation/Tests',
+      'vendor-prefixed/symfony/translation-contracts/Tests',
+      'vendor-prefixed/cerdic/css-tidy/css_optimiser.php',
+      'vendor-prefixed/gregwar/captcha/demo',
+    ]);
+
+    return $this
+      ->taskExec($task)
+      ->rawArg(implode(' ', [$filesToExcludeString, $filesToCheckString]))
+      ->run();
   }
 
   public function qaLintJavascript() {
@@ -394,7 +440,7 @@ class RoboFile extends \Robo\Tasks {
       'tests/_output',
       'tests/_support/_generated',
       'vendor',
-      'vendor-prefixed',
+      'vendor-prefixed/gregwar/captcha/demo',
       'views',
     ];
     $stringFilesToCheck = !empty($filesToCheck) ? implode(' ', $filesToCheck) : '.';

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -375,6 +375,7 @@ class RoboFile extends \Robo\Tasks {
       'vendor-prefixed/',
       'mailpoet.php',
     ]);
+    // The list of files and folders to exclude is coming from build.sh
     $filesToExcludeString = '--exclude ' . implode(' --exclude ', [
       'vendor-prefixed/symfony/dependency-injection/Compiler',
       'vendor-prefixed/symfony/dependency-injection/Config',
@@ -440,7 +441,7 @@ class RoboFile extends \Robo\Tasks {
       'tests/_output',
       'tests/_support/_generated',
       'vendor',
-      'vendor-prefixed/gregwar/captcha/demo',
+      'vendor-prefixed',
       'views',
     ];
     $stringFilesToCheck = !empty($filesToCheck) ? implode(' ', $filesToCheck) : '.';


### PR DESCRIPTION
This PR includes a PHP lint job for `vendor` and `vendor-prefixed` folders that are included in the final build.

From the links below, WordPress.org plugin directory pre-commit hook lints on PHP7.4
Sources:
https://meta.trac.wordpress.org/ticket/3791#comment:36
https://wordpress.slack.com/archives/C02QB8GMM/p1619603847340700

The added job uses MailPoet WordPress 7.4 image. 
The lint function includes the files/folders that are present on the final build.
I have used [build.sh](https://github.com/mailpoet/mailpoet/blob/master/build.sh) as reference to exclude files/folders from the vendor-prefixed linted files.

[MAILPOET-3905]

[MAILPOET-3905]: https://mailpoet.atlassian.net/browse/MAILPOET-3905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ