### PR TITLE
Add Woo memberships segment [MAILPOET-3880]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -909,6 +909,15 @@ class RoboFile extends \Robo\Tasks {
     $this->say("Release '$version[name]' info was published on Slack.");
   }
 
+  public function downloadWooCommerceMembershipsZip($tag = null) {
+    if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
+      $this->yell("Skipping download of WooCommerce Memberships", 40, 'red');
+      exit(0); // Exit with 0 since it is a valid state for some environments
+    }
+    $this->createGithubClient('woocommerce/woocommerce-memberships')
+      ->downloadReleaseZip('woocommerce-memberships.zip', __DIR__ . '/tests/plugins/', $tag);
+  }
+
   public function downloadWooCommerceSubscriptionsZip($tag = null) {
     if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
       $this->yell("Skipping download of WooCommerce Subscriptions", 40, 'red');

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_membership.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_membership.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect } from 'react';
+import MailPoet from 'mailpoet';
+import { filter } from 'lodash/fp';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+import ReactSelect from 'common/form/react_select/react_select';
+import Select from 'common/form/select/select';
+import { Grid } from 'common/grid';
+
+import {
+  AnyValueTypes,
+  SegmentTypes,
+  SelectOption,
+  WindowMembershipPlans,
+  WooCommerceMembershipFormItem,
+} from '../types';
+
+enum WooCommerceMembershipsActionTypes {
+  MEMBER_OF = 'isMemberOf',
+}
+
+export const WooCommerceMembershipOptions = [
+  { value: WooCommerceMembershipsActionTypes.MEMBER_OF, label: MailPoet.I18n.t('segmentsActiveMembership'), group: SegmentTypes.WooCommerceMembership },
+];
+
+export function validateWooCommerceMembership(
+  formItem: WooCommerceMembershipFormItem
+): boolean {
+  const isIncomplete = !formItem.plan_ids || !formItem.plan_ids.length || !formItem.operator;
+  if (
+    formItem.action === WooCommerceMembershipsActionTypes.MEMBER_OF
+    && isIncomplete
+  ) {
+    return false;
+  }
+  return true;
+}
+
+type Props = {
+  filterIndex: number;
+}
+
+export const WooCommerceMembershipFields: React.FunctionComponent<Props> = ({ filterIndex }) => {
+  const segment: WooCommerceMembershipFormItem = useSelect(
+    (select) => select('mailpoet-dynamic-segments-form').getSegmentFilter(filterIndex),
+    [filterIndex]
+  );
+
+  const { updateSegmentFilter, updateSegmentFilterFromEvent } = useDispatch('mailpoet-dynamic-segments-form');
+
+  const membershipPlans: WindowMembershipPlans = useSelect(
+    (select) => select('mailpoet-dynamic-segments-form').getMembershipPlans(),
+    []
+  );
+  const planOptions = membershipPlans.map((plan) => ({
+    value: plan.id,
+    label: plan.name,
+  }));
+
+  useEffect(() => {
+    if (
+      (segment.action === WooCommerceMembershipsActionTypes.MEMBER_OF)
+      && (segment.operator !== AnyValueTypes.ANY)
+      && (segment.operator !== AnyValueTypes.ALL)
+      && (segment.operator !== AnyValueTypes.NONE)
+    ) {
+      updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
+
+  return (
+    <>
+      <Grid.CenteredRow>
+        <Select
+          key="select-operator"
+          value={segment.operator}
+          onChange={(e) => updateSegmentFilterFromEvent(
+            'operator',
+            filterIndex,
+            e
+          )}
+          automationId="select-operator"
+        >
+          <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+          <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+          <option value={AnyValueTypes.NONE}>{MailPoet.I18n.t('noneOf')}</option>
+        </Select>
+      </Grid.CenteredRow>
+      <Grid.CenteredRow>
+        <ReactSelect
+          isMulti
+          dimension="small"
+          key="select-segment-membership-plan"
+          isFullWidth
+          placeholder={MailPoet.I18n.t('selectWooMembership')}
+          options={planOptions}
+          value={filter(
+            (option) => {
+              if (!segment.plan_ids) return false;
+              return segment.plan_ids.indexOf(option.value) !== -1;
+            },
+            planOptions
+          )}
+          onChange={(options: SelectOption[]): void => updateSegmentFilter(
+            { plan_ids: (options || []).map((x: SelectOption) => x.value) },
+            filterIndex
+          )}
+          automationId="select-segment-plans"
+        />
+      </Grid.CenteredRow>
+    </>
+  );
+};

--- a/mailpoet/assets/js/src/segments/dynamic/form_filter_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/form_filter_fields.tsx
@@ -9,12 +9,14 @@ import {
 import { EmailFields } from './dynamic_segments_filters/email';
 import { SubscriberFields } from './dynamic_segments_filters/subscriber';
 import { WooCommerceFields } from './dynamic_segments_filters/woocommerce';
+import { WooCommerceMembershipFields } from './dynamic_segments_filters/woocommerce_membership';
 import { WooCommerceSubscriptionFields } from './dynamic_segments_filters/woocommerce_subscription';
 
 const filterFieldsMap = {
   [SegmentTypes.Email]: EmailFields,
   [SegmentTypes.WooCommerce]: WooCommerceFields,
   [SegmentTypes.WordPressRole]: SubscriberFields,
+  [SegmentTypes.WooCommerceMembership]: WooCommerceMembershipFields,
   [SegmentTypes.WooCommerceSubscription]: WooCommerceSubscriptionFields,
 };
 

--- a/mailpoet/assets/js/src/segments/dynamic/store/all_available_filters.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/all_available_filters.ts
@@ -4,9 +4,13 @@ import { GroupFilterValue } from '../types';
 import { EmailSegmentOptions } from '../dynamic_segments_filters/email';
 import { SubscriberSegmentOptions } from '../dynamic_segments_filters/subscriber';
 import { WooCommerceOptions } from '../dynamic_segments_filters/woocommerce';
+import { WooCommerceMembershipOptions } from '../dynamic_segments_filters/woocommerce_membership';
 import { WooCommerceSubscriptionOptions } from '../dynamic_segments_filters/woocommerce_subscription';
 
-export function getAvailableFilters(canUseWooSubscriptions: boolean): GroupFilterValue[] {
+export function getAvailableFilters(
+  canUseWooSubscriptions: boolean,
+  canUseWooMembership: boolean
+): GroupFilterValue[] {
   const filters: GroupFilterValue[] = [
     {
       label: MailPoet.I18n.t('email'),
@@ -21,6 +25,12 @@ export function getAvailableFilters(canUseWooSubscriptions: boolean): GroupFilte
     filters.push({
       label: MailPoet.I18n.t('woocommerce'),
       options: WooCommerceOptions,
+    });
+  }
+  if (MailPoet.isWoocommerceActive && canUseWooMembership) {
+    filters.push({
+      label: MailPoet.I18n.t('woocommerceMemberships'),
+      options: WooCommerceMembershipOptions,
     });
   }
   if (MailPoet.isWoocommerceActive && canUseWooSubscriptions) {

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -9,6 +9,7 @@ import {
   SubscriberCount,
   WindowCustomFields,
   WindowEditableRoles,
+  WindowMembershipPlans,
   WindowNewslettersList,
   WindowProductCategories,
   WindowProducts,
@@ -18,6 +19,9 @@ import {
 
 export const getProducts = (state: StateType): WindowProducts => (
   state.products
+);
+export const getMembershipPlans = (state: StateType): WindowMembershipPlans => (
+  state.membershipPlans
 );
 export const getSubscriptionProducts = (state: StateType): WindowSubscriptionProducts => (
   state.subscriptionProducts

--- a/mailpoet/assets/js/src/segments/dynamic/store/store.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/store.ts
@@ -24,10 +24,12 @@ export const createStore = (): void => {
   const defaultState: StateType = {
     products: window.mailpoet_products,
     staticSegmentsList: window.mailpoet_static_segments_list,
+    membershipPlans: window.mailpoet_membership_plans,
     subscriptionProducts: window.mailpoet_subscription_products,
     productCategories: window.mailpoet_product_categories,
     newslettersList: window.mailpoet_newsletters_list,
     wordpressRoles: window.wordpress_editable_roles_list,
+    canUseWooMemberships: window.mailpoet_can_use_woocommerce_memberships,
     canUseWooSubscriptions: window.mailpoet_can_use_woocommerce_subscriptions,
     wooCurrencySymbol: window.mailpoet_woocommerce_currency_symbol,
     wooCountries: window.mailpoet_woocommerce_countries,
@@ -45,7 +47,10 @@ export const createStore = (): void => {
       loading: false,
     },
     errors: [],
-    allAvailableFilters: getAvailableFilters(window.mailpoet_can_use_woocommerce_subscriptions),
+    allAvailableFilters: getAvailableFilters(
+      window.mailpoet_can_use_woocommerce_subscriptions,
+      window.mailpoet_can_use_woocommerce_memberships
+    ),
   };
 
   const config = {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -3,6 +3,7 @@ export enum SegmentTypes {
   WordPressRole = 'userRole',
   SubscribedDate = 'subscribedDate',
   WooCommerce = 'woocommerce',
+  WooCommerceMembership = 'woocommerceMembership',
   WooCommerceSubscription = 'woocommerceSubscription'
 }
 
@@ -83,6 +84,11 @@ export interface WooCommerceFormItem extends FormItem {
   country_code?: string[];
 }
 
+export interface WooCommerceMembershipFormItem extends FormItem {
+  plan_ids?: string[];
+  operator?: AnyValueTypes;
+}
+
 export interface WooCommerceSubscriptionFormItem extends FormItem {
   product_ids?: string[];
   operator?: AnyValueTypes;
@@ -129,6 +135,11 @@ export type WindowProducts = {
   name: string;
 }[];
 
+export type WindowMembershipPlans = {
+  id: string;
+  name: string;
+}[];
+
 export type WindowSubscriptionProducts = {
   id: string;
   name: string;
@@ -169,11 +180,13 @@ export type StaticSegment = {
 export interface SegmentFormDataWindow extends Window {
   wordpress_editable_roles_list: WindowEditableRoles;
   mailpoet_products: WindowProducts;
+  mailpoet_membership_plans: WindowMembershipPlans;
   mailpoet_subscription_products: WindowSubscriptionProducts;
   mailpoet_product_categories: WindowProductCategories;
   mailpoet_woocommerce_countries: WindowWooCommerceCountries;
   mailpoet_newsletters_list: WindowNewslettersList;
   mailpoet_custom_fields: WindowCustomFields;
+  mailpoet_can_use_woocommerce_memberships: boolean;
   mailpoet_can_use_woocommerce_subscriptions: boolean;
   mailpoet_woocommerce_currency_symbol: string;
   mailpoet_static_segments_list: StaticSegment[];
@@ -181,10 +194,12 @@ export interface SegmentFormDataWindow extends Window {
 
 export interface StateType {
   products: WindowProducts;
+  membershipPlans: WindowMembershipPlans;
   subscriptionProducts: WindowSubscriptionProducts;
   wordpressRoles: WindowEditableRoles;
   productCategories: WindowProductCategories;
   newslettersList: WindowNewslettersList;
+  canUseWooMemberships: boolean;
   canUseWooSubscriptions: boolean;
   wooCurrencySymbol: string;
   wooCountries: WindowWooCommerceCountries;

--- a/mailpoet/assets/js/src/segments/dynamic/validator.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/validator.ts
@@ -2,12 +2,14 @@ import { AnyFormItem, SegmentTypes } from './types';
 import { validateEmail } from './dynamic_segments_filters/email';
 import { validateWooCommerce } from './dynamic_segments_filters/woocommerce';
 import { validateSubscriber } from './dynamic_segments_filters/subscriber';
+import { validateWooCommerceMembership } from './dynamic_segments_filters/woocommerce_membership';
 import { validateWooCommerceSubscription } from './dynamic_segments_filters/woocommerce_subscription';
 
 const validationMap = {
   [SegmentTypes.Email]: validateEmail,
   [SegmentTypes.WooCommerce]: validateWooCommerce,
   [SegmentTypes.WordPressRole]: validateSubscriber,
+  [SegmentTypes.WooCommerceMembership]: validateWooCommerceMembership,
   [SegmentTypes.WooCommerceSubscription]: validateWooCommerceSubscription,
 };
 

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -141,6 +141,7 @@ class Segments {
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();
 
     $data['products'] = $this->wpPostListLoader->getProducts();
+    $data['membership_plans'] = $this->wpPostListLoader->getMembershipPlans();
     $data['subscription_products'] = $this->wpPostListLoader->getSubscriptionProducts();
     $data['is_woocommerce_active'] = $this->woocommerceHelper->isWooCommerceActive();
     $wcCountries = $this->woocommerceHelper->isWooCommerceActive() ? $this->woocommerceHelper->getAllowedCountries() : [];
@@ -150,6 +151,9 @@ class Segments {
         'code' => $code,
       ];
     }, array_keys($wcCountries), $wcCountries);
+    $data['can_use_woocommerce_memberships'] = $this->segmentDependencyValidator->canUseDynamicFilterType(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP
+    );
     $data['can_use_woocommerce_subscriptions'] = $this->segmentDependencyValidator->canUseDynamicFilterType(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION
     );

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -15,6 +15,7 @@ use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
@@ -157,6 +158,7 @@ class Reporter {
       'Segment > not opened' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_NOT_OPENED),
       'Segment > opened' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_OPENED),
       'Segment > machine-opened' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_EMAIL, EmailAction::ACTION_MACHINE_OPENED),
+      'Segment > is active member of' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP, WooCommerceMembership::ACTION_MEMBER_OF),
       'Segment > has an active subscription' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION, WooCommerceSubscription::ACTION_HAS_ACTIVE),
       'Segment > is in country' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCountry::ACTION_CUSTOMER_COUNTRY),
       'Segment > MailPoet custom field' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE),

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -308,6 +308,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\UserRole::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent::class)->setPublic(true);

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -13,6 +13,7 @@ class DynamicSegmentFilterData {
   const TYPE_USER_ROLE = 'userRole';
   const TYPE_EMAIL = 'email';
   const TYPE_WOOCOMMERCE = 'woocommerce';
+  const TYPE_WOOCOMMERCE_MEMBERSHIP = 'woocommerceMembership';
   const TYPE_WOOCOMMERCE_SUBSCRIPTION = 'woocommerceSubscription';
 
   public const CONNECT_TYPE_AND = 'and';

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -22,6 +22,7 @@ class SegmentEntity {
 
   const TYPE_WP_USERS = 'wp_users';
   const TYPE_WC_USERS = 'woocommerce_users';
+  const TYPE_WC_MEMBERSHIPS = 'woocommerce_memberships';
   const TYPE_DEFAULT = 'default';
   const TYPE_DYNAMIC = 'dynamic';
   const TYPE_WITHOUT_LIST = 'without-list';
@@ -136,7 +137,7 @@ class SegmentEntity {
   }
 
   public function isStatic(): bool {
-    return in_array($this->getType(), [self::TYPE_DEFAULT, self::TYPE_WP_USERS, self::TYPE_WC_USERS], true);
+    return in_array($this->getType(), [self::TYPE_DEFAULT, self::TYPE_WP_USERS, self::TYPE_WC_USERS, self::TYPE_WC_MEMBERSHIPS], true);
   }
 
   public function getAverageEngagementScore(): ?float {

--- a/mailpoet/lib/Models/Segment.php
+++ b/mailpoet/lib/Models/Segment.php
@@ -19,6 +19,7 @@ class Segment extends Model {
   public static $_table = MP_SEGMENTS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
   const TYPE_WP_USERS = SegmentEntity::TYPE_WP_USERS;
   const TYPE_WC_USERS = SegmentEntity::TYPE_WC_USERS;
+  const TYPE_WC_MEMBERSHIPS = SegmentEntity::TYPE_WC_MEMBERSHIPS;
   const TYPE_DEFAULT = SegmentEntity::TYPE_DEFAULT;
 
   public function __construct() {

--- a/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
@@ -20,4 +20,5 @@ class InvalidFilterException extends InvalidStateException {
   const MISSING_COUNTRY = 13;
   const MISSING_FILTER = 14;
   const MISSING_OPERATOR = 15;
+  const MISSING_PLAN_ID = 16;
 };

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -13,6 +13,7 @@ use MailPoet\Segments\DynamicSegments\Filters\SubscriberSegment;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
@@ -61,6 +62,8 @@ class FilterDataMapper {
         return $this->createEmail($filterData);
       case DynamicSegmentFilterData::TYPE_WOOCOMMERCE:
         return $this->createWooCommerce($filterData);
+      case DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP:
+        return $this->createWooCommerceMembership($filterData);
       case DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION:
         return $this->createWooCommerceSubscription($filterData);
       default:
@@ -234,6 +237,27 @@ class FilterDataMapper {
       $filterData['total_spent_type'] = $data['total_spent_type'];
       $filterData['total_spent_amount'] = $data['total_spent_amount'];
       $filterData['total_spent_days'] = $data['total_spent_days'];
+    } else {
+      throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
+    }
+    return new DynamicSegmentFilterData($filterType, $action, $filterData);
+  }
+
+  /**
+   * @throws InvalidFilterException
+   */
+  private function createWooCommerceMembership(array $data): DynamicSegmentFilterData {
+    if (empty($data['action'])) throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    $filterData = [
+      'connect' => $data['connect'],
+    ];
+    $filterType = DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP;
+    $action = $data['action'];
+    if ($data['action'] === WooCommerceMembership::ACTION_MEMBER_OF) {
+      if (!isset($data['plan_ids']) || !is_array($data['plan_ids'])) throw new InvalidFilterException('Missing plan', InvalidFilterException::MISSING_PLAN_ID);
+      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      $filterData['operator'] = $data['operator'];
+      $filterData['plan_ids'] = $data['plan_ids'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -16,6 +16,7 @@ use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
@@ -42,6 +43,9 @@ class FilterFactory {
 
   /** @var WooCommerceTotalSpent */
   private $wooCommerceTotalSpent;
+
+  /** @var WooCommerceMembership */
+  private $wooCommerceMembership;
 
   /** @var WooCommerceSubscription */
   private $wooCommerceSubscription;
@@ -75,6 +79,7 @@ class FilterFactory {
     EmailOpensAbsoluteCountAction $emailOpensAbsoluteCount,
     WooCommerceNumberOfOrders $wooCommerceNumberOfOrders,
     WooCommerceTotalSpent $wooCommerceTotalSpent,
+    WooCommerceMembership $wooCommerceMembership,
     WooCommerceSubscription $wooCommerceSubscription,
     SubscriberSubscribedDate $subscriberSubscribedDate,
     SubscriberScore $subscriberScore,
@@ -86,6 +91,7 @@ class FilterFactory {
     $this->wooCommerceCategory = $wooCommerceCategory;
     $this->wooCommerceCountry = $wooCommerceCountry;
     $this->wooCommerceNumberOfOrders = $wooCommerceNumberOfOrders;
+    $this->wooCommerceMembership = $wooCommerceMembership;
     $this->wooCommerceSubscription = $wooCommerceSubscription;
     $this->emailOpensAbsoluteCount = $emailOpensAbsoluteCount;
     $this->wooCommerceTotalSpent = $wooCommerceTotalSpent;
@@ -105,6 +111,8 @@ class FilterFactory {
         return $this->userRole($action);
       case DynamicSegmentFilterData::TYPE_EMAIL:
         return $this->email($action);
+      case DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP:
+        return $this->wooCommerceMembership();
       case DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION:
         return $this->wooCommerceSubscription();
       case DynamicSegmentFilterData::TYPE_WOOCOMMERCE:
@@ -135,6 +143,10 @@ class FilterFactory {
       return $this->emailActionClickAny;
     }
     return $this->emailAction;
+  }
+
+  private function wooCommerceMembership() {
+    return $this->wooCommerceMembership;
   }
 
   private function wooCommerceSubscription() {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceMembership.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceMembership.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Util\Security;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class WooCommerceMembership implements Filter {
+  const ACTION_MEMBER_OF = 'isMemberOf';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    $this->entityManager = $entityManager;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    /** @var array */
+    $planIds = $filterData->getParam('plan_ids');
+    $operator = $filterData->getParam('operator');
+    $parameterSuffix = $filter->getId() ?: Security::generateRandomString();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+
+    // ALL OF
+    if ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
+      $this->applyPostJoin($queryBuilder);
+      $this->applyParentPostJoin($queryBuilder);
+      return $queryBuilder
+        ->andWhere("posts.post_parent IN (:plans" . $parameterSuffix . ")")
+        ->groupBy("$subscribersTable.id")
+        ->having("COUNT($subscribersTable.id) = :count$parameterSuffix")
+        ->setParameter('plans' . $parameterSuffix, $planIds, Connection::PARAM_STR_ARRAY)
+        ->setParameter('count' . $parameterSuffix, count($planIds));
+    }
+
+    // NONE OF
+    if ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+      $subQueryBuilder = $this->entityManager->getConnection()
+        ->createQueryBuilder()
+        ->from($subscribersTable)
+        ->select("DISTINCT $subscribersTable.id");
+      $this->applyPostJoin($subQueryBuilder);
+      $this->applyParentPostJoin($subQueryBuilder);
+      $subQueryBuilder
+        ->andWhere("posts.post_parent IN (:plans" . $parameterSuffix . ")");
+      return $queryBuilder->where("{$subscribersTable}.id NOT IN ({$subQueryBuilder->getSQL()})")
+        ->setParameter('plans' . $parameterSuffix, $planIds, Connection::PARAM_STR_ARRAY);
+    }
+
+    // ANY
+    $this->applyPostJoin($queryBuilder);
+    $this->applyParentPostJoin($queryBuilder);
+    return $queryBuilder
+      ->andWhere("posts.post_parent IN (:plans" . $parameterSuffix . ")")
+      ->setParameter('plans' . $parameterSuffix, $planIds, Connection::PARAM_STR_ARRAY);
+  }
+
+  private function applyPostJoin(QueryBuilder $queryBuilder): QueryBuilder {
+    global $wpdb;
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return $queryBuilder->innerJoin(
+      $subscribersTable,
+      $wpdb->posts,
+      'posts',
+      "posts.post_type = 'wc_user_membership' AND posts.post_status IN ('wcm-active', 'wcm-complimentary', 'wcm-free_trial', 'wcm-pending') AND posts.post_author=$subscribersTable.wp_user_id"
+    );
+  }
+
+  private function applyParentPostJoin(QueryBuilder $queryBuilder): QueryBuilder {
+    global $wpdb;
+    return $queryBuilder->innerJoin(
+      'posts',
+      $wpdb->posts,
+      'parentposts',
+      'posts.post_parent = parentposts.id AND parentposts.post_type = "wc_membership_plan" AND parentposts.post_status = "publish"'
+    );
+  }
+}

--- a/mailpoet/lib/Segments/SegmentDependencyValidator.php
+++ b/mailpoet/lib/Segments/SegmentDependencyValidator.php
@@ -20,6 +20,11 @@ class SegmentDependencyValidator {
     'name' => 'WooCommerce',
   ];
 
+  private const WOOCOMMERCE_MEMBERSHIPS_PLUGIN = [
+    'id' => 'woocommerce-memberships/woocommerce-memberships.php',
+    'name' => 'WooCommerce Memberships',
+  ];
+
   private const WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN = [
     'id' => 'woocommerce-subscriptions/woocommerce-subscriptions.php',
     'name' => 'WooCommerce Subscriptions',
@@ -27,6 +32,10 @@ class SegmentDependencyValidator {
 
   private const REQUIRED_PLUGINS_BY_TYPE = [
     DynamicSegmentFilterData::TYPE_WOOCOMMERCE => [
+      self::WOOCOMMERCE_PLUGIN,
+    ],
+    DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP => [
+      self::WOOCOMMERCE_MEMBERSHIPS_PLUGIN,
       self::WOOCOMMERCE_PLUGIN,
     ],
     DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION => [

--- a/mailpoet/lib/WP/AutocompletePostListLoader.php
+++ b/mailpoet/lib/WP/AutocompletePostListLoader.php
@@ -23,6 +23,14 @@ class AutocompletePostListLoader {
     return $this->formatPosts($products);
   }
 
+  public function getMembershipPlans() {
+    $products = $this->wp->getResultsFromWpDb(
+      "SELECT `ID`, `post_title` FROM {$this->wp->getWPTableName('posts')} WHERE `post_type` = %s AND `post_status` = 'publish' ORDER BY `post_title` ASC;",
+      'wc_membership_plan'
+    );
+    return $this->formatPosts($products);
+  }
+
   public function getSubscriptionProducts() {
     $products = $this->wp->getResultsFromWpDb(
       "SELECT `ID`, `post_title` FROM {$this->wp->getWPTableName('posts')} AS p

--- a/mailpoet/tests/DataFactories/WooCommerceMembership.php
+++ b/mailpoet/tests/DataFactories/WooCommerceMembership.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MailPoet\Test\DataFactories;
+
+class WooCommerceMembership {
+  /** @var \AcceptanceTester */
+  private $tester;
+
+  public function __construct(
+    \AcceptanceTester $tester
+  ) {
+    $this->tester = $tester;
+  }
+
+  public function createPlan($name) {
+    $createCommand = ['wc', 'memberships', 'plan', 'create'];
+    $createCommand[] = "--name='{$name}'";
+    $createOutput = $this->tester->cliToString($createCommand);
+    $planOut = $this->tester->cliToString(['wc', 'membership_plan', 'get', $createOutput, '--format=json']);
+    return json_decode($planOut, true);
+  }
+
+  public function createMember(int $userId, int $planId) {
+    $createCommand = ['wc', 'user_membership', 'create'];
+    $createCommand[] = "--customer_id='{$userId}'";
+    $createCommand[] = "--plan_id='{$userId}'";
+    $createOutput = $this->tester->cliToString($createCommand);
+    $membershipOut = $this->tester->cliToString(['wc', 'user_membership', 'get', $createOutput, '--format=json']);
+    return json_decode($membershipOut, true);
+  }
+}

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -47,6 +47,7 @@ class AcceptanceTester extends \Codeception\Actor {
   const AUTHORIZED_SENDING_EMAIL = 'staff@mailpoet.com';
   const LISTING_LOADING_SELECTOR = '.mailpoet-listing-loading';
   const WOO_COMMERCE_PLUGIN = 'woocommerce';
+  const WOO_COMMERCE_MEMBERSHIPS_PLUGIN = 'woocommerce-memberships';
   const WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN = 'woocommerce-subscriptions';
 
   /**
@@ -367,6 +368,16 @@ class AcceptanceTester extends \Codeception\Actor {
   public function deactivateWooCommerce() {
     $i = $this;
     $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_PLUGIN]);
+  }
+
+  public function activateWooCommerceMemberships() {
+    $i = $this;
+    $i->cli(['plugin', 'activate', self::WOO_COMMERCE_MEMBERSHIPS_PLUGIN]);
+  }
+
+  public function deactivateWooCommerceMemberships() {
+    $i = $this;
+    $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_MEMBERSHIPS_PLUGIN]);
   }
 
   public function activateWooCommerceSubscriptions() {

--- a/mailpoet/tests/_support/PluginsExtension.php
+++ b/mailpoet/tests/_support/PluginsExtension.php
@@ -12,6 +12,7 @@ class PluginsExtension extends Extension {
   ];
 
   public function setupInitialPluginsState() {
+    exec('wp plugin deactivate woocommerce-memberships --allow-root');
     exec('wp plugin deactivate woocommerce-subscriptions --allow-root');
     exec('wp plugin deactivate woocommerce --allow-root');
   }

--- a/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\User;
+use MailPoet\Test\DataFactories\WooCommerceMembership;
+
+class WooCommerceMembershipsSegmentCest {
+  public function _before(\AcceptanceTester $i, $scenario) {
+    if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_MEMBERSHIPS_PLUGIN)) {
+      $scenario->skip('Can‘t test without woocommerce-memberships');
+    }
+    (new Settings())->withWooCommerceListImportPageDisplayed(true);
+    (new Settings())->withCookieRevenueTrackingDisabled();
+    $i->activateWooCommerce();
+  }
+
+  public function _after(\AcceptanceTester $i) {
+    $i->deactivateWooCommerce();
+  }
+
+  public function createSegmentForMembershipPlan(\AcceptanceTester $i) {
+    $i->activateWooCommerceMemberships();
+    $membershipFactory = new WooCommerceMembership($i);
+    $plan1 = $membershipFactory->createPlan('Plan 1');
+    $plan2 = $membershipFactory->createPlan('Plan 2');
+    $plan3 = $membershipFactory->createPlan('Plan 3');
+
+    $userFactory = new User();
+    $subscriber1 = $userFactory->createUser('Sub Scriber1', 'subscriber', 'subscriber1@example.com');
+    $subscriber2 = $userFactory->createUser('Sub Scriber2', 'subscriber', 'subscriber2@example.com');
+    $userFactory->createUser('Sub Scriber3', 'subscriber', 'subscriber3@example.com');
+    $userFactory->createUser('Sub Scriber4', 'subscriber', 'subscriber4@example.com');
+
+    $membershipFactory->createMember($subscriber1->ID, $plan1['id']);
+    $membershipFactory->createMember($subscriber2->ID, $plan2['id']);
+    $membershipFactory->createMember($subscriber2->ID, $plan3['id']);
+
+    $segmentActionSelectElement = '[data-automation-id="select-segment-action"]';
+    $operatorSelectElement = '[data-automation-id="select-operator"]';
+    $segmentTitle = 'Woo Membership';
+    $i->wantTo('Create dynamic segment for memberships');
+    $i->login();
+    $i->amOnMailpoetPage('Lists');
+    $i->click('[data-automation-id="new-segment"]');
+    $i->fillField(['name' => 'name'], $segmentTitle);
+    $i->fillField(['name' => 'description'], 'Desc ' . $segmentTitle);
+    $i->selectOptionInReactSelect('is member of', $segmentActionSelectElement);
+    $i->selectOptionInReactSelect('Plan 1', '[data-automation-id="select-segment-plans"]');
+    $i->selectOptionInReactSelect('Plan 2', '[data-automation-id="select-segment-plans"]');
+    $i->waitForText('This segment has');
+
+    // Check for none of
+    $i->selectOption($operatorSelectElement, 'none of');
+    $i->waitForText('Calculating segment size…');
+    $i->waitForText('This segment has 3 subscribers.'); // subscriber3@example.com, subscriber4@example.com, and admin user
+    // Check for all of
+    $i->selectOption($operatorSelectElement, 'all of');
+    $i->waitForText('Calculating segment size…');
+    $i->waitForText('This segment has 1 subscribers.'); // subscriber2@example.com
+    // Check for any of
+    $i->selectOption($operatorSelectElement, 'any of'); // subscriber2@example.com and subscriber1@example.com
+    $i->waitForText('Calculating segment size…');
+    $i->waitForText('This segment has 2 subscribers.');
+
+    $i->seeNoJSErrors();
+    $i->click('Save');
+    $i->wantTo('Check that segment contains correct subscribers');
+    $i->waitForElement('[data-automation-id="filters_all"]');
+    $i->waitForText($segmentTitle);
+    $i->clickItemRowActionByItemName($segmentTitle, 'View Subscribers');
+    $i->waitForText('subscriber1@example.com');
+    $i->waitForText('subscriber2@example.com');
+
+    $i->wantTo('Check that MailPoet plugin works when admin disables WooCommerce Memberships');
+    $i->deactivateWooCommerceMemberships();
+    $i->amOnMailpoetPage('Lists');
+    $i->waitForElement('[data-automation-id="dynamic-segments-tab"]');
+    $i->click('[data-automation-id="dynamic-segments-tab"]');
+    $i->waitForText($segmentTitle);
+    $i->canSee('Activate the WooCommerce Memberships plugin to see the number of subscribers and enable the editing of this segment.');
+
+    $i->wantTo('Check that admin can‘t add new memberships segment when WooCommerce Memberships is not active');
+    $i->click('[data-automation-id="new-segment"]');
+    $i->waitForElement($segmentActionSelectElement);
+    $i->fillField("$segmentActionSelectElement input", 'is member of');
+    $i->canSee('No options', $segmentActionSelectElement);
+  }
+}

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -30,8 +30,10 @@
     var mailpoet_newsletters_list = <%= json_encode(newsletters_list)  %>;
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
     var mailpoet_products = <%= json_encode(products) %>;
+    var mailpoet_membership_plans = <%= json_encode(membership_plans) %>;
     var mailpoet_subscription_products = <%= json_encode(subscription_products) %>;
     var is_woocommerce_active = <%= json_encode(is_woocommerce_active)  %>;
+    var mailpoet_can_use_woocommerce_memberships = <%= json_encode(can_use_woocommerce_memberships)  %>;
     var mailpoet_can_use_woocommerce_subscriptions = <%= json_encode(can_use_woocommerce_subscriptions)  %>;
     var mailpoet_woocommerce_currency_symbol = <%= json_encode(woocommerce_currency_symbol)  %>;
     var mailpoet_woocommerce_countries = <%= json_encode(woocommerce_countries)  %>;
@@ -187,6 +189,9 @@
     'subscribedToList': __('subscribed to list'),
     'segmentsSubscriber': __('WordPress user role'),
     'mailpoetCustomField': __('MailPoet custom field'),
+    'segmentsActiveMembership': __('is member of'),
+    'woocommerceMemberships': _x('WooCommerce Memberships', 'Dynamic segment creation: User selects this to use any WooCommerce Memberships filters'),
+    'selectWooMembership': __('Search membership plans'),
     'segmentsActiveSubscription': __('has active subscription'),
     'woocommerceSubscriptions': _x('WooCommerce Subscriptions', 'Dynamic segment creation: User selects this to use any WooCommerce Subscriptions filters'),
     'selectWooSubscription': __('Search subscriptions'),


### PR DESCRIPTION
[MAILPOET-3880]

[MAILPOET-3880]: https://mailpoet.atlassian.net/browse/MAILPOET-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to Products and create a new product called `1-month membership` (add some $ value)
2. Go to WooCommerce > Memberships
3. Create one more membership plan and name it whatever (can be named `1-month membership` as well)
4. Make sure to add the length `1 month` and also to include created product `1-month membership` from the first step
5. Now that you have `1-month membership` plan and product created, go and purchase it with a few accounts (can be even a guest order)
6. Purchase also the one already created called `1-week membership` with some account
7. Now that you have purchased at least 2-3 orders, make sure the orders are marked as `completed` at WooCommerce > Orders page
8. Now you have data ready-made for testing, go to MailPoet > Lists
9. Create a new segment and verify it according to the specification from the Jira ticket above
10. Make sure that after saving such segment that you have some subscribers who have bought membership products are counted in the results (by clicking `view subscribers` link for your segment, click `recalculate now` button if you don't see them)