### PR TITLE
Offer to download or activate the premium plugin - MAILPOET-3971

### DIFF
--- a/mailpoet/assets/js/src/common/premium_banner_with_upgrade/premium_banner_with_upgrade.tsx
+++ b/mailpoet/assets/js/src/common/premium_banner_with_upgrade/premium_banner_with_upgrade.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import MailPoet from 'mailpoet';
+import PremiumRequired from 'common/premium_required/premium_required';
+import Button from 'common/button/button';
+import ReactStringReplace from 'react-string-replace';
+
+type Props = {
+  message: React.ReactNode;
+  actionButton: React.ReactNode;
+};
+
+interface BannerWindow extends Window {
+  mailpoet_has_valid_api_key: boolean;
+  mailpoet_has_valid_premium_key: boolean;
+  mailpoet_subscribers_count: number;
+  mailpoet_subscribers_limit: number | boolean;
+  mailpoet_subscribers_limit_reached: boolean;
+  mailpoet_premium_active: boolean;
+  mailpoet_premium_plugin_installed: boolean;
+  mailpoet_premium_plugin_download_url: string;
+  mailpoet_premium_plugin_activation_url: string;
+}
+
+declare let window: BannerWindow;
+
+const limitReached = window.mailpoet_subscribers_limit_reached;
+const limitValue = window.mailpoet_subscribers_limit;
+const subscribersCountTowardsLimit = window.mailpoet_subscribers_count;
+const premiumActive = window.mailpoet_premium_active;
+const hasValidApiKey = window.mailpoet_has_valid_api_key || window.mailpoet_has_valid_premium_key;
+const downloadUrl = window.mailpoet_premium_plugin_download_url;
+const activationUrl = window.mailpoet_premium_plugin_activation_url;
+const isPremiumPluginInstalled = window.mailpoet_premium_plugin_installed;
+
+const getBannerMessage = (translationKey) => {
+  const message = MailPoet.I18n.t(translationKey);
+  return (
+    <p>
+      {ReactStringReplace(
+        message,
+        /(\[subscribersCount]|\[subscribersLimit])/g,
+        (match) => ((match === '[subscribersCount]') ? subscribersCountTowardsLimit : limitValue)
+      )}
+    </p>
+  );
+};
+
+const getCtaButton = (translationKey, link = null, target = '_blank') => (
+  <Button
+    href={link}
+    target={target}
+    rel="noopener noreferrer"
+  >
+    {MailPoet.I18n.t(translationKey)}
+  </Button>
+);
+
+const PremiumBannerWithUpgrade: React.FunctionComponent<Props> = (
+  { message, actionButton }: Props
+) => {
+  let bannerMessage: React.ReactNode;
+  let ctaButton: React.ReactNode;
+
+  if (hasValidApiKey && !premiumActive) {
+    bannerMessage = getBannerMessage('premiumFeatureDescription');
+
+    ctaButton = isPremiumPluginInstalled
+      ? getCtaButton('premiumFeatureButtonActivatePremium', activationUrl, '_self')
+      : getCtaButton('premiumFeatureButtonDownloadPremium', downloadUrl);
+  } else if (limitReached) {
+    bannerMessage = getBannerMessage('premiumFeatureDescriptionSubscribersLimitReached');
+
+    const link = hasValidApiKey
+      ? MailPoet.MailPoetComUrlFactory.getUpgradeUrl()
+      : MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(subscribersCountTowardsLimit + 1);
+
+    ctaButton = getCtaButton('premiumFeatureButtonUpgradePlan', link);
+  } else {
+    // use the provided information
+    bannerMessage = message;
+    ctaButton = actionButton;
+  }
+
+  return (
+    <PremiumRequired
+      title={MailPoet.I18n.t('premiumFeature')}
+      message={bannerMessage}
+      actionButton={ctaButton}
+    />
+  );
+};
+
+export default PremiumBannerWithUpgrade;

--- a/mailpoet/assets/js/src/common/premium_banner_with_upgrade/premium_banner_with_upgrade.tsx
+++ b/mailpoet/assets/js/src/common/premium_banner_with_upgrade/premium_banner_with_upgrade.tsx
@@ -19,6 +19,7 @@ interface BannerWindow extends Window {
   mailpoet_premium_plugin_installed: boolean;
   mailpoet_premium_plugin_download_url: string;
   mailpoet_premium_plugin_activation_url: string;
+  mailpoet_plugin_half_key: string;
 }
 
 declare let window: BannerWindow;
@@ -31,8 +32,9 @@ const hasValidApiKey = window.mailpoet_has_valid_api_key || window.mailpoet_has_
 const downloadUrl = window.mailpoet_premium_plugin_download_url;
 const activationUrl = window.mailpoet_premium_plugin_activation_url;
 const isPremiumPluginInstalled = window.mailpoet_premium_plugin_installed;
+const halfKey = window.mailpoet_plugin_half_key;
 
-const getBannerMessage = (translationKey) => {
+const getBannerMessage = (translationKey: string) => {
   const message = MailPoet.I18n.t(translationKey);
   return (
     <p>
@@ -45,7 +47,7 @@ const getBannerMessage = (translationKey) => {
   );
 };
 
-const getCtaButton = (translationKey, link = null, target = '_blank') => (
+const getCtaButton = (translationKey: string, link: string, target = '_blank') => (
   <Button
     href={link}
     target={target}
@@ -71,7 +73,7 @@ const PremiumBannerWithUpgrade: React.FunctionComponent<Props> = (
     bannerMessage = getBannerMessage('premiumFeatureDescriptionSubscribersLimitReached');
 
     const link = hasValidApiKey
-      ? MailPoet.MailPoetComUrlFactory.getUpgradeUrl()
+      ? MailPoet.MailPoetComUrlFactory.getUpgradeUrl(halfKey)
       : MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(subscribersCountTowardsLimit + 1);
 
     ctaButton = getCtaButton('premiumFeatureButtonUpgradePlan', link);

--- a/mailpoet/assets/js/src/mailpoet.js
+++ b/mailpoet/assets/js/src/mailpoet.js
@@ -29,6 +29,10 @@ var MailPoet = {
   settings: window.mailpoet_settings,
   trackingConfig: window.mailpoet_tracking_config || {},
   Date,
+  isPremiumPluginInstalled: window.mailpoet_premium_plugin_installed,
+  premiumPluginDownloadUrl: window.mailpoet_premium_plugin_download_url,
+  premiumPluginActivationUrl: window.mailpoet_premium_plugin_activation_url,
+  pluginPartialKey: window.mailpoet_plugin_partial_key,
 };
 
 // Expose MailPoet globally

--- a/mailpoet/assets/js/src/mailpoet_com_url_factory.js
+++ b/mailpoet/assets/js/src/mailpoet_com_url_factory.js
@@ -23,8 +23,8 @@ const MailPoetComUrlFactory = referralId => {
       getUrl(baseUrl, 'pricing', { subscribers })
     ),
 
-    getUpgradeUrl: () => (
-      getUrl(baseShopUrl, '/upgrade', {})
+    getUpgradeUrl: (key) => (
+      getUrl(baseShopUrl, '/orders/upgrade/' + key, {})
     ),
 
     getPurchasePlanUrl: (subscribersCount) => (

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MailPoet from 'mailpoet';
 import Button from 'common/button/button';
-import PremiumRequired from 'common/premium_required/premium_required';
+import PremiumBannerWithUpgrade from 'common/premium_banner_with_upgrade/premium_banner_with_upgrade';
 
 const SkipDisplayingDetailedStats = () => {
   const ctaButton = (
@@ -27,8 +27,7 @@ const SkipDisplayingDetailedStats = () => {
 
   return (
     <div className="mailpoet-stats-premium-required">
-      <PremiumRequired
-        title={MailPoet.I18n.t('premiumFeature')}
+      <PremiumBannerWithUpgrade
         message={description}
         actionButton={ctaButton}
       />
@@ -40,34 +39,6 @@ const PremiumBanner = () => {
   if (!window.mailpoet_display_detailed_stats) {
     return (
       <SkipDisplayingDetailedStats />
-    );
-  }
-  if (window.mailpoet_subscribers_limit_reached) {
-    const hasValidApiKey = window.mailpoet_has_valid_api_key;
-    const title = MailPoet.I18n.t('upgradeRequired');
-    const youReachedTheLimit = MailPoet.I18n.t(hasValidApiKey ? 'newsletterYourPlanLimit' : 'newsletterFreeVersionLimit')
-      .replace('[subscribersLimit]', window.mailpoet_subscribers_limit)
-      .replace('[subscribersCount]', window.mailpoet_subscribers_count);
-    const upgradeLink = hasValidApiKey
-      ? 'https://account.mailpoet.com/upgrade'
-      : `https://account.mailpoet.com/?s=${window.mailpoet_subscribers_count + 1}`;
-
-    return (
-      <div className="mailpoet-stats-premium-required">
-        <PremiumRequired
-          title={title}
-          message={(<p>{youReachedTheLimit}</p>)}
-          actionButton={(
-            <Button
-              target="_blank"
-              rel="noopener noreferrer"
-              href={upgradeLink}
-            >
-              {MailPoet.I18n.t('upgradeNow')}
-            </Button>
-          )}
-        />
-      </div>
     );
   }
   return null;

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
@@ -36,7 +36,7 @@ const SkipDisplayingDetailedStats = () => {
 };
 
 const PremiumBanner = () => {
-  if (!window.mailpoet_display_detailed_stats) {
+  if (!MailPoet.premiumActive || MailPoet.subscribersLimitReached) {
     return (
       <SkipDisplayingDetailedStats />
     );

--- a/mailpoet/assets/js/src/segments/dynamic/premium_banner.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/premium_banner.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MailPoet from 'mailpoet';
-import PremiumRequired from 'common/premium_required/premium_required';
+import PremiumBannerWithUpgrade from 'common/premium_banner_with_upgrade/premium_banner_with_upgrade';
 import Button from 'common/button/button';
 import ReactStringReplace from 'react-string-replace';
 
@@ -34,8 +34,7 @@ const DynamicSegmentsPremiumBanner: React.FunctionComponent = () => {
   );
 
   return (
-    <PremiumRequired
-      title={MailPoet.I18n.t('premiumFeature')}
+    <PremiumBannerWithUpgrade
       message={getBannerMessage({})}
       actionButton={getCtaButton({})}
     />

--- a/mailpoet/assets/js/src/subscribers/stats/no_access_info.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/no_access_info.tsx
@@ -1,79 +1,34 @@
 import React from 'react';
 import MailPoet from 'mailpoet';
-import PremiumRequired from 'common/premium_required/premium_required';
+import PremiumBannerWithUpgrade from 'common/premium_banner_with_upgrade/premium_banner_with_upgrade';
 import Button from 'common/button/button';
 import ReactStringReplace from 'react-string-replace';
 
-type Props = {
-  limitReached: boolean;
-  limitValue: number;
-  subscribersCountTowardsLimit: number;
-  premiumActive: boolean;
-  hasValidApiKey: boolean;
-  hasPremiumSupport: boolean;
-}
-
-const NoAccessInfo: React.FunctionComponent<Props> = ({
-  limitReached,
-  limitValue,
-  subscribersCountTowardsLimit,
-  premiumActive,
-  hasValidApiKey,
-  hasPremiumSupport,
-}: Props) => {
+const NoAccessInfo: React.FunctionComponent = () => {
   const getBannerMessage: React.FunctionComponent = () => {
-    let message = MailPoet.I18n.t('premiumRequired');
-    if (!premiumActive) {
-      return (
-        <p>
-          {ReactStringReplace(
-            message,
-            /\[link](.*?)\[\/link]/g,
-            (match) => (
-              <a key={match} href={MailPoet.premiumLink}>{match}</a>
-            )
-          )}
-        </p>
-      );
-    }
-    // Covers premium with paid plan
-    if (hasPremiumSupport) {
-      message = MailPoet.I18n.t('planLimitReached');
-    } else { // Covers premium without apikey and premium with free plan api key
-      message = MailPoet.I18n.t('freeLimitReached');
-    }
+    const message = MailPoet.I18n.t('premiumRequired');
     return (
       <p>
         {ReactStringReplace(
           message,
-          /(\[subscribersCount]|\[subscribersLimit])/g,
-          (match) => ((match === '[subscribersCount]') ? subscribersCountTowardsLimit : limitValue)
+          /\[link](.*?)\[\/link]/g,
+          (match) => (
+            <a key={match} href={MailPoet.premiumLink}>{match}</a>
+          )
         )}
       </p>
     );
   };
 
   const getCtaButton: React.FunctionComponent = () => (
-    premiumActive && limitReached ? (
-      <Button
-        href={
-          hasValidApiKey
-            ? MailPoet.MailPoetComUrlFactory.getUpgradeUrl()
-            : MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(subscribersCountTowardsLimit + 1)
-        }
-      >
-        {MailPoet.I18n.t('premiumBannerCtaUpgrade')}
-      </Button>
-    ) : (
-      <Button
-        href={MailPoet.MailPoetComUrlFactory.getFreePlanUrl({
-          utm_medium: 'stats',
-          utm_campaign: 'signup',
-        })}
-      >
-        {MailPoet.I18n.t('premiumBannerCtaFree')}
-      </Button>
-    )
+    <Button
+      href={MailPoet.MailPoetComUrlFactory.getFreePlanUrl({
+        utm_medium: 'stats',
+        utm_campaign: 'signup',
+      })}
+    >
+      {MailPoet.I18n.t('premiumBannerCtaFree')}
+    </Button>
   );
 
   return (
@@ -90,8 +45,7 @@ const NoAccessInfo: React.FunctionComponent<Props> = ({
         <tr>
           <td colSpan={4}>
             <div className="mailpoet-subscriber-stats-no-access-content">
-              <PremiumRequired
-                title={premiumActive && limitReached ? MailPoet.I18n.t('upgradeRequired') : MailPoet.I18n.t('premiumFeature')}
+              <PremiumBannerWithUpgrade
                 message={getBannerMessage({})}
                 actionButton={getCtaButton({})}
               />

--- a/mailpoet/assets/js/src/subscribers/stats/opened_email_stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/opened_email_stats.tsx
@@ -18,14 +18,7 @@ const OpenedEmailsStats: React.FunctionComponent<Props> = ({ params, location }:
       {MailPoet.I18n.t('openedEmailsHeading')}
     </Heading>
     {!MailPoet.premiumActive || MailPoet.subscribersLimitReached ? (
-      <NoAccessInfo
-        limitReached={MailPoet.subscribersLimitReached}
-        limitValue={MailPoet.subscribersLimit}
-        subscribersCountTowardsLimit={MailPoet.subscribersCount}
-        premiumActive={MailPoet.premiumActive}
-        hasValidApiKey={MailPoet.hasValidApiKey}
-        hasPremiumSupport={MailPoet.hasPremiumSupport}
-      />
+      <NoAccessInfo />
     ) : (
       Hooks.applyFilters('mailpoet_subscribers_opened_emails_stats', params, location)
     )}

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -158,6 +158,7 @@ class Newsletters {
     $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
     $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
+    $data['plugin_half_key'] = $this->servicesChecker->generateHalfApiKey();
 
     if (!$data['premium_plugin_active']) {
       $data['free_premium_subscribers_limit'] = License::FREE_PREMIUM_SUBSCRIBERS_LIMIT;

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -108,6 +108,8 @@ class Newsletters {
 
   public function render() {
     global $wp_roles; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $installer = new Installer(Installer::PREMIUM_PLUGIN_SLUG);
+    $pluginInformation = $installer->retrievePluginInformation();
 
     $data = [];
 
@@ -152,6 +154,10 @@ class Newsletters {
     $data['newsletters_count'] = Newsletter::count();
     $data['mailpoet_feature_flags'] = $this->featuresController->getAllFlags();
     $data['transactional_emails_opt_in_notice_dismissed'] = $this->userFlags->get('transactional_emails_opt_in_notice_dismissed');
+    $data['has_premium_support'] = $this->subscribersFeature->hasPremiumSupport();
+    $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
+    $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
 
     if (!$data['premium_plugin_active']) {
       $data['free_premium_subscribers_limit'] = License::FREE_PREMIUM_SUBSCRIBERS_LIMIT;

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -158,7 +158,7 @@ class Newsletters {
     $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
     $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
-    $data['plugin_half_key'] = $this->servicesChecker->generateHalfApiKey();
+    $data['plugin_partial_key'] = $this->servicesChecker->generatePartialApiKey();
 
     if (!$data['premium_plugin_active']) {
       $data['free_premium_subscribers_limit'] = License::FREE_PREMIUM_SUBSCRIBERS_LIMIT;

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -5,6 +5,7 @@ namespace MailPoet\AdminPages\Pages;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\API\JSON\ResponseBuilders\CustomFieldsResponseBuilder;
 use MailPoet\Cache\TransientCache;
+use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\DynamicSegmentFilterData;
@@ -93,6 +94,9 @@ class Segments {
   }
 
   public function render() {
+    $installer = new Installer(Installer::PREMIUM_PLUGIN_SLUG);
+    $pluginInformation = $installer->retrievePluginInformation();
+
     $data = [];
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('segments');
 
@@ -106,6 +110,12 @@ class Segments {
     $data['has_premium_support'] = $this->subscribersFeature->hasPremiumSupport();
     $data['link_premium'] = $this->wp->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-premium');
     $data['mss_key_invalid'] = ($this->servicesChecker->isMailPoetAPIKeyValid() === false);
+
+    $data['premium_plugin_active'] = $this->servicesChecker->isPremiumPluginActive();
+    $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
+    $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
+
     $customFields = $this->customFieldsRepository->findBy([], ['name' => 'asc']);
     $data['custom_fields'] = $this->customFieldsResponseBuilder->buildBatch($customFields);
 

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -115,7 +115,7 @@ class Segments {
     $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
     $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
-    $data['plugin_half_key'] = $this->servicesChecker->generateHalfApiKey();
+    $data['plugin_partial_key'] = $this->servicesChecker->generatePartialApiKey();
 
     $customFields = $this->customFieldsRepository->findBy([], ['name' => 'asc']);
     $data['custom_fields'] = $this->customFieldsResponseBuilder->buildBatch($customFields);

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -115,6 +115,7 @@ class Segments {
     $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
     $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
+    $data['plugin_half_key'] = $this->servicesChecker->generateHalfApiKey();
 
     $customFields = $this->customFieldsRepository->findBy([], ['name' => 'asc']);
     $data['custom_fields'] = $this->customFieldsResponseBuilder->buildBatch($customFields);

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Cache\TransientCache;
+use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Form\Block;
 use MailPoet\Listing\PageLimit;
@@ -68,6 +69,9 @@ class Subscribers {
   }
 
   public function render() {
+    $installer = new Installer(Installer::PREMIUM_PLUGIN_SLUG);
+    $pluginInformation = $installer->retrievePluginInformation();
+
     $data = [];
 
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('subscribers');
@@ -100,10 +104,15 @@ class Subscribers {
     $data['subscribers_limit'] = $this->subscribersFeature->getSubscribersLimit();
     $data['subscribers_limit_reached'] = $this->subscribersFeature->check();
     $data['has_valid_api_key'] = $this->subscribersFeature->hasValidApiKey();
+    $data['has_valid_premium_key'] = $this->subscribersFeature->hasValidPremiumKey();
     $data['subscriber_count'] = $this->subscribersFeature->getSubscribersCount();
     $data['has_premium_support'] = $this->subscribersFeature->hasPremiumSupport();
     $data['link_premium'] = $this->wp->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-premium');
     $data['tracking_config'] = $this->trackingConfig->getConfig();
+
+    $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
+    $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
 
     $subscribersCacheCreatedAt = $this->transientCache->getOldestCreatedAt(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY);
     $subscribersCacheCreatedAt = $subscribersCacheCreatedAt ?: Carbon::now();

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -113,6 +113,7 @@ class Subscribers {
     $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
     $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
+    $data['plugin_half_key'] = $this->servicesChecker->generateHalfApiKey();
 
     $subscribersCacheCreatedAt = $this->transientCache->getOldestCreatedAt(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY);
     $subscribersCacheCreatedAt = $subscribersCacheCreatedAt ?: Carbon::now();

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -113,7 +113,7 @@ class Subscribers {
     $data['premium_plugin_installed'] = $data['premium_plugin_active'] || Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG);
     $data['premium_plugin_download_url'] = $pluginInformation->download_link ?? null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data['premium_plugin_activation_url'] = $installer->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
-    $data['plugin_half_key'] = $this->servicesChecker->generateHalfApiKey();
+    $data['plugin_partial_key'] = $this->servicesChecker->generatePartialApiKey();
 
     $subscribersCacheCreatedAt = $this->transientCache->getOldestCreatedAt(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY);
     $subscribersCacheCreatedAt = $subscribersCacheCreatedAt ?: Carbon::now();

--- a/mailpoet/lib/Config/Installer.php
+++ b/mailpoet/lib/Config/Installer.php
@@ -10,6 +10,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class Installer {
   const PREMIUM_PLUGIN_SLUG = 'mailpoet-premium';
+  const PREMIUM_PLUGIN_PATH = 'mailpoet-premium/mailpoet-premium.php';
 
   private $slug;
 
@@ -25,6 +26,14 @@ class Installer {
 
   public function init() {
     WPFunctions::get()->addFilter('plugins_api', [$this, 'getPluginInformation'], 10, 3);
+  }
+
+  public function generatePluginActivationUrl(string $plugin): string {
+    return WPFunctions::get()->adminUrl('plugins.php?' . implode('&', [
+      'action=activate',
+      'plugin=' . urlencode($plugin),
+      '_wpnonce=' . wp_create_nonce('activate-plugin_' . $plugin),
+    ]));
   }
 
   public function getPluginInformation($data, $action = '', $args = null) {

--- a/mailpoet/lib/Config/Installer.php
+++ b/mailpoet/lib/Config/Installer.php
@@ -32,7 +32,7 @@ class Installer {
     return WPFunctions::get()->adminUrl('plugins.php?' . implode('&', [
       'action=activate',
       'plugin=' . urlencode($plugin),
-      '_wpnonce=' . wp_create_nonce('activate-plugin_' . $plugin),
+      '_wpnonce=' . WPFunctions::get()->wpCreateNonce('activate-plugin_' . $plugin),
     ]));
   }
 

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -25,6 +25,10 @@ class ServicesChecker {
     $this->subscribersFeature = ContainerWrapper::getInstance()->get(SubscribersFeature::class);
   }
 
+  public function isPremiumPluginActive() {
+    return License::getLicense() ? true : false;
+  }
+
   public function isMailPoetAPIKeyValid($displayErrorNotice = true, $forceCheck = false) {
     if (!$forceCheck && !Bridge::isMPSendingServiceEnabled()) {
       return null;

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -167,7 +167,7 @@ class ServicesChecker {
   }
 
   public function generateHalfApiKey() {
-    $key = $this->getAnyValidKey();
+    $key = (string)($this->getAnyValidKey());
 
     $halfKeyLength = (int)(strlen($key) / 2);
 

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -166,11 +166,13 @@ class ServicesChecker {
     return null;
   }
 
-  public function generateHalfApiKey() {
+  public function generatePartialApiKey(): string {
     $key = (string)($this->getAnyValidKey());
+    if ($key) {
+      $halfKeyLength = (int)(strlen($key) / 2);
 
-    $halfKeyLength = (int)(strlen($key) / 2);
-
-    return substr($key, 0, $halfKeyLength);
+      return substr($key, 0, $halfKeyLength);
+    }
+    return '';
   }
 }

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -165,4 +165,12 @@ class ServicesChecker {
     }
     return null;
   }
+
+  public function generateHalfApiKey() {
+    $key = $this->getAnyValidKey();
+
+    $halfKeyLength = (int)(strlen($key) / 2);
+
+    return substr($key, 0, $halfKeyLength);
+  }
 }

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -31,6 +31,7 @@
       var mailpoet_mss_key_invalid = <%= mss_key_invalid ? 'true' : 'false' %>;
       var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
       var mailpoet_products = <%= json_encode(products) %>;
+      var mailpoet_plugin_half_key = <%= json_encode(plugin_half_key) %>;
 
       var has_mss_key_specified = <%= json_encode(has_mss_key_specified) %>;
       var mailpoet_account_url = '<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&email=" ~ current_wp_user.user_email|escape('js')) %>';

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -63,6 +63,10 @@
       var mailpoet_newsletters_count = <%= newsletters_count %>;
       var mailpoet_send_transactional_emails = <%= json_encode(settings.send_transactional_emails == '1') %>;
       var mailpoet_settings = <%= json_encode(settings) %>;
+      var mailpoet_has_premium_support = <%= has_premium_support ? 'true' : 'false' %>;
+      var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
+      var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
+      var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
 
       <% if not(premium_plugin_active) %>
         var mailpoet_free_premium_subscribers_limit = <%= free_premium_subscribers_limit %>;
@@ -218,6 +222,11 @@
     'createFirstEmailTitle': __('Create your first email'),
     'seeVideoGuide': __('See video guide'),
     'premiumFeature': __('This is a Premium feature'),
+    'premiumFeatureDescription':  __('Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.'),
+    'premiumFeatureButtonDownloadPremium':  __('Download MailPoet Premium plugin'),
+    'premiumFeatureButtonActivatePremium':  __('Activate MailPoet Premium plugin'),
+    'premiumFeatureDescriptionSubscribersLimitReached':  __('Congratulations, you now have [subscribersCount] subscribers! Your plan is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.'),
+    'premiumFeatureButtonUpgradePlan':  __('Upgrade your plan'),
     'learnMore': __('Learn more'),
     'regularNewsletterTypeTitle': __('Newsletter'),
     'regularNewsletterTypeDescription': __('Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.'),

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -1,6 +1,7 @@
 <% extends 'layout.html' %>
 
 <% block content %>
+<% include('shared_config.html') %>
   <div id="newsletters_container"></div>
 
   <script type="text/javascript">
@@ -31,7 +32,6 @@
       var mailpoet_mss_key_invalid = <%= mss_key_invalid ? 'true' : 'false' %>;
       var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
       var mailpoet_products = <%= json_encode(products) %>;
-      var mailpoet_plugin_half_key = <%= json_encode(plugin_half_key) %>;
 
       var has_mss_key_specified = <%= json_encode(has_mss_key_specified) %>;
       var mailpoet_account_url = '<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&email=" ~ current_wp_user.user_email|escape('js')) %>';
@@ -64,10 +64,6 @@
       var mailpoet_newsletters_count = <%= newsletters_count %>;
       var mailpoet_send_transactional_emails = <%= json_encode(settings.send_transactional_emails == '1') %>;
       var mailpoet_settings = <%= json_encode(settings) %>;
-      var mailpoet_has_premium_support = <%= has_premium_support ? 'true' : 'false' %>;
-      var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
-      var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
-      var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
 
       <% if not(premium_plugin_active) %>
         var mailpoet_free_premium_subscribers_limit = <%= free_premium_subscribers_limit %>;

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -39,6 +39,10 @@
     var mailpoet_woocommerce_countries = <%= json_encode(woocommerce_countries)  %>;
     var mailpoet_tracking_config = <%= json_encode(tracking_config) %>;
     var mailpoet_subscribers_counts_cache_created_at = <%= json_encode(subscribers_counts_cache_created_at) %>;
+    var mailpoet_premium_active = <%= json_encode(premium_plugin_active) %>;
+    var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
+    var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
+    var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
 
   </script>
 <% endblock %>
@@ -254,6 +258,11 @@
     'premiumFeature': __('This is a Premium feature'),
     'premiumFeatureMultipleConditions': __('Your current MailPoet plan does not support advanced segments with multiple conditions. Upgrade to the MailPoet Premium plan to more precisely target your emails based on how people engage with your business. [link]Learn more.[/link]'),
     'premiumBannerCtaFree': __('Sign Up for Free'),
+    'premiumFeatureDescription':  __('Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.'),
+    'premiumFeatureButtonDownloadPremium':  __('Download MailPoet Premium plugin'),
+    'premiumFeatureButtonActivatePremium':  __('Activate MailPoet Premium plugin'),
+    'premiumFeatureDescriptionSubscribersLimitReached':  __('Congratulations, you now have [subscribersCount] subscribers! Your plan is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.'),
+    'premiumFeatureButtonUpgradePlan':  __('Upgrade your plan'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -43,6 +43,7 @@
     var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
     var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
     var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
+    var mailpoet_plugin_half_key = <%= json_encode(plugin_half_key) %>;
 
   </script>
 <% endblock %>

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -1,6 +1,7 @@
 <% extends 'layout.html' %>
 
 <% block content %>
+<% include('shared_config.html') %>
   <div id="segments_container"></div>
 
   <script type="text/javascript">
@@ -40,11 +41,6 @@
     var mailpoet_tracking_config = <%= json_encode(tracking_config) %>;
     var mailpoet_subscribers_counts_cache_created_at = <%= json_encode(subscribers_counts_cache_created_at) %>;
     var mailpoet_premium_active = <%= json_encode(premium_plugin_active) %>;
-    var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
-    var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
-    var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
-    var mailpoet_plugin_half_key = <%= json_encode(plugin_half_key) %>;
-
   </script>
 <% endblock %>
 

--- a/mailpoet/views/shared_config.html
+++ b/mailpoet/views/shared_config.html
@@ -1,0 +1,9 @@
+
+<script type="text/javascript">
+  <% autoescape 'js' %>
+    var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
+    var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
+    var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
+    var mailpoet_plugin_partial_key = <%= json_encode(plugin_partial_key) %>;
+  <% endautoescape %>
+</script>

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -23,11 +23,15 @@
     var mailpoet_subscribers_limit = <%= subscribers_limit ? subscribers_limit : 'false'  %>;
     var mailpoet_subscribers_limit_reached = <%= subscribers_limit_reached ? 'true' : 'false' %>;
     var mailpoet_has_valid_api_key = <%= has_valid_api_key ? 'true' : 'false' %>;
+    var mailpoet_has_valid_premium_key = <%= has_valid_premium_key ? 'true' : 'false' %>;
     var mailpoet_mss_key_invalid = <%= mss_key_invalid ? 'true' : 'false' %>;
     var mailpoet_subscribers_count = <%= subscriber_count %>;
     var mailpoet_has_premium_support = <%= has_premium_support ? 'true' : 'false' %>;
     var mailpoet_premium_link = <%= json_encode(link_premium) %>;
     var mailpoet_subscribers_counts_cache_created_at = <%= json_encode(subscribers_counts_cache_created_at) %>;
+    var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
+    var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
+    var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
   </script>
 <% endblock %>
 
@@ -145,6 +149,11 @@
     'planLimitReached': __('Congratulations, you now have [subscribersCount] subscribers! Your plan is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.'),
     'premiumBannerCtaFree': __('Sign Up for Free'),
     'premiumBannerCtaUpgrade': __('Upgrade Now'),
+    'premiumFeatureDescription':  __('Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.'),
+    'premiumFeatureButtonDownloadPremium':  __('Download MailPoet Premium plugin'),
+    'premiumFeatureButtonActivatePremium':  __('Activate MailPoet Premium plugin'),
+    'premiumFeatureDescriptionSubscribersLimitReached':  __('Congratulations, you now have [subscribersCount] subscribers! Your plan is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.'),
+    'premiumFeatureButtonUpgradePlan':  __('Upgrade your plan'),
     'columnAction': _x('Action', 'Table column label for subscriber actions e.g. email open, link clicked'),
     'columnActionOn': _x('Action on', 'Table column label for date when subscriber action happened'),
     'columnCount': _x('Count', 'Table column label for count of subscriber actions'),

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -32,6 +32,7 @@
     var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
     var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
     var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
+    var mailpoet_plugin_half_key = <%= json_encode(plugin_half_key) %>;
   </script>
 <% endblock %>
 

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -1,6 +1,7 @@
 <% extends 'layout.html' %>
 
 <% block content %>
+<% include('shared_config.html') %>
   <div id="subscribers_container"></div>
 
   <script type="text/javascript">
@@ -29,10 +30,6 @@
     var mailpoet_has_premium_support = <%= has_premium_support ? 'true' : 'false' %>;
     var mailpoet_premium_link = <%= json_encode(link_premium) %>;
     var mailpoet_subscribers_counts_cache_created_at = <%= json_encode(subscribers_counts_cache_created_at) %>;
-    var mailpoet_premium_plugin_installed = <%= json_encode(premium_plugin_installed) %>;
-    var mailpoet_premium_plugin_download_url = <%= json_encode(premium_plugin_download_url) %>;
-    var mailpoet_premium_plugin_activation_url = <%= json_encode(premium_plugin_activation_url) %>;
-    var mailpoet_plugin_half_key = <%= json_encode(plugin_half_key) %>;
   </script>
 <% endblock %>
 


### PR DESCRIPTION
Offer to download or activate the premium plugin or upgrade plan in premium banner

[MAILPOET-3971](https://mailpoet.atlassian.net/browse/MAILPOET-3971)

Related to https://github.com/mailpoet/shop/pull/669

Testing instructions:
1. Make sure to downgrade Premium plugin to be 3.77.0 in order to test this pull request as this PR is on 3.77.0. Please head over [to this page to download](https://github.com/mailpoet/mailpoet-premium/releases) and upload 3.77.0 build. After that follow the next steps.
2. Go to MailPoet > Emails page
3. Click on statistics link for any of the sent newsletters to access the statistics page
4. On this page you could see the banner that is mentioned in the Jira ticket above. Please follow all three cases from the [Jira specification](https://mailpoet.atlassian.net/browse/MAILPOET-3971) to verify that the banner is present with the appropriate content is in the banner.
5. Three cases to test: With inactive Premium plugin; With not installed Premium plugin; With applied lower-tier subscription (go to call for testing p2 post to find the key to be applied before testing (under IMPORTANT NOTES BEFORE TESTING & SUBSCRIPTION KEYS section));