### PR TITLE
Add check that createdAt is not null [MAILPOET-4067]

### DIFF
--- a/mailpoet/lib/API/JSON/ResponseBuilders/CustomFieldsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/CustomFieldsResponseBuilder.php
@@ -23,7 +23,7 @@ class CustomFieldsResponseBuilder {
       'name' => $customField->getName(),
       'type' => $customField->getType(),
       'params' => $customField->getParams(),
-      'created_at' => $customField->getCreatedAt()->format('Y-m-d H:i:s'),
+      'created_at' => ($createdAt = $customField->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null,
       'updated_at' => $customField->getUpdatedAt()->format('Y-m-d H:i:s'),
     ];
   }

--- a/mailpoet/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
@@ -25,7 +25,7 @@ class FormsResponseBuilder {
       'body' => $form->getBody(),
       'settings' => $form->getSettings(),
       'styles' => $form->getStyles(),
-      'created_at' => $form->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $form->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $form->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $form->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
     ];

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewsletterTemplatesResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewsletterTemplatesResponseBuilder.php
@@ -15,7 +15,7 @@ class NewsletterTemplatesResponseBuilder {
       'name' => $template->getName(),
       'readonly' => $template->getReadonly(),
       'body' => $template->getBody(),
-      'created_at' => $template->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $template->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $template->getUpdatedAt()->format(self::DATE_FORMAT),
       'newsletter_id' => ($newsletter = $template->getNewsletter()) ? $newsletter->getId() : null,
     ];

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -61,7 +61,7 @@ class NewslettersResponseBuilder {
       'preheader' => $newsletter->getPreheader(),
       'body' => $newsletter->getBody(),
       'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format(self::DATE_FORMAT) : null,
-      'created_at' => $newsletter->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $newsletter->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $newsletter->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $newsletter->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'parent_id' => ($parent = $newsletter->getParent()) ? $parent->getId() : null,
@@ -204,7 +204,7 @@ class NewslettersResponseBuilder {
       'name' => $segment->getName(),
       'type' => $segment->getType(),
       'description' => $segment->getDescription(),
-      'created_at' => $segment->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $segment->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $segment->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
     ];
@@ -224,7 +224,7 @@ class NewslettersResponseBuilder {
       'priority' => (string)$task->getPriority(), // (string) for BC
       'scheduled_at' => ($scheduledAt = $task->getScheduledAt()) ? $scheduledAt->format(self::DATE_FORMAT) : null,
       'processed_at' => ($processedAt = $task->getProcessedAt()) ? $processedAt->format(self::DATE_FORMAT) : null,
-      'created_at' => $queue->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $queue->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $queue->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $queue->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'meta' => $queue->getMeta(),

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -29,7 +29,7 @@ class SegmentsResponseBuilder {
       'name' => $segment->getName(),
       'type' => $segment->getType(),
       'description' => $segment->getDescription(),
-      'created_at' => $segment->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $segment->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $segment->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'average_engagement_score' => $segment->getAverageEngagementScore(),

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -64,7 +64,7 @@ class SubscribersResponseBuilder {
       'count_confirmations' => $subscriber->getConfirmationsCount(),
       'wp_user_id' => $subscriber->getWpUserId(),
       'is_woocommerce_user' => $subscriber->getIsWoocommerceUser(),
-      'created_at' => $subscriber->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $subscriber->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'engagement_score' => $subscriber->getEngagementScore(),
     ];
   }
@@ -80,7 +80,7 @@ class SubscribersResponseBuilder {
       'last_name' => $subscriberEntity->getLastName(),
       'first_name' => $subscriberEntity->getFirstName(),
       'email' => $subscriberEntity->getEmail(),
-      'created_at' => $subscriberEntity->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $subscriberEntity->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $subscriberEntity->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $subscriberEntity->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'subscribed_ip' => $subscriberEntity->getSubscribedIp(),
@@ -106,7 +106,7 @@ class SubscribersResponseBuilder {
         $result[] = [
           'id' => $subscription->getId(),
           'subscriber_id' => (string)$subscriberEntity->getId(),
-          'created_at' => $subscription->getCreatedAt()->format(self::DATE_FORMAT),
+          'created_at' => ($createdAt = $subscription->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
           'segment_id' => (string)$segment->getId(),
           'status' => $subscription->getStatus(),
           'updated_at' => $subscription->getUpdatedAt()->format(self::DATE_FORMAT),

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -42,7 +42,7 @@ class Logs {
         'id' => $log->getId(),
         'name' => $log->getName(),
         'message' => $log->getMessage(),
-        'created_at' => $log->getCreatedAt()->format('Y-m-d H:i:s'),
+        'created_at' => ($createdAt = $log->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null,
       ];
     }
     $this->pageRenderer->displayPage('logs.html', $data);

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -138,7 +138,7 @@ class NewsletterEditor {
       'confirmed_ip' => $subscriber->getConfirmedIp(),
       'confirmed_at' => ($confirmedAt = $subscriber->getConfirmedAt()) ? $confirmedAt->format(self::DATE_FORMAT) : null,
       'last_subscribed_at' => ($lastSubscribedAt = $subscriber->getLastSubscribedAt()) ? $lastSubscribedAt->format(self::DATE_FORMAT) : null,
-      'created_at' => $subscriber->getCreatedAt()->format(self::DATE_FORMAT),
+      'created_at' => ($createdAt = $subscriber->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => $subscriber->getUpdatedAt()->format(self::DATE_FORMAT),
       'deleted_at' => ($deletedAt = $subscriber->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'unconfirmed_data' => $subscriber->getUnconfirmedData(),

--- a/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
+++ b/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
@@ -53,7 +53,7 @@ class WooCommercePastOrders extends SimpleWorker {
 
     $orderIds = $this->woocommerceHelper->wcGetOrders([
       'status' => 'completed',
-      'date_completed' => '>=' . $oldestClick->getCreatedAt()->format('Y-m-d H:i:s'),
+      'date_completed' => '>=' . (($createdAt = $oldestClick->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null),
       'orderby' => 'ID',
       'order' => 'ASC',
       'limit' => self::BATCH_SIZE,

--- a/mailpoet/lib/Doctrine/EntityTraits/CreatedAtTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/CreatedAtTrait.php
@@ -7,17 +7,16 @@ use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
 
 trait CreatedAtTrait {
   /**
-   * @ORM\Column(type="datetimetz")
-   * @var DateTimeInterface
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
    */
   private $createdAt;
 
-  /** @return DateTimeInterface */
-  public function getCreatedAt() {
+  public function getCreatedAt(): ?DateTimeInterface {
     return $this->createdAt;
   }
 
-  public function setCreatedAt(DateTimeInterface $createdAt) {
+  public function setCreatedAt(DateTimeInterface $createdAt): void {
     $this->createdAt = $createdAt;
   }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
@@ -71,7 +71,9 @@ class TimestampListenerTest extends EventListenersBaseTest {
     $entity->setName('Updated');
     $this->entityManager->flush();
 
-    expect($entity->getCreatedAt()->format('Y-m-d H:i:s'))->equals('2000-01-01 12:00:00');
+    $createdAt = $entity->getCreatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
+    expect($createdAt->format('Y-m-d H:i:s'))->equals('2000-01-01 12:00:00');
     expect($entity->getUpdatedAt())->equals($this->now);
   }
 

--- a/mailpoet/tests/integration/Logging/LogHandlerTest.php
+++ b/mailpoet/tests/integration/Logging/LogHandlerTest.php
@@ -38,7 +38,9 @@ class LogHandlerTest extends \MailPoetTest {
 
     $log = $this->repository->findOneBy(['name' => 'name'], ['id' => 'desc']);
     assert($log instanceof LogEntity);
-    expect($log->getCreatedAt()->format('Y-m-d H:i:s'))->equals($time->format('Y-m-d H:i:s'));
+    $createdAt = $log->getCreatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
+    expect($createdAt->format('Y-m-d H:i:s'))->equals($time->format('Y-m-d H:i:s'));
   }
 
   public function testItPurgesOldLogs() {
@@ -133,7 +135,9 @@ class LogHandlerTest extends \MailPoetTest {
 
     $log = $logRepository->findOneBy(['name' => 'name'], ['id' => 'desc']);
     assert($log instanceof LogEntity);
-    expect($log->getCreatedAt()->format('Y-m-d H:i:s'))->equals($time->format('Y-m-d H:i:s'));
+    $createdAt = $log->getCreatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
+    expect($createdAt->format('Y-m-d H:i:s'))->equals($time->format('Y-m-d H:i:s'));
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -155,12 +155,14 @@ class SubscriberActionsTest extends \MailPoetTest {
     expect($subscriber->getFirstName())->equals('Donald');
     expect($subscriber->getLastName())->equals('Trump');
 
+    $createdAt = $subscriber->getCreatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
     expect($subscriber->getWpUserId())->null();
     expect($subscriber->getIsWoocommerceUser())->equals(0);
     expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNCONFIRMED);
-    expect($subscriber->getCreatedAt()->format('Y-m-d H:i:s'))->notEquals('1984-03-09 00:00:01');
+    expect($createdAt->format('Y-m-d H:i:s'))->notEquals('1984-03-09 00:00:01');
     expect($subscriber->getUpdatedAt()->format('Y-m-d H:i:s'))->notEquals('1984-03-09 00:00:02');
-    expect($subscriber->getCreatedAt()->getTimestamp())->equals($subscriber->getUpdatedAt()->getTimestamp(), 2);
+    expect($createdAt->getTimestamp())->equals($subscriber->getUpdatedAt()->getTimestamp(), 2);
     expect($subscriber->getDeletedAt())->null();
   }
 


### PR DESCRIPTION
Because we use the trait for `createdAt` in all Doctrine entities, and some have this column nullable. I wanted to prevent a similar issue in the future, so I changed the return type in the trait to `DateTimeInterface|null`. PHPStan will help to catch this error now.

[MAILPOET-4067]

[MAILPOET-4067]: https://mailpoet.atlassian.net/browse/MAILPOET-4067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ