### PR TITLE
Update migration check for email action segments data migration [MAILPOET-3951]

### DIFF
--- a/mailpoet/lib/Config/Migrator.php
+++ b/mailpoet/lib/Config/Migrator.php
@@ -861,8 +861,8 @@ class Migrator {
 
   private function migrateEmailActionsFilters(): bool {
     global $wpdb;
-    // skip the migration if the DB version is higher than 3.77.0 or is not set (a new installation)
-    if (version_compare($this->settings->get('db_version', '3.77.1'), '3.77.0', '>')) {
+    // skip the migration if the DB version is higher than 3.77.1 or is not set (a new installation)
+    if (version_compare($this->settings->get('db_version', '3.77.2'), '3.77.1', '>')) {
       return false;
     }
 


### PR DESCRIPTION
After the emergency release, we need to update the version check in migration.

[MAILPOET-3951]

[MAILPOET-3951]: https://mailpoet.atlassian.net/browse/MAILPOET-3951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ