### PR TITLE
Fix stats create segment [PREMIUM-173]

### DIFF
--- a/mailpoet/assets/js/src/listing/filters.jsx
+++ b/mailpoet/assets/js/src/listing/filters.jsx
@@ -53,6 +53,7 @@ class ListingFilters extends React.Component {
           ref={(c) => { this[`filter-${i}`] = c; }}
           key={`filter-${filter}`}
           name={filter}
+          automationId={`listing_filter_${filter}`}
           onChange={this.handleFilterAction}
         >
           { filters[filter].map((option) => (

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email_statistics_clicks.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email_statistics_clicks.tsx
@@ -137,6 +137,7 @@ export const EmailClickStatisticsFields: React.FunctionComponent<Props> = ({ fil
               isMulti
               dimension="small"
               isFullWidth
+              automationId="segment-link-select"
               placeholder={MailPoet.I18n.t('allLinksPlaceholder')}
               options={links.length ? links : [{ value: 0, label: MailPoet.I18n.t('noLinksHint'), isDisabled: true }]}
               value={filter(


### PR DESCRIPTION
This PR adds a couple of automation_ids used in an acceptance test in the premium plugin. See [related PR](https://github.com/mailpoet/mailpoet-premium/pull/533).

[PREMIUM-173]

[PREMIUM-173]: https://mailpoet.atlassian.net/browse/PREMIUM-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ