### PR TITLE
Wizard displays 'false' on From Name and From Address MAILPOET-4062

### DIFF
--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -227,8 +227,8 @@ class Populator {
   }
 
   private function createDefaultSettings() {
-    $currentUser = $this->wp->wpGetCurrentUser();
     $settingsDbVersion = $this->settings->fetch('db_version');
+    $currentUser = $this->wp->wpGetCurrentUser();
 
     // set cron trigger option to default method
     if (!$this->settings->fetch(CronTrigger::SETTING_NAME)) {
@@ -238,14 +238,19 @@ class Populator {
     }
 
     // set default sender info based on current user
-    $sender = [
-      'name' => $currentUser->display_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      'address' => $currentUser->user_email, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $defaultSender = [
+      'name' => $currentUser->display_name ?: '', // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      'address' => $currentUser->user_email ?: '', // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     ];
+    $savedSender = $this->settings->fetch('sender', []);
 
-    // set default from name & address
-    if (!$this->settings->fetch('sender')) {
-      $this->settings->set('sender', $sender);
+    /**
+     * Set default from name & address
+     * In some cases ( like when the plugin is getting activated other than from WP Admin ) user data may not
+     * still be set at this stage, so setting the defaults for `sender` is postponed
+     */
+    if (empty($savedSender) || empty($savedSender['address'])) {
+      $this->settings->set('sender', $defaultSender);
     }
 
     // enable signup confirmation by default


### PR DESCRIPTION
### This fixed issue in explained in [MAILPOET-4062]


### The cause:
For instances where plugin is not activated normally via WP admin (like for example when making Jurassic.ninja pre-install and activate MailPoet or throw [WP-CLI](https://wp-cli.org/)) the properties of `WP_User` are not correctly set thus incorrect values (false since it's the fallback for these fields) end up in `mailpoet_settings` table as `sender` default settings and the user sees these values when they initially see the MailPoet wizard.

### How to test:

1. Deactivate MailPoet plugin if it's active
2. Remove all MailPoet tables from you db
3. Activate the plugin by taking ssh to `wordpress` container using `./do ssh`
4. While in the `wordpress` container run `wp plugin activate mailpoet` to activate the plugin
5. Please note that activating the plugin via a none-UI method is the key to reproduce the issue ( or confirm the fix )
6. Visit [MailPoet welcome wizar](http://mp3.localhost/wp-admin/admin.php?page=mailpoet-welcome-wizard&mailpoet_redirect=http%3A%2F%2Fmp3.localhost%2Fwp-admin%2Fadmin.php%3Fpage%3Dmailpoet-newsletters#/steps/1) by clicking on MailPoet higher level entry on the left sidebar or clicking on the provided link
7. Confirm seeing empty (or valid values) in  `From Name` and `From Address` fields

![Screenshot 2022-01-31 at 16 47 30](https://user-images.githubusercontent.com/789421/151825979-1fb8ca79-d259-4499-a0b4-1c6af0cf5141.png)

[MAILPOET-4062]: https://mailpoet.atlassian.net/browse/MAILPOET-4062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ