### PR TITLE
Upgrade acceptance tests environment

### DIFF
--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -37,8 +37,6 @@ class DefaultsExtension extends Extension {
     update_option('users_can_register', '1', 'yes');
     update_site_option('registration', 'user');
     update_option('permalink_structure', '/%year%/%monthnum%/%day%/%postname%/', 'yes');
-    update_option('template', 'twentynineteen', 'yes');
-    update_option('stylesheet', 'twentynineteen', 'yes');
 
     // posts & pages
     $this->createPost('post', 'hello-world', 'Hello world!', 'Hello from WordPress.');

--- a/mailpoet/tests/acceptance/Forms/EditorAddDividerCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddDividerCest.php
@@ -53,8 +53,10 @@ class EditorAddDividerCest {
     $i->wantTo('Check divider on front end');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
-    $i->assertAttributeContains('[data-automation-id="form_divider"]', 'style', 'height: 10px;');
-    $i->assertAttributeContains('[data-automation-id="form_divider"]', 'style', 'width: 10%;');
-    $i->assertAttributeContains('[data-automation-id="form_divider"]', 'style', 'border-top: 10px dotted black;');
+    $i->assertCssProperty('[data-automation-id="form_divider"]', 'height', '10px');
+    $i->assertAttributeContains('[data-automation-id="form_divider"]', 'style', 'width: 10%');
+    $i->assertCssProperty('[data-automation-id="form_divider"]', 'border-top-width', '10px');
+    $i->assertCssProperty('[data-automation-id="form_divider"]', 'border-top-style', 'dotted');
+    $i->assertCssProperty('[data-automation-id="form_divider"]', 'border-top-color', 'rgba(0, 0, 0, 1)');
   }
 }

--- a/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
@@ -34,7 +34,7 @@ class EditorButtonStylesCest {
     $i->wantTo('Check element has styles');
     $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'border-width: 10px;');
     $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'font-weight: bold;');
-    
+
     $i->wantTo('Save form');
     $i->saveFormInEditor();
 
@@ -47,8 +47,8 @@ class EditorButtonStylesCest {
     $i->wantTo('Check styles are applied on frontend page');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
-    $i->assertAttributeContains('[data-automation-id="subscribe-submit-button"]', 'style', 'border-width: 10px;');
-    $i->assertAttributeContains('[data-automation-id="subscribe-submit-button"]', 'style', 'font-weight: bold;');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'font-weight', '700');
     $i->seeInField('[data-automation-id="subscribe-submit-button"]', 'Join Now');
   }
 }

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -100,6 +100,10 @@ wp plugin activate woocommerce-subscriptions
 # activate theme
 wp theme activate twentytwentyone
 
+if [[ $CIRCLE_JOB == *"_oldest"* ]]; then
+  wp theme activate twentynineteen
+fi
+
 # print info about installed plugins
 wp plugin get woocommerce
 wp plugin get woocommerce-subscriptions

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -97,6 +97,9 @@ sed -i "s/define( *'WP_DEBUG', false *);/$CONFIG/" /wp-core/wp-config.php
 wp plugin activate woocommerce
 wp plugin activate woocommerce-subscriptions
 
+# activate theme
+wp theme activate twentytwentyone
+
 # print info about installed plugins
 wp plugin get woocommerce
 wp plugin get woocommerce-subscriptions

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   codeception:
-    image : mailpoet/wordpress:8.0-cli_20220126.1
+    image: mailpoet/wordpress:8.0-cli_20220126.1
     depends_on:
       - mailhog
       - wordpress
@@ -33,7 +33,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-5.8_php8.0_20211216.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-5.9_php8.0_20220127.1}
     depends_on:
       - chrome
       - mailhog

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.8'
+version: '3.9'
 
 services:
   codeception:
-    image: mailpoet/wordpress:7.4-cli_20210126.1
+    image : mailpoet/wordpress:8.0-cli_20220126.1
     depends_on:
       - mailhog
       - wordpress


### PR DESCRIPTION
This PR upgrades the acceptance tests to use PHP8.0 for the running environment and WP-5.9-PHP8.0 for the WordPress image.

Uses the new images from:
https://github.com/mailpoet/wordpress-images/pull/28
https://github.com/mailpoet/wordpress-images/pull/29

A few tests have been updated to work both also with `seleniarm/standalone-chromium`, using `assertCssProperty`

The theme 2019 is no longer present on WP5.9. On this PR we conditionally load 2021 or 2019 depending on the CircleCI job.

To update your local tests:
Before running the new tests `./do d:d` and delete the  file `mailpoet/tests/_data/acceptancebackup.sql`

[MAILPOET-4014]

[MAILPOET-4014]: https://mailpoet.atlassian.net/browse/MAILPOET-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ