### PR TITLE
Fix failing acceptance tests [MAILPOET-4095]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
           command: |
             ./do download:woo-commerce-zip 6.0.0
             ./do download:woo-commerce-subscriptions-zip 3.0.14
+            ./do download:woo-commerce-memberships-zip 1.22.9
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |
@@ -320,6 +321,9 @@ jobs:
       woo_subscriptions_version:
         type: string
         default: ''
+      woo_memberships_version:
+        type: string
+        default: ''
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
@@ -350,6 +354,14 @@ jobs:
                 command: |
                     cd tests/docker
                     docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
+      - when:
+          condition: << parameters.woo_memberships_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Memberships
+                command: |
+                    cd tests/docker
+                    docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
       - run:
           name: Group acceptance tests
           command: |
@@ -563,6 +575,7 @@ workflows:
           name: acceptance_latest
           woo_core_version: latest
           woo_subscriptions_version: latest
+          woo_memberships_version: latest
           requires:
             - build
       - acceptance_tests:
@@ -570,6 +583,7 @@ workflows:
           name: acceptance_oldest
           woo_core_version: 4.0.1
           woo_subscriptions_version: 3.0.10
+          woo_memberships_version: 1.22.9
           mysql_command: --max_allowed_packet=100M
           mysql_image_version: 5.5-ram
           wordpress_image_version: wp-5.3_php7.2_20211213.1

--- a/mailpoet/tasks/GithubClient.php
+++ b/mailpoet/tasks/GithubClient.php
@@ -32,11 +32,18 @@ class GithubClient {
     if (!$release) {
       throw new \Exception("Release $tag not found");
     }
-    $namesToCheck = [
-      $zip,
-      str_replace('.zip', ".$tag.zip", $zip),
-      str_replace('.zip', "-$tag.zip", $zip),
-    ];
+    $namesToCheck = [$zip];
+    if ($tag) {
+      $namesToCheck[] = str_replace('.zip', ".$tag.zip", $zip);
+      $namesToCheck[] = str_replace('.zip', "-$tag.zip", $zip);
+    }
+    // We use the last version name to find a zip file
+    $lastVersion = $release['tag_name'];
+    if ($lastVersion !== $tag) {
+      $namesToCheck[] = str_replace('.zip', ".$lastVersion.zip", $zip);
+      $namesToCheck[] = str_replace('.zip', "-$lastVersion.zip", $zip);
+    }
+
     $assetDownloadUrl = null;
     $assetDownloadInfo = null;
     foreach ($release['assets'] as $asset) {

--- a/mailpoet/tests/DataFactories/WooCommerceMembership.php
+++ b/mailpoet/tests/DataFactories/WooCommerceMembership.php
@@ -16,16 +16,18 @@ class WooCommerceMembership {
     $createCommand = ['wc', 'memberships', 'plan', 'create'];
     $createCommand[] = "--name='{$name}'";
     $createOutput = $this->tester->cliToString($createCommand);
-    $planOut = $this->tester->cliToString(['wc', 'membership_plan', 'get', $createOutput, '--format=json']);
+    preg_match('!\d+!', $createOutput, $matches);
+    $planOut = $this->tester->cliToString(['wc', 'membership_plan', 'get', reset($matches), '--format=json', '--user=admin']);
     return json_decode($planOut, true);
   }
 
   public function createMember(int $userId, int $planId) {
-    $createCommand = ['wc', 'user_membership', 'create'];
+    $createCommand = ['wc', 'user_membership', 'create', '--user=admin'];
     $createCommand[] = "--customer_id='{$userId}'";
-    $createCommand[] = "--plan_id='{$userId}'";
+    $createCommand[] = "--plan_id='{$planId}'";
     $createOutput = $this->tester->cliToString($createCommand);
-    $membershipOut = $this->tester->cliToString(['wc', 'user_membership', 'get', $createOutput, '--format=json']);
+    preg_match('!\d+!', $createOutput, $matches);
+    $membershipOut = $this->tester->cliToString(['wc', 'user_membership', 'get', reset($matches), '--format=json', '--user=admin']);
     return json_decode($membershipOut, true);
   }
 }

--- a/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
@@ -25,7 +25,6 @@ class WooCommerceMembershipsSegmentCest {
     $membershipFactory = new WooCommerceMembership($i);
     $plan1 = $membershipFactory->createPlan('Plan 1');
     $plan2 = $membershipFactory->createPlan('Plan 2');
-    $plan3 = $membershipFactory->createPlan('Plan 3');
 
     $userFactory = new User();
     $subscriber1 = $userFactory->createUser('Sub Scriber1', 'subscriber', 'subscriber1@example.com');
@@ -34,8 +33,8 @@ class WooCommerceMembershipsSegmentCest {
     $userFactory->createUser('Sub Scriber4', 'subscriber', 'subscriber4@example.com');
 
     $membershipFactory->createMember($subscriber1->ID, $plan1['id']);
+    $membershipFactory->createMember($subscriber2->ID, $plan1['id']);
     $membershipFactory->createMember($subscriber2->ID, $plan2['id']);
-    $membershipFactory->createMember($subscriber2->ID, $plan3['id']);
 
     $segmentActionSelectElement = '[data-automation-id="select-segment-action"]';
     $operatorSelectElement = '[data-automation-id="select-operator"]';

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -79,6 +79,19 @@ if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-subscriptions" ]]; then
   unzip -q -o "$WOOCOMMERCE_SUBS_ZIP" -d /wp-core/wp-content/plugins/
 fi
 
+# Install WooCommerce Memberships
+if [[ ! -d "/wp-core/wp-content/plugins/woocommerce-memberships" ]]; then
+  WOOCOMMERCE_MEMBERSHIPS_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce-memberships.zip"
+  if [ ! -f "$WOOCOMMERCE_MEMBERSHIPS_ZIP" ]; then
+    echo "WooCommerce Memberships plugin zip not found. Downloading WooCommerce Memberships plugin latest zip"
+    cd /project
+    ./do download:woo-commerce-memberships-zip latest
+    cd /wp-core/wp-content/plugins
+  fi
+  echo "Unzip Woocommerce Memberships plugin from $WOOCOMMERCE_MEMBERSHIPS_ZIP"
+  unzip -q -o "$WOOCOMMERCE_MEMBERSHIPS_ZIP" -d /wp-core/wp-content/plugins/
+fi
+
 # add configuration
 CONFIG=''
 CONFIG+="define('WP_DEBUG', true);\n"
@@ -96,10 +109,12 @@ sed -i "s/define( *'WP_DEBUG', false *);/$CONFIG/" /wp-core/wp-config.php
 # activate all plugins which source code want to access in tests runtime
 wp plugin activate woocommerce
 wp plugin activate woocommerce-subscriptions
+wp plugin activate woocommerce-memberships
 
 # print info about installed plugins
 wp plugin get woocommerce
 wp plugin get woocommerce-subscriptions
+wp plugin get woocommerce-memberships
 
 # activate MailPoet
 wp plugin activate mailpoet/mailpoet.php


### PR DESCRIPTION
This PR fixes a few issues with acceptance tests:
- a missing plugin WooCommerce Memberships
- incorrect arguments in the membership data factory
- inconsistency in prepared data in an acceptance test