### PR TITLE
Incorrect use of $metas index in SendingQueue [MAILPOET-3943]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -295,6 +295,7 @@ class SendingQueue {
         $preparedSubscribersIds = [];
         $unsubscribeUrls = [];
         $statistics = [];
+        $metas = [];
       }
     }
     if ($processingMethod === 'bulk') {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -445,8 +445,8 @@ class SendingQueueTest extends \MailPoetTest {
       Subscriber::create(),
       Subscriber::create(),
     ];
-    $subscribers[0]->set('id', 1);
-    $subscribers[1]->set('id', 2);
+    $subscribers[0]->set('id', '1');
+    $subscribers[1]->set('id', '2');
     $subscribers[0]->set('status', 'status-1');
     $subscribers[1]->set('status', 'status-2');
     $subscribers[0]->set('source', 'source-1');


### PR DESCRIPTION
Fixes [MAILPOET-3943](https://mailpoet.atlassian.net/browse/MAILPOET-3943)
Fixes #3803

When processing the Queue in Cron/Workers/SendingQueue/SendingQueue, there are two distinct methods to do so: `bulk` and `individual`.

We loop through all subscribers and gather the individualized data like newsletter body for each subscriber. Those are stored in several arrays.

In case the processing method is `individual`, we send the newsletter immediately and resetting the mentioned arrays.

`$metas` did not get reset which resulted in #3803.

This PR adds a test to ensure the correct data gets send and resets the `$metas` array like the other arrays get resetted.