### PR TITLE
Enable Xdebug develop mode

### DIFF
--- a/dev/xdebug.ini
+++ b/dev/xdebug.ini
@@ -1,4 +1,4 @@
-xdebug.mode=debug
+xdebug.mode=debug,develop
 xdebug.output_dir="/var/www/html"
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9000


### PR DESCRIPTION
In order to test the change proposed here, it is necessary to stop the dev environment, rebuild the wordpress service (`docker-compose build wordpress`), start the environment again, and check phpinfo() to confirm that `develop` is included in `xdebug.mode`. 

[MAILPOET-4098]

[MAILPOET-4098]: https://mailpoet.atlassian.net/browse/MAILPOET-4098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ