### PR TITLE
Subscribers::listing endpoint does not find subscribers without segment who are trashed [MAILPOET-3975]

### DIFF
--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -310,7 +310,6 @@ class SegmentSubscribersRepository {
           $queryBuilder->expr()->eq('ssg.status', ':statusSubscribed'),
           $queryBuilder->expr()->notIn('ssg.segment', $deletedSegmentsQueryBuilder->getDQL())
         ))
-      ->andWhere('s.deletedAt IS NULL')
       ->andWhere('ssg.id IS NULL')
       ->setParameter('statusSubscribed', SubscriberEntity::STATUS_SUBSCRIBED);
   }

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -503,6 +503,62 @@ class SubscribersTest extends \MailPoetTest {
     );
   }
 
+  public function testItCanFilterSubscribersWithoutSegment() {
+    $subscriber = Subscriber::createOrUpdate(
+      [
+        'email' => 'no-segment@example.com',
+        'status' => Subscriber::STATUS_SUBSCRIBED,
+        'segments' => [],
+        'source' => Source::API,
+      ]
+    );
+    $trashedSubscriber = Subscriber::createOrUpdate(
+      [
+        'email' => 'no-segment-in-trash@example.com',
+        'status' => Subscriber::STATUS_SUBSCRIBED,
+        'segments' => [],
+        'source' => Source::API,
+      ]
+    );
+    $trashedSubscriber->trash()->save();
+
+    $result = $this->endpoint->listing(
+      [
+        'filter' => [
+          'segment' => SubscriberListingRepository::FILTER_WITHOUT_LIST,
+        ],
+        'group' => 'all',
+      ]
+    );
+    $data = $result->getData();
+    $meta = $result->meta;
+
+    self::assertEquals(2, $meta['count'], "Did not find exactly two subscribers without list");
+    self::assertCount(2, $data['data'], "Did not return exactly two subscribers without list");
+    $foundSubscriberIds = array_map(
+      function (array $data): int {
+        return (int)$data['id'];
+      }, $data['data']
+    );
+    self::assertTrue(in_array((int)$this->subscriber1->getId(), $foundSubscriberIds, true), 'Subscriber 1 was not found.');
+    self::assertTrue(in_array((int)$subscriber->id(), $foundSubscriberIds, true), 'New subscriber without list was not found.');
+
+    $result = $this->endpoint->listing(
+      [
+        'filter' => [
+          'segment' => SubscriberListingRepository::FILTER_WITHOUT_LIST,
+        ],
+        'group' => 'trash',
+      ]
+    );
+    $data = $result->getData();
+    $meta = $result->meta;
+
+    self::assertEquals(1, $meta['count'], "Did not find exactly one trashed subscriber without list.");
+    self::assertCount(1, $data['data'], "Did not return exactly one trashed subscriber without list.");
+    self::assertEquals($trashedSubscriber->id(), $data['data'][0]['id'], "Did not return the trashed subscriber without list.");
+  }
+
   public function testItCanBulkDeleteSelectionOfSubscribers() {
     $deletableSubscriber = Subscriber::createOrUpdate([
       'email' => 'to.be.removed@mailpoet.com',


### PR DESCRIPTION
Fixes MAILPOET-3975

The Subscribers::listing endpoint failed to return the correct data, when filtering for trashed subscribers who are not attached to a segment.

This happened, because the SQL statement queried for subscribers who where `deletedAt IS NOT NULL AND deletedAt IS NULL`.

The `SegmentSubscribersRepository::addConstraintsForSubscribersWithoutSegment()` extended the query for subscribers and insisted, that these subscribers where not deleted and by doing so, it produced a conflict with the trash condition, which narrowed the query to only deleted subscribers. 455e6f9 removes the "is-not-deleted" condition in `addConstraintsForSubscribersWithoutSegment()`.

**What is affected by this change?**
`addConstraintsForSubscribersWithoutSegment()` is used by the Subscribers::listing endpoint. After the change, this listing endpoint returns the correct values as tested in 9e27be2.

Furthermore, `addConstraintsForSubscribersWithoutSegment()` is used by `SegmentSubscribersRepository::getSubscribersWithoutSegmentCount()`. A quick search through the codebase seemed to result in no method consumes `getSubscribersWithoutSegmentCount()`, but maybe this method is called in some opaque way a simple text search does not reveal.