### PR TITLE
Update stats email to reflect redesign [MAILPOET-3324]

### DIFF
--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -144,9 +144,9 @@ class Worker {
     $context = [
       'subject' => $subject,
       'preheader' => sprintf(_x(
-        '%1$s%% opens, %2$s%% clicks, %3$s%% unsubscribes in a nutshell.', 'newsletter open rate, click rate and unsubscribe rate', 'mailpoet'),
-        number_format($opened, 2),
+        '%1$s%% clicks, %2$s%% opens, %3$s%% unsubscribes in a nutshell.', 'newsletter open rate, click rate and unsubscribe rate', 'mailpoet'),
         number_format($clicked, 2),
+        number_format($opened, 2),
         number_format($unsubscribed, 2)
       ),
       'topLinkClicks' => 0,

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -136,6 +136,7 @@ class Worker {
     $statistics = $this->newsletterStatisticsRepository->getStatistics($newsletter);
     $clicked = ($statistics->getClickCount() * 100) / $statistics->getTotalSentCount();
     $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();
+    $machineOpened = ($statistics->getMachineOpenCount() * 100) / $statistics->getTotalSentCount();
     $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $statistics->getTotalSentCount();
     $subject = $sendingQueue->getNewsletterRenderedSubject();
     $subscribersCount = $this->subscribersRepository->getTotalSubscribers();
@@ -153,6 +154,7 @@ class Worker {
       'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters&stats=' . $newsletter->getId()),
       'clicked' => $clicked,
       'opened' => $opened,
+      'machineOpened' => $machineOpened,
       'subscribersLimitReached' => $this->subscribersFeature->check(),
       'hasValidApiKey' => $hasValidApiKey,
       'subscribersLimit' => $this->subscribersFeature->getSubscribersLimit(),

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -138,6 +138,7 @@ class Worker {
     $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();
     $machineOpened = ($statistics->getMachineOpenCount() * 100) / $statistics->getTotalSentCount();
     $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $statistics->getTotalSentCount();
+    $bounced = ($statistics->getBounceCount() * 100) / $statistics->getTotalSentCount();
     $subject = $sendingQueue->getNewsletterRenderedSubject();
     $subscribersCount = $this->subscribersRepository->getTotalSubscribers();
     $hasValidApiKey = $this->subscribersFeature->hasValidApiKey();
@@ -155,6 +156,8 @@ class Worker {
       'clicked' => $clicked,
       'opened' => $opened,
       'machineOpened' => $machineOpened,
+      'unsubscribed' => $unsubscribed,
+      'bounced' => $bounced,
       'subscribersLimitReached' => $this->subscribersFeature->check(),
       'hasValidApiKey' => $hasValidApiKey,
       'subscribersLimit' => $this->subscribersFeature->getSubscribersLimit(),

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -271,9 +271,9 @@ class Functions extends AbstractExtension {
   }
 
   public function clickedStatsColor($clicked) {
-    if ($clicked > 3) {
+    if ($clicked > 30) {
       return '#7ed321';
-    } elseif ($clicked > 1) {
+    } elseif ($clicked > 10) {
       return '#ff9f00';
     } else {
       return '#f559c3';

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -272,11 +272,11 @@ class Functions extends AbstractExtension {
 
   public function clickedStatsColor($clicked) {
     if ($clicked > 3) {
-      return '#2993ab';
+      return '#7ed321';
     } elseif ($clicked > 1) {
-      return '#f0b849';
+      return '#ff9f00';
     } else {
-      return '#d54e21';
+      return '#f559c3';
     }
   }
 
@@ -292,11 +292,11 @@ class Functions extends AbstractExtension {
 
   public function clickedStatsText($clicked) {
     if ($clicked > 3) {
-      return __('EXCELLENT', 'mailpoet');
+      return __('Excellent', 'mailpoet');
     } elseif ($clicked > 1) {
-      return __('GOOD', 'mailpoet');
+      return __('Good', 'mailpoet');
     } else {
-      return __('BAD', 'mailpoet');
+      return __('Average', 'mailpoet');
     }
   }
 

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -261,9 +261,9 @@ class Functions extends AbstractExtension {
   }
 
   public function statsColor($percentage) {
-    if ($percentage > 30) {
+    if ($percentage > 3) {
       return '#7ed321';
-    } elseif ($percentage > 10) {
+    } elseif ($percentage > 1) {
       return '#ff9f00';
     } else {
       return '#f559c3';

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -150,6 +150,11 @@ class Functions extends AbstractExtension {
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
+        'stats_number_format_i18n',
+        [$this, 'statsNumberFormatI18n'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
         'add_referral_id',
         [$this, 'addReferralId'],
         ['is_safe' => ['all']]
@@ -283,6 +288,25 @@ class Functions extends AbstractExtension {
     } else {
       return __('Average', 'mailpoet');
     }
+  }
+
+  /**
+   * Wrapper around number_format_i18n() to return two decimals digits if the number
+   * is smaller than 0.1 and one decimal digit if the number is equal or greater
+   * than 0.1.
+   *
+   * @param int|float $number
+   *
+   * @return string
+   */
+  public function statsNumberFormatI18n($number) {
+    if ($number < 0.1) {
+      $decimals = 2;
+    } else {
+      $decimals = 1;
+    }
+
+    return number_format_i18n($number, $decimals);
   }
 
   public function addReferralId($url) {

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -135,13 +135,8 @@ class Functions extends AbstractExtension {
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
-        'opened_stats_color',
-        [$this, 'openedStatsColor'],
-        ['is_safe' => ['all']]
-      ),
-      new TwigFunction(
-        'clicked_stats_color',
-        [$this, 'clickedStatsColor'],
+        'stats_color',
+        [$this, 'statsColor'],
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
@@ -260,20 +255,10 @@ class Functions extends AbstractExtension {
     return $this->woocommerceHelper->isWooCommerceActive();
   }
 
-  public function openedStatsColor($opened) {
-    if ($opened > 30) {
-      return '#2993ab';
-    } elseif ($opened > 10) {
-      return '#f0b849';
-    } else {
-      return '#d54e21';
-    }
-  }
-
-  public function clickedStatsColor($clicked) {
-    if ($clicked > 30) {
+  public function statsColor($percentage) {
+    if ($percentage > 30) {
       return '#7ed321';
-    } elseif ($clicked > 10) {
+    } elseif ($percentage > 10) {
       return '#ff9f00';
     } else {
       return '#f559c3';

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -216,7 +216,7 @@ class WorkerTest extends \MailPoetTest {
       ->with(
        $this->anything(),
        $this->callback(function($context){
-         return $context['preheader'] === '40.00% opens, 60.00% clicks, 20.00% unsubscribes in a nutshell.';
+         return $context['preheader'] === '60.00% clicks, 40.00% opens, 20.00% unsubscribes in a nutshell.';
        }));
 
     $this->statsNotifications->process();

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -221,7 +221,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                      <span style="color: <%= stats_color(opened) %>;">
+                      <span>
                         <strong><%= stats_number_format_i18n(opened) %>%</strong>
                       </span>
                     </h2>
@@ -232,7 +232,7 @@
                     <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                          <span style="color: <%= stats_color(opened) %>">
+                          <span>
                             <%= __('opened') %>
                           </span>
                         </td>
@@ -253,7 +253,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                      <span style="color: <%= stats_color(machineOpened) %>;">
+                      <span>
                         <strong><%= stats_number_format_i18n(machineOpened) %>%</strong>
                       </span>
                     </h2>
@@ -264,7 +264,7 @@
                     <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                          <span style="color: <%= stats_color(machineOpened) %>">
+                          <span>
                             <%= __('machine-opened') %>
                           </span>
                         </td>
@@ -305,7 +305,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                        <span style="color: <%= stats_color(unsubscribed) %>;">
+                        <span>
                           <strong><%= stats_number_format_i18n(unsubscribed) %>%</strong>
                         </span>
                     </h2>
@@ -316,7 +316,7 @@
                     <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                            <span style="color: <%= stats_color(unsubscribed) %>">
+                            <span>
                               <%= __('unsubscribed') %>
                             </span>
                         </td>
@@ -337,7 +337,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                        <span style="color: <%= stats_color(bounced) %>;">
+                        <span>
                           <strong><%= stats_number_format_i18n(bounced) %>%</strong>
                         </span>
                     </h2>
@@ -348,7 +348,7 @@
                     <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                            <span style="color: <%= stats_color(bounced) %>">
+                            <span>
                               <%= __('bounced') %>
                             </span>
                         </td>

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -170,7 +170,7 @@
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
                       <span style="color: <%= stats_color(clicked) %>">
-                        <strong><%= number_format_i18n(clicked, 1) %>%</strong>
+                        <strong><%= stats_number_format_i18n(clicked) %>%</strong>
                       </span>
                     </h2>
                   </td>
@@ -222,7 +222,7 @@
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
                       <span style="color: <%= stats_color(opened) %>;">
-                        <strong><%= number_format_i18n(opened, 1) %>%</strong>
+                        <strong><%= stats_number_format_i18n(opened) %>%</strong>
                       </span>
                     </h2>
                   </td>
@@ -254,7 +254,7 @@
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
                       <span style="color: <%= stats_color(machineOpened) %>;">
-                        <strong><%= number_format_i18n(machineOpened, 1) %>%</strong>
+                        <strong><%= stats_number_format_i18n(machineOpened) %>%</strong>
                       </span>
                     </h2>
                   </td>
@@ -306,7 +306,7 @@
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
                         <span style="color: <%= stats_color(unsubscribed) %>;">
-                          <strong><%= number_format_i18n(unsubscribed, 1) %>%</strong>
+                          <strong><%= stats_number_format_i18n(unsubscribed) %>%</strong>
                         </span>
                     </h2>
                   </td>
@@ -338,7 +338,7 @@
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
                         <span style="color: <%= stats_color(bounced) %>;">
-                          <strong><%= number_format_i18n(bounced, 1) %>%</strong>
+                          <strong><%= stats_number_format_i18n(bounced) %>%</strong>
                         </span>
                     </h2>
                   </td>

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -287,6 +287,90 @@
       </table>
     </td>
   </tr>
+  <tr>
+    <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+        <tbody>
+        <tr>
+          <td align="center" style="font-size:0;border-collapse:collapse">
+            <!--[if mso]>
+            <table border="0" width="100%" cellpadding="0" cellspacing="0">
+              <tbody>
+              <tr>
+                <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
+                    <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
+                        <span style="color: <%= stats_color(unsubscribed) %>;">
+                          <strong><%= number_format_i18n(unsubscribed, 1) %>%</strong>
+                        </span>
+                    </h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
+                      <tr>
+                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
+                            <span style="color: <%= stats_color(unsubscribed) %>">
+                              <%= __('unsubscribed') %>
+                            </span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
+                    <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
+                        <span style="color: <%= stats_color(bounced) %>;">
+                          <strong><%= number_format_i18n(bounced, 1) %>%</strong>
+                        </span>
+                    </h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
+                      <tr>
+                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
+                            <span style="color: <%= stats_color(bounced) %>">
+                              <%= __('bounced') %>
+                            </span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            <![endif]-->
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
   <% if topLinkClicks > 0 %>
     <tr>
       <td class="mailpoet_content" align="center" style="border-collapse:collapse">

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -157,7 +157,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                         <tr>
                           <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
-                            <a class="mailpoet_button" href="" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= opened_stats_color(opened) %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:100px ;line-height:20px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:10px ;font-weight:normal ">
+                            <a class="mailpoet_button" href="" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= stats_color(opened) %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:100px ;line-height:20px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:10px ;font-weight:normal ">
                               <%= opened_stats_text(opened) %>
                             </a></td>
                         </tr>
@@ -168,7 +168,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                      <span style="color: <%= opened_stats_color(opened) %>;">
+                      <span style="color: <%= stats_color(opened) %>;">
                         <strong><%= number_format_i18n(opened, 1) %>%</strong>
                       </span>
                     </h2>
@@ -179,7 +179,7 @@
                     <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                          <span style="color: <%= opened_stats_color(opened) %>">
+                          <span style="color: <%= stats_color(opened) %>">
                             <%= __('open rate') %>
                           </span>
                         </td>
@@ -203,7 +203,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                         <tr>
                           <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
-                            <a class="mailpoet_button" href="" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= clicked_stats_color(clicked) %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:100px ;line-height:20px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:10px ;font-weight:normal ">
+                            <a class="mailpoet_button" href="" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= stats_color(clicked) %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:100px ;line-height:20px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:10px ;font-weight:normal ">
                               <%= clicked_stats_text(clicked) %>
                             </a>
                           </td>
@@ -215,7 +215,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
                     <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                      <span style="color: <%= clicked_stats_color(clicked) %>">
+                      <span style="color: <%= stats_color(clicked) %>">
                         <strong><%= number_format_i18n(clicked, 1) %>%</strong>
                       </span>
                     </h2>
@@ -226,7 +226,7 @@
                     <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                          <span style="color: <%= clicked_stats_color(clicked) %>">
+                          <span style="color: <%= stats_color(clicked) %>">
                             <%= __('click rate') %>
                           </span>
                         </td>

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -157,52 +157,6 @@
                       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                         <tr>
                           <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
-                            <a class="mailpoet_button" href="" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= stats_color(opened) %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:100px ;line-height:20px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:10px ;font-weight:normal ">
-                              <%= opened_stats_text(opened) %>
-                            </a></td>
-                        </tr>
-                      </table>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
-                    <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
-                      <span style="color: <%= stats_color(opened) %>;">
-                        <strong><%= number_format_i18n(opened, 1) %>%</strong>
-                      </span>
-                    </h2>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
-                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
-                      <tr>
-                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                          <span style="color: <%= stats_color(opened) %>">
-                            <%= __('open rate') %>
-                          </span>
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                </tr>
-                </tbody>
-              </table>
-            </div>
-            <!--[if mso]>
-            </td>
-            <td width="330" valign="top">
-            <![endif]-->
-            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
-              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
-                <tbody>
-                <tr>
-                  <td class="mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
-                    <div>
-                      <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
-                        <tr>
-                          <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
                             <a class="mailpoet_button" href="" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= stats_color(clicked) %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:100px ;line-height:20px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:10px ;font-weight:normal ">
                               <%= clicked_stats_text(clicked) %>
                             </a>
@@ -227,7 +181,91 @@
                       <tr>
                         <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
                           <span style="color: <%= stats_color(clicked) %>">
-                            <%= __('click rate') %>
+                            <%= __('clicked') %>
+                          </span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            <![endif]-->
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+        <tbody>
+        <tr>
+          <td align="center" style="font-size:0;border-collapse:collapse">
+            <!--[if mso]>
+            <table border="0" width="100%" cellpadding="0" cellspacing="0">
+              <tbody>
+              <tr>
+                <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
+                    <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
+                      <span style="color: <%= stats_color(opened) %>;">
+                        <strong><%= number_format_i18n(opened, 1) %>%</strong>
+                      </span>
+                    </h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
+                      <tr>
+                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
+                          <span style="color: <%= stats_color(opened) %>">
+                            <%= __('opened') %>
+                          </span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-left:20px;padding-right:20px">
+                    <h2 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#222222;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:40px;line-height:64px">
+                      <span style="color: <%= stats_color(machineOpened) %>;">
+                        <strong><%= number_format_i18n(machineOpened, 1) %>%</strong>
+                      </span>
+                    </h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
+                      <tr>
+                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
+                          <span style="color: <%= stats_color(machineOpened) %>">
+                            <%= __('machine-opened') %>
                           </span>
                         </td>
                       </tr>

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -2,126 +2,138 @@
 
 <% block content %>
   <tr>
-  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
-    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
-      <tbody>
-      <tr>
-        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
-          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
-            <tbody>
-            <tr>
-              <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
-            </tr>
-            <tr>
-              <td class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="center" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
-                <img src="<%= cdn_url('logo-orange-400x122.png') %>" width="80" alt="new_logo_orange" style="height:auto;max-width:100%;-ms-interpolation-mode:bicubic;border:0;display:block;outline:none;text-align:center" />
-              </td>
-            </tr>
-            <tr>
-              <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
-            </tr>
-            <tr>
-              <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
-                <h1 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#111111;font-family:'Trebuchet MS','Lucida Grande','Lucida Sans Unicode','Lucida Sans',Tahoma,sans-serif;font-size:40px;line-height:64px">
-                  <strong><%= __('Your stats are in!') %></strong>
-                </h1>
-              </td>
-            </tr>
-            <tr>
-              <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
-                <h3 class="title" style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 6px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:20px;line-height:32px">
-                  <em><%= subject %></em>
-                </h3>
-              </td>
-            </tr>
-            <tr>
-              <td class="mailpoet_spacer" height="55" valign="top" style="border-collapse:collapse"></td>
-            </tr>
-            </tbody>
-          </table>
-        </td>
-      </tr>
-      </tbody>
-    </table>
-  </td>
-  </tr>
-  <% if subscribersLimitReached %>
-  <tr>
-    <td class="mailpoet_content" align="center" style="border-collapse:collapse;background-color:#fe5301!important" bgcolor="#fe5301">
-      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+    <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
         <tbody>
-          <tr>
-            <td style="border-collapse:collapse;padding-left:0;padding-right:0">
-              <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
-                <tbody>
-  <tr>
-    <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
-  </tr>
-  <tr>
-    <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
-      <table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
-    <tbody><tr>
-      <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:left">
-        <span style="color: #ffffff;"><strong><%= __('Congratulations, you now have more than [subscribersLimit] subscribers!')|replace({'[subscribersLimit]': subscribersLimit}) %></strong></span><br><br>
-      </td>
-    </tr></tbody></table>
-<table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
-    <tbody><tr>
-      <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:left">
-        <span style="color: #ffffff;"><strong></strong></span>
-      </td>
-    </tr></tbody></table>
-<table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
-    <tbody><tr>
-      <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:left">
-        <span style="color: #ffffff;"><%= __('Our free version is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.')|replace({'[subscribersLimit]': subscribersLimit}) %></span>
-      </td>
-    </tr></tbody></table>
-    </td>
-  </tr>
-  <tr>
-    <td class="mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px">
-      <div>
-        <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
-          <tbody><tr>
-            <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center"><!--[if mso]>
-              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
-                href=""
-                style="height:50px;
-                       width:288px;
-                       v-text-anchor:middle;"
-                arcsize="6%"
-                strokeweight="0px"
-                strokecolor="#0074a2"
-                fillcolor="#ffffff">
-              <w:anchorlock/>
-              <center style="color:#fe5301;
-                font-family:Arial;
-                font-size:20px;
-                font-weight:bold;">Upgrade Now
-              </center>
-              </v:roundrect>
-              <![endif]--><a class="mailpoet_button" href="<%= upgradeNowLink %>" style="color:#fe5301;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:#ffffff;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:288px;line-height:50px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:20px;font-weight:normal"> Upgrade Now</a>
-            </td>
-          </tr>
-        </tbody></table>
-      </div>
-    </td>
-  </tr>
-  <tr>
-    <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
-  </tr>
-  <tr>
-    <td class="mailpoet_spacer" bgcolor="#ffffff" height="26" valign="top" style="border-collapse:collapse"></td>
-  </tr>
-                </tbody>
-              </table>
-            </td>
-          </tr>
+        <tr>
+          <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+            <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="center" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                  <img src="<%= cdn_url('logo-orange-400x122.png') %>" width="80" alt="new_logo_orange" style="height:auto;max-width:100%;-ms-interpolation-mode:bicubic;border:0;display:block;outline:none;text-align:center"/>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                  <h1 style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 12px;color:#111111;font-family:'Trebuchet MS','Lucida Grande','Lucida Sans Unicode','Lucida Sans',Tahoma,sans-serif;font-size:40px;line-height:64px">
+                    <strong><%= __('Your stats are in!') %></strong>
+                  </h1>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                  <h3 class="title" style="text-align:center;padding:0;font-style:normal;font-weight:normal;margin:0 0 6px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:20px;line-height:32px">
+                    <em><%= subject %></em>
+                  </h3>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="55" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
         </tbody>
       </table>
     </td>
   </tr>
+  <% if subscribersLimitReached %>
+    <tr>
+      <td class="mailpoet_content" align="center" style="border-collapse:collapse;background-color:#fe5301!important" bgcolor="#fe5301">
+        <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+          <tbody>
+          <tr>
+            <td style="border-collapse:collapse;padding-left:0;padding-right:0">
+              <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
+                    <table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
+                      <tbody>
+                      <tr>
+                        <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:left">
+                          <span style="color: #ffffff;"><strong><%= __('Congratulations, you now have more than [subscribersLimit] subscribers!')|replace({'[subscribersLimit]': subscribersLimit}) %></strong></span><br><br>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                    <table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
+                      <tbody>
+                      <tr>
+                        <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:left">
+                          <span style="color: #ffffff;"><strong></strong></span>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                    <table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
+                      <tbody>
+                      <tr>
+                        <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:left">
+                          <span style="color: #ffffff;"><%= __('Our free version is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.')|replace({'[subscribersLimit]': subscribersLimit}) %></span>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px">
+                    <div>
+                      <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+                        <tbody>
+                        <tr>
+                          <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center">
+                            <!--[if mso]>
+                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml"
+                                           xmlns:w="urn:schemas-microsoft-com:office:word"
+                                           href=""
+                                           style="height:50px; width:288px; v-text-anchor:middle;"
+                                           arcsize="6%"
+                                           strokeweight="0px"
+                                           strokecolor="#0074a2"
+                                           fillcolor="#ffffff">
+                                <w:anchorlock/>
+                                <center style="color:#fe5301;
+                                  font-family:Arial;
+                                  font-size:20px;
+                                  font-weight:bold;">Upgrade Now
+                                </center>
+                              </v:roundrect>
+                            <![endif]-->
+                            <a class="mailpoet_button" href="<%= upgradeNowLink %>" style="color:#fe5301;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:#ffffff;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:288px;line-height:50px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:20px;font-weight:normal">Upgrade Now</a>
+                          </td>
+                        </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_spacer" bgcolor="#ffffff" height="26" valign="top" style="border-collapse:collapse"></td>
+                </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
   <% endif %>
   <tr>
     <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
@@ -139,7 +151,8 @@
               <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
                 <tbody>
                 <tr>
-                  <td class="mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                  <td class="mailpoet_padded_vertical mailpoet_padded_side" valign="top"
+                      style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
                     <div>
                       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                         <tr>
@@ -170,7 +183,8 @@
                             <%= __('open rate') %>
                           </span>
                         </td>
-                      </tr></table>
+                      </tr>
+                    </table>
                   </td>
                 </tr>
                 </tbody>
@@ -216,96 +230,101 @@
                             <%= __('click rate') %>
                           </span>
                         </td>
-                      </tr></table>
+                      </tr>
+                    </table>
                   </td>
                 </tr>
                 </tbody>
               </table>
-            </div><!--[if mso]>
+            </div>
+            <!--[if mso]>
             </td>
             </tr>
             </tbody>
             </table>
-            <![endif]--></td>
+            <![endif]-->
+          </td>
         </tr>
         </tbody>
       </table>
     </td>
   </tr>
   <% if topLinkClicks > 0 %>
-  <tr>
-    <td class="mailpoet_content" align="center" style="border-collapse:collapse">
-      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
-        <tbody>
-        <tr>
-          <td style="padding-left:0;padding-right:0;border-collapse:collapse">
-            <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
-              <tbody>
-              <tr>
-                <td class="mailpoet_divider" valign="top" style="padding:26.5px 20px 26.5px 20px;border-collapse:collapse">
-                  <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
-                    <tr>
-                      <td class="mailpoet_divider-cell" style="border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8;border-collapse:collapse">
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-    </td>
-  </tr>
-  <tr>
-    <td class="mailpoet_content" align="center" style="border-collapse:collapse">
-      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
-        <tbody>
-        <tr>
-          <td style="padding-left:0;padding-right:0;border-collapse:collapse">
-            <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
-              <tbody>
-              <tr>
-                <td class="mailpoet_header_footer_padded mailpoet_header" style="line-height:38.4px;text-align:center ;color:#222222 ;font-family:'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif ;font-size:24px ;border-collapse:collapse;padding:10px 20px">
-                  <span style="font-weight: 600;">
-                    <%= __('Most clicked link') %>
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
-                  <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
-                    <tr>
-                      <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                        <% if topLink starts with 'http' %>
-                        <a href="<%= topLink %>" target="_blank" rel="noopener noreferrer" style="color:#008282;text-decoration:underline">
-                          <%= topLink %>
-                        </a>
-                        <% else %>
-                        <%= topLink %>
-                        <% endif %>
-                      </td>
-                    </tr></table>
-                  <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
-                    <tr>
-                      <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
-                        <span style="color: #000000;">
-                          <%= __('%s unique clicks')|replace({'%s': topLinkClicks}) %>
-                        </span>
-                      </td>
-                    </tr></table>
-                </td>
-              </tr>
-              </tbody>
-            </table>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-    </td>
-  </tr>
+    <tr>
+      <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+        <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+          <tbody>
+          <tr>
+            <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+              <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_divider" valign="top" style="padding:26.5px 20px 26.5px 20px;border-collapse:collapse">
+                    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                      <tr>
+                        <td class="mailpoet_divider-cell" style="border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8;border-collapse:collapse"></td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+        <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+          <tbody>
+          <tr>
+            <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+              <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_header_footer_padded mailpoet_header" style="line-height:38.4px;text-align:center ;color:#222222 ;font-family:'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif ;font-size:24px ;border-collapse:collapse;padding:10px 20px">
+                    <span style="font-weight: 600;">
+                      <%= __('Most clicked link') %>
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;padding-top:0;border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
+                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
+                      <tr>
+                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
+                          <% if topLink starts with 'http' %>
+                            <a href="<%= topLink %>" target="_blank" rel="noopener noreferrer"
+                               style="color:#008282;text-decoration:underline">
+                              <%= topLink %>
+                            </a>
+                          <% else %>
+                            <%= topLink %>
+                          <% endif %>
+                        </td>
+                      </tr>
+                    </table>
+                    <table style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse" width="100%" cellpadding="0">
+                      <tr>
+                        <td class="mailpoet_paragraph" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px">
+                          <span style="color: #000000;">
+                            <%= __('%s unique clicks')|replace({'%s': topLinkClicks}) %>
+                          </span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
   <% endif %>
   <tr>
     <td class="mailpoet_content" align="center" style="border-collapse:collapse">
@@ -319,8 +338,7 @@
                 <td class="mailpoet_divider" valign="top" style="padding:6.5px 20px 6.5px 20px;border-collapse:collapse">
                   <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                     <tr>
-                      <td class="mailpoet_divider-cell" style="border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8;border-collapse:collapse">
-                      </td>
+                      <td class="mailpoet_divider-cell" style="border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8;border-collapse:collapse"></td>
                     </tr>
                   </table>
                 </td>
@@ -336,7 +354,8 @@
                         <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
                           <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#fe5301 ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:288px ;line-height:50px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:20px ;font-weight:normal ">
                             <%= __('View all stats') %>
-                          </a></td>
+                          </a>
+                        </td>
                       </tr>
                     </table>
                   </div>

--- a/mailpoet/views/emails/statsNotification.txt
+++ b/mailpoet/views/emails/statsNotification.txt
@@ -19,11 +19,16 @@
   <%= upgradeNowLink %>
 <% endif %>
 
-<%= __('open rate') %>: <%= number_format_i18n(opened) %>%
-  <%= opened_stats_text(opened) %>
-
-<%= __('click rate') %>: <%= number_format_i18n(clicked) %>%
+<%= stats_number_format_i18n(clicked) %>% <%= __('clicked') %>
   <%= clicked_stats_text(clicked) %>
+
+<%= stats_number_format_i18n(opened) %>% <%= __('opened') %>
+
+<%= stats_number_format_i18n(machineOpened) %>% <%= __('machine-opened') %>
+
+<%= stats_number_format_i18n(unsubscribed) %>% <%= __('unsubscribed') %>
+
+<%= stats_number_format_i18n(bounced) %>% <%= __('bounced') %>
 
 <% if topLinkClicks > 0 %>
 <%= __('Most clicked link') %>

--- a/mailpoet/views/emails/statsNotification.txt
+++ b/mailpoet/views/emails/statsNotification.txt
@@ -23,7 +23,7 @@
   <%= opened_stats_text(opened) %>
 
 <%= __('click rate') %>: <%= number_format_i18n(clicked) %>%
-  <%= clicked_stats_text(opened) %>
+  <%= clicked_stats_text(clicked) %>
 
 <% if topLinkClicks > 0 %>
 <%= __('Most clicked link') %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -109,7 +109,7 @@
                                          arcsize="15%"
                                          strokeweight="0px"
                                          strokecolor="#0074a2"
-                                         fillcolor="<%= opened_stats_color(newsletter.opened) %>">
+                                         fillcolor="<%= stats_color(newsletter.opened) %>">
                               <w:anchorlock/>
                               <center style="color:#ffffff;
                       font-family:Arial;
@@ -117,7 +117,7 @@
                       font-weight:bold;"><%= opened_stats_text(newsletter.opened) %>
                               </center>
                             </v:roundrect>
-                            <![endif]--><a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= opened_stats_color(newsletter.opened) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
+                            <![endif]--><a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.opened) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
                               <%= opened_stats_text(newsletter.opened) %>
                             </a>
                           </td>
@@ -129,7 +129,7 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                      <span style="color: <%= opened_stats_color(newsletter.opened) %>;">
+                      <span style="color: <%= stats_color(newsletter.opened) %>;">
                         <strong><%= number_format_i18n(newsletter.opened, 1) %>% </strong>
                         <span style="color: #000000;">
                           <%= __('open rate') %>
@@ -160,7 +160,7 @@
                                          arcsize="15%"
                                          strokeweight="0px"
                                          strokecolor="#0074a2"
-                                         fillcolor="<%= clicked_stats_color(newsletter.clicked) %>">
+                                         fillcolor="<%= stats_color(newsletter.clicked) %>">
                               <w:anchorlock/>
                               <center style="color:#ffffff;
                       font-family:Arial;
@@ -168,7 +168,7 @@
                       font-weight:bold;"><%= clicked_stats_text(newsletter.clicked) %>
                               </center>
                             </v:roundrect>
-                            <![endif]--><a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= clicked_stats_color(newsletter.clicked) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
+                            <![endif]--><a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.clicked) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
                               <%= clicked_stats_text(newsletter.clicked) %>
                             </a>
                           </td>
@@ -180,9 +180,9 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                      <span style="color: <%= clicked_stats_color(newsletter.clicked) %>;">
+                      <span style="color: <%= stats_color(newsletter.clicked) %>;">
                         <strong>
-                          <span style="color: <%= clicked_stats_color(newsletter.clicked) %>;"><%= number_format_i18n(newsletter.clicked, 1) %>%</span>
+                          <span style="color: <%= stats_color(newsletter.clicked) %>;"><%= number_format_i18n(newsletter.clicked, 1) %>%</span>
                         </strong>
                         <span style="color: #000000;">
                           <%= __('click rate') %>


### PR DESCRIPTION
One of the first commits that I made in this PR was one to fix indentation issues in statsNotification.html. This might make it more convenient to review the changes in this PR commit by commit instead of everything at once.

I wasn't sure what is the best way to trigger a stats notification e-mail to test the changes that I implemented here. What I did was I changed the visibility of the method \MailPoet\Cron\Workers\StatsNotifications\Worker::constructNewsletter() to public and then I created a test in the WorkerTest.php file that would send the email and also write its contents to an HTML file. I also needed to change the constructor of the test class to define `$this->newsletterEntity = $newsletterEntity;`. Below is the snippet that I used for the test. Let me know if there is a better way to test this email (or emails in general).

```php
  public function testVerifyEmail() {
    $statsNotifications = $this->diContainer->get(Worker::class);
    $statsNotificationRepository = $this->diContainer->get(StatsNotificationsRepository::class);
    $statsNotificationEntity = $statsNotificationRepository->findOneById(1);
    $newsletter = $statsNotifications->constructNewsletter($statsNotificationEntity);
    $headers = ['From: test@test.com'];
    $headers_html = array_merge($headers, ['Content-Type: text/html; charset=UTF-8']);
    wp_mail('test@test.com', $newsletter['subject'] . ' (html)', $newsletter['body']['html'], $headers_html);
    wp_mail('test@test.com', $newsletter['subject'] . '(text)', $newsletter['body']['text'], $headers);
    file_put_contents('/var/www/html/email.html', $newsletter['body']['html']);
  }
``` 

Also, I should note that while working on this ticket I found a bug in the code that gets the number of bounced emails. So the percentage displayed in the email will be wrong until #3946 is merged.

[MAILPOET-3324]

[MAILPOET-3324]: https://mailpoet.atlassian.net/browse/MAILPOET-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ