### PR TITLE
Only store relevant meta for WooCommerce emails [MAILPOET-3518]

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -5,6 +5,7 @@ namespace MailPoet\AutomaticEmails\WooCommerce\Events;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Logging\LoggerFactory;
+use MailPoet\Models\Newsletter;
 use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\AutomaticEmailsRepository;
 use MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler;
@@ -126,18 +127,17 @@ class PurchasedInCategory {
     }
 
     $schedulingCondition = function($automaticEmail) use ($orderedProductCategories, $subscriber) {
-      $meta = $automaticEmail->getMeta();
+      $matchedCategories = $this->getProductCategoryIdsMatchingNewsletterTrigger($automaticEmail, $orderedProductCategories);
+      if (empty($matchedCategories)) {
+        return false;
+      }
 
-      if (empty($meta['option'])) return false;
       if ($this->repository->wasScheduledForSubscriber($automaticEmail->id, $subscriber->id)) {
-        $sentAllProducts = $this->repository->alreadySentAllProducts($automaticEmail->id, $subscriber->id, 'orderedProductCategories', $orderedProductCategories);
+        $sentAllProducts = $this->repository->alreadySentAllProducts($automaticEmail->id, $subscriber->id, 'orderedProductCategories', $matchedCategories);
         if ($sentAllProducts) return false;
       }
 
-      $metaCategories = array_column($meta['option'], 'id');
-      $matchedCategories = array_intersect($metaCategories, $orderedProductCategories);
-
-      return !empty($matchedCategories);
+      return true;
     };
 
     $this->loggerFactory->getLogger(self::SLUG)->addInfo(
@@ -152,7 +152,28 @@ class PurchasedInCategory {
       self::SLUG,
       $schedulingCondition,
       $subscriber->id,
-      ['orderedProductCategories' => $orderedProductCategories]
+      ['orderedProductCategories' => $orderedProductCategories],
+      [$this, 'metaModifier']
     );
+  }
+
+  public function metaModifier(Newsletter $automaticEmail, array $meta): array {
+    $orderedProductCategoryIds = $meta['orderedProductCategories'] ?? null;
+    if (empty($orderedProductCategoryIds)) {
+      return $meta;
+    }
+    $meta['orderedProductCategories'] = $this->getProductCategoryIdsMatchingNewsletterTrigger($automaticEmail, $orderedProductCategoryIds);
+
+    return $meta;
+  }
+
+  private function getProductCategoryIdsMatchingNewsletterTrigger(Newsletter $automaticEmail, array $orderedCategoryIds): array {
+    $automaticEmailMeta = $automaticEmail->getMeta();
+    if (empty($automaticEmailMeta['option'])) {
+      return [];
+    }
+    $emailTriggeringCategoryIds = array_column($automaticEmailMeta['option'], 'id');
+
+    return array_intersect($emailTriggeringCategoryIds, $orderedCategoryIds);
   }
 }

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -25,6 +25,15 @@ class AutomaticEmailScheduler {
     foreach ($newsletters as $newsletter) {
       if ($newsletter->event !== $event) continue;
       if (is_callable($schedulingCondition) && !$schedulingCondition($newsletter)) continue;
+
+      /**
+       * $meta will be the same for all newsletters by default. If we need to store newsletter-specific meta, the
+       * $metaModifier callback can be used.
+       *
+       * This was introduced because of WooCommerce product purchase automatic emails. We only want to store the
+       * product IDs that specifically triggered a newsletter, but $meta includes ALL the product IDs
+       * or category IDs from an order.
+       */
       if (is_callable($metaModifier)) {
         $meta = $metaModifier($newsletter, $meta);
       }

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -19,12 +19,15 @@ class AutomaticEmailScheduler {
     $this->wp = $wp;
   }
 
-  public function scheduleAutomaticEmail($group, $event, $schedulingCondition = false, $subscriberId = false, $meta = false) {
+  public function scheduleAutomaticEmail($group, $event, $schedulingCondition = false, $subscriberId = false, $meta = false, $metaModifier = null) {
     $newsletters = Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
     if (empty($newsletters)) return false;
     foreach ($newsletters as $newsletter) {
       if ($newsletter->event !== $event) continue;
       if (is_callable($schedulingCondition) && !$schedulingCondition($newsletter)) continue;
+      if (is_callable($metaModifier)) {
+        $meta = $metaModifier($newsletter, $meta);
+      }
       $this->createAutomaticEmailSendingTask($newsletter, $subscriberId, $meta);
     }
   }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
@@ -87,7 +87,8 @@ class PurchasedInCategoryTest extends \MailPoetTest {
     $this->event->scheduleEmail(3);
     $scheduledTask = Sending::getByNewsletterId($newsletter->id);
     $queue = $scheduledTask->queue();
-    expect($queue->getMeta())->equals(['orderedProductCategories' => ['15', '16']]);
+    // We only want to record the ID for the category that triggered the newsletter
+    expect($queue->getMeta())->equals(['orderedProductCategories' => ['15']]);
     expect($scheduledTask)->notEmpty();
   }
 

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
@@ -91,197 +91,109 @@ class PurchasedProductTest extends \MailPoetTest {
   }
 
   public function testItDoesNotScheduleEmailWhenAlreadySent() {
-    $newsletter = Newsletter::createOrUpdate(
-      [
-        'subject' => 'WooCommerce',
-        'preheader' => 'preheader',
-        'type' => Newsletter::TYPE_AUTOMATIC,
-        'status' => Newsletter::STATUS_ACTIVE,
-      ]
-    );
-    $productId = 1000;
-    $this->_createNewsletterOption(
-      [
-        'sendTo' => 'user',
-        'group' => WooCommerce::SLUG,
-        'event' => PurchasedProduct::SLUG,
-        'afterTimeType' => 'days',
-        'afterTimeNumber' => 1,
-        'meta' => json_encode(
-          [
-            'option' => [
-              ['id' => $productId],
-            ],
-          ]),
-      ],
-      $newsletter->id
-    );
-    $customerEmail = 'test@example.com';
-    $subscriber = Subscriber::createOrUpdate(Fixtures::get('subscriber_template'));
-    $subscriber->email = $customerEmail;
-    $subscriber->isWoocommerceUser = 1;
-    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
-    $subscriber->save();
-
-    $subscriberSegment = SubscriberSegment::create();
-    $subscriberSegment->hydrate([
-      'subscriber_id' => $subscriber->id,
-      'segment_id' => Segment::getWooCommerceSegment()->id,
-      'status' => Subscriber::STATUS_SUBSCRIBED,
-    ]);
-    $subscriberSegment->save();
-
-    $orderDetails = Stub::make(
-      new OrderDetails(),
-      [
-        'get_billing_email' => 'test@example.com',
-        'get_items' => function() use ($productId) {
-          return [
-            Stub::make(
-              \WC_Order_Item_Product::class,
-              [
-                'get_product_id' => $productId,
-              ]
-            ),
-          ];
-        },
-      ]
-    );
-    $orderDetails->total = 'order_total';
-    $orderId = 12;
-    $helper = Stub::make(WCHelper::class, [
-      'wcGetOrder' => $orderDetails,
-    ]);
-
-    $event = new PurchasedProduct($helper);
-
-    // ensure there are no existing scheduled tasks
-    $scheduledTask = Sending::getByNewsletterId($newsletter->id);
-    expect($scheduledTask)->false();
-
-    $event->scheduleEmailWhenProductIsPurchased($orderId);
-    $queue1 = SendingQueue::where('newsletter_id', $newsletter->id)->findMany();
+    WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000]);
+    $event = $this->createOrderEvent($subscriber, [1000]);
+    $event->scheduleEmailWhenProductIsPurchased(12);
+    $queue1 = SendingQueue::where('newsletter_id', $email->id)->findMany();
 
     // Create a second order with the same product and some additional product.
     // This was a cause for a duplicate email: https://mailpoet.atlassian.net/browse/MAILPOET-3254
-    $orderDetails = Stub::make(
-      new OrderDetails(),
-      [
-        'get_billing_email' => 'test@example.com',
-        'get_items' => function() use ($productId) {
-          return [
-            Stub::make(
-              \WC_Order_Item_Product::class,
-              [
-                'get_product_id' => $productId,
-              ]
-            ),
-            Stub::make(
-              \WC_Order_Item_Product::class,
-              [
-                'get_product_id' => '12345', // Dummy extra product ID
-              ]
-            ),
-          ];
-        },
-      ]
-    );
-    $orderDetails->total = 'order_total';
-    $orderId = 13;
-    $helper = Stub::make(WCHelper::class, [
-      'wcGetOrder' => $orderDetails,
-    ]);
-
-    $event = new PurchasedProduct($helper);
-
-    $event->scheduleEmailWhenProductIsPurchased($orderId);
-    $queue2 = SendingQueue::where('newsletter_id', $newsletter->id)->findMany();
+    $event2 = $this->createOrderEvent($subscriber, [1000, 12345]);
+    $event2->scheduleEmailWhenProductIsPurchased(13);
+    $queue2 = SendingQueue::where('newsletter_id', $email->id)->findMany();
     expect($queue2)->count(count($queue1));
+  }
+
+  public function testItDoesntCreateASecondSendingTaskWhenAlreadySentWhat() {
+    WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000]);
+    $event = $this->createOrderEvent($subscriber, [1000]);
+    $this->triggerEmailForState('completed', $email, $event);
+    $queues = SendingQueue::where('newsletter_id', $email->id)->findMany();
+    expect($queues)->count(1);
+
+    // Create a second order with the same product and some additional product.
+    // This was a cause for a duplicate email: https://mailpoet.atlassian.net/browse/MAILPOET-3254
+    $event2 = $this->createOrderEvent($subscriber, [1000, 12345]);
+    $sendingTask2 = $this->triggerEmailForState('completed', $email, $event2);
+    $queues = SendingQueue::where('newsletter_id', $email->id)->findMany();
+    expect($queues)->count(1);
+  }
+
+  public function testItCreatesASecondSendingTaskAfterTriggerUpdated() {
+    WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000]);
+    $event = $this->createOrderEvent($subscriber, [1000, 12345]);
+    $this->triggerEmailForState('completed', $email, $event);
+    $queues = SendingQueue::where('newsletter_id', $email->id)->findMany();
+    expect($queues)->count(1);
+
+    $this->updateEmailTriggerIds($email, [1000, 12345]);
+
+    $event2 = $this->createOrderEvent($subscriber, [1000, 12345]);
+    $this->triggerEmailForState('completed', $email, $event2);
+    $queues = SendingQueue::where('newsletter_id', $email->id)->findMany();
+    expect($queues)->count(2);
   }
 
   public function testItDoesNotScheduleEmailWhenPurchasedProductDoesNotMatchConfiguredProductIds() {
     WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
-    $newsletter = Newsletter::createOrUpdate(
-      [
-        'subject' => 'WooCommerce',
-        'preheader' => 'preheader',
-        'type' => Newsletter::TYPE_AUTOMATIC,
-        'status' => Newsletter::STATUS_ACTIVE,
-      ]
-    );
-    $productId = 1000;
-    $incorrectProductIds = [
-      2000,
-      3000,
-    ];
-    $this->_createNewsletterOption(
-      [
-        'sendTo' => 'user',
-        'group' => WooCommerce::SLUG,
-        'event' => PurchasedProduct::SLUG,
-        'afterTimeType' => 'days',
-        'afterTimeNumber' => 1,
-        'meta' => json_encode(
-          [
-            'option' => [
-              ['id' => $productId],
-            ],
-          ]),
-      ],
-      $newsletter->id
-    );
-    $customerEmail = 'test@example.com';
-    $subscriber = Subscriber::createOrUpdate(Fixtures::get('subscriber_template'));
-    $subscriber->email = $customerEmail;
-    $subscriber->isWoocommerceUser = 1;
-    $subscriber->save();
-
-    $orderDetails = Stub::make(
-      new OrderDetails(),
-      [
-        'get_billing_email' => 'test@example.com',
-        'get_items' => function() use ($incorrectProductIds) {
-          return [
-            Stub::make(
-              new ItemDetails(),
-              [
-                'get_product_id' => $incorrectProductIds[0],
-              ]
-            ),
-            Stub::make(
-              new ItemDetails(),
-              [
-                'get_product_id' => $incorrectProductIds[1],
-              ]
-            ),
-          ];
-        },
-      ]
-    );
-    $orderDetails->total = 'order_total';
-    $orderId = 12;
-    $helper = Stub::make(WCHelper::class, [
-      'wcGetOrder' => $orderDetails,
-    ]);
-    $event = new PurchasedProduct($helper);
-
-    WPFunctions::get()->doAction('woocommerce_order_status_completed', $orderId);
-    $event->scheduleEmailWhenProductIsPurchased($orderId);
-    $scheduledTask = Sending::getByNewsletterId($newsletter->id);
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([2000, 3000]);
+    $event = $this->createOrderEvent($subscriber, [1000]);
+    $scheduledTask = $this->triggerEmailForState('completed', $email, $event);
     expect($scheduledTask)->isEmpty();
   }
 
   public function testItSchedulesEmailForProcessingOrder() {
     WPFunctions::get()->removeAllFilters('woocommerce_order_status_processing');
-    $this->_runTestItSchedulesEmailForState('processing');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000]);
+    $event = $this->createOrderEvent($subscriber, [1000]);
+    $scheduledTask = $this->triggerEmailForState('processing', $email, $event);
+    expect($scheduledTask)->notEmpty();
+    $queue = $scheduledTask->queue();
+    expect($queue->getMeta())->equals(['orderedProducts' => [1000]]);
   }
 
   public function testItSchedulesEmailForCompletedOrder() {
     WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
-    $this->_runTestItSchedulesEmailForState('completed');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000]);
+    $event = $this->createOrderEvent($subscriber, [1000]);
+    $scheduledTask = $this->triggerEmailForState('completed', $email, $event);
+    expect($scheduledTask)->notEmpty();
+    $queue = $scheduledTask->queue();
+    expect($queue->getMeta())->equals(['orderedProducts' => [1000]]);
   }
 
-  public function _runTestItSchedulesEmailForState($state) {
+  public function testItOnlySavesMetaDataForProductIdsMatchingTriggerIds() {
+    WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000]);
+    $event = $this->createOrderEvent($subscriber, [1000, 1002]);
+    $scheduledTask = $this->triggerEmailForState('completed', $email, $event);
+    expect($scheduledTask)->notEmpty();
+    $queue = $scheduledTask->queue();
+    expect($queue->getMeta())->equals(['orderedProducts' => [1000]]);
+  }
+
+  public function testItDoesNotSaveOtherTriggerIds() {
+    WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
+    $subscriber = $this->createWooSubscriber();
+    $email = $this->createEmailTriggeredByProductIds([1000, 2000]);
+    $event = $this->createOrderEvent($subscriber, [1000]);
+    $scheduledTask = $this->triggerEmailForState('completed', $email, $event);
+    expect($scheduledTask)->notEmpty();
+    $queue = $scheduledTask->queue();
+    expect($queue->getMeta())->equals(['orderedProducts' => [1000]]);
+  }
+
+  private function createEmailTriggeredByProductIds(array $triggerProductIds): Newsletter {
     $newsletter = Newsletter::createOrUpdate(
       [
         'subject' => 'WooCommerce',
@@ -290,83 +202,84 @@ class PurchasedProductTest extends \MailPoetTest {
         'status' => Newsletter::STATUS_ACTIVE,
       ]
     );
-    $productId = 1000;
-    $incorrectProductId = 2000;
+    $newsletterOptionsData = [
+      'sendTo' => 'user', // "Already sent" test fails without this
+      'group' => WooCommerce::SLUG,
+      'event' => PurchasedProduct::SLUG,
+      'afterTimeType' => 'days',
+      'afterTimeNumber' => 1,
+    ];
+    $meta = ['option' => []];
+    foreach ($triggerProductIds as $id) {
+      $meta['option'][] = ['id' => $id];
+    }
+    $newsletterOptionsData['meta'] = json_encode($meta);
     $this->_createNewsletterOption(
-      [
-        'group' => WooCommerce::SLUG,
-        'event' => PurchasedProduct::SLUG,
-        'afterTimeType' => 'days',
-        'afterTimeNumber' => 1,
-        'meta' => json_encode(
-          [
-            'option' => [
-              ['id' => $productId],
-            ],
-          ]),
-      ],
+      $newsletterOptionsData,
       $newsletter->id
     );
-    $customerEmail = 'test@example.com';
-    $subscriber = Subscriber::createOrUpdate(Fixtures::get('subscriber_template'));
-    $subscriber->email = $customerEmail;
-    $subscriber->isWoocommerceUser = 1;
-    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
-    $subscriber->save();
 
-    $subscriberSegment = SubscriberSegment::create();
-    $subscriberSegment->hydrate([
-      'subscriber_id' => $subscriber->id,
-      'segment_id' => Segment::getWooCommerceSegment()->id,
-      'status' => Subscriber::STATUS_SUBSCRIBED,
-    ]);
-    $subscriberSegment->save();
+    return $newsletter;
+  }
 
+  private function createOrderEvent(Subscriber $customer, array $purchasedProductIds) {
     $orderDetails = Stub::make(
       new OrderDetails(),
       [
-        'get_billing_email' => 'test@example.com',
-        'get_items' => function() use ($incorrectProductId, $productId) {
-          return [
-            Stub::make(
+        'get_billing_email' => $customer->get('email'),
+        'get_items' => function() use ($purchasedProductIds) {
+          return array_map(function($id) {
+            return Stub::make(
               \WC_Order_Item_Product::class,
               [
-                'get_product_id' => $incorrectProductId,
+                'get_product_id' => $id,
               ]
-            ),
-            Stub::make(
-              \WC_Order_Item_Product::class,
-              [
-                'get_product_id' => $productId,
-              ]
-            ),
-          ];
+            );
+          }, $purchasedProductIds);
         },
       ]
     );
     $orderDetails->total = 'order_total';
-    $orderId = 12;
     $helper = Stub::make(WCHelper::class, [
       'wcGetOrder' => $orderDetails,
     ]);
 
-    $event = new PurchasedProduct($helper);
-
-    // ensure there are no existing scheduled tasks
-    $scheduledTask = Sending::getByNewsletterId($newsletter->id);
-    expect($scheduledTask)->false();
-
-    // when 'woocommerce_order_status_$state' hook is triggered, an email should be scheduled
-    WPFunctions::get()->doAction('woocommerce_order_status_' . $state, $orderId);
-    $event->scheduleEmailWhenProductIsPurchased($orderId);
-    $scheduledTask = Sending::getByNewsletterId($newsletter->id);
-    expect($scheduledTask)->notEmpty();
-    $queue = $scheduledTask->queue();
-    expect($queue->getMeta())->equals(['orderedProducts' => [$incorrectProductId, $productId]]);
-    return $orderId;
+    return new PurchasedProduct($helper);
   }
 
-  public function _createNewsletterOption(array $options, $newsletterId) {
+  private function triggerEmailForState(
+    string $wooOrderState,
+    Newsletter $newsletter,
+    PurchasedProduct $purchasedProductEvent
+  ) {
+    // Order ID isn't important because we're mocking wcGetOrder in the purchase event to always return the same thing
+    $orderId = 12;
+
+    // when 'woocommerce_order_status_$state' hook is triggered an email is scheduled when appropriate
+    WPFunctions::get()->doAction('woocommerce_order_status_' . $wooOrderState, $orderId);
+    $purchasedProductEvent->scheduleEmailWhenProductIsPurchased($orderId);
+
+    return Sending::getByNewsletterId($newsletter->id);
+  }
+
+  private function updateEmailTriggerIds(Newsletter $newsletter, array $triggerIds) {
+    $metaOptionField = NewsletterOptionField::where('name', 'meta')->findOne();
+    $this->assertInstanceOf(NewsletterOptionField::class, $metaOptionField);
+    $newsletterMetaOption = NewsletterOption::where(['newsletter_id' => $newsletter->id, 'option_field_id' => $metaOptionField->id])->findOne();
+    $this->assertInstanceOf(NewsletterOption::class, $newsletterMetaOption);
+    $optionValue = json_decode($newsletterMetaOption->value, true);
+    $this->assertIsArray($optionValue);
+    $optionValue['option'] = [];
+    foreach ($triggerIds as $triggerId) {
+      $optionValue['option'][] = ['id' => $triggerId];
+    }
+    $newValue = json_encode($optionValue);
+    $this->assertIsString($newValue);
+    $newsletterMetaOption->set('value', $newValue);
+    $newsletterMetaOption->save();
+  }
+
+  private function _createNewsletterOption(array $options, $newsletterId) {
     foreach ($options as $option => $value) {
       $newsletterOptionField = NewsletterOptionField::where('name', $option)
         ->where('newsletter_type', Newsletter::TYPE_AUTOMATIC)
@@ -397,6 +310,23 @@ class PurchasedProductTest extends \MailPoetTest {
         $newsletterOption->save();
       }
     }
+  }
+
+  private function createWooSubscriber(array $data = []) {
+    $data = array_merge(Fixtures::get('subscriber_template'), $data);
+    $subscriber = Subscriber::createOrUpdate($data);
+    $subscriber->isWoocommerceUser = 1;
+    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+
+    $subscriberSegment = SubscriberSegment::create();
+    $subscriberSegment->hydrate([
+      'subscriber_id' => $subscriber->id,
+      'segment_id' => Segment::getWooCommerceSegment()->id,
+      'status' => Subscriber::STATUS_SUBSCRIBED,
+    ]);
+    $subscriberSegment->save();
+
+    return $subscriber->save();
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
@@ -106,23 +106,6 @@ class PurchasedProductTest extends \MailPoetTest {
     expect($queue2)->count(count($queue1));
   }
 
-  public function testItDoesntCreateASecondSendingTaskWhenAlreadySentWhat() {
-    WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
-    $subscriber = $this->createWooSubscriber();
-    $email = $this->createEmailTriggeredByProductIds([1000]);
-    $event = $this->createOrderEvent($subscriber, [1000]);
-    $this->triggerEmailForState('completed', $email, $event);
-    $queues = SendingQueue::where('newsletter_id', $email->id)->findMany();
-    expect($queues)->count(1);
-
-    // Create a second order with the same product and some additional product.
-    // This was a cause for a duplicate email: https://mailpoet.atlassian.net/browse/MAILPOET-3254
-    $event2 = $this->createOrderEvent($subscriber, [1000, 12345]);
-    $sendingTask2 = $this->triggerEmailForState('completed', $email, $event2);
-    $queues = SendingQueue::where('newsletter_id', $email->id)->findMany();
-    expect($queues)->count(1);
-  }
-
   public function testItCreatesASecondSendingTaskAfterTriggerUpdated() {
     WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
     $subscriber = $this->createWooSubscriber();


### PR DESCRIPTION
[MAILPOET-3518] please check testing instructions for 2 test cases inside Jira ticket.

This PR changes the way meta data is stored for automatic emails sent when a customer purchases a specified WooCommerce product or a product in a particular category. Previously we were storing all the product or category IDs associated with the order even if they weren't the IDs that triggered the newsletter. With this change, we only store the IDs that actually triggered the email, meaning the following scenario can occur:

1. There is an automatic email set up to send when a user purchases product ID 10
2. A customer makes a purchase that includes product IDs 10 and 15
3. The user receives the automatic email
4. The site admin updates the automatic email to be triggered when product ID 10 OR 15 is purchased
5. The same customer makes a purchase that includes product ID 15
6. The user receives the automatic email again

Previously, we would have stored product IDs 10 AND 15 at step 2 above, so the customer wouldn't receive the email in step 6 because it looked like that email had already been sent due to purchasing product 15 in step 2, even though that wasn't the case.

I refactored some of the existing tests in `PurchasedProductTest` because many of them required the same setup steps. I would request that whoever reviews this please double check that I didn't inadvertently alter the behavior of any existing tests.

[MAILPOET-3518]: https://mailpoet.atlassian.net/browse/MAILPOET-3518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ