### PR TITLE
Update montly stats email to reflect redesign [MAILPOET-4102]

### DIFF
--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -143,10 +143,12 @@ class AutomatedEmails extends SimpleWorker {
       $newsletter = $row['newsletter'];
       $clicked = ($statistics->getClickCount() * 100) / $statistics->getTotalSentCount();
       $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();
+      $machineOpened = ($statistics->getMachineOpenCount() * 100) / $statistics->getTotalSentCount();
       $context['newsletters'][] = [
         'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters#/stats/' . $newsletter->getId()),
         'clicked' => $clicked,
         'opened' => $opened,
+        'machineOpened' => $machineOpened,
         'subject' => $newsletter->getSubject(),
       ];
     }

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -144,11 +144,15 @@ class AutomatedEmails extends SimpleWorker {
       $clicked = ($statistics->getClickCount() * 100) / $statistics->getTotalSentCount();
       $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();
       $machineOpened = ($statistics->getMachineOpenCount() * 100) / $statistics->getTotalSentCount();
+      $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $statistics->getTotalSentCount();
+      $bounced = ($statistics->getBounceCount() * 100) / $statistics->getTotalSentCount();
       $context['newsletters'][] = [
         'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters#/stats/' . $newsletter->getId()),
         'clicked' => $clicked,
         'opened' => $opened,
         'machineOpened' => $machineOpened,
+        'unsubscribed' => $unsubscribed,
+        'bounced' => $bounced,
         'subject' => $newsletter->getSubject(),
       ];
     }

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -140,11 +140,6 @@ class Functions extends AbstractExtension {
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
-        'opened_stats_text',
-        [$this, 'openedStatsText'],
-        ['is_safe' => ['all']]
-      ),
-      new TwigFunction(
         'clicked_stats_text',
         [$this, 'clickedStatsText'],
         ['is_safe' => ['all']]
@@ -267,16 +262,6 @@ class Functions extends AbstractExtension {
       return '#ff9f00';
     } else {
       return '#f559c3';
-    }
-  }
-
-  public function openedStatsText($opened) {
-    if ($opened > 30) {
-      return __('EXCELLENT', 'mailpoet');
-    } elseif ($opened > 10) {
-      return __('GOOD', 'mailpoet');
-    } else {
-      return __('BAD', 'mailpoet');
     }
   }
 

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -176,12 +176,9 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                        <span style="color: <%= stats_color(newsletter.opened) %>;">
-                          <strong><%= stats_number_format_i18n(newsletter.opened) %>% </strong>
-                          <span style="color: #000000;">
-                            <%= __('opened') %>
-                          </span>
-                        </span>
+                      <span>
+                        <strong><%= stats_number_format_i18n(newsletter.opened) %>%</strong> <%= __('opened') %>
+                      </span>
                     </h3>
                   </td>
                 </tr>
@@ -198,14 +195,9 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                        <span style="color: <%= stats_color(newsletter.machineOpened) %>;">
-                          <strong>
-                            <span style="color: <%= stats_color(newsletter.machineOpened) %>;"><%= stats_number_format_i18n(newsletter.machineOpened) %>%</span>
-                          </strong>
-                          <span style="color: #000000;">
-                            <%= __('machine-opened') %>
-                          </span>
-                        </span>
+                      <span>
+                        <strong><%= stats_number_format_i18n(newsletter.machineOpened) %>%</strong> <%= __('machine-opened') %>
+                      </span>
                     </h3>
                   </td>
                 </tr>
@@ -243,11 +235,8 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                      <span style="color: <%= stats_color(newsletter.unsubscribed) %>;">
-                        <strong><%= stats_number_format_i18n(newsletter.unsubscribed) %>% </strong>
-                        <span style="color: #000000;">
-                          <%= __('unsubscribed') %>
-                        </span>
+                      <span>
+                        <strong><%= stats_number_format_i18n(newsletter.unsubscribed) %>%</strong> <%= __('unsubscribed') %>
                       </span>
                     </h3>
                   </td>
@@ -265,14 +254,9 @@
                 <tr>
                   <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                          <span style="color: <%= stats_color(newsletter.bounced) %>;">
-                            <strong>
-                              <span style="color: <%= stats_color(newsletter.bounced) %>;"><%= stats_number_format_i18n(newsletter.bounced) %>%</span>
-                            </strong>
-                            <span style="color: #000000;">
-                              <%= __('bounced') %>
-                            </span>
-                          </span>
+                      <span>
+                        <strong><%= stats_number_format_i18n(newsletter.bounced) %>%</strong> <%= __('bounced') %>
+                      </span>
                     </h3>
                   </td>
                 </tr>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -112,59 +112,6 @@
                                          arcsize="15%"
                                          strokeweight="0px"
                                          strokecolor="#0074a2"
-                                         fillcolor="<%= stats_color(newsletter.opened) %>">
-                              <w:anchorlock/>
-                              <center style="color:#ffffff; font-family:Arial; font-size:10px; font-weight:bold;">
-                                <%= opened_stats_text(newsletter.opened) %>
-                              </center>
-                            </v:roundrect>
-                            <![endif]-->
-                            <a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.opened) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
-                              <%= opened_stats_text(newsletter.opened) %>
-                            </a>
-                          </td>
-                        </tr>
-                      </table>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
-                    <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
-                      <span style="color: <%= stats_color(newsletter.opened) %>;">
-                        <strong><%= number_format_i18n(newsletter.opened, 1) %>% </strong>
-                        <span style="color: #000000;">
-                          <%= __('open rate') %>
-                        </span>
-                      </span>
-                    </h3>
-                  </td>
-                </tr>
-                </tbody>
-              </table>
-            </div>
-            <!--[if mso]>
-            </td>
-            <td width="330" valign="top">
-            <![endif]-->
-            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
-              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
-                <tbody>
-                <tr>
-                  <td class="mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px">
-                    <div>
-                      <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
-                        <tr>
-                          <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center">
-                            <!--[if mso]>
-                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
-                                         href="<%= newsletter.linkStats %>"
-                                         style="height:20px;
-                             width:80px;
-                             v-text-anchor:middle;"
-                                         arcsize="15%"
-                                         strokeweight="0px"
-                                         strokecolor="#0074a2"
                                          fillcolor="<%= stats_color(newsletter.clicked) %>">
                               <w:anchorlock/>
                               <center style="color:#ffffff; font-family:Arial; font-size:10px; font-weight:bold;">
@@ -186,12 +133,79 @@
                     <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
                       <span style="color: <%= stats_color(newsletter.clicked) %>;">
                         <strong>
-                          <span style="color: <%= stats_color(newsletter.clicked) %>;"><%= number_format_i18n(newsletter.clicked, 1) %>%</span>
+                          <span style="color: <%= stats_color(newsletter.clicked) %>;"><%= stats_number_format_i18n(newsletter.clicked) %>%</span>
                         </strong>
                         <span style="color: #000000;">
-                          <%= __('click rate') %>
+                          <%= __('clicked') %>
                         </span>
                       </span>
+                    </h3>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            <![endif]-->
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+
+  <tr>
+    <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+        <tbody>
+        <tr>
+          <td align="center" style="border-collapse:collapse;font-size:0">
+            <!--[if mso]>
+            <table border="0" width="100%" cellpadding="0" cellspacing="0">
+              <tbody>
+              <tr>
+                <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
+                    <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
+                        <span style="color: <%= stats_color(newsletter.opened) %>;">
+                          <strong><%= stats_number_format_i18n(newsletter.opened) %>% </strong>
+                          <span style="color: #000000;">
+                            <%= __('opened') %>
+                          </span>
+                        </span>
+                    </h3>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
+                    <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
+                        <span style="color: <%= stats_color(newsletter.machineOpened) %>;">
+                          <strong>
+                            <span style="color: <%= stats_color(newsletter.machineOpened) %>;"><%= stats_number_format_i18n(newsletter.machineOpened) %>%</span>
+                          </strong>
+                          <span style="color: #000000;">
+                            <%= __('machine-opened') %>
+                          </span>
+                        </span>
                     </h3>
                   </td>
                 </tr>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -224,6 +224,73 @@
       </table>
     </td>
   </tr>
+
+  <tr>
+    <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+        <tbody>
+        <tr>
+          <td align="center" style="border-collapse:collapse;font-size:0">
+            <!--[if mso]>
+            <table border="0" width="100%" cellpadding="0" cellspacing="0">
+              <tbody>
+              <tr>
+                <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
+                    <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
+                      <span style="color: <%= stats_color(newsletter.unsubscribed) %>;">
+                        <strong><%= stats_number_format_i18n(newsletter.unsubscribed) %>% </strong>
+                        <span style="color: #000000;">
+                          <%= __('unsubscribed') %>
+                        </span>
+                      </span>
+                    </h3>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            <td width="330" valign="top">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+              <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
+                <tbody>
+                <tr>
+                  <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
+                    <h3 style="margin:0 0 5.4px;color:#333333;font-family:'Courier New',Courier,'Lucida Sans Typewriter','Lucida Typewriter',monospace;font-size:18px;line-height:21.6px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal">
+                          <span style="color: <%= stats_color(newsletter.bounced) %>;">
+                            <strong>
+                              <span style="color: <%= stats_color(newsletter.bounced) %>;"><%= stats_number_format_i18n(newsletter.bounced) %>%</span>
+                            </strong>
+                            <span style="color: #000000;">
+                              <%= __('bounced') %>
+                            </span>
+                          </span>
+                    </h3>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso]>
+            </td>
+            </tr>
+            </tbody>
+            </table>
+            <![endif]-->
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
 <% endfor %>
 
 <tr>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -87,12 +87,14 @@
       <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
         <tbody>
         <tr>
-          <td align="center" style="border-collapse:collapse;font-size:0"><!--[if mso]>
+          <td align="center" style="border-collapse:collapse;font-size:0">
+            <!--[if mso]>
             <table border="0" width="100%" cellpadding="0" cellspacing="0">
               <tbody>
               <tr>
                 <td width="330" valign="top">
-            <![endif]--><div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
               <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
                 <tbody>
                 <tr>
@@ -100,7 +102,8 @@
                     <div>
                       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
                         <tr>
-                          <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center"><!--[if mso]>
+                          <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center">
+                            <!--[if mso]>
                             <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
                                          href="<%= newsletter.linkStats %>"
                                          style="height:20px;
@@ -111,13 +114,12 @@
                                          strokecolor="#0074a2"
                                          fillcolor="<%= stats_color(newsletter.opened) %>">
                               <w:anchorlock/>
-                              <center style="color:#ffffff;
-                      font-family:Arial;
-                      font-size:10px;
-                      font-weight:bold;"><%= opened_stats_text(newsletter.opened) %>
+                              <center style="color:#ffffff; font-family:Arial; font-size:10px; font-weight:bold;">
+                                <%= opened_stats_text(newsletter.opened) %>
                               </center>
                             </v:roundrect>
-                            <![endif]--><a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.opened) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
+                            <![endif]-->
+                            <a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.opened) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
                               <%= opened_stats_text(newsletter.opened) %>
                             </a>
                           </td>
@@ -140,10 +142,12 @@
                 </tr>
                 </tbody>
               </table>
-            </div><!--[if mso]>
+            </div>
+            <!--[if mso]>
             </td>
             <td width="330" valign="top">
-            <![endif]--><div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+            <![endif]-->
+            <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
               <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="border-collapse:collapse;width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0">
                 <tbody>
                 <tr>
@@ -151,7 +155,8 @@
                     <div>
                       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
                         <tr>
-                          <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center"><!--[if mso]>
+                          <td class="mailpoet_button-container" style="border-collapse:collapse;text-align:center">
+                            <!--[if mso]>
                             <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word"
                                          href="<%= newsletter.linkStats %>"
                                          style="height:20px;
@@ -162,13 +167,12 @@
                                          strokecolor="#0074a2"
                                          fillcolor="<%= stats_color(newsletter.clicked) %>">
                               <w:anchorlock/>
-                              <center style="color:#ffffff;
-                      font-family:Arial;
-                      font-size:10px;
-                      font-weight:bold;"><%= clicked_stats_text(newsletter.clicked) %>
+                              <center style="color:#ffffff; font-family:Arial; font-size:10px; font-weight:bold;">
+                                <%= clicked_stats_text(newsletter.clicked) %>
                               </center>
                             </v:roundrect>
-                            <![endif]--><a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.clicked) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
+                            <![endif]-->
+                            <a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="color:#ffffff;text-decoration:none !important;display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-align:center;background-color:<%= stats_color(newsletter.clicked) %>;border-color:#0074a2;border-width:0px;border-radius:3px;border-style:solid;width:80px;line-height:20px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:10px;font-weight:normal">
                               <%= clicked_stats_text(newsletter.clicked) %>
                             </a>
                           </td>
@@ -193,12 +197,14 @@
                 </tr>
                 </tbody>
               </table>
-            </div><!--[if mso]>
+            </div>
+            <!--[if mso]>
             </td>
             </tr>
             </tbody>
             </table>
-            <![endif]--></td>
+            <![endif]-->
+          </td>
         </tr>
         </tbody>
       </table>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
@@ -7,8 +7,11 @@
 <% for newsletter in newsletters %>
 ------------------------------------------
   <%= newsletter.subject %>
-  <%= __('open rate') %>: <%= number_format_i18n(newsletter.opened, 1) %>% (<%= opened_stats_text(newsletter.opened) %>)
-  <%= __('click rate') %>: <%= number_format_i18n(newsletter.clicked, 1) %>% (<%= clicked_stats_text(newsletter.clicked) %>)
+  <%= stats_number_format_i18n(newsletter.clicked) %>% <%= __('clicked') %> (<%= clicked_stats_text(newsletter.clicked) %>)
+  <%= stats_number_format_i18n(newsletter.opened) %>% <%= __('opened') %>
+  <%= stats_number_format_i18n(newsletter.machineOpened) %>% <%= __('machine-opened') %>
+  <%= stats_number_format_i18n(newsletter.unsubscribed) %>% <%= __('unsubscribed') %>
+  <%= stats_number_format_i18n(newsletter.bounced) %>% <%= __('bounced') %>
   <%= __('View all stats') %>
     <%= newsletter.linkStats %>
 <% endfor %>


### PR DESCRIPTION
This PR should be reviewed after #3949 as it expands upon it. It is likely that it will be necessary to rebase this branch. Feel free to do it or ask me to do it.

Again, I was not sure what was the best way to trigger this e-mail to test the changes, so I created a hack using an integration test. I had to make the methods \MailPoet\Cron\Workers\StatsNotifications\AutomatedEmails::getNewsletters() and \MailPoet\Cron\Workers\StatsNotifications\AutomatedEmails::constructNewsletter() public and then used the following code in AutomatedEmailsTest.php:

```php
  public function testItSendsEmail() {
    Newsletter::createOrUpdate([
      'id' => 8763,
      'subject' => 'Subject',
      'type' => 'welcome',
      'status' => 'active',
    ]);
    $this->createQueue(8763, 10);
    $this->createClicks(8763, 5);
    $this->createOpens(8763, 2);

    Newsletter::createOrUpdate([
      'id' => 8765,
      'subject' => 'Another Subject',
      'type' => 'welcome',
      'status' => 'active',
    ]);
    $this->createQueue(8765, 50);
    $this->createClicks(8765, 23);
    $this->createOpens(8765, 13);

    $statsNotifications = $this->diContainer->get(AutomatedEmails::class);
    $newsletters = $statsNotifications->getNewsletters();
    $result = $statsNotifications->constructNewsletter($newsletters);
    file_put_contents('/var/www/html/email2.html', $result['body']['html']);
    file_put_contents('/var/www/html/email2.txt', $result['body']['text']);
  }
```

[MAILPOET-4102]

[MAILPOET-4102]: https://mailpoet.atlassian.net/browse/MAILPOET-4102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ