### PR TITLE
Fix acceptance oldest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,9 @@ jobs:
       mysql_image_version:
         type: string
         default: ''
+      codeception_image_version:
+        type: string
+        default: ''
       wordpress_image_version:
         type: string
         default: ''
@@ -323,6 +326,7 @@ jobs:
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
+      CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
       WORDPRESS_IMAGE_VERSION: << parameters.wordpress_image_version >>
     steps:
       - attach_workspace:
@@ -572,6 +576,7 @@ workflows:
           woo_subscriptions_version: 3.0.10
           mysql_command: --max_allowed_packet=100M
           mysql_image_version: 5.5-ram
+          codeception_image_version: 7.4-cli_20210126.1
           wordpress_image_version: wp-5.3_php7.2_20211213.1
           requires:
             - build

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   codeception:
-    image: mailpoet/wordpress:8.0-cli_20220126.1
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220126.1}
     depends_on:
       - mailhog
       - wordpress


### PR DESCRIPTION
Fixes acceptance_oldest that I broke here: https://github.com/mailpoet/mailpoet/pull/3942
This PR adds a variable for the Codeception image so that we can use a different image for acceptance_oldest tests.
Follows what we do for the WordPress image.

Tested [here](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/8695/workflows/2e073d73-ab15-45bc-a92b-461b23590dd7). I temporarily added the job to this branch.

[MAILPOET-4014]

[MAILPOET-4014]: https://mailpoet.atlassian.net/browse/MAILPOET-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ