### PR TITLE
Remove uninstall.php [MAILPOET-3961]

### DIFF
--- a/mailpoet/build.sh
+++ b/mailpoet/build.sh
@@ -143,7 +143,6 @@ cp $plugin_name-cron.php $plugin_name
 cp $plugin_name.php $plugin_name
 cp mailpoet_initializer.php $plugin_name
 cp readme.txt $plugin_name
-cp uninstall.php $plugin_name
 
 # Prefix all PHP files with "<?php if (!defined('ABSPATH')) exit; ?>"
 echo '[BUILD] Adding ABSPATH ensuring prefix to all PHP files (to avoid path disclosure)'

--- a/mailpoet/tests/integration/WP/FunctionsTest.php
+++ b/mailpoet/tests/integration/WP/FunctionsTest.php
@@ -93,6 +93,10 @@ class FunctionsTest extends \MailPoetTest {
     expect($called)->false();
   }
 
+  public function testPluginisNotUninstallablePlugin() {
+    self::assertFalse(is_uninstallable_plugin('mailpoet/mailpoet.php'));
+  }
+
   public function _after() {
     global $content_width; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $content_width = $this->contentWidth; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/uninstall.php
+++ b/mailpoet/uninstall.php
@@ -1,4 +1,0 @@
-<?php
-if (!defined('WP_UNINSTALL_PLUGIN')) exit;
-
-// Runs on uninstallation, not on deactivation.


### PR DESCRIPTION
Fixes [MAILPOET-3961](https://mailpoet.atlassian.net/browse/MAILPOET-3961)

When you delete the plugin through the WordPress admin interface, you currently see the following prompt:
![image](https://user-images.githubusercontent.com/6458412/152300358-3675dc3b-9e9e-42e6-bb56-1ae26f0d8f22.png)

MailPoet ships with an _uninstall.php_. The purpose of this file is e.g. to delete database tables, options etc. when deinstalling the plugin ([docs](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/)). But currently our _uninstall.php_ does nothing of that sort (see d988c04), therefore the message is misleading.

This PR removes the _uninstall.php_, which then results in the following prompt:
![image](https://user-images.githubusercontent.com/6458412/152300933-69be7ba1-00dc-40cf-9d4b-3420e5045959.png)

Currently, we do not have a proper uninstall route, but it is unlikely we would use the _uninstall.php_ as reinstalling the plugin from scratch is a way often used by our users to troubleshoot.

Registering a deinstalling hook or having an _uninstall.php_ will mean, our plugin is "uninstallable", and therefore  `is_uninstallable_plugin('mailpoet/mailpoet.php)`would return true. The integration test checks that this is no longer the case.

# Testing instructions
1. Go to All Plugins page
2. Click to deactivate MailPoet 3 plugin
3. Click to Delete the plugin
4. Observe the confirmation message in a dialog box and make sure it is now without "and its data" at the end
5. Click Cancel button