### PR TITLE
Bump WP tested up to tag to 5.9

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 5.3
-Tested up to: 5.8
+Tested up to: 5.9
 Stable tag: 3.80.0
 Requires PHP: 7.2
 License: GPLv3


### PR DESCRIPTION
I tested just a few of the main MailPoet pages and confirmed that they are working. I'm trusting the acceptance tests would have caught issues if there are any. I also read the [WP 5.9 field guide](https://make.wordpress.org/core/2022/01/10/wordpress-5-9-field-guide/) and couldn't find anything highlighted there with the potential to impact us.

[MAILPOET-4085]

[MAILPOET-4085]: https://mailpoet.atlassian.net/browse/MAILPOET-4085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ