### PR TITLE
Storybook is not accessible in browser when ran on container [MAILPOET-4078]

### DIFF
--- a/docker-compose.override.macos-sample.yml
+++ b/docker-compose.override.macos-sample.yml
@@ -6,8 +6,6 @@ services:
     image: mariadb:10.5.8
 
   wordpress:
-    ports:
-      - "8083:8083"
     volumes:
       - nfs-wordpress:/var/www/html
       - nfs-mailpoet:/var/www/html/wp-content/plugins/mailpoet

--- a/docker-compose.override.macos-sample.yml
+++ b/docker-compose.override.macos-sample.yml
@@ -6,6 +6,8 @@ services:
     image: mariadb:10.5.8
 
   wordpress:
+    ports:
+      - "8083:8083"
     volumes:
       - nfs-wordpress:/var/www/html
       - nfs-mailpoet:/var/www/html/wp-content/plugins/mailpoet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         GID: ${GID:-1000}
     ports:
       - "8002:80"
-      - "8083:8083"
+      - "8083:8083" # Storybook port number, see package.json
     depends_on:
       - db
       - smtp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         GID: ${GID:-1000}
     ports:
       - "8002:80"
+      - "8083:8083"
     depends_on:
       - db
       - smtp


### PR DESCRIPTION
### Description

This PR exposes the Storybook port number to the Docker host to make the Storybook accessible [Mailpoet-4078]

### How to test

- Run `./do storybook:watch`
- Confirm storybook is accessible under localhost:8083 

[MAILPOET-4078]

[MAILPOET-4078]: https://mailpoet.atlassian.net/browse/MAILPOET-4078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ