### PR TITLE
Update a string displayed in the manage subscriptions page [MAILPOET-4068]

### DIFF
--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -105,7 +105,7 @@ class ManageSubscriptionFormRenderer {
       'redirectUrl' => $this->urlHelper->getCurrentUrl(),
       'email' => $subscriber->email,
       'token' => $this->linkTokens->getToken($subscriberEntity),
-      'editEmailInfo' => __('Need to change your email address? Unsubscribe here, then simply sign up again.', 'mailpoet'),
+      'editEmailInfo' => __('Need to change your email address? Unsubscribe using the form below, then simply sign up again.', 'mailpoet'),
       'formHtml' => $this->formRenderer->renderBlocks($form, [], null, $honeypot = false, $captcha = false),
       'formState' => $formState,
     ];

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -26,7 +26,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="1"  data-parsley-required="true" data-parsley-group="segments" data-parsley-errors-container="\.mailpoet_error_segments" data-parsley-required-message="Please select a list." \/> Test segment/');
-    expect($form)->stringContainsString('Need to change your email address? Unsubscribe here, then simply sign up again.');
+    expect($form)->stringContainsString('Need to change your email address? Unsubscribe using the form below, then simply sign up again.');
   }
 
   public function testItAppliesFieldsFilter() {


### PR DESCRIPTION
Change to make the meaning of the sentence more clear.

[MAILPOET-4068]

[MAILPOET-4068]: https://mailpoet.atlassian.net/browse/MAILPOET-4068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Testing instructions
1. Go to MailPoet > Emails
2. Create and send one simple newsletter to yourself
3. Click on Manage Subscription link inside the newsletter
4. Confirm the updated sentence (check the specs in Jira)