### PR TITLE
Revert "Enable Xdebug develop mode" [MAILPOET-4121]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ To use XDebug inside the **cron**, you need to pass a URL argument `&XDEBUG_TRIG
 [in the cron request](https://github.com/mailpoet/mailpoet/blob/bf7bd6d2d9090ed6ec7b8b575bb7d6b08e663a52/lib/Cron/CronHelper.php#L155-L166).
 Alternatively, you can add `XDEBUG_TRIGGER: yes` to the `wordpress` service in `docker-compose.yml` and restart it (which will run XDebug also for all other requests).
 
+## Xdebug develop mode
+[Xdebug develop mode](https://xdebug.org/docs/develop) is disabled by default because it causes performance issues due to conflicts with the DI container.
+
+It can be enabled when needed using the `XDEBUG_MODE` environment variable. For example, it is possible to enable it by adding the following to `docker-compose.override.yml`:
+
+```
+environment:
+    XDEBUG_MODE: debug, develop
+```
+
 ## 💾 NFS volume sharing for Mac
 NFS volumes can bring more stability and performance on Docker for Mac. To setup NFS volume sharing run:
 ```shell

--- a/dev/xdebug.ini
+++ b/dev/xdebug.ini
@@ -1,4 +1,4 @@
-xdebug.mode=debug,develop
+xdebug.mode=debug
 xdebug.output_dir="/var/www/html"
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9000


### PR DESCRIPTION
It seems that on some machines (maybe Macs?), enabling the Xdebug develop mode significantly impacts the performance of the WP site. On a quick investigation, our impression is that this is related to the DI container that we use. So for now, we are opting to revert this change. It is possible to enable the develop mode when needed using an environment variable that can be added to docker-compose.override.yml.

For more information, see this Slack thread: p1643895995581989-slack-C01G2EDTMQF

Reverts mailpoet/mailpoet#3945

[MAILPOET-4121]

[MAILPOET-4121]: https://mailpoet.atlassian.net/browse/MAILPOET-4121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ