### PR TITLE
Add subscriber detection from Woo Session [MAILPOET-4101]

### DIFF
--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -214,6 +214,9 @@ if (!class_exists(WC_Session::class)) {
   class WC_Session {
     public function __unset($name) {
     }
+
+    public function get($key) {
+    }
   }
 }
 
@@ -226,6 +229,8 @@ if (!function_exists('WC')) {
     }
   }
   class WooCommerce { // phpcs:ignore
+    public $session;
+
     public function mailer() {
       return new WC_Mailer;
     }


### PR DESCRIPTION
[MAILPOET-4101]

[MAILPOET-4101]: https://mailpoet.atlassian.net/browse/MAILPOET-4101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Testing instructions
1. Go to MailPoet > Subscribers and create a new subscriber (any name, subscription status and list)
2. Open http://gs.qawp.net in a private window (incognito)
3. Add any product to cart and proceed to the checkout
4. Fill all required fields with valid information and using subscriber's email from the step 1
5. Make sure to fill invalid post code, something like "jjjjjj" which is totally invalid
6. Click to place an order and trigger error for invalid post code
7. Reload the checkout page
8. Now go in a normal window as logged-in admin and go to Subscribers page
9. Click the statistics link for created subscriber from step 1
10. Make sure you see the latest date at the top: "Last engagement: " it should be the exact time/date when you tried to place an order in step 6