### PR TITLE
Fix action_argument_value of shortcode will be string if empty [MAILPOET-4151]

### DIFF
--- a/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -151,7 +151,7 @@ class Shortcodes {
         '';
       $shortcodeDetails['action_argument_value'] = !empty($shortcodeDetails['argument_value']) ?
         $shortcodeDetails['argument_value'] :
-        false;
+        '';
       $shortcodeDetails['arguments'] = !empty($shortcodeDetails['arguments']) ?
         $shortcodeDetails['arguments'] : [];
 

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -372,6 +372,15 @@ class ShortcodesTest extends \MailPoetTest {
     }
   }
 
+  public function testItCanProcessShortcodeWithEmptyDefault() {
+    $shortcode = '[subscriber:lastname | default:]';
+    $shortcodesObject = $this->shortcodesObject;
+    $subscriberWithoutLastname = new SubscriberEntity();
+    $shortcodesObject->setSubscriber($subscriberWithoutLastname);
+    $result = $shortcodesObject->process([$shortcode]);
+    expect($result[0])->equals('');
+  }
+
   public function testItCanProcessCustomLinkShortcodes() {
     $shortcodesObject = $this->shortcodesObject;
     $shortcodesObject->setWpUserPreview(false);


### PR DESCRIPTION
Fixes [MAILPOET-4151]



[MAILPOET-4151]: https://mailpoet.atlassian.net/browse/MAILPOET-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ