### PR TITLE
Fix Typescript and eslint warnings in cookie_settings.tsx [MAILPOET-4159]

### DIFF
--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/cookie_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/cookie_settings.tsx
@@ -8,7 +8,7 @@ type Props = {
   settingsPlacementKey: string;
 }
 
-const CookieSettings: React.FunctionComponent<Props> = ({ settingsPlacementKey }: Props) => {
+function CookieSettings({ settingsPlacementKey }: Props): JSX.Element {
   const cookieExpirationValues = [3, 7, 14, 30, 60, 90];
   const formSettings = useSelect(
     (select) => select('mailpoet-form-editor').getFormSettings(),
@@ -25,11 +25,11 @@ const CookieSettings: React.FunctionComponent<Props> = ({ settingsPlacementKey }
         { value: 1, label: MailPoet.I18n.t('formPlacementCookieExpirationDay') },
         ...cookieExpirationValues.map((cookieExpirationValue) => ({
           value: cookieExpirationValue,
-          label: MailPoet.I18n.t('formPlacementCookieExpirationDays').replace('%1s', cookieExpirationValue),
+          label: MailPoet.I18n.t('formPlacementCookieExpirationDays').replace('%1s', cookieExpirationValue.toString()),
         }))]}
       onChange={compose([changeFormSettings, assocPath(`formPlacement.${settingsPlacementKey}.cookieExpiration`, __, formSettings)])}
     />
   );
-};
+}
 
 export default CookieSettings;


### PR DESCRIPTION
There was an issue in argument type in the string replace function. Also, it seems that after changes introduced in [update eslint PR](https://github.com/mailpoet/mailpoet/pull/3968) we need to declare components using the function keyword see https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md.


[MAILPOET-4159]

[MAILPOET-4159]: https://mailpoet.atlassian.net/browse/MAILPOET-4159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ