### PR TITLE
Fix Turkish translation issue

### DIFF
--- a/mailpoet/lib/Twig/I18n.php
+++ b/mailpoet/lib/Twig/I18n.php
@@ -54,7 +54,7 @@ class I18n extends AbstractExtension {
     $output[] = '<script type="text/javascript">';
     foreach ($translations as $key => $translation) {
       $output[] =
-        'MailPoet.I18n.add("' . $key . '", "' . str_replace('"', '\"', $translation) . '");';
+        'MailPoet.I18n.add("' . $key . '", "' . str_replace(['"', "\n", "\r"], ['\"', " ", ""], $translation) . '");';
     }
     $output[] = '</script>';
     return join("\n", $output);


### PR DESCRIPTION
### Testing
I found that this is already fixed by translators. In order to replicate the issue, you need to use the mailpoet-tr_TR.mo.zip unzip it to `mailpoet/langs` folder, and switch your site to use the Turkish language.

[MAILPOET-4153]
[mailpoet-tr_TR.mo.zip](https://github.com/mailpoet/mailpoet/files/8131430/mailpoet-tr_TR.mo.zip)


[MAILPOET-4153]: https://mailpoet.atlassian.net/browse/MAILPOET-4153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ