### PR TITLE
Fix acceptance_oldest tests

### DIFF
--- a/mailpoet/assets/js/src/public.jsx
+++ b/mailpoet/assets/js/src/public.jsx
@@ -67,7 +67,7 @@ jQuery(($) => {
    * @return {string} The name of the cookie for the form
    */
   function getFormCookieName(form) {
-    const formId = form.find('input[name="data[form_id]"').val();
+    const formId = form.find('input[name="data[form_id]"]').val();
     return `popup_form_dismissed_${formId}`;
   }
 


### PR DESCRIPTION
Fix a selector that was missing the closing bracket on the context.
No JS errors or any issues with the newer versions but it was failing on acceptance oldest.

To test:
I have run the acceptance_oldest tests with this branch, (temporarily modifying the CircleCI config), results here: 
https://app.circleci.com/pipelines/github/mailpoet/mailpoet/8929/workflows/7191214d-ca64-4a44-bf64-9cb7f6397596


[MAILPOET-4161]

[MAILPOET-4161]: https://mailpoet.atlassian.net/browse/MAILPOET-4161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ