### PR TITLE
Button says "Send" instead of "Schedule" even if the schedule time is in the future MAILPOET-4163

### DIFF
--- a/eslint-config/.eslintrc.ts.json
+++ b/eslint-config/.eslintrc.ts.json
@@ -98,6 +98,14 @@
   },
   "overrides": [
     {
+      "files": ["*.spec.ts"],
+      "rules": {
+        "no-unused-expressions": "off"
+      }
+    }
+  ],
+  "overrides": [
+    {
       "files": ["**/_stories/*.tsx"],
       "rules": {
         "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]

--- a/mailpoet/assets/js/src/date.ts
+++ b/mailpoet/assets/js/src/date.ts
@@ -19,7 +19,7 @@ export const MailPoetDate : {
   full: (date: MomentInput) => string,
   time: (date: MomentInput) => string,
   convertFormat: (format: string) => string,
-  isInFuture: (dateString: string) => boolean
+  isInFuture: (dateString: string, currentTime: MomentInput) => boolean
 } = {
   version: 0.1,
   options: {},
@@ -178,5 +178,5 @@ export const MailPoetDate : {
 
     return convertedFormat.join('');
   },
-  isInFuture: (dateString: string): boolean => new Date(dateString).getTime() > Date.now(),
+  isInFuture: (dateString: string, currentTime: MomentInput): boolean => Moment(dateString).isAfter(currentTime, 's'),
 } as const;

--- a/mailpoet/assets/js/src/form/types/field.ts
+++ b/mailpoet/assets/js/src/form/types/field.ts
@@ -1,0 +1,29 @@
+import { ComponentType, ReactNode } from 'react';
+import { FieldType } from './fieldType';
+
+export type Segment = unknown; // @TODO: add properties
+
+export type Field = {
+  name: string;
+  id?: string;
+  api_version?: string;
+  endpoint?: string;
+  tooltip?: string;
+  customLabel?: string;
+  className?: string;
+  disabled?: false
+  label?: string;
+  tip?: string | null | ReactNode | Array<ReactNode>;
+  placeholder?: string;
+  type?: FieldType;
+  component?: ComponentType;
+  fields?: Array<Field>;
+  validation?: Record<string, string | boolean | number>;
+  inline?: boolean,
+  multiple?: boolean,
+  onBeforeChange?: () => void,
+  filter?: (segment: Segment) => boolean,
+  getLabel?: (segment: Segment) => string,
+  getCount?: (segment: Segment) => string,
+  transformChangedValue?: (arg: unknown) => Segment,
+};

--- a/mailpoet/assets/js/src/form/types/fieldType.ts
+++ b/mailpoet/assets/js/src/form/types/fieldType.ts
@@ -1,0 +1,1 @@
+export type FieldType = 'reactComponent' | 'text' | 'selection' | 'textarea' | 'date' | 'select' | 'checkbox';

--- a/mailpoet/assets/js/src/form/types/index.ts
+++ b/mailpoet/assets/js/src/form/types/index.ts
@@ -1,0 +1,2 @@
+export * from './fieldType';
+export * from './field';

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -94,8 +94,10 @@ interface Window {
   mailpoet_email_volume_limit_reached: boolean;
   mailpoet_current_wp_user_email: string;
   mailpoet_current_time?: string;
+  mailpoet_current_date?: string;
   mailpoet_tomorrow_date?: string;
   mailpoet_schedule_time_of_day?: string;
   mailpoet_date_display_format?: string;
   mailpoet_date_storage_format?: string;
+  mailpoet_current_date_time?: string;
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -93,4 +93,9 @@ interface Window {
   mailpoet_email_volume_limit: string;
   mailpoet_email_volume_limit_reached: boolean;
   mailpoet_current_wp_user_email: string;
+  mailpoet_current_time?: string;
+  mailpoet_tomorrow_date?: string;
+  mailpoet_schedule_time_of_day?: string;
+  mailpoet_date_display_format?: string;
+  mailpoet_date_storage_format?: string;
 }

--- a/mailpoet/assets/js/src/newsletters/models/index.ts
+++ b/mailpoet/assets/js/src/newsletters/models/index.ts
@@ -1,0 +1,1 @@
+export * from './newsletter';

--- a/mailpoet/assets/js/src/newsletters/models/newsletter.ts
+++ b/mailpoet/assets/js/src/newsletters/models/newsletter.ts
@@ -1,4 +1,20 @@
-type NewsLetterType = 'standard';
+export enum NewsletterType {
+  Standard = 'standard',
+  Automatic = 'automatic',
+  Welcome = 'welcome',
+  Notification = 'notification',
+  NotificationHistory = 'notification_history',
+  WCTransactional = 'wc_transactional',
+  ReEngagement = 're_engagement'
+}
+
+export enum NewsletterStatus {
+  Draft = 'draft',
+  Scheduled = 'scheduled',
+  Sending = 'sending',
+  Sent = 'sent',
+  Active = 'active',
+}
 
 export type NewsLetter = {
   body: {
@@ -33,9 +49,9 @@ export type NewsLetter = {
   sender_address: string;
   sender_name: string;
   sent_at: null | string;
-  status: string;
+  status: NewsletterStatus;
   subject: string;
-  type: NewsLetterType;
+  type: NewsletterType;
   unsubscribe_token: string;
   updated_at: string;
 }

--- a/mailpoet/assets/js/src/newsletters/models/newsletter.ts
+++ b/mailpoet/assets/js/src/newsletters/models/newsletter.ts
@@ -1,0 +1,41 @@
+type NewsLetterType = 'standard';
+
+export type NewsLetter = {
+  body: {
+    blockDefaults: unknown;
+    content: unknown;
+    globalStyles: {
+      body: CSSStyleDeclaration;
+      h1: CSSStyleDeclaration;
+      h2: CSSStyleDeclaration;
+      h3: CSSStyleDeclaration;
+      link: CSSStyleDeclaration;
+      text: CSSStyleDeclaration;
+      wrapper: CSSStyleDeclaration;
+    }
+  }
+  created_at: string;
+  deleted_at: null | string;
+  ga_campaign: string;
+  hash: string;
+  id: string;
+  options: {
+    isScheduled: string;
+    scheduledAt: string;
+    disabled?: string;
+  };
+  parent_id: null | string;
+  preheader: string;
+  queue: boolean;
+  reply_to_address: string;
+  reply_to_name: string
+  segments: Array<unknown>
+  sender_address: string;
+  sender_name: string;
+  sent_at: null | string;
+  status: string;
+  subject: string;
+  type: NewsLetterType;
+  unsubscribe_token: string;
+  updated_at: string;
+}

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -4,7 +4,7 @@ import _ from 'underscore';
 import ListingHeadingStepsRoute from 'newsletters/listings/heading_steps_route';
 import { Button } from 'common';
 import Form from 'form/form.jsx';
-import StandardNewsletterFields from 'newsletters/send/standard.jsx';
+import StandardNewsletterFields from 'newsletters/send/standard';
 import NotificationNewsletterFields from 'newsletters/send/notification.jsx';
 import WelcomeNewsletterFields from 'newsletters/send/welcome.jsx';
 import AutomaticEmailFields from 'newsletters/send/automatic.jsx';

--- a/mailpoet/assets/js/src/newsletters/send/automatic.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/automatic.jsx
@@ -1,6 +1,6 @@
 import MailPoet from 'mailpoet';
 import SendEventConditions from 'newsletters/automatic_emails/send_event_conditions.jsx';
-import GATrackingField from 'newsletters/send/ga_tracking.jsx';
+import GATrackingField from 'newsletters/send/ga_tracking';
 
 const emails = window.mailpoet_woocommerce_automatic_emails || [];
 

--- a/mailpoet/assets/js/src/newsletters/send/ga_tracking.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/ga_tracking.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'underscore';
 import MailPoet from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
+import { Field } from '../../form/types';
 
 // Track once per page load
 const trackCampaignNameTyped = _.once(() => MailPoet.trackEvent('User has typed a GA campaign name'));
@@ -25,10 +26,11 @@ const tip = ReactStringReplace(
   )
 );
 
-export default {
+const field: Field = {
   name: 'ga_campaign',
   label: MailPoet.I18n.t('gaCampaignLine'),
   tip,
   type: 'text',
   onBeforeChange: trackCampaignNameTyped,
 };
+export default field;

--- a/mailpoet/assets/js/src/newsletters/send/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/notification.jsx
@@ -3,7 +3,7 @@ import MailPoet from 'mailpoet';
 import Hooks from 'wp-js-hooks';
 import Scheduling from 'newsletters/types/notification/scheduling.jsx';
 import SenderField from 'newsletters/send/sender_address_field.jsx';
-import GATrackingField from 'newsletters/send/ga_tracking.jsx';
+import GATrackingField from 'newsletters/send/ga_tracking';
 
 let fields = [
   {

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -4,10 +4,10 @@ import Hooks from 'wp-js-hooks';
 
 import DateTime from 'newsletters/send/date_time.jsx';
 import SenderField from 'newsletters/send/sender_address_field.jsx';
-import GATrackingField from 'newsletters/send/ga_tracking.jsx';
+import GATrackingField from 'newsletters/send/ga_tracking';
 import Toggle from 'common/form/toggle/toggle';
-import { ReactComponentLike } from 'prop-types';
-import { NewsLetter } from '../models';
+import { NewsLetter, NewsletterStatus } from '../models';
+import { Field } from '../../form/types';
 
 const currentTime = window.mailpoet_current_time || '00:00';
 const tomorrowDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
@@ -23,13 +23,7 @@ type StandardSchedulingProps = {
       value: string;
     },
   }) => void;
-  field: {
-    name: string;
-    disabled: false
-    label: string;
-    type: 'reactComponent';
-    component: ReactComponentLike;
-  }
+  field: Field
 }
 
 class StandardScheduling extends Component<StandardSchedulingProps> {
@@ -120,7 +114,7 @@ class StandardScheduling extends Component<StandardSchedulingProps> {
   }
 }
 
-let fields = [
+let fields: Array<Field> = [
   {
     name: 'email-header',
     label: null,
@@ -162,16 +156,16 @@ let fields = [
     api_version: window.mailpoet_api_version,
     endpoint: 'segments',
     multiple: true,
-    filter: function filter(segment) {
+    filter: function filter(segment: { deleted_at: string }): boolean {
       return !segment.deleted_at;
     },
-    getLabel: function getLabel(segment) {
+    getLabel: function getLabel(segment: { name: string }): string {
       return segment.name;
     },
     getCount: function getCount(segment: { subscribers: string }): string {
       return parseInt(segment.subscribers, 10).toLocaleString();
     },
-    transformChangedValue: function transformChangedValue(segmentIds: string[]) {
+    transformChangedValue: function transformChangedValue(segmentIds: string[]): unknown[] {
       const allSegments = this.getItems() || [];
       return segmentIds.map((id) => allSegments.find((segment) => segment.id === id));
     },
@@ -257,8 +251,8 @@ export default {
         : MailPoet.I18n.t('send')),
     };
 
-    if (newsletter.status === 'sent'
-      || newsletter.status === 'sending') {
+    if (newsletter.status === NewsletterStatus.Sent
+      || newsletter.status === NewsletterStatus.Sending) {
       options.disabled = 'disabled';
     }
 

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, Component } from 'react';
 import MailPoet from 'mailpoet';
 import Hooks from 'wp-js-hooks';
+import Moment from 'moment';
 
 import DateTime from 'newsletters/send/date_time.jsx';
 import SenderField from 'newsletters/send/sender_address_field.jsx';
@@ -239,16 +240,18 @@ type SendButtonOptions = {
 export default {
   getFields: (): typeof fields => fields,
   getSendButtonOptions: (newsletter: Partial<NewsLetter> = {}): SendButtonOptions => {
+    const currentDateTime = Moment(window.mailpoet_current_date_time);
     const isScheduled = (
       typeof newsletter.options === 'object'
       && newsletter.options?.isScheduled === '1'
-      && MailPoet.Date.isInFuture(newsletter.options.scheduledAt)
+      && MailPoet.Date.isInFuture(newsletter.options?.scheduledAt, currentDateTime)
     );
 
     const options: SendButtonOptions = {
       value: (isScheduled
         ? MailPoet.I18n.t('schedule')
-        : MailPoet.I18n.t('send')),
+        : MailPoet.I18n.t('send')
+      ),
     };
 
     if (newsletter.status === NewsletterStatus.Sent

--- a/mailpoet/assets/js/src/newsletters/send/welcome.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/welcome.jsx
@@ -2,7 +2,7 @@ import MailPoet from 'mailpoet';
 import Hooks from 'wp-js-hooks';
 import Scheduling from 'newsletters/types/welcome/scheduling.jsx';
 import SenderField from 'newsletters/send/sender_address_field.jsx';
-import GATrackingField from 'newsletters/send/ga_tracking.jsx';
+import GATrackingField from 'newsletters/send/ga_tracking';
 
 let fields = [
   {

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -139,6 +139,7 @@ class Newsletters {
     $data['tomorrow_date'] = $dateTime->getCurrentDateTime()->modify( "+1 day" )
       ->format( DateTime::DEFAULT_DATE_FORMAT );
     $data['current_time'] = $dateTime->getCurrentTime();
+    $data['current_date_time'] = $dateTime->getCurrentDateTime()->format(DateTime::DEFAULT_DATE_TIME_FORMAT);
     $data['schedule_time_of_day'] = $dateTime->getTimeInterval(
       '00:00:00',
       '+1 hour',

--- a/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
@@ -30,4 +30,38 @@ class ScheduleNewsletterCest {
     $i->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
 
   }
+
+  public function scheduleStandardNewsletterButtonCaption(\AcceptanceTester $i) {
+    $i->wantTo('Check the submit button caption on time change');
+    $newsletterTitle = 'Schedule Test Newsletter';
+
+    // step 1 - Prepare post notification data
+    $newsletterFactory = new Newsletter();
+    $newsletter = $newsletterFactory->withSubject($newsletterTitle)
+      ->create();
+    $segmentName = $i->createListWithSubscriber();
+    $currentDateTime = new \DateTime(strval($i->executeJS('return window.mailpoet_current_date_time')));
+    $dayNumber = $currentDateTime->format('d');
+
+    // step 2 - Go to newsletter send page
+    $i->login();
+    $i->amEditingNewsletter($newsletter->getId());
+    $i->click('Next');
+    $i->waitForElement('[data-automation-id="newsletter_send_form"]');
+    $i->selectOptionInSelect2($segmentName);
+    $i->click('[data-automation-id="email-schedule-checkbox"]');
+
+    // step 3 - Pick today's date
+    $i->waitForElement('form input[name=date]');
+    $i->click('form input[name=date]');
+    $i->click(['class' => "react-datepicker__day--0{$dayNumber}"]);
+
+    // `Schedule` caption - change time to 1 hour after now
+    $i->selectOption('form select[name=time]', $currentDateTime->modify("+1 hour")->format('g:00 a'));
+    $i->see("Schedule", "button span");
+
+    // `Send` caption - change time to 1 hour before now
+    $i->selectOption('form select[name=time]', $currentDateTime->modify("-1 hour")->format('g:00 a'));
+    $i->see("Send", "button span");
+  }
 }

--- a/mailpoet/tests/javascript/utilities/date.spec.ts
+++ b/mailpoet/tests/javascript/utilities/date.spec.ts
@@ -1,30 +1,36 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import { MailPoetDate } from '../../../assets/js/src/date';
 
 describe('MailPoetDate', () => {
   describe('isInFuture', () => {
-    let now;
+    let now: Moment | undefined;
     beforeEach(() => {
       now = moment(Date.now());
     });
 
     it('Should work correctly for present', () => {
-      expect(MailPoetDate.isInFuture(now.toISOString())).to.be.false;
+      expect(MailPoetDate.isInFuture(now.toISOString(), now)).to.be.false;
     });
 
     it('Should work correctly for future dates', () => {
-      const tomorrow = moment().add(1, 'days').toISOString();
+      const tomorrow = now.clone().add(1, 'days').toISOString();
 
-      expect(MailPoetDate.isInFuture(now.add(1, 'seconds').toISOString())).to.be.true;
-      expect(MailPoetDate.isInFuture(tomorrow)).to.be.true;
+      expect(
+        MailPoetDate.isInFuture(now.clone().add(1, 'seconds').toISOString(), now),
+        '1 second in future'
+      ).to.be.true;
+      expect(MailPoetDate.isInFuture(tomorrow, now.valueOf())).to.be.true;
     });
 
     it('Should work correctly for past dates ', () => {
-      const yesterday = now.add(-1, 'days').toISOString();
+      const yesterday = now.clone().add(-1, 'days');
 
-      expect(MailPoetDate.isInFuture(now.add(-1, 'seconds').toISOString())).to.be.false;
-      expect(MailPoetDate.isInFuture(yesterday)).to.be.false;
+      expect(
+        MailPoetDate.isInFuture(now.clone().add(-1, 'seconds').toISOString(), now),
+        '1 second in the past'
+      ).to.be.false;
+      expect(MailPoetDate.isInFuture(yesterday.toISOString(), now), 'yesterday').to.be.false;
     });
   });
 });

--- a/mailpoet/tsconfig.json
+++ b/mailpoet/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "include": [
-    "assets/js/src/**/*"
+    "assets/js/src/**/*",
+    "tests/javascript/**/*.ts",
+    "tests/javascript_newsletter_editor/**/*.ts",
   ],
   "compilerOptions": {
     "target": "es5",                        /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
@@ -8,7 +10,7 @@
     "strict": false,                         /* Enable all strict type-checking options. */
     "jsx": "react-jsx",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "baseUrl": "./assets/js/src",           /* Base directory to resolve non-absolute module names. */
-    "rootDir": "./assets/js/src",           /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": ".",                         /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -23,6 +23,7 @@
       var mailpoet_current_date = <%= json_encode(current_date) %>;
       var mailpoet_tomorrow_date = <%= json_encode(tomorrow_date) %>;
       var mailpoet_current_time = <%= json_encode(current_time) %>;
+      var mailpoet_current_date_time = <%= json_encode(current_date_time) %>;
       var mailpoet_schedule_time_of_day = <%= json_encode(schedule_time_of_day) %>;
       var mailpoet_date_display_format = "<%= wp_date_format() %>";
       var mailpoet_site_url = "<%= site_url %>";


### PR DESCRIPTION
### This PR fixed the issue with scheduling newsletters for future/past dates/times.

This PR initially makes some cleanup and then applies the fix as follows:
- Define NewsLetter type
- Define component props type
- Add acceptance test for past/future time

### Testing:
- Pick a newsletter and visit `Edit` page
- Visit the `Send` page by clicking `Next` on the the editor page
- Toggle the `schedule` option on
- Verify that the primary submit button this page reads `Send` for past dates/times and `Schedule` for future dates/times, note that time is calculated based on the time show in `Your website’s time is {time}`

[MAILPOET-4163]

[MAILPOET-4163]: https://mailpoet.atlassian.net/browse/MAILPOET-4163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ