### PR TITLE
Automation prototyping [MAILPOET-4136]

### DIFF
--- a/mailpoet/assets/js/src/automation/api.tsx
+++ b/mailpoet/assets/js/src/automation/api.tsx
@@ -41,6 +41,7 @@ export const useMutation = <T extends Data>(path: string, config?: RequestInit):
         ...config,
         ...init,
         headers: {
+          'content-type': 'application/json',
           ...(init?.headers ?? {}),
           'x-wp-nonce': api.nonce,
         },

--- a/mailpoet/assets/js/src/automation/api.tsx
+++ b/mailpoet/assets/js/src/automation/api.tsx
@@ -19,27 +19,31 @@ type State<T> = {
 };
 
 type Result<T> = [
-  () => Promise<void>,
+  (init?: RequestInit) => Promise<void>,
   State<T>,
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Data = Record<string, any>;
 
-export const useMutation = <T extends Data>(path: string, init?: RequestInit): Result<T> => {
+export const useMutation = <T extends Data>(path: string, config?: RequestInit): Result<T> => {
   const [state, setState] = useState<State<T>>({
     data: undefined,
     loading: false,
     error: undefined,
   });
 
-  const mutation = useCallback(async () => {
+  const mutation = useCallback(async (init?: RequestInit) => {
     setState((prevState) => ({ ...prevState, loading: true }));
     const response = await request(
       path,
       {
+        ...config,
         ...init,
-        headers: { ...(init?.headers ?? {}), 'X-WP-Nonce': api.nonce },
+        headers: {
+          ...(init?.headers ?? {}),
+          'x-wp-nonce': api.nonce,
+        },
       }
     );
 
@@ -53,7 +57,7 @@ export const useMutation = <T extends Data>(path: string, init?: RequestInit): R
     } finally {
       setState((prevState) => ({ ...prevState, loading: false }));
     }
-  }, [init, path]);
+  }, [config, path]);
 
   return [mutation, state];
 };

--- a/mailpoet/assets/js/src/automation/automation.tsx
+++ b/mailpoet/assets/js/src/automation/automation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { CreateTestingWorkflowButton } from './testing';
 import { useMutation, useQuery } from './api';
 
 function ApiCheck(): JSX.Element {
@@ -53,6 +54,7 @@ function App(): JSX.Element {
   return (
     <div>
       <ApiCheck />
+      <CreateTestingWorkflowButton />
       <RecreateSchemaButton />
       <DeleteSchemaButton />
     </div>

--- a/mailpoet/assets/js/src/automation/id.tsx
+++ b/mailpoet/assets/js/src/automation/id.tsx
@@ -1,0 +1,13 @@
+const bytes = 8; // = hex string of 16 chars
+
+const byteToHex = (byte: number): string => byte.toString(16).padStart(2, '0');
+
+export const id = (): string => {
+  if (!window.crypto || !window.crypto.getRandomValues) {
+    throw new Error("Web Crypto API 'crypto.getRandomValues' is not available");
+  }
+
+  return Array.from(window.crypto.getRandomValues(new Uint8Array(bytes)))
+    .map(byteToHex)
+    .join('');
+};

--- a/mailpoet/assets/js/src/automation/testing.tsx
+++ b/mailpoet/assets/js/src/automation/testing.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useMutation } from './api';
+import { id } from './id';
+
+const createWaitStep = () => ({
+  id: id(),
+  type: 'action',
+  key: 'core:wait',
+  args: {
+    seconds: 60,
+  },
+});
+
+const createTrigger = (nextStepId: string) => ({
+  id: id(),
+  type: 'trigger',
+  key: 'mailpoet:segment:subscribed',
+  next_step_id: nextStepId,
+});
+
+const createWorkflow = () => {
+  const wait = createWaitStep();
+  const trigger = createTrigger(wait.id);
+  return {
+    name: `Test ${new Date().toISOString()}`,
+    steps: {
+      [trigger.id]: trigger,
+      [wait.id]: wait,
+    },
+  };
+};
+
+export function CreateTestingWorkflowButton(): JSX.Element {
+  const [createSchema, { loading, error }] = useMutation('workflows', { method: 'POST' });
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => createSchema({
+          body: JSON.stringify(createWorkflow()),
+        })}
+        disabled={loading}
+      >
+        Create testing workflow
+      </button>
+      {error && (<div>{error?.data?.message ?? 'An unknown error occurred'}</div>)}
+    </div>
+  );
+}

--- a/mailpoet/lib/AdminPages/Pages/Automation.php
+++ b/mailpoet/lib/AdminPages/Pages/Automation.php
@@ -3,7 +3,7 @@
 namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
-use MailPoet\Automation\Migrations\Migrator;
+use MailPoet\Automation\Engine\Migrations\Migrator;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Automation {

--- a/mailpoet/lib/Automation/Engine/API/API.php
+++ b/mailpoet/lib/Automation/Engine/API/API.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API;
+namespace MailPoet\Automation\Engine\API;
 
-use MailPoet\Automation\API\Endpoints\SystemDatabaseEndpoint;
-use MailPoet\Automation\API\Endpoints\WorkflowsEndpoint;
-use MailPoet\Automation\Exceptions\Exception;
-use MailPoet\Automation\WordPress;
+use MailPoet\Automation\Engine\API\Endpoints\SystemDatabaseEndpoint;
+use MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint;
+use MailPoet\Automation\Engine\Exceptions\Exception;
+use MailPoet\Automation\Engine\WordPress;
 use ReflectionClass;
 use Throwable;
 

--- a/mailpoet/lib/Automation/Engine/API/Endpoint.php
+++ b/mailpoet/lib/Automation/Engine/API/Endpoint.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API;
+namespace MailPoet\Automation\Engine\API;
 
-use MailPoet\Automation\Exceptions;
+use MailPoet\Automation\Engine\Exceptions;
 
 abstract class Endpoint {
   public function get(Request $request): Response {

--- a/mailpoet/lib/Automation/Engine/API/EndpointFactory.php
+++ b/mailpoet/lib/Automation/Engine/API/EndpointFactory.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API;
+namespace MailPoet\Automation\Engine\API;
 
 use MailPoet\InvalidStateException;
 use MailPoetVendor\Psr\Container\ContainerInterface;

--- a/mailpoet/lib/Automation/Engine/API/Endpoints/SystemDatabaseEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/API/Endpoints/SystemDatabaseEndpoint.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API\Endpoints;
+namespace MailPoet\Automation\Engine\API\Endpoints;
 
-use MailPoet\Automation\API\Endpoint;
-use MailPoet\Automation\API\Request;
-use MailPoet\Automation\API\Response;
-use MailPoet\Automation\Migrations\Migrator;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\API\Request;
+use MailPoet\Automation\Engine\API\Response;
+use MailPoet\Automation\Engine\Migrations\Migrator;
 use MailPoet\Features\FeatureFlagsController;
 use MailPoet\Features\FeaturesController;
 

--- a/mailpoet/lib/Automation/Engine/API/Endpoints/WorkflowsEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/API/Endpoints/WorkflowsEndpoint.php
@@ -5,9 +5,26 @@ namespace MailPoet\Automation\Engine\API\Endpoints;
 use MailPoet\Automation\Engine\API\Endpoint;
 use MailPoet\Automation\Engine\API\Request;
 use MailPoet\Automation\Engine\API\Response;
+use MailPoet\Automation\Engine\Builder\CreateWorkflowController;
 
 class WorkflowsEndpoint extends Endpoint {
+  /** @var CreateWorkflowController */
+  private $createController;
+
+  public function __construct(
+    CreateWorkflowController $createController
+  ) {
+    $this->createController = $createController;
+  }
+
   public function get(Request $request): Response {
     return new Response(['message' => 'Hello world.']);
+  }
+
+  public function post(Request $request): Response {
+    // TODO: validation
+    $body = $request->getBody();
+    $this->createController->createWorkflow($body);
+    return new Response();
   }
 }

--- a/mailpoet/lib/Automation/Engine/API/Endpoints/WorkflowsEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/API/Endpoints/WorkflowsEndpoint.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API\Endpoints;
+namespace MailPoet\Automation\Engine\API\Endpoints;
 
-use MailPoet\Automation\API\Endpoint;
-use MailPoet\Automation\API\Request;
-use MailPoet\Automation\API\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\API\Request;
+use MailPoet\Automation\Engine\API\Response;
 
 class WorkflowsEndpoint extends Endpoint {
   public function get(Request $request): Response {

--- a/mailpoet/lib/Automation/Engine/API/ErrorResponse.php
+++ b/mailpoet/lib/Automation/Engine/API/ErrorResponse.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API;
+namespace MailPoet\Automation\Engine\API;
 
 class ErrorResponse extends Response {
   public function __construct(

--- a/mailpoet/lib/Automation/Engine/API/Request.php
+++ b/mailpoet/lib/Automation/Engine/API/Request.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API;
+namespace MailPoet\Automation\Engine\API;
 
-use MailPoet\Automation\Exceptions;
+use MailPoet\Automation\Engine\Exceptions;
 use WP_REST_Request;
 
 class Request {

--- a/mailpoet/lib/Automation/Engine/API/Response.php
+++ b/mailpoet/lib/Automation/Engine/API/Response.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\API;
+namespace MailPoet\Automation\Engine\API;
 
 use WP_REST_Response;
 

--- a/mailpoet/lib/Automation/Engine/Builder/CreateWorkflowController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/CreateWorkflowController.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Builder;
+
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\Workflows\Step;
+use MailPoet\Automation\Engine\Workflows\Workflow;
+
+class CreateWorkflowController {
+  /** @var WorkflowStorage */
+  private $storage;
+
+  public function __construct(
+    WorkflowStorage $storage
+  ) {
+    $this->storage = $storage;
+  }
+
+  public function createWorkflow(array $data): Workflow {
+    // TODO: data & workflow validation (trigger existence, graph consistency, etc.)
+    $steps = [];
+    foreach ($data['steps'] as $step) {
+      $steps[] = new Step(
+        $step['id'],
+        $step['type'],
+        $step['key'],
+        $step['next_step_id'] ?? null,
+        $step['args'] ?? []
+      );
+    }
+    $workflow = new Workflow($data['name'], $steps);
+
+    $this->storage->createWorkflow($workflow);
+    return $workflow;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+class ActionScheduler {
+  private const GROUP_ID = 'mailpoet-automation';
+
+  public function enqueue(string $hook, array $args = []): int {
+    return as_enqueue_async_action($hook, $args, self::GROUP_ID);
+  }
+
+  public function schedule(int $timestamp, string $hook, array $args = []): int {
+    return as_schedule_single_action($timestamp, $hook, $args, self::GROUP_ID);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
@@ -12,4 +12,8 @@ class ActionScheduler {
   public function schedule(int $timestamp, string $hook, array $args = []): int {
     return as_schedule_single_action($timestamp, $hook, $args, self::GROUP_ID);
   }
+
+  public function hasScheduledAction(string $hook, array $args = []): bool {
+    return as_has_scheduled_action($hook, $args, self::GROUP_ID);
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -77,6 +77,10 @@ class StepRunner {
       throw Exceptions::workflowRunNotFound($workflowRunId);
     }
 
+    if ($workflowRun->getStatus() !== WorkflowRun::STATUS_RUNNING) {
+      throw Exceptions::workflowRunNotRunning($workflowRunId, $workflowRun->getStatus());
+    }
+
     $workflow = $this->workflowStorage->getWorkflow($workflowRun->getWorkflowId());
     if (!$workflow) {
       throw Exceptions::workflowNotFound($workflowRun->getWorkflowId());

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -50,11 +50,17 @@ class StepRunner {
 
   /** @param mixed $args */
   public function run($args): void {
+    // TODO: args validation
+    if (!is_array($args)) {
+      throw new InvalidStateException();
+    }
+
     // Action Scheduler catches only Exception instances, not other errors.
     // We need to convert them to exceptions to be processed and logged.
     try {
       $this->runStep($args);
     } catch (Throwable $e) {
+      $this->workflowRunStorage->updateStatus((int)$args['workflow_run_id'], WorkflowRun::STATUS_FAILED);
       if (!$e instanceof Exception) {
         throw new Exception($e->getMessage(), intval($e->getCode()), $e);
       }
@@ -62,13 +68,7 @@ class StepRunner {
     }
   }
 
-  /** @param mixed $args */
-  private function runStep($args): void {
-    // TODO: args validation
-    if (!is_array($args)) {
-      throw new InvalidStateException();
-    }
-
+  private function runStep(array $args): void {
     $workflowRunId = $args['workflow_run_id'];
     $stepId = $args['step_id'];
 

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -2,9 +2,11 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use Exception;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\WordPress;
+use Throwable;
 
 class StepRunner {
   /** @var WordPress */
@@ -22,6 +24,20 @@ class StepRunner {
 
   /** @param mixed $args */
   public function run($args): void {
+    // Action Scheduler catches only Exception instances, not other errors.
+    // We need to convert them to exceptions to be processed and logged.
+    try {
+      $this->runStep($args);
+    } catch (Throwable $e) {
+      if (!$e instanceof Exception) {
+        throw new Exception($e->getMessage(), intval($e->getCode()), $e);
+      }
+      throw $e;
+    }
+  }
+
+  /** @param mixed $args */
+  private function runStep($args): void {
     // TODO: args validation
     if (!is_array($args)) {
       throw new InvalidStateException();

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\WordPress;
+
+class StepRunner {
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WordPress $wordPress
+  ) {
+    $this->wordPress = $wordPress;
+  }
+
+  public function initialize(): void {
+    $this->wordPress->addAction(Hooks::WORKFLOW_STEP, [$this, 'run']);
+  }
+
+  /** @param mixed $args */
+  public function run($args): void {
+    // TODO: args validation
+    if (!is_array($args)) {
+      throw new InvalidStateException();
+    }
+
+    // TODO: process step
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Control;
 
 use Exception;
+use MailPoet\Automation\Engine\Control\Steps\ActionStepRunner;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Hooks;
@@ -12,6 +13,9 @@ use MailPoet\Automation\Engine\WordPress;
 use Throwable;
 
 class StepRunner {
+  /** @var ActionStepRunner */
+  private $actionStepRunner;
+
   /** @var WordPress */
   private $wordPress;
 
@@ -22,10 +26,12 @@ class StepRunner {
   private $workflowStorage;
 
   public function __construct(
+    ActionStepRunner $actionStepRunner,
     WordPress $wordPress,
     WorkflowRunStorage $workflowRunStorage,
     WorkflowStorage $workflowStorage
   ) {
+    $this->actionStepRunner = $actionStepRunner;
     $this->wordPress = $wordPress;
     $this->workflowRunStorage = $workflowRunStorage;
     $this->workflowStorage = $workflowStorage;
@@ -74,6 +80,13 @@ class StepRunner {
       throw Exceptions::workflowStepNotFound($stepId);
     }
 
-    // TODO: process step based on its type
+    $stepType = $step->getType();
+    if ($stepType === Step::TYPE_ACTION) {
+      $this->actionStepRunner->run($step, $workflow, $workflowRun);
+    } else {
+      throw new InvalidStateException();
+    }
+
+    // TODO: enqueue next step / complete workflow
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/Steps/ActionStepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/Steps/ActionStepRunner.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control\Steps;
+
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Workflows\Step;
+use MailPoet\Automation\Engine\Workflows\Workflow;
+use MailPoet\Automation\Engine\Workflows\WorkflowRun;
+
+class ActionStepRunner {
+  /** @var Registry */
+  private $registry;
+
+  public function __construct(
+    Registry $registry
+  ) {
+    $this->registry = $registry;
+  }
+
+  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun): void {
+    $action = $this->registry->getAction($step->getKey());
+    if (!$action) {
+      throw new InvalidStateException();
+    }
+    $action->run($workflow, $workflowRun, $step);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -4,9 +4,11 @@ namespace MailPoet\Automation\Engine\Control;
 
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\WorkflowRunStorage;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Automation\Engine\Workflows\Trigger;
+use MailPoet\Automation\Engine\Workflows\WorkflowRun;
 
 class TriggerHandler {
   /** @var ActionScheduler */
@@ -18,14 +20,19 @@ class TriggerHandler {
   /** @var WorkflowStorage */
   private $workflowStorage;
 
+  /** @var WorkflowRunStorage */
+  private $workflowRunStorage;
+
   public function __construct(
     ActionScheduler $actionScheduler,
     WordPress $wordPress,
-    WorkflowStorage $workflowStorage
+    WorkflowStorage $workflowStorage,
+    WorkflowRunStorage $workflowRunStorage
   ) {
     $this->actionScheduler = $actionScheduler;
     $this->wordPress = $wordPress;
     $this->workflowStorage = $workflowStorage;
+    $this->workflowRunStorage = $workflowRunStorage;
   }
 
   public function initialize(): void {
@@ -40,7 +47,10 @@ class TriggerHandler {
         throw Exceptions::workflowTriggerNotFound($workflow->getId(), $trigger->getKey());
       }
 
-      // TODO: create new workflow run
+      $workflowRun = new WorkflowRun($workflow->getId(), $trigger->getKey());
+      $this->workflowRunStorage->createWorkflowRun($workflowRun);
+
+      // TODO: enqueue next workflow step
     }
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -48,9 +48,14 @@ class TriggerHandler {
       }
 
       $workflowRun = new WorkflowRun($workflow->getId(), $trigger->getKey());
-      $this->workflowRunStorage->createWorkflowRun($workflowRun);
+      $workflowRunId = $this->workflowRunStorage->createWorkflowRun($workflowRun);
 
-      // TODO: enqueue next workflow step
+      $this->actionScheduler->enqueue(Hooks::WORKFLOW_STEP, [
+        [
+          'workflow_run_id' => $workflowRunId,
+          'step_id' => $step->getNextStepId(),
+        ],
+      ]);
     }
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Engine\Workflows\Trigger;
+
+class TriggerHandler {
+  /** @var ActionScheduler */
+  private $actionScheduler;
+
+  /** @var WordPress */
+  private $wordPress;
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  public function __construct(
+    ActionScheduler $actionScheduler,
+    WordPress $wordPress,
+    WorkflowStorage $workflowStorage
+  ) {
+    $this->actionScheduler = $actionScheduler;
+    $this->wordPress = $wordPress;
+    $this->workflowStorage = $workflowStorage;
+  }
+
+  public function initialize(): void {
+    $this->wordPress->addAction(Hooks::TRIGGER, [$this, 'processTrigger']);
+  }
+
+  public function processTrigger(Trigger $trigger): void {
+    $workflows = $this->workflowStorage->getActiveWorkflowsByTrigger($trigger);
+    foreach ($workflows as $workflow) {
+      $step = $workflow->getTrigger($trigger->getKey());
+      if (!$step) {
+        throw Exceptions::workflowTriggerNotFound($workflow->getId(), $trigger->getKey());
+      }
+
+      // TODO: create new workflow run
+    }
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -6,10 +6,14 @@ use MailPoet\Automation\Engine\API\API;
 use MailPoet\Automation\Engine\Control\StepRunner;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Integrations\Core\CoreIntegration;
 
 class Engine {
   /** @var API */
   private $api;
+
+  /** @var CoreIntegration */
+  private $coreIntegration;
 
   /** @var Registry */
   private $registry;
@@ -28,6 +32,7 @@ class Engine {
 
   public function __construct(
     API $api,
+    CoreIntegration $coreIntegration,
     Registry $registry,
     StepRunner $stepRunner,
     TriggerHandler $triggerHandler,
@@ -35,6 +40,7 @@ class Engine {
     WorkflowStorage $workflowStorage
   ) {
     $this->api = $api;
+    $this->coreIntegration = $coreIntegration;
     $this->registry = $registry;
     $this->stepRunner = $stepRunner;
     $this->triggerHandler = $triggerHandler;
@@ -50,6 +56,7 @@ class Engine {
     $this->stepRunner->initialize();
     $this->triggerHandler->initialize();
 
+    $this->coreIntegration->register($this->registry);
     $this->wordPress->doAction(Hooks::INITIALIZE, [$this->registry]);
     $this->registerActiveTriggerHooks();
   }

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -8,10 +8,20 @@ class Engine {
   /** @var API */
   private $api;
 
+  /** @var Registry */
+  private $registry;
+
+  /** @var WordPress */
+  private $wordPress;
+
   public function __construct(
-    API $api
+    API $api,
+    Registry $registry,
+    WordPress $wordPress
   ) {
     $this->api = $api;
+    $this->registry = $registry;
+    $this->wordPress = $wordPress;
   }
 
   public function initialize(): void {
@@ -19,5 +29,7 @@ class Engine {
     require_once __DIR__ . '/../../../vendor/woocommerce/action-scheduler/action-scheduler.php';
 
     $this->api->initialize();
+
+    $this->wordPress->doAction(Hooks::INITIALIZE, [$this->registry]);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\API\API;
+use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 
 class Engine {
@@ -11,6 +12,9 @@ class Engine {
 
   /** @var Registry */
   private $registry;
+
+  /** @var TriggerHandler */
+  private $triggerHandler;
 
   /** @var WordPress */
   private $wordPress;
@@ -21,11 +25,13 @@ class Engine {
   public function __construct(
     API $api,
     Registry $registry,
+    TriggerHandler $triggerHandler,
     WordPress $wordPress,
     WorkflowStorage $workflowStorage
   ) {
     $this->api = $api;
     $this->registry = $registry;
+    $this->triggerHandler = $triggerHandler;
     $this->wordPress = $wordPress;
     $this->workflowStorage = $workflowStorage;
   }
@@ -35,6 +41,7 @@ class Engine {
     require_once __DIR__ . '/../../../vendor/woocommerce/action-scheduler/action-scheduler.php';
 
     $this->api->initialize();
+    $this->triggerHandler->initialize();
 
     $this->wordPress->doAction(Hooks::INITIALIZE, [$this->registry]);
     $this->registerActiveTriggerHooks();

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation;
+namespace MailPoet\Automation\Engine;
 
-use MailPoet\Automation\API\API;
+use MailPoet\Automation\Engine\API\API;
 
-class Automation {
+class Engine {
   /** @var API */
   private $api;
 
@@ -16,7 +16,7 @@ class Automation {
 
   public function initialize(): void {
     // register Action Scheduler (when behind feature flag, do it only on initialization)
-    require_once __DIR__ . '/../../vendor/woocommerce/action-scheduler/action-scheduler.php';
+    require_once __DIR__ . '/../../../vendor/woocommerce/action-scheduler/action-scheduler.php';
 
     $this->api->initialize();
   }

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\API\API;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 
 class Engine {
   /** @var API */
@@ -14,14 +15,19 @@ class Engine {
   /** @var WordPress */
   private $wordPress;
 
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
   public function __construct(
     API $api,
     Registry $registry,
-    WordPress $wordPress
+    WordPress $wordPress,
+    WorkflowStorage $workflowStorage
   ) {
     $this->api = $api;
     $this->registry = $registry;
     $this->wordPress = $wordPress;
+    $this->workflowStorage = $workflowStorage;
   }
 
   public function initialize(): void {
@@ -31,5 +37,16 @@ class Engine {
     $this->api->initialize();
 
     $this->wordPress->doAction(Hooks::INITIALIZE, [$this->registry]);
+    $this->registerActiveTriggerHooks();
+  }
+
+  private function registerActiveTriggerHooks(): void {
+    $triggerKeys = $this->workflowStorage->getActiveTriggerKeys();
+    foreach ($triggerKeys as $triggerKey) {
+      $instance = $this->registry->getTrigger($triggerKey);
+      if ($instance) {
+        $instance->registerHooks();
+      }
+    }
   }
 }

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\API\API;
+use MailPoet\Automation\Engine\Control\StepRunner;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 
@@ -12,6 +13,9 @@ class Engine {
 
   /** @var Registry */
   private $registry;
+
+  /** @var StepRunner */
+  private $stepRunner;
 
   /** @var TriggerHandler */
   private $triggerHandler;
@@ -25,12 +29,14 @@ class Engine {
   public function __construct(
     API $api,
     Registry $registry,
+    StepRunner $stepRunner,
     TriggerHandler $triggerHandler,
     WordPress $wordPress,
     WorkflowStorage $workflowStorage
   ) {
     $this->api = $api;
     $this->registry = $registry;
+    $this->stepRunner = $stepRunner;
     $this->triggerHandler = $triggerHandler;
     $this->wordPress = $wordPress;
     $this->workflowStorage = $workflowStorage;
@@ -41,6 +47,7 @@ class Engine {
     require_once __DIR__ . '/../../../vendor/woocommerce/action-scheduler/action-scheduler.php';
 
     $this->api->initialize();
+    $this->stepRunner->initialize();
     $this->triggerHandler->initialize();
 
     $this->wordPress->doAction(Hooks::INITIALIZE, [$this->registry]);

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -16,6 +16,7 @@ class Exceptions {
   private const WORKFLOW_RUN_NOT_FOUND = 'mailpoet_automation_workflow_run_not_found';
   private const WORKFLOW_STEP_NOT_FOUND = 'mailpoet_automation_workflow_step_not_found';
   private const WORKFLOW_TRIGGER_NOT_FOUND = 'mailpoet_automation_workflow_trigger_not_found';
+  private const WORKFLOW_RUN_NOT_RUNNING = 'mailpoet_automation_workflow_run_not_running';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -76,5 +77,11 @@ class Exceptions {
     return NotFoundException::create()
       ->withErrorCode(self::WORKFLOW_TRIGGER_NOT_FOUND)
       ->withMessage(__(sprintf("Workflow trigger with key '%s' not found in workflow ID '%s'.", $key, $workflowId), 'mailpoet'));
+  }
+
+  public static function workflowRunNotRunning(int $id, string $status): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::WORKFLOW_RUN_NOT_RUNNING)
+      ->withMessage(__(sprintf("Workflow run with ID '%s' is not running. Status: %s", $id, $status), 'mailpoet'));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 
 class Exceptions {
@@ -10,6 +11,7 @@ class Exceptions {
   private const DATABASE_ERROR = 'mailpoet_automation_database_error';
   private const API_METHOD_NOT_ALLOWED = 'mailpoet_automation_api_method_not_allowed';
   private const API_NO_JSON_BODY = 'mailpoet_automation_api_no_json_body';
+  private const WORKFLOW_TRIGGER_NOT_FOUND = 'mailpoet_automation_workflow_trigger_not_found';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -40,5 +42,11 @@ class Exceptions {
     return UnexpectedValueException::create()
       ->withErrorCode(self::API_NO_JSON_BODY)
       ->withMessage(__('No JSON body passed.', 'mailpoet'));
+  }
+
+  public static function workflowTriggerNotFound(int $workflowId, string $key): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::WORKFLOW_TRIGGER_NOT_FOUND)
+      ->withMessage(__(sprintf("Workflow trigger with key '%s' not found in workflow ID '%s'.", $key, $workflowId), 'mailpoet'));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -11,6 +11,7 @@ class Exceptions {
   private const DATABASE_ERROR = 'mailpoet_automation_database_error';
   private const API_METHOD_NOT_ALLOWED = 'mailpoet_automation_api_method_not_allowed';
   private const API_NO_JSON_BODY = 'mailpoet_automation_api_no_json_body';
+  private const JSON_NOT_OBJECT = 'mailpoet_automation_json_not_object';
   private const WORKFLOW_NOT_FOUND = 'mailpoet_automation_workflow_not_found';
   private const WORKFLOW_RUN_NOT_FOUND = 'mailpoet_automation_workflow_run_not_found';
   private const WORKFLOW_STEP_NOT_FOUND = 'mailpoet_automation_workflow_step_not_found';
@@ -45,6 +46,12 @@ class Exceptions {
     return UnexpectedValueException::create()
       ->withErrorCode(self::API_NO_JSON_BODY)
       ->withMessage(__('No JSON body passed.', 'mailpoet'));
+  }
+
+  public static function jsonNotObject(string $json): UnexpectedValueException {
+    return UnexpectedValueException::create()
+      ->withErrorCode(self::JSON_NOT_OBJECT)
+      ->withMessage(__(sprintf("JSON string '%s' doesn't encode an object.", $json), 'mailpoet'));
   }
 
   public static function workflowNotFound(int $id): NotFoundException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation;
+namespace MailPoet\Automation\Engine;
 
-use MailPoet\Automation\Exceptions\InvalidStateException;
-use MailPoet\Automation\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 
 class Exceptions {
   private const MIGRATION_FAILED = 'mailpoet_automation_migration_failed';

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 
 class Exceptions {
   private const MIGRATION_FAILED = 'mailpoet_automation_migration_failed';
+  private const DATABASE_ERROR = 'mailpoet_automation_database_error';
   private const API_METHOD_NOT_ALLOWED = 'mailpoet_automation_api_method_not_allowed';
   private const API_NO_JSON_BODY = 'mailpoet_automation_api_no_json_body';
 
@@ -20,6 +21,12 @@ class Exceptions {
     return InvalidStateException::create()
       ->withErrorCode(self::MIGRATION_FAILED)
       ->withMessage(__(sprintf('Migration failed: %s', $error), 'mailpoet'));
+  }
+
+  public static function databaseError(string $error): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::DATABASE_ERROR)
+      ->withMessage(__(sprintf('Database error: %s', $error), 'mailpoet'));
   }
 
   public static function apiMethodNotAllowed(): UnexpectedValueException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -11,6 +11,9 @@ class Exceptions {
   private const DATABASE_ERROR = 'mailpoet_automation_database_error';
   private const API_METHOD_NOT_ALLOWED = 'mailpoet_automation_api_method_not_allowed';
   private const API_NO_JSON_BODY = 'mailpoet_automation_api_no_json_body';
+  private const WORKFLOW_NOT_FOUND = 'mailpoet_automation_workflow_not_found';
+  private const WORKFLOW_RUN_NOT_FOUND = 'mailpoet_automation_workflow_run_not_found';
+  private const WORKFLOW_STEP_NOT_FOUND = 'mailpoet_automation_workflow_step_not_found';
   private const WORKFLOW_TRIGGER_NOT_FOUND = 'mailpoet_automation_workflow_trigger_not_found';
 
   public function __construct() {
@@ -42,6 +45,24 @@ class Exceptions {
     return UnexpectedValueException::create()
       ->withErrorCode(self::API_NO_JSON_BODY)
       ->withMessage(__('No JSON body passed.', 'mailpoet'));
+  }
+
+  public static function workflowNotFound(int $id): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::WORKFLOW_NOT_FOUND)
+      ->withMessage(__(sprintf("Workflow with ID '%s' not found.", $id), 'mailpoet'));
+  }
+
+  public static function workflowRunNotFound(int $id): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::WORKFLOW_RUN_NOT_FOUND)
+      ->withMessage(__(sprintf("Workflow run with ID '%s' not found.", $id), 'mailpoet'));
+  }
+
+  public static function workflowStepNotFound(string $id): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::WORKFLOW_STEP_NOT_FOUND)
+      ->withMessage(__(sprintf("Workflow step with ID '%s' not found.", $id), 'mailpoet'));
   }
 
   public static function workflowTriggerNotFound(int $workflowId, string $key): NotFoundException {

--- a/mailpoet/lib/Automation/Engine/Exceptions/AccessDeniedException.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/AccessDeniedException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 /**
  * USE: When an action is forbidden for given actor (although generally valid).

--- a/mailpoet/lib/Automation/Engine/Exceptions/ConflictException.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/ConflictException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 /**
  * USE: When the main action produces conflict (i.e. duplicate key).

--- a/mailpoet/lib/Automation/Engine/Exceptions/Exception.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/Exception.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 use Throwable;
 

--- a/mailpoet/lib/Automation/Engine/Exceptions/InvalidStateException.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/InvalidStateException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 /**
  * USE: An application state that should not occur. Can be subclassed for feature-specific exceptions.

--- a/mailpoet/lib/Automation/Engine/Exceptions/NotFoundException.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/NotFoundException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 /**
  * USE: When the main resource we're interested in doesn't exist.

--- a/mailpoet/lib/Automation/Engine/Exceptions/RuntimeException.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/RuntimeException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 /**
  * USE: Generic runtime error. When possible, use a more specific exception instead.

--- a/mailpoet/lib/Automation/Engine/Exceptions/UnexpectedValueException.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/UnexpectedValueException.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Exceptions;
+namespace MailPoet\Automation\Engine\Exceptions;
 
 /**
  * USE: When wrong data VALUE is received.

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -4,4 +4,5 @@ namespace MailPoet\Automation\Engine;
 
 class Hooks {
   public const INITIALIZE = 'mailpoet/automation/initialize';
+  public const TRIGGER = 'mailpoet/automation/trigger';
 }

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -5,4 +5,5 @@ namespace MailPoet\Automation\Engine;
 class Hooks {
   public const INITIALIZE = 'mailpoet/automation/initialize';
   public const TRIGGER = 'mailpoet/automation/trigger';
+  public const WORKFLOW_STEP = 'mailpoet/automation/workflow/step';
 }

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine;
+
+class Hooks {
+  public const INITIALIZE = 'mailpoet/automation/initialize';
+}

--- a/mailpoet/lib/Automation/Engine/Integration.php
+++ b/mailpoet/lib/Automation/Engine/Integration.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine;
+
+interface Integration {
+  public function register(Registry $registry): void;
+}

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -32,10 +32,23 @@ class Migrator {
         PRIMARY KEY (id)
       );
     ");
+
+    $this->runQuery("
+      CREATE TABLE {$this->prefix}workflow_runs (
+        id int(11) unsigned NOT NULL AUTO_INCREMENT,
+        workflow_id int(11) unsigned NOT NULL,
+        trigger_key int(11) unsigned NOT NULL,
+        status varchar(255) NOT NULL,
+        created_at timestamp NOT NULL,
+        updated_at timestamp NOT NULL,
+        PRIMARY KEY (id)
+      );
+    ");
   }
 
   public function deleteSchema(): void {
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflows");
+    $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_runs");
   }
 
   public function hasSchema(): bool {

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -50,6 +50,20 @@ class Migrator {
   public function deleteSchema(): void {
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflows");
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_runs");
+
+    // clean Action Scheduler data
+    $this->runQuery("
+      DELETE FROM {$this->wpdb->prefix}actionscheduler_claims WHERE claim_id IN (
+        SELECT claim_id FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook LIKE '%mailpoet/automation%'
+      )
+    ");
+    $this->runQuery("
+      DELETE FROM {$this->wpdb->prefix}actionscheduler_logs WHERE action_id IN (
+        SELECT action_id FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook LIKE '%mailpoet/automation%'
+      )
+    ");
+    $this->runQuery("DELETE FROM {$this->wpdb->prefix}actionscheduler_actions WHERE hook LIKE '%mailpoet/automation%'");
+    $this->runQuery("DELETE FROM {$this->wpdb->prefix}actionscheduler_groups WHERE slug = 'mailpoet-automation'");
   }
 
   public function hasSchema(): bool {

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -37,7 +37,7 @@ class Migrator {
       CREATE TABLE {$this->prefix}workflow_runs (
         id int(11) unsigned NOT NULL AUTO_INCREMENT,
         workflow_id int(11) unsigned NOT NULL,
-        trigger_key int(11) unsigned NOT NULL,
+        trigger_key varchar(255) NOT NULL,
         status varchar(255) NOT NULL,
         created_at timestamp NOT NULL,
         updated_at timestamp NOT NULL,

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -23,9 +23,11 @@ class Migrator {
       CREATE TABLE {$this->prefix}workflows (
         id int(11) unsigned NOT NULL AUTO_INCREMENT,
         name varchar(255) NOT NULL,
+        status varchar(255) NOT NULL,
         created_at timestamp NOT NULL,
         updated_at timestamp NOT NULL,
         deleted_at timestamp NULL,
+        trigger_keys longtext NOT NULL,
         steps longtext,
         PRIMARY KEY (id)
       );

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -26,7 +26,7 @@ class Migrator {
         created_at timestamp NOT NULL,
         updated_at timestamp NOT NULL,
         deleted_at timestamp NULL,
-        data longtext,
+        steps longtext,
         PRIMARY KEY (id)
       );
     ");

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -41,6 +41,7 @@ class Migrator {
         status varchar(255) NOT NULL,
         created_at timestamp NOT NULL,
         updated_at timestamp NOT NULL,
+        subjects longtext,
         PRIMARY KEY (id)
       );
     ");

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -67,7 +67,7 @@ class Migrator {
   }
 
   public function hasSchema(): bool {
-    $pattern = str_replace('_', '\\_', $this->prefix) . '%';
+    $pattern = $this->wpdb->esc_like($this->prefix) . '%';
     return $this->runQuery("SHOW TABLES LIKE '$pattern'") > 0;
   }
 

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Migrations;
+namespace MailPoet\Automation\Engine\Migrations;
 
-use MailPoet\Automation\Exceptions;
+use MailPoet\Automation\Engine\Exceptions;
 use wpdb;
 
 class Migrator {

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -25,7 +25,7 @@ class Migrator {
         name varchar(255) NOT NULL,
         created_at timestamp NOT NULL,
         updated_at timestamp NOT NULL,
-        deleted_at timestamp NOT NULL,
+        deleted_at timestamp NULL,
         data longtext,
         PRIMARY KEY (id)
       );

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine;
+
+use MailPoet\Automation\Engine\Workflows\Action;
+use MailPoet\Automation\Engine\Workflows\Trigger;
+
+class Registry {
+  /** @var array<string, Trigger> */
+  private $triggers = [];
+
+  /** @var array<string, Action> */
+  private $actions = [];
+
+  public function addTrigger(Trigger $trigger): void {
+    $key = $trigger->getKey();
+    if (isset($this->triggers[$key])) {
+      throw new \Exception(); // TODO
+    }
+    $this->triggers[$key] = $trigger;
+  }
+
+  public function getTrigger(string $key): ?Trigger {
+    return $this->triggers[$key] ?? null;
+  }
+
+  /** @return array<string, Trigger> */
+  public function getTriggers(): array {
+    return $this->triggers;
+  }
+
+  public function addAction(Action $action): void {
+    $key = $action->getKey();
+    if (isset($this->actions[$key])) {
+      throw new \Exception(); // TODO
+    }
+    $this->actions[$key] = $action;
+  }
+
+  public function getAction(string $key): ?Action {
+    return $this->actions[$key] ?? null;
+  }
+
+  /** @return array<string, Action> */
+  public function getActions(): array {
+    return $this->actions;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Storage;
+
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Workflows\WorkflowRun;
+use wpdb;
+
+class WorkflowRunStorage {
+  /** @var string */
+  private $table;
+
+  /** @var wpdb */
+  private $wpdb;
+
+  public function __construct() {
+    global $wpdb;
+    $this->table = $wpdb->prefix . 'mailpoet_automation_workflow_runs';
+    $this->wpdb = $wpdb;
+  }
+
+  public function createWorkflowRun(WorkflowRun $workflowRun): int {
+    $result = $this->wpdb->insert($this->table, $workflowRun->toArray());
+    if ($result === false) {
+      throw Exceptions::databaseError($this->wpdb->last_error);
+    }
+    return $this->wpdb->insert_id;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -26,4 +26,10 @@ class WorkflowRunStorage {
     }
     return $this->wpdb->insert_id;
   }
+
+  public function getWorkflowRun(int $id): ?WorkflowRun {
+    $query = strval($this->wpdb->prepare("SELECT * FROM $this->table WHERE id = %d", $id));
+    $data = $this->wpdb->get_row($query, ARRAY_A);
+    return $data ? WorkflowRun::fromArray((array)$data) : null;
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -32,4 +32,12 @@ class WorkflowRunStorage {
     $data = $this->wpdb->get_row($query, ARRAY_A);
     return $data ? WorkflowRun::fromArray((array)$data) : null;
   }
+
+  public function updateStatus(int $id, string $status): void {
+    $query = strval($this->wpdb->prepare("UPDATE $this->table SET status = %s WHERE id = %d", $status, $id));
+    $result = $this->wpdb->query($query);
+    if ($result === false) {
+      throw Exceptions::databaseError($this->wpdb->last_error);
+    }
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -28,6 +28,12 @@ class WorkflowStorage {
     return $this->wpdb->insert_id;
   }
 
+  public function getWorkflow(int $id): ?Workflow {
+    $query = strval($this->wpdb->prepare("SELECT * FROM $this->table WHERE id = %d", $id));
+    $data = $this->wpdb->get_row($query, ARRAY_A);
+    return $data ? Workflow::fromArray((array)$data) : null;
+  }
+
   /** @return string[] */
   public function getActiveTriggerKeys(): array {
     $query = strval(

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Utils\Json;
 use MailPoet\Automation\Engine\Workflows\Trigger;
 use MailPoet\Automation\Engine\Workflows\Workflow;
 use wpdb;
@@ -47,7 +48,7 @@ class WorkflowStorage {
     $triggerKeys = [];
     foreach ($result as $item) {
       /** @var string[] $keys */
-      $keys = (array)json_decode($item, true);
+      $keys = Json::decode($item);
       $triggerKeys = array_merge($triggerKeys, $keys);
     }
     return array_unique($triggerKeys);

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Workflows\Trigger;
 use MailPoet\Automation\Engine\Workflows\Workflow;
 use wpdb;
 
@@ -44,5 +45,21 @@ class WorkflowStorage {
       $triggerKeys = array_merge($triggerKeys, $keys);
     }
     return array_unique($triggerKeys);
+  }
+
+  /** @return Workflow[] */
+  public function getActiveWorkflowsByTrigger(Trigger $trigger): array {
+    $query = strval(
+      $this->wpdb->prepare(
+        "SELECT * FROM $this->table WHERE status = %s AND trigger_keys LIKE %s",
+        Workflow::STATUS_ACTIVE,
+        '%' . $this->wpdb->esc_like($trigger->getKey()) . '%'
+      )
+    );
+
+    $data = $this->wpdb->get_results($query, ARRAY_A);
+    return array_map(function (array $workflowData) {
+      return Workflow::fromArray($workflowData);
+    }, (array)$data);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -26,4 +26,23 @@ class WorkflowStorage {
     }
     return $this->wpdb->insert_id;
   }
+
+  /** @return string[] */
+  public function getActiveTriggerKeys(): array {
+    $query = strval(
+      $this->wpdb->prepare(
+        "SELECT DISTINCT trigger_keys FROM $this->table WHERE status = %s",
+        Workflow::STATUS_ACTIVE
+      )
+    );
+    $result = $this->wpdb->get_col($query);
+
+    $triggerKeys = [];
+    foreach ($result as $item) {
+      /** @var string[] $keys */
+      $keys = (array)json_decode($item, true);
+      $triggerKeys = array_merge($triggerKeys, $keys);
+    }
+    return array_unique($triggerKeys);
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Storage;
+
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Workflows\Workflow;
+use wpdb;
+
+class WorkflowStorage {
+  /** @var string */
+  private $table;
+
+  /** @var wpdb */
+  private $wpdb;
+
+  public function __construct() {
+    global $wpdb;
+    $this->table = $wpdb->prefix . 'mailpoet_automation_workflows';
+    $this->wpdb = $wpdb;
+  }
+
+  public function createWorkflow(Workflow $workflow): int {
+    $result = $this->wpdb->insert($this->table, $workflow->toArray());
+    if (!$result) {
+      throw Exceptions::databaseError($this->wpdb->last_error);
+    }
+    return $this->wpdb->insert_id;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Utils/Json.php
+++ b/mailpoet/lib/Automation/Engine/Utils/Json.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Utils;
+
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+
+class Json {
+  public static function encode(array $value): string {
+    $json = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION);
+    $error = json_last_error();
+    if ($error || $json === false) {
+      throw new InvalidStateException(json_last_error_msg(), (string)$error);
+    }
+    return $json;
+  }
+
+  public static function decode(string $json): array {
+    $value = json_decode($json, true);
+    $error = json_last_error();
+    if ($error) {
+      throw new InvalidStateException(json_last_error_msg(), (string)$error);
+    }
+    if (!is_array($value)) {
+      throw Exceptions::jsonNotObject($json);
+    }
+    return $value;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -7,6 +7,10 @@ class WordPress {
     return add_action($hookName, $callback, $priority, $acceptedArgs);
   }
 
+  public function doAction(string $hookName, array ...$arg): void {
+    do_action($hookName, ...$arg);
+  }
+
   public function currentUserCan(string $capability, array ...$args): bool {
     return current_user_can($capability, ...$args);
   }

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation;
+namespace MailPoet\Automation\Engine;
 
 class WordPress {
   public function addAction(string $hookName, callable $callback, int $priority = 10, int $acceptedArgs = 1): bool {

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -8,7 +8,7 @@ class WordPress {
   }
 
   public function currentUserCan(string $capability, array ...$args): bool {
-    return current_user_can($capability, $args);
+    return current_user_can($capability, ...$args);
   }
 
   public function registerRestRoute(string $namespace, string $route, array $args = [], bool $override = false): bool {

--- a/mailpoet/lib/Automation/Engine/Workflows/Action.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Action.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+interface Action {
+  public function getKey(): string;
+
+  public function getName(): string;
+
+  public function run(Workflow $workflow, WorkflowRun $workflowRun, Step $step): void;
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/Field.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Field.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+class Field {
+  public const TYPE_BOOLEAN = 'boolean';
+  public const TYPE_INTEGER = 'integer';
+  public const TYPE_STRING = 'string';
+  public const TYPE_ENUM = 'enum';
+
+  /** @var string */
+  private $key;
+
+  /** @var string */
+  private $type;
+
+  /** @var string */
+  private $name;
+
+  /** @var callable */
+  private $factory;
+
+  /** @var array */
+  private $args;
+
+  public function __construct(
+    string $key,
+    string $type,
+    string $name,
+    callable $factory,
+    array $args = []
+  ) {
+
+    $this->key = $key;
+    $this->type = $type;
+    $this->name = $name;
+    $this->factory = $factory;
+    $this->args = $args;
+  }
+
+  public function getKey(): string {
+    return $this->key;
+  }
+
+  public function getType(): string {
+    return $this->type;
+  }
+
+  public function getName(): string {
+    return $this->name;
+  }
+
+  public function getFactory(): callable {
+    return $this->factory;
+  }
+
+  public function getArgs(): array {
+    return $this->args;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/Step.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Step.php
@@ -5,4 +5,63 @@ namespace MailPoet\Automation\Engine\Workflows;
 class Step {
   public const TYPE_TRIGGER = 'trigger';
   public const TYPE_ACTION = 'action';
+
+  /** @var string */
+  private $id;
+
+  /** @var string */
+  private $type;
+
+  /** @var string */
+  private $key;
+
+  /** @var string|null */
+  private $nextStepId;
+
+  /** @var array */
+  private $args;
+
+  public function __construct(
+    string $id,
+    string $type,
+    string $key,
+    ?string $nextStepId,
+    array $args = []
+  ) {
+    $this->id = $id;
+    $this->type = $type;
+    $this->key = $key;
+    $this->nextStepId = $nextStepId;
+    $this->args = $args;
+  }
+
+  public function getId(): string {
+    return $this->id;
+  }
+
+  public function getType(): string {
+    return $this->type;
+  }
+
+  public function getKey(): string {
+    return $this->key;
+  }
+
+  public function getNextStepId(): ?string {
+    return $this->nextStepId;
+  }
+
+  public function getArgs(): array {
+    return $this->args;
+  }
+
+  public function toArray(): array {
+    return [
+      'id' => $this->id,
+      'type' => $this->type,
+      'key' => $this->key,
+      'next_step_id' => $this->nextStepId,
+      'args' => $this->args,
+    ];
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Step.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Step.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+class Step {
+  public const TYPE_TRIGGER = 'trigger';
+  public const TYPE_ACTION = 'action';
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Subject.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+interface Subject {
+  public function getKey(): string;
+
+  /** array<SubjectField> */
+  public function getFields(): array;
+
+  public function load(array $args): void;
+
+  public function pack(): array;
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/Trigger.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Trigger.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+interface Trigger {
+  public function getKey(): string;
+
+  public function getName(): string;
+
+  public function registerHooks(): void;
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Workflow.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Workflows;
 
 use DateTimeImmutable;
+use MailPoet\Automation\Engine\Utils\Json;
 
 class Workflow {
   public const STATUS_ACTIVE = 'active';
@@ -86,10 +87,12 @@ class Workflow {
       'status' => $this->status,
       'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
       'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
-      'steps' => json_encode(array_map(function (Step $step) {
-        return $step->toArray();
-      }, $this->steps)),
-      'trigger_keys' => json_encode(
+      'steps' => Json::encode(
+        array_map(function (Step $step) {
+          return $step->toArray();
+        }, $this->steps)
+      ),
+      'trigger_keys' => Json::encode(
         array_reduce($this->steps, function (array $triggerKeys, Step $step): array {
           if ($step->getType() === Step::TYPE_TRIGGER) {
             $triggerKeys[] = $step->getKey();
@@ -102,7 +105,7 @@ class Workflow {
 
   public static function fromArray(array $data): self {
     // TODO: validation
-    $workflow = new self($data['name'], self::parseSteps(json_decode($data['steps'], true)));
+    $workflow = new self($data['name'], self::parseSteps(Json::decode($data['steps'])));
     $workflow->id = (int)$data['id'];
     $workflow->status = $data['status'];
     $workflow->createdAt = $data['created_at'];

--- a/mailpoet/lib/Automation/Engine/Workflows/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Workflow.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+use DateTimeImmutable;
+
+class Workflow {
+  public const STATUS_ACTIVE = 'active';
+  public const STATUS_INACTIVE = 'inactive';
+
+  /** @var int */
+  private $id;
+
+  /** @var string */
+  private $name;
+
+  /** @var string */
+  private $status = self::STATUS_INACTIVE;
+
+  /** @var DateTimeImmutable */
+  private $createdAt;
+
+  /** @var DateTimeImmutable */
+  private $updatedAt;
+
+  /** @var array<string, Step> */
+  private $steps;
+
+  /** @param Step[] $steps */
+  public function __construct(
+    string $name,
+    array $steps
+  ) {
+    $this->name = $name;
+    $this->steps = [];
+    foreach ($steps as $step) {
+      $this->steps[$step->getId()] = $step;
+    }
+
+    $now = new DateTimeImmutable();
+    $this->createdAt = $now;
+    $this->updatedAt = $now;
+  }
+
+  public function getId(): int {
+    return $this->id;
+  }
+
+  public function getName(): string {
+    return $this->name;
+  }
+
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  public function getCreatedAt(): DateTimeImmutable {
+    return $this->createdAt;
+  }
+
+  public function getUpdatedAt(): DateTimeImmutable {
+    return $this->updatedAt;
+  }
+
+  /** @return array<string, Step> */
+  public function getSteps(): array {
+    return $this->steps;
+  }
+
+  public function getStep(string $id): ?Step {
+    return $this->steps[$id] ?? null;
+  }
+
+  public function getTrigger(string $key): ?Step {
+    foreach ($this->steps as $step) {
+      if ($step->getType() === Step::TYPE_TRIGGER && $step->getKey() === $key) {
+        return $step;
+      }
+    }
+    return null;
+  }
+
+  public function toArray(): array {
+    return [
+      'name' => $this->name,
+      'status' => $this->status,
+      'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
+      'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
+      'steps' => json_encode(array_map(function (Step $step) {
+        return $step->toArray();
+      }, $this->steps)),
+      'trigger_keys' => json_encode(
+        array_reduce($this->steps, function (array $triggerKeys, Step $step): array {
+          if ($step->getType() === Step::TYPE_TRIGGER) {
+            $triggerKeys[] = $step->getKey();
+          }
+          return $triggerKeys;
+        }, [])
+      ),
+    ];
+  }
+
+  public static function fromArray(array $data): self {
+    // TODO: validation
+    $workflow = new self($data['name'], self::parseSteps(json_decode($data['steps'], true)));
+    $workflow->id = (int)$data['id'];
+    $workflow->status = $data['status'];
+    $workflow->createdAt = $data['created_at'];
+    $workflow->updatedAt = $data['updated_at'];
+    return $workflow;
+  }
+
+  private static function parseSteps(array $data): array {
+    $steps = [];
+    foreach ($data as $step) {
+      $steps[] = new Step(
+        $step['id'],
+        $step['type'],
+        $step['key'],
+        $step['next_step_id'] ?? null,
+        $step['args'] ?? []
+      );
+    }
+    return $steps;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/WorkflowRun.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/WorkflowRun.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+use DateTimeImmutable;
+
+class WorkflowRun {
+  public const STATUS_RUNNING = 'running';
+  public const STATUS_COMPLETE = 'complete';
+  public const STATUS_CANCELLED = 'cancelled';
+  public const STATUS_FAILED = 'failed';
+
+  /** @var int */
+  private $id;
+
+  /** @var int */
+  private $workflowId;
+
+  /** @var string */
+  private $triggerKey;
+
+  /** @var string */
+  private $status = self::STATUS_RUNNING;
+
+  /** @var DateTimeImmutable */
+  private $createdAt;
+
+  /** @var DateTimeImmutable */
+  private $updatedAt;
+
+  public function __construct(
+    int $workflowId,
+    string $triggerKey
+  ) {
+    $this->workflowId = $workflowId;
+    $this->triggerKey = $triggerKey;
+
+    $now = new DateTimeImmutable();
+    $this->createdAt = $now;
+    $this->updatedAt = $now;
+  }
+
+  public function getId(): int {
+    return $this->id;
+  }
+
+  public function getWorkflowId(): int {
+    return $this->workflowId;
+  }
+
+  public function getTriggerKey(): string {
+    return $this->triggerKey;
+  }
+
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  public function getCreatedAt(): DateTimeImmutable {
+    return $this->createdAt;
+  }
+
+  public function getUpdatedAt(): DateTimeImmutable {
+    return $this->updatedAt;
+  }
+
+  public function toArray(): array {
+    return [
+      'workflow_id' => $this->workflowId,
+      'trigger_key' => $this->triggerKey,
+      'status' => $this->status,
+      'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
+      'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
+    ];
+  }
+
+  public static function fromArray(array $data): self {
+    $workflowRun = new WorkflowRun((int)$data['workflow_id'], $data['trigger_key']);
+    $workflowRun->id = (int)$data['id'];
+    $workflowRun->status = $data['status'];
+    $workflowRun->createdAt = $data['created_at'];
+    $workflowRun->createdAt = $data['updated_at'];
+    return $workflowRun;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/WorkflowRun.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/WorkflowRun.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Workflows;
 
 use DateTimeImmutable;
+use MailPoet\Automation\Engine\Utils\Json;
 
 class WorkflowRun {
   public const STATUS_RUNNING = 'running';
@@ -81,7 +82,7 @@ class WorkflowRun {
       'status' => $this->status,
       'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
       'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
-      'subjects' => json_encode(
+      'subjects' => Json::encode(
         array_reduce($this->subjects, function (array $subjects, Subject $subject): array {
           $subjects[$subject->getKey()] = $subject->pack();
           return $subjects;
@@ -91,7 +92,7 @@ class WorkflowRun {
   }
 
   public static function fromArray(array $data): self {
-    $workflowRun = new WorkflowRun((int)$data['workflow_id'], $data['trigger_key'], (array)json_decode($data['subjects'], true));
+    $workflowRun = new WorkflowRun((int)$data['workflow_id'], $data['trigger_key'], Json::decode($data['subjects']));
     $workflowRun->id = (int)$data['id'];
     $workflowRun->status = $data['status'];
     $workflowRun->createdAt = $data['created_at'];

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/WaitAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/WaitAction.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\Core\Actions;
+
+use MailPoet\Automation\Engine\Control\ActionScheduler;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Workflows\Action;
+use MailPoet\Automation\Engine\Workflows\Step;
+use MailPoet\Automation\Engine\Workflows\Workflow;
+use MailPoet\Automation\Engine\Workflows\WorkflowRun;
+
+class WaitAction implements Action {
+  /** @var ActionScheduler */
+  private $actionScheduler;
+
+  public function __construct(
+    ActionScheduler $actionScheduler
+  ) {
+    $this->actionScheduler = $actionScheduler;
+  }
+
+  public function getKey(): string {
+    return 'core:wait';
+  }
+
+  public function getName(): string {
+    return __('Wait', 'mailpoet');
+  }
+
+  public function run(Workflow $workflow, WorkflowRun $workflowRun, Step $step): void {
+    $this->actionScheduler->schedule(time() + $step->getArgs()['seconds'], Hooks::WORKFLOW_STEP, [
+      [
+        'workflow_run_id' => $workflowRun->getId(),
+        'step_id' => $step->getNextStepId(),
+      ],
+    ]);
+
+    // TODO: call a step complete ($id) hook instead?
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/Core/CoreIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/Core/CoreIntegration.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\Core;
+
+use MailPoet\Automation\Engine\Integration;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Integrations\Core\Actions\WaitAction;
+
+class CoreIntegration implements Integration {
+  /** @var WaitAction */
+  private $waitAction;
+
+  public function __construct(
+    WaitAction $waitAction
+  ) {
+    $this->waitAction = $waitAction;
+  }
+
+  public function register(Registry $registry): void {
+    $registry->addAction($this->waitAction);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet;
+
+use MailPoet\Automation\Engine\Integration;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger;
+
+class MailPoetIntegration implements Integration {
+  /** @var SegmentSubscribedTrigger */
+  private $segmentSubscribedTrigger;
+
+  public function __construct(
+    SegmentSubscribedTrigger $segmentSubscribedTrigger
+  ) {
+    $this->segmentSubscribedTrigger = $segmentSubscribedTrigger;
+  }
+
+  public function register(Registry $registry): void {
+    $registry->addTrigger($this->segmentSubscribedTrigger);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Subjects;
+
+use MailPoet\Automation\Engine\Workflows\Field;
+use MailPoet\Automation\Engine\Workflows\Subject;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\InvalidStateException;
+use MailPoet\NotFoundException;
+use MailPoet\Segments\SegmentsRepository;
+
+class SegmentSubject implements Subject {
+  /** @var Field[] */
+  private $fields;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var SegmentEntity|null */
+  private $segment;
+
+  public function __construct(
+    SegmentsRepository $segmentsRepository
+  ) {
+    $this->segmentsRepository = $segmentsRepository;
+
+    $this->fields = [
+      // name
+      new Field(
+        'mailpoet:segment:name',
+        Field::TYPE_STRING,
+        __('Segment name', 'mailpoet'),
+        function () {
+          return $this->getSegment()->getName();
+        }
+      ),
+    ];
+  }
+
+  public function getKey(): string {
+    return 'mailpoet:segment';
+  }
+
+  public function getFields(): array {
+    return $this->fields;
+  }
+
+  public function load(array $args): void {
+    $id = $args['segment_id'];
+    $this->segment = $this->segmentsRepository->findOneById($args['segment_id']);
+    if (!$this->segment) {
+      throw NotFoundException::create()->withMessage(__(sprintf("Segment with ID '%s' not found.", $id), 'mailpoet'));
+    }
+  }
+
+  public function pack(): array {
+    $segment = $this->getSegment();
+    return ['segment_id' => $segment->getId()];
+  }
+
+  private function getSegment(): SegmentEntity {
+    if (!$this->segment) {
+      throw InvalidStateException::create()->withMessage(__('Segment was not loaded.', 'mailpoet'));
+    }
+    return $this->segment;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SubscriberSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SubscriberSubject.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Subjects;
+
+use MailPoet\Automation\Engine\Workflows\Field;
+use MailPoet\Automation\Engine\Workflows\Subject;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\InvalidStateException;
+use MailPoet\NotFoundException;
+use MailPoet\Subscribers\SubscribersRepository;
+
+class SubscriberSubject implements Subject {
+  /** @var Field[] */
+  private $fields;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var SubscriberEntity|null */
+  private $subscriber;
+
+  public function __construct(
+    SubscribersRepository $subscribersRepository
+  ) {
+    $this->subscribersRepository = $subscribersRepository;
+
+    $this->fields = [
+      // email
+      new Field(
+        'mailpoet:subscriber:email',
+        Field::TYPE_STRING,
+        __('Subscriber email', 'mailpoet'),
+        function () {
+          return $this->getSubscriber()->getEmail();
+        }
+      ),
+
+      // status
+      new Field(
+        'mailpoet:subscriber:status',
+        Field::TYPE_ENUM,
+        __('Subscriber status', 'mailpoet'),
+        function () {
+          return $this->getSubscriber()->getStatus();
+        },
+        [
+          SubscriberEntity::STATUS_SUBSCRIBED => __('Subscribed', 'mailpoet'),
+          SubscriberEntity::STATUS_UNCONFIRMED => __('Unconfirmed', 'mailpoet'),
+          SubscriberEntity::STATUS_UNSUBSCRIBED => __('Unsubscribed', 'mailpoet'),
+          SubscriberEntity::STATUS_INACTIVE => __('Inactive', 'mailpoet'),
+          SubscriberEntity::STATUS_BOUNCED => __('Bounced', 'mailpoet'),
+        ]
+      ),
+    ];
+  }
+
+  public function getKey(): string {
+    return 'mailpoet:subscriber';
+  }
+
+  public function getFields(): array {
+    return $this->fields;
+  }
+
+  public function load(array $args): void {
+    $id = $args['subscriber_id'];
+    $this->subscriber = $this->subscribersRepository->findOneById($id);
+    if (!$this->subscriber) {
+      throw NotFoundException::create()->withMessage(__(sprintf("Subscriber with ID '%s' not found.", $id), 'mailpoet'));
+    }
+  }
+
+  public function pack(): array {
+    $subscriber = $this->getSubscriber();
+    return ['subscriber_id' => $subscriber->getId()];
+  }
+
+  private function getSubscriber(): SubscriberEntity {
+    if (!$this->subscriber) {
+      throw InvalidStateException::create()->withMessage(__('Subscriber was not loaded.', 'mailpoet'));
+    }
+    return $this->subscriber;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SegmentSubscribedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SegmentSubscribedTrigger.php
@@ -4,15 +4,29 @@ namespace MailPoet\Automation\Integrations\MailPoet\Triggers;
 
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Workflows\Trigger;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\InvalidStateException;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SegmentSubscribedTrigger implements Trigger {
+  /** @var SegmentSubject */
+  private $segmentSubject;
+
+  /** @var SubscriberSubject */
+  private $subscriberSubject;
+
   /** @var WPFunctions */
   private $wp;
 
   public function __construct(
+    SegmentSubject $segmentSubject,
+    SubscriberSubject $subscriberSubject,
     WPFunctions $wp
   ) {
+    $this->segmentSubject = $segmentSubject;
+    $this->subscriberSubject = $subscriberSubject;
     $this->wp = $wp;
   }
 
@@ -25,14 +39,30 @@ class SegmentSubscribedTrigger implements Trigger {
   }
 
   public function getSubjects(): array {
-    return [];
+    return [
+      $this->segmentSubject,
+      $this->subscriberSubject,
+    ];
   }
 
   public function registerHooks(): void {
     $this->wp->addAction('mailpoet_segment_subscribed', [$this, 'handleSubscription'], 10, 2);
   }
 
-  public function handleSubscription(): void {
-    $this->wp->doAction(Hooks::TRIGGER, $this, []);
+  public function handleSubscription(SubscriberSegmentEntity $subscriberSegment): void {
+    $segment = $subscriberSegment->getSegment();
+    $subscriber = $subscriberSegment->getSubscriber();
+
+    if (!$segment || !$subscriber) {
+      throw new InvalidStateException();
+    }
+
+    $this->segmentSubject->load(['segment_id' => $segment->getId()]);
+    $this->subscriberSubject->load(['subscriber_id' => $subscriber->getId()]);
+
+    $this->wp->doAction(Hooks::TRIGGER, $this, [
+      $this->segmentSubject,
+      $this->subscriberSubject,
+    ]);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SegmentSubscribedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SegmentSubscribedTrigger.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Triggers;
+
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Workflows\Trigger;
+use MailPoet\WP\Functions as WPFunctions;
+
+class SegmentSubscribedTrigger implements Trigger {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function getKey(): string {
+    return 'mailpoet:segment:subscribed';
+  }
+
+  public function getName(): string {
+    return __('Subscribed to segment');
+  }
+
+  public function getSubjects(): array {
+    return [];
+  }
+
+  public function registerHooks(): void {
+    $this->wp->addAction('mailpoet_segment_subscribed', [$this, 'handleSubscription'], 10, 2);
+  }
+
+  public function handleSubscription(): void {
+    $this->wp->doAction(Hooks::TRIGGER, $this, []);
+  }
+}

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -4,7 +4,7 @@ namespace MailPoet\Config;
 
 use MailPoet\API\JSON\API;
 use MailPoet\AutomaticEmails\AutomaticEmails;
-use MailPoet\Automation\Automation;
+use MailPoet\Automation\Engine\Engine;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\Features\FeaturesController;
 use MailPoet\InvalidStateException;
@@ -88,8 +88,8 @@ class Initializer {
   /** @var SubscriberActivityTracker */
   private $subscriberActivityTracker;
 
-  /** @var Automation */
-  private $automation;
+  /** @var Engine */
+  private $automationEngine;
 
   /** @var FeaturesController */
   private $featuresController;
@@ -118,7 +118,7 @@ class Initializer {
     AutomaticEmails $automaticEmails,
     SubscriberActivityTracker $subscriberActivityTracker,
     AssetsLoader $assetsLoader,
-    Automation $automation,
+    Engine $automationEngine,
     FeaturesController $featuresController
   ) {
     $this->rendererFactory = $rendererFactory;
@@ -142,7 +142,7 @@ class Initializer {
     $this->automaticEmails = $automaticEmails;
     $this->subscriberActivityTracker = $subscriberActivityTracker;
     $this->assetsLoader = $assetsLoader;
-    $this->automation = $automation;
+    $this->automationEngine = $automationEngine;
     $this->featuresController = $featuresController;
   }
 
@@ -164,7 +164,7 @@ class Initializer {
     }
 
     if ($this->featuresController->isSupported(FeaturesController::AUTOMATION)) {
-      $this->automation->initialize();
+      $this->automationEngine->initialize();
     }
 
     // activation function

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -5,6 +5,8 @@ namespace MailPoet\Config;
 use MailPoet\API\JSON\API;
 use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Automation\Engine\Engine;
+use MailPoet\Automation\Engine\Hooks as AutomationHooks;
+use MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\Features\FeaturesController;
 use MailPoet\InvalidStateException;
@@ -91,6 +93,9 @@ class Initializer {
   /** @var Engine */
   private $automationEngine;
 
+  /** @var MailPoetIntegration */
+  private $automationMailPoetIntegration;
+
   /** @var FeaturesController */
   private $featuresController;
 
@@ -119,6 +124,7 @@ class Initializer {
     SubscriberActivityTracker $subscriberActivityTracker,
     AssetsLoader $assetsLoader,
     Engine $automationEngine,
+    MailPoetIntegration $automationMailPoetIntegration,
     FeaturesController $featuresController
   ) {
     $this->rendererFactory = $rendererFactory;
@@ -143,6 +149,7 @@ class Initializer {
     $this->subscriberActivityTracker = $subscriberActivityTracker;
     $this->assetsLoader = $assetsLoader;
     $this->automationEngine = $automationEngine;
+    $this->automationMailPoetIntegration = $automationMailPoetIntegration;
     $this->featuresController = $featuresController;
   }
 
@@ -206,6 +213,13 @@ class Initializer {
       $this,
       'multisiteDropTables',
     ]);
+
+    if ($this->featuresController->isSupported(FeaturesController::AUTOMATION)) {
+      WPFunctions::get()->addAction(AutomationHooks::INITIALIZE, [
+        $this->automationMailPoetIntegration,
+        'register',
+      ]);
+    }
 
     $this->hooks->initEarlyHooks();
   }

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -163,10 +163,6 @@ class Initializer {
       ));
     }
 
-    if ($this->featuresController->isSupported(FeaturesController::AUTOMATION)) {
-      $this->automationEngine->initialize();
-    }
-
     // activation function
     WPFunctions::get()->registerActivationHook(
       Env::$file,
@@ -264,6 +260,10 @@ class Initializer {
       $this->setupWoocommerceBlocksIntegration();
       $this->subscriberActivityTracker->trackActivity();
       $this->postEditorBlock->init();
+
+      if ($this->featuresController->isSupported(FeaturesController::AUTOMATION)) {
+        $this->automationEngine->initialize();
+      }
 
       WPFunctions::get()->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -118,6 +118,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
+    // Automation - core integration
+    $container->autowire(\MailPoet\Automation\Integrations\Core\Actions\WaitAction::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\Core\CoreIntegration::class)->setPublic(true);
     // Automation - MailPoet integration
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -118,6 +118,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
+    // Automation - MailPoet integration
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration::class)->setPublic(true);
+     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Activator::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -112,6 +112,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Config

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -107,6 +107,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setArgument('$container', new Reference(ContainerWrapper::class));
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\SystemDatabaseEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -108,6 +108,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\SystemDatabaseEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\TriggerHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -101,15 +101,15 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AutomaticEmails\WooCommerce\Events\PurchasedInCategory::class)->setPublic(true);
     $container->autowire(\MailPoet\AutomaticEmails\WooCommerce\Events\PurchasedProduct::class)->setPublic(true);
     // Automation
-    $container->autowire(\MailPoet\Automation\API\API::class)->setPublic(true);
-    $container->autowire(\MailPoet\Automation\API\EndpointFactory::class)
+    $container->autowire(\MailPoet\Automation\Engine\API\API::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\API\EndpointFactory::class)
       ->setPublic(true)
       ->setArgument('$container', new Reference(ContainerWrapper::class));
-    $container->autowire(\MailPoet\Automation\API\Endpoints\SystemDatabaseEndpoint::class)->setPublic(true);
-    $container->autowire(\MailPoet\Automation\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
-    $container->autowire(\MailPoet\Automation\Automation::class)->setPublic(true);
-    $container->autowire(\MailPoet\Automation\Migrations\Migrator::class)->setPublic(true);
-    $container->autowire(\MailPoet\Automation\WordPress::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\SystemDatabaseEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Activator::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -109,6 +109,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -110,6 +110,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Config

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -109,6 +109,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\StepRunner::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\TriggerHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -110,6 +110,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\StepRunner::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\Steps\ActionStepRunner::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\TriggerHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -120,6 +120,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - MailPoet integration
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject::class)->setPublic(true);
      $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -121,6 +121,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Automation - MailPoet integration
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject::class)->setPublic(true);
      $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -108,6 +108,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\SystemDatabaseEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\API\Endpoints\WorkflowsEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\TriggerHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);

--- a/mailpoet/tests/integration/API/MP/APITest.php
+++ b/mailpoet/tests/integration/API/MP/APITest.php
@@ -13,6 +13,7 @@ use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
@@ -25,6 +26,7 @@ use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Idiorm\ORM;
 
 class APITest extends \MailPoetTest {
@@ -57,7 +59,9 @@ class APITest extends \MailPoetTest {
       $this->diContainer->get(SubscriberSegmentRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscribersResponseBuilder::class),
-      Stub::makeEmpty(WelcomeScheduler::class)
+      Stub::makeEmpty(WelcomeScheduler::class),
+      $this->diContainer->get(FeaturesController::class),
+      $this->diContainer->get(WPFunctions::class)
     );
   }
 

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -11,6 +11,7 @@ use MailPoet\API\MP\v1\Subscribers;
 use MailPoet\Config\Changelog;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -20,6 +21,7 @@ use MailPoet\Subscribers\RequiredCustomFieldValidator;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class SubscribersTest extends \MailPoetTest {
 
@@ -47,7 +49,9 @@ class SubscribersTest extends \MailPoetTest {
       $this->diContainer->get(SubscriberSegmentRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscribersResponseBuilder::class),
-      Stub::makeEmpty(WelcomeScheduler::class)
+      Stub::makeEmpty(WelcomeScheduler::class),
+      $this->diContainer->get(FeaturesController::class),
+      $this->diContainer->get(WPFunctions::class)
     );
   }
 
@@ -178,6 +182,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => SettingsController::getInstance(),
+        'featuresController' => $this->diContainer->get(FeaturesController::class),
       ]
     );
 

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -7,6 +7,7 @@ use MailPoet\Config\Renderer;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Form\AssetsController;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterOption;
@@ -217,7 +218,8 @@ class PagesTest extends \MailPoetTest {
       $container->get(ManageSubscriptionFormRenderer::class),
       $container->get(SubscriberHandler::class),
       $this->subscribersRepository,
-      $container->get(TrackingConfig::class)
+      $container->get(TrackingConfig::class),
+      $container->get(FeaturesController::class)
     );
   }
 }


### PR DESCRIPTION
[MAILPOET-4136]

[MAILPOET-4136]: https://mailpoet.atlassian.net/browse/MAILPOET-4136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This is an initial **prototype** for running automation workflows. It includes:

1. **Workflow** data definition, table, API to create them, etc.
2. **Workflow run** data definition, table, and related services.
3. **Step** definition and runner service.
4. **Trigger** interface and handler.
5. **Action** interface and runner service.
6. **Subject** interface for carrying data through the workflow.
7. **Integration** interface as a wrapper for added triggers, actions, and subjects (e.g. "MailPoet integration").
8. **MailPoet** integration with:
    - `Segment-subscribed` trigger (triggered when the state of a subscription to a segment becomes `subscribed`).
    - `Segment` subject.
    - `Subscriber` subject.
9. **Core** integration with:
    - `Wait` action.
10. A **testing button to create a workflow** in the UI.

To **create and test a workflow**:
1. Ensure you're running MailPoet under a domain name (`mailpoet.localhost`, `mp3.localhost`, etc.) so that WP Cron and Action Scheduler work.
2. Activate the automation feature on the experimental features page (`?page=mailpoet-experimental`).
3. Go to the automation page (`?page=mailpoet-automation`).
4. Click on `Create testing workflow`.
5. Go to the DB and change the workflow status to `active` (look for `wp_mailpoet_automation_workflows ` table).
6. Subscribe a new subscriber (e.g. via a subscription form).
7. Once the subscription is confirmed, the workflow will be triggered (see in `wp_mailpoet_automation_workflow_runs` and Action Scheduler tables).
8. The workflow only has a trigger and a 60s wait action. After the 60s the workflow run will be completed.

It **doesn't include** yet:
1. Tests.
2. Data validation.
3. Logging.
9. Connection to premium features.

I recommend going commit-by-commit as I tried to make them well-ordered and their titles and descriptions explanatory.

The APIs can be seen as drafts that can be significantly changed. I'll be happy for any feedback.