### PR TITLE
Prevent sending more emails than allowed [MAILPOET-4122]

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -45,6 +45,8 @@ class Help {
     $systemInfoData = $this->helpscoutBeacon->getData(true);
     $cronPingResponse = $this->cronHelper->pingDaemon();
 
+    $mailerLog = MailerLog::getMailerLog();
+    $mailerLog['sent'] = MailerLog::sentSince();
     $systemStatusData = [
       'cron' => [
         'url' => $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING),
@@ -56,7 +58,7 @@ class Help {
         'isReachable' => $this->bridge->pingBridge(),
       ],
       'cronStatus' => $this->cronHelper->getDaemon(),
-      'queueStatus' => MailerLog::getMailerLog(),
+      'queueStatus' => $mailerLog,
     ];
     $systemStatusData['cronStatus']['accessible'] = $this->cronHelper->isDaemonAccessible();
     $systemStatusData['queueStatus']['tasksStatusCounts'] = $this->tasksState->getCountsPerStatus();

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -209,7 +209,14 @@ class MailerLog {
    * @return MailerLogData|null
    */
   public static function incrementSentCount(): ?array {
+    $settings = SettingsController::getInstance();
+    $mailerConfig = $settings->get(Mailer::MAILER_CONFIG_SETTING_NAME);
+    // do not enforce sending limit for MailPoet's sending method
+    if ($mailerConfig['method'] === Mailer::METHOD_MAILPOET) {
+      return null;
+    }
     $mailerLog = self::getMailerLog();
+
     // do not increment count if sending limit is reached
     if (self::isSendingLimitReached($mailerLog)) {
       return null;

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -260,12 +260,21 @@ class MailerLog {
   }
 
   /**
-   * @param int $sinceSeconds
+   * @param int|null $sinceSeconds
    * @param MailerLogData|null $mailerLog
    * @return int
    */
-  private static function sentSince(int $sinceSeconds, array $mailerLog = null): int {
+  public static function sentSince(int $sinceSeconds = null, array $mailerLog = null): int {
 
+    if ($sinceSeconds === null) {
+      $settings = SettingsController::getInstance();
+      $mailerConfig = $settings->get(Mailer::MAILER_CONFIG_SETTING_NAME);
+      if (empty($mailerConfig['frequency'])) {
+        $defaultSettings = $settings->getAllDefaults();
+        $mailerConfig['frequency'] = $defaultSettings['mta']['frequency'];
+      }
+      $sinceSeconds = (int)$mailerConfig['frequency']['interval'] * Mailer::SENDING_LIMIT_INTERVAL_MULTIPLIER;
+    }
     $sinceDate = date('Y-m-d H:i:s', time() - $sinceSeconds);
     $mailerLog = self::getMailerLog($mailerLog);
 

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -651,11 +651,6 @@ parameters:
 			path: ../../lib/Listing/ListingRepository.php
 
 		-
-			message: "#^Variable \\$mailer in empty\\(\\) is never defined\\.$#"
-			count: 1
-			path: ../../lib/Mailer/MailerLog.php
-
-		-
 			message: "#^Parameter \\#1 \\$timeout of method MailPoetVendor\\\\Swift_Transport_EsmtpTransport\\:\\:setTimeout\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Mailer/Methods/SMTP.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -651,11 +651,6 @@ parameters:
 			path: ../../lib/Listing/ListingRepository.php
 
 		-
-			message: "#^Variable \\$mailer in empty\\(\\) is never defined\\.$#"
-			count: 1
-			path: ../../lib/Mailer/MailerLog.php
-
-		-
 			message: "#^Parameter \\#1 \\$timeout of method MailPoetVendor\\\\Swift_Transport_EsmtpTransport\\:\\:setTimeout\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Mailer/Methods/SMTP.php

--- a/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
@@ -14,7 +14,8 @@ use MailPoet\Settings\SettingsController;
 class MailerTest extends \MailPoetTest {
   public function testItResumesSending() {
     // create mailer log with a "paused" status
-    $mailerLog = ['status' => MailerLog::STATUS_PAUSED];
+    $mailerLog = MailerLog::getMailerLog();
+    $mailerLog['status'] = MailerLog::STATUS_PAUSED;
     MailerLog::updateMailerLog($mailerLog);
     $mailerLog = MailerLog::getMailerLog();
     expect($mailerLog['status'])->equals(MailerLog::STATUS_PAUSED);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -65,9 +65,9 @@ class MailerTest extends \MailPoetTest {
 
   public function testItUpdatesMailerLogSentCount() {
     $mailerLog = $this->mailerTask->getMailerLog();
-    expect($mailerLog['sent'])->equals(0);
+    expect(array_sum($mailerLog['sent']))->equals(0);
     $mailerLog = $this->mailerTask->updateSentCount();
-    expect($mailerLog['sent'])->equals(1);
+    expect(array_sum($mailerLog['sent']))->equals(1);
   }
 
   public function testItGetsProcessingMethod() {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -371,8 +371,12 @@ class NewsletterTest extends \MailPoetTest {
       self::fail('Sending error exception was not thrown.');
     } catch (\Exception $e) {
       $mailerLog = MailerLog::getMailerLog();
-      expect($mailerLog['error']['operation'])->equals('queue_save');
-      expect($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
+
+      expect(is_array($mailerLog['error']));
+      if (is_array($mailerLog['error'])) {
+        expect($mailerLog['error']['operation'])->equals('queue_save');
+        expect($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
+      }
     }
   }
 
@@ -392,8 +396,11 @@ class NewsletterTest extends \MailPoetTest {
       self::fail('Sending error exception was not thrown.');
     } catch (\Exception $e) {
       $mailerLog = MailerLog::getMailerLog();
-      expect($mailerLog['error']['operation'])->equals('queue_save');
-      expect($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
+      expect(is_array($mailerLog['error']));
+      if (is_array($mailerLog['error'])) {
+        expect($mailerLog['error']['operation'])->equals('queue_save');
+        expect($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
+      }
     }
   }
 
@@ -426,8 +433,11 @@ class NewsletterTest extends \MailPoetTest {
       self::fail('Sending error exception was not thrown.');
     } catch (\Exception $e) {
       $mailerLog = MailerLog::getMailerLog();
-      expect($mailerLog['error']['operation'])->equals('queue_save');
-      expect($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
+      expect(is_array($mailerLog['error']));
+      if (is_array($mailerLog['error'])) {
+        expect($mailerLog['error']['operation'])->equals('queue_save');
+        expect($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
+      }
     }
   }
 

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -33,6 +33,17 @@ class MailerLogTest extends \MailPoetTest {
     expect($mailerLog['started'])->greaterThan($resultExpectedGreaterThan);
   }
 
+  public function testItDoesNotIncrementWhenSendingMethodIsMailpoet() {
+
+    $expectedCount = MailerLog::sentSince();
+    $settings = SettingsController::getInstance();
+    $mailerConfig = $settings->get(Mailer::MAILER_CONFIG_SETTING_NAME);
+    $mailerConfig['method'] = Mailer::METHOD_MAILPOET;
+    $settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, $mailerConfig);
+    expect(MailerLog::incrementSentCount())->null();
+    expect(MailerLog::sentSince())->equals($expectedCount);
+  }
+
   public function testItCreatesMailer() {
     $resultExpectedGreaterThan = time() - 1;
     $mailerLog = MailerLog::createMailerLog();

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -123,7 +123,10 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
     $controller->checkAuthorizedEmailAddresses();
     $error = MailerLog::getError();
-    expect($error['operation'])->equals(MailerError::OPERATION_SEND);
+    expect(is_array($error));
+    if (is_array($error)) {
+      expect($error['operation'])->equals(MailerError::OPERATION_SEND);
+    }
   }
 
   public function testItDoesNotResetMailerLogItErrorPersists() {
@@ -135,7 +138,10 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
     $controller->checkAuthorizedEmailAddresses();
     $error = MailerLog::getError();
-    expect($error['operation'])->equals(MailerError::OPERATION_AUTHORIZATION);
+    expect(is_array($error));
+    if (is_array($error)) {
+      expect($error['operation'])->equals(MailerError::OPERATION_AUTHORIZATION);
+    }
   }
 
   private function checkUnauthorizedInNewsletter($type, $status) {


### PR DESCRIPTION
Fixes [MAILPOET-4122]

Before this PR, MailPoet was able to send more emails than the settings allowed for.

# A conceptual problem
Before this PR, we calculated whether the sending limit was reached in a data model, which consisted out of the number of emails sent since a fixed timestamp. So, once we started a new "series", we would set the timestamp and then just count up until the limit was reached. Once the limit was reached, we would check if the timestamp we had was outdated, in which case we would reset the number of emails, set a new timestamp and continue sending.

This model had some flaws:
1. Example: Limit is 100 emails, allowed timespan is 1 minute. Lets say our last "series" consisted of 50 emails. This left 50 unused "spots". Before we would check whether the timestamp was outdated (hence, we were in a new timespan), we would fill those spots. Then we would create a new timespan and would allow for 100 more emails, although we already did send 50.
2. We had no idea about the distribution of the emails, which we send. Theoretically this could lead to a timespan, where one email was send at the beginning and 99 in the last second. Although our timespan was filled and we would restart, this could lead to sending more than 100 emails in a minute.

This PR suggests a different approach: A "rolling timeframe". Each second we send an email would create a new entry in an array with the number of emails we did send in this second. When we calculate how many emails where send in the last 60 seconds, we `array_sum()` all entries in this timeframe. Once entries are outdated and fall out of the timeframe, we delete them. With the current UI, we can set the sending timeframe up to 30 minutes, which leaves us with max. 1800 entries in this array. A "rolling timeframe" keeps the information about distribution and therefore tackles the two flaws of the previous model. ([23d09b5](https://github.com/mailpoet/mailpoet/pull/4001/commits/23d09b59f0ce3a5637b47e6c2dc0f1c4d7a8151c))

~A problem of keeping track~
~A second problem existed, as we did not count all emails, which we did send. MailPoet offers the possibility to send all transactional emails. If you set a limit on how many emails you want to send in a given timeframe, those emails need to be accounted for. They weren't. This PR will~
~1. Enforce the sending execution requirements in the `Mailer::send()` method. So far, this requirements have been only checked in the SendingQueue, which does not go through the `Mailer::send()` method. Transactional emails and other emails are send via `Mailer::send()`. Besides the sending limit the execution requirements also count for sending paused or blocked by a retry waiting period.~
~2. Increment the count of the emails send, when they are send using `Mailer::send()`.~

~What happens when an transactional email can not be send?~
~At the moment, MailPoet has no queue for transactional emails. If an error occurs, MailPoet falls back to the default PHPMailer and attempts to send the email. This behavior remains.~
~(6a23fb4)~

~A non-static MailerLog~
~The MailerLog class so far was a static class. This PR rewrote the class and got rid of its static attributes (bf5d41fd1e121d586516bc54a6c334f4f42afe76)~

# Introduce a phpstan-type MailerLogData
The data with which the MailerLog works is a simple array. The array stores the data whether the sending is paused, what errors occurred and so on. As it is just an array and not an object/entity, this can easily lead to errors, we would like to prevent (e.g. an array key is expected to be present, but it isn't and therefore notices are thrown). This PR typecasts most methods and introduces an phpstan-type, so that PHPStan can easily detect missing or misspelled array keys.

(83846fc)

[MAILPOET-4122]: https://mailpoet.atlassian.net/browse/MAILPOET-4122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ