### PR TITLE
Expand inactive subscriber criteria

### DIFF
--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -117,7 +117,7 @@ class Clicks {
       // track open event
       $this->opens->track($data, $displayImage = false);
       // Update engagement date
-      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
+      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
     }
     $url = $this->processUrl($link->getUrl(), $newsletter, $subscriber, $queue, $wpUserPreview);
     $this->redirectToUrl($url);

--- a/mailpoet/lib/Statistics/Track/Opens.php
+++ b/mailpoet/lib/Statistics/Track/Opens.php
@@ -63,7 +63,7 @@ class Opens {
             $this->statisticsOpensRepository->flush();
           }
         }
-        $this->subscribersRepository->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
+        $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
         return $this->returnResponse($displayImage);
       }
       $statistics = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
@@ -74,7 +74,7 @@ class Opens {
       }
       $this->statisticsOpensRepository->persist($statistics);
       $this->statisticsOpensRepository->flush();
-      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber, $userAgent ?? null);
+      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
       $this->statisticsOpensRepository->recalculateSubscriberScore($subscriber);
     }
     return $this->returnResponse($displayImage);

--- a/mailpoet/lib/Subscribers/InactiveSubscribersController.php
+++ b/mailpoet/lib/Subscribers/InactiveSubscribersController.php
@@ -79,8 +79,6 @@ class InactiveSubscribersController {
       return false;
     }
 
-    // We take into account only emails which have at least one opening tracked
-    // to ensure that tracking was enabled for the particular email
     $inactiveTaskIdsTable = 'inactive_task_ids';
     if (!$this->inactiveTaskIdsTableCreated) {
       $inactiveTaskIdsTableSql = "
@@ -98,7 +96,7 @@ class InactiveSubscribersController {
       $this->inactiveTaskIdsTableCreated = true;
     }
 
-    // Select subscribers who received at least a number of tracked emails but didn't open any
+    // Select subscribers who received at least a number of emails after  threshold date
     $startId = (int)$startId;
     $endId = $startId + $batchSize;
     $inactiveSubscriberIdsTmpTable = 'inactive_subscriber_ids';

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -7,7 +7,6 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
-use MailPoet\Entities\UserAgentEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Carbon\CarbonImmutable;
@@ -320,16 +319,13 @@ class SubscribersRepository extends Repository {
       ->getResult();
   }
 
-  public function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity, ?UserAgentEntity $userAgent = null): void {
-    if ($userAgent instanceof UserAgentEntity && $userAgent->getUserAgentType() === UserAgentEntity::USER_AGENT_TYPE_MACHINE) {
-      return;
-    }
+  public function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity): void {
     $now = CarbonImmutable::createFromTimestamp((int)$this->wp->currentTime('timestamp'));
     // Do not update engagement if was recently updated to avoid unnecessary updates in DB
     if ($subscriberEntity->getLastEngagementAt() && $subscriberEntity->getLastEngagementAt() > $now->subMinute()) {
       return;
     }
-    // Update last engagement for human (and also unknown) user agent
+    // Update last engagement
     $subscriberEntity->setLastEngagementAt($now);
     $this->flush();
   }


### PR DESCRIPTION
This PR changes the inactive subscriber criteria to:

d) The subscriber has not clicked or opened any emails in X months (as specified in settings), human or machine. Currently, we discard machine opens/clicks. (updated condition)
b) The subscriber has received at least 3 emails in the last X months (setting value) (updated condition)

It also removes old code on the tests and comments that were no longer true.

(c), (e), (f), and (g) are already implemented and covered by existing tests on: 
tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php and tests/integration/Subscribers/InactiveSubscribersControllerTest.php

[MAILPOET-4081]


[MAILPOET-4081]: https://mailpoet.atlassian.net/browse/MAILPOET-4081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ