### PR TITLE
Exclude orders not payed and on hold from calculating purchase segments [MAILPOET-4127]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -107,7 +107,7 @@ class WooCommerceCategory implements Filter {
         'orderStats',
         'customer.customer_id = orderStats.customer_id'
       )
-      ->andWhere("orderStats.status NOT IN ('wc-cancelled', 'wc-failed')");
+      ->andWhere("orderStats.status NOT IN ('wc-cancelled', 'wc-on-hold', 'wc-pending', 'wc-failed')");
   }
 
   private function applyProductJoin(QueryBuilder $queryBuilder): QueryBuilder {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -88,7 +88,7 @@ class WooCommerceProduct implements Filter {
       'customer',
       $wpdb->prefix . 'wc_order_stats',
       'orderStats',
-      'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN ("wc-cancelled", "wc-failed")'
+      'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN ("wc-cancelled", "wc-on-hold", "wc-pending", "wc-failed")'
     );
   }
 


### PR DESCRIPTION
Fixes [MAILPOET-4127]

To test:

1. Create Pending payment and On-hold orders.
2. Create a “Purchased this product” segment with this product
3. Customers should not appear in the segment
4. Create a “Purchased in category” segment with this product
5. Customers should not appear in the segment


[MAILPOET-4127]: https://mailpoet.atlassian.net/browse/MAILPOET-4127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ