### PR TITLE
Force action scheduler in acceptance tests to run [MAILPOET-4169]

### DIFF
--- a/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
@@ -87,7 +87,7 @@ class WooCommerceDynamicSegmentsCest {
 
     // run action scheduler to sync customer and order data to lookup tables
     $i->wait(2);
-    $i->cli(['action-scheduler', 'run']);
+    $i->cli(['action-scheduler', 'run', '--force']);
 
     $i->wantTo('Check subscriber is in category segment');
     $i->amOnMailpoetPage('Lists');
@@ -121,7 +121,7 @@ class WooCommerceDynamicSegmentsCest {
 
     // run action scheduler to sync customer and order data to lookup tables
     $i->wait(2);
-    $i->cli(['action-scheduler', 'run']);
+    $i->cli(['action-scheduler', 'run', '--force']);
 
     $i->wantTo('Check subscriber is in category segment');
     $i->amOnMailpoetPage('Lists');
@@ -153,7 +153,7 @@ class WooCommerceDynamicSegmentsCest {
 
     // run action scheduler to sync customer and order data to lookup tables
     $i->wait(2);
-    $i->cli(['action-scheduler', 'run']);
+    $i->cli(['action-scheduler', 'run', '--force']);
 
     $i->wantTo('Check there is one subscriber in the number of orders segments (the segment was configured to match customers that placed one order in the last day)');
     $i->amOnMailpoetPage('Lists');
@@ -178,7 +178,7 @@ class WooCommerceDynamicSegmentsCest {
 
     // run action scheduler to sync customer and order data to lookup tables
     $i->wait(2);
-    $i->cli(['action-scheduler', 'run']);
+    $i->cli(['action-scheduler', 'run', '--force']);
 
     $i->wantTo('Check that there is one subscriber in the total spent segment');
     $i->amOnMailpoetPage('Lists');
@@ -203,7 +203,7 @@ class WooCommerceDynamicSegmentsCest {
 
     // run action scheduler to sync customer and order data to lookup tables
     $i->wait(2);
-    $i->cli(['action-scheduler', 'run']);
+    $i->cli(['action-scheduler', 'run', '--force']);
 
     $i->wantTo('Check that there is one subscriber in customer country segment');
     $i->amOnMailpoetPage('Lists');


### PR DESCRIPTION
Fixes [MAILPOET-4169]

This PR applies the `--force` parameter to the CLI calls in the acceptance tests, which run the action scheduler.

This will result in the CLI returning a warning instead of an error [#](https://github.com/woocommerce/action-scheduler/blob/2d58fd29e9a17725009d78a029b0550112437a26/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php#L57-L63).

As far as I understand, the problem with having multiple concurrent runs can be server resources [#](https://actionscheduler.org/perf/#increasing-concurrent-batches). I did some test runs in CircleCI and so far the tests never failed. I think, we need to see, if server resources would be a problem for us, but I do not expect so.

[MAILPOET-4169]: https://mailpoet.atlassian.net/browse/MAILPOET-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ