### PR TITLE
Add custom styles to CaptchaRenderer [MAILPOET-4134]

### DIFF
--- a/mailpoet/lib/Form/Util/Styles.php
+++ b/mailpoet/lib/Form/Util/Styles.php
@@ -108,7 +108,7 @@ class Styles {
 
     $typeSpecificStyles = $this->getFormTypeSpecificStyles($selector, $displayType);
 
-    $messagesStyles = $this->renderMessagesStyles($formSettings, $selector);
+    $messagesStyles = $this->renderFormMessageStyles($form, $selector);
 
     $additionalStyles = $selector . ' .mailpoet_paragraph.last {margin-bottom: 0} ';
     $media .= " @media (min-width: 500px) {{$selector} .last .mailpoet_paragraph:last-child {margin-bottom: 0}} ";
@@ -174,6 +174,14 @@ class Styles {
 
   private function getWidthValue(array $width) {
     return $width['value'] . ($width['unit'] === 'percent' ? '%' : 'px');
+  }
+
+  public function renderFormMessageStyles(FormEntity $form, string $selector): string {
+    $formSettings = $form->getSettings();
+    if (!is_array($formSettings)) {
+      return '';
+    }
+    return $this->renderMessagesStyles($formSettings, $selector);
   }
 
   private function renderMessagesStyles(array $formSettings, string $selector): string {

--- a/mailpoet/lib/Subscription/CaptchaRenderer.php
+++ b/mailpoet/lib/Subscription/CaptchaRenderer.php
@@ -5,6 +5,7 @@ namespace MailPoet\Subscription;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Form\FormsRepository;
 use MailPoet\Form\Renderer as FormRenderer;
+use MailPoet\Form\Util\Styles;
 use MailPoet\Util\Url as UrlHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -27,13 +28,17 @@ class CaptchaRenderer {
   /** @var FormsRepository */
   private $formsRepository;
 
+  /** @var Styles */
+  private $styles;
+
   public function __construct(
     UrlHelper $urlHelper,
     WPFunctions $wp,
     CaptchaSession $captchaSession,
     SubscriptionUrlFactory $subscriptionUrlFactory,
     FormsRepository $formsRepository,
-    FormRenderer $formRenderer
+    FormRenderer $formRenderer,
+    Styles $styles
   ) {
     $this->urlHelper = $urlHelper;
     $this->wp = $wp;
@@ -41,6 +46,7 @@ class CaptchaRenderer {
     $this->subscriptionUrlFactory = $subscriptionUrlFactory;
     $this->formRenderer = $formRenderer;
     $this->formsRepository = $formsRepository;
+    $this->styles = $styles;
   }
 
   public function getCaptchaPageTitle() {
@@ -101,6 +107,7 @@ class CaptchaRenderer {
     $formHtml = '<form method="POST" ' .
       'action="' . admin_url('admin-post.php?action=mailpoet_subscription_form') . '" ' .
       'class="mailpoet_form mailpoet_captcha_form" ' .
+      'id="mailpoet_captcha_form" ' .
       'novalidate>';
     $formHtml .= '<input type="hidden" name="data[form_id]" value="' . $formId . '" />';
     $formHtml .= '<input type="hidden" name="data[captcha_session_id]" value="' . htmlspecialchars($this->captchaSession->getId()) . '" />';
@@ -124,6 +131,10 @@ class CaptchaRenderer {
     $formHtml .= '</div>';
     $formHtml .= $this->renderFormMessages($formModel, $showSuccessMessage, $showErrorMessage);
     $formHtml .= '</form>';
+    $formHtml .= '<style>' . $this->styles->renderFormMessageStyles(
+      $formModel,
+      '#mailpoet_captcha_form'
+    ) . '</style>';
     return $formHtml;
   }
 

--- a/mailpoet/tests/unit/Form/Util/StylesTest.php
+++ b/mailpoet/tests/unit/Form/Util/StylesTest.php
@@ -144,12 +144,18 @@ class StylesTest extends \MailPoetUnitTest {
     $form['settings'] = ['error_validation_color' => 'xxx'];
     $styles = $this->styles->renderFormSettingsStyles($this->createForm($form), '#prefix', FormEntity::DISPLAY_TYPE_OTHERS);
     expect($styles)->stringContainsString('#prefix .mailpoet_validate_error {color: xxx}');
+
+    $styles = $this->styles->renderFormMessageStyles($this->createForm($form), '#prefix');
+    expect($styles)->stringContainsString('#prefix .mailpoet_validate_error {color: xxx}');
   }
 
   public function testItShouldRenderSuccessMessageColor() {
     $form = Fixtures::get('simple_form_body');
     $form['settings'] = ['success_validation_color' => 'xxx'];
     $styles = $this->styles->renderFormSettingsStyles($this->createForm($form), '#prefix', FormEntity::DISPLAY_TYPE_OTHERS);
+    expect($styles)->stringContainsString('#prefix .mailpoet_validate_success {color: xxx}');
+
+    $styles = $this->styles->renderFormMessageStyles($this->createForm($form), '#prefix');
     expect($styles)->stringContainsString('#prefix .mailpoet_validate_success {color: xxx}');
   }
 


### PR DESCRIPTION
Fixes [MAILPOET-4134]

This PR utilizes the `Form\Util\Styles` class to apply the custom styles defined in a form also to the captcha form, thus rendering the error and success messages in the correct colors.

[MAILPOET-4134]: https://mailpoet.atlassian.net/browse/MAILPOET-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing Instructions:
1. Go to MailPoet > Forms
2. Edit one of the forms and make sure to set `Success Message Color` / `Error Message Color` colors to something like Black / Purple. Save the form at the end. Setting these colors can be found under Styles tab on the right.
3. Open Private window and go to front-end to trigger such form
4. Fill everything required and submit the form
5. When redirected to a new page to fill Captcha information, fill it and proceed further
6. Observe at the end the Success / Error message colors. Should reflect what you have set in the Styles settings. Previously, it was white all the time no matter what you set.