### PR TITLE
Add transactional sending method to system info [MAILPOET-4148]

### DIFF
--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -108,6 +108,7 @@ class Reporter {
       'MailPoet Premium version' => (defined('MAILPOET_PREMIUM_VERSION')) ? MAILPOET_PREMIUM_VERSION : 'N/A',
       'Total number of subscribers' => $this->subscribersFeature->getSubscribersCount(),
       'Sending Method' => isset($mta['method']) ? $mta['method'] : null,
+      "Send all site's emails with" => $this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method',
       'Date of plugin installation' => $this->settings->get('installed_at'),
       'Subscribe in comments' => (boolean)$this->settings->get('subscribe.on_comment.enabled', false),
       'Subscribe in registration form' => (boolean)$this->settings->get('subscribe.on_register.enabled', false),

--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -75,6 +75,7 @@ class Beacon {
         $mta['frequency']['emails'],
         $mta['frequency']['interval']
       ),
+      "Send all site's emails with" => $this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method',
       'Task Scheduler method' => $this->settings->get('cron_trigger.method'),
       'Cron ping URL' => $cronPingUrl,
       'Default FROM address' => $this->settings->get('sender.address'),

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -123,6 +123,14 @@ class BeaconTest extends \MailPoetTest {
     expect($this->beaconData['Plugin installed at'])->equals($this->settings->get('installed_at'));
   }
 
+  public function testItReturnsTransactionalEmailSendingMethod() {
+    $this->settings->set('send_transactional_emails', '');
+    $beacon = $this->diContainer->get(Beacon::class);
+    expect($beacon->getData()["Send all site's emails with"])->equals('default WordPress sending method');
+    $this->settings->set('send_transactional_emails', '1');
+    expect($beacon->getData()["Send all site's emails with"])->equals('current sending method');
+  }
+
   public function testItReturnsTotalNumberOfSubscribers() {
     // unsubscribed users are not taken into account
     expect($this->beaconData['Total number of subscribers'])->equals(2);


### PR DESCRIPTION
This PR adds the transactional sending method advanced setting to the system info tab on the Help page, as well as to the data we collect for analytics.

## Advanced Setting 
`/wp-admin/admin.php?page=mailpoet-settings#/advanced`
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/8656640/158456538-554b34a6-b56a-411f-bd83-b9b0d8213869.png">

## System Info Tab 
`/wp-admin/admin.php?page=mailpoet-help#/systemInfo`
<img width="783" alt="image" src="https://user-images.githubusercontent.com/8656640/158458669-fa131f6d-60dc-4312-b1ab-26868c965f49.png">

## Analytics Data
Viewing analytics data requires that the "Share anonymous data" advanced setting is set to `Yes`
<img width="574" alt="image" src="https://user-images.githubusercontent.com/8656640/158457936-cb412d41-6190-4f5f-9a84-f03d7ecfc928.png">

The easiest way I found to inspect the analytics data was by looking at the `mailpoet_analytics_data` variable in the browser console.

<img width="842" alt="image" src="https://user-images.githubusercontent.com/8656640/158457711-0067254f-e2e1-4976-9d4f-2a8ccd2b8345.png">

However, this variable is not populated on every page load. It's created periodically whenever analytics are due to be sent in. You can make the plugin believe that it's time to send analytics again by deleting the `analytics_last_sent` setting from `wp_mailpoet_settings`.
<img width="647" alt="image" src="https://user-images.githubusercontent.com/8656640/158458297-49a076d1-5312-4513-aa40-89dc2f04f14c.png">

[MAILPOET-4148]

[MAILPOET-4148]: https://mailpoet.atlassian.net/browse/MAILPOET-4148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ