### PR TITLE
Update counts on tabs when searching [MAILPOET-3535]

### DIFF
--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -487,8 +487,6 @@ class Listing extends React.Component {
 
     this.setState({
       group,
-      filter: {},
-      search: '',
       page: 1,
     }, () => {
       this.setParams();

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -1142,16 +1142,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot access offset 'status' on mixed\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot access offset 'subscribersCount' on mixed\\.$#"
 			count: 1
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
@@ -1168,11 +1158,6 @@ parameters:
 		-
 			message: "#^Cannot call method isStatic\\(\\) on mixed\\.$#"
 			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 3
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
 		-

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -1142,16 +1142,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot access offset 'status' on mixed\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot access offset 'subscribersCount' on mixed\\.$#"
 			count: 1
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
@@ -1168,11 +1158,6 @@ parameters:
 		-
 			message: "#^Cannot call method isStatic\\(\\) on mixed\\.$#"
 			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 3
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
 		-


### PR DESCRIPTION
Fixes [MAILPOET-3535]

In order to update the tab count, we need to perform the count query with the restrictions of the current search in place. This is what happens in f2e5a81. This of course has impacts on the performance as these are more detailed SQL queries, we need to run.

I tested a bit between master and this PR (having ~1950 subscribers in the database), the loading difference for a normal request (without e.g. a specific search query) are on average < 100ms, the same goes for queries with a specific search term.

5eb02c8 prevents the resetting of the filters and search terms, when switching between the tabs.

[MAILPOET-3535]: https://mailpoet.atlassian.net/browse/MAILPOET-3535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
Check the steps and examples in the Jira above.