### PR TITLE
Refactor SubscribersFinder to use Doctrine instead of Paris [MAILPOET-3925]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -128,7 +128,7 @@ class SendingQueue extends APIEndpoint {
       $queue->status = SendingQueueModel::STATUS_SCHEDULED;
       $queue->scheduledAt = Scheduler::formatDatetimeString($newsletterEntity->getOptionValue('scheduledAt'));
     } else {
-      $segments = $newsletter->segments()->findMany();
+      $segments = $newsletterEntity->getSegmentIds();
       $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($queue->task(), $segments);
       if (!$subscribersCount) {
         return $this->errorResponse([

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -135,7 +135,11 @@ class Scheduler {
       }
 
       // ensure that subscribers are in segments
-      $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($queue->task(), $segments);
+      $taskModel = $queue->task();
+      $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);
+      if ($taskEntity instanceof ScheduledTaskEntity) {
+        $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments);
+      }
     }
 
     if (empty($subscribersCount)) {
@@ -168,7 +172,13 @@ class Scheduler {
     if ($newsletter->sendTo === 'segment') {
       $segment = $this->segmentsRepository->findOneById($newsletter->segment);
       if ($segment instanceof SegmentEntity) {
-        $result = $this->subscribersFinder->addSubscribersToTaskFromSegments($queue->task(), [(int)$segment->getId()]);
+        $taskModel = $queue->task();
+        $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);
+
+        if ($taskEntity instanceof ScheduledTaskEntity) {
+          $result = $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, [(int)$segment->getId()]);
+        }
+
         if (empty($result)) {
           $queue->delete();
           return false;
@@ -198,7 +208,12 @@ class Scheduler {
 
     if ($newsletterEntity instanceof NewsletterEntity) {
       $segments = $newsletterEntity->getSegmentIds();
-      $this->subscribersFinder->addSubscribersToTaskFromSegments($task->task(), $segments);
+      $taskModel = $task->task();
+      $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);
+
+      if ($taskEntity instanceof ScheduledTaskEntity) {
+        $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments);
+      }
     }
 
     // update current queue

--- a/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
@@ -12,6 +12,9 @@ use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
  * @ORM\Table(name="scheduled_task_subscribers")
  */
 class ScheduledTaskSubscriberEntity {
+  const STATUS_UNPROCESSED = 0;
+  const STATUS_PROCESSED = 1;
+
   use CreatedAtTrait;
   use UpdatedAtTrait;
   use SafeToOneAssociationLoadTrait;

--- a/mailpoet/lib/Models/ScheduledTaskSubscriber.php
+++ b/mailpoet/lib/Models/ScheduledTaskSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Models;
 
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -13,8 +14,8 @@ use MailPoet\WP\Functions as WPFunctions;
  * @property string $error
  */
 class ScheduledTaskSubscriber extends Model {
-  const STATUS_UNPROCESSED = 0;
-  const STATUS_PROCESSED = 1;
+  const STATUS_UNPROCESSED = ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED;
+  const STATUS_PROCESSED = ScheduledTaskSubscriberEntity::STATUS_PROCESSED;
 
   const FAIL_STATUS_OK = 0;
   const FAIL_STATUS_FAILED = 1;

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -2,12 +2,12 @@
 
 namespace MailPoet\Segments;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\InvalidStateException;
-use MailPoet\Models\ScheduledTask;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -54,12 +54,12 @@ class SubscribersFinder {
   }
 
   /**
-   * @param ScheduledTask $task
+   * @param ScheduledTaskEntity $task
    * @param array<int>    $segmentIds
    *
    * @return float|int
    */
-  public function addSubscribersToTaskFromSegments(ScheduledTask $task, array $segmentIds) {
+  public function addSubscribersToTaskFromSegments(ScheduledTaskEntity $task, array $segmentIds) {
     // Prepare subscribers on the DB side for performance reasons
     $staticSegmentIds = [];
     $dynamicSegmentIds = [];
@@ -84,12 +84,12 @@ class SubscribersFinder {
   }
 
   /**
-   * @param ScheduledTask $task
+   * @param ScheduledTaskEntity $task
    * @param array<int> $segmentIds
    *
    * @return int
    */
-  private function addSubscribersToTaskFromStaticSegments(ScheduledTask $task, array $segmentIds) {
+  private function addSubscribersToTaskFromStaticSegments(ScheduledTaskEntity $task, array $segmentIds) {
     $processedStatus = ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED;
     $subscribersStatus = SubscriberEntity::STATUS_SUBSCRIBED;
     $relationStatus = SubscriberEntity::STATUS_SUBSCRIBED;
@@ -110,7 +110,7 @@ class SubscribersFinder {
        AND relation.`status` = ?
        AND relation.`segment_id` IN (?)",
       [
-        $task->id,
+        $task->getId(),
         $processedStatus,
         $subscribersStatus,
         $relationStatus,
@@ -129,12 +129,12 @@ class SubscribersFinder {
   }
 
   /**
-   * @param ScheduledTask        $task
+   * @param ScheduledTaskEntity $task
    * @param array<int> $segmentIds
    *
    * @return int
    */
-  private function addSubscribersToTaskFromDynamicSegments(ScheduledTask $task, array $segmentIds) {
+  private function addSubscribersToTaskFromDynamicSegments(ScheduledTaskEntity $task, array $segmentIds) {
     $count = 0;
     foreach ($segmentIds as $segmentId) {
       $count += $this->addSubscribersToTaskFromDynamicSegment($task, (int)$segmentId);
@@ -142,7 +142,7 @@ class SubscribersFinder {
     return $count;
   }
 
-  private function addSubscribersToTaskFromDynamicSegment(ScheduledTask $task, int $segmentId) {
+  private function addSubscribersToTaskFromDynamicSegment(ScheduledTaskEntity $task, int $segmentId) {
     $count = 0;
     $subscribers = $this->segmentSubscriberRepository->getSubscriberIdsInSegment($segmentId);
     if ($subscribers) {
@@ -151,7 +151,7 @@ class SubscribersFinder {
     return $count;
   }
 
-  private function addSubscribersToTaskByIds(ScheduledTask $task, array $subscriberIds) {
+  private function addSubscribersToTaskByIds(ScheduledTaskEntity $task, array $subscriberIds) {
     $scheduledTaskSubscriberTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
     $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
 
@@ -166,7 +166,7 @@ class SubscribersFinder {
        AND subscribers.`status` = ?
        AND subscribers.`id` IN (?)",
       [
-        $task->id,
+        $task->getId(),
         ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
         SubscriberEntity::STATUS_SUBSCRIBED,
         $subscriberIds,

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -2,10 +2,10 @@
 
 namespace MailPoet\Segments;
 
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\Subscriber;
 use MailPoetVendor\Idiorm\ORM;
 
@@ -94,7 +94,7 @@ class SubscribersFinder {
        AND relation.`segment_id` IN (' . join(',', array_map('intval', $segmentIds)) . ')',
       [
         $task->id,
-        ScheduledTaskSubscriber::STATUS_UNPROCESSED,
+        ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
         Subscriber::STATUS_SUBSCRIBED,
         Subscriber::STATUS_SUBSCRIBED,
       ]
@@ -136,7 +136,7 @@ class SubscribersFinder {
        AND subscribers.`id` IN (' . join(',', array_map('intval', $subscriberIds)) . ')',
       [
         $task->id,
-        ScheduledTaskSubscriber::STATUS_UNPROCESSED,
+        ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
         Subscriber::STATUS_SUBSCRIBED,
       ]
     );

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -15,17 +15,22 @@ class SubscribersFinder {
   /** @var SegmentSubscribersRepository  */
   private $segmentSubscriberRepository;
 
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
   public function __construct(
-    SegmentSubscribersRepository $segmentSubscriberRepository
+    SegmentSubscribersRepository $segmentSubscriberRepository,
+    SegmentsRepository $segmentsRepository
   ) {
     $this->segmentSubscriberRepository = $segmentSubscriberRepository;
+    $this->segmentsRepository = $segmentsRepository;
   }
 
   public function findSubscribersInSegments($subscribersToProcessIds, $newsletterSegmentsIds) {
     $result = [];
     foreach ($newsletterSegmentsIds as $segmentId) {
-      $segment = Segment::findOne($segmentId);
-      if (!$segment instanceof Segment) {
+      $segment = $this->segmentsRepository->findOneById($segmentId);
+      if (!$segment instanceof SegmentEntity) {
         continue; // skip deleted segments
       }
       $result = array_merge($result, $this->findSubscribersInSegment($segment, $subscribersToProcessIds));
@@ -33,9 +38,9 @@ class SubscribersFinder {
     return $this->unique($result);
   }
 
-  private function findSubscribersInSegment(Segment $segment, $subscribersToProcessIds): array {
+  private function findSubscribersInSegment(SegmentEntity $segment, $subscribersToProcessIds): array {
     try {
-      return $this->segmentSubscriberRepository->findSubscribersIdsInSegment((int)$segment->id, $subscribersToProcessIds);
+      return $this->segmentSubscriberRepository->findSubscribersIdsInSegment((int)$segment->getId(), $subscribersToProcessIds);
     } catch (InvalidStateException $e) {
       return [];
     }

--- a/mailpoet/tests/DataFactories/Segment.php
+++ b/mailpoet/tests/DataFactories/Segment.php
@@ -53,6 +53,11 @@ class Segment {
     return $this;
   }
 
+  public function withType($type) {
+    $this->data['type'] = $type;
+    return $this;
+  }
+
   public function create(): SegmentEntity {
     $segment = $this->saveController->save($this->data);
     if (($this->data['deleted_at'] ?? null) instanceof \DateTimeInterface) {

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -97,6 +97,7 @@ class Subscriber {
    * @return $this
    */
   public function withSegments(array $segments) {
+    $this->segments = [];
     foreach ($segments as $segment) {
       $this->segments[$segment->getId()] = $segment;
     }

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -79,7 +79,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
       $this->diContainer->get(Bridge::class),
-      $this->diContainer->get(SubscribersFinder::class)
+      $this->diContainer->get(SubscribersFinder::class),
+      $this->diContainer->get(ScheduledTasksRepository::class)
     );
     $res = $sendingQueue->add(['newsletter_id' => $this->newsletter->getId()]);
     expect($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
@@ -147,7 +148,8 @@ class SendingQueueTest extends \MailPoetTest {
       Stub::make(Bridge::class, [
         'isMailpoetSendingServiceEnabled' => true,
       ]),
-      $this->diContainer->get(SubscribersFinder::class)
+      $this->diContainer->get(SubscribersFinder::class),
+      $this->diContainer->get(ScheduledTasksRepository::class)
     );
     $response = $sendingQueue->add(['newsletter_id' => $newsletter->getId()]);
     $response = $response->getData();

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -69,7 +69,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->getId()]));
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->getId()], [$this->segment3->getId()]);
     expect($subscribers)->count(1);
     expect($subscribers)->contains($this->subscriber3->getId());
@@ -83,7 +83,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->getId()]));
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->getId()], [$this->segment3->getId(), $this->segment3->getId()]);
     expect($subscribers)->count(1);
   }
@@ -120,7 +120,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber1->getId()]));
     $this->segment2->setType(SegmentEntity::TYPE_DYNAMIC);
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
     $subscribersCount = $finder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [
@@ -140,7 +140,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber2->getId()]));
     $this->segment3->setType(SegmentEntity::TYPE_DYNAMIC);
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
     $subscribersCount = $finder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -9,10 +9,10 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
-use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class SubscribersFinderTest extends \MailPoetTest {
@@ -32,9 +32,10 @@ class SubscribersFinderTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->segment1 = Segment::createOrUpdate(['name' => 'Segment 1', 'type' => 'default']);
-    $this->segment2 = Segment::createOrUpdate(['name' => 'Segment 2', 'type' => 'default']);
-    $this->segment3 = Segment::createOrUpdate(['name' => 'Segment 3', 'type' => 'not default']);
+    $segmentFactory = new SegmentFactory();
+    $this->segment1 = $segmentFactory->withName('Segment 1')->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->segment2 = $segmentFactory->withName('Segment 2')->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->segment3 = $segmentFactory->withName('Segment 3')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
     $this->subscriber1 = Subscriber::createOrUpdate([
       'email' => 'john@mailpoet.com',
       'first_name' => 'John',
@@ -47,7 +48,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       'last_name' => 'Doe',
       'status' => Subscriber::STATUS_SUBSCRIBED,
       'segments' => [
-        $this->segment1->id,
+        $this->segment1->getId(),
       ],
     ]);
     $this->subscriber3 = Subscriber::createOrUpdate([
@@ -56,7 +57,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       'last_name' => 'Doe',
       'status' => Subscriber::STATUS_SUBSCRIBED,
       'segments' => [
-        $this->segment3->id,
+        $this->segment3->getId(),
       ],
     ]);
     SubscriberSegment::resubscribeToAllSegments($this->subscriber2);
@@ -68,7 +69,7 @@ class SubscribersFinderTest extends \MailPoetTest {
 
   public function testFindSubscribersInSegmentInSegmentDefaultSegment() {
     $deletedSegmentId = 1000; // non-existent segment
-    $subscribers = $this->subscribersFinder->findSubscribersInSegments([$this->subscriber2->id], [$this->segment1->id, $deletedSegmentId]);
+    $subscribers = $this->subscribersFinder->findSubscribersInSegments([$this->subscriber2->id], [$this->segment1->getId(), $deletedSegmentId]);
     expect($subscribers)->count(1);
     expect($subscribers[$this->subscriber2->id])->equals($this->subscriber2->id);
   }
@@ -82,7 +83,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber3->id]));
 
     $finder = new SubscribersFinder($mock, $this->segmentsRepository);
-    $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->id], [$this->segment3->id]);
+    $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->id], [$this->segment3->getId()]);
     expect($subscribers)->count(1);
     expect($subscribers)->contains($this->subscriber3->id);
   }
@@ -96,7 +97,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber3->id]));
 
     $finder = new SubscribersFinder($mock, $this->segmentsRepository);
-    $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->id], [$this->segment3->id, $this->segment3->id]);
+    $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->id], [$this->segment3->getId(), $this->segment3->getId()]);
     expect($subscribers)->count(1);
   }
 
@@ -104,8 +105,8 @@ class SubscribersFinderTest extends \MailPoetTest {
     $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [
-        $this->getDummySegment($this->segment1->id, Segment::TYPE_DEFAULT),
-        $this->getDummySegment($this->segment2->id, Segment::TYPE_DEFAULT),
+        $this->segment1->getId(),
+        $this->segment2->getId(),
       ]
     );
     expect($subscribersCount)->equals(1);
@@ -113,10 +114,11 @@ class SubscribersFinderTest extends \MailPoetTest {
   }
 
   public function testItDoesNotAddSubscribersToTaskFromNoSegment() {
+    $this->segment3->setType('Invalid type');
     $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [
-        $this->getDummySegment($this->segment1->id, 'UNKNOWN SEGMENT'),
+        $this->segment3->getId(),
       ]
     );
     expect($subscribersCount)->equals(0);
@@ -129,12 +131,13 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('getSubscriberIdsInSegment')
       ->will($this->returnValue([$this->subscriber1->id]));
+    $this->segment2->setType(SegmentEntity::TYPE_DYNAMIC);
 
     $finder = new SubscribersFinder($mock, $this->segmentsRepository);
     $subscribersCount = $finder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [
-        $this->getDummySegment($this->segment2->id, SegmentEntity::TYPE_DYNAMIC),
+        $this->segment2->getId(),
       ]
     );
     expect($subscribersCount)->equals(1);
@@ -148,26 +151,20 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('getSubscriberIdsInSegment')
       ->will($this->returnValue([$this->subscriber2->id]));
+    $this->segment3->setType(SegmentEntity::TYPE_DYNAMIC);
 
     $finder = new SubscribersFinder($mock, $this->segmentsRepository);
     $subscribersCount = $finder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [
-        $this->getDummySegment($this->segment1->id, Segment::TYPE_DEFAULT),
-        $this->getDummySegment($this->segment2->id, Segment::TYPE_DEFAULT),
-        $this->getDummySegment($this->segment3->id, SegmentEntity::TYPE_DYNAMIC),
+        $this->segment1->getId(),
+        $this->segment2->getId(),
+        $this->segment3->getId(),
       ]
     );
 
     expect($subscribersCount)->equals(1);
     expect($this->sending->getSubscribers())->equals([$this->subscriber2->id]);
-  }
-
-  private function getDummySegment($id, $type) {
-    $segment = Segment::create();
-    $segment->id = $id;
-    $segment->type = $type;
-    return $segment;
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -3,15 +3,16 @@
 namespace MailPoet\Segments;
 
 use Codeception\Util\Stub;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Models\DynamicSegmentFilter;
-use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\ScheduledTaskSubscriber;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Tasks\Sending as SendingTask;
-use MailPoetVendor\Idiorm\ORM;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class SubscribersFinderTest extends \MailPoetTest {
@@ -31,12 +32,6 @@ class SubscribersFinderTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
-    ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . Segment::$_table);
-    ORM::raw_execute('TRUNCATE ' . SubscriberSegment::$_table);
-    ORM::raw_execute('TRUNCATE ' . DynamicSegmentFilter::$_table);
-    ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
     $this->segment1 = Segment::createOrUpdate(['name' => 'Segment 1', 'type' => 'default']);
     $this->segment2 = Segment::createOrUpdate(['name' => 'Segment 2', 'type' => 'default']);
     $this->segment3 = Segment::createOrUpdate(['name' => 'Segment 3', 'type' => 'not default']);
@@ -173,5 +168,15 @@ class SubscribersFinderTest extends \MailPoetTest {
     $segment->id = $id;
     $segment->type = $type;
     return $segment;
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->truncateEntity(ScheduledTaskEntity::class);
+    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
+    $this->truncateEntity(SegmentEntity::class);
+    $this->truncateEntity(SubscriberSegmentEntity::class);
+    $this->truncateEntity(DynamicSegmentFilterEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -26,6 +26,9 @@ class SubscribersFinderTest extends \MailPoetTest {
   /** @var SubscribersFinder */
   private $subscribersFinder;
 
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
   public function _before() {
     parent::_before();
     ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
@@ -64,6 +67,7 @@ class SubscribersFinderTest extends \MailPoetTest {
     SubscriberSegment::resubscribeToAllSegments($this->subscriber2);
     SubscriberSegment::resubscribeToAllSegments($this->subscriber3);
     $this->sending = SendingTask::create();
+    $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscribersFinder = $this->diContainer->get(SubscribersFinder::class);
   }
 
@@ -82,7 +86,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->id]));
 
-    $finder = new SubscribersFinder($mock);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->id], [$this->segment3->id]);
     expect($subscribers)->count(1);
     expect($subscribers)->contains($this->subscriber3->id);
@@ -96,7 +100,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->id]));
 
-    $finder = new SubscribersFinder($mock);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->id], [$this->segment3->id, $this->segment3->id]);
     expect($subscribers)->count(1);
   }
@@ -131,7 +135,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('getSubscriberIdsInSegment')
       ->will($this->returnValue([$this->subscriber1->id]));
 
-    $finder = new SubscribersFinder($mock);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
     $subscribersCount = $finder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [
@@ -150,7 +154,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('getSubscriberIdsInSegment')
       ->will($this->returnValue([$this->subscriber2->id]));
 
-    $finder = new SubscribersFinder($mock);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository);
     $subscribersCount = $finder->addSubscribersToTaskFromSegments(
       $this->sending->task(),
       [


### PR DESCRIPTION
[MAILPOET-3925]

[MAILPOET-3925]: https://mailpoet.atlassian.net/browse/MAILPOET-3925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Steps:
1. Go to MailPoet > Lists > Segments tab
2. Make sure you see some segment that counts at least 3 subscribers (or make a new segment instead)
3. Send simple newsletter to that segment and make sure they have received newsletter