### PR TITLE
Set an empty subscriber when no Subscriber found for ViewInBrowser

### DIFF
--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -132,6 +132,23 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $this->expectViewThrowsExceptionWithMessage($this->viewInBrowserController, $data, 'Subscriber did not receive the newsletter yet');
   }
 
+  public function testUsesEmptySubscriberWhenNotLoggedIn() {
+
+    $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
+      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
+        assert($subscriber !== null); // PHPStan
+        expect($subscriber)->notNull();
+        expect($subscriber->getId())->equals(0);
+      }),
+    ]);
+
+    $viewInBrowserController = $this->createController($viewInBrowserRenderer);
+
+    $data = $this->browserPreviewData;
+    unset($data['subscriber_id']);
+    $viewInBrowserController->view($data);
+  }
+
   public function testItSetsSubscriberToLoggedInWPUserWhenPreviewIsEnabled() {
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
       'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {


### PR DESCRIPTION
Fixes [MAILPOET-4190]

The problem in MAILPOET-4190 is we try to render the shortcode without a subscriber set, which just returns the plain shortcode [#](https://github.com/mailpoet/mailpoet/blob/9ea484c972000f861cfff3b9f613428a04aadd42/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php#L37-L39). We rely on this behavior, as in some processes, we run our newsletter through the shortcode processes to prepare them and then again with the actual subscriber.

Therefore this PR proposes to use an empty `SubscriberEntity` when rendering the BrowserView and we do not have a subscriber at hand.

This PR also proposes to move all "find the subscriber"-logic into the `ViewInBrowserController::getSubscriber()`. So in case of no subscriber is found but we are in the preview mode, we try to find the subscriber for the logged in user now also in `ViewInBrowserController::getSubscriber()`.

[MAILPOET-4190]: https://mailpoet.atlassian.net/browse/MAILPOET-4190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Pages > Add New Page
2. Place this shortcode and save the page: [mailpoet_archive]
3. Send some simple newsletter but place this shortcode [subscriber:firstname | default:Subscriber] in the title and somewhere in the newsletter content. Something like `Hi, [subscriber:firstname | default:Subscriber]`.
4. Log out
5. Go to the page you have created recently and make sure you see Hi, Subscriber in the title and in the content.
6. Log in
7. Check the same page that you see Hi, (your admin First Name).