### PR TITLE
Unique tokens for subscription form submissions [MAILPOET-2030]

### DIFF
--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -106,7 +106,13 @@ class API {
       $this->requestMethod === 'subscribe'
     );
 
-    if (!$ignoreToken && $this->checkToken() === false) {
+    $nonceAction = 'mailpoet_token';
+    
+    if (isset($this->requestData['mailpoet_action']) && $this->requestData['mailpoet_action'] !== '') {
+      $nonceAction .= sprintf("_%s", $this->requestData['mailpoet_action']);
+    }
+
+    if (!$ignoreToken && $this->checkToken($nonceAction) === false) {
       $errorMessage = WPFunctions::get()->__("Sorry, but we couldn't connect to the MailPoet server. Please refresh the web page and try again.", 'mailpoet');
       $errorResponse = $this->createErrorResponse(Error::UNAUTHORIZED, $errorMessage, Response::STATUS_UNAUTHORIZED);
       return $errorResponse->send();
@@ -228,8 +234,8 @@ class API {
       $this->accessControl->validatePermission($permissions['global']);
   }
 
-  public function checkToken() {
-    return WPFunctions::get()->wpVerifyNonce($this->requestToken, 'mailpoet_token');
+  public function checkToken($action = 'mailpoet_token') {
+    return WPFunctions::get()->wpVerifyNonce($this->requestToken, $action);
   }
 
   public function setTokenAndAPIVersion() {

--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -187,8 +187,11 @@ class DisplayFormInWPContent {
       $templateData['enableExitIntent'] = true;
     }
 
+    $uniqueFormAction = Security::generateRandomString();
+    $templateData['mailpoetAction'] = $uniqueFormAction;
+    
     // generate security token
-    $templateData['token'] = Security::generateToken();
+    $templateData['token'] = Security::generateToken('mailpoet_token_' . $uniqueFormAction);
 
     // add API version
     $templateData['api_version'] = API::CURRENT_VERSION;

--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -191,7 +191,7 @@ class DisplayFormInWPContent {
     $templateData['mailpoetAction'] = $uniqueFormAction;
     
     // generate security token
-    $templateData['token'] = Security::generateToken('mailpoet_token_' . $uniqueFormAction);
+    $templateData['token'] = Security::generateTokenForUniqueAction($uniqueFormAction);
 
     // add API version
     $templateData['api_version'] = API::CURRENT_VERSION;

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -251,7 +251,7 @@ class Widget extends \WP_Widget {
       $data['mailpoetAction'] = $uniqueFormAction;
 
       // generate security token
-      $data['token'] = Security::generateToken('mailpoet_token_' . $uniqueFormAction);
+      $data['token'] = Security::generateTokenForUniqueAction($uniqueFormAction);
 
       // add API version
       $data['api_version'] = API::CURRENT_VERSION;

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -247,8 +247,11 @@ class Widget extends \WP_Widget {
         ((int)$_GET['mailpoet_error'] === $form->getId())
       );
 
+      $uniqueFormAction = Security::generateRandomString();
+      $data['mailpoetAction'] = $uniqueFormAction;
+
       // generate security token
-      $data['token'] = Security::generateToken();
+      $data['token'] = Security::generateToken('mailpoet_token_' . $uniqueFormAction);
 
       // add API version
       $data['api_version'] = API::CURRENT_VERSION;

--- a/mailpoet/lib/Util/Security.php
+++ b/mailpoet/lib/Util/Security.php
@@ -35,7 +35,7 @@ class Security {
    * Generate random lowercase alphanumeric string.
    * 1 lowercase alphanumeric character = 6 bits (because log2(36) = 5.17)
    * So 3 bytes = 4 characters
-   * @param int $length Minimal lenght is 5
+   * @param int $length Minimal length is 5
    * @return string
    */
   public static function generateRandomString($length = 5): string {

--- a/mailpoet/lib/Util/Security.php
+++ b/mailpoet/lib/Util/Security.php
@@ -12,6 +12,7 @@ use MailPoet\WP\Functions as WPFunctions;
 class Security {
   const HASH_LENGTH = 12;
   const UNSUBSCRIBE_TOKEN_LENGTH = 15;
+  const UNIQUE_ACTION_PREFIX = 'mailpoetUniqueAction_';
 
   /** @var NewslettersRepository */
   private $newslettersRepository;
@@ -29,6 +30,44 @@ class Security {
 
   public static function generateToken($action = 'mailpoet_token') {
     return WPFunctions::get()->wpCreateNonce($action);
+  }
+
+  public static function generateTokenForUniqueAction(string $action) {
+    return self::generateToken(self::UNIQUE_ACTION_PREFIX . $action);
+  }
+
+  public static function getUniqueAction(string $action) {
+    return self::UNIQUE_ACTION_PREFIX . $action;
+  }
+
+  public static function isActionUnique(string $action): bool {
+    return strpos($action, self::UNIQUE_ACTION_PREFIX) === 0;
+  }
+
+  public static function checkTokenForUniqueAction(string $token, string $action): bool {
+    return self::checkToken($token, self::getUniqueAction($action));
+  }
+
+  public static function checkToken(string $token, string $action = 'mailpoet_token'): bool {
+    $isNonceValid = WPFunctions::get()->wpVerifyNonce($token, $action);
+
+    if (!$isNonceValid || !self::isActionUnique($action)) {
+      return $isNonceValid;
+    }
+
+    /** Nonces that were generated for a unique action should truly only ever be used once */
+    $transientName = 'mailpoetUsedNonce_' . $token;
+    $hasNonceAlreadyBeenUsed = WPFunctions::get()->getTransient($transientName);
+
+    if ($hasNonceAlreadyBeenUsed) {
+      return false;
+    }
+
+    // The default nonce life from WordPress uses DAY_IN_SECONDS (86400)
+    $expiration = WPFunctions::get()->applyFilters('nonce_life', 86400);
+    WPFunctions::get()->setTransient($transientName, true, $expiration);
+
+    return true;
   }
 
   /**

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -563,6 +563,10 @@ class Functions {
     return wp_login_url($redirect, $forceReauth);
   }
 
+  public function wpNonceTick() {
+    return wp_nonce_tick();
+  }
+
   public function wpParseArgs($args, $defaults = '') {
     return wp_parse_args($args, $defaults);
   }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -34,9 +34,6 @@ class APITest extends \MailPoetTest {
   /** @var ErrorHandler */
   private $errorHandler;
 
-  /** @var SettingsController */
-  private $settings;
-
   public function _before() {
     parent::_before();
     // create WP user
@@ -54,12 +51,10 @@ class APITest extends \MailPoetTest {
     $this->container->autowire(APITestNamespacedEndpointStubV2::class)->setPublic(true);
     $this->container->compile();
     $this->errorHandler = $this->container->get(ErrorHandler::class);
-    $this->settings = $this->container->get(SettingsController::class);
     $this->api = new JSONAPI(
       $this->container,
       $this->container->get(AccessControl::class),
       $this->errorHandler,
-      $this->settings,
       new WPFunctions
     );
   }
@@ -237,7 +232,7 @@ class APITest extends \MailPoetTest {
       ['validatePermission' => false]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, new WPFunctions);
     $api->addEndpointNamespace($namespace['name'], $namespace['version']);
     $api->setRequestData($data, Endpoint::TYPE_POST);
     $response = $api->processRoute();
@@ -259,7 +254,7 @@ class APITest extends \MailPoetTest {
       ]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, new WPFunctions);
     expect($api->validatePermissions(null, $permissions))->false();
 
     $accessControl = Stub::make(
@@ -271,7 +266,7 @@ class APITest extends \MailPoetTest {
         }),
       ]
     );
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, new WPFunctions);
     expect($api->validatePermissions(null, $permissions))->true();
   }
 
@@ -293,7 +288,7 @@ class APITest extends \MailPoetTest {
       ]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, new WPFunctions);
     expect($api->validatePermissions('test', $permissions))->false();
 
     $accessControl = Stub::make(
@@ -306,7 +301,7 @@ class APITest extends \MailPoetTest {
       ]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, new WPFunctions);
     expect($api->validatePermissions('test', $permissions))->true();
   }
 

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -15,7 +15,7 @@ use MailPoet\API\JSON\v2\APITestNamespacedEndpointStubV2;
 use MailPoet\Config\AccessControl;
 use MailPoet\DI\ContainerConfigurator;
 use MailPoet\DI\ContainerFactory;
-use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
 
@@ -72,9 +72,9 @@ class APITest extends \MailPoetTest {
       $this->api,
       'setupAjax',
       [
+        'requestToken' => Security::generateToken(),
         'wp' => new WPFunctions,
         'processRoute' => Stub::makeEmpty(new SuccessResponse),
-        'settings' => $this->container->get(SettingsController::class),
       ]
     );
     $api->setupAjax();

--- a/mailpoet/tests/integration/Util/SecurityIntegrationTest.php
+++ b/mailpoet/tests/integration/Util/SecurityIntegrationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MailPoet\Test\Util;
+
+use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
+
+class SecurityIntegrationTest extends \MailPoetTest {
+  public function testItCanGenerateAndVerifyTokens() {
+    $token = Security::generateToken();
+    expect(Security::checkToken($token))->true();
+  }
+
+  public function testItRejectsIncorrectTokens() {
+    expect(Security::checkToken('not a real token'))->false();
+  }
+
+  public function testItCanGenerateAndVerifyTokensForUniqueActions() {
+    $token = Security::generateTokenForUniqueAction('uniqueAction');
+    expect(Security::checkTokenForUniqueAction($token, 'uniqueAction'))->true();
+  }
+
+  public function testItRejectsTokensCreatedForADifferentAction() {
+    $token = Security::generateTokenForUniqueAction('uniqueAction');
+    expect(Security::checkToken($token, 'someOtherAction'))->false();
+  }
+
+  public function testItDoesNotAllowReUseOfTokensForUniqueActions() {
+    $token = Security::generateTokenForUniqueAction('uniqueAction');
+    expect(Security::checkTokenForUniqueAction($token, 'uniqueAction'))->true();
+    expect(Security::checkTokenForUniqueAction($token, 'uniqueAction'))->false();
+  }
+
+  public function testItDoesAllowReuseOfTokensForNonUniqueActions() {
+    $token = Security::generateToken();
+    expect(Security::checkToken($token))->true();
+    expect(Security::checkToken($token))->true();
+  }
+
+  public function _before() {
+    global $wpdb;
+    // Clean up transients used to check if a token has already been used because they persist between tests
+    $results = $wpdb->get_results( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '%mailpoetUsedNonce_%'" );
+    foreach ($results as $result) {
+      // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      WPFunctions::get()->deleteOption($result->option_name);
+    }
+    WPFunctions::set(new WPFunctions);
+  }
+}

--- a/mailpoet/views/form/front_end_form.html
+++ b/mailpoet/views/form/front_end_form.html
@@ -56,6 +56,7 @@
       <input type="hidden" name="token" value="<%= token %>" />
       <input type="hidden" name="api_version" value="<%= api_version %>" />
       <input type="hidden" name="endpoint" value="subscribers" />
+      <input type="hidden" name="data[mailpoet_action]" value="<%= mailpoetAction %>" />
       <input type="hidden" name="mailpoet_method" value="subscribe" />
 
       <%= html | raw %>

--- a/mailpoet/views/form/front_end_form.html
+++ b/mailpoet/views/form/front_end_form.html
@@ -56,7 +56,7 @@
       <input type="hidden" name="token" value="<%= token %>" />
       <input type="hidden" name="api_version" value="<%= api_version %>" />
       <input type="hidden" name="endpoint" value="subscribers" />
-      <input type="hidden" name="data[mailpoet_action]" value="<%= mailpoetAction %>" />
+      <input type="hidden" name="data[mailpoet_unique_action]" value="<%= mailpoetAction %>" />
       <input type="hidden" name="mailpoet_method" value="subscribe" />
 
       <%= html | raw %>


### PR DESCRIPTION
This PR alters subscription forms to always include a unique CSRF token. It also prevents these tokens from being reused.

[MAILPOET-2030]