### PR TITLE
Update name of 1and1 web host in settings [MAILPOET-4196]

### DIFF
--- a/mailpoet/lib/Settings/Hosts.php
+++ b/mailpoet/lib/Settings/Hosts.php
@@ -52,11 +52,6 @@ class Hosts {
   ];
 
   private static $web = [
-    '1and1' => [
-        'name' => '1and1',
-        'emails' => 30,
-        'interval' => 5,
-    ],
     'bluehost' => [
         'name' => 'BlueHost',
         'emails' => 70,
@@ -131,6 +126,11 @@ class Hosts {
         'name' => 'Infomaniak',
         'emails' => 20,
         'interval' => 15,
+    ],
+    '1and1' => [
+      'name' => 'IONOS by 1&1',
+      'emails' => 30,
+      'interval' => 5,
     ],
     'justhost' => [
         'name' => 'JustHost',


### PR DESCRIPTION
[MAILPOET-4196]

[MAILPOET-4196]: https://mailpoet.atlassian.net/browse/MAILPOET-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Steps:
1. Go to MailPoet > Settings > Send With tab
2. Click to configure custom sending method
3. Set to send with own host
4. Click the dropdown and make sure you see `IONOS by 1&1` on the list and that you don't see `1&1`.