### PR TITLE
Inline Security::generateToken for clarity [MAILPOET-2030]

### DIFF
--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -7,7 +7,6 @@ use MailPoet\Config\Renderer as TemplateRenderer;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\SubscriberSubscribeController;
-use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 
 class DisplayFormInWPContent {
@@ -188,7 +187,7 @@ class DisplayFormInWPContent {
     }
 
     // generate security token
-    $templateData['token'] = Security::generateToken();
+    $templateData['token'] = $this->wp->wpCreateNonce('mailpoet_token');
 
     // add API version
     $templateData['api_version'] = API::CURRENT_VERSION;

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\FormEntity;
 use MailPoet\Form\Renderer as FormRenderer;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 
 // phpcs:disable Generic.Files.InlineHTML
@@ -249,7 +248,7 @@ class Widget extends \WP_Widget {
       );
 
       // generate security token
-      $data['token'] = Security::generateToken();
+      $data['token'] = $this->wp->wpCreateNonce('mailpoet_token');
 
       // add API version
       $data['api_version'] = API::CURRENT_VERSION;

--- a/mailpoet/lib/Util/Security.php
+++ b/mailpoet/lib/Util/Security.php
@@ -7,7 +7,6 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\WP\Functions as WPFunctions;
 
 class Security {
   const HASH_LENGTH = 12;
@@ -25,10 +24,6 @@ class Security {
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->subscribersRepository = $subscribersRepository;
-  }
-
-  public static function generateToken($action = 'mailpoet_token') {
-    return WPFunctions::get()->wpCreateNonce($action);
   }
 
   /**

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -73,11 +73,15 @@ class APITest extends \MailPoetTest {
         expect($api instanceof JSONAPI)->true();
       }
     );
+    $wpStub = Stub::make(new WPFunctions, [
+      'wpVerifyNonce' => asCallable(function() {
+        return true;
+      })]);
     $api = Stub::makeEmptyExcept(
       $this->api,
       'setupAjax',
       [
-        'wp' => new WPFunctions,
+        'wp' => $wpStub,
         'processRoute' => Stub::makeEmpty(new SuccessResponse),
         'settings' => $this->container->get(SettingsController::class),
       ]

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -14,7 +14,6 @@ use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscription\Form;
-use MailPoet\Util\Security;
 use MailPoet\Util\Url as UrlHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Idiorm\ORM;
@@ -62,7 +61,7 @@ class FormTest extends \MailPoetTest {
         'form_id' => $this->form->getId(),
         $obfuscatedEmail => $this->testEmail,
       ],
-      'token' => Security::generateToken(),
+      'token' => WPFunctions::get()->wpCreateNonce('mailpoet_token'),
       'api_version' => 'v1',
       'endpoint' => 'subscribers',
       'mailpoet_method' => 'subscribe',


### PR DESCRIPTION
This is a refactor to inline `Security::genreateToken`. The only thing Security::generateToken was providing was a default value for the $action, which created a pattern of using the same $action everywhere, which may not be the best way to go. It was obfuscating what we were really doing under the hood.

This is a followup to #4025, which we decided wouldn't make sense to implement.

[MAILPOET-2030]: https://mailpoet.atlassian.net/browse/MAILPOET-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
