### PR TITLE
Add subscriber counts to MixPanel [MAILPOET-4204]

### DIFF
--- a/mailpoet/lib/Listing/ListingDefinition.php
+++ b/mailpoet/lib/Listing/ListingDefinition.php
@@ -32,13 +32,13 @@ class ListingDefinition {
 
   public function __construct(
     string $group = null,
-    array $filters,
+    array $filters = [],
     string $search = null,
-    array $parameters,
-    string $sortBy,
-    string $sortOrder,
-    int $offset,
-    int $limit,
+    array $parameters = [],
+    string $sortBy = 'created_at',
+    string $sortOrder = 'desc',
+    int $offset = 0,
+    int $limit = 20,
     array $selection = []
   ) {
     $this->group = $group;


### PR DESCRIPTION
Fixes [MAILPOET-4204]

This PR adds the subscriber counts to our MixPanel data. Example: 
![image](https://user-images.githubusercontent.com/6458412/160343736-18af7d88-51c0-40dc-bb22-f81df8903d70.png)

It utilizes the SubscriberListingRepository and therefore uses the same data source, the JSON API uses to display those data for the user.

The PR extends the constructor of the ListingDefintion by assigning some default values. The values chosen are the ones, which are used when visiting the Subscriber Listing page and not changing any value.

[MAILPOET-4204]: https://mailpoet.atlassian.net/browse/MAILPOET-4204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ