### PR TITLE
Fix critical error in woo checkout block [MAILPOET-4206]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             ./do download:woo-commerce-zip 6.2.0
             ./do download:woo-commerce-subscriptions-zip 3.0.14
             ./do download:woo-commerce-memberships-zip 1.22.9
-            ./do download:woo-commerce-blocks-zip 6.9.0
+            ./do download:woo-commerce-blocks-zip 7.2.1
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -50,7 +50,7 @@ class WooCommerceBlocksIntegration {
       [$this, 'registerCheckoutFrontendBlocks']
     );
     $this->wp->addAction(
-      'woocommerce_blocks_checkout_update_order_from_request',
+      '__experimental_woocommerce_blocks_checkout_update_order_from_request',
       [$this, 'processCheckoutBlockOptin'],
       10,
       2


### PR DESCRIPTION
Fixes [MAILPOET-4206]

The `woocommerce_blocks_checkout_update_order_from_request` hook is deprecated, but the implementation of the deprecation contains a bug (see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6133). We can not jump to the latest iteration of the hook as we want to stay compatible for a while with older plugin versions of the Woo blocks plugin.

This PR falls back to the `__experimental_woocommerce_blocks_checkout_update_order_from_request` hook, which allows us to quickly circle around this issue for now until we can safely upgrade the hook.

[MAILPOET-4206]: https://mailpoet.atlassian.net/browse/MAILPOET-4206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ