### PR TITLE
Fix doctrine metadata loading errors [MAILPOET-4218]

### DIFF
--- a/mailpoet/lib/Doctrine/CacheOnlyMappingDriver.php
+++ b/mailpoet/lib/Doctrine/CacheOnlyMappingDriver.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace MailPoet\Doctrine;
+
+use MailPoet\RuntimeException;
+use MailPoetVendor\Doctrine\Persistence\Mapping\ClassMetadata;
+use MailPoetVendor\Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use MailPoetVendor\Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Intended to be used in production environment where we rely on metadata cache for reading all metadata.
+ */
+class CacheOnlyMappingDriver implements MappingDriver {
+  /** @var string */
+  protected $cacheSalt = '__CLASSMETADATA__';
+
+  /** @var CacheItemPoolInterface */
+  private $metaDataCache;
+
+  public function __construct(
+    CacheItemPoolInterface $metaDataCache
+  ) {
+    $this->metaDataCache = $metaDataCache;
+  }
+
+  /**
+   * @inerhitDoc
+   */
+  public function loadMetadataForClass($className, ClassMetadata $metadata) {
+    // We don't need to load anything it is all cached.
+  }
+
+  /**
+   * @inerhitDoc
+   */
+  public function getAllClassNames() {
+    throw new RuntimeException('CacheOnlyMappingDriver::getAllClassNames should not be called');
+  }
+
+  /**
+   * @inerhitDoc
+   */
+  public function isTransient($className) {
+    // Everything in cache are metadata and class with metadata is non-transient
+    // See https://github.com/doctrine/persistence/blob/b07e347a24e7a19a2b6462e00a6dff899e4c2dd2/src/Persistence/Mapping/Driver/MappingDriver.php#L34
+    return !$this->metaDataCache->hasItem($this->getCacheKey($className));
+  }
+
+  /**
+   * Copy pasted from MailPoetVendor\Doctrine\Persistence\Mapping\AbstractClassMetadataFactory
+   */
+  protected function getCacheKey(string $className) : string {
+    return str_replace('\\', '__', $className) . $this->cacheSalt;
+  }
+}

--- a/mailpoet/prefixer/composer.json
+++ b/mailpoet/prefixer/composer.json
@@ -2,9 +2,9 @@
   "require": {
     "php": ">=7.2",
     "cerdic/css-tidy": "2.0.1",
-    "doctrine/common": "3.2.1",
-    "doctrine/dbal": "2.13.6",
-    "doctrine/orm": "2.10.4",
+    "doctrine/common": "3.2.2",
+    "doctrine/dbal": "2.13.8",
+    "doctrine/orm": "2.11.2",
     "gregwar/captcha": "^1.1",
     "monolog/monolog": "2.4.0",
     "nesbot/carbon": "2.57.0",

--- a/mailpoet/prefixer/composer.lock
+++ b/mailpoet/prefixer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de406e855d4a9b4ce21b8a4dc00cb515",
+    "content-hash": "4a63526f1fe710225fa976bbbbd0a4bb",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -54,79 +54,6 @@
                 "source": "https://github.com/Cerdic/CSSTidy/tree/v2.0.1"
             },
             "time": "2022-02-21T15:33:09+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T14:14:24+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -298,16 +225,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "e927fc2410c8723d053b8032e591cdff76587cdb"
+                "reference": "295082d3750987065912816a9d536c2df735f637"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/e927fc2410c8723d053b8032e591cdff76587cdb",
-                "reference": "e927fc2410c8723d053b8032e591cdff76587cdb",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/295082d3750987065912816a9d536c2df735f637",
+                "reference": "295082d3750987065912816a9d536c2df735f637",
                 "shasum": ""
             },
             "require": {
@@ -316,7 +243,7 @@
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "^1.2.0",
+                "phpstan/phpstan": "^1.4.1",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
                 "squizlabs/php_codesniffer": "^3.0",
@@ -368,7 +295,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/3.2.1"
+                "source": "https://github.com/doctrine/common/tree/3.2.2"
             },
             "funding": [
                 {
@@ -384,20 +311,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-26T22:39:45+00:00"
+            "time": "2022-02-02T09:15:57+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.6",
+            "version": "2.13.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "67ef6d0327ccbab1202b39e0222977a47ed3ef2f"
+                "reference": "dc9b3c3c8592c935a6e590441f9abc0f9eba335b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/67ef6d0327ccbab1202b39e0222977a47ed3ef2f",
-                "reference": "67ef6d0327ccbab1202b39e0222977a47ed3ef2f",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/dc9b3c3c8592c935a6e590441f9abc0f9eba335b",
+                "reference": "dc9b3c3c8592c935a6e590441f9abc0f9eba335b",
                 "shasum": ""
             },
             "require": {
@@ -410,13 +337,13 @@
             "require-dev": {
                 "doctrine/coding-standard": "9.0.0",
                 "jetbrains/phpstorm-stubs": "2021.1",
-                "phpstan/phpstan": "1.2.0",
-                "phpunit/phpunit": "^7.5.20|^8.5|9.5.10",
+                "phpstan/phpstan": "1.4.6",
+                "phpunit/phpunit": "^7.5.20|^8.5|9.5.16",
                 "psalm/plugin-phpunit": "0.16.1",
-                "squizlabs/php_codesniffer": "3.6.1",
+                "squizlabs/php_codesniffer": "3.6.2",
                 "symfony/cache": "^4.4",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "4.13.0"
+                "vimeo/psalm": "4.22.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -477,7 +404,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.6"
+                "source": "https://github.com/doctrine/dbal/tree/2.13.8"
             },
             "funding": [
                 {
@@ -493,7 +420,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-26T20:11:05+00:00"
+            "time": "2022-03-09T15:25:46+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -871,24 +798,24 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.10.4",
+            "version": "2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "cccb2e2fdfed2969afb3d65c5ea82bafdefbe1a7"
+                "reference": "9c351e044478135aec1755e2c0c0493a4b6309db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/cccb2e2fdfed2969afb3d65c5ea82bafdefbe1a7",
-                "reference": "cccb2e2fdfed2969afb3d65c5ea82bafdefbe1a7",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/9c351e044478135aec1755e2c0c0493a4b6309db",
+                "reference": "9c351e044478135aec1755e2c0c0493a4b6309db",
                 "shasum": ""
             },
             "require": {
-                "composer/package-versions-deprecated": "^1.8",
+                "composer-runtime-api": "^2",
                 "doctrine/cache": "^1.12.1 || ^2.1.1",
                 "doctrine/collections": "^1.5",
                 "doctrine/common": "^3.0.3",
-                "doctrine/dbal": "^2.13.1 || ^3.1.1",
+                "doctrine/dbal": "^2.13.1 || ^3.2",
                 "doctrine/deprecations": "^0.5.3",
                 "doctrine/event-manager": "^1.1",
                 "doctrine/inflector": "^1.4 || ^2.0",
@@ -896,8 +823,7 @@
                 "doctrine/lexer": "^1.0",
                 "doctrine/persistence": "^2.2",
                 "ext-ctype": "*",
-                "ext-pdo": "*",
-                "php": "^7.1 ||^8.0",
+                "php": "^7.1 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3",
                 "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
                 "symfony/polyfill-php72": "^1.23",
@@ -910,12 +836,12 @@
                 "doctrine/annotations": "^1.13",
                 "doctrine/coding-standard": "^9.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "1.2.0",
+                "phpstan/phpstan": "1.4.6",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
                 "squizlabs/php_codesniffer": "3.6.2",
-                "symfony/cache": "^4.4 || ^5.2",
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.15.0"
+                "vimeo/psalm": "4.22.0"
             },
             "suggest": {
                 "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",
@@ -964,9 +890,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.10.4"
+                "source": "https://github.com/doctrine/orm/tree/2.11.2"
             },
-            "time": "2021-12-20T21:23:47+00:00"
+            "time": "2022-03-09T15:23:58+00:00"
         },
         {
             "name": "doctrine/persistence",

--- a/mailpoet/prefixer/fix-doctrine.php
+++ b/mailpoet/prefixer/fix-doctrine.php
@@ -25,9 +25,27 @@ $php7CachedItem = file_get_contents(__DIR__ . "/../vendor-prefixed/doctrine/cach
 $php7CachedItem = str_replace('final class CacheItem', 'final class TypedCacheItem', $php7CachedItem);
 file_put_contents(__DIR__ . "/../vendor-prefixed/doctrine/cache/lib/Doctrine/Common/Cache/Psr6/TypedCacheItem.php", $php7CachedItem);
 
+// Replace PHP8 syntax in ReflectionReadonlyProperty.
+// The class is used only in PHP8.1 but it fail to pass pre-commit checks in the plugin repository
+// See https://github.com/doctrine/orm/commit/580b9196e65adaacc05b9f7a50654739ad995597#diff-732e324167dd49e48b221477c3e0f6d7934f3eb5ec0970dbf1c06f6c7df15398R3790-R3793
+$readonlyProxy = file_get_contents(__DIR__ . "/../vendor-prefixed/doctrine/orm/lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php");
+$readonlyProxy = str_replace(
+  [
+    'public function __construct(private ReflectionProperty $wrappedProperty)',
+    'parent::__construct($wrappedProperty->class, $wrappedProperty->name);',
+  ],
+  [
+    "/** @var ReflectionProperty */\n    private \$wrappedProperty;\n\n    public function __construct(ReflectionProperty \$wrappedProperty)",
+    "\$this->wrappedProperty = \$wrappedProperty;\n    parent::__construct(\$wrappedProperty->class, \$wrappedProperty->name);",
+  ],
+  $readonlyProxy
+);
+file_put_contents(__DIR__ . "/../vendor-prefixed/doctrine/orm/lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php", $readonlyProxy);
+
+
 // cleanup file types by extension
 exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name '*.xsd' -delete");
-exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name 'phpstan.neon' -delete");
+exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name 'phpstan*.neon' -delete");
 exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name 'build.xml' -delete");
 exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name 'psalm.xml' -delete");
 exec('find ' . __DIR__ . "/../vendor-prefixed/doctrine -type f -name 'build.properties' -delete");

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -149,6 +149,11 @@ if [[ $CIRCLE_JOB == *"_with_premium_"* ]]; then
 fi
 
 cd /wp-core/wp-content/plugins/mailpoet
+# Remove Doctrine Annotations (no need since generated metadata are packed)
+if [[ $CIRCLE_JOB ]]; then
+  rm -rf ./vendor-prefixed/doctrine/annotations
+  ./tools/vendor/composer.phar dump-autoload
+fi
 
 /project/vendor/bin/codecept run acceptance $@
 exitcode=$?


### PR DESCRIPTION
This PR updates doctrine packages (after [the original update commit was reverted due to issues](https://github.com/mailpoet/mailpoet/pull/4042)) and fixes the issues.

In the production environment, we used to rely on Metadata MappingDriver not being used at all when all metadata are cached. The recent changes in `doctrine/orm` revealed that it is not the case and the driver is used in a [couple](https://github.com/doctrine/persistence/blob/b07e347a24e7a19a2b6462e00a6dff899e4c2dd2/src/Persistence/Mapping/AbstractClassMetadataFactory.php#L478) [of](https://github.com/doctrine/persistence/blob/b07e347a24e7a19a2b6462e00a6dff899e4c2dd2/src/Persistence/Mapping/AbstractClassMetadataFactory.php#L336) places regardless there is some cache. 

We were a bit lucky that we hadn't run into these issues earlier. We used to use [PHPDriver](https://github.com/mailpoet/mailpoet/blob/2668af08b7cbe37fb9fb528bae03c3468ebaf1af/mailpoet/lib/Doctrine/ConfigurationFactory.php#L47-L48) and it accitentally returned correct values that worked, but after [a change in doctrine/orm](https://github.com/doctrine/orm/pull/8285) the PHPDriver was no longer ok for all use-cases.

## Testing
It was causing a couple of issues, so please make sure that:
1) Admin is able to edit an existing newsletter and create a new one using a template
2) Admin is able to set a list to a subscriber (while editing a subscriber)
3) Customer is able to subscribe through MailPoet's form in the Anonymous/Private window

 [MAILPOET-4218]

[MAILPOET-4218]: https://mailpoet.atlassian.net/browse/MAILPOET-4218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ