### PR TITLE
Update Readme.txt to include information on 3rd party

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -145,6 +145,20 @@ We welcome experienced translators to translate directly on [our Transifex proje
 
 Have a question for us? Reach us at security@ our domain, or report security issues to our [Bug Bounty program](https://hackerone.com/automattic).
 
+= Use of 3rd Party Services =
+
+To improve user experience, MailPoet may use the following 3rd party libraries if the _Load 3rd-party libraries_ setting is enabled:
+
+* Google Fonts - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts)
+
+* HelpScout - used to show help tooltips throughout the plugin, easily access documentation, and contact our customer support team. This functionality may load scripts from [https://beacon-v2.helpscout.net/](https://beacon-v2.helpscout.net/)
+
+* Mixpanel - used to send data about the usage of the MailPoet plugin when you [agree with sharing usage data with us](https://kb.mailpoet.com/article/130-sharing-your-data-with-us)
+
+* Satismeter - used to ask for feedback.
+
+Loading all these libraries is disabled by default. The option can be enabled in the _MailPoet's Settings > Advanced > Load 3rd-party libraries_.
+
 == Frequently Asked Questions ==
 
 = Does MailPoet store the data of the user's subscribers? =


### PR DESCRIPTION
This PR adds information to the file Readme.txt about the use of 3rd party services in the plugin. This change was requested by the WP.org plugin team.

Compared to the original text in the Jira ticket, I have capitalized the title and modified the periods on the list to be consistent with the other lists' punctuation.

[MAILPOET-4229]

[MAILPOET-4229]: https://mailpoet.atlassian.net/browse/MAILPOET-4229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ