### PR TITLE
Update release:publish to use mailpoet.pot file from CircleCI [MAILPOET-4173]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -111,12 +111,12 @@ class RoboFile extends \Robo\Tasks {
       )->run();
   }
 
-  public function translationsGetPotFileFromCircleCI() {
+  public function translationsGetPotFileFromBuild() {
     $potFilePathInsideZip = 'mailpoet/lang/mailpoet.pot';
     $potFilePath = 'lang/mailpoet.pot';
 
     if (!is_file(self::ZIP_BUILD_PATH)) {
-      $this->yell('mailpoet.zip file is missing. You must first download it from CircleCI using `./do release:download-zip`.', 40, 'red');
+      $this->yell('mailpoet.zip file is missing. You must first download it using `./do release:download-zip`.', 40, 'red');
       exit(1);
     }
 
@@ -850,7 +850,7 @@ class RoboFile extends \Robo\Tasks {
         return $this->releaseDownloadZip();
       })
       ->addCode(function () {
-        return $this->translationsGetPotFileFromCircleCI();
+        return $this->translationsGetPotFileFromBuild();
       })
       ->addCode(function () {
         return $this->translationsPush();

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -120,7 +120,7 @@ class RoboFile extends \Robo\Tasks {
       exit(1);
     }
 
-    if (!is_file('mailpoet/lang')) {
+    if (!file_exists(__DIR__ . '/lang')) {
       $this->taskExec('mkdir -p ' . __DIR__ . '/lang')->run();
     }
 


### PR DESCRIPTION
This PR changes the Robo command release:publish to use the mailpoet.pot file that is present in the zip file in the release branch of the CircleCI build. Before we were using the mailpoet.pot file present in the local repository, which meant it could contain undesired local changes that should not be included when creating a new MailPoet release.

A new Robo command was created to get the zip file from CircleCI called translations:get-pot-file-from-circle-ci. The old translations:build was preserved as it is used inside mailpoet/build.sh.

To test the changes here, I suggest commenting out all the commands that are called inside \RoboFile::releasePublish() after \RoboFile::translationsGetPotFileFromCircleCI() and then running `./do release:publish`. You can try the `release:publish` command before and after running `./do release:download-zip`. I'm not sure if there is a way to test the full `release:publish` command without actually creating a release. It would be nice to have a way to do that.

[MAILPOET-4173]

[MAILPOET-4173]: https://mailpoet.atlassian.net/browse/MAILPOET-4173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ