### PR TITLE
Mailpoet 3992 to show a specific error message for pending approval users

### DIFF
--- a/mailpoet/assets/js/src/listing/notices.jsx
+++ b/mailpoet/assets/js/src/listing/notices.jsx
@@ -76,6 +76,16 @@ function MailerError(props) {
     () => <br key={`br-${brKey++}`} /> // eslint-disable-line no-plusplus
   );
 
+  if (props.mta_log.error.operation === 'pending_approval') {
+    return (
+      <div className="mailpoet_notice notice notice-error">
+        <p>
+          { message }
+        </p>
+      </div>
+    );
+  }
+
   if (props.mta_log.error.operation === 'insufficient_privileges') {
     return (
       <div className="mailpoet_notice notice notice-error">

--- a/mailpoet/lib/Mailer/MailerError.php
+++ b/mailpoet/lib/Mailer/MailerError.php
@@ -10,6 +10,7 @@ class MailerError {
   const OPERATION_AUTHORIZATION = 'authorization';
   const OPERATION_INSUFFICIENT_PRIVILEGES = 'insufficient_privileges';
   const OPERATION_EMAIL_LIMIT_REACHED = 'email_limit_reached';
+  const OPERATION_PENDING_APPROVAL = 'pending_approval';
 
   const LEVEL_HARD = 'hard';
   const LEVEL_SOFT = 'soft';
@@ -18,6 +19,7 @@ class MailerError {
   const MESSAGE_EMAIL_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges';
   const MESSAGE_EMAIL_NOT_AUTHORIZED = 'The email address is not authorized';
   const MESSAGE_EMAIL_VOLUME_LIMIT_REACHED = 'Email volume limit reached';
+  const MESSAGE_PENDING_APPROVAL = 'Key is valid, but not approved yet; you can send only to authorized email addresses at the moment';
 
   /** @var string */
   private $operation;

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -196,10 +196,32 @@ class MailPoetMapper {
     return "{$message}<br/>";
   }
 
+  private function getPendingApprovalMessage(): string {
+    $message = __("Your subscription is currently [link]pending approval[/link].You’ll soon be able to send once our team reviews your account. In the meantime, you can send previews to your authorized emails.", 'mailpoet');
+    $message = Helpers::replaceLinkTags(
+      $message,
+      'https://kb.mailpoet.com/article/350-pending-approval-subscription',
+      [
+        'target' => '_blank',
+        'rel' => 'noopener noreferrer',
+        'data-beacon-article' => '5fbd3942cff47e00160bd248',
+      ],
+      'link'
+    );
+
+    return "{$message}<br/>";
+  }
+
   /**
- * Returns error $message and $operation for API::RESPONSE_CODE_CAN_NOT_SEND
- */
-  private function getCanNotSendError(array $result, array $sender): array {
+   * Returns error $message and $operation for API::RESPONSE_CODE_CAN_NOT_SEND
+   */
+  private function getCanNotSendError(array $result, $sender): array {
+    if ($result['message'] === MailerError::MESSAGE_PENDING_APPROVAL) {
+      $operation = MailerError::OPERATION_PENDING_APPROVAL;
+      $message = $this->getPendingApprovalMessage();
+      return [$operation, $message];
+    }
+
     if ($result['message'] === MailerError::MESSAGE_EMAIL_INSUFFICIENT_PRIVILEGES) {
       $operation = MailerError::OPERATION_INSUFFICIENT_PRIVILEGES;
       $message = $this->getInsufficientPrivilegesMessage();

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -205,8 +205,7 @@ class MailPoetMapper {
         'target' => '_blank',
         'rel' => 'noopener noreferrer',
         'data-beacon-article' => '5fbd3942cff47e00160bd248',
-      ],
-      'link'
+      ]
     );
 
     return "{$message}<br/>";

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -12,9 +12,14 @@ class Helpers {
     return json_last_error() == JSON_ERROR_NONE;
   }
 
-  public static function replaceLinkTags($source, $link = false, $attributes = [], $linkTag = false) {
-    if (!$link) return $source;
-    $linkTag = ($linkTag) ? $linkTag : self::LINK_TAG;
+  public static function replaceLinkTags(
+    string $source,
+    string $link,
+    array $attributes = [],
+    string $linkTag = self::LINK_TAG
+  ) {
+    if (empty($link)) return $source;
+
     $attributes = array_map(function($key) use ($attributes) {
       return sprintf('%s="%s"', $key, $attributes[$key]);
     }, array_keys($attributes));

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -169,4 +169,19 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     expect($error->getLevel())->equals(MailerError::LEVEL_HARD);
     expect($error->getMessage())->equals('Error while sending. Invalid MSS response format.');
   }
+
+  public function testGetPendingApprovalMessage() {
+    $apiResult = [
+      'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
+      'status' => API::SENDING_STATUS_SEND_ERROR,
+      'message' => MailerError::MESSAGE_PENDING_APPROVAL,
+    ];
+    $error = $this->mapper->getErrorForResult($apiResult, $this->subscribers);
+    expect($error)->isInstanceOf(MailerError::class);
+    expect($error->getOperation())->equals(MailerError::OPERATION_PENDING_APPROVAL);
+    expect($error->getLevel())->equals(MailerError::LEVEL_HARD);
+    expect($error->getMessage())->stringContainsString('pending approval');
+    expect($error->getMessage())->stringContainsString("You’ll soon be able to send once our team reviews your account.");
+  }
+
 }


### PR DESCRIPTION
This PR adds a separate message to the Emails listing page ( see attachment ) if the user's account is pending approval.

### To test:
1. Make sure you have MSS as sending method at `MailPoet` > `Settings` > `Send With` tab
2. Now go to `Plugins` > `Plugin File Editor` and make sure you see `MailPoet 3 (New)` as selected plugin.
Now locate the file [API.php](https://github.com/mailpoet/mailpoet/blob/9b71a7804cd7d3c8724c9ac877cc62def4d3a697/mailpoet/lib/Services/Bridge/API.php) under `Plugin Files` on the right sidebar, it should be under `lib` > `Services` > `Bridge` > `API.php` and add the following code into the beginning of the method [sendMessages](https://github.com/mailpoet/mailpoet/blob/9b71a7804cd7d3c8724c9ac877cc62def4d3a697/mailpoet/lib/Services/Bridge/API.php#L103) (exactly under "public function sendMessages($messageBody) {") Save it and continue the step 3.
```
    return [
      'status' => self::SENDING_STATUS_SEND_ERROR,
      'message' => MailerError::OPERATION_PENDING_APPROVAL,
      'code' => 403,
    ];
```
3. Tyy to send a newsletter and verify you see the notice in attachment on the listing page

![Screenshot on 2022-04-06 at 16-14-59](https://user-images.githubusercontent.com/789421/161995596-76d8b917-dafb-416e-ab12-5145bcb6e95c.png)

NOTE: Please revert the changes in API.php by removing the code that you added just for this test, and save it.

[MAILPOET-3992]

[MAILPOET-3992]: https://mailpoet.atlassian.net/browse/MAILPOET-3992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ