### PR TITLE
Disable segments validation when form ID is empty [MAILPOET-4155]

### DIFF
--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -47,11 +47,12 @@ class BlockRendererHelper {
       }, $errorMessages)) . ']';
     }
 
-    if ($blockId === 'segments') {
+    // Segments should be required only when form ID is not empty. That allows save form on subscription management site when any segment is not checked.
+    if ($blockId === 'segments' && $formId) {
       $rules['required'] = true;
       $rules['mincheck'] = 1;
       $rules['group'] = $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
+      $rules['errors-container'] = '.mailpoet_error_' . $blockId . '_' . $formId;
       $rules['required-message'] = __('Please select a list.', 'mailpoet');
     }
 

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -27,8 +27,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     expect($form)->stringContainsString('<input type="hidden" name="data[email]" value="subscriber@test.com" />');
     expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
-    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="1" checked="checked" data-parsley-required="true" data-parsley-group="segments" data-parsley-errors-container="\.mailpoet_error_segments" data-parsley-required-message="Please select a list." \/> Test segment/');
-    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="1" checked="checked" data-parsley-required="true" data-parsley-group="segments" data-parsley-errors-container="\.mailpoet_error_segments" data-parsley-required-message="Please select a list." \/> Test segment/');
+    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="1" checked="checked"  \/> Test segment/');
     expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  \/>/');
     expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  \/>/');
 


### PR DESCRIPTION
[MAILPOET-4155]

[MAILPOET-4155]: https://mailpoet.atlassian.net/browse/MAILPOET-4155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test:
1. Make a form with the block List Selection
2. Add a few lists to be selected within
3. Subscribe to the form on the front-end and select all available lists
4. Confirm the subscription
5. Send a newsletter and make sure that the email used in step 3 has received the newsletter
6. When you receive the newsletter, click on Manage Subscription link
7. Uncheck all lists and save changes
8. Go to MailPoet > Subscribers and edit the user with email used in step 3
9. Make sure you see all lists unchecked
10. Check the list that has Welcome email set and save the changes (make sure you have received the Welcome email after saving)