### PR TITLE
Add logging of failed mss and premium key validations on API [MAILPOET-4051]

### DIFF
--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -60,6 +60,7 @@ class API {
         $body = json_decode($this->wp->wpRemoteRetrieveBody($result), true);
         break;
       default:
+        $this->logKeyCheckError((int)$code, 'mss');
         $body = null;
         break;
     }
@@ -82,6 +83,7 @@ class API {
         }
         break;
       default:
+        $this->logKeyCheckError((int)$code, 'premium');
         $body = null;
         break;
     }
@@ -206,5 +208,14 @@ class API {
       'curl_info' => $this->curlHandle ? curl_getinfo($this->curlHandle) : 'n/a',
     ];
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_MSS)->error('requests-curl.failed', $logData);
+  }
+
+  private function logKeyCheckError(int $code, string $keyType): void {
+    $logData = [
+      'http_code' => $code,
+      'home_url' => $this->wp->homeUrl(),
+      'key_type' => $keyType,
+    ];
+    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_MSS)->error('key-validation.failed', $logData);
   }
 }

--- a/mailpoet/tests/integration/Services/BridgeApiTest.php
+++ b/mailpoet/tests/integration/Services/BridgeApiTest.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace MailPoet\Services\Bridge;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Logging\LogRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Monolog\Logger;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class BridgeApiTest extends \MailPoetTest {
+
+  /** @var API */
+  private $api;
+
+  /** @var WPFunctions & MockObject */
+  private $wpMock;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  public function _before() {
+    parent::_before();
+    $this->wpMock = $this->createMock(WPFunctions::class);
+    $this->api = new API('test-api-key', $this->wpMock);
+    $this->logRepository = $this->diContainer->get(LogRepository::class);
+    $this->cleanUp();
+  }
+
+  public function testItDoesntLogsWhenPremiumKeyCheckPass() {
+    $this->wpMock
+      ->expects($this->once())
+      ->method('wpRemoteRetrieveResponseCode')
+      ->willReturn(200);
+    $this->wpMock
+      ->expects($this->once())
+      ->method('wpRemoteRetrieveBody')
+      ->willReturn('');
+    $this->api->checkPremiumKey();
+    $logs = $this->logRepository->findAll();
+    expect($logs)->count(0);
+  }
+
+  public function testItLogsWhenPremiumKeyCheckFails() {
+    $this->wpMock
+      ->expects($this->once())
+      ->method('wpRemoteRetrieveResponseCode')
+      ->willReturn(401);
+    $this->wpMock
+      ->expects($this->once())
+      ->method('homeUrl')
+      ->willReturn('www.home-example.com');
+    $this->api->checkPremiumKey();
+    $logs = $this->logRepository->findAll();
+    expect($logs)->count(1);
+    $errorLog = $logs[0];
+    $this->assertInstanceOf(LogEntity::class, $errorLog);
+    expect($errorLog->getLevel())->equals(Logger::ERROR);
+    expect($errorLog->getMessage())->stringContainsString('www.home-example.com');
+    expect($errorLog->getMessage())->stringContainsString('key-validation.failed');
+    expect($errorLog->getMessage())->stringContainsString('"key_type":"premium"');
+  }
+
+  public function testItDoesntLogsWhenMssKeyCheckPass() {
+    $this->wpMock
+      ->expects($this->once())
+      ->method('wpRemoteRetrieveResponseCode')
+      ->willReturn(200);
+    $this->wpMock
+      ->expects($this->once())
+      ->method('wpRemoteRetrieveBody')
+      ->willReturn('');
+    $this->api->checkMSSKey();
+    $logs = $this->logRepository->findAll();
+    expect($logs)->count(0);
+  }
+
+  public function testItLogsWhenMssKeyCheckFails() {
+    $this->wpMock
+      ->expects($this->once())
+      ->method('wpRemoteRetrieveResponseCode')
+      ->willReturn(401);
+    $this->wpMock
+      ->expects($this->once())
+      ->method('homeUrl')
+      ->willReturn('www.home-example.com');
+    $this->api->checkMSSKey();
+    $logs = $this->logRepository->findAll();
+    expect($logs)->count(1);
+    $errorLog = $logs[0];
+    $this->assertInstanceOf(LogEntity::class, $errorLog);
+    expect($errorLog->getLevel())->equals(Logger::ERROR);
+    expect($errorLog->getMessage())->stringContainsString('www.home-example.com');
+    expect($errorLog->getMessage())->stringContainsString('key-validation.failed');
+    expect($errorLog->getMessage())->stringContainsString('"key_type":"mss"');
+  }
+
+  private function cleanUp() {
+    $this->truncateEntity(LogEntity::class);
+  }
+}


### PR DESCRIPTION
# Testing instructions

1. Go to MailPoet > Settings > Key Activation tab
2. Enter an invalid Key (anything really)
3. Go to `/wp-admin/admin.php?page=mailpoet-logs` and look for logs with `mss.ERROR: key-validation.failed`
4. Verify they contain `"home_url":"https://gs.qawp.net",` info

[MAILPOET-4051]

[MAILPOET-4051]: https://mailpoet.atlassian.net/browse/MAILPOET-4051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ