### PR TITLE
Alter CookieCest test for multisite [MAILPOET-4060]

### DIFF
--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -109,7 +109,14 @@ class Registration {
       $segmentIds
     );
 
-    // start subscriber tracking (by email, we don't have WP user ID yet)
-    $this->subscriberHandler->identifyByEmail($email);
+
+    /**
+     * On multisite headers are already sent at this point, tracking will start
+     * once the user has activated his account at a later stage.
+     **/
+    if (!headers_sent()) {
+      // start subscriber tracking (by email, we don't have WP user ID yet)
+      $this->subscriberHandler->identifyByEmail($email);
+    }
   }
 }

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -38,11 +38,17 @@ class SubscriberCookieCest {
       $i->checkOption('#mailpoet_subscribe_on_register');
       $i->click('Next');
       $i->waitForText('mutestuser is your new username');
-    }
 
-    // temporarily bypass the test when MULTISITE=1 as it fails in multisite mode ATM
-    if (getenv('MULTISITE')) {
-      return;
+      /**
+       * The tracking cookie will be set once the registrant has activated
+       * the wp_user account
+       **/
+      $i->amOnMailboxAppPage();
+      $i->waitForElement('.subject.unread', 10);
+      $i->click(Locator::contains('span.subject.unread', 'Activate'));
+      $i->switchToIframe('#preview-html');
+      $i->click(Locator::contains('a', 'wp-activate.php'));
+      $i->waitForText('Your account is now active');
     }
 
     // subscriber cookie should be set right after signup


### PR DESCRIPTION
Fixes [MAILPOET-4060]

In a multisite, the tracking cookie is not set when you sign up to the site and you checked the newsletter checkbox. The problem is that at that point in the process the headers are already sent, so we can not send the Cookie from the server:
![image](https://user-images.githubusercontent.com/6458412/162441502-64629d05-8266-4d59-acbe-1bebfe770156.png)

This PR alters the test and checks for the cookie once the user follows the link to wp-activate.php (at which point, the cookie will be set) and prevents the attempt to set a cookie.



[MAILPOET-4060]: https://mailpoet.atlassian.net/browse/MAILPOET-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ