### PR TITLE
Revert "Revert "Process arguments better when querying posts for automated latest content [MAILPOET-4082]""

### DIFF
--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -3,6 +3,7 @@
 namespace MailPoet\API\JSON\v1;
 
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
+use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\Config\AccessControl;
 use MailPoet\Newsletter\AutomatedLatestContent as ALC;
 use MailPoet\Newsletter\BlockPostQuery;
@@ -77,29 +78,28 @@ class AutomatedLatestContent extends APIEndpoint {
   }
 
   /**
-   * @param \WP_Post[] $posts
-   * @return \WP_Post[]
+   * Fetches posts for Posts static block
    */
-  private function getPermittedPosts($posts) {
-    return array_filter($posts, function ($post) {
-      return $this->permissionHelper->checkReadPermission($post);
-    });
-  }
-
-  public function getPosts($data = []) {
+  public function getPosts(array $data = []): SuccessResponse {
     return $this->successResponse(
-      $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery(['args' => $data])))
+      $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery(['args' => $data, 'dynamic' => false])))
     );
   }
 
-  public function getTransformedPosts($data = []) {
+  /**
+   * Fetches products for Abandoned Cart Content dynamic block
+   */
+  public function getTransformedPosts(array $data = []): SuccessResponse {
     $posts = $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery(['args' => $data])));
     return $this->successResponse(
       $this->ALC->transformPosts($data, $posts)
     );
   }
 
-  public function getBulkTransformedPosts($data = []) {
+  /**
+   * Fetches different post types for ALC dynamic block
+   */
+  public function getBulkTransformedPosts(array $data = []): SuccessResponse {
     $usedPosts = [];
     $renderedPosts = [];
 
@@ -114,5 +114,15 @@ class AutomatedLatestContent extends APIEndpoint {
     }
 
     return $this->successResponse($renderedPosts);
+  }
+
+  /**
+   * @param \WP_Post[] $posts
+   * @return \WP_Post[]
+   */
+  private function getPermittedPosts($posts) {
+    return array_filter($posts, function ($post) {
+      return $this->permissionHelper->checkReadPermission($post);
+    });
   }
 }

--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -5,6 +5,7 @@ namespace MailPoet\API\JSON\v1;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\Config\AccessControl;
 use MailPoet\Newsletter\AutomatedLatestContent as ALC;
+use MailPoet\Newsletter\BlockPostQuery;
 use MailPoet\Util\APIPermissionHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Posts as WPPosts;
@@ -87,12 +88,12 @@ class AutomatedLatestContent extends APIEndpoint {
 
   public function getPosts($data = []) {
     return $this->successResponse(
-      $this->getPermittedPosts($this->ALC->getPosts($data))
+      $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery(['args' => $data])))
     );
   }
 
   public function getTransformedPosts($data = []) {
-    $posts = $this->getPermittedPosts($this->ALC->getPosts($data));
+    $posts = $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery(['args' => $data])));
     return $this->successResponse(
       $this->ALC->transformPosts($data, $posts)
     );
@@ -103,7 +104,8 @@ class AutomatedLatestContent extends APIEndpoint {
     $renderedPosts = [];
 
     foreach ($data['blocks'] as $block) {
-      $posts = $this->getPermittedPosts($this->ALC->getPosts($block, $usedPosts));
+      $query = new BlockPostQuery(['args' => $block, 'postsToExclude' => $usedPosts]);
+      $posts = $this->getPermittedPosts($this->ALC->getPosts($query));
       $renderedPosts[] = $this->ALC->transformPosts($block, $posts);
 
       foreach ($posts as $post) {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -84,6 +84,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\API\JSON\v1\SubscriberStats::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\WoocommerceSettings::class)->setPublic(true);
+    $container->autowire(\MailPoet\Util\APIPermissionHelper::class)->setPublic(true);
     // API response builders
     $container->autowire(\MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\ResponseBuilders\NewsletterTemplatesResponseBuilder::class);

--- a/mailpoet/lib/Newsletter/AutomatedLatestContent.php
+++ b/mailpoet/lib/Newsletter/AutomatedLatestContent.php
@@ -65,7 +65,7 @@ class AutomatedLatestContent {
       'post_type' => (isset($args['contentType'])) ? $args['contentType'] : 'post',
       'post_status' => (isset($args['postStatus'])) ? $args['postStatus'] : 'publish',
       'orderby' => 'date',
-      'order' => ($args['sortBy'] === 'newest') ? 'DESC' : 'ASC',
+      'order' => isset($args['sortBy']) && in_array($args['sortBy'], ['newest', 'DESC']) ? 'DESC' : 'ASC',
     ];
     if (!empty($args['offset']) && (int)$args['offset'] > 0) {
       $parameters['offset'] = (int)$args['offset'];

--- a/mailpoet/lib/Newsletter/AutomatedLatestContent.php
+++ b/mailpoet/lib/Newsletter/AutomatedLatestContent.php
@@ -2,13 +2,11 @@
 
 namespace MailPoet\Newsletter;
 
-use DateTimeInterface;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\Editor\Transformer;
 use MailPoet\WP\Functions as WPFunctions;
 
 class AutomatedLatestContent {
-  const DEFAULT_POSTS_PER_PAGE = 10;
 
   /** @var LoggerFactory */
   private $loggerFactory;
@@ -47,66 +45,27 @@ class AutomatedLatestContent {
     $query->is_home = false; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
-  public function getPosts($args, $postsToExclude = [], $newsletterId = false, $newerThanTimestamp = false) {
-    $this->newsletterId = $newsletterId;
+  public function getPosts(BlockPostQuery $query) {
+    $this->newsletterId = $query->newsletterId;
     // Get posts as logged out user, so private posts hidden by other plugins (e.g. UAM) are also excluded
     $currentUserId = $this->wp->getCurrentUserId();
     $this->wp->wpSetCurrentUser(0);
 
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
       'loading automated latest content',
-      ['args' => $args, 'posts_to_exclude' => $postsToExclude, 'newsletter_id' => $newsletterId, 'newer_than_timestamp' => $newerThanTimestamp]
+      [
+        'args' => $query->args,
+        'posts_to_exclude' => $query->postsToExclude,
+        'newsletter_id' => $query->newsletterId,
+        'newer_than_timestamp' => $query->newerThanTimestamp,
+      ]
     );
-    $postsPerPage = (!empty($args['amount']) && (int)$args['amount'] > 0)
-      ? (int)$args['amount']
-      : self::DEFAULT_POSTS_PER_PAGE;
-    $parameters = [
-      'posts_per_page' => $postsPerPage,
-      'post_type' => (isset($args['contentType'])) ? $args['contentType'] : 'post',
-      'post_status' => (isset($args['postStatus'])) ? $args['postStatus'] : 'publish',
-      'orderby' => 'date',
-      'order' => isset($args['sortBy']) && in_array($args['sortBy'], ['newest', 'DESC']) ? 'DESC' : 'ASC',
-    ];
-    if (!empty($args['offset']) && (int)$args['offset'] > 0) {
-      $parameters['offset'] = (int)$args['offset'];
-    }
-    if (isset($args['search'])) {
-      $parameters['s'] = $args['search'];
-    }
-    if (isset($args['posts']) && is_array($args['posts'])) {
-      $parameters['post__in'] = $args['posts'];
-      $parameters['posts_per_page'] = -1; // Get all posts with matching IDs
-    }
-    if (!empty($postsToExclude)) {
-      $parameters['post__not_in'] = $postsToExclude;
-    }
-    $parameters['tax_query'] = $this->constructTaxonomiesQuery($args);
-
-    // WP posts with the type attachment have always post_status `inherit`
-    if ($parameters['post_type'] === 'attachment' && $parameters['post_status'] === 'publish') {
-      $parameters['post_status'] = 'inherit';
-    }
-
-    // This enables using posts query filters for get_posts, where by default
-    // it is disabled.
-    // However, it also enables other plugins and themes to hook in and alter
-    // the query.
-    $parameters['suppress_filters'] = false;
-
-    if ($newerThanTimestamp instanceof DateTimeInterface) {
-      $parameters['date_query'] = [
-        [
-          'column' => 'post_date',
-          'after' => $newerThanTimestamp->format('Y-m-d H:i:s'),
-        ],
-      ];
-    }
 
     // set low priority to execute 'ensureConstistentQueryType' before any other filter
     $filterPriority = defined('PHP_INT_MIN') ? constant('PHP_INT_MIN') : ~PHP_INT_MAX;
     $this->wp->addAction('pre_get_posts', [$this, 'ensureConsistentQueryType'], $filterPriority);
-    $this->_attachSentPostsFilter($newsletterId);
-
+    $this->_attachSentPostsFilter($query->newsletterId);
+    $parameters = $query->getQueryParams();
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
       'getting automated latest content',
       ['parameters' => $parameters]
@@ -115,7 +74,7 @@ class AutomatedLatestContent {
     $this->logPosts($posts);
 
     $this->wp->removeAction('pre_get_posts', [$this, 'ensureConsistentQueryType'], $filterPriority);
-    $this->_detachSentPostsFilter($newsletterId);
+    $this->_detachSentPostsFilter($query->newsletterId);
     $this->wp->wpSetCurrentUser($currentUserId);
     return $posts;
   }
@@ -123,43 +82,6 @@ class AutomatedLatestContent {
   public function transformPosts($args, $posts) {
     $transformer = new Transformer($args);
     return $transformer->transform($posts);
-  }
-
-  public function constructTaxonomiesQuery($args) {
-    $taxonomiesQuery = [];
-    if (isset($args['terms']) && is_array($args['terms'])) {
-      $taxonomies = [];
-      // Categorize terms based on their taxonomies
-      foreach ($args['terms'] as $term) {
-        $taxonomy = $term['taxonomy'];
-        if (!isset($taxonomies[$taxonomy])) {
-          $taxonomies[$taxonomy] = [];
-        }
-        $taxonomies[$taxonomy][] = $term['id'];
-      }
-
-      foreach ($taxonomies as $taxonomy => $terms) {
-        if (!empty($terms)) {
-          $tax = [
-            'taxonomy' => $taxonomy,
-            'field' => 'id',
-            'terms' => $terms,
-          ];
-          if ($args['inclusionType'] === 'exclude') $tax['operator'] = 'NOT IN';
-          $taxonomiesQuery[] = $tax;
-        }
-      }
-      if (!empty($taxonomiesQuery)) {
-        // With exclusion we want to use 'AND', because we want posts that
-        // don't have excluded tags/categories. But with inclusion we want to
-        // use 'OR', because we want posts that have any of the included
-        // tags/categories
-        $taxonomiesQuery['relation'] = ($args['inclusionType'] === 'exclude') ? 'AND' : 'OR';
-      }
-    }
-
-    // make $taxonomies_query nested to avoid conflicts with plugins that use taxonomies
-    return empty($taxonomiesQuery) ? [] : [$taxonomiesQuery];
   }
 
   private function _attachSentPostsFilter($newsletterId) {

--- a/mailpoet/lib/Newsletter/BlockPostQuery.php
+++ b/mailpoet/lib/Newsletter/BlockPostQuery.php
@@ -29,11 +29,19 @@ class BlockPostQuery {
   public $newsletterId = false;
 
   /***
-   * Translates to \WP_Query::date_query => ['column' => 'post_date', 'after' => {date string}]
+   * Translates to \WP_Query::date_query => array{'column': 'post_date', 'after': date string}
    *
    * @var bool|DateTimeInterface|null
    */
   public $newerThanTimestamp = false;
+
+  /**
+   * If it's a dynamic block
+   * Dynamic blocks are not allowed to query none-public posts
+   *
+   * @var bool
+   */
+  public $dynamic = true;
 
   /**
    * @param array{
@@ -51,6 +59,7 @@ class BlockPostQuery {
    *    postsToExclude?: int[],
    *    newsletterId?: int|false|null,
    *    newerThanTimestamp?: bool|DateTimeInterface|null,
+   *    dynamic?: bool,
    * } $query
    * @return void
    */
@@ -61,18 +70,17 @@ class BlockPostQuery {
     $this->postsToExclude = $query['postsToExclude'] ?? [];
     $this->newsletterId = $query['newsletterId'] ?? false;
     $this->newerThanTimestamp = $query['newerThanTimestamp'] ?? false;
+    $this->dynamic = $query['dynamic'] ?? true;
   }
 
   public function getPostType(): string {
     return $this->args['contentType'] ?? 'post';
   }
 
-  /**
-   * Returns post status
-   *
-   * @return string
-   */
   public function getPostStatus(): string {
+    if ($this->dynamic) {
+      return 'publish';
+    }
     return $this->args['postStatus'] ?? 'publish';
   }
 

--- a/mailpoet/lib/Newsletter/BlockPostQuery.php
+++ b/mailpoet/lib/Newsletter/BlockPostQuery.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace MailPoet\Newsletter;
+
+use DateTimeInterface;
+
+class BlockPostQuery {
+  const DEFAULT_POSTS_PER_PAGE = 10;
+
+  /**
+   * @var array{
+   *     amount?: int,
+   *     offset?: int,
+   *     posts?: int[],
+   *     contentType?: string,
+   *     postStatus?: string,
+   *     search?: string,
+   *     sortBy?: 'newest' | 'DESC' | 'ASC',
+   *     terms?: array{'taxonomy': string, 'id': int}[],
+   *     inclusionType?: 'include'|'exclude'
+   * } $args
+   */
+  public $args = [];
+
+  /*** @var null|int[] \WP_Query::post__not_in  */
+  public $postsToExclude = [];
+
+  /** @var int|false */
+  public $newsletterId = false;
+
+  /***
+   * Translates to \WP_Query::date_query => ['column' => 'post_date', 'after' => {date string}]
+   *
+   * @var bool|DateTimeInterface|null
+   */
+  public $newerThanTimestamp = false;
+
+  /**
+   * @param array{
+   *    args?: array{
+   *     amount?: int,
+   *     offset?: int,
+   *     posts?: int[],
+   *     contentType?: string,
+   *     postStatus?: string,
+   *     search?: string,
+   *     sortBy?: 'newest' | 'DESC' | 'ASC',
+   *     terms?: array{'taxonomy': string, 'id': int}[],
+   *     inclusionType?: 'include'|'exclude'
+   *    },
+   *    postsToExclude?: int[],
+   *    newsletterId?: int|false|null,
+   *    newerThanTimestamp?: bool|DateTimeInterface|null,
+   * } $query
+   * @return void
+   */
+  public function __construct(
+    array $query = []
+  ) {
+    $this->args = $query['args'] ?? [];
+    $this->postsToExclude = $query['postsToExclude'] ?? [];
+    $this->newsletterId = $query['newsletterId'] ?? false;
+    $this->newerThanTimestamp = $query['newerThanTimestamp'] ?? false;
+  }
+
+  public function getPostType(): string {
+    return $this->args['contentType'] ?? 'post';
+  }
+
+  /**
+   * Returns post status
+   *
+   * @return string
+   */
+  public function getPostStatus(): string {
+    return $this->args['postStatus'] ?? 'publish';
+  }
+
+  public function getOrder(): string {
+    return isset($this->args['sortBy']) && in_array($this->args['sortBy'], ['newest', 'DESC']) ? 'DESC' : 'ASC';
+  }
+
+  /**
+   * @see https://developer.wordpress.org/reference/classes/wp_query/#taxonomy-parameters
+   * @return array[] array{relation: string, taxonomy: string, field: string, terms: int/string/array, operator: string}
+   */
+  private function constructTaxonomiesQuery(): array {
+    $taxonomiesQuery = [];
+    if (isset($this->args['terms']) && is_array($this->args['terms'])) {
+      $taxonomies = [];
+      // Categorize terms based on their taxonomies
+      foreach ($this->args['terms'] as $term) {
+        $taxonomy = $term['taxonomy'];
+        if (!isset($taxonomies[$taxonomy])) {
+          $taxonomies[$taxonomy] = [];
+        }
+        $taxonomies[$taxonomy][] = $term['id'];
+      }
+
+      foreach ($taxonomies as $taxonomy => $terms) {
+        if (!empty($terms)) {
+          $tax = [
+            'taxonomy' => $taxonomy,
+            'field' => 'id',
+            'terms' => $terms,
+          ];
+          if (isset($this->args['inclusionType']) && $this->args['inclusionType'] === 'exclude') $tax['operator'] = 'NOT IN';
+          $taxonomiesQuery[] = $tax;
+        }
+      }
+      if (!empty($taxonomiesQuery)) {
+        // With exclusion we want to use 'AND', because we want posts that
+        // don't have excluded tags/categories. But with inclusion we want to
+        // use 'OR', because we want posts that have any of the included
+        // tags/categories
+        $taxonomiesQuery['relation'] = (isset($this->args['inclusionType']) && $this->args['inclusionType'] === 'exclude')
+          ? 'AND'
+          : 'OR';
+      }
+    }
+
+    // make $taxonomies_query nested to avoid conflicts with plugins that use taxonomies
+    return empty($taxonomiesQuery) ? [] : [$taxonomiesQuery];
+  }
+
+  public function getQueryParams(): array {
+    $postsPerPage = (!empty($this->args['amount']) && (int)$this->args['amount'] > 0)
+      ? (int)$this->args['amount']
+      : self::DEFAULT_POSTS_PER_PAGE;
+    $parameters = [
+      'posts_per_page' => $postsPerPage,
+      'post_type' => $this->getPostType(),
+      'post_status' => $this->getPostStatus(),
+      'orderby' => 'date',
+      'order' => $this->getOrder(),
+    ];
+    if (!empty($this->args['offset']) && (int)$this->args['offset'] > 0) {
+      $parameters['offset'] = (int)$this->args['offset'];
+    }
+    if (isset($this->args['search'])) {
+      $parameters['s'] = $this->args['search'];
+    }
+    if (isset($this->args['posts']) && is_array($this->args['posts'])) {
+      $parameters['post__in'] = $this->args['posts'];
+      $parameters['posts_per_page'] = -1; // Get all posts with matching IDs
+    }
+    if (!empty($this->postsToExclude)) {
+      $parameters['post__not_in'] = $this->postsToExclude;
+    }
+
+    // WP posts with the type attachment have always post_status `inherit`
+    if ($parameters['post_type'] === 'attachment' && $parameters['post_status'] === 'publish') {
+      $parameters['post_status'] = 'inherit';
+    }
+
+    // This enables using posts query filters for get_posts, where by default
+    // it is disabled.
+    // However, it also enables other plugins and themes to hook in and alter
+    // the query.
+    $parameters['suppress_filters'] = false;
+
+    if ($this->newerThanTimestamp instanceof DateTimeInterface) {
+      $parameters['date_query'] = [
+        [
+          'column' => 'post_date',
+          'after' => $this->newerThanTimestamp->format('Y-m-d H:i:s'),
+        ],
+      ];
+    }
+
+    $parameters['tax_query'] = $this->constructTaxonomiesQuery();
+    return $parameters;
+  }
+}

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AutomatedLatestContentBlock.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AutomatedLatestContentBlock.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\AutomatedLatestContent;
+use MailPoet\Newsletter\BlockPostQuery;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 
 class AutomatedLatestContentBlock {
@@ -47,7 +48,13 @@ class AutomatedLatestContentBlock {
       }
     }
     $postsToExclude = $this->getRenderedPosts((int)$newsletterId);
-    $aLCPosts = $this->ALC->getPosts($args, $postsToExclude, $newsletterId, $newerThanTimestamp);
+    $query = new BlockPostQuery([
+      'args' => $args,
+      'postsToExclude' => $postsToExclude,
+      'newsletterId' => $newsletterId,
+      'newerThanTimestamp' => $newerThanTimestamp,
+    ]);
+    $aLCPosts = $this->ALC->getPosts($query);
     foreach ($aLCPosts as $post) {
       $postsToExclude[] = $post->ID;
     }

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AutomatedLatestContentBlock.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AutomatedLatestContentBlock.php
@@ -53,6 +53,7 @@ class AutomatedLatestContentBlock {
       'postsToExclude' => $postsToExclude,
       'newsletterId' => $newsletterId,
       'newerThanTimestamp' => $newerThanTimestamp,
+      'dynamic' => true,
     ]);
     $aLCPosts = $this->ALC->getPosts($query);
     foreach ($aLCPosts as $post) {

--- a/mailpoet/lib/Util/APIPermissionHelper.php
+++ b/mailpoet/lib/Util/APIPermissionHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MailPoet\Util;
+
+if (!class_exists('\WP_REST_Posts_Controller')) {
+  require_once ABSPATH . '/wp-includes/rest-api/endpoints/class-wp-rest-controller.php';
+  require_once ABSPATH . '/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php';
+}
+
+class APIPermissionHelper extends \WP_REST_Posts_Controller {
+  public function __construct() {
+    // constructor is needed to override parent constructor
+  }
+
+  public function checkReadPermission(\WP_Post $post): bool {
+    return parent::check_read_permission($post);
+  }
+
+  /**
+   * Checks if a given post type can be viewed or managed.
+   * Refrain from checking `show_in_rest` contrary to what parent::check_is_post_type_allowed does
+   *
+   * @param \WP_Post_Type|string $post_type Post type name or object.
+   * @return bool Whether the post type is allowed in REST.
+   * @see parent::check_is_post_type_allowed
+   */
+  // phpcs:disable PSR1.Methods.CamelCapsMethodName
+  protected function check_is_post_type_allowed($post_type) {
+    if (!is_object($post_type)) {
+      $post_type = get_post_type_object($post_type);
+    }
+
+    return !empty($post_type) && $post_type->public;
+  }
+}

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -674,7 +674,7 @@ parameters:
 		-
 			message: "#^Variable \\$terms in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
-			path: ../../lib/Newsletter/AutomatedLatestContent.php
+			path: ../../lib/Newsletter/BlockPostQuery.php
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -674,7 +674,7 @@ parameters:
 		-
 			message: "#^Variable \\$terms in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
-			path: ../../lib/Newsletter/AutomatedLatestContent.php
+			path: ../../lib/Newsletter/BlockPostQuery.php
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -688,7 +688,7 @@ parameters:
 		-
 			message: "#^Variable \\$terms in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
-			path: ../../lib/Newsletter/AutomatedLatestContent.php
+			path: ../../lib/Newsletter/BlockPostQuery.php
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
@@ -109,7 +109,7 @@ class AutomatedLatestContentAPITest extends \MailPoetTest {
     $this->deleteAllPosts();
   }
 
-  private function loginWithRole(string $role): void {
+  private function loginWithRole(string $role): \WP_User {
     $username = uniqid("testUser");
     $email = "$username@test.com";
     $existingUser = $this->wp->getUserBy("email", $email);
@@ -129,6 +129,8 @@ class AutomatedLatestContentAPITest extends \MailPoetTest {
 
     $this->wp->wpSetCurrentUser($user->ID);
     $this->createdUsers[] = $user;
+
+    return $user;
   }
 
   private function deleteAllPosts() {
@@ -216,7 +218,11 @@ class AutomatedLatestContentAPITest extends \MailPoetTest {
     expect($this->getPostTitles($result->data))->contains($publicPost["post_title"]);
     expect($this->getPostTitles($result->data))->contains($privatePost["post_title"]);
 
-    $this->loginWithRole("administrator");
+    $user = $this->loginWithRole("administrator");
+    if (is_multisite()) {
+      grant_super_admin($user->ID);
+    }
+
     $result = $this->alcAPI->getPosts(['postStatus' => "any", "contentType" => "post"]);
     expect($result->data)->count(3);
     expect($this->getPostTitles($result->data))->contains($publicPost["post_title"]);

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace MailPoet\Test\Newsletter;
+
+use MailPoet\API\JSON\v1\AutomatedLatestContent as ALCAPI;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Newsletter\AutomatedLatestContent;
+use MailPoet\Util\APIPermissionHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+class AutomatedLatestContentAPITest extends \MailPoetTest {
+
+  /*** @var array WP_User[] */
+  private $createdUsers = [];
+
+  /*** @var ALCAPI */
+  private $alcAPI;
+
+  /*** @var WPFunctions */
+  private $wp;
+
+  private static $alcBlock = [
+    'type' => 'automatedLatestContentLayout',
+    'withLayout' => true,
+    'amount' => '2',
+    'contentType' => 'post',
+    'terms' => [],
+    'inclusionType' => 'include',
+    'displayType' => 'excerpt',
+    'titleFormat' => 'h2',
+    'titleAlignment' => 'left',
+    'titleIsLink' => false,
+    'imageFullWidth' => true,
+    'titlePosition' => 'abovePost',
+    'featuredImagePosition' => 'left',
+    'fullPostFeaturedImagePosition' => 'none',
+    'showAuthor' => 'no',
+    'authorPrecededBy' => 'Author:',
+    'showCategories' => 'no',
+    'categoriesPrecededBy' => 'Categories:',
+    'readMoreType' => 'button',
+    'readMoreText' => 'Read more',
+    'readMoreButton' => [
+      'type' => 'button',
+      'text' => 'Read more',
+      'url' => '[postLink]',
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#e2973f',
+          'borderColor' => '#e2973f',
+          'borderWidth' => '0px',
+          'borderRadius' => '5px',
+          'borderStyle' => 'solid',
+          'width' => '110px',
+          'lineHeight' => '40px',
+          'fontColor' => '#ffffff',
+          'fontFamily' => 'Arial',
+          'fontSize' => '14px',
+          'fontWeight' => 'bold',
+          'textAlign' => 'left',
+        ],
+      ],
+      'context' => 'automatedLatestContentLayout.readMoreButton',
+    ],
+    'sortBy' => 'newest',
+    'showDivider' => false,
+    'divider' => [
+      'type' => 'divider',
+      'styles' => [
+        'block' => [
+          'backgroundColor' => 'transparent',
+          'padding' => '13px',
+          'borderStyle' => 'solid',
+          'borderWidth' => '3px',
+          'borderColor' => '#aaaaaa',
+        ],
+      ],
+      'context' => 'automatedLatestContentLayout.divider',
+    ],
+    'backgroundColor' => '#ffffff',
+    'backgroundColorAlternate' => '#eeeeee',
+  ];
+
+  public function _before() {
+    parent::_before();
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+    $loggerFactory = $this->diContainer->get(LoggerFactory::class);
+
+    $alc = $this->make($this->diContainer->get(AutomatedLatestContent::class), [
+      "loggerFactory" => $loggerFactory,
+      "wp" => $this->wp,
+      "transformPosts" => function ($block, $post) {
+        return $post;
+      },
+    ]);
+    $apiPermissionHelper = $this->diContainer->get(APIPermissionHelper::class);
+    $this->alcAPI = new ALCAPI($alc, $apiPermissionHelper, $this->wp);
+
+    $this->deleteAllPosts();
+  }
+
+  public function _after() {
+    parent::_after();
+
+    foreach ($this->createdUsers as $user) {
+      wp_delete_user($user->ID);
+    }
+
+    $this->deleteAllPosts();
+  }
+
+  private function loginWithRole(string $role): void {
+    $username = uniqid("testUser");
+    $email = "$username@test.com";
+    $existingUser = $this->wp->getUserBy("email", $email);
+
+    if ($existingUser) {
+      wp_delete_user($existingUser->ID);
+    }
+
+    wp_insert_user( [
+      'user_login' => $username,
+      'user_email' => $email,
+      'user_pass' => '',
+    ]);
+    $user = $this->wp->getUserBy("email", $email);
+
+    $user->add_role($role);
+
+    $this->wp->wpSetCurrentUser($user->ID);
+    $this->createdUsers[] = $user;
+  }
+
+  private function deleteAllPosts() {
+    global $wpdb;
+    $wpdb->query("TRUNCATE TABLE $wpdb->posts");
+  }
+
+  public function testGetBulkTransformedPosts() {
+    $publishedPostTitle = 'Published Post';
+    wp_insert_post([
+      'post_title' => 'Private Post',
+      'post_content' => 'contents',
+      'post_status' => 'private',
+    ]);
+    wp_insert_post([
+      'post_title' => $publishedPostTitle,
+      'post_content' => 'contents',
+      'post_status' => 'publish',
+    ]);
+
+    $singleBlockQuery = array_merge(self::$alcBlock, ['postStatus' => "any"]);
+    $result = $this->alcAPI->getBulkTransformedPosts([
+      "blocks" => [$singleBlockQuery],
+    ]);
+    expect($result->data)->count(1);
+
+    expect(array_flatten($result->data)[0]->post_title)->equals($publishedPostTitle);
+
+    $this->loginWithRole("editor");
+    $result = $this->alcAPI->getBulkTransformedPosts([
+      "blocks" => [$singleBlockQuery],
+    ]);
+    expect($result->data)->count(1);
+    expect(array_flatten($result->data)[0]->post_title)->equals($publishedPostTitle);
+
+    $this->loginWithRole("administrator");
+    $result = $this->alcAPI->getBulkTransformedPosts([
+      "blocks" => [$singleBlockQuery],
+    ]);
+    expect($result->data)->count(1);
+    expect(array_flatten($result->data)[0]->post_title)->equals($publishedPostTitle);
+  }
+
+  /**
+   * @param \WP_Post[] $posts
+   * @return string[]
+   */
+  private function getPostTitles($posts): array {
+    return array_map(function (\WP_Post $post) {
+      return $post->post_title;// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }, $posts);
+  }
+
+  public function testGetPosts() {
+    $privatePost = [
+      'post_title' => 'Private Post',
+      'post_content' => 'contents',
+      'post_status' => 'private',
+    ];
+    $publicPost = [
+      'post_title' => 'Published Post',
+      'post_content' => 'contents',
+      'post_status' => 'publish',
+    ];
+    $draftPost = [
+      'post_title' => 'Draft Post',
+      'post_content' => 'contents',
+      'post_status' => 'draft',
+    ];
+
+    array_map(function ($postarr){
+      wp_insert_post($postarr);
+    }, [$privatePost, $publicPost, $draftPost]);
+
+    $result = $this->alcAPI->getPosts(['postStatus' => "any", "contentType" => "post"]);
+
+    $this->loginWithRole("reader");
+    expect($result->data)->count(1);
+    expect($this->getPostTitles($result->data))->contains($publicPost['post_title']);
+
+
+    $this->loginWithRole("editor");
+    $result = $this->alcAPI->getPosts(['postStatus' => "any", "contentType" => "post"]);
+    expect($result->data)->count(2);
+    expect($this->getPostTitles($result->data))->contains($publicPost["post_title"]);
+    expect($this->getPostTitles($result->data))->contains($privatePost["post_title"]);
+
+    $this->loginWithRole("administrator");
+    $result = $this->alcAPI->getPosts(['postStatus' => "any", "contentType" => "post"]);
+    expect($result->data)->count(3);
+    expect($this->getPostTitles($result->data))->contains($publicPost["post_title"]);
+    expect($this->getPostTitles($result->data))->contains($draftPost["post_title"]);
+    expect($this->getPostTitles($result->data))->contains($privatePost["post_title"]);
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Newsletter;
 
 use MailPoet\Newsletter\AutomatedLatestContent;
+use MailPoet\Newsletter\BlockPostQuery;
 
 class AutomatedLatestContentTest extends \MailPoetTest {
   /** @var AutomatedLatestContent */
@@ -32,7 +33,8 @@ class AutomatedLatestContentTest extends \MailPoetTest {
       'inclusionType' => 'include',
     ];
 
-    expect($this->alc->constructTaxonomiesQuery($args))->equals([
+    $query = new BlockPostQuery(['args' => $args]);
+    expect($query->getQueryParams()['tax_query'])->equals([
       [
         [
           'taxonomy' => 'post_tag',
@@ -64,7 +66,7 @@ class AutomatedLatestContentTest extends \MailPoetTest {
       'inclusionType' => 'exclude',
     ];
 
-    $query = $this->alc->constructTaxonomiesQuery($args);
+    $query = (new BlockPostQuery(['args' => $args]))->getQueryParams()['tax_query'];
 
     expect($query[0][0]['operator'])->equals('NOT IN');
     expect($query[0]['relation'])->equals('AND');

--- a/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
@@ -78,6 +78,8 @@ class AbandonedCartContentTest extends \MailPoetTest {
       $this->wp->wpDeletePost((int)$product->ID);
     }
 
+    register_post_type("product", ['public' => true]);
+
     $this->productIds = [];
     $this->productIds[] = $this->createPost('Product 1', '2020-05-01 01:01:01', 'product');
     $this->productIds[] = $this->createPost('Product 2', '2020-06-01 01:01:01', 'product');

--- a/mailpoet/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
+++ b/mailpoet/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
@@ -28,20 +28,16 @@ class SubscriptionUrlFactoryTest extends \MailPoetTest {
   }
 
   public function testGetReEngagementUrlReturnsUrlToUserSelectedPage() {
-    global $wp_rewrite;
 
     $settings = $this->diContainer->get(SettingsController::class);
-    $settings->set('reEngagement', ['page' => 2]);
+    $postId = wp_insert_post([
+      'post_title' => 'testGetReEngagementUrlReturnsUrlToUserSelectedPage',
+      'post_status' => 'publish',
+    ]);
+    $settings->set('reEngagement', ['page' => $postId]);
+    $expectedUrl = get_permalink($postId);
 
-    $pagePermaStructure = $wp_rewrite->get_page_permastruct();
-
-    // this check is needed because on CircleCI permalinks are enabled and on the local environments not necessarily.
-    if ($pagePermaStructure) {
-      $expectedUrl = '/sample-page/';
-    } else {
-      $expectedUrl = '/?page_id=2';
-    }
-
+    $this->assertIsString($expectedUrl, "Permalink is a valid string");
     $this->assertStringContainsString($expectedUrl, $this->subscriptionUrlFactory->getReEngagementUrl($this->subscriber));
   }
 

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -137,6 +137,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->entityManager->clear();
     $this->restoreGlobals();
     wp_set_current_user(0);
+    $this->cleanUpCustomEntities();
     parent::tearDown();
   }
 
@@ -200,6 +201,12 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
       foreach (self::$savedGlobals[$globalName] ?? [] as $key => $value) {
         $GLOBALS[$globalName][$key] = is_object($value) ? clone $value : $value;
       }
+    }
+  }
+
+  protected function cleanUpCustomEntities() {
+    if (post_type_exists('product')) {
+      unregister_post_type('product');
     }
   }
 }


### PR DESCRIPTION
Reverts mailpoet/mailpoet#4068

Testing:

Note: This pull request doesn't have simple steps to test it. This change is directly affecting Post Notifications part of the plugin. Please test that it is working as expected, here are some tips to test it:

1. Go to Posts and make a 1-2 posts and make sure you have received Post Notification email about the latest posts on site
2. Go to MailPoet > Emails > Post Notifications tab
3. Edit the existing or create a new post notification email but make sure to test ALC (Automatic Latest Content) block and its settings in the right sidebar (click the block to see the right sidebar and then click `Display Options` link to see full settings of the block)
4. Test receiving PN email after you make some changes/tests of that ALC block