### PR TITLE
Check for uniqueness when updating segment name [MAILPOET-4199]

### DIFF
--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -126,7 +126,10 @@ class SegmentsRepository extends Repository {
       if (!$segment instanceof SegmentEntity) {
         throw new NotFoundException("Segment with ID [{$id}] was not found.");
       }
-      $segment->setName($name);
+      if ($name !== $segment->getName()) {
+        $this->verifyNameIsUnique($name, $id);
+        $segment->setName($name);
+      }
       $segment->setDescription($description);
     } else {
       $this->verifyNameIsUnique($name, $id);

--- a/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
@@ -137,6 +137,15 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     $this->segmentsRepository->createOrUpdate('Existing Segment');
   }
 
+  public function testItChecksForDuplicateNameWhenUpdatingExistingSegmentName() {
+    $segment = $this->createDefaultSegment('Test');
+    $this->createDefaultSegment('Existing');
+    $this->segmentsRepository->flush();
+    $this->expectException(ConflictException::class);
+    $this->expectExceptionMessage("Could not create new segment with name [Existing] because a segment with that name already exists.");
+    $this->segmentsRepository->createOrUpdate('Existing', $segment->getDescription(), $segment->getType(), [], $segment->getId());
+  }
+
   private function createDefaultSegment(string $name): SegmentEntity {
     $segment = new SegmentEntity($name, SegmentEntity::TYPE_DEFAULT, 'description');
     $this->entityManager->persist($segment);


### PR DESCRIPTION
This PR ensures that we run our own check for uniqueness on a segment's name when updating an existing segment so users don't end up seeing a doctrine exception if they attempt to update a segment's name to a name that already exists.

Throwing our own `ConflictException` means that  we'll display a more user-friendly message, one that we're already using and have translations for, because [we catch that exception](http://github.com/mailpoet/mailpoet/blob/f4e30789afc2ef66ab4fcf8a091f8c33000e47eb/mailpoet/lib/API/JSON/v1/Segments.php#L128-L132).

It's worth noting that the `ConflictException` message itself, which refers to creating a new segment, is never displayed to the user.

Before:
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/8656640/163020564-d395d269-3e09-417b-a3f9-7d9a7331bdea.png">

After:
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/8656640/163020630-d0a590c2-eb13-4266-9dcc-8996d30159eb.png">

[MAILPOET-4199]

[MAILPOET-4199]: https://mailpoet.atlassian.net/browse/MAILPOET-4199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test steps inside the Jira ticket.