### PR TITLE
Change INSERT ON DUPLICATE KEY UPDATE query

### DIFF
--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -306,15 +306,16 @@ class WooCommerce {
     $now = (Carbon::createFromTimestamp($this->wp->currentTime('timestamp')))->format('Y-m-d H:i:s');
     $source = Source::WOOCOMMERCE_USER;
     foreach ($emails as $email) {
-      $subscribersValues[] = "(1, '{$email}', '{$status}', '{$now}', '{$now}', '{$source}')";
+      $email = strval($this->connection->quote($email));
+      $subscribersValues[] = "(1, {$email}, '{$status}', '{$now}', '{$now}', '{$source}')";
     }
 
     // Update existing subscribers
     $this->connection->executeQuery('
       UPDATE ' . $subscribersTable . ' mps
       SET mps.is_woocommerce_user = 1
-      WHERE mps.email IN ("' . implode('","', $emails) . '")
-    ');
+      WHERE mps.email IN (:emails)
+    ', ['emails' => $emails], ['emails' => Connection::PARAM_STR_ARRAY]);
 
     // Insert new subscribers
     $this->connection->executeQuery('

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -309,10 +309,17 @@ class WooCommerce {
       $subscribersValues[] = "(1, '{$email}', '{$status}', '{$now}', '{$now}', '{$source}')";
     }
 
+    // Update existing subscribers
+    $this->connection->executeQuery('
+      UPDATE ' . $subscribersTable . ' mps
+      SET mps.is_woocommerce_user = 1
+      WHERE mps.email IN ("' . implode('","', $emails) . '")
+    ');
+
+    // Insert new subscribers
     $this->connection->executeQuery('
       INSERT IGNORE INTO ' . $subscribersTable . ' (`is_woocommerce_user`, `email`, `status`, `created_at`, `last_subscribed_at`, `source`) VALUES
       ' . implode(',', $subscribersValues) . '
-      ON DUPLICATE KEY UPDATE is_woocommerce_user = 1
     ');
 
     return count($emails);
@@ -485,6 +492,7 @@ class WooCommerce {
     if ($this->needsCollationChange()) {
       $collation = "COLLATE $this->mailpoetEmailCollation";
     }
+
     $this->connection->executeQuery("
       CREATE TEMPORARY TABLE {$tmpTableName}
         (`email` varchar(150) NOT NULL, UNIQUE(`email`)) {$collation}


### PR DESCRIPTION
Split the` INSERT ON DUPLICATE KEY UPDATE` query into two queries to avoid this bug: https://jira.mariadb.org/browse/MDEV-28310

I don't know how to test that the replication bug is not happening.

Automated tests using the modified query are still passing.

[MAILPOET-4248]

[MAILPOET-4248]: https://mailpoet.atlassian.net/browse/MAILPOET-4248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ