### PR TITLE
Fix acceptance subscriber cookie test [MAILPOET-4249]

### DIFF
--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -214,4 +214,8 @@ class Settings {
     $this->settings->set('installed_at', $date);
     return $this;
   }
+
+  public function withTransactionEmailsViaMailPoet() {
+    $this->settings->set('send_transactional_emails', true);
+  }
 }

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -43,7 +43,7 @@ class SubscriberCookieCest {
       $i->waitForText('mutestuser is your new username');
 
       /**
-       * The tracking cookie will be set once the registrant has activated
+       * The tracking cookie will be set once the registrant has activated and logged into
        * the wp_user account
        **/
       $i->amOnMailboxAppPage();
@@ -53,8 +53,15 @@ class SubscriberCookieCest {
       $i->click(Locator::contains('a', 'wp-activate.php'));
       $i->switchToNextTab();
       $i->waitForText('Your account is now active');
-    }
+      $password = str_replace([' ', 'Password:'], '', strval($i->grabTextFrom("//div[@id='signup-welcome'] /p[2]")));
+      $i->click('Log in');
+      $i->wait(1);// this needs to be here, Username is not filled properly without this line
+      $i->fillField('Username', 'mutestuser');
+      $i->fillField('Password', $password);
+      $i->click('Log In');
+      $i->waitForText('Dashboard');
 
+    }
     // subscriber cookie should be set right after signup
     $this->checkSubscriberCookie($i, $email);
   }

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -18,7 +18,10 @@ class SubscriberCookieCest {
   public function setSubscriberCookieOnSignup(AcceptanceTester $i) {
     $i->wantTo('Set subscriber cookie on signup');
 
-    (new Settings())->withSubscribeOnRegisterEnabled();
+    (new Settings())
+      ->withSubscribeOnRegisterEnabled()
+      ->withTransactionEmailsViaMailPoet();
+
     $email = 'test-user@example.com';
 
     // signup
@@ -46,8 +49,9 @@ class SubscriberCookieCest {
       $i->amOnMailboxAppPage();
       $i->waitForElement('.subject.unread', 10);
       $i->click(Locator::contains('span.subject.unread', 'Activate'));
-      $i->switchToIframe('#preview-html');
+      $i->waitForText('To activate your user');
       $i->click(Locator::contains('a', 'wp-activate.php'));
+      $i->switchToNextTab();
       $i->waitForText('Your account is now active');
     }
 


### PR DESCRIPTION
I found 2 issues:

1) The account activation email was not delivered to MailHog, and clicking on the activation link was not working. Fixed in the first commit. Please see the info in the commit message.
2) The cookie was not set on the activation page. After discussing it with @JanJakes I fixed the test by adding logging and verifying the cookie after logging in. Please see more info in the commit message of the second commit.

I temporarily activated the multisite test on this branch. Here is [a passing test run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/9553/workflows/5928a457-d433-436e-aa8d-b501cfb4b180/jobs/174950).

[MAILPOET-4249]

[MAILPOET-4249]: https://mailpoet.atlassian.net/browse/MAILPOET-4249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ