### PR TITLE
Non-static scheduler

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -79,6 +79,9 @@ class Newsletters extends APIEndpoint {
   /** @var TrackingConfig */
   private $trackingConfig;
 
+  /** @var Scheduler */
+  private $scheduler;
+
   public function __construct(
     Listing\Handler $listingHandler,
     WPFunctions $wp,
@@ -93,7 +96,8 @@ class Newsletters extends APIEndpoint {
     SendPreviewController $sendPreviewController,
     NewsletterSaveController $newsletterSaveController,
     NewsletterUrl $newsletterUrl,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    Scheduler $scheduler
   ) {
     $this->listingHandler = $listingHandler;
     $this->wp = $wp;
@@ -109,6 +113,7 @@ class Newsletters extends APIEndpoint {
     $this->newsletterSaveController = $newsletterSaveController;
     $this->newsletterUrl = $newsletterUrl;
     $this->trackingConfig = $trackingConfig;
+    $this->scheduler = $scheduler;
   }
 
   public function get($data = []) {
@@ -212,7 +217,7 @@ class Newsletters extends APIEndpoint {
           APIError::BAD_REQUEST => __('This email has incorrect state.', 'mailpoet'),
         ]);
       }
-      $nextRunDate = Scheduler::getNextRunDate($scheduleOption->getValue());
+      $nextRunDate = $this->scheduler->getNextRunDate($scheduleOption->getValue());
       $queues = $newsletter->getQueues();
       foreach ($queues as $queue) {
         $task = $queue->getTask();

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -48,6 +48,9 @@ class SendingQueue extends APIEndpoint {
   /** @var MailerFactory */
   private $mailerFactory;
 
+  /** @var Scheduler */
+  private $scheduler;
+
   public function __construct(
     SubscribersFeature $subscribersFeature,
     NewslettersRepository $newsletterRepository,
@@ -55,7 +58,8 @@ class SendingQueue extends APIEndpoint {
     Bridge $bridge,
     SubscribersFinder $subscribersFinder,
     ScheduledTasksRepository $scheduledTasksRepository,
-    MailerFactory $mailerFactory
+    MailerFactory $mailerFactory,
+    Scheduler $scheduler
   ) {
     $this->subscribersFeature = $subscribersFeature;
     $this->subscribersFinder = $subscribersFinder;
@@ -64,6 +68,7 @@ class SendingQueue extends APIEndpoint {
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->mailerFactory = $mailerFactory;
+    $this->scheduler = $scheduler;
   }
 
   public function add($data = []) {
@@ -138,7 +143,7 @@ class SendingQueue extends APIEndpoint {
 
       // set queue status
       $queue->status = SendingQueueModel::STATUS_SCHEDULED;
-      $queue->scheduledAt = Scheduler::formatDatetimeString($newsletterEntity->getOptionValue('scheduledAt'));
+      $queue->scheduledAt = $this->scheduler->formatDatetimeString($newsletterEntity->getOptionValue('scheduledAt'));
     } else {
       $segments = $newsletterEntity->getSegmentIds();
       $taskModel = $queue->task();

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -38,7 +38,7 @@ class FirstPurchase {
       $helper = new WCHelper();
     }
     $this->helper = $helper;
-    $this->scheduler = new AutomaticEmailScheduler();
+    $this->scheduler = ContainerWrapper::getInstance()->get(AutomaticEmailScheduler::class);
     $this->loggerFactory = LoggerFactory::getInstance();
     $this->repository = ContainerWrapper::getInstance()->get(AutomaticEmailsRepository::class);
   }

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -34,7 +34,7 @@ class PurchasedInCategory {
       $woocommerceHelper = new WCHelper();
     }
     $this->woocommerceHelper = $woocommerceHelper;
-    $this->scheduler = new AutomaticEmailScheduler();
+    $this->scheduler = ContainerWrapper::getInstance()->get(AutomaticEmailScheduler::class);
     $this->loggerFactory = LoggerFactory::getInstance();
     $this->repository = ContainerWrapper::getInstance()->get(AutomaticEmailsRepository::class);
   }

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -35,7 +35,7 @@ class PurchasedProduct {
       $helper = new WCHelper();
     }
     $this->helper = $helper;
-    $this->scheduler = new AutomaticEmailScheduler();
+    $this->scheduler = ContainerWrapper::getInstance()->get(AutomaticEmailScheduler::class);
     $this->loggerFactory = LoggerFactory::getInstance();
     $this->repository = ContainerWrapper::getInstance()->get(AutomaticEmailsRepository::class);
   }

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -45,6 +45,9 @@ class Scheduler {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var NewsletterScheduler */
+  private $scheduler;
+
   public function __construct(
     SubscribersFinder $subscribersFinder,
     LoggerFactory $loggerFactory,
@@ -52,7 +55,8 @@ class Scheduler {
     CronWorkerScheduler $cronWorkerScheduler,
     ScheduledTasksRepository $scheduledTasksRepository,
     NewslettersRepository $newslettersRepository,
-    SegmentsRepository $segmentsRepository
+    SegmentsRepository $segmentsRepository,
+    NewsletterScheduler $scheduler
   ) {
     $this->cronHelper = $cronHelper;
     $this->subscribersFinder = $subscribersFinder;
@@ -61,6 +65,7 @@ class Scheduler {
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsRepository = $segmentsRepository;
+    $this->scheduler = $scheduler;
   }
 
   public function process($timer = false) {
@@ -291,7 +296,7 @@ class Scheduler {
       $queue->delete();
       return;
     } else {
-      $nextRunDate = NewsletterScheduler::getNextRunDate($newsletter->schedule);
+      $nextRunDate = $this->scheduler->getNextRunDate($newsletter->schedule);
       if (!$nextRunDate) {
         $queue->delete();
         return;

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -440,6 +440,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->register(\MailPoet\Util\CdnAssetUrl::class)
       ->setPublic(true)
       ->setFactory([__CLASS__, 'getCdnAssetsUrl']);
+    $container->autowire(\MailPoet\Newsletter\Scheduler\Scheduler::class)->setPublic(true);
     // Validator
     $container->autowire(Validator::class)->setPublic(true);
     // WooCommerce

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -71,6 +71,9 @@ class NewsletterSaveController {
   /** @var ApiDataSanitizer */
   private $dataSanitizer;
 
+  /** @var Scheduler */
+  private $scheduler;
+
   public function __construct(
     AuthorizedEmailsController $authorizedEmailsController,
     Emoji $emoji,
@@ -85,7 +88,8 @@ class NewsletterSaveController {
     SettingsController $settings,
     Security $security,
     WPFunctions $wp,
-    ApiDataSanitizer $dataSanitizer
+    ApiDataSanitizer $dataSanitizer,
+    Scheduler $scheduler
   ) {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->emoji = $emoji;
@@ -101,6 +105,7 @@ class NewsletterSaveController {
     $this->security = $security;
     $this->wp = $wp;
     $this->dataSanitizer = $dataSanitizer;
+    $this->scheduler = $scheduler;
   }
 
   public function save(array $data = []): NewsletterEntity {
@@ -349,7 +354,7 @@ class NewsletterSaveController {
 
     // generate the new schedule from options and get the new "next run" date
     $schedule = $this->postNotificationScheduler->processPostNotificationSchedule($newsletter);
-    $nextRunDateString = Scheduler::getNextRunDate($schedule);
+    $nextRunDateString = $this->scheduler->getNextRunDate($schedule);
     $nextRunDate = $nextRunDateString ? Carbon::createFromFormat('Y-m-d H:i:s', $nextRunDateString) : null;
     if ($nextRunDate === false) {
       throw InvalidStateException::create()->withMessage('Invalid next run date generated');

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -13,14 +13,19 @@ class AutomaticEmailScheduler {
   /** @var WPFunctions|null */
   private $wp;
 
+  /** @var Scheduler */
+  private $scheduler;
+
   public function __construct(
+    Scheduler $scheduler,
     ?WPFunctions $wp = null
   ) {
+    $this->scheduler = $scheduler;
     $this->wp = $wp;
   }
 
   public function scheduleAutomaticEmail($group, $event, $schedulingCondition = false, $subscriberId = false, $meta = false, $metaModifier = null) {
-    $newsletters = Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
+    $newsletters = $this->scheduler->getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
     if (empty($newsletters)) return false;
     foreach ($newsletters as $newsletter) {
       if ($newsletter->event !== $event) continue;
@@ -42,7 +47,7 @@ class AutomaticEmailScheduler {
   }
 
   public function scheduleOrRescheduleAutomaticEmail($group, $event, $subscriberId, $meta = false) {
-    $newsletters = Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
+    $newsletters = $this->scheduler->getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
     if (empty($newsletters)) {
       return false;
     }
@@ -63,7 +68,7 @@ class AutomaticEmailScheduler {
   }
 
   public function rescheduleAutomaticEmail($group, $event, $subscriberId) {
-    $newsletters = Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
+    $newsletters = $this->scheduler->getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
     if (empty($newsletters)) {
       return false;
     }
@@ -82,7 +87,7 @@ class AutomaticEmailScheduler {
   }
 
   public function cancelAutomaticEmail($group, $event, $subscriberId) {
-    $newsletters = Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
+    $newsletters = $this->scheduler->getNewsletters(Newsletter::TYPE_AUTOMATIC, $group);
     if (empty($newsletters)) {
       return false;
     }
@@ -114,7 +119,7 @@ class AutomaticEmailScheduler {
     $sendingTask->status = SendingQueue::STATUS_SCHEDULED;
     $sendingTask->priority = SendingQueue::PRIORITY_MEDIUM;
 
-    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
+    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
     return $sendingTask->save();
   }
 
@@ -124,7 +129,7 @@ class AutomaticEmailScheduler {
       $sendingTask->__set('meta', $meta);
     }
     // compute new 'scheduled_at' from now
-    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
+    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
     $sendingTask->save();
   }
 }

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -7,21 +7,16 @@ use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Tasks\Sending as SendingTask;
-use MailPoet\WP\Functions as WPFunctions;
 
 class AutomaticEmailScheduler {
-  /** @var WPFunctions|null */
-  private $wp;
 
   /** @var Scheduler */
   private $scheduler;
 
   public function __construct(
-    Scheduler $scheduler,
-    ?WPFunctions $wp = null
+    Scheduler $scheduler
   ) {
     $this->scheduler = $scheduler;
-    $this->wp = $wp;
   }
 
   public function scheduleAutomaticEmail($group, $event, $schedulingCondition = false, $subscriberId = false, $meta = false, $metaModifier = null) {
@@ -119,7 +114,7 @@ class AutomaticEmailScheduler {
     $sendingTask->status = SendingQueue::STATUS_SCHEDULED;
     $sendingTask->priority = SendingQueue::PRIORITY_MEDIUM;
 
-    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
+    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber);
     return $sendingTask->save();
   }
 
@@ -129,7 +124,7 @@ class AutomaticEmailScheduler {
       $sendingTask->__set('meta', $meta);
     }
     // compute new 'scheduled_at' from now
-    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber, $this->wp);
+    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay($newsletter->afterTimeType, $newsletter->afterTimeNumber);
     $sendingTask->save();
   }
 }

--- a/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
@@ -40,17 +40,22 @@ class PostNotificationScheduler {
   /** @var NewsletterPostsRepository */
   private $newsletterPostsRepository;
 
+  /** @var Scheduler */
+  private $scheduler;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
     NewsletterOptionsRepository $newsletterOptionsRepository,
     NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository,
-    NewsletterPostsRepository $newsletterPostsRepository
+    NewsletterPostsRepository $newsletterPostsRepository,
+    Scheduler $scheduler
   ) {
     $this->loggerFactory = LoggerFactory::getInstance();
     $this->newslettersRepository = $newslettersRepository;
     $this->newsletterOptionsRepository = $newsletterOptionsRepository;
     $this->newsletterOptionFieldsRepository = $newsletterOptionFieldsRepository;
     $this->newsletterPostsRepository = $newsletterPostsRepository;
+    $this->scheduler = $scheduler;
   }
 
   public function transitionHook($newStatus, $oldStatus, $post) {
@@ -100,7 +105,7 @@ class PostNotificationScheduler {
     if (!$scheduleOption) {
       return null;
     }
-    $nextRunDate = Scheduler::getNextRunDate($scheduleOption->getValue());
+    $nextRunDate = $this->scheduler->getNextRunDate($scheduleOption->getValue());
     if (!$nextRunDate) {
       return null;
     }

--- a/mailpoet/lib/Newsletter/Scheduler/Scheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/Scheduler.php
@@ -9,9 +9,17 @@ use MailPoetVendor\Carbon\Carbon;
 class Scheduler {
   const MYSQL_TIMESTAMP_MAX = '2038-01-19 03:14:07';
 
-  public static function getNextRunDate($schedule, $fromTimestamp = false) {
-    $wp = new WPFunctions();
-    $fromTimestamp = ($fromTimestamp) ? $fromTimestamp : $wp->currentTime('timestamp');
+  /** @var WPFunctions  */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function getNextRunDate($schedule, $fromTimestamp = false) {
+    $fromTimestamp = ($fromTimestamp) ? $fromTimestamp : $this->wp->currentTime('timestamp');
     try {
       $schedule = \Cron\CronExpression::factory($schedule);
       $nextRunDate = $schedule->getNextRunDate(Carbon::createFromTimestamp($fromTimestamp))
@@ -22,9 +30,8 @@ class Scheduler {
     return $nextRunDate;
   }
 
-  public static function getPreviousRunDate($schedule, $fromTimestamp = false) {
-    $wp = WPFunctions::get();
-    $fromTimestamp = ($fromTimestamp) ? $fromTimestamp : $wp->currentTime('timestamp');
+  public function getPreviousRunDate($schedule, $fromTimestamp = false) {
+    $fromTimestamp = ($fromTimestamp) ? $fromTimestamp : $this->wp->currentTime('timestamp');
     try {
       $schedule = \Cron\CronExpression::factory($schedule);
       $previousRunDate = $schedule->getPreviousRunDate(Carbon::createFromTimestamp($fromTimestamp))
@@ -35,8 +42,8 @@ class Scheduler {
     return $previousRunDate;
   }
 
-  public static function getScheduledTimeWithDelay($afterTimeType, $afterTimeNumber, $wp = null): Carbon {
-    $wp = $wp ?? WPFunctions::get();
+  public function getScheduledTimeWithDelay($afterTimeType, $afterTimeNumber, $wp = null): Carbon {
+    $wp = $wp ?? $this->wp;
     $currentTime = Carbon::createFromTimestamp($wp->currentTime('timestamp'));
     switch ($afterTimeType) {
       case 'minutes':
@@ -59,7 +66,7 @@ class Scheduler {
     return $currentTime;
   }
 
-  public static function getNewsletters($type, $group = false) {
+  public function getNewsletters($type, $group = false) {
     return Newsletter::getPublished()
       ->filter('filterType', $type, $group)
       ->filter('filterStatus', Newsletter::STATUS_ACTIVE)
@@ -67,7 +74,7 @@ class Scheduler {
       ->findMany();
   }
 
-  public static function formatDatetimeString($datetimeString) {
+  public function formatDatetimeString($datetimeString) {
     return Carbon::parse($datetimeString)->format('Y-m-d H:i:s');
   }
 }

--- a/mailpoet/lib/Newsletter/Scheduler/Scheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/Scheduler.php
@@ -42,9 +42,8 @@ class Scheduler {
     return $previousRunDate;
   }
 
-  public function getScheduledTimeWithDelay($afterTimeType, $afterTimeNumber, $wp = null): Carbon {
-    $wp = $wp ?? $this->wp;
-    $currentTime = Carbon::createFromTimestamp($wp->currentTime('timestamp'));
+  public function getScheduledTimeWithDelay($afterTimeType, $afterTimeNumber): Carbon {
+    $currentTime = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
     switch ($afterTimeType) {
       case 'minutes':
         $currentTime->addMinutes($afterTimeNumber);

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -30,6 +30,9 @@ class WelcomeScheduler {
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
 
+  /** @var Scheduler  */
+  private $scheduler;
+
   /** @var WPFunctions|null */
   private $wp;
 
@@ -38,12 +41,14 @@ class WelcomeScheduler {
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
     ScheduledTasksRepository $scheduledTasksRepository,
+    Scheduler $scheduler,
     ?WPFunctions $wp = null
   ) {
     $this->subscribersRepository = $subscribersRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->scheduler = $scheduler;
     $this->wp = $wp;
   }
 
@@ -121,7 +126,7 @@ class WelcomeScheduler {
     $sendingTask->setSubscribers([$subscriberId]);
     $sendingTask->status = SendingQueue::STATUS_SCHEDULED;
     $sendingTask->priority = SendingQueue::PRIORITY_HIGH;
-    $sendingTask->scheduledAt = Scheduler::getScheduledTimeWithDelay(
+    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay(
       $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE),
       $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER),
       $this->wp

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -12,7 +12,6 @@ use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
-use MailPoet\WP\Functions as WPFunctions;
 
 class WelcomeScheduler {
 
@@ -33,23 +32,18 @@ class WelcomeScheduler {
   /** @var Scheduler  */
   private $scheduler;
 
-  /** @var WPFunctions|null */
-  private $wp;
-
   public function __construct(
     SubscribersRepository $subscribersRepository,
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
     ScheduledTasksRepository $scheduledTasksRepository,
-    Scheduler $scheduler,
-    ?WPFunctions $wp = null
+    Scheduler $scheduler
   ) {
     $this->subscribersRepository = $subscribersRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->scheduler = $scheduler;
-    $this->wp = $wp;
   }
 
   public function scheduleSubscriberWelcomeNotification($subscriberId, $segments) {
@@ -128,8 +122,7 @@ class WelcomeScheduler {
     $sendingTask->priority = SendingQueue::PRIORITY_HIGH;
     $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay(
       $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE),
-      $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER),
-      $this->wp
+      $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER)
     );
     return $sendingTask->save();
   }

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -15,6 +15,7 @@ use MailPoet\Mailer\MailerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
+use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SubscribersFinder;
@@ -82,7 +83,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->diContainer->get(Bridge::class),
       $this->diContainer->get(SubscribersFinder::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
-      $this->diContainer->get(MailerFactory::class)
+      $this->diContainer->get(MailerFactory::class),
+      $this->diContainer->get(Scheduler::class)
     );
     $res = $sendingQueue->add(['newsletter_id' => $this->newsletter->getId()]);
     expect($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
@@ -152,7 +154,8 @@ class SendingQueueTest extends \MailPoetTest {
       ]),
       $this->diContainer->get(SubscribersFinder::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
-      $this->diContainer->get(MailerFactory::class)
+      $this->diContainer->get(MailerFactory::class),
+      $this->diContainer->get(Scheduler::class)
     );
     $response = $sendingQueue->add(['newsletter_id' => $newsletter->getId()]);
     $response = $response->getData();

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -90,7 +90,7 @@ class AbandonedCartTest extends \MailPoetTest {
       $wcHelper,
       $subscriberCookie,
       $this->diContainer->get(SubscriberActivityTracker::class),
-      new AutomaticEmailScheduler($wp)
+      $this->diContainer->get(AutomaticEmailScheduler::class)
     );
     $result = $event->getEventDetails();
     expect($result)->notEmpty();
@@ -263,12 +263,13 @@ class AbandonedCartTest extends \MailPoetTest {
 
   private function createAbandonedCartEmail() {
     $settings = $this->diContainer->get(SettingsController::class);
+    $automaticEmailScheduler = $this->diContainer->get(AutomaticEmailScheduler::class);
     return $this->make(AbandonedCart::class, [
       'wp' => $this->wp,
       'wooCommerceHelper' => $this->wooCommerceHelperMock,
       'subscriberCookie' => new SubscriberCookie(new Cookies(), new TrackingConfig($settings)),
       'subscriberActivityTracker' => $this->subscriberActivityTrackerMock,
-      'scheduler' => new AutomaticEmailScheduler(),
+      'scheduler' => $automaticEmailScheduler,
     ]);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -29,6 +29,7 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Idiorm\ORM;
 use WP_User;
+use MailPoet\Newsletter\Scheduler\Scheduler as NewsletterScheduler;
 
 class SchedulerTest extends \MailPoetTest {
   public $cronHelper;
@@ -50,6 +51,9 @@ class SchedulerTest extends \MailPoetTest {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var NewsletterScheduler */
+  private $newsletterScheduler;
+
   public function _before() {
     parent::_before();
     $this->loggerFactory = LoggerFactory::getInstance();
@@ -59,11 +63,21 @@ class SchedulerTest extends \MailPoetTest {
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
+    $this->newsletterScheduler = $this->diContainer->get(NewsletterScheduler::class);
   }
 
   public function testItThrowsExceptionWhenExecutionLimitIsReached() {
     try {
-      $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+      $scheduler = new Scheduler(
+        $this->makeEmpty(SubscribersFinder::class),
+        $this->loggerFactory,
+        $this->cronHelper,
+        $this->cronWorkerScheduler,
+        $this->scheduledTasksRepository,
+        $this->newslettersRepository,
+        $this->segmentsRepository,
+        $this->newsletterScheduler
+      );
       $scheduler->process(microtime(true) - $this->cronHelper->getDaemonExecutionLimit());
       self::fail('Maximum execution time limit exception was not thrown.');
     } catch (\Exception $e) {
@@ -93,7 +107,16 @@ class SchedulerTest extends \MailPoetTest {
     expect($notificationHistory)->isEmpty();
 
     // create notification history and ensure that it exists
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->createNotificationHistory($newsletter->id);
     $notificationHistory = Newsletter::where('type', Newsletter::TYPE_NOTIFICATION_HISTORY)
       ->where('parent_id', $newsletter->id)
@@ -110,7 +133,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // queue and associated newsletter should be deleted when interval type is set to "immediately"
     expect(SendingQueue::findMany())->notEmpty();
@@ -128,7 +160,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // queue's next run date should change when interval type is set to anything
     // other than "immediately"
@@ -162,7 +203,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return false and delete queue when subscriber is not a WP user
     $result = $scheduler->verifyWPSubscriber($subscriber->id, $newsletter, $queue);
@@ -186,7 +236,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return false and delete queue when subscriber role is different from the one
     // specified for the welcome email
@@ -209,7 +268,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return true when user exists and WP role matches the one specified for the welcome email
     $result = $scheduler->verifyWPSubscriber($subscriber->id, $newsletter, $queue);
@@ -231,7 +299,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // true when user exists and has any role
     $result = $scheduler->verifyWPSubscriber($subscriber->id, $newsletter, $queue);
@@ -245,7 +322,16 @@ class SchedulerTest extends \MailPoetTest {
     $queue->setSubscribers([]);
 
     // delete queue when the list of subscribers to process is blank
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $result = $scheduler->processWelcomeNewsletter($newsletter, $queue);
     expect($result)->false();
     expect(SendingQueue::findMany())->count(0);
@@ -319,7 +405,16 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItFailsMailpoetSubscriberVerificationWhenSubscriberDoesNotExist() {
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $newsletter = $this->_createNewsletter();
     $queue = $this->_createQueue($newsletter->id);
 
@@ -340,7 +435,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return false
     $result = $scheduler->verifyMailpoetSubscriber($subscriber->id, $newsletter, $queue);
@@ -372,7 +476,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return false
     $result = $scheduler->verifyMailpoetSubscriber($subscriber->id, $newsletter, $queue);
@@ -404,7 +517,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return false
     $result = $scheduler->verifyMailpoetSubscriber($subscriber->id, $newsletter, $queue);
@@ -428,7 +550,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return true after successful verification
     $result = $scheduler->verifyMailpoetSubscriber($subscriber->id, $newsletter, $queue);
@@ -451,7 +582,16 @@ class SchedulerTest extends \MailPoetTest {
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
     $queue = $this->_createQueue($newsletter->id);
-    $scheduler = new Scheduler($this->subscribersFinder, $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->subscribersFinder,
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return true
     expect($scheduler->processScheduledStandardNewsletter($newsletter, $queue))->true();
@@ -492,7 +632,18 @@ class SchedulerTest extends \MailPoetTest {
     $newsletterSegment = $this->_createNewsletterSegment($newsletter->id, $segment->id);
 
     // delete or reschedule queue when there are no subscribers in segments
-    $scheduler = $this->construct(Scheduler::class, [$this->subscribersFinder, $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository], [
+    $scheduler = $this->construct(
+      Scheduler::class,
+      [
+        $this->subscribersFinder,
+        $this->loggerFactory,
+        $this->cronHelper,
+        $this->cronWorkerScheduler,
+        $this->scheduledTasksRepository,
+        $this->newslettersRepository,
+        $this->segmentsRepository,
+        $this->newsletterScheduler
+      ], [
       'deleteQueueOrUpdateNextRunDate' => Expected::exactly(1, function() {
         return false;
       }),
@@ -516,7 +667,16 @@ class SchedulerTest extends \MailPoetTest {
     $newsletter = Newsletter::filter('filterWithOptions', Newsletter::TYPE_NOTIFICATION)
       ->findOne($newsletter->id);
     assert($newsletter instanceof Newsletter);
-    $scheduler = new Scheduler($this->subscribersFinder, $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->subscribersFinder,
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     // return true
     expect($scheduler->processPostNotificationNewsletter($newsletter, $queue))->true();
@@ -543,7 +703,16 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItFailsToProcessWhenScheduledQueuesNotFound() {
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     expect($scheduler->process())->false();
   }
 
@@ -551,7 +720,16 @@ class SchedulerTest extends \MailPoetTest {
     $queue = $this->_createQueue(1);
     $queue->scheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $queue->save();
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->process();
     expect(SendingQueue::findMany())->count(0);
   }
@@ -563,7 +741,16 @@ class SchedulerTest extends \MailPoetTest {
     $queue = $this->_createQueue($newsletter->id);
     $queue->scheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $queue->save();
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->process();
     expect(SendingQueue::findMany())->count(0);
   }
@@ -655,7 +842,16 @@ class SchedulerTest extends \MailPoetTest {
     $newsletter = $this->_createNewsletter(Newsletter::TYPE_STANDARD, Newsletter::STATUS_DRAFT);
     $queue = $this->_createQueue($newsletter->id);
     $finder = $this->makeEmpty(SubscribersFinder::class);
-    $scheduler = new Scheduler($finder, $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $finder,
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
 
     $scheduler->processScheduledStandardNewsletter($newsletter, $queue);
     $refetchedTask = ScheduledTask::where('id', $task->id)->findOne();
@@ -694,7 +890,16 @@ class SchedulerTest extends \MailPoetTest {
     expect($task->getSubscribers())->equals([$subscriber->id]);
 
     // task should have its status set to null (i.e., sending)
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->process();
     $task = SendingTask::getByNewsletterId($newsletter->id);
     expect($task->status)->null();
@@ -718,7 +923,16 @@ class SchedulerTest extends \MailPoetTest {
     expect($task->getSubscribers())->equals([$subscriber->id]);
 
     // task should be deleted
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->process();
     $task = SendingTask::getByNewsletterId($newsletter->id);
     expect($task)->false();
@@ -746,7 +960,16 @@ class SchedulerTest extends \MailPoetTest {
     expect($task->newsletterId)->equals($newsletter->id);
 
     // task should have its status set to null (i.e., sending)
-    $scheduler = new Scheduler($this->subscribersFinder, $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->subscribersFinder,
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->process();
     $task = SendingTask::getByNewsletterId($newsletter->id);
     expect($task->status)->null();
@@ -763,7 +986,16 @@ class SchedulerTest extends \MailPoetTest {
     $queue->scheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $queue->updatedAt = $originalUpdated;
     $queue->save();
-    $scheduler = new Scheduler($this->makeEmpty(SubscribersFinder::class), $this->loggerFactory, $this->cronHelper, $this->cronWorkerScheduler, $this->scheduledTasksRepository, $this->newslettersRepository, $this->segmentsRepository);
+    $scheduler = new Scheduler(
+      $this->makeEmpty(SubscribersFinder::class),
+      $this->loggerFactory,
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->newslettersRepository,
+      $this->segmentsRepository,
+      $this->newsletterScheduler
+    );
     $scheduler->process();
     $newQueue = ScheduledTask::findOne($queue->taskId);
     assert($newQueue instanceof ScheduledTask);

--- a/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
@@ -70,7 +70,7 @@ class AbandonedCartContentTest extends \MailPoetTest {
     $this->block = $this->diContainer->get(AbandonedCartContent::class);
     $this->wp = $this->diContainer->get(WPFunctions::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    $this->automaticEmailScheduler = new AutomaticEmailScheduler();
+    $this->automaticEmailScheduler = $this->diContainer->get(AutomaticEmailScheduler::class);
 
     // Clear old products
     $products = $this->wp->getPosts(['post_type' => 'product']);

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -21,10 +21,13 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
   /** @var NewsletterSaveController */
   private $saveController;
 
+  /** @var Scheduler */
+  private $scheduler;
   public function _before() {
     parent::_before();
     $this->cleanup();
     $this->saveController = $this->diContainer->get(NewsletterSaveController::class);
+    $this->scheduler = $this->diContainer->get(Scheduler::class);
   }
 
   public function testItCanSaveANewsletter() {
@@ -168,7 +171,8 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     })->first();
     expect($task1->getScheduledAt())->notEquals($currentTime);
     assert($scheduleOption instanceof NewsletterOptionEntity); // PHPStan
-    expect($task1->getScheduledAt())->equals(Scheduler::getNextRunDate($scheduleOption->getValue()));
+
+    expect($task1->getScheduledAt())->equals($this->scheduler->getNextRunDate($scheduleOption->getValue()));
     expect($task2->getScheduledAt())->null();
   }
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -178,7 +178,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $wpMock->expects($this->any())
       ->method('currentTime')
       ->willReturn($currentTime->getTimestamp());
-    $automaticEmailScheduler = new AutomaticEmailScheduler(new Scheduler($wpMock), $wpMock);
+    $automaticEmailScheduler = new AutomaticEmailScheduler(new Scheduler($wpMock));
     // email should only be scheduled if it matches condition ("send to segment")
     $automaticEmailScheduler->scheduleAutomaticEmail('some_group', 'some_event', $condition);
     $result = SendingQueue::findMany();

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -23,7 +23,7 @@ class AutomaticEmailTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->automaticEmailScheduler = new AutomaticEmailScheduler;
+    $this->automaticEmailScheduler = $this->diContainer->get(AutomaticEmailScheduler::class);
   }
 
   public function testItCreatesScheduledAutomaticEmailSendingTaskForUser() {
@@ -178,7 +178,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $wpMock->expects($this->any())
       ->method('currentTime')
       ->willReturn($currentTime->getTimestamp());
-    $automaticEmailScheduler = new AutomaticEmailScheduler($wpMock);
+    $automaticEmailScheduler = new AutomaticEmailScheduler(new Scheduler($wpMock), $wpMock);
     // email should only be scheduled if it matches condition ("send to segment")
     $automaticEmailScheduler->scheduleAutomaticEmail('some_group', 'some_event', $condition);
     $result = SendingQueue::findMany();

--- a/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
@@ -16,14 +16,23 @@ use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Idiorm\ORM;
 
 class SchedulerTest extends \MailPoetTest {
+
+  /** @var Scheduler */
+  private $testee;
+
+  public function _before() {
+    parent::_before();
+    $this->testee = $this->diContainer->get(Scheduler::class);
+  }
+
   public function testItGetsActiveNewslettersFilteredByTypeAndGroup() {
     $this->_createNewsletter($type = Newsletter::TYPE_WELCOME);
 
     // no newsletters with type "notification" should be found
-    expect(Scheduler::getNewsletters(Newsletter::TYPE_NOTIFICATION))->isEmpty();
+    expect($this->testee->getNewsletters(Newsletter::TYPE_NOTIFICATION))->isEmpty();
 
     // one newsletter with type "welcome" should be found
-    expect(Scheduler::getNewsletters(Newsletter::TYPE_WELCOME))->count(1);
+    expect($this->testee->getNewsletters(Newsletter::TYPE_WELCOME))->count(1);
 
     // one automatic email belonging to "test" group should be found
     $newsletter = $this->_createNewsletter($type = Newsletter::TYPE_AUTOMATIC);
@@ -35,32 +44,32 @@ class SchedulerTest extends \MailPoetTest {
       ]
     );
 
-    expect(Scheduler::getNewsletters(Newsletter::TYPE_AUTOMATIC, 'group_does_not_exist'))->isEmpty();
-    expect(Scheduler::getNewsletters(Newsletter::TYPE_WELCOME, 'test'))->count(1);
+    expect($this->testee->getNewsletters(Newsletter::TYPE_AUTOMATIC, 'group_does_not_exist'))->isEmpty();
+    expect($this->testee->getNewsletters(Newsletter::TYPE_WELCOME, 'test'))->count(1);
   }
 
   public function testItCanGetNextRunDate() {
     // it accepts cron syntax and returns next run date
     $currentTime = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     Carbon::setTestNow($currentTime); // mock carbon to return current time
-    expect(Scheduler::getNextRunDate('* * * * *'))
+    expect($this->testee->getNextRunDate('* * * * *'))
       ->equals($currentTime->addMinute()->format('Y-m-d H:i:00'));
     // when invalid CRON expression is used, false response is returned
-    expect(Scheduler::getNextRunDate('invalid CRON expression'))->false();
+    expect($this->testee->getNextRunDate('invalid CRON expression'))->false();
   }
 
   public function testItCanGetPreviousRunDate() {
     // it accepts cron syntax and returns previous run date
     $currentTime = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     Carbon::setTestNow($currentTime); // mock carbon to return current time
-    expect(Scheduler::getPreviousRunDate('* * * * *'))
+    expect($this->testee->getPreviousRunDate('* * * * *'))
       ->equals($currentTime->subMinute()->format('Y-m-d H:i:00'));
     // when invalid CRON expression is used, false response is returned
-    expect(Scheduler::getPreviousRunDate('invalid CRON expression'))->false();
+    expect($this->testee->getPreviousRunDate('invalid CRON expression'))->false();
   }
 
   public function testItFormatsDatetimeString() {
-    expect(Scheduler::formatDatetimeString('April 20, 2016 4pm'))
+    expect($this->testee->formatDatetimeString('April 20, 2016 4pm'))
       ->equals('2016-04-20 16:00:00');
   }
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -467,6 +467,7 @@ class WelcomeTest extends \MailPoetTest {
       $this->segmentRepository,
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
+      $this->diContainer->get(Scheduler::class),
       $wpMock
     );
   }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -467,8 +467,7 @@ class WelcomeTest extends \MailPoetTest {
       $this->segmentRepository,
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
-      $this->diContainer->get(Scheduler::class),
-      $wpMock
+      new Scheduler($wpMock)
     );
   }
 

--- a/mailpoet/tests/unit/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/unit/Newsletter/Scheduler/SchedulerTest.php
@@ -14,6 +14,9 @@ class SchedulerTest extends \MailPoetUnitTest {
   /** @var Carbon */
   private $currentTime;
 
+  /** @var Scheduler */
+  private $testee;
+
   public function _before() {
     parent::_before();
     $this->currentTime = Carbon::now();
@@ -24,36 +27,37 @@ class SchedulerTest extends \MailPoetUnitTest {
       'currentTime' => $this->currentTime->getTimestamp(),
     ]);
     $this->wp = $wp;
+    $this->testee = new Scheduler($this->wp);
   }
 
   public function testItScheduleTimeWithDelayByHours(): void {
-    $scheduledAt = Scheduler::getScheduledTimeWithDelay('hours', 6, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('hours', 6, $this->wp);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addHours(6);
     expect($scheduledAt)->equals($expectedDate);
 
-    $scheduledAt = Scheduler::getScheduledTimeWithDelay('hours', 38, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('hours', 38, $this->wp);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addHours(38);
     expect($scheduledAt)->equals($expectedDate);
   }
 
   public function testItScheduleTimeWithDelayByDays(): void {
-    $scheduledAt = Scheduler::getScheduledTimeWithDelay('days', 23, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('days', 23, $this->wp);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addDays(23);
     expect($scheduledAt)->equals($expectedDate);
   }
 
   public function testItScheduleTimeWithDelayByWeek(): void {
-    $scheduledAt = Scheduler::getScheduledTimeWithDelay('weeks', 2, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 2, $this->wp);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addWeeks(2);
     expect($scheduledAt)->equals($expectedDate);
 
-    $scheduledAt = Scheduler::getScheduledTimeWithDelay('weeks', 14, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 14, $this->wp);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addWeeks(14);
     expect($scheduledAt)->equals($expectedDate);
   }
 
   public function testItDoesNotScheduleTimeWithDelayOutOfRange(): void {
-    $scheduledAt = Scheduler::getScheduledTimeWithDelay('weeks', 4000, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 4000, $this->wp);
     $maxDate = Carbon::createFromFormat('Y-m-d H:i:s', Scheduler::MYSQL_TIMESTAMP_MAX);
     expect($scheduledAt)->equals($maxDate);
   }

--- a/mailpoet/tests/unit/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/unit/Newsletter/Scheduler/SchedulerTest.php
@@ -8,8 +8,6 @@ use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class SchedulerTest extends \MailPoetUnitTest {
-  /** @var WPFunctions */
-  private $wp;
 
   /** @var Carbon */
   private $currentTime;
@@ -26,38 +24,37 @@ class SchedulerTest extends \MailPoetUnitTest {
     $wp = $this->makeEmpty(WPFunctions::class, [
       'currentTime' => $this->currentTime->getTimestamp(),
     ]);
-    $this->wp = $wp;
-    $this->testee = new Scheduler($this->wp);
+    $this->testee = new Scheduler($wp);
   }
 
   public function testItScheduleTimeWithDelayByHours(): void {
-    $scheduledAt = $this->testee->getScheduledTimeWithDelay('hours', 6, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('hours', 6);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addHours(6);
     expect($scheduledAt)->equals($expectedDate);
 
-    $scheduledAt = $this->testee->getScheduledTimeWithDelay('hours', 38, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('hours', 38);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addHours(38);
     expect($scheduledAt)->equals($expectedDate);
   }
 
   public function testItScheduleTimeWithDelayByDays(): void {
-    $scheduledAt = $this->testee->getScheduledTimeWithDelay('days', 23, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('days', 23);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addDays(23);
     expect($scheduledAt)->equals($expectedDate);
   }
 
   public function testItScheduleTimeWithDelayByWeek(): void {
-    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 2, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 2);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addWeeks(2);
     expect($scheduledAt)->equals($expectedDate);
 
-    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 14, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 14);
     $expectedDate = (Carbon::createFromTimestamp($this->currentTime->timestamp))->addWeeks(14);
     expect($scheduledAt)->equals($expectedDate);
   }
 
   public function testItDoesNotScheduleTimeWithDelayOutOfRange(): void {
-    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 4000, $this->wp);
+    $scheduledAt = $this->testee->getScheduledTimeWithDelay('weeks', 4000);
     $maxDate = Carbon::createFromFormat('Y-m-d H:i:s', Scheduler::MYSQL_TIMESTAMP_MAX);
     expect($scheduledAt)->equals($maxDate);
   }


### PR DESCRIPTION
Fixes [MAILPOET-4252]

[MAILPOET-4252]: https://mailpoet.atlassian.net/browse/MAILPOET-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test steps:
1. Go to MailPoet > Emails
2. Schedule a new simple newsletter to be sent to your email today (remember the date/time)
3. Go to MailPoet Debug, copy the password shown and click Adminer link
4. Paste the password and click Login
5. Click [wp_mailpoet_scheduled_tasks](https://gs.qawp.net/wp-content/plugins/mailpoet-debug-trunk/adminer.php?server=localhost&username=admin_gsqawpuser&db=admin_gsqawpdb&table=wp_mailpoet_scheduled_tasks) table when inside
6. Click Select data link
7. Click twice time `scheduled_at` row to sort it to the last newsletter
8. You need to find your scheduled newsletter here, look for the date/time and seek for what you scheduled in step 2. When you find it, click Edit link to edit that `sending` newsletter
9. Now just edit the scheduled_at date to be sent in the next few minutes... (just change the time to be 5 mins in front of now)
10. Click Save button
11. Now just wait for it to be sent (at that time that you set) and check inbox to receive the scheduled newsletter

Note: Please remember these steps as it will be required in the future to edit your scheduled newsletters and execute them sooner.