### PR TITLE
Fix failing tests of AutomatedLatestContent::getPosts in MU

### DIFF
--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
@@ -96,11 +96,21 @@ class AutomatedLatestContentAPITest extends \MailPoetTest {
     $apiPermissionHelper = $this->diContainer->get(APIPermissionHelper::class);
     $this->alcAPI = new ALCAPI($alc, $apiPermissionHelper, $this->wp);
 
+    if (is_multisite()) {
+      // switch to the first blog in a network install, this should be removed when we add full support for MU
+      switch_to_blog(1);
+    }
+
     $this->deleteAllPosts();
   }
 
   public function _after() {
     parent::_after();
+
+    // we've switched to blog_id=1
+    if (is_multisite()) {
+      restore_current_blog();
+    }
 
     foreach ($this->createdUsers as $user) {
       wp_delete_user($user->ID);


### PR DESCRIPTION
The issue was that on the CI we are switching the blog to a blog with id other than 1 when testing on MU.

### The fix:
Since we are not fully supporting MU a switch to blog_id = 1 was added to run the MU test only against the first blog.

[[MAILPOET-4082]]

[MAILPOET-4082]: https://mailpoet.atlassian.net/browse/MAILPOET-4082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ