### PR TITLE
[MAILPOET-4236] Prevent activation of invalid automatic newsletters

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -17,12 +17,12 @@ use MailPoet\Listing;
 use MailPoet\Newsletter\Listing\NewsletterListingRepository;
 use MailPoet\Newsletter\NewsletterSaveController;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Preview\SendPreviewController;
 use MailPoet\Newsletter\Preview\SendPreviewException;
 use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Url as NewsletterUrl;
-use MailPoet\Newsletter\Validator;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -76,11 +76,8 @@ class Newsletters extends APIEndpoint {
   /** @var NewsletterUrl */
   private $newsletterUrl;
 
-  /** @var TrackingConfig */
-  private $trackingConfig;
-
-  /** @var Validator */
-  private $validator;
+  /** @var NewsletterValidator */
+  private $newsletterValidator;
 
   /** @var Scheduler */
   private $scheduler;
@@ -100,7 +97,7 @@ class Newsletters extends APIEndpoint {
     NewsletterSaveController $newsletterSaveController,
     NewsletterUrl $newsletterUrl,
     Scheduler $scheduler,
-    Validator $validator
+    NewsletterValidator $newsletterValidator
   ) {
     $this->listingHandler = $listingHandler;
     $this->wp = $wp;
@@ -116,7 +113,7 @@ class Newsletters extends APIEndpoint {
     $this->newsletterSaveController = $newsletterSaveController;
     $this->newsletterUrl = $newsletterUrl;
     $this->scheduler = $scheduler;
-    $this->validator = $validator;
+    $this->newsletterValidator = $newsletterValidator;
   }
 
   public function get($data = []) {
@@ -188,7 +185,7 @@ class Newsletters extends APIEndpoint {
     }
 
     if ($status === NewsletterEntity::STATUS_ACTIVE) {
-      $validationError = $this->validator->validate($newsletter);
+      $validationError = $this->newsletterValidator->validate($newsletter);
       if ($validationError !== null) {
         return $this->errorResponse([APIError::FORBIDDEN => $validationError], [], Response::STATUS_FORBIDDEN);
       }

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -25,7 +25,6 @@ use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
-use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\Security;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -64,9 +63,6 @@ class Newsletters extends APIEndpoint {
   /** @var Emoji */
   private $emoji;
 
-  /** @var SubscribersFeature */
-  private $subscribersFeature;
-
   /** @var SendPreviewController */
   private $sendPreviewController;
 
@@ -92,7 +88,6 @@ class Newsletters extends APIEndpoint {
     NewslettersResponseBuilder $newslettersResponseBuilder,
     PostNotificationScheduler $postNotificationScheduler,
     Emoji $emoji,
-    SubscribersFeature $subscribersFeature,
     SendPreviewController $sendPreviewController,
     NewsletterSaveController $newsletterSaveController,
     NewsletterUrl $newsletterUrl,
@@ -108,7 +103,6 @@ class Newsletters extends APIEndpoint {
     $this->newslettersResponseBuilder = $newslettersResponseBuilder;
     $this->postNotificationScheduler = $postNotificationScheduler;
     $this->emoji = $emoji;
-    $this->subscribersFeature = $subscribersFeature;
     $this->sendPreviewController = $sendPreviewController;
     $this->newsletterSaveController = $newsletterSaveController;
     $this->newsletterUrl = $newsletterUrl;
@@ -169,12 +163,6 @@ class Newsletters extends APIEndpoint {
       return $this->badRequest([
         APIError::BAD_REQUEST => __('You need to specify a status.', 'mailpoet'),
       ]);
-    }
-
-    if ($status === NewsletterEntity::STATUS_ACTIVE && $this->subscribersFeature->check()) {
-      return $this->errorResponse([
-        APIError::FORBIDDEN => __('Subscribers limit reached.', 'mailpoet'),
-      ], [], Response::STATUS_FORBIDDEN);
     }
 
     $newsletter = $this->getNewsletter($data);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -24,7 +24,6 @@ use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Newsletter\Validator;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\TrackingConfig;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\Security;
@@ -100,7 +99,6 @@ class Newsletters extends APIEndpoint {
     SendPreviewController $sendPreviewController,
     NewsletterSaveController $newsletterSaveController,
     NewsletterUrl $newsletterUrl,
-    TrackingConfig $trackingConfig,
     Scheduler $scheduler,
     Validator $validator
   ) {
@@ -117,7 +115,6 @@ class Newsletters extends APIEndpoint {
     $this->sendPreviewController = $sendPreviewController;
     $this->newsletterSaveController = $newsletterSaveController;
     $this->newsletterUrl = $newsletterUrl;
-    $this->trackingConfig = $trackingConfig;
     $this->scheduler = $scheduler;
     $this->validator = $validator;
   }
@@ -195,28 +192,6 @@ class Newsletters extends APIEndpoint {
       if ($validationError !== null) {
         return $this->errorResponse([APIError::FORBIDDEN => $validationError], [], Response::STATUS_FORBIDDEN);
       }
-    }
-
-    // if the re-engagement email doesn't contain the re-engage link, it can't be activated
-    if ($newsletter->getType() === NewsletterEntity::TYPE_RE_ENGAGEMENT && $status === NewsletterEntity::STATUS_ACTIVE) {
-      if (strpos($newsletter->getContent(), '[link:subscription_re_engage_url]') === false) {
-        return $this->errorResponse([
-          APIError::FORBIDDEN => __(
-            'A re-engagement email must include a link with [link:subscription_re_engage_url] shortcode.',
-            'mailpoet'
-          ),
-        ], [], Response::STATUS_FORBIDDEN);
-      }
-    }
-
-    $tracking_enabled = $this->trackingConfig->isEmailTrackingEnabled();
-    if (!$tracking_enabled && $newsletter->getType() === NewsletterEntity::TYPE_RE_ENGAGEMENT && $status === NewsletterEntity::STATUS_ACTIVE) {
-      return $this->errorResponse([
-        APIError::FORBIDDEN => __(
-          'Re-engagement emails are disabled because open and click tracking is disabled in MailPoet → Settings → Advanced.',
-          'mailpoet'
-        ),
-      ], [], Response::STATUS_FORBIDDEN);
     }
 
     $this->newslettersRepository->prefetchOptions([$newsletter]);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -25,6 +25,7 @@ use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\Security;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -63,6 +64,9 @@ class Newsletters extends APIEndpoint {
   /** @var Emoji */
   private $emoji;
 
+  /** @var SubscribersFeature */
+  private $subscribersFeature;
+
   /** @var SendPreviewController */
   private $sendPreviewController;
 
@@ -87,6 +91,7 @@ class Newsletters extends APIEndpoint {
     NewsletterListingRepository $newsletterListingRepository,
     NewslettersResponseBuilder $newslettersResponseBuilder,
     PostNotificationScheduler $postNotificationScheduler,
+    SubscribersFeature $subscribersFeature,
     Emoji $emoji,
     SendPreviewController $sendPreviewController,
     NewsletterSaveController $newsletterSaveController,
@@ -102,6 +107,7 @@ class Newsletters extends APIEndpoint {
     $this->newsletterListingRepository = $newsletterListingRepository;
     $this->newslettersResponseBuilder = $newslettersResponseBuilder;
     $this->postNotificationScheduler = $postNotificationScheduler;
+    $this->subscribersFeature = $subscribersFeature;
     $this->emoji = $emoji;
     $this->sendPreviewController = $sendPreviewController;
     $this->newsletterSaveController = $newsletterSaveController;
@@ -163,6 +169,12 @@ class Newsletters extends APIEndpoint {
       return $this->badRequest([
         APIError::BAD_REQUEST => __('You need to specify a status.', 'mailpoet'),
       ]);
+    }
+
+    if ($status === NewsletterEntity::STATUS_ACTIVE && $this->subscribersFeature->check()) {
+      return $this->errorResponse([
+        APIError::FORBIDDEN => __('Subscribers limit reached.', 'mailpoet'),
+      ], [], Response::STATUS_FORBIDDEN);
     }
 
     $newsletter = $this->getNewsletter($data);

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -14,10 +14,10 @@ use MailPoet\Mailer\MailerFactory;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\SendingQueue as SendingQueueModel;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
-use MailPoet\Newsletter\Validator;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -45,11 +45,11 @@ class SendingQueue extends APIEndpoint {
   /** @var MailerFactory */
   private $mailerFactory;
 
+  /** @var NewsletterValidator */
+  private $newsletterValidator;
+  
   /** @var Scheduler */
   private $scheduler;
-
-  /** @var Validator */
-  private $validator;
 
   public function __construct(
     SubscribersFeature $subscribersFeature,
@@ -59,7 +59,7 @@ class SendingQueue extends APIEndpoint {
     ScheduledTasksRepository $scheduledTasksRepository,
     MailerFactory $mailerFactory,
     Scheduler $scheduler,
-    Validator $validator
+    NewsletterValidator $newsletterValidator
   ) {
     $this->subscribersFeature = $subscribersFeature;
     $this->subscribersFinder = $subscribersFinder;
@@ -68,7 +68,7 @@ class SendingQueue extends APIEndpoint {
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->mailerFactory = $mailerFactory;
     $this->scheduler = $scheduler;
-    $this->validator = $validator;
+    $this->newsletterValidator = $newsletterValidator;
   }
 
   public function add($data = []) {
@@ -97,7 +97,7 @@ class SendingQueue extends APIEndpoint {
       ]);
     }
 
-    $validationError = $this->validator->validate($newsletterEntity);
+    $validationError = $this->newsletterValidator->validate($newsletterEntity);
     if ($validationError) {
       return $this->errorResponse([
         APIError::BAD_REQUEST => $validationError,

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -392,6 +392,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\AutomaticEmailsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterHtmlSanitizer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Url::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Validator::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Links\Links::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Listing\NewsletterListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Options\NewsletterOptionsRepository::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -392,7 +392,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\AutomaticEmailsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterHtmlSanitizer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Url::class)->setPublic(true);
-    $container->autowire(\MailPoet\Newsletter\Validator::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\NewsletterValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Links\Links::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Listing\NewsletterListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Options\NewsletterOptionsRepository::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -5,7 +5,6 @@ namespace MailPoet\Newsletter;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
-use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Validator\ValidationException;
 
 class NewsletterValidator {
@@ -16,22 +15,16 @@ class NewsletterValidator {
   /** @var TrackingConfig */
   private $trackingConfig;
 
-  /** @var SubscribersFeature */
-  private $subscribersFeature;
-
   public function __construct(
     Bridge $bridge,
-    TrackingConfig $trackingConfig,
-    SubscribersFeature $subscribersFeature
+    TrackingConfig $trackingConfig
   ) {
     $this->bridge = $bridge;
     $this->trackingConfig = $trackingConfig;
-    $this->subscribersFeature = $subscribersFeature;
   }
   
   public function validate(NewsletterEntity $newsletterEntity): ?string {
     try {
-      $this->validateSubscriberLimit();
       $this->validateBody($newsletterEntity);
       $this->validateUnsubscribeRequirements($newsletterEntity);
       $this->validateReEngagementRequirements($newsletterEntity);
@@ -93,12 +86,6 @@ class NewsletterValidator {
       strpos($content, '"type":"automatedLatestContentLayout"') === false
     ) {
       throw new ValidationException(__('Please add an “Automatic Latest Content” widget to the email from the right sidebar.', 'mailpoet'));
-    }
-  }
-
-  private function validateSubscriberLimit(): void {
-    if ($this->subscribersFeature->check()) {
-      throw new ValidationException(__('Subscribers limit reached.', 'mailpoet'));
     }
   }
 }

--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -5,6 +5,7 @@ namespace MailPoet\Newsletter;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Validator\ValidationException;
 
 class NewsletterValidator {
@@ -15,16 +16,22 @@ class NewsletterValidator {
   /** @var TrackingConfig */
   private $trackingConfig;
 
+  /** @var SubscribersFeature */
+  private $subscribersFeature;
+
   public function __construct(
     Bridge $bridge,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    SubscribersFeature $subscribersFeature
   ) {
     $this->bridge = $bridge;
     $this->trackingConfig = $trackingConfig;
+    $this->subscribersFeature = $subscribersFeature;
   }
   
   public function validate(NewsletterEntity $newsletterEntity): ?string {
     try {
+      $this->validateSubscriberLimit();
       $this->validateBody($newsletterEntity);
       $this->validateUnsubscribeRequirements($newsletterEntity);
       $this->validateReEngagementRequirements($newsletterEntity);
@@ -86,6 +93,12 @@ class NewsletterValidator {
       strpos($content, '"type":"automatedLatestContentLayout"') === false
     ) {
       throw new ValidationException('Please add an “Automatic Latest Content” widget to the email from the right sidebar.');
+    }
+  }
+
+  private function validateSubscriberLimit(): void {
+    if ($this->subscribersFeature->check()) {
+      throw new ValidationException('Subscribers limit reached.');
     }
   }
 }

--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -7,7 +7,7 @@ use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Validator\ValidationException;
 
-class Validator {
+class NewsletterValidator {
   
   /** @var Bridge */
   private $bridge;
@@ -27,7 +27,8 @@ class Validator {
     try {
       $this->validateBody($newsletterEntity);
       $this->validateUnsubscribeRequirements($newsletterEntity);
-      $this->validateReengagementRequirements($newsletterEntity);
+      $this->validateReEngagementRequirements($newsletterEntity);
+      $this->validateAutomaticLatestContentRequirements($newsletterEntity);
     } catch (ValidationException $exception) {
       return __($exception->getMessage(), 'mailpoet');
     }
@@ -61,7 +62,7 @@ class Validator {
     }
   }
 
-  private function validateReengagementRequirements(NewsletterEntity $newsletterEntity): void {
+  private function validateReEngagementRequirements(NewsletterEntity $newsletterEntity): void {
     if ($newsletterEntity->getType() !== NewsletterEntity::TYPE_RE_ENGAGEMENT) {
       return;
     }
@@ -72,6 +73,19 @@ class Validator {
 
     if (!$this->trackingConfig->isEmailTrackingEnabled()) {
       throw new ValidationException('Re-engagement emails are disabled because open and click tracking is disabled in MailPoet → Settings → Advanced.');
+    }
+  }
+
+  private function validateAutomaticLatestContentRequirements(NewsletterEntity $newsletterEntity) {
+    if ($newsletterEntity->getType() !== NewsletterEntity::TYPE_NOTIFICATION) {
+      return;
+    }
+    $content = $newsletterEntity->getContent();
+    if (
+      strpos($content, '"type":"automatedLatestContent"') === false && 
+      strpos($content, '"type":"automatedLatestContentLayout"') === false
+    ) {
+      throw new ValidationException('Please add an “Automatic Latest Content” widget to the email from the right sidebar.');
     }
   }
 }

--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -37,7 +37,7 @@ class NewsletterValidator {
       $this->validateReEngagementRequirements($newsletterEntity);
       $this->validateAutomaticLatestContentRequirements($newsletterEntity);
     } catch (ValidationException $exception) {
-      return __($exception->getMessage(), 'mailpoet');
+      return $exception->getMessage();
     }
     return null;
   }
@@ -51,12 +51,12 @@ class NewsletterValidator {
     $hasUnsubscribeLink = strpos($content, '[link:subscription_unsubscribe]') !== false;
 
     if (!$hasUnsubscribeLink && !$hasUnsubscribeUrl) {
-      throw new ValidationException('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
+      throw new ValidationException(__('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.', 'mailpoet'));
     }
   }
 
   private function validateBody(NewsletterEntity $newsletterEntity): void {
-    $emptyBodyErrorMessage = 'Poet, please add prose to your masterpiece before you send it to your followers.';
+    $emptyBodyErrorMessage = __('Poet, please add prose to your masterpiece before you send it to your followers.', 'mailpoet');
     $content = $newsletterEntity->getContent();
 
     if ($content === '') {
@@ -75,11 +75,11 @@ class NewsletterValidator {
     }
 
     if (strpos($newsletterEntity->getContent(), '[link:subscription_re_engage_url]') === false) {
-      throw new ValidationException('A re-engagement email must include a link with [link:subscription_re_engage_url] shortcode.');
+      throw new ValidationException(__('A re-engagement email must include a link with [link:subscription_re_engage_url] shortcode.', 'mailpoet'));
     }
 
     if (!$this->trackingConfig->isEmailTrackingEnabled()) {
-      throw new ValidationException('Re-engagement emails are disabled because open and click tracking is disabled in MailPoet → Settings → Advanced.');
+      throw new ValidationException(__('Re-engagement emails are disabled because open and click tracking is disabled in MailPoet → Settings → Advanced.', 'mailpoet'));
     }
   }
 
@@ -92,13 +92,13 @@ class NewsletterValidator {
       strpos($content, '"type":"automatedLatestContent"') === false && 
       strpos($content, '"type":"automatedLatestContentLayout"') === false
     ) {
-      throw new ValidationException('Please add an “Automatic Latest Content” widget to the email from the right sidebar.');
+      throw new ValidationException(__('Please add an “Automatic Latest Content” widget to the email from the right sidebar.', 'mailpoet'));
     }
   }
 
   private function validateSubscriberLimit(): void {
     if ($this->subscribersFeature->check()) {
-      throw new ValidationException('Subscribers limit reached.');
+      throw new ValidationException(__('Subscribers limit reached.', 'mailpoet'));
     }
   }
 }

--- a/mailpoet/lib/Newsletter/Validator.php
+++ b/mailpoet/lib/Newsletter/Validator.php
@@ -22,21 +22,31 @@ class Validator {
       && is_array($newsletterEntity->getBody())
       && $newsletterEntity->getBody()['content']
     ) {
-      $body = json_encode($newsletterEntity->getBody()['content']);
-      if ($body === false) {
-        return __('Poet, please add prose to your masterpiece before you send it to your followers.');
+      $content = $newsletterEntity->getBody()['content'];
+      $encodedBody = json_encode($content);
+      if ($encodedBody === false) {
+        return $this->emptyContentErrorMessage();
+      } else {
+        $blocks = $content['blocks'] ?? [];
+        if (empty($blocks)) {
+          return $this->emptyContentErrorMessage();
+        }
       }
 
       if (
         $this->bridge->isMailpoetSendingServiceEnabled()
-        && (strpos($body, '[link:subscription_unsubscribe_url]') === false)
-        && (strpos($body, '[link:subscription_unsubscribe]') === false)
+        && (strpos($encodedBody, '[link:subscription_unsubscribe_url]') === false)
+        && (strpos($encodedBody, '[link:subscription_unsubscribe]') === false)
       ) {
         return __('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
       }
     } else {
-      return __('Poet, please add prose to your masterpiece before you send it to your followers.');
+      return $this->emptyContentErrorMessage();
     }
     return null;
+  }
+  
+  private function emptyContentErrorMessage(): string {
+    return __('Poet, please add prose to your masterpiece before you send it to your followers.');
   }
 }

--- a/mailpoet/lib/Newsletter/Validator.php
+++ b/mailpoet/lib/Newsletter/Validator.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace MailPoet\Newsletter;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Services\Bridge;
+
+class Validator {
+  
+  /** @var Bridge */
+  private $bridge;
+  
+  public function __construct(
+    Bridge $bridge
+  ) {
+    $this->bridge = $bridge;
+  }
+  
+  public function validate(NewsletterEntity $newsletterEntity): ?string {
+    if (
+      $newsletterEntity->getBody()
+      && is_array($newsletterEntity->getBody())
+      && $newsletterEntity->getBody()['content']
+    ) {
+      $body = json_encode($newsletterEntity->getBody()['content']);
+      if ($body === false) {
+        return __('Poet, please add prose to your masterpiece before you send it to your followers.');
+      }
+
+      if (
+        $this->bridge->isMailpoetSendingServiceEnabled()
+        && (strpos($body, '[link:subscription_unsubscribe_url]') === false)
+        && (strpos($body, '[link:subscription_unsubscribe]') === false)
+      ) {
+        return __('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
+      }
+    } else {
+      return __('Poet, please add prose to your masterpiece before you send it to your followers.');
+    }
+    return null;
+  }
+}

--- a/mailpoet/lib/Newsletter/Validator.php
+++ b/mailpoet/lib/Newsletter/Validator.php
@@ -4,49 +4,74 @@ namespace MailPoet\Newsletter;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Services\Bridge;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Validator\ValidationException;
 
 class Validator {
   
   /** @var Bridge */
   private $bridge;
-  
+
+  /** @var TrackingConfig */
+  private $trackingConfig;
+
   public function __construct(
-    Bridge $bridge
+    Bridge $bridge,
+    TrackingConfig $trackingConfig
   ) {
     $this->bridge = $bridge;
+    $this->trackingConfig = $trackingConfig;
   }
   
   public function validate(NewsletterEntity $newsletterEntity): ?string {
-    if (
-      $newsletterEntity->getBody()
-      && is_array($newsletterEntity->getBody())
-      && $newsletterEntity->getBody()['content']
-    ) {
-      $content = $newsletterEntity->getBody()['content'];
-      $encodedBody = json_encode($content);
-      if ($encodedBody === false) {
-        return $this->emptyContentErrorMessage();
-      } else {
-        $blocks = $content['blocks'] ?? [];
-        if (empty($blocks)) {
-          return $this->emptyContentErrorMessage();
-        }
-      }
-
-      if (
-        $this->bridge->isMailpoetSendingServiceEnabled()
-        && (strpos($encodedBody, '[link:subscription_unsubscribe_url]') === false)
-        && (strpos($encodedBody, '[link:subscription_unsubscribe]') === false)
-      ) {
-        return __('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
-      }
-    } else {
-      return $this->emptyContentErrorMessage();
+    try {
+      $this->validateBody($newsletterEntity);
+      $this->validateUnsubscribeRequirements($newsletterEntity);
+      $this->validateReengagementRequirements($newsletterEntity);
+    } catch (ValidationException $exception) {
+      return __($exception->getMessage(), 'mailpoet');
     }
     return null;
   }
-  
-  private function emptyContentErrorMessage(): string {
-    return __('Poet, please add prose to your masterpiece before you send it to your followers.');
+
+  private function validateUnsubscribeRequirements(NewsletterEntity $newsletterEntity): void {
+    if (!$this->bridge->isMailpoetSendingServiceEnabled()) {
+      return;
+    }
+    $content = $newsletterEntity->getContent();
+    $hasUnsubscribeUrl = strpos($content, '[link:subscription_unsubscribe_url]') !== false;
+    $hasUnsubscribeLink = strpos($content, '[link:subscription_unsubscribe]') !== false;
+
+    if (!$hasUnsubscribeLink && !$hasUnsubscribeUrl) {
+      throw new ValidationException('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
+    }
+  }
+
+  private function validateBody(NewsletterEntity $newsletterEntity): void {
+    $emptyBodyErrorMessage = 'Poet, please add prose to your masterpiece before you send it to your followers.';
+    $content = $newsletterEntity->getContent();
+
+    if ($content === '') {
+      throw new ValidationException($emptyBodyErrorMessage);
+    }
+
+    $contentBlocks = $newsletterEntity->getBody()['content']['blocks'] ?? [];
+    if (count($contentBlocks) < 1) {
+      throw new ValidationException($emptyBodyErrorMessage);
+    }
+  }
+
+  private function validateReengagementRequirements(NewsletterEntity $newsletterEntity): void {
+    if ($newsletterEntity->getType() !== NewsletterEntity::TYPE_RE_ENGAGEMENT) {
+      return;
+    }
+
+    if (strpos($newsletterEntity->getContent(), '[link:subscription_re_engage_url]') === false) {
+      throw new ValidationException('A re-engagement email must include a link with [link:subscription_re_engage_url] shortcode.');
+    }
+
+    if (!$this->trackingConfig->isEmailTrackingEnabled()) {
+      throw new ValidationException('Re-engagement emails are disabled because open and click tracking is disabled in MailPoet → Settings → Advanced.');
+    }
   }
 }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -1472,11 +1472,6 @@ parameters:
 			path: ../../tests/acceptance/Subscribers/SubscriberCookieCest.php
 
 		-
-			message: "#^Parameter \\#1 \\$body of method MailPoet\\\\Entities\\\\NewsletterEntity\\:\\:setBody\\(\\) expects array\\|null, mixed given\\.$#"
-			count: 1
-			path: ../../tests/integration/API/JSON/v1/SendingQueueTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$needle of method Codeception\\\\Verify\\\\Verify\\:\\:stringContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 4
 			path: ../../tests/integration/API/JSON/v1/ServicesTest.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -1477,11 +1477,6 @@ parameters:
 			path: ../../tests/acceptance/Subscribers/SubscriberCookieCest.php
 
 		-
-			message: "#^Parameter \\#1 \\$body of method MailPoet\\\\Entities\\\\NewsletterEntity\\:\\:setBody\\(\\) expects array\\|null, mixed given\\.$#"
-			count: 1
-			path: ../../tests/integration/API/JSON/v1/SendingQueueTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$needle of method Codeception\\\\Verify\\\\Verify\\:\\:stringContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 4
 			path: ../../tests/integration/API/JSON/v1/ServicesTest.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -1506,11 +1506,6 @@ parameters:
 			path: ../../tests/acceptance/Subscribers/SubscriberCookieCest.php
 
 		-
-			message: "#^Parameter \\#1 \\$body of method MailPoet\\\\Entities\\\\NewsletterEntity\\:\\:setBody\\(\\) expects array\\|null, mixed given\\.$#"
-			count: 1
-			path: ../../tests/integration/API/JSON/v1/SendingQueueTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$needle of method Codeception\\\\Verify\\\\Verify\\:\\:stringContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 4
 			path: ../../tests/integration/API/JSON/v1/ServicesTest.php

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\DataFactories;
 
+use Codeception\Util\Fixtures;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
@@ -12,6 +13,7 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -55,6 +57,10 @@ class Newsletter {
     assert(is_string($body));
     $this->data['body'] = json_decode($body, true);
     return $this;
+  }
+
+  public function withDefaultBody() {
+    return $this->withBody(json_decode(Fixtures::get('newsletter_body_template'), true));
   }
 
   /**
@@ -137,6 +143,11 @@ class Newsletter {
       12 => '1', # nthWeekDay
       13 => '0 0 * * *', # schedule
     ]);
+    return $this;
+  }
+
+  public function withReengagementType() {
+    $this->data['type'] = NewsletterEntity::TYPE_RE_ENGAGEMENT;
     return $this;
   }
 
@@ -332,6 +343,7 @@ class Newsletter {
       $newsletter->setSenderAddress('john.doe@example.com');
       $newsletter->setSenderName('John Doe');
     }
+    $newsletter->setHash(Security::generateHash());
     if (isset($this->data['parent'])) $newsletter->setParent($this->data['parent']);
     if (isset($this->data['deleted_at'])) $newsletter->setDeletedAt($this->data['deleted_at']);
     return $newsletter;

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -22,7 +22,6 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\NewslettersRepository;
-use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
@@ -226,9 +225,7 @@ class NewslettersTest extends \MailPoetTest {
   public function testItReturnsErrorIfSubscribersLimitReached() {
     $endpoint = $this->createNewslettersEndpointWithMocks([
       'cronHelper' => $this->cronHelper,
-      'newsletterValidator' => $this->getServiceWithOverrides(NewsletterValidator::class, [
-        'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true])
-      ])
+      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true])
     ]);
     $res = $endpoint->setStatus([
       'id' => $this->newsletter->getId(),

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -35,6 +35,7 @@ use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
+use MailPoet\Newsletter\Validator;
 use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -693,14 +694,15 @@ class NewslettersTest extends \MailPoetTest {
       $this->diContainer->get(NewsletterSaveController::class),
       $this->diContainer->get(Url::class),
       $this->diContainer->get(TrackingConfig::class),
-      $this->scheduler
+      $this->scheduler,
+      $this->diContainer->get(Validator::class)
     );
   }
 
   private function createNewsletter(string $subject, string $type): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setSubject($subject);
-    $newsletter->setBody(Fixtures::get('newsletter_body_template'));
+    $newsletter->setBody((array)json_decode(Fixtures::get('newsletter_body_template'), true));
     $newsletter->setType($type);
     $newsletter->setHash(Security::generateHash());
     $this->newsletterRepository->persist($newsletter);

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -173,7 +173,7 @@ class NewslettersTest extends \MailPoetTest {
     $wp = Stub::make(new WPFunctions, [
       'applyFilters' => asCallable([WPHooksHelper::class, 'applyFilters']),
     ]);
-    $this->endpoint = $this->createNewslettersEndpointWithMocks([
+    $this->endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'wp' => $wp,
       'cronHelper' => $this->cronHelper,
     ]);
@@ -223,7 +223,7 @@ class NewslettersTest extends \MailPoetTest {
   }
 
   public function testItReturnsErrorIfSubscribersLimitReached() {
-    $endpoint = $this->createNewslettersEndpointWithMocks([
+    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'cronHelper' => $this->cronHelper,
       'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true])
     ]);
@@ -364,7 +364,7 @@ class NewslettersTest extends \MailPoetTest {
     $wp = Stub::make(new WPFunctions, [
       'doAction' => asCallable([WPHooksHelper::class, 'doAction']),
     ]);
-    $this->endpoint = $this->createNewslettersEndpointWithMocks([
+    $this->endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'wp' => $wp,
       'cronHelper' => $this->cronHelper,
     ]);
@@ -585,7 +585,7 @@ class NewslettersTest extends \MailPoetTest {
 
   public function testItCanSendAPreview() {
     $subscriber = 'test@subscriber.com';
-    $endpoint = $this->createNewslettersEndpointWithMocks([
+    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'sendPreviewController' => $this->make(SendPreviewController::class, [
         'sendPreview' => null,
       ]),
@@ -601,7 +601,7 @@ class NewslettersTest extends \MailPoetTest {
 
   public function testItReturnsMailerErrorWhenSendingFailed() {
     $subscriber = 'test@subscriber.com';
-    $endpoint = $this->createNewslettersEndpointWithMocks([
+    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'sendPreviewController' => $this->make(SendPreviewController::class, [
         'sendPreview' => Expected::once(function () {
           throw new SendPreviewException('The email could not be sent: failed');
@@ -634,7 +634,7 @@ class NewslettersTest extends \MailPoetTest {
       'applyFilters' => asCallable([WPHooksHelper::class, 'applyFilters']),
       'doAction' => asCallable([WPHooksHelper::class, 'doAction']),
     ]);
-    $this->endpoint = $this->createNewslettersEndpointWithMocks([
+    $this->endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'wp' => $wp,
       'cronHelper' => $this->cronHelper,
       'emoji' => $emoji,
@@ -666,10 +666,6 @@ class NewslettersTest extends \MailPoetTest {
     $this->truncateEntity(SendingQueueEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SubscriberSegmentEntity::class);
-  }
-
-  private function createNewslettersEndpointWithMocks(array $mocks): Newsletters {
-    return $this->getServiceWithOverrides(Newsletters::class, $mocks);
   }
 
   private function createNewsletterOptionField(string $name, string $type): NewsletterOptionFieldEntity {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\API\JSON\v1;
 
 use Codeception\Stub\Expected;
-use Codeception\Util\Fixtures;
 use Codeception\Util\Stub;
 use Helper\WordPressHooks as WPHooksHelper;
 use MailPoet\API\JSON\Response as APIResponse;
@@ -26,6 +25,7 @@ use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Listing\NewsletterListingRepository;
 use MailPoet\Newsletter\NewsletterSaveController;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
@@ -35,13 +35,12 @@ use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
-use MailPoet\Newsletter\Validator;
 use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
-use MailPoet\Util\Security;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -111,8 +110,8 @@ class NewslettersTest extends \MailPoetTest {
         ),
       ]
     );
-    $this->newsletter = $this->createNewsletter('My Standard Newsletter', NewsletterEntity::TYPE_STANDARD);
-    $this->postNotification = $this->createNewsletter('My Post Notification', NewsletterEntity::TYPE_NOTIFICATION);
+    $this->newsletter = (new Newsletter())->withDefaultBody()->withSubject('My Standard Newsletter')->create();
+    $this->postNotification = (new Newsletter())->withPostNotificationsType()->withSubject('My Post Notification')->loadBodyFrom('newsletterWithALC.json')->create();
 
     $this->createNewsletterOptionField(NewsletterOptionFieldEntity::NAME_IS_SCHEDULED, NewsletterEntity::TYPE_STANDARD);
     $this->createNewsletterOptionField(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT, NewsletterEntity::TYPE_STANDARD);
@@ -127,7 +126,7 @@ class NewslettersTest extends \MailPoetTest {
       if (!$sentAt) {
         continue;
       }
-      $sentNewsletters[$i] = $this->createNewsletter("Sent newsletter {$i}", NewsletterEntity::TYPE_STANDARD);
+      $sentNewsletters[$i] = (new Newsletter())->withSubject("Sent newsletter {$i}")->create();
       $sentNewsletters[$i]->setSentAt($sentAt);
     }
     $this->newsletterRepository->flush();
@@ -693,19 +692,8 @@ class NewslettersTest extends \MailPoetTest {
       $this->diContainer->get(NewsletterSaveController::class),
       $this->diContainer->get(Url::class),
       $this->scheduler,
-      $this->diContainer->get(Validator::class)
+      $this->diContainer->get(NewsletterValidator::class)
     );
-  }
-
-  private function createNewsletter(string $subject, string $type): NewsletterEntity {
-    $newsletter = new NewsletterEntity();
-    $newsletter->setSubject($subject);
-    $newsletter->setBody((array)json_decode(Fixtures::get('newsletter_body_template'), true));
-    $newsletter->setType($type);
-    $newsletter->setHash(Security::generateHash());
-    $this->newsletterRepository->persist($newsletter);
-    $this->newsletterRepository->flush();
-    return $newsletter;
   }
 
   private function createNewsletterOptionField(string $name, string $type): NewsletterOptionFieldEntity {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -39,7 +39,6 @@ use MailPoet\Newsletter\Validator;
 use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\TrackingConfig;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\Security;
@@ -693,7 +692,6 @@ class NewslettersTest extends \MailPoetTest {
       $mocks['sendPreviewController'] ?? $this->diContainer->get(SendPreviewController::class),
       $this->diContainer->get(NewsletterSaveController::class),
       $this->diContainer->get(Url::class),
-      $this->diContainer->get(TrackingConfig::class),
       $this->scheduler,
       $this->diContainer->get(Validator::class)
     );

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -19,18 +19,14 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
-use MailPoet\Listing\Handler;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
-use MailPoet\Newsletter\Listing\NewsletterListingRepository;
-use MailPoet\Newsletter\NewsletterSaveController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
 use MailPoet\Newsletter\Preview\SendPreviewException;
-use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
@@ -40,7 +36,7 @@ use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\Newsletter;
-use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -181,7 +177,6 @@ class NewslettersTest extends \MailPoetTest {
     $this->endpoint = $this->createNewslettersEndpointWithMocks([
       'wp' => $wp,
       'cronHelper' => $this->cronHelper,
-      'subscribersFeature' => Stub::make(SubscribersFeature::class),
     ]);
     $response = $this->endpoint->get(['id' => $this->newsletter->getId()]);
 
@@ -231,7 +226,9 @@ class NewslettersTest extends \MailPoetTest {
   public function testItReturnsErrorIfSubscribersLimitReached() {
     $endpoint = $this->createNewslettersEndpointWithMocks([
       'cronHelper' => $this->cronHelper,
-      'subscribersFeature' => Stub::make(SubscribersFeature::class, ['check' => true]),
+      'newsletterValidator' => $this->getServiceWithOverrides(NewsletterValidator::class, [
+        'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true])
+      ])
     ]);
     $res = $endpoint->setStatus([
       'id' => $this->newsletter->getId(),
@@ -373,7 +370,6 @@ class NewslettersTest extends \MailPoetTest {
     $this->endpoint = $this->createNewslettersEndpointWithMocks([
       'wp' => $wp,
       'cronHelper' => $this->cronHelper,
-      'subscribersFeature' => Stub::make(SubscribersFeature::class),
     ]);
 
     $response = $this->endpoint->duplicate(['id' => $this->newsletter->getId()]);
@@ -645,7 +641,6 @@ class NewslettersTest extends \MailPoetTest {
       'wp' => $wp,
       'cronHelper' => $this->cronHelper,
       'emoji' => $emoji,
-      'subscribersFeature' => Stub::make(SubscribersFeature::class),
     ]);
 
     $response = $this->endpoint->showPreview($data);
@@ -677,23 +672,7 @@ class NewslettersTest extends \MailPoetTest {
   }
 
   private function createNewslettersEndpointWithMocks(array $mocks): Newsletters {
-    return new Newsletters(
-      $this->diContainer->get(Handler::class),
-      $mocks['wp'] ?? $this->diContainer->get(WPFunctions::class),
-      $this->diContainer->get(SettingsController::class),
-      $mocks['cronHelper'] ?? $this->diContainer->get(CronHelper::class),
-      $this->diContainer->get(NewslettersRepository::class),
-      $this->diContainer->get(NewsletterListingRepository::class),
-      $this->diContainer->get(NewslettersResponseBuilder::class),
-      $this->diContainer->get(PostNotificationScheduler::class),
-      $mocks['emoji'] ?? $this->diContainer->get(Emoji::class),
-      $mocks['subscribersFeature'] ?? $this->diContainer->get(SubscribersFeature::class),
-      $mocks['sendPreviewController'] ?? $this->diContainer->get(SendPreviewController::class),
-      $this->diContainer->get(NewsletterSaveController::class),
-      $this->diContainer->get(Url::class),
-      $this->scheduler,
-      $this->diContainer->get(NewsletterValidator::class)
-    );
+    return $this->getServiceWithOverrides(Newsletters::class, $mocks);
   }
 
   private function createNewsletterOptionField(string $name, string $type): NewsletterOptionFieldEntity {

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -23,6 +23,7 @@ use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
+use MailPoet\Settings\TrackingConfig;
 use MailPoet\Tasks\Sending;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 
@@ -170,7 +171,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->diContainer->get(Scheduler::class),
       new Validator(Stub::make(Bridge::class, [
         'isMailpoetSendingServiceEnabled' => true,
-      ]))
+      ]), $this->diContainer->get(TrackingConfig::class))
     );
     $response = $sendingQueue->add(['newsletter_id' => $newsletter->getId()]);
     $response = $response->getData();

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -13,12 +13,12 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
-use MailPoet\Newsletter\Validator;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -86,7 +86,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->diContainer->get(ScheduledTasksRepository::class),
       $this->diContainer->get(MailerFactory::class),
       $this->diContainer->get(Scheduler::class),
-      $this->diContainer->get(Validator::class)
+      $this->diContainer->get(NewsletterValidator::class)
     );
     $res = $sendingQueue->add(['newsletter_id' => $this->newsletter->getId()]);
     expect($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
@@ -169,7 +169,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->diContainer->get(ScheduledTasksRepository::class),
       $this->diContainer->get(MailerFactory::class),
       $this->diContainer->get(Scheduler::class),
-      new Validator(Stub::make(Bridge::class, [
+      new NewsletterValidator(Stub::make(Bridge::class, [
         'isMailpoetSendingServiceEnabled' => true,
       ]), $this->diContainer->get(TrackingConfig::class))
     );

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -139,20 +139,6 @@ class SendingQueueTest extends \MailPoetTest {
     expect($response['errors'][0]['error'])->stringContainsString('bad_request');
   }
 
-  public function testItRejectsNewslettersWithoutContentBlocks() {
-    $newsletter = new NewsletterEntity();
-    $newsletter->setSubject('subject');
-    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
-    $newsletter->setBody(['content' => ['type' => 'container', 'columnLayout' => false, 'orientation' => 'vertical']]);
-    $this->entityManager->persist($newsletter);
-    $this->entityManager->flush();
-    $sendingQueue = $this->diContainer->get(SendingQueueAPI::class);
-    $response = $sendingQueue->add(['newsletter_id' => $newsletter->getId()]);
-    $result = $response->getData();
-    expect($result['errors'][0])->array();
-    expect($result['errors'][0]['message'])->stringContainsString('Poet, please add prose to your masterpiece before you send it to your followers');
-  }
-
   private function _createOrUpdateNewsletterOptions(NewsletterEntity $newsletter, $newsletterType, $options) {
     $newsletterOptionFieldRepository = $this->diContainer->get(NewsletterOptionFieldsRepository::class);
     $newsletterOptionRepository = $this->diContainer->get(NewsletterOptionsRepository::class);

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -18,6 +18,7 @@ use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Validator;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -80,11 +81,11 @@ class SendingQueueTest extends \MailPoetTest {
       ]),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
-      $this->diContainer->get(Bridge::class),
       $this->diContainer->get(SubscribersFinder::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
       $this->diContainer->get(MailerFactory::class),
-      $this->diContainer->get(Scheduler::class)
+      $this->diContainer->get(Scheduler::class),
+      $this->diContainer->get(Validator::class)
     );
     $res = $sendingQueue->add(['newsletter_id' => $this->newsletter->getId()]);
     expect($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
@@ -149,13 +150,13 @@ class SendingQueueTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersFeature::class),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
-      Stub::make(Bridge::class, [
-        'isMailpoetSendingServiceEnabled' => true,
-      ]),
       $this->diContainer->get(SubscribersFinder::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
       $this->diContainer->get(MailerFactory::class),
-      $this->diContainer->get(Scheduler::class)
+      $this->diContainer->get(Scheduler::class),
+      new Validator(Stub::make(Bridge::class, [
+        'isMailpoetSendingServiceEnabled' => true,
+      ]))
     );
     $response = $sendingQueue->add(['newsletter_id' => $newsletter->getId()]);
     $response = $response->getData();

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -11,15 +11,10 @@ use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Mailer\MailerFactory;
-use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
-use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Newsletter\Sending\SendingQueuesRepository;
-use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
@@ -76,18 +71,12 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItReturnsErrorIfSubscribersLimitReached() {
-    $sendingQueue = new SendingQueueAPI(
-      Stub::make(SubscribersFeature::class, [
+    $sendingQueue = $this->getServiceWithOverrides(SendingQueueAPI::class, [
+      'subscribersFeature' => Stub::make(SubscribersFeature::class, [
         'check' => true,
-      ]),
-      $this->diContainer->get(NewslettersRepository::class),
-      $this->diContainer->get(SendingQueuesRepository::class),
-      $this->diContainer->get(SubscribersFinder::class),
-      $this->diContainer->get(ScheduledTasksRepository::class),
-      $this->diContainer->get(MailerFactory::class),
-      $this->diContainer->get(Scheduler::class),
-      $this->diContainer->get(NewsletterValidator::class)
-    );
+      ])
+    ]);
+
     $res = $sendingQueue->add(['newsletter_id' => $this->newsletter->getId()]);
     expect($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
     $res = $sendingQueue->resume(['newsletter_id' => $this->newsletter->getId()]);

--- a/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
@@ -7,6 +7,7 @@ use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Util\License\Features\Subscribers;
 
 class NewsletterValidatorTest extends \MailPoetTest {
   /** @var NewsletterValidator */
@@ -104,6 +105,15 @@ class NewsletterValidatorTest extends \MailPoetTest {
     $newsletter = (new Newsletter())->loadBodyFrom('newsletterWithALC.json')->withPostNotificationsType()->create();
     $validationError = $this->newsletterValidator->validate($newsletter);
     expect($validationError)->null();
+  }
+
+  public function testItIsNotValidIfSubscriberLimitReached() {
+    $newsletter = (new Newsletter())->withDefaultBody()->create();
+    $validator = $this->getServiceWithOverrides(NewsletterValidator::class, [
+      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true])
+    ]);
+    $validationError = $validator->validate($newsletter);
+    expect($validationError)->equals('Subscribers limit reached.');
   }
 
 }

--- a/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace MailPoet\Test\Newsletter;
+
+use Codeception\Util\Stub;
+use MailPoet\Newsletter\NewsletterValidator;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Test\DataFactories\Newsletter;
+
+class NewsletterValidatorTest extends \MailPoetTest {
+  /** @var NewsletterValidator */
+  private $newsletterValidator;
+
+  public function _before() {
+    parent::_before();
+    $this->newsletterValidator = $this->diContainer->get(NewsletterValidator::class);
+  }
+
+  public function testUnsubscribeFooterIsNotRequiredIfNotUsingMSS() {
+      $newsletter = (new Newsletter())->loadBodyFrom('newsletterWithTextNoFooter.json')->create();
+      $validationError = $this->newsletterValidator->validate($newsletter);
+      expect($validationError)->null();
+  }
+
+  public function testUnsubscribeFooterRequiredIfUsingMSS() {
+    $newsletter = (new Newsletter())->loadBodyFrom('newsletterWithTextNoFooter.json')->create();
+    $bridge = Stub::make(Bridge::class, ['isMailpoetSendingServiceEnabled' => true]);
+    $validator = $this->getServiceWithOverrides(NewsletterValidator::class, ['bridge' => $bridge]);
+    $validationError = $validator->validate($newsletter);
+    expect($validationError)->equals('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
+  }
+
+  public function testItRequiresBodyContent() {
+    $newsletter = (new Newsletter())->withBody('')->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->equals('Poet, please add prose to your masterpiece before you send it to your followers.');
+  }
+
+  public function testItRequiresContentBlocks() {
+    $newsletter = (new Newsletter())->withBody(['content' => ['type' => 'container', 'columnLayout' => false, 'orientation' => 'vertical', 'blocks' => []]])->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->equals('Poet, please add prose to your masterpiece before you send it to your followers.');
+  }
+
+  public function testItIsValidWithAContentBlock() {
+    $newsletter = (new Newsletter())->withBody(['content' => ['type' => 'container', 'columnLayout' => false, 'orientation' => 'vertical', 'blocks' => [
+      [
+        'type' => 'text',
+        'text' => 'Some text'
+      ]
+    ]]])->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->null();
+  }
+
+
+  public function testItRequiresReengagementShortcodes() {
+    $newsletter = (new Newsletter())->withReengagementType()->withDefaultBody()->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->equals('A re-engagement email must include a link with [link:subscription_re_engage_url] shortcode.');
+  }
+
+  public function testReengagementNewsletterIsValidWithRequiredShortcode() {
+    $newsletter = (new Newsletter())->withReengagementType()->withBody([
+      'content' => [
+        'blocks' => [
+          [
+            'type' => 'text',
+            'text' => '[link:subscription_re_engage_url]',
+          ]
+        ]
+      ]
+    ])->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->null();
+  }
+
+  public function testItRequiresTrackingForReengagementEmails() {
+    $newsletter = (new Newsletter())->withReengagementType()->withBody([
+      'content' => [
+        'blocks' => [
+          [
+            'type' => 'text',
+            'text' => '[link:subscription_re_engage_url]',
+          ]
+        ]
+      ]
+    ])->create();
+    $validator = $this->getServiceWithOverrides(NewsletterValidator::class, [
+      'trackingConfig' => Stub::make(TrackingConfig::class, ['isEmailTrackingEnabled' => false])
+    ]);
+    $validationError = $validator->validate($newsletter);
+    expect($validationError)->equals('Re-engagement emails are disabled because open and click tracking is disabled in MailPoet → Settings → Advanced.');
+  }
+
+  public function testAlcEmailFailsValidationWithoutAlcBlock() {
+    $newsletter = (new Newsletter())->withDefaultBody()->withPostNotificationsType()->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->equals('Please add an “Automatic Latest Content” widget to the email from the right sidebar.');
+  }
+
+  public function testAlcEmailPassesWithAlcBlock() {
+    $newsletter = (new Newsletter())->loadBodyFrom('newsletterWithALC.json')->withPostNotificationsType()->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    expect($validationError)->null();
+  }
+
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
@@ -7,7 +7,6 @@ use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Test\DataFactories\Newsletter;
-use MailPoet\Util\License\Features\Subscribers;
 
 class NewsletterValidatorTest extends \MailPoetTest {
   /** @var NewsletterValidator */
@@ -106,14 +105,4 @@ class NewsletterValidatorTest extends \MailPoetTest {
     $validationError = $this->newsletterValidator->validate($newsletter);
     expect($validationError)->null();
   }
-
-  public function testItIsNotValidIfSubscriberLimitReached() {
-    $newsletter = (new Newsletter())->withDefaultBody()->create();
-    $validator = $this->getServiceWithOverrides(NewsletterValidator::class, [
-      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true])
-    ]);
-    $validationError = $validator->validate($newsletter);
-    expect($validationError)->equals('Subscribers limit reached.');
-  }
-
 }

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use Codeception\Stub;
 use MailPoet\Automation\Engine\Engine;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Migrations\Migrator;
@@ -184,26 +185,19 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
   }
 
   /**
-   * Retrieve a clone of a DI service with specific private/protected properties replaced
+   * Retrieve a clone of a DI service with properties overridden by name, including
+   * protected and private properties. 
    *
    * @template T of object
    * @param class-string<T> $id
    * @param array<string, Object> $overrides
-   *  string = protected/private property name
-   *  Object = replacement for that property
+   *  string = property name
+   *  Object = replacement
    * @return T
    */
   public function getServiceWithOverrides(string $id, array $overrides) {
     $instance = $this->diContainer->get($id);
-    $clone = clone $instance;
-    $reflection = new \ReflectionClass($clone);
-    foreach ($overrides as $propertyName => $override) {
-      $property = $reflection->getProperty($propertyName);
-      $property->setAccessible(true);
-      $property->setValue($clone, $override);
-      $property->setAccessible(false);
-    }
-    return $clone;
+    return Stub::copy($instance, $overrides);
   }
 
   public static function markTestSkipped(string $message = ''): void {

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -183,6 +183,29 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     return $method->invokeArgs($object, $parameters);
   }
 
+  /**
+   * Retrieve a clone of a DI service with specific private/protected properties replaced
+   *
+   * @template T of object
+   * @param class-string<T> $id
+   * @param array<string, Object> $overrides
+   *  string = protected/private property name
+   *  Object = replacement for that property
+   * @return T
+   */
+  public function getServiceWithOverrides(string $id, array $overrides) {
+    $instance = $this->diContainer->get($id);
+    $clone = clone $instance;
+    $reflection = new \ReflectionClass($clone);
+    foreach ($overrides as $propertyName => $override) {
+      $property = $reflection->getProperty($propertyName);
+      $property->setAccessible(true);
+      $property->setValue($clone, $override);
+      $property->setAccessible(false);
+    }
+    return $clone;
+  }
+
   public static function markTestSkipped(string $message = ''): void {
     $branchName = getenv('CIRCLE_BRANCH');
     if ($branchName === 'master' || $branchName === 'release') {


### PR DESCRIPTION
This PR prevents a user from activating an automatic email (e.g. Welcome emails, post notification emails) from the email listing page if the newsletter is not valid for some reason. These reasons include:

1. There is no content
2. Emails are set to be sent through MSS and the newsletter does not include an unsubscribe link or URL
3. It is a re-engagement email and it doesn't include the `[link:subscription_re_engage_url]` shortcode
4. It is a re-engagement email and click tracking is disabled
5. It is a post notification email and it doesn't include an "Automated Latest Content" widget

Currently we are not checking for any of these things when toggling the status of a newsletter on a listing page like the following:

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/8656640/163870227-ae88e916-8d0a-4b1d-a984-7371a4cff4fa.png">

I decided to extract validation into its own service so that we can be more consistent wherever we need to validate if a newsletter is ready to be activated. We're not currently being consistent about what we're checking for where:

`\MailPoet\API\JSON\v1\Newsletters::setStatus` checks for reengagement requirements
`\MailPoet\API\JSON\v1\SendingQueue::validateNewsletter` checks for body content as well as unsubscribe links
https://github.com/mailpoet/mailpoet/blob/95857d74b97ff6443877c0811817d43920c6a430/mailpoet/assets/js/src/newsletter_editor/components/save.js#L316-L374 checks for empty content, re-engagement links, unsubscribe links, and ALC content.

## Ideas / Questions
1. Should we run this validation before creating a sending task for a newsletter? It's possible for a newsletter to go from a valid to invalid state after activation, for example if it's activated with a non-MSS sending method and then the sending method gets switched to MSS later.
2. I think it might make sense to replace some of the frontend validation code with something like an AJAX call to an endpoint that calls this new code. We currently have a lot of duplicated logic between the frontend and backend, with some validations only ever being handled in the frontend code. Keeping validation in both places will require more maintenance going forward and could lead to subtle issues where a newsletter could be considered valid in one context but not the other.

I definitely don't want to make the scope of this ticket too big, so if there are other things we would want to consider I think it would be best to create a followup ticket.

[MAILPOET-4236]

[MAILPOET-4236]: https://mailpoet.atlassian.net/browse/MAILPOET-4236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ