### PR TITLE
Improve message for confirmation emails [MAILPOET-4149]

### DIFF
--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -96,7 +96,8 @@ class SubscribersTest extends \MailPoetTest {
       $container->get(SubscriberListingRepository::class),
       $container->get(SegmentsRepository::class),
       $container->get(SubscriberSaveController::class),
-      $container->get(SubscriberSubscribeController::class)
+      $container->get(SubscriberSubscribeController::class),
+      $container->get(SettingsController::class)
     );
     $this->obfuscatedEmail = $obfuscator->obfuscate('email');
     $this->obfuscatedSegments = $obfuscator->obfuscate('segments');
@@ -943,6 +944,13 @@ class SubscribersTest extends \MailPoetTest {
     $this->entityManager->flush();
     $response = $this->endpoint->sendConfirmationEmail(['id' => $this->subscriber1->getId()]);
     expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+  }
+
+  public function testItDisplaysProperErrorMessageWhenConfirmationEmailsAreDisabled() {
+    $this->settings->set('signup_confirmation.enabled', false);
+    $response = $this->endpoint->sendConfirmationEmail(['id' => $this->subscriber1->getId()]);
+    expect($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    expect($response->errors[0]['message'])->equals('Sign-up confirmation is disabled in your <a href="admin.php?page=mailpoet-settings#/signup">MailPoet settings</a>. Please enable it to resend confirmation emails or update your subscriber’s status manually.');
   }
 
   public function testItKeepsSpecialSegmentsUnchangedAfterSaving() {


### PR DESCRIPTION
[MAILPOET-4149]

[MAILPOET-4149]: https://mailpoet.atlassian.net/browse/MAILPOET-4149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Use a third-party sending method in `MailPoet` > `Settings` > `Send With…` (can be Your Host)
2. Disable signup confirmation in `MailPoet` > `Settings` > `Sign-up Confirmation`
3. Go to Subscribers page and try to `resend email confirmation` for any `Unconfirmed` subscriber (in case you don't have, edit one and set it to be unconfirmed status)
4. Verify that you see the error message correctly, test the link inside the sentence and make sure it leads to the settings page
Note: Additionally, enable the Sign-up Confirmation in the settings and try to resent the confirmation, make sure you have received it and click the link in email to confirm the subscription. Make sure the subscriber is subscribed again.