### PR TITLE
Prevent unnecessary SQL inserts [MAILPOET-4267]

### DIFF
--- a/mailpoet/lib/Cron/CronHelper.php
+++ b/mailpoet/lib/Cron/CronHelper.php
@@ -91,6 +91,10 @@ class CronHelper {
   }
 
   public function deactivateDaemon($daemon) {
+    // We do not need to deactivate an inactive daemon
+    if (isset($daemon['status']) && $daemon['status'] === self::DAEMON_STATUS_INACTIVE) {
+      return;
+    }
     $daemon['status'] = self::DAEMON_STATUS_INACTIVE;
     $this->settings->set(
       self::DAEMON_SETTING,

--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -80,8 +80,11 @@ class WordPress {
   }
 
   private function checkRunInterval() {
-    $lastRunAt = (int)$this->settings->get(self::LAST_RUN_AT_SETTING, 0);
     $runInterval = $this->wp->applyFilters('mailpoet_cron_trigger_wordpress_run_interval', self::RUN_INTERVAL);
+    if ($runInterval === -1) {
+      return true;
+    }
+    $lastRunAt = (int)$this->settings->get(self::LAST_RUN_AT_SETTING, 0);
     $runIntervalElapsed = (time() - $lastRunAt) >= $runInterval;
     if ($runIntervalElapsed) {
       $this->settings->set(self::LAST_RUN_AT_SETTING, time());


### PR DESCRIPTION
Part of [MAILPOET-4267]

This PR reduces two SQL inserts which happen on every request. Currently we write the last time we did run the cron, so we can compare whether we need to run it now. As by default we compare like `time() - $lastRun >= -1`, we always run and always write to the database. In case we would check against `-1` we therefore can `return true;` early and prevent the SQL write.

The second part of this PR is concerned with the deactivation of the daemon, which is also a SQL write. The basic conclusion is, we do not need to deactivate an inactive daemon and could save this write, which otherwise will occur on most of the requests:
https://github.com/mailpoet/mailpoet/blob/c08bde077b684c72d12bc1e2de94b6df17772d19/mailpoet/lib/Cron/Triggers/WordPress.php#L73-L80
The `run()` method is exeuted in the `init` hook. As established `checkRunInterval()` will return `true` and `checkExecutionRequirements()` will most of the time return `false` (e.g. empty Queue). We therefore `stop()` which is to `deactivateDaemon()`


[MAILPOET-4267]: https://mailpoet.atlassian.net/browse/MAILPOET-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ