### PR TITLE
Do not wait for the HTTP response in the cron  [MAILPOET-4267]

### DIFF
--- a/mailpoet/lib/Cron/CronHelper.php
+++ b/mailpoet/lib/Cron/CronHelper.php
@@ -10,7 +10,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class CronHelper {
   const DAEMON_EXECUTION_LIMIT = 20; // seconds
-  const DAEMON_REQUEST_TIMEOUT = 5; // seconds
+  const DAEMON_REQUEST_TIMEOUT = 0.0001; // seconds
   const DAEMON_SETTING = 'cron_daemon';
   const DAEMON_STATUS_ACTIVE = 'active';
   const DAEMON_STATUS_INACTIVE = 'inactive';
@@ -106,7 +106,7 @@ class CronHelper {
     $url = $this->getCronUrl(
       CronDaemonEndpoint::ACTION_PING_RESPONSE
     );
-    $result = $this->queryCronUrl($url);
+    $result = $this->queryCronUrl($url, true);
     if (is_wp_error($result)) return $result->get_error_message();
     $response = $this->wp->wpRemoteRetrieveBody($result);
     $response = substr(trim($response), -strlen(DaemonHttpRunner::PING_SUCCESS_RESPONSE)) === DaemonHttpRunner::PING_SUCCESS_RESPONSE ?
@@ -155,13 +155,13 @@ class CronHelper {
     return null;
   }
 
-  public function queryCronUrl($url) {
+  public function queryCronUrl(string $url, bool $waitForResponse = false) {
     $args = $this->wp->applyFilters(
       'mailpoet_cron_request_args',
       [
-        'blocking' => true,
+        'blocking' => $waitForResponse,
         'sslverify' => false,
-        'timeout' => self::DAEMON_REQUEST_TIMEOUT,
+        'timeout' => $waitForResponse ? 5 : self::DAEMON_REQUEST_TIMEOUT,
         'user-agent' => 'MailPoet Cron',
       ]
     );

--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -34,7 +34,7 @@ class CronHelperTest extends \MailPoetTest {
 
   public function testItDefinesConstants() {
     expect(CronHelper::DAEMON_EXECUTION_LIMIT)->equals(20);
-    expect(CronHelper::DAEMON_REQUEST_TIMEOUT)->equals(5);
+    expect(CronHelper::DAEMON_REQUEST_TIMEOUT)->equals(0.0001);
     expect(CronHelper::DAEMON_SETTING)->equals('cron_daemon');
   }
 
@@ -159,11 +159,11 @@ class CronHelperTest extends \MailPoetTest {
         'run_start' => null,
       ],
       [
-        'run_access' => $time - 4,
+        'run_access' => $time - 0.00001,
         'run_start' => null,
       ],
       [
-        'run_access' => $time - 4,
+        'run_access' => $time - 0.00001,
         'run_start' => $time - 10,
       ],
     ];


### PR DESCRIPTION
Part of [MAILPOET-4267]

When we send the post request to start the cron, we do not need to wait until
we receive a response. When we ping the cron to see, whether the endpoint is
working, we do need the response. This PR adds a switch to the method
to speed up the post request where possible.

*DO NOT MERGE YET, I NEED TO DO SOME MORE RESEARCH*

[MAILPOET-4267]: https://mailpoet.atlassian.net/browse/MAILPOET-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ