### PR TITLE
Correctly set `dynamic` arg false for Posts block requests

### DIFF
--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -90,7 +90,12 @@ class AutomatedLatestContent extends APIEndpoint {
    * Fetches products for Abandoned Cart Content dynamic block
    */
   public function getTransformedPosts(array $data = []): SuccessResponse {
-    $posts = $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery(['args' => $data])));
+    $posts = $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery([
+      'args' => $data,
+      // If the request is for Posts block then we are fetching data for a static block
+      'dynamic' => !(isset($data['type']) && $data['type'] === "posts"),
+    ]
+    )));
     return $this->successResponse(
       $this->ALC->transformPosts($data, $posts)
     );


### PR DESCRIPTION
Fixes [MAILPOET-4278]

[MAILPOET-4278]: https://mailpoet.atlassian.net/browse/MAILPOET-4278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instr.:
1. Create a new post at All Posts and schedule it for sending for any date in the future
2. Create a new post and save it as a draft
3. Go to Newsletter Editor
4. Try to add a Posts block but set to show Scheduled posts, then click Insert button to add your scheduled post, make sure you see it added... send the newsletter to yourself and check if you see it.
5. Try to add a Posts block but set to show Drafts posts, then click Insert button to add your drafted post, make sure you see it added... send the newsletter to yourself and check if you see it.
6. Make some tests around the Posts block to ensure it is working as expected (no any issues around the block in the editor, its settings etc)