### PR TITLE
Fix twig_compare function in prefixed version of twig [MAILPOET-4279]

### DIFF
--- a/mailpoet/prefixer/fix-twig.php
+++ b/mailpoet/prefixer/fix-twig.php
@@ -15,6 +15,60 @@ $replacements = [
     ],
   ],
   [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/EqualBinary.php',
+    'find' => [
+      'twig_compare(\'',
+    ],
+    'replace' => [
+      '\\\\MailPoetVendor\\\\twig_compare(\'',
+    ],
+  ],
+  [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/GreaterBinary.php',
+    'find' => [
+      'twig_compare(\'',
+    ],
+    'replace' => [
+      '\\\\MailPoetVendor\\\\twig_compare(\'',
+    ],
+  ],
+  [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/GreaterEqualBinary.php',
+    'find' => [
+      'twig_compare(\'',
+    ],
+    'replace' => [
+      '\\\\MailPoetVendor\\\\twig_compare(\'',
+    ],
+  ],
+  [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/LessBinary.php',
+    'find' => [
+      'twig_compare(\'',
+    ],
+    'replace' => [
+      '\\\\MailPoetVendor\\\\twig_compare(\'',
+    ],
+  ],
+  [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/LessEqualBinary.php',
+    'find' => [
+      'twig_compare(\'',
+    ],
+    'replace' => [
+      '\\\\MailPoetVendor\\\\twig_compare(\'',
+    ],
+  ],
+  [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/NotEqualBinary.php',
+    'find' => [
+      'twig_compare(\'',
+    ],
+    'replace' => [
+      '\\\\MailPoetVendor\\\\twig_compare(\'',
+    ],
+  ],
+  [
     'file' => '../vendor-prefixed/twig/twig/src/Node/Expression/Binary/NotInBinary.php',
     'find' => [
       '\'!twig_in_filter(\'',


### PR DESCRIPTION
I searched for all occurrences of twig_compare calls and replaced occurrences in strings that are used in generated code with namespace prefixed twig_compare.

Note the fix is applied within composer installation so you need to run `./do install` when testing locally.

## Verification
The [older build from master](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/9662/workflows/36881a03-1533-4ffb-8100-24fef45f6ad0/jobs/176220/artifacts) was not working on PHP7.4 and below.

[MAILPOET-4279]

[MAILPOET-4279]: https://mailpoet.atlassian.net/browse/MAILPOET-4279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ