### PR TITLE
Refactor NewslettersResponseBuilder to Doctrine [MAILPOET-4138]

### DIFF
--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -48,6 +48,19 @@ class SendingQueuesRepository extends Repository {
       ->getOneOrNullResult();
   }
 
+  public function countAllByNewsletterAndTaskStatus(NewsletterEntity $newsletter, string $status): int {
+    return intval($this->entityManager->createQueryBuilder()
+      ->select('count(s.task)')
+      ->from(SendingQueueEntity::class, 's')
+      ->join('s.task', 't')
+      ->where('t.status = :status')
+      ->andWhere('s.newsletter = :newsletter')
+      ->setParameter('status', $status)
+      ->setParameter('newsletter', $newsletter)
+      ->getQuery()
+      ->getSingleScalarResult());
+  }
+
   public function getTaskIdsByNewsletterId(int $newsletterId): array {
     $results = $this->entityManager->createQueryBuilder()
       ->select('IDENTITY(s.task) as task_id')

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -6,6 +6,7 @@ use Codeception\Util\Stub;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
@@ -41,7 +42,8 @@ class NewslettersResponseBuilderTest extends \MailPoetTest {
     ]);
     $newsletterRepository = Stub::make(NewslettersRepository::class);
     $newsletterUrl = $this->diContainer->get(Url::class);
-    $responseBuilder = new NewslettersResponseBuilder($em, $newsletterRepository, $newsletterStatsRepository, $newsletterUrl);
+    $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    $responseBuilder = new NewslettersResponseBuilder($em, $newsletterRepository, $newsletterStatsRepository, $newsletterUrl, $sendingQueuesRepository);
     $response = $responseBuilder->build($newsletter, [
       NewslettersResponseBuilder::RELATION_CHILDREN_COUNT,
       NewslettersResponseBuilder::RELATION_TOTAL_SENT,

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -33,6 +33,7 @@ use MailPoet\Newsletter\Preview\SendPreviewException;
 use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
 use MailPoet\Router\Router;
@@ -107,7 +108,8 @@ class NewslettersTest extends \MailPoetTest {
             $this->diContainer->get(EntityManager::class),
             $this->makeEmpty(WCHelper::class)
           ),
-          $this->diContainer->get(Url::class)
+          $this->diContainer->get(Url::class),
+          $this->diContainer->get(SendingQueuesRepository::class)
         ),
       ]
     );


### PR DESCRIPTION
This PR removes all uses of the old Paris model from the class NewslettersResponseBuilder and its corresponding integration test class. To do that it was necessary to create a new method in SendingQueuesRepository to count queues based on newsletter and task status.

To test manually, I checked that the number of scheduled tasks for a welcome email that is displayed under "Status" in /wp-admin/admin.php?page=mailpoet-newsletters#/welcome matched after and before the changes proposed here.

[MAILPOET-4138]

[MAILPOET-4138]: https://mailpoet.atlassian.net/browse/MAILPOET-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Please test Welcome emails (creating, receiving...)