### PR TITLE
Refactor ImportExportFactory to Doctrine [MAILPOET-4139]

### DIFF
--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -38,4 +38,17 @@ class CustomFieldsRepository extends Repository {
     $this->entityManager->flush();
     return $field;
   }
+
+  public function findAllAsArray() {
+    $customFieldsTable = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+
+    $query = $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select('*')
+      ->from($customFieldsTable)
+      ->execute();
+
+    return $query->fetchAllAssociative();
+  }
 }

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -2,9 +2,9 @@
 
 namespace MailPoet\Subscribers\ImportExport;
 
+use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Models\CustomField;
 use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Util\Helpers;
 
@@ -18,11 +18,15 @@ class ImportExportFactory {
   /** @var SegmentsSimpleListRepository */
   private $segmentsListRepository;
 
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
   public function __construct(
     $action = null
   ) {
     $this->action = $action;
     $this->segmentsListRepository = ContainerWrapper::getInstance()->get(SegmentsSimpleListRepository::class);
+    $this->customFieldsRepository = ContainerWrapper::getInstance()->get(CustomFieldsRepository::class);
   }
 
   public function getSegments() {
@@ -80,7 +84,7 @@ class ImportExportFactory {
   }
 
   public function getSubscriberCustomFields() {
-    return CustomField::findArray();
+    return $this->customFieldsRepository->findAllAsArray();
   }
 
   public function formatSubscriberCustomFields($subscriberCustomFields) {

--- a/mailpoet/tests/DataFactories/CustomField.php
+++ b/mailpoet/tests/DataFactories/CustomField.php
@@ -40,6 +40,11 @@ class CustomField {
     return $this;
   }
 
+  public function withType(string $type): CustomField {
+    $this->data['type'] = $type;
+    return $this;
+  }
+
   public function create(): CustomFieldEntity {
     $customField = $this->repository->createOrUpdate($this->data);
     foreach ($this->data['subscribers'] as $subscriberData) {


### PR DESCRIPTION
This PR removes all Paris code from the classes ImportExportFactory and ImportExportFactoryTest and replaces it with Doctrine code. In the process, it was necessary to create a new CustomFieldsRepository::findAllAsArray() method to replace CustomField::findArray(). I'm unsure if the way that I implemented CustomFieldsRepository::findAllAsArray() is the best way as I don't have much experience with Doctrine.

[MAILPOET-4139]

[MAILPOET-4139]: https://mailpoet.atlassian.net/browse/MAILPOET-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Subscribers
2. Please test Import/Export, it should work as expected... this PR touches the whole import/export process