### PR TITLE
Add autocomplete attribute for text inputs in forms [MAILPOET-4284]

### DIFF
--- a/mailpoet/lib/Form/Block/Text.php
+++ b/mailpoet/lib/Form/Block/Text.php
@@ -34,8 +34,10 @@ class Text {
   public function render(array $block, array $formSettings): string {
     $type = 'text';
     $automationId = ' ';
+    $autocomplete = 'on';
     if ($block['id'] === 'email') {
       $type = 'email';
+      $autocomplete = 'email';
     }
 
     if (in_array($block['id'], ['email', 'last_name', 'first_name'], true)) {
@@ -54,7 +56,7 @@ class Text {
 
     $html .= $this->rendererHelper->renderLabel($block, $formSettings);
 
-    $html .= '<input type="' . $type . '" class="mailpoet_text" ';
+    $html .= '<input type="' . $type . '" autocomplete="' . $autocomplete . '" class="mailpoet_text" ';
 
     $html .= 'name="data[' . $name . ']" ';
 

--- a/mailpoet/lib/Form/Block/Text.php
+++ b/mailpoet/lib/Form/Block/Text.php
@@ -46,9 +46,6 @@ class Text {
 
     $styles = $this->inputStylesRenderer->renderForTextInput($block['styles'] ?? [], $formSettings);
 
-    if (in_array($block['id'], ['email', 'last_name', 'first_name'], true)) {
-      $automationId = 'data-automation-id="form_' . $block['id'] . '" ';
-    }
     $name = $this->rendererHelper->getFieldName($block);
 
     $html = '';

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -25,11 +25,11 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     $form = $this->formRenderer->renderForm($subscriber);
     expect($form)->regExp('/<form class="mailpoet-manage-subscription" method="post" action="[a-z0-9:\/\._]+wp-admin\/admin-post.php" novalidate>/');
     expect($form)->stringContainsString('<input type="hidden" name="data[email]" value="subscriber@test.com" />');
-    expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
-    expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
+    expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
+    expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="1" checked="checked"  \/> Test segment/');
-    expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  \/>/');
-    expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  \/>/');
+    expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  \/>/');
+    expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  \/>/');
 
     expect($form)->stringContainsString('Need to change your email address? Unsubscribe using the form below, then simply sign up again.');
   }
@@ -49,7 +49,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
         return $fields;
     });
     $form = $this->formRenderer->renderForm($subscriber);
-    expect($form)->regExp('/<input type="text" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Additional info" value=""  \/>/');
+    expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Additional info" value=""  \/>/');
   }
 
   private function getSegment(): SegmentEntity {


### PR DESCRIPTION
[Here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility) is a list of supported browsers.

The main issue was not working autocomplete for the email field when a form does not contain other text fields.

How to test
1. Create a form with the email field only
2. Disable Chrome browser extensions that can affect native autocomplete as 1Password
3. Visit a page with the form and test the autocomplete functionality

[MAILPOET-4284]

[MAILPOET-4284]: https://mailpoet.atlassian.net/browse/MAILPOET-4284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ