### PR TITLE
Fix HelpTooltip component import MAILPOET-4288

### DIFF
--- a/mailpoet/assets/js/src/help-tooltip-helper.js
+++ b/mailpoet/assets/js/src/help-tooltip-helper.js
@@ -14,5 +14,3 @@ export const MailPoetHelpTooltip = {
     );
   },
 };
-
-export { Tooltip };

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -8,7 +8,7 @@ import { MailPoetNotice } from './notice';
 // side effect - extends MailPoet object in initializeMixpanelWhenLoaded
 import { MailPoetForceTrackEvent, MailPoetTrackEvent } from './analytics_event';
 import { MailPoetNum } from './num';
-import { MailPoetHelpTooltip } from './help-tooltip';
+import { MailPoetHelpTooltip } from './help-tooltip-helper';
 import { MailPoetIframe } from './iframe';
 
 // A placeholder for MailPoet object

--- a/mailpoet/assets/js/src/newsletters/templates/import_template.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates/import_template.jsx
@@ -1,7 +1,7 @@
 import { createRef, Component } from 'react';
 import _ from 'underscore';
 import { MailPoet } from 'mailpoet';
-import HelpTooltip from 'help-tooltip.jsx';
+import { Tooltip } from 'help-tooltip.jsx';
 import PropTypes from 'prop-types';
 import { GlobalContext } from 'context/index.jsx';
 
@@ -94,7 +94,7 @@ class ImportTemplate extends Component {
       <div className="mailpoet-template-import">
         <h4>
           {MailPoet.I18n.t('importTemplateTitle')}
-          <HelpTooltip
+          <Tooltip
             tooltip={MailPoet.I18n.t('helpTooltipTemplateUpload')}
             place="right"
             className="tooltip-help-import-template"


### PR DESCRIPTION
Fixes [MAILPOET-4288]

## Notes:
- Having js/ts (x) files with same name caused wrong imports, this is mitigated by making the file names different.


[MAILPOET-4288]: https://mailpoet.atlassian.net/browse/MAILPOET-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ