### PR TITLE
Cleanup cached files in dev env on install [MAILPOET-4262]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -22,6 +22,7 @@ class RoboFile extends \Robo\Tasks {
       ->exec('npm ci --prefer-offline')
       ->exec('cd .. && npm ci --prefer-offline')
       ->exec('cd ../eslint-config && npm ci --prefer-offline')
+      ->addCode([$this, 'cleanupCachedFiles'])
       ->run();
   }
 

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -25,6 +25,13 @@ class RoboFile extends \Robo\Tasks {
       ->run();
   }
 
+  public function cleanupCachedFiles() {
+    $this->say('Cleaning up generated folder.');
+    $this->_exec('rm -rf ' . __DIR__ . '/generated/*');
+    $this->say('Cleaning up PHPStan cache.');
+    $this->_exec('rm -rf ' . __DIR__ . '/temp/*');
+  }
+
   public function update() {
     return $this->taskExecStack()
       ->stopOnFail()


### PR DESCRIPTION
This PR introduces a new command `./do cleanup:cached-files` that removes all files from the `generated` folder and PHPStan cached files. It also adds the command as the last step of `./do install` command. 

The idea behind this is that after updating dependencies often the generated files become outdated and may cause strange and confusing errors.

[MAILPOET-4262]

[MAILPOET-4262]: https://mailpoet.atlassian.net/browse/MAILPOET-4262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ