### PR TITLE
Introduce switch to use ExtendSchema for newer WooCommerce block installations  [MAILPOET-4276]

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -42,12 +42,14 @@ parameters:
     - '/Parameter #1 \$cssOrXPath of method AcceptanceTester::moveMouseOver\(\) expects string\|null, array<string, string> given./'
     - '/Function expect invoked with 1 parameter, 0 required\./'
     - '/Call to method getName\(\) on an unknown class _generated\\([a-zA-Z])*Cookie/' # codeception generate incorrect return type in ../../tests/_support/_generated
+    - '/Call to static method container\(\) on an unknown class/'
+    - '/Class Automattic\\WooCommerce\\StoreApi\\Schemas\\ExtendSchema not found./'
     -
       message: "#^Cannot cast string|void to string\\.$#"
       count: 2
       path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
     -
-      message: "#^Cannot cast string|void to string\\.$#"
+      message: "#^Cannot cast string|void to string.$#"
       count: 3
       path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
   reportUnmatchedIgnoredErrors: true

--- a/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
@@ -8,6 +8,7 @@ use MailPoet\Segments\WooCommerce as WooSegment;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\WooCommerce\Helper as WooHelper;
 use MailPoet\WooCommerce\Subscription;
 use MailPoet\WP\Functions;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -37,7 +38,8 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
       $this->settings,
       $this->diContainer->get(Subscription::class),
       $this->wcSegmentMock,
-      $this->diContainer->get(SubscribersRepository::class)
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(WooHelper::class)
     );
     $this->cleanup();
   }


### PR DESCRIPTION
Fixes [MAILPOET-4276] and [MAILPOET-4208]

The `ExtendRestApi::class` is deprecated since WooCommerce Blocks  version 7.2.0 [#](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e192c1d378c57a5dec459d653334c3f0969775ba/src/Domain/Bootstrap.php#L288-L294).

Since we want to remain compatible also with older versions of the WooCommerce Blocks plugin, this PR introduces a PluginHelper class with which we can easily check the version of a currently installed plugin.

Depending on this version, we load either the `ExtendRestApi::class` or the `ExtendSchema::class`.

[MAILPOET-4276]: https://mailpoet.atlassian.net/browse/MAILPOET-4276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-4208]: https://mailpoet.atlassian.net/browse/MAILPOET-4208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ