### PR TITLE
Adjust used Docker container to run integration tests [MAILPOET-4251]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
           name: 'Set up virtual host'
           command: echo 127.0.0.1 mailpoet.loc | sudo tee -a /etc/hosts
       - run:
-          name: 'Pull acceptance test docker images'
+          name: 'Pull test docker images'
           # Pull docker images with 3 retries
           command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - when:
@@ -356,7 +356,7 @@ jobs:
                 name: Download WooCommerce Core
                 command: |
                   cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -364,7 +364,7 @@ jobs:
                 name: Download WooCommerce Subscriptions
                 command: |
                   cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_memberships_version >>
           steps:
@@ -372,7 +372,7 @@ jobs:
                 name: Download WooCommerce Memberships
                 command: |
                   cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_blocks_version >>
           steps:
@@ -380,7 +380,7 @@ jobs:
                 name: Download WooCommerce Blocks
                 command: |
                   cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-blocks-zip << parameters.woo_blocks_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-blocks-zip << parameters.woo_blocks_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - run:
           name: Group acceptance tests
           command: |
@@ -394,7 +394,7 @@ jobs:
           command: |
             mkdir -m 777 -p tests/_output/exceptions
             cd tests/docker
-            docker-compose run -e SKIP_DEPS=1 -e CIRCLE_BRANCH=${CIRCLE_BRANCH} -e CIRCLE_JOB=${CIRCLE_JOB} -e MULTISITE=<< parameters.multisite >> codeception -g circleci_split_group --steps --debug -vvv --html --xml
+            docker-compose run -e SKIP_DEPS=1 -e CIRCLE_BRANCH=${CIRCLE_BRANCH} -e CIRCLE_JOB=${CIRCLE_JOB} -e MULTISITE=<< parameters.multisite >> codeception_acceptance -g circleci_split_group --steps --debug -vvv --html --xml
       - run:
           name: Check exceptions
           command: |
@@ -438,29 +438,31 @@ jobs:
           path: /tmp/fake-mailer/
           destination: fake-mailer
   integration_tests:
+    working_directory: /home/circleci/mailpoet/mailpoet
+    machine:
+      image: ubuntu-2004:202111-01
+    environment:
+      CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
     parameters:
-      executor:
+      codeception_image_version:
         type: string
-        default: wpcli_php_mysql_latest
-      setup_command:
-        type: string
-        default: source ../.circleci/setup.bash && setup php7
+        default: ''
+      multisite:
+        type: integer
+        default: 0
       run_command:
         type: string
-        default: ./do test:integration --xml
-    executor: << parameters.executor >>
+        default: |
+          mkdir -m 777 -p tests/_output/exceptions
+          cd tests/docker
+          docker-compose run -e SKIP_DEPS=1 -e CIRCLE_BRANCH=${CIRCLE_BRANCH} -e CIRCLE_JOB=${CIRCLE_JOB} -e MULTISITE=<< parameters.multisite >> codeception_integration --steps --debug -vvv --html --xml
     steps:
       - attach_workspace:
           at: /home/circleci/mailpoet
       - run:
-          name: 'Set up virtual host'
-          command: echo 127.0.0.1 mailpoet.loc | sudo tee -a /etc/hosts
-      - run:
-          name: 'Prepare example.com for testing'
-          command: echo 127.0.0.1 example.com | sudo tee -a /etc/hosts
-      - run:
-          name: 'Set up test environment'
-          command: << parameters.setup_command >>
+          name: 'Pull test docker images'
+          # Pull docker images with 3 retries
+          command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - run:
           name: 'PHP Integration tests'
           command: << parameters.run_command >>
@@ -470,8 +472,8 @@ jobs:
           path: tests/_output
           destination: codeception
       - store_artifacts:
-          path: /tmp/fake-mailer/
-          destination: fake-mailer
+          path: /mailhog-data
+          destination: mailhog-data
   build_release_zip:
     executor: wpcli_php_mysql_latest
     resource_class: medium+
@@ -560,9 +562,8 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           <<: *only_master_and_release
+          multisite: 1
           name: integration_tests_multisite
-          setup_command: source ../.circleci/setup.bash && setup php7_multisite
-          run_command: ./do test:multisite-integration --xml
           requires:
             - unit_tests
             - static_analysis_php7
@@ -629,7 +630,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          executor: wpcli_php_mysql_oldest
+          codeception_image_version: 7.2-cli_20220605.0
           requires:
             - build
       - build_premium:

--- a/.circleci/mailpoet_php.ini
+++ b/.circleci/mailpoet_php.ini
@@ -6,4 +6,3 @@ sendmail_path = /usr/local/bin/fake-sendmail.php
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
 date.timezone = UTC
-

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ environment:
     XDEBUG_MODE: debug, develop
 ```
 
+## Xdebug for integration tests
+
+- In Languages & Preferences > PHP > Servers create a new sever named `MailPoetTest`, set the host to `localhost` and port to `80` and set following path mappings:
+
+```shell
+wordpress        -> /wp-core
+mailpoet         -> /wp-core/wp-content/plugins/mailpoet
+mailpoet-premium -> /wp-core/wp-content/plugins/mailpoet-premium
+mailpoet/vendor/bin/codecept -> /project/vendor/bin/codecept
+mailpoet/vendor/bin/wp -> /usr/local/bin/wp
+```
+
+- Add `XDEBUG_TRIGGER: 1` environment to `mailpoet/tests/docker/docker-compose.yml` -> codeception service to start triggering Xdebug
+- Make PHPStorm listen to connections by clicking on the phone icon
+
 ## 💾 NFS volume sharing for Mac
 
 NFS volumes can bring more stability and performance on Docker for Mac. To setup NFS volume sharing run:

--- a/do
+++ b/do
@@ -65,7 +65,7 @@ elif [ "$1" = "acceptance" ]; then
   else
     cd mailpoet
   fi
-  COMPOSE_HTTP_TIMEOUT=200 docker-compose run codeception -e KEEP_DEPS=1 --steps --debug -vvv
+  COMPOSE_HTTP_TIMEOUT=200 docker-compose run codeception_acceptance -e KEEP_DEPS=1 --steps --debug -vvv
   cd ..
 
 elif [ "$1" = "build" ]; then
@@ -82,9 +82,12 @@ else
   docker_service="wordpress"
   plugin_directory="mailpoet"
   params=("$@")
-  if [ "$1" = "--test" -o "$2" = "--test" ]; then
-    docker_service="test_wordpress"
+
+  if [ "$1" = "--test" -o "$2" = "--test"  ]; then
     params=("${params[@]:1}")
+    cd mailpoet
+   ./do ${params[*]}
+   exit 1
   fi
   if [ "$1" = "--premium" -o "$2" = "--premium" ]; then
     plugin_directory="mailpoet-premium"

--- a/mailpoet/.env.sample
+++ b/mailpoet/.env.sample
@@ -4,7 +4,7 @@ WP_TEST_MAILER_ENABLE_SENDING=true
 WP_TEST_ENABLE_NETWORK_TESTS=true
 
 # Optional: for multisite acceptance tests
-WP_ROOT_MULTISITE=/var/www/wordpress
+WP_ROOT_MULTISITE=/var/www/html
 WP_TEST_MULTISITE_SLUG=
 HTTP_HOST= # URL of your site (used for multisite env, equals to DOMAIN_CURRENT_SITE from wp-config.php)
 

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1148,6 +1148,7 @@ class RoboFile extends \Robo\Tasks {
 
   private function runTestsInContainer(array $opts) {
     $testType = $opts['test_type'] ?? 'acceptance';
+    $this->doctrineGenerateCache();
 
     return $this->taskExec(
       'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -180,36 +180,13 @@ class RoboFile extends \Robo\Tasks {
     return $this->_exec($command);
   }
 
-  public function testIntegration(array $opts = ['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false]) {
-    if (getenv('MAILPOET_DEV_SITE')) {
-      $run = $this->confirm("You are about to run tests on the development site. Your DB data will be erased. \nDo you want to proceed?", false);
-      if (!$run) {
-        return;
-      }
-    }
-    $command = 'vendor/bin/codecept run integration -vvv';
-
-    if ($opts['multisite']) {
-      $command = 'MULTISITE=true ' . $command;
-    }
-
-    if ($opts['file']) {
-      $command .= ' -f ' . $opts['file'];
-    }
-
-    if ($opts['xml']) {
-      $command .= ' --xml';
-    }
-
-    if ($opts['debug']) {
-      $command .= ' --debug';
-    }
-
-    return $this->_exec($command);
+  public function testIntegration(array $opts = ['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false]) {
+    return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 
-  public function testMultisiteIntegration($opts = ['file' => null, 'xml' => false, 'multisite' => true]) {
-    return $this->testIntegration($opts);
+  public function testMultisiteIntegration($opts = ['file' => null, 'xml' => false, 'multisite' => true, 'skip-deps' => false]) {
+    return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
+
   }
 
   public function testCoverage($opts = ['file' => null, 'xml' => false]) {
@@ -272,24 +249,11 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'timeout' => null]) {
-    return $this->taskExec(
-      'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
-      ($opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
-      ($opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
-      'codeception --steps --debug -vvv ' .
-      '-f ' . ($opts['file'] ? $opts['file'] : '')
-    )->dir(__DIR__ . '/tests/docker')->run();
+    return $this->runTestsInContainer($opts);
   }
 
   public function testAcceptanceMultisite($opts = ['file' => null, 'skip-deps' => false, 'timeout' => null]) {
-    return $this->taskExec(
-      'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
-      ($opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
-      ($opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
-      '-e MULTISITE=1 ' .
-      'codeception --steps --debug -vvv ' .
-      '-f ' . ($opts['file'] ? $opts['file'] : '')
-    )->dir(__DIR__ . '/tests/docker')->run();
+    return $this->runTestsInContainer(array_merge($opts, ['multisite' => true]));
   }
 
   public function deleteDocker() {
@@ -1180,5 +1144,19 @@ class RoboFile extends \Robo\Tasks {
       'driver' => \MailPoet\Doctrine\ConnectionFactory::DRIVER,
       'platform' => new $platformClass,
     ], $configuration);
+  }
+
+  private function runTestsInContainer(array $opts) {
+    $testType = $opts['test_type'] ?? 'acceptance';
+
+    return $this->taskExec(
+      'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
+      (isset($opts['skip-deps']) && $opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
+      (isset($opts['timeout']) && $opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
+      (isset($opts['multisite']) && $opts['multisite'] ? '-e MULTISITE=1 ' : '-e MULTISITE=0 ') .
+      "codeception_{$testType} --steps --debug -vvv " .
+      (isset($opts['xml']) && $opts['xml'] ? '--xml ' : '') .
+      '-f ' . (isset($opts['file']) && $opts['file'] ? $opts['file'] : '')
+    )->dir(__DIR__ . '/tests/docker')->run();
   }
 }

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -489,9 +489,10 @@ class WooCommerce {
     // Insert WC customer emails to a temporary table and ensure matching collations
     // between MailPoet and WooCommerce emails for left join to use an index
     $tmpTableName = Env::$dbPrefix . 'tmp_wc_emails';
-    $collation = '';
     if ($this->needsCollationChange()) {
       $collation = "COLLATE $this->mailpoetEmailCollation";
+    } else {
+      $collation = "COLLATE $this->wpPostmetaValueCollation";
     }
 
     $this->connection->executeQuery("

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use MailPoet\Subscription\Captcha;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 
@@ -29,7 +30,8 @@ class GutenbergFormBlockCest {
     $settings
       ->withConfirmationEmailSubject()
       ->withConfirmationEmailBody()
-      ->withConfirmationEmailEnabled();
+      ->withConfirmationEmailEnabled()
+      ->withCaptchaType(Captcha::TYPE_DISABLED);
   }
 
   public function subscriptionGutenbergBlock(\AcceptanceTester $i): void {

--- a/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Acceptance;
 
 use Codeception\Util\Locator;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
@@ -25,7 +26,8 @@ class SubscribeToMultipleListsCest {
     $settings
       ->withConfirmationEmailEnabled()
       ->withConfirmationEmailBody()
-      ->withConfirmationEmailSubject('Subscribe to multiple test subject');
+      ->withConfirmationEmailSubject('Subscribe to multiple test subject')
+      ->withCaptchaType(Captcha::TYPE_DISABLED);
 
     $formFactory->withDefaultSuccessMessage();
 

--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Acceptance;
 
 use Codeception\Util\Locator;
+use MailPoet\Subscription\Captcha;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 
@@ -25,7 +26,8 @@ class SubscriptionFormCest {
     $settings
       ->withConfirmationEmailSubject()
       ->withConfirmationEmailBody()
-      ->withConfirmationEmailEnabled();
+      ->withConfirmationEmailEnabled()
+      ->withCaptchaType(Captcha::TYPE_DISABLED);
 
     $formName = 'Subscription Acceptance Test Form';
     $formFactory = new Form();

--- a/mailpoet/tests/docker/docker-compose.override.macos-sample.yml
+++ b/mailpoet/tests/docker/docker-compose.override.macos-sample.yml
@@ -9,7 +9,12 @@ services:
   chrome:
     image: seleniarm/standalone-chromium:4.0.0-20211213
 
-  codeception:
+  codeception_acceptance:
+    volumes:
+      - nfs-mailpoet:/project
+      - nfs-mailpoet:/wp-core/wp-content/plugins/mailpoet
+
+  codeception_integration:
     volumes:
       - nfs-mailpoet:/project
       - nfs-mailpoet:/wp-core/wp-content/plugins/mailpoet

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_TABLE_PREFIX: mp_
       TEST_TYPE: acceptance
+      PHP_IDE_CONFIG: 'serverName=MailPoetTest'
+
   codeception_integration:
     image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
     depends_on:
@@ -50,6 +52,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_TABLE_PREFIX: mp_
       TEST_TYPE: integration
+      PHP_IDE_CONFIG: 'serverName=MailPoetTest'
 
   smtp:
     image: mailhog/mailhog:v1.0.0

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -53,6 +53,7 @@ services:
 
   smtp:
     image: mailhog/mailhog:v1.0.0
+    hostname: mailhog
     ports:
       - 1025:1025
       - 8025:8025

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -1,10 +1,35 @@
 version: '3.9'
 
 services:
-  codeception:
+  codeception_acceptance:
     image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220126.1}
     depends_on:
-      - mailhog
+      - smtp
+      - wordpress
+      - chrome
+    volumes:
+      - wp-core:/wp-core
+      - mailhog-data:/mailhog-data
+      - ../..:/project
+      - ../..:/wp-core/wp-content/plugins/mailpoet
+      - ./codeception/docker-entrypoint.sh:/docker-entrypoint.sh
+      - ../../../dev/php.ini:/usr/local/etc/php/conf.d/php_user.ini
+      - ../../../dev/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
+    entrypoint: /docker-entrypoint.sh
+    environment:
+      WP_ROOT: /wp-core
+      WP_ROOT_MULTISITE: /wp-core
+      WP_TEST_MULTISITE_SLUG: php7_multisite
+      HTTP_HOST: test.local
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_TABLE_PREFIX: mp_
+      TEST_TYPE: acceptance
+  codeception_integration:
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
+    depends_on:
+      - smtp
       - wordpress
     volumes:
       - wp-core:/wp-core
@@ -15,12 +40,16 @@ services:
     entrypoint: /docker-entrypoint.sh
     environment:
       WP_ROOT: /wp-core
+      WP_ROOT_MULTISITE: /wp-core
+      WP_TEST_MULTISITE_SLUG: php7_multisite
+      HTTP_HOST: test.local
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_TABLE_PREFIX: mp_
+      TEST_TYPE: integration
 
-  mailhog:
+  smtp:
     image: mailhog/mailhog:v1.0.0
     ports:
       - 1025:1025
@@ -35,8 +64,7 @@ services:
   wordpress:
     image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-5.9_php8.0_20220127.1}
     depends_on:
-      - chrome
-      - mailhog
+      - smtp
       - mysql
     volumes:
       - wp-core:/var/www/html

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   codeception_acceptance:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220126.1}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
     depends_on:
       - smtp
       - wordpress
@@ -37,6 +37,8 @@ services:
       - ../..:/project
       - ../..:/wp-core/wp-content/plugins/mailpoet
       - ./codeception/docker-entrypoint.sh:/docker-entrypoint.sh
+      - ../../../dev/php.ini:/usr/local/etc/php/conf.d/php_user.ini
+      - ../../../dev/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
     entrypoint: /docker-entrypoint.sh
     environment:
       WP_ROOT: /wp-core
@@ -54,7 +56,7 @@ services:
     ports:
       - 1025:1025
       - 8025:8025
-    user: root
+    user: ${UID:-1000}:${GID:-1000}
     environment:
       MH_STORAGE: maildir
       MH_MAILDIR_PATH: /mailhog-data
@@ -108,7 +110,6 @@ services:
     ports:
       - 4444
       - 5900:5900
-
 volumes:
   wp-core:
   mailhog-data:

--- a/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
@@ -36,7 +36,8 @@ class AutomatedLatestContentTest extends \MailPoetTest {
   }
 
   public function testItGetTerms() {
-    $response = $this->endpoint->getTerms();
+
+    $response = $this->endpoint->getTerms(['taxonomies' => ['category']]);
 
     $this->assertInstanceOf(SuccessResponse::class, $response);
     $this->assertCount(1, $response->data);

--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -253,7 +253,7 @@ class CronHelperTest extends \MailPoetTest {
   }
 
   public function testItGetsSubsiteUrlOnMultisiteEnvironment() {
-    if ((boolean)getenv('MULTISITE') === true) {
+    if (is_multisite()) {
       expect($this->cronHelper->getSiteUrl())->stringContainsString((string)getenv('WP_TEST_MULTISITE_SLUG'));
     }
   }

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -23,10 +23,6 @@ if ((boolean)getenv('MULTISITE') === true) {
 }
 require_once($wpLoadFile);
 
-if (!defined('MP_SETTINGS_TABLE')) {
-  die('MailPoet must be activated in the tests site (usually http://localhost:8003) before running the integration tests');
-}
-
 $console = new \Codeception\Lib\Console\Output([]);
 $console->writeln('Loading WP core... (' . $wpLoadFile . ')');
 


### PR DESCRIPTION
### This PR:
Uses the setup and the docker image used to run acceptance tests to run integration tests for single and multi-site installs as well. In doing so the Robofile is adjusted, some failing tests have been fixed, new docker images have been generated and used, the docker-compose config is adjusted and CircleCI config has been update.

### How to test:
- Make sure the tests pass for on CI for single and multi-site
- Verify the Xdebug debugging experience is acceptable by following the setup description added to the README.md file




[MAILPOET-4251]

[MAILPOET-4251]: https://mailpoet.atlassian.net/browse/MAILPOET-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ