### PR TITLE
Add user role hook [MAILPOET-2834]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -261,6 +261,11 @@ class Hooks {
       6, 2
     );
     $this->wp->addAction(
+      'add_user_role',
+      [$this->wpSegment, 'synchronizeUser'],
+      6, 1
+    );
+    $this->wp->addAction(
       'delete_user',
       [$this->wpSegment, 'synchronizeUser'],
       1

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -266,6 +266,11 @@ class Hooks {
       6, 1
     );
     $this->wp->addAction(
+      'set_user_role',
+      [$this->wpSegment, 'synchronizeUser'],
+      6, 1
+    );
+    $this->wp->addAction(
       'delete_user',
       [$this->wpSegment, 'synchronizeUser'],
       1

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -114,7 +114,9 @@ class WelcomeScheduler {
       }
     }
     $previouslyScheduledNotification = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($newsletter, $subscriberId);
-    if (!empty($previouslyScheduledNotification)) return;
+    if (!empty($previouslyScheduledNotification)) {
+      return;
+    }
     $sendingTask = SendingTask::create();
     $sendingTask->newsletterId = $newsletter->getId();
     $sendingTask->setSubscribers([$subscriberId]);

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -82,7 +82,7 @@ class WelcomeScheduler {
         $newRole = $wpUser['roles'];
         if (
           $newsletterRole === self::WORDPRESS_ALL_ROLES ||
-          !array_diff($oldRole, $newRole)
+          !array_diff($newRole, $oldRole)
         ) {
           continue;
         }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -162,7 +162,7 @@ class WP {
 
       // welcome email
       $scheduleWelcomeNewsletter = false;
-      if (in_array($currentFilter, ['profile_update', 'user_register', 'add_user_role'])) {
+      if (in_array($currentFilter, ['profile_update', 'user_register', 'add_user_role', 'set_user_role'])) {
         $scheduleWelcomeNewsletter = true;
       }
       if ($scheduleWelcomeNewsletter === true) {

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -162,7 +162,7 @@ class WP {
 
       // welcome email
       $scheduleWelcomeNewsletter = false;
-      if (in_array($currentFilter, ['profile_update', 'user_register'])) {
+      if (in_array($currentFilter, ['profile_update', 'user_register', 'add_user_role'])) {
         $scheduleWelcomeNewsletter = true;
       }
       if ($scheduleWelcomeNewsletter === true) {

--- a/mailpoet/tests/integration/Segments/WPTestUser.php
+++ b/mailpoet/tests/integration/Segments/WPTestUser.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MailPoet\Test\Segments;
+
+class WPTestUser extends \WP_User {
+  public $orderId;
+
+  /**
+   * The native \WP_User::add_role() method contains the 'add_role' hook, which triggers
+   * MailPoet to synchronize the user. Therefore, we overwrite the method here
+   * for cases, where we do not want to trigger the synchronization but just want to
+   * assign a role to a user.
+   */
+  public function add_role($role)
+  {
+    if (empty($role)) {
+      return;
+    }
+
+    $this->caps[$role] = true;
+    update_user_meta($this->ID, $this->cap_key, $this->caps);
+    $this->get_role_caps();
+    $this->update_user_level_from_caps();
+  }
+}

--- a/mailpoet/tests/integration/Segments/WPUserWithExtraProps.php
+++ b/mailpoet/tests/integration/Segments/WPUserWithExtraProps.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace MailPoet\Test\Segments;
-
-class WPUserWithExtraProps extends \WP_User {
-  public $orderId;
-}

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -19,7 +19,7 @@ use MailPoet\WooCommerce\Helper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
-require_once('WPUserWithExtraProps.php');
+require_once('WPTestUser.php');
 
 class WooCommerceTest extends \MailPoetTest {
   public $customerRoleAdded;
@@ -691,7 +691,7 @@ class WooCommerceTest extends \MailPoetTest {
    * Those tests are testing user synchronisation, so we need data in wp_users table which has not been synchronised to
    * mailpoet database yet. We cannot use wp_insert_user functions because they would do the sync on insert.
    *
-   * @return WPUserWithExtraProps
+   * @return WPTestUser
    */
   private function insertRegisteredCustomer($number = null, $firstName = null, $lastName = null) {
     global $wpdb;
@@ -732,7 +732,7 @@ class WooCommerceTest extends \MailPoetTest {
       ", ['id' => $id, 'lastName' => $lastName]);
     }
     // add customer role
-    $user = new WPUserWithExtraProps($id);
+    $user = new WPTestUser($id);
     $user->add_role('customer');
     $this->userEmails[] = $user->user_email; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     return $user;


### PR DESCRIPTION
Fixes [MAILPOET-2834]

Current behavior:
When an administrator changes the role of a user on the profile page, we synchronize the user which means, we send an welcome email, if for the role a welcome email exists.
When a plugin updates a user using either `$user->add_role()` or `$user->set_role()` we do not synchronize the user and thus not send the welcome email.

This PR enables us, to listen for those changes as well.

Notes:
00c34867da8eabeea4bec177e3798ef839c64014 We use `$user->add_role()` in our tests which lead to side effects (where e.g. a WooCommerce user is now a WordPress user). The commit extends the `\WPUserWithExtraProps` we use in our integration tests and overwrites the default `add_role()` and does not fire the hook. Question to me would be, if we should rename `WPUserWithExtraProps` :thinking: 

MAILPOET-2834 has a fix, which suggested to fire `profile_update` on `add_user_role` (at least it provided it as a workaround for users facing the problem). I did not go down this route, as `profile_update` suggests, we are on the profile page and third parties might try to hook in with this assumption.

I did a quick test in combination with WooCommerce. My fear: `add_user_role()` might lead to a wrong attribution of the `source` in the `wp_mailpoet_subscribers` table. This seems not to be the case. `woocommerce_new_customer` is fired after `set_role` and `user_register`, so there is no alteration of behavior and the source will be overwritten e.g. `woocommerce` or in case of the checkout with `woocommerce_checkout`.



[MAILPOET-2834]: https://mailpoet.atlassian.net/browse/MAILPOET-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ