### PR TITLE
Deprecate some Paris models [MAILPOET-4150]

### DIFF
--- a/mailpoet/lib/Models/DynamicSegmentFilter.php
+++ b/mailpoet/lib/Models/DynamicSegmentFilter.php
@@ -8,12 +8,16 @@ use MailPoet\WP\Functions as WPFunctions;
 /**
  * @property array|string|null $filterData
  * @property string $segmentId
+ * @deprecated This model is deprecated. Use \MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository and
+ * \MailPoet\Entities\DynamicSegmentFilterEntity.
+ * This class can be removed after 2022-11-04.
  */
 class DynamicSegmentFilter extends Model {
 
   public static $_table = MP_DYNAMIC_SEGMENTS_FILTERS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
 
   public function save() {
+    self::deprecationError(__METHOD__);
     if (is_null($this->filterData)) {
       $this->filterData = [];
     }
@@ -26,6 +30,7 @@ class DynamicSegmentFilter extends Model {
   }
 
   public static function getAllBySegmentIds($segmentIds) {
+    self::deprecationError(__METHOD__);
     if (empty($segmentIds)) return [];
     $query = self::tableAlias('filters')
       ->whereIn('filters.segment_id', $segmentIds);
@@ -35,6 +40,7 @@ class DynamicSegmentFilter extends Model {
   }
 
   public function __get($name) {
+    self::deprecationError($name);
     $name = Helpers::camelCaseToUnderscore($name);
     $value = parent::__get($name);
     if ($name === 'filter_data' && $value !== null && WPFunctions::get()->isSerialized($value)) {
@@ -43,7 +49,16 @@ class DynamicSegmentFilter extends Model {
     return $value;
   }
 
+  /**
+   * @deprecated This is here for displaying the deprecation warning for static calls.
+   */
+  public static function __callStatic($name, $arguments) {
+    self::deprecationError($name);
+    return parent::__callStatic($name, $arguments);
+  }
+
   public static function deleteAllBySegmentIds($segmentIds) {
+    self::deprecationError(__METHOD__);
     if (empty($segmentIds)) return;
 
     $query = self::tableAlias('filters')
@@ -51,5 +66,9 @@ class DynamicSegmentFilter extends Model {
 
     $query->deleteMany();
 
+  }
+
+  private static function deprecationError($methodName) {
+    trigger_error(' Calling ' . esc_html($methodName) . ' is deprecated and will be removed. Use \MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository and respective Doctrine entities instead.', E_USER_DEPRECATED);
   }
 }

--- a/mailpoet/lib/Models/StatisticsClicks.php
+++ b/mailpoet/lib/Models/StatisticsClicks.php
@@ -8,7 +8,34 @@ namespace MailPoet\Models;
  * @property int $queueId
  * @property int $linkId
  * @property int $count
+ *
+ * @deprecated This model is deprecated. Use \MailPoet\Statistics\StatisticsClicksRepository and
+ * \MailPoet\Entities\StatisticsClickEntity
+ * This class can be removed after 2022-11-04.
  */
 class StatisticsClicks extends Model {
   public static $_table = MP_STATISTICS_CLICKS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for properties.
+   */
+  public function __get($key) {
+    self::deprecationError('property "' . $key . '"');
+    return parent::__get($key);
+  }
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for static calls.
+   */
+  public static function __callStatic($name, $arguments) {
+    self::deprecationError($name);
+    return parent::__callStatic($name, $arguments);
+  }
+
+  private static function deprecationError($methodName) {
+    trigger_error(
+      'Calling ' . esc_html($methodName) . ' is deprecated and will be removed. Use \MailPoet\Statistics\StatisticsClicksRepository and \MailPoet\Entities\StatisticsClickEntity.',
+      E_USER_DEPRECATED
+    );
+  }
 }

--- a/mailpoet/lib/Models/StatisticsNewsletters.php
+++ b/mailpoet/lib/Models/StatisticsNewsletters.php
@@ -2,6 +2,10 @@
 
 namespace MailPoet\Models;
 
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
 /**
  * @property string|null $sentAt
  */
@@ -34,6 +38,8 @@ class StatisticsNewsletters extends Model {
   }
 
   public static function getAllForSubscriber(Subscriber $subscriber) {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+
     return static::tableAlias('statistics')
       ->select('statistics.newsletter_id', 'newsletter_id')
       ->select('newsletter_rendered_subject')
@@ -45,7 +51,7 @@ class StatisticsNewsletters extends Model {
         'queue'
       )
       ->leftOuterJoin(
-        StatisticsOpens::$_table,
+        $entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName(),
         'statistics.newsletter_id = opens.newsletter_id AND statistics.subscriber_id = opens.subscriber_id',
         'opens'
       )

--- a/mailpoet/lib/Models/StatisticsOpens.php
+++ b/mailpoet/lib/Models/StatisticsOpens.php
@@ -6,11 +6,16 @@ namespace MailPoet\Models;
  * @property int $newsletterId
  * @property int $subscriberId
  * @property int $queueId
+ * @deprecated This model is deprecated. Use \MailPoet\Statistics\StatisticsOpensRepository and
+ * \MailPoet\Entities\StatisticsOpenEntity
+ * This class can be removed after 2022-11-04.
  */
 class StatisticsOpens extends Model {
   public static $_table = MP_STATISTICS_OPENS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
 
   public static function getOrCreate($subscriberId, $newsletterId, $queueId) {
+    self::deprecationError(__METHOD__);
+
     $statistics = self::where('subscriber_id', $subscriberId)
       ->where('newsletter_id', $newsletterId)
       ->where('queue_id', $queueId)
@@ -23,5 +28,28 @@ class StatisticsOpens extends Model {
       $statistics->save();
     }
     return $statistics;
+  }
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for properties.
+   */
+  public function __get($key) {
+    self::deprecationError('property "' . $key . '"');
+    return parent::__get($key);
+  }
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for static calls.
+   */
+  public static function __callStatic($name, $arguments) {
+    self::deprecationError($name);
+    return parent::__callStatic($name, $arguments);
+  }
+
+  private static function deprecationError($methodName) {
+    trigger_error(
+      'Calling ' . esc_html($methodName) . ' is deprecated and will be removed. Use \MailPoet\Statistics\StatisticsOpensRepository and \MailPoet\Entities\StatisticsOpenEntity.',
+      E_USER_DEPRECATED
+    );
   }
 }

--- a/mailpoet/lib/Models/StatisticsWooCommercePurchases.php
+++ b/mailpoet/lib/Models/StatisticsWooCommercePurchases.php
@@ -10,7 +10,33 @@ namespace MailPoet\Models;
  * @property int $orderId
  * @property string $orderCurrency
  * @property float $orderPriceTotal
+ * @deprecated This model is deprecated. Use \MailPoet\Statistics\StatisticsWooCommercePurchasesRepository
+ * and \MailPoet\Entities\StatisticsWooCommercePurchaseEntity
+ * This class can be removed after 2022-11-04.
  */
 class StatisticsWooCommercePurchases extends Model {
   public static $_table = MP_STATISTICS_WOOCOMMERCE_PURCHASES_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for properties.
+   */
+  public function __get($key) {
+    self::deprecationError('property "' . $key . '"');
+    return parent::__get($key);
+  }
+
+  /**
+   * @deprecated This is here for displaying the deprecation warning for static calls.
+   */
+  public static function __callStatic($name, $arguments) {
+    self::deprecationError($name);
+    return parent::__callStatic($name, $arguments);
+  }
+
+  private static function deprecationError($methodName) {
+    trigger_error(
+      'Calling ' . esc_html($methodName) . ' is deprecated and will be removed. Use \MailPoet\Statistics\StatisticsWooCommercePurchasesRepository and \MailPoet\Entities\StatisticsWooCommercePurchaseEntity.',
+      E_USER_DEPRECATED
+    );
+  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -133,15 +133,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
   }
 
   public function testItRenders() {
-    $newsletter = $this->newsletterFactory
-      ->withSubject('Subject')
-      ->withWelcomeTypeForSegment(1)
-      ->withActiveStatus()
-      ->withSendingQueue(['count_processed' => 10])
-      ->create();
-
-    $this->createClicks($newsletter, 5);
-    $this->createOpens($newsletter, 2);
+    $this->createNewsletterClicksAndOpens();
     $this->renderer->expects($this->exactly(2))
       ->method('render');
     $this->renderer->expects($this->at(0))
@@ -161,15 +153,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
   }
 
   public function testItSends() {
-    $newsletter = $this->newsletterFactory
-      ->withSubject('Subject')
-      ->withWelcomeTypeForSegment(1)
-      ->withActiveStatus()
-      ->withSendingQueue(['count_processed' => 10])
-      ->create();
-
-    $this->createClicks($newsletter, 5);
-    $this->createOpens($newsletter, 2);
+    $this->createNewsletterClicksAndOpens();
 
     $this->renderer->expects($this->exactly(2))
       ->method('render');
@@ -190,15 +174,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
   }
 
   public function testItPreparesContext() {
-    $newsletter = $this->newsletterFactory
-      ->withSubject('Subject')
-      ->withWelcomeTypeForSegment(1)
-      ->withActiveStatus()
-      ->withSendingQueue(['count_processed' => 10])
-      ->create();
-
-    $this->createClicks($newsletter, 5);
-    $this->createOpens($newsletter, 2);
+    $this->createNewsletterClicksAndOpens();
     $this->renderer->expects($this->exactly(2)) // html + text template
       ->method('render')
       ->with(
@@ -211,15 +187,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
   }
 
   public function testItAddsNewsletterStatsToContext() {
-    $newsletter = $this->newsletterFactory
-      ->withSubject('Subject')
-      ->withWelcomeTypeForSegment(1)
-      ->withActiveStatus()
-      ->withSendingQueue(['count_processed' => 10])
-      ->create();
-
-    $this->createClicks($newsletter, 5);
-    $this->createOpens($newsletter, 2);
+    $this->createNewsletterClicksAndOpens();
 
     $this->renderer->expects($this->exactly(2)) // html + text template
       ->method('render')
@@ -249,5 +217,17 @@ class AutomatedEmailsTest extends \MailPoetTest {
       $subscriber = (new SubscriberFactory())->create();
       (new StatisticsOpensFactory($newsletter, $subscriber))->create();
     }
+  }
+
+  private function createNewsletterClicksAndOpens() {
+    $newsletter = $this->newsletterFactory
+      ->withSubject('Subject')
+      ->withWelcomeTypeForSegment(1)
+      ->withActiveStatus()
+      ->withSendingQueue(['count_processed' => 10])
+      ->create();
+
+    $this->createClicks($newsletter, 5);
+    $this->createOpens($newsletter, 2);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -13,8 +13,6 @@ use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Models\SendingQueue;
-use MailPoet\Models\StatisticsClicks;
-use MailPoet\Models\StatisticsOpens;
 use MailPoet\Newsletter\Shortcodes\Categories\Link as LinkShortcodeCategory;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
 use MailPoet\Settings\TrackingConfig;
@@ -49,6 +47,12 @@ class ClicksTest extends \MailPoetTest {
 
   /** @var Clicks */
   private $clicks;
+
+  /** @var StatisticsClicksRepository */
+  private $statisticsClicksRepository;
+
+  /** @var StatisticsOpensRepository */
+  private $statisticsOpensRepository;
 
   public function _before() {
     parent::_before();
@@ -107,6 +111,9 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class)
     );
+
+    $this->statisticsClicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
+    $this->statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
   }
 
   public function testItAbortsWhenTrackDataIsEmptyOrMissingLink() {
@@ -151,8 +158,9 @@ class ClicksTest extends \MailPoetTest {
       'redirectToUrl' => null,
     ], $this);
     $clicks->track($data);
-    expect(StatisticsClicks::findMany())->isEmpty();
-    expect(StatisticsOpens::findMany())->isEmpty();
+
+    expect($this->statisticsClicksRepository->findAll())->isEmpty();
+    expect($this->statisticsOpensRepository->findAll())->isEmpty();
   }
 
   public function testItTracksClickAndOpenEvent() {
@@ -171,8 +179,9 @@ class ClicksTest extends \MailPoetTest {
       'redirectToUrl' => null,
     ], $this);
     $clicks->track($data);
-    expect(StatisticsClicks::findMany())->notEmpty();
-    expect(StatisticsOpens::findMany())->notEmpty();
+
+    expect($this->statisticsClicksRepository->findAll())->notEmpty();
+    expect($this->statisticsOpensRepository->findAll())->notEmpty();
   }
 
   public function testItTracksUserAgent() {
@@ -424,9 +433,10 @@ class ClicksTest extends \MailPoetTest {
       'redirectToUrl' => null,
     ], $this);
     $clicks->track($this->trackData);
-    expect(StatisticsClicks::findMany()[0]->count)->equals(1);
+
+    expect($this->statisticsClicksRepository->findAll()[0]->getCount())->equals(1);
     $clicks->track($this->trackData);
-    expect(StatisticsClicks::findMany()[0]->count)->equals(2);
+    expect($this->statisticsClicksRepository->findAll()[0]->getCount())->equals(2);
   }
 
   public function testItConvertsShortcodesToUrl() {

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -10,7 +10,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
-use MailPoet\Models\StatisticsOpens;
 use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\Statistics\Track\Opens;
 use MailPoet\Statistics\UserAgentsRepository;
@@ -98,7 +97,7 @@ class OpensTest extends \MailPoetTest {
       'returnResponse' => Expected::exactly(1),
     ], $this);
     $opens->track(false);
-    expect(StatisticsOpens::findMany())->isEmpty();
+    expect($this->statisticsOpensRepository->findAll())->isEmpty();
   }
 
   public function testItDoesNotTrackOpenEventFromWpUserWhenPreviewIsEnabled() {
@@ -113,7 +112,7 @@ class OpensTest extends \MailPoetTest {
       'returnResponse' => null,
     ], $this);
     $opens->track($data);
-    expect(StatisticsOpens::findMany())->isEmpty();
+    expect($this->statisticsOpensRepository->findAll())->isEmpty();
   }
 
   public function testItReturnsNothingWhenImageDisplayIsDisabled() {
@@ -129,7 +128,7 @@ class OpensTest extends \MailPoetTest {
       'returnResponse' => null,
     ], $this);
     $opens->track($this->trackData);
-    expect(StatisticsOpens::findMany())->notEmpty();
+    expect($this->statisticsOpensRepository->findAll())->notEmpty();
   }
 
   public function testItDoesNotTrackRepeatedOpenEvents() {
@@ -143,7 +142,7 @@ class OpensTest extends \MailPoetTest {
     for ($count = 0; $count <= 2; $count++) {
       $opens->track($this->trackData);
     }
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
   }
 
   public function testItReturnsImageAfterTracking() {
@@ -208,7 +207,7 @@ class OpensTest extends \MailPoetTest {
     $opens->track($this->trackData);
     $this->trackData->userAgent = 'User agent3';
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $opens = $this->statisticsOpensRepository->findAll();
     expect($opens)->count(1);
     $open = $opens[0];
@@ -229,7 +228,7 @@ class OpensTest extends \MailPoetTest {
     $humanUserAgentName = 'Human User Agent';
     $this->trackData->userAgent = $humanUserAgentName;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -243,7 +242,7 @@ class OpensTest extends \MailPoetTest {
     $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $this->trackData->userAgent = $machineUserAgentName;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -267,7 +266,7 @@ class OpensTest extends \MailPoetTest {
     $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $this->trackData->userAgent = $machineUserAgentName;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -281,7 +280,7 @@ class OpensTest extends \MailPoetTest {
     $humanUserAgentName = 'Human User Agent';
     $this->trackData->userAgent = $humanUserAgentName;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -304,7 +303,7 @@ class OpensTest extends \MailPoetTest {
     // Track Unknown User Agent
     $this->trackData->userAgent = null;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -315,7 +314,7 @@ class OpensTest extends \MailPoetTest {
     $machineUserAgentName = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $this->trackData->userAgent = $machineUserAgentName;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -335,7 +334,7 @@ class OpensTest extends \MailPoetTest {
     // Track Unknown User Agent
     $this->trackData->userAgent = null;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);
@@ -346,7 +345,7 @@ class OpensTest extends \MailPoetTest {
     $humanUserAgentName = 'User Agent';
     $this->trackData->userAgent = $humanUserAgentName;
     $opens->track($this->trackData);
-    expect(count(StatisticsOpens::findMany()))->equals(1);
+    expect(count($this->statisticsOpensRepository->findAll()))->equals(1);
     $openEntities = $this->statisticsOpensRepository->findAll();
     expect($openEntities)->count(1);
     $openEntity = reset($openEntities);


### PR DESCRIPTION
This PR removes usages from test classes and then deprecates the following models:

- MailPoet\Models\DynamicSegmentFilter: simply deprecated as it was already not being used.
- MailPoet\Models\StatisticsClicks: calls in the test classes replaced with Doctrine code and model deprecated.
- MailPoet\Models\StatisticsOpens: calls in the test classes replaced with Doctrine code and model deprecated.
- MailPoet\Models\StatisticsWooCommercePurchases: calls in the test classes replaced with Doctrine code and model deprecated.

This PR is the first in a few that I plan to create to deprecate all the models that are used only in the tests and are listed in the ticket [MAILPOET-4150]. I'm opting to split this ticket into multiple PRs to make reviewing the code changes easier.

[MAILPOET-4150]

[MAILPOET-4150]: https://mailpoet.atlassian.net/browse/MAILPOET-4150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4150]: https://mailpoet.atlassian.net/browse/MAILPOET-4150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ