### PR TITLE
Remove some PHPStan Level 6 errors

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/DynamicSegmentsListingRepository.php
+++ b/mailpoet/lib/Segments/DynamicSegments/DynamicSegmentsListingRepository.php
@@ -7,7 +7,7 @@ use MailPoet\Segments\SegmentListingRepository;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class DynamicSegmentsListingRepository extends SegmentListingRepository {
-  protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {
+  protected function applyParameters(QueryBuilder $queryBuilder, array $parameters): void {
     $queryBuilder
       ->andWhere('s.type = :type')
       ->setParameter('type', SegmentEntity::TYPE_DYNAMIC);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -153,23 +153,17 @@ class FilterFactory {
     return $this->emailAction;
   }
 
-  /**
-   * @return WooCommerceMembership
-   */
-  private function wooCommerceMembership() {
+  private function wooCommerceMembership(): WooCommerceMembership {
     return $this->wooCommerceMembership;
   }
 
-  /**
-   * @return WooCommerceSubscription
-   */
-  private function wooCommerceSubscription() {
+  private function wooCommerceSubscription(): WooCommerceSubscription {
     return $this->wooCommerceSubscription;
   }
 
   /**
    * @param ?string $action
-   * @return WooCommerceCategory|WooCommerceCountry|WooCommerceNumberOfOrders|WooCommerceProduct|WooCommerceTotalSpent
+   * @return Filter
    */
   private function wooCommerce(?string $action) {
     if ($action === WooCommerceProduct::ACTION_PRODUCT) {

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -122,7 +122,11 @@ class FilterFactory {
     }
   }
 
-  private function userRole($action) {
+  /**
+   * @param ?string $action
+   * @return MailPoetCustomFields|SubscriberScore|SubscriberSegment|SubscriberSubscribedDate|UserRole
+   */
+  private function userRole(?string $action) {
     if ($action === SubscriberSubscribedDate::TYPE) {
       return $this->subscriberSubscribedDate;
     } elseif ($action === SubscriberScore::TYPE) {
@@ -135,7 +139,11 @@ class FilterFactory {
     return $this->userRole;
   }
 
-  private function email($action) {
+  /**
+   * @param ?string $action
+   * @return EmailAction|EmailActionClickAny|EmailOpensAbsoluteCountAction
+   */
+  private function email(?string $action) {
     $countActions = [EmailOpensAbsoluteCountAction::TYPE, EmailOpensAbsoluteCountAction::MACHINE_TYPE];
     if (in_array($action, $countActions)) {
       return $this->emailOpensAbsoluteCount;
@@ -145,15 +153,25 @@ class FilterFactory {
     return $this->emailAction;
   }
 
+  /**
+   * @return WooCommerceMembership
+   */
   private function wooCommerceMembership() {
     return $this->wooCommerceMembership;
   }
 
+  /**
+   * @return WooCommerceSubscription
+   */
   private function wooCommerceSubscription() {
     return $this->wooCommerceSubscription;
   }
 
-  private function wooCommerce($action) {
+  /**
+   * @param ?string $action
+   * @return WooCommerceCategory|WooCommerceCountry|WooCommerceNumberOfOrders|WooCommerceProduct|WooCommerceTotalSpent
+   */
+  private function wooCommerce(?string $action) {
     if ($action === WooCommerceProduct::ACTION_PRODUCT) {
       return $this->wooCommerceProduct;
     } elseif ($action === WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS) {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -54,7 +54,7 @@ class EmailAction implements Filter {
     }
   }
 
-  private function applyForClickedActions(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData, string $parameterSuffix) {
+  private function applyForClickedActions(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData, string $parameterSuffix): QueryBuilder {
     $operator = $filterData->getParam('operator') ?? DynamicSegmentFilterData::OPERATOR_ANY;
     $action = $filterData->getAction();
     $newsletterId = $filterData->getParam('newsletter_id');
@@ -119,7 +119,7 @@ class EmailAction implements Filter {
     return $queryBuilder;
   }
 
-  private function applyForOpenedActions(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData, string $parameterSuffix) {
+  private function applyForOpenedActions(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData, string $parameterSuffix): QueryBuilder {
     $operator = $filterData->getParam('operator') ?? DynamicSegmentFilterData::OPERATOR_ANY;
     $action = $filterData->getAction();
     $newsletters = $filterData->getParam('newsletters');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -148,7 +148,7 @@ class WooCommerceCategory implements Filter {
       ->from($table);
   }
 
-  private function getCategoriesWithChildren(array $categoriesId) {
+  private function getCategoriesWithChildren(array $categoriesId): array {
     $allIds = [];
 
     foreach ($categoriesId as $categoryId) {
@@ -158,7 +158,7 @@ class WooCommerceCategory implements Filter {
     return array_unique($allIds);
   }
 
-  private function getAllCategoryIds(int $categoryId) {
+  private function getAllCategoryIds(int $categoryId): array {
     $subcategories = $this->wp->getTerms('product_cat', ['child_of' => $categoryId]);
     if (!is_array($subcategories) || empty($subcategories)) return [$categoryId];
     $ids = array_map(function($category) {

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -48,6 +48,9 @@ class SegmentsRepository extends Repository {
     return SegmentEntity::class;
   }
 
+  /**
+   * @return SegmentEntity|null
+   */
   public function getWPUsersSegment() {
     return $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
   }
@@ -172,12 +175,19 @@ class SegmentsRepository extends Repository {
     return $segment;
   }
 
-  public function bulkDelete(array $ids, $type = SegmentEntity::TYPE_DEFAULT) {
+  /**
+   * @param array  $ids   Array of segment ids to delete
+   * @param string $type  Type of segment to delete
+   *
+   * @return int Number of segments deleted
+   */
+  public function bulkDelete(array $ids, $type = SegmentEntity::TYPE_DEFAULT): int {
     if (empty($ids)) {
       return 0;
     }
 
-    return $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, $type) {
+    $count = 0;
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, $type, &$count) {
       $subscriberSegmentTable = $entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
       $segmentTable = $entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
       $segmentFiltersTable = $entityManager->getClassMetadata(DynamicSegmentFilterEntity::class)->getTableName();
@@ -199,15 +209,15 @@ class SegmentsRepository extends Repository {
         'ids' => $ids,
       ], ['ids' => Connection::PARAM_INT_ARRAY]);
 
-      return $entityManager->getConnection()->executeStatement("
-         DELETE s FROM $segmentTable s
-         WHERE s.`id` IN (:ids)
-         AND s.`type` = :type
-      ", [
-        'ids' => $ids,
-        'type' => $type,
-      ], ['ids' => Connection::PARAM_INT_ARRAY]);
+      $queryBuilder = $entityManager->createQueryBuilder();
+      $count = $queryBuilder->delete(SegmentEntity::class, 's')
+        ->where('s.id IN (:ids)')
+        ->andWhere('s.type = :type')
+        ->setParameter('ids', $ids, Connection::PARAM_INT_ARRAY)
+        ->setParameter('type', $type, \PDO::PARAM_STR)
+        ->getQuery()->execute();
     });
+    return $count;
   }
 
   public function bulkTrash(array $ids, string $type = SegmentEntity::TYPE_DEFAULT): int {

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -48,10 +48,7 @@ class SegmentsRepository extends Repository {
     return SegmentEntity::class;
   }
 
-  /**
-   * @return SegmentEntity|null
-   */
-  public function getWPUsersSegment() {
+  public function getWPUsersSegment(): ?SegmentEntity {
     return $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
   }
 
@@ -175,13 +172,7 @@ class SegmentsRepository extends Repository {
     return $segment;
   }
 
-  /**
-   * @param array  $ids   Array of segment ids to delete
-   * @param string $type  Type of segment to delete
-   *
-   * @return int Number of segments deleted
-   */
-  public function bulkDelete(array $ids, $type = SegmentEntity::TYPE_DEFAULT): int {
+  public function bulkDelete(array $ids, string $type = SegmentEntity::TYPE_DEFAULT): int {
     if (empty($ids)) {
       return 0;
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
@@ -14,6 +14,7 @@ use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class FilterHandlerTest extends \MailPoetTest {
 
@@ -26,7 +27,7 @@ class FilterHandlerTest extends \MailPoetTest {
   /** @var SubscriberEntity */
   private $subscriber2;
 
-  public function _before() {
+  public function _before(): void {
     $this->cleanWpUsers();
     $this->filterHandler = $this->diContainer->get(FilterHandler::class);
     $this->tester->createWordPressUser('user-role-test1@example.com', 'editor');
@@ -53,7 +54,7 @@ class FilterHandlerTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testItAppliesFilter() {
+  public function testItAppliesFilter(): void {
     $segment = $this->getSegment('editor');
     $statement = $this->filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
     assert($statement instanceof Statement);
@@ -80,7 +81,7 @@ class FilterHandlerTest extends \MailPoetTest {
     return $segment;
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -89,7 +90,7 @@ class FilterHandlerTest extends \MailPoetTest {
       ->from($subscribersTable);
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanWpUsers();
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SegmentEntity::class);
@@ -100,7 +101,7 @@ class FilterHandlerTest extends \MailPoetTest {
     $this->truncateEntity(ScheduledTaskEntity::class);
   }
 
-  private function cleanWpUsers() {
+  private function cleanWpUsers(): void {
     $emails = ['user-role-test1@example.com', 'user-role-test2@example.com', 'user-role-test3@example.com'];
     foreach ($emails as $email) {
       $this->tester->deleteWordPressUser($email);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
@@ -15,6 +15,7 @@ use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class EmailActionClickAnyTest extends \MailPoetTest {
   /** @var EmailActionClickAny */
@@ -22,12 +23,16 @@ class EmailActionClickAnyTest extends \MailPoetTest {
 
   /** @var NewsletterEntity */
   private $newsletter;
+  /** @var SubscriberEntity */
   public $subscriberOpenedNotClicked;
+  /** @var SubscriberEntity */
   public $subscriberNotSent;
+  /** @var SubscriberEntity */
   public $subscriberNotOpened;
+  /** @var SubscriberEntity */
   public $subscriberOpenedClicked;
 
-  public function _before() {
+  public function _before(): void {
     $this->cleanData();
     $this->emailAction = $this->diContainer->get(EmailActionClickAny::class);
     $this->newsletter = new NewsletterEntity();
@@ -59,7 +64,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     $this->addClickedToLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
   }
 
-  public function testGetClickedAnyLink() {
+  public function testGetClickedAnyLink(): void {
     $subscriberClickedExcludedLinks = $this->createSubscriber('opened_clicked_excluded@example.com');
     $this->createStatsNewsletter($subscriberClickedExcludedLinks);
     $this->createStatisticsOpens($subscriberClickedExcludedLinks);
@@ -78,7 +83,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -100,7 +105,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createSubscriber(string $email) {
+  private function createSubscriber(string $email): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);
     $subscriber->setLastName('Last');
@@ -111,7 +116,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  private function createStatsNewsletter(SubscriberEntity $subscriber) {
+  private function createStatsNewsletter(SubscriberEntity $subscriber): StatisticsNewsletterEntity {
     $queue = $this->newsletter->getLatestQueue();
     assert($queue instanceof SendingQueueEntity);
     $stats = new StatisticsNewsletterEntity($this->newsletter, $queue, $subscriber);
@@ -120,7 +125,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     return $stats;
   }
 
-  private function createStatisticsOpens(SubscriberEntity $subscriber) {
+  private function createStatisticsOpens(SubscriberEntity $subscriber): StatisticsOpenEntity {
     $queue = $this->newsletter->getLatestQueue();
     assert($queue instanceof SendingQueueEntity);
     $open = new StatisticsOpenEntity($this->newsletter, $queue, $subscriber);
@@ -129,7 +134,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     return $open;
   }
 
-  private function addClickedToLink(string $link, NewsletterEntity $newsletter, SubscriberEntity $subscriber) {
+  private function addClickedToLink(string $link, NewsletterEntity $newsletter, SubscriberEntity $subscriber): void {
     $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $link = new NewsletterLinkEntity($this->newsletter, $queue, $link, uniqid());
@@ -146,11 +151,11 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanData();
   }
 
-  private function cleanData() {
+  private function cleanData(): void {
     $this->truncateEntity(NewsletterEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(StatisticsOpenEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -15,6 +15,7 @@ use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class EmailActionTest extends \MailPoetTest {
   /** @var EmailAction */
@@ -27,12 +28,16 @@ class EmailActionTest extends \MailPoetTest {
   /** @var NewsletterEntity */
   private $newsletter3;
 
+  /** @var SubscriberEntity */
   public $subscriberOpenedNotClicked;
+  /** @var SubscriberEntity */
   public $subscriberNotSent;
+  /** @var SubscriberEntity */
   public $subscriberNotOpened;
+  /** @var SubscriberEntity */
   public $subscriberOpenedClicked;
 
-  public function _before() {
+  public function _before(): void {
     $this->cleanData();
     $this->emailAction = $this->diContainer->get(EmailAction::class);
     $this->newsletter = new NewsletterEntity();
@@ -99,7 +104,7 @@ class EmailActionTest extends \MailPoetTest {
     $this->createStatisticsOpens($subscriberOpenedNotClicked4, $this->newsletter3);
   }
 
-  public function testGetOpened() {
+  public function testGetOpened(): void {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, [
       'newsletters' => [$this->newsletter->getId()],
     ]);
@@ -115,7 +120,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('opened_not_clicked@example.com');
   }
 
-  public function testGetOpenedOperatorAny() {
+  public function testGetOpenedOperatorAny(): void {
     $segmentFilter = $this->getSegmentFilter(
       EmailAction::ACTION_OPENED,
       [
@@ -141,7 +146,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber4->getEmail())->equals('opened_not_clicked4@example.com');
   }
 
-  public function testGetOpenedOperatorAll() {
+  public function testGetOpenedOperatorAll(): void {
     $segmentFilter = $this->getSegmentFilter(
       EmailAction::ACTION_OPENED,
       [
@@ -158,7 +163,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_not_clicked4@example.com');
   }
 
-  public function testGetOpenedOperatorNone() {
+  public function testGetOpenedOperatorNone(): void {
     $segmentFilter = $this->getSegmentFilter(
       EmailAction::ACTION_OPENED,
       [
@@ -175,7 +180,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('not_opened@example.com');
   }
 
-  public function testGetClickedWithoutSavedLinks() {
+  public function testGetClickedWithoutSavedLinks(): void {
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
@@ -189,7 +194,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
-  public function testGetClickedWithAnyOfLinks() {
+  public function testGetClickedWithAnyOfLinks(): void {
     // 2 Links each clicked by a different subscriber
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
@@ -208,7 +213,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
-  public function testGetClickedWithAllOfLinks() {
+  public function testGetClickedWithAllOfLinks(): void {
     // 2 Links both clicked by $this->subscriberOpenedClicked and second one clicked only by other subscriber
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked); // id 2
@@ -229,7 +234,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
-  public function testGetClickedWithAllOfAndNoSavedLinks() {
+  public function testGetClickedWithAllOfAndNoSavedLinks(): void {
     // 2 Links both clicked by $this->subscriberOpenedClicked and second one clicked only by other subscriber
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked); // id 2
@@ -250,7 +255,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
   }
 
-  public function testGetClickedWrongLink() {
+  public function testGetClickedWrongLink(): void {
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [2],
@@ -262,7 +267,7 @@ class EmailActionTest extends \MailPoetTest {
     expect(count($result))->equals(0);
   }
 
-  public function testGetClickedWithNoneOfLinks() {
+  public function testGetClickedWithNoneOfLinks(): void {
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
@@ -281,7 +286,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('not_opened@example.com');
   }
 
-  public function testGetClickedWithNoneAndNoSavedLinks() {
+  public function testGetClickedWithNoneAndNoSavedLinks(): void {
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
@@ -300,7 +305,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('not_opened@example.com');
   }
 
-  public function testOpensNotIncludeMachineOpens() {
+  public function testOpensNotIncludeMachineOpens(): void {
     $subscriberOpenedMachine = $this->createSubscriber('opened_machine@example.com');
     $this->createStatsNewsletter($subscriberOpenedMachine, $this->newsletter);
     $open = $this->createStatisticsOpens($subscriberOpenedMachine, $this->newsletter);
@@ -317,7 +322,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($result)->equals(2);
   }
 
-  public function testMachineOpensAny() {
+  public function testMachineOpensAny(): void {
     $subscriberOpenedMachine = $this->createSubscriber('opened_machine@example.com');
     $this->createStatsNewsletter($subscriberOpenedMachine, $this->newsletter);
     $open = $this->createStatisticsOpens($subscriberOpenedMachine, $this->newsletter);
@@ -340,7 +345,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($result)->equals(1);
   }
 
-  public function testMachineOpensAll() {
+  public function testMachineOpensAll(): void {
     $subscriberOpenedMachine = $this->createSubscriber('opened_machine@example.com');
     $this->createStatsNewsletter($subscriberOpenedMachine, $this->newsletter);
     $this->createStatsNewsletter($subscriberOpenedMachine, $this->newsletter2);
@@ -370,7 +375,7 @@ class EmailActionTest extends \MailPoetTest {
     expect($result)->equals(1);
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -389,7 +394,7 @@ class EmailActionTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createSubscriber(string $email) {
+  private function createSubscriber(string $email): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);
     $subscriber->setLastName('Last');
@@ -400,7 +405,7 @@ class EmailActionTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  private function createStatsNewsletter(SubscriberEntity $subscriber, NewsletterEntity $newsletter) {
+  private function createStatsNewsletter(SubscriberEntity $subscriber, NewsletterEntity $newsletter): StatisticsNewsletterEntity {
     $queue = $this->newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $stats = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
@@ -409,7 +414,7 @@ class EmailActionTest extends \MailPoetTest {
     return $stats;
   }
 
-  private function createStatisticsOpens(SubscriberEntity $subscriber, NewsletterEntity $newsletter) {
+  private function createStatisticsOpens(SubscriberEntity $subscriber, NewsletterEntity $newsletter): StatisticsOpenEntity {
     $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $open = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
@@ -436,7 +441,7 @@ class EmailActionTest extends \MailPoetTest {
     return $link;
   }
 
-  private function addClickToLink(NewsletterLinkEntity $link, SubscriberEntity $subscriberEntity) {
+  private function addClickToLink(NewsletterLinkEntity $link, SubscriberEntity $subscriberEntity): StatisticsClickEntity {
     $newsletter = $link->getNewsletter();
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
     $queue = $link->getQueue();
@@ -453,11 +458,11 @@ class EmailActionTest extends \MailPoetTest {
     return $click;
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanData();
   }
 
-  private function cleanData() {
+  private function cleanData(): void {
     $this->truncateEntity(NewsletterEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(StatisticsOpenEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -14,12 +14,13 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   /** @var EmailOpensAbsoluteCountAction */
   private $action;
 
-  public function _before() {
+  public function _before(): void {
     $this->cleanData();
     $this->action = $this->diContainer->get(EmailOpensAbsoluteCountAction::class);
     $newsletter1 = $this->createNewsletter();
@@ -90,7 +91,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testGetOpened() {
+  public function testGetOpened(): void {
     $segmentFilter = $this->getSegmentFilter(2, 'more', 3);
     $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
@@ -101,7 +102,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened-3-newsletters@example.com');
   }
 
-  public function testGetMachineOpened() {
+  public function testGetMachineOpened(): void {
     $segmentFilter = $this->getSegmentFilter(1, 'more', 5, EmailOpensAbsoluteCountAction::MACHINE_TYPE);
     $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)->execute();
     $this->assertInstanceOf(Statement::class, $statement);
@@ -112,7 +113,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     expect($subscriber1->getEmail())->equals('opened-3-newsletters@example.com');
   }
 
-  public function testGetOpenedOld() {
+  public function testGetOpenedOld(): void {
     $segmentFilter = $this->getSegmentFilter(2, 'more', 7);
     $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -128,7 +129,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('opened-old-opens@example.com');
   }
 
-  public function testGetOpenedLess() {
+  public function testGetOpenedLess(): void {
     $segmentFilter = $this->getSegmentFilter(3, 'less', 3);
     $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -144,7 +145,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     expect($subscriber2->getEmail())->equals('opened-old-opens@example.com');
   }
 
-  public function testGetOpenedEquals() {
+  public function testGetOpenedEquals(): void {
     $segmentFilter = $this->getSegmentFilter(1, 'equals', 3);
     $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -158,7 +159,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     $this->assertSame('opened-old-opens@example.com', $subscriber1->getEmail());
   }
 
-  public function testGetOpenedNotEquals() {
+  public function testGetOpenedNotEquals(): void {
     $segmentFilter = $this->getSegmentFilter(2, 'not_equals', 3);
     $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -175,7 +176,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     $this->assertSame('opened-old-opens@example.com', $subscriber2->getEmail());
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -198,7 +199,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createSubscriber(string $email) {
+  private function createSubscriber(string $email): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);
     $subscriber->setLastName('Last');
@@ -209,7 +210,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  private function createNewsletter() {
+  private function createNewsletter(): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setSubject('newsletter 1');
     $newsletter->setStatus('sent');
@@ -225,7 +226,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     return $newsletter;
   }
 
-  private function createStatsNewsletter(SubscriberEntity $subscriber, NewsletterEntity $newsletter) {
+  private function createStatsNewsletter(SubscriberEntity $subscriber, NewsletterEntity $newsletter): StatisticsNewsletterEntity {
     $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $stats = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
@@ -234,7 +235,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     return $stats;
   }
 
-  private function createStatisticsOpens(SubscriberEntity $subscriber, NewsletterEntity $newsletter) {
+  private function createStatisticsOpens(SubscriberEntity $subscriber, NewsletterEntity $newsletter): StatisticsOpenEntity {
     $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $open = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
@@ -243,11 +244,11 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     return $open;
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanData();
   }
 
-  private function cleanData() {
+  private function cleanData(): void {
     $this->truncateEntity(NewsletterEntity::class);
     $this->truncateEntity(ScheduledTaskEntity::class);
     $this->truncateEntity(SendingQueueEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class MailPoetCustomFieldsTest extends \MailPoetTest {
 
@@ -18,7 +19,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
   /** @var SubscriberEntity[] */
   private $subscribers = [];
 
-  public function _before() {
+  public function _before(): void {
     $this->cleanData();
     $this->filter = $this->diContainer->get(MailPoetCustomFields::class);
     $this->subscribers = [];
@@ -28,7 +29,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testItFiltersSubscribersWithTextEquals() {
+  public function testItFiltersSubscribersWithTextEquals(): void {
     $subscriber = $this->subscribers[2];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_TEXT);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, 'some value'));
@@ -53,7 +54,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersSubscribersWithTextContains() {
+  public function testItFiltersSubscribersWithTextContains(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_TEXT);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, 'some value'));
@@ -78,7 +79,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersSubscribersTextNotEquals() {
+  public function testItFiltersSubscribersTextNotEquals(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_TEXT);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, 'something else'));
@@ -104,7 +105,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersSubscribersTextMoreThan() {
+  public function testItFiltersSubscribersTextMoreThan(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_TEXT);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, '3'));
@@ -130,7 +131,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersSubscribersTextLessThan() {
+  public function testItFiltersSubscribersTextLessThan(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_TEXT);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, '1'));
@@ -156,7 +157,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersRadio() {
+  public function testItFiltersRadio(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_RADIO);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, 'Option 2'));
@@ -181,7 +182,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersCheckboxChecked() {
+  public function testItFiltersCheckboxChecked(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_CHECKBOX);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($subscriber, $customField, '1'));
@@ -206,7 +207,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($subscriber->getEmail());
   }
 
-  public function testItFiltersCheckboxUnChecked() {
+  public function testItFiltersCheckboxUnChecked(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_CHECKBOX);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '1'));
@@ -231,7 +232,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[1]->getEmail());
   }
 
-  public function testItFiltersMonthDate() {
+  public function testItFiltersMonthDate(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2021-04-01 00:00:00'));
@@ -257,7 +258,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[0]->getEmail());
   }
 
-  public function testItFiltersDateYear() {
+  public function testItFiltersDateYear(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2017-03-14 00:00:00'));
@@ -283,7 +284,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[0]->getEmail());
   }
 
-  public function testItFiltersDateYearBefore() {
+  public function testItFiltersDateYearBefore(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2016-03-14 00:00:00'));
@@ -310,7 +311,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[0]->getEmail());
   }
 
-  public function testItFiltersDateMonthYear() {
+  public function testItFiltersDateMonthYear(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2016-04-01 00:00:00'));
@@ -336,7 +337,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[1]->getEmail());
   }
 
-  public function testItFiltersDateMonthYearBefore() {
+  public function testItFiltersDateMonthYearBefore(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2016-04-01 00:00:00'));
@@ -363,7 +364,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[0]->getEmail());
   }
 
-  public function testItFiltersFullDate() {
+  public function testItFiltersFullDate(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2016-04-01 00:00:00'));
@@ -389,7 +390,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[1]->getEmail());
   }
 
-  public function testItFiltersFullDateAfter() {
+  public function testItFiltersFullDateAfter(): void {
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
     $this->entityManager->persist($customField);
     $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2016-04-01 00:00:00'));
@@ -416,7 +417,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     expect($filteredSubscriber->getEmail())->equals($this->subscribers[1]->getEmail());
   }
 
-  private function getSegmentFilter($segmentFilterData): DynamicSegmentFilterEntity {
+  private function getSegmentFilter(DynamicSegmentFilterData $segmentFilterData): DynamicSegmentFilterEntity {
     $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
     $this->entityManager->persist($segment);
     $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
@@ -435,7 +436,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  private function createCustomField($type, $params = []): CustomFieldEntity {
+  private function createCustomField(string $type, array $params = []): CustomFieldEntity {
     $customField = new CustomFieldEntity();
     $customField->setType($type);
     $customField->setParams($params);
@@ -443,7 +444,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     return $customField;
   }
 
-  private function cleanData() {
+  private function cleanData(): void {
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(CustomFieldEntity::class);
     $this->truncateEntity(SubscriberCustomFieldEntity::class);
@@ -451,7 +452,7 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
@@ -7,13 +7,14 @@ use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberScoreTest extends \MailPoetTest {
 
   /** @var SubscriberScore */
   private $filter;
 
-  public function _before() {
+  public function _before(): void {
     $this->filter = $this->diContainer->get(SubscriberScore::class);
     $this->cleanUp();
 
@@ -50,7 +51,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testGetHigherThan() {
+  public function testGetHigherThan(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberScore::HIGHER_THAN, '80');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -63,7 +64,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12345@example.com');
   }
 
-  public function testGetLowerThan() {
+  public function testGetLowerThan(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberScore::LOWER_THAN, '30');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -81,7 +82,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12@example.com');
   }
 
-  public function testGetEquals() {
+  public function testGetEquals(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberScore::EQUALS, '50');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -94,7 +95,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e123@example.com');
   }
 
-  public function testGetNotEquals() {
+  public function testGetNotEquals(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberScore::NOT_EQUALS, '50');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -120,7 +121,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12345@example.com');
   }
 
-  public function testGetUnknown() {
+  public function testGetUnknown(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberScore::UNKNOWN, '');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -134,7 +135,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e123456@example.com');
   }
 
-  public function testGetNotUnknown() {
+  public function testGetNotUnknown(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberScore::NOT_UNKNOWN, '');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -164,7 +165,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12345@example.com');
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -186,7 +187,7 @@ class SubscriberScoreTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function cleanUp() {
+  private function cleanUp(): void {
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberSegmentTest extends \MailPoetTest {
   /** @var SubscriberSegment */
@@ -19,7 +20,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
   /** @var SegmentEntity */
   private $segment2;
 
-  public function _before() {
+  public function _before(): void {
     $this->filter = $this->diContainer->get(SubscriberSegment::class);
 
     $this->cleanUp();
@@ -51,7 +52,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testSubscribedAnyOf() {
+  public function testSubscribedAnyOf(): void {
     $segmentFilter = $this->getSegmentFilter(DynamicSegmentFilterData::OPERATOR_ANY, [$this->segment1->getId(), $this->segment2->getId()]);
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -69,7 +70,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('a2@example.com');
   }
 
-  public function testSubscribedAllOf() {
+  public function testSubscribedAllOf(): void {
     $segmentFilter = $this->getSegmentFilter(DynamicSegmentFilterData::OPERATOR_ALL, [$this->segment1->getId(), $this->segment2->getId()]);
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -84,7 +85,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('a1@example.com');
   }
 
-  public function testSubscribedNoneOf() {
+  public function testSubscribedNoneOf(): void {
     $segmentFilter = $this->getSegmentFilter(DynamicSegmentFilterData::OPERATOR_NONE, [$this->segment1->getId()]);
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -115,7 +116,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -124,7 +125,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
       ->from($subscribersTable);
   }
 
-  private function cleanUp() {
+  private function cleanUp(): void {
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -8,13 +8,14 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberSubscribedDateTest extends \MailPoetTest {
 
   /** @var SubscriberSubscribedDate */
   private $filter;
 
-  public function _before() {
+  public function _before(): void {
     $this->filter = $this->diContainer->get(SubscriberSubscribedDate::class);
     $this->cleanUp();
 
@@ -45,7 +46,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testGetBefore() {
+  public function testGetBefore(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::BEFORE, CarbonImmutable::now()->subDays(3)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -58,7 +59,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12345@example.com');
   }
 
-  public function testGetAfter() {
+  public function testGetAfter(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::AFTER, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -76,7 +77,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12@example.com');
   }
 
-  public function testGetOn() {
+  public function testGetOn(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::ON, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -91,7 +92,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     $this->assertSame('e123@example.com', $subscriber->getEmail());
   }
 
-  public function testGetNotOn() {
+  public function testGetNotOn(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::NOT_ON, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -118,7 +119,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     $this->assertSame('e12345@example.com', $subscriber4->getEmail());
   }
 
-  public function testGetInTheLast() {
+  public function testGetInTheLast(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::IN_THE_LAST, '2');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -136,7 +137,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12@example.com');
   }
 
-  public function testGetNotInTheLast() {
+  public function testGetNotInTheLast(): void {
     $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::NOT_IN_THE_LAST, '3');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
@@ -154,7 +155,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     expect($subscriber->getEmail())->equals('e12345@example.com');
   }
 
-  private function getQueryBuilder() {
+  private function getQueryBuilder(): QueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     return $this->entityManager
       ->getConnection()
@@ -176,7 +177,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function cleanUp() {
+  private function cleanUp(): void {
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -30,7 +30,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   /** @var int[] */
   private $categoryIds;
 
-  public function _before() {
+  public function _before(): void {
     $this->wooCommerceCategory = $this->diContainer->get(WooCommerceCategory::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
 
@@ -61,7 +61,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->addToOrder(4, $this->orderIds[3], $this->productIds[1], $customerId4PendingPayment);
   }
 
-  public function testItGetsSubscribersThatPurchasedProductsInAnyCategory() {
+  public function testItGetsSubscribersThatPurchasedProductsInAnyCategory(): void {
     $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
     $segmentFilter = $this->getSegmentFilter($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ANY);
     $queryBuilder = $this->wooCommerceCategory->apply($this->getQueryBuilder(), $segmentFilter);
@@ -73,7 +73,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->assertSame($expectedEmails, $emails);
   }
 
-  public function testItGetsSubscribersThatDidNotPurchasedProducts() {
+  public function testItGetsSubscribersThatDidNotPurchasedProducts(): void {
     $expectedEmails = [
       'a1@example.com',
       'a2@example.com',
@@ -91,7 +91,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->assertSame($expectedEmails, $emails);
   }
 
-  public function testItGetsSubscribersThatPurchasedAllProducts() {
+  public function testItGetsSubscribersThatPurchasedAllProducts(): void {
     $segmentFilter = $this->getSegmentFilter($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $queryBuilder = $this->wooCommerceCategory->apply($this->getQueryBuilder(), $segmentFilter);
     $statement = $queryBuilder->execute();
@@ -168,7 +168,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     return $orderId;
   }
 
-  private function createProduct(string $name, array $terms) {
+  private function createProduct(string $name, array $terms): int {
     $productData = [
       'post_type' => 'product',
       'post_status' => 'publish',
@@ -181,11 +181,13 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     return $productId;
   }
 
-  private function createCategory(string $name) {
-    return wp_create_category($name);
+  private function createCategory(string $name): int {
+    $categoryId =  wp_create_category($name);
+    $this->assertIsInt($categoryId);
+    return $categoryId;
   }
 
-  private function addToOrder(int $orderItemId, int $orderId, int $productId, int $customerId) {
+  private function addToOrder(int $orderItemId, int $orderId, int $productId, int $customerId): void {
     global $wpdb;
     $this->connection->executeQuery("
       INSERT INTO {$wpdb->prefix}wc_order_product_lookup (order_item_id, order_id, product_id, customer_id, variation_id, product_qty, date_created)
@@ -201,11 +203,11 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanUp();
   }
 
-  private function cleanUp() {
+  private function cleanUp(): void {
     global $wpdb;
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(SubscriberEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -72,7 +72,7 @@ class WooCommerceCountryTest extends \MailPoetTest {
     expect($subscriber3->getEmail())->equals('customer3@example.com');
   }
 
-  public function testItAppliesFilterNone() {
+  public function testItAppliesFilterNone(): void {
     $segmentFilter = $this->getSegmentFilter(['CZ','US'], DynamicSegmentFilterData::OPERATOR_NONE);
     $queryBuilder = $this->wooCommerceCountry->apply($this->getQueryBuilder(), $segmentFilter);
     $statement = $queryBuilder->execute();
@@ -118,7 +118,7 @@ class WooCommerceCountryTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createCustomerLookupData(array $data) {
+  private function createCustomerLookupData(array $data): void {
     global $wpdb;
     $connection = $this->entityManager->getConnection();
     $customerLookupTable = $wpdb->prefix . 'wc_customer_lookup';

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -25,7 +25,7 @@ class WooCommerceProductTest extends \MailPoetTest {
   /** @var int[] */
   private $orderIds;
 
-  public function _before() {
+  public function _before(): void {
     $this->wooCommerceProduct = $this->diContainer->get(WooCommerceProduct::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
 
@@ -53,7 +53,7 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->addToOrder(4, $this->orderIds[3], $this->productIds[0], $customerIdPendingPayment);
   }
 
-  public function testItGetsSubscribersThatPurchasedAnyProducts() {
+  public function testItGetsSubscribersThatPurchasedAnyProducts(): void {
     $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
     $segmentFilter = $this->getSegmentFilter($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
     $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
@@ -65,7 +65,7 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->assertSame($expectedEmails, $emails);
   }
 
-  public function testItGetsSubscribersThatDidNotPurchasedProducts() {
+  public function testItGetsSubscribersThatDidNotPurchasedProducts(): void {
     $expectedEmails = [
       'a1@example.com',
       'a2@example.com',
@@ -83,7 +83,7 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->assertSame($expectedEmails, $emails);
   }
 
-  public function testItGetsSubscribersThatPurchasedAllProducts() {
+  public function testItGetsSubscribersThatPurchasedAllProducts(): void {
     $segmentFilter = $this->getSegmentFilter($this->productIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
     $statement = $queryBuilder->execute();
@@ -160,16 +160,19 @@ class WooCommerceProductTest extends \MailPoetTest {
     return $orderId;
   }
 
-  private function createProduct(string $name) {
+  private function createProduct(string $name): int
+  {
     $productData = [
       'post_type' => 'product',
       'post_status' => 'publish',
       'post_title' => $name,
     ];
-    return wp_insert_post($productData);
+    $productId =  wp_insert_post($productData);
+    $this->assertIsInt($productId);
+    return $productId;
   }
 
-  private function addToOrder(int $orderItemId, int $orderId, int $productId, int $customerId) {
+  private function addToOrder(int $orderItemId, int $orderId, int $productId, int $customerId): void {
     global $wpdb;
     $this->connection->executeQuery("
       INSERT INTO {$wpdb->prefix}wc_order_product_lookup (order_item_id, order_id, product_id, customer_id, variation_id, product_qty, date_created)
@@ -185,11 +188,11 @@ class WooCommerceProductTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanUp();
   }
 
-  private function cleanUp() {
+  private function cleanUp(): void {
     global $wpdb;
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(SubscriberEntity::class);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -26,10 +26,12 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   ];
   private const SUBSCRIBER_EMAILS = self::ACTIVE_EMAILS + self::INACTIVE_EMAILS;
 
+  /** @var array */
   private $subscriptions = [];
+  /** @var array */
   private $products = [];
 
-  public function _before() {
+  public function _before(): void {
 
     Database::createLookUpTables();
 
@@ -48,7 +50,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     }
   }
 
-  public function testAllSubscribersFoundWithOperatorAny() {
+  public function testAllSubscribersFoundWithOperatorAny(): void {
     $testee = $this->diContainer->get(WooCommerceSubscription::class);
     $queryBuilder = $this->getQueryBuilder();
     $filter = $this->getSegmentFilter(
@@ -64,7 +66,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     }
   }
 
-  public function testAllSubscribersFoundWithOperatorNoneOf() {
+  public function testAllSubscribersFoundWithOperatorNoneOf(): void {
     $product = $this->createProduct("Another newsletter");
     $notToBeFoundEmail = "not-to-be-found@example.com";
     $subscriberId = $this->tester->createWordPressUser($notToBeFoundEmail, "subscriber");
@@ -92,7 +94,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     $this->tester->deleteWordPressUser($notToBeFoundEmail);
   }
 
-  public function testAllSubscribersFoundWithOperatorAllOf() {
+  public function testAllSubscribersFoundWithOperatorAllOf(): void {
     $this->createProduct("Another newsletter");
     $notToBeFoundEmail = "not-to-be-found@example.com";
     $toBeFoundEmail = "find-me@example.com";
@@ -210,7 +212,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
       ->from($subscribersTable);
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanUp();
 
     global $wpdb;
@@ -218,7 +220,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     $this->connection->executeQuery("DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_items");
   }
 
-  public function cleanUp() {
+  public function cleanUp(): void {
     global $wpdb;
     foreach (self::SUBSCRIBER_EMAILS as $email) {
       $this->tester->deleteWordPressUser($email);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
@@ -13,13 +13,13 @@ class SegmentSaveControllerTest extends \MailPoetTest {
   /** @var SegmentSaveController */
   private $saveController;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->cleanup();
     $this->saveController = $this->diContainer->get(SegmentSaveController::class);
   }
 
-  public function testItCanSaveASegment() {
+  public function testItCanSaveASegment(): void {
     $segmentData = [
       'name' => 'Test Segment',
       'description' => 'Description',
@@ -46,7 +46,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     ]);
   }
 
-  public function testItCanRemoveRedundantFilter() {
+  public function testItCanRemoveRedundantFilter(): void {
     $segment = $this->createSegment('Test Segment');
     $this->addDynamicFilter($segment, ['editor']);
     $this->addDynamicFilter($segment, ['administrator']);
@@ -80,7 +80,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     ]);
   }
 
-  public function testItCheckDuplicateSegment() {
+  public function testItCheckDuplicateSegment(): void {
     $name = 'Test name';
     $this->createSegment($name);
     $segmentData = [
@@ -97,7 +97,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     $this->saveController->save($segmentData);
   }
 
-  public function testItValidatesSegmentFilterData() {
+  public function testItValidatesSegmentFilterData(): void {
     $name = 'Test name';
     $this->createSegment($name);
     $segmentData = [
@@ -132,7 +132,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     return $dynamicFilter;
   }
 
-  private function cleanup() {
+  private function cleanup(): void {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }

--- a/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
@@ -14,13 +14,13 @@ class SegmentsRepositoryTest extends \MailPoetTest {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->cleanup();
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
   }
 
-  public function testItCanBulkTrashDefaultSegments() {
+  public function testItCanBulkTrashDefaultSegments(): void {
     $segment1 = $this->createDefaultSegment('Segment 1');
     $segment2 = $this->createDefaultSegment('Segment 2');
     $this->entityManager->flush();
@@ -32,7 +32,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     expect($segment2->getDeletedAt())->isInstanceOf(\DateTimeInterface::class);
   }
 
-  public function testItCanBulkTrashDynamicSegments() {
+  public function testItCanBulkTrashDynamicSegments(): void {
     $segment1 = $this->createDynamicSegmentEntityForEditorUsers();
     $segment2 = $this->createDynamicSegmentEntityForEditorUsers();
     $this->entityManager->flush();
@@ -44,7 +44,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     expect($segment2->getDeletedAt())->isInstanceOf(\DateTimeInterface::class);
   }
 
-  public function testItSkipTrashingForActivelyUsedDefaultSegments() {
+  public function testItSkipTrashingForActivelyUsedDefaultSegments(): void {
     $segment1 = $this->createDefaultSegment('Segment 1');
     $segment2 = $this->createDefaultSegment('Segment 2');
     $this->addActiveNewsletterToSegment($segment1);
@@ -57,7 +57,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     expect($segment2->getDeletedAt())->isInstanceOf(\DateTimeInterface::class);
   }
 
-  public function testItSkipTrashingForActivelyUsedDynamicSegments() {
+  public function testItSkipTrashingForActivelyUsedDynamicSegments(): void {
     $segment1 = $this->createDynamicSegmentEntityForEditorUsers();
     $segment2 = $this->createDynamicSegmentEntityForEditorUsers();
     $this->addActiveNewsletterToSegment($segment2);
@@ -70,7 +70,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     expect($segment2->getDeletedAt())->null();
   }
 
-  public function testItReturnsCountsOfSegmentsWithMultipleFilters() {
+  public function testItReturnsCountsOfSegmentsWithMultipleFilters(): void {
     // No Segments
     $count = $this->segmentsRepository->getSegmentCountWithMultipleFilters();
     expect($count)->equals(0);
@@ -108,14 +108,14 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     expect($count)->equals(2);
   }
 
-  public function testItCanCheckForUniqueNames() {
+  public function testItCanCheckForUniqueNames(): void {
     $this->createDefaultSegment('Test');
     $this->segmentsRepository->flush();
     expect($this->segmentsRepository->isNameUnique('Test', null))->false();
     expect($this->segmentsRepository->isNameUnique('Unique Name', null))->true();
   }
 
-  public function testItCanForcefullyVerifyUniquenessOfName() {
+  public function testItCanForcefullyVerifyUniquenessOfName(): void {
     $this->createDefaultSegment('Test');
     $this->segmentsRepository->flush();
     try {
@@ -129,7 +129,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     $this->segmentsRepository->verifyNameIsUnique('Test', null);
   }
 
-  public function testItChecksForDuplicateNameWhenCreatingNewSegment() {
+  public function testItChecksForDuplicateNameWhenCreatingNewSegment(): void {
     $this->createDefaultSegment('Existing Segment');
     $this->segmentsRepository->flush();
     $this->expectException(ConflictException::class);
@@ -137,7 +137,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     $this->segmentsRepository->createOrUpdate('Existing Segment');
   }
 
-  public function testItChecksForDuplicateNameWhenUpdatingExistingSegmentName() {
+  public function testItChecksForDuplicateNameWhenUpdatingExistingSegmentName(): void {
     $segment = $this->createDefaultSegment('Test');
     $this->createDefaultSegment('Existing');
     $this->segmentsRepository->flush();
@@ -166,7 +166,7 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     return $segment;
   }
 
-  private function addActiveNewsletterToSegment(SegmentEntity $segmentEntity) {
+  private function addActiveNewsletterToSegment(SegmentEntity $segmentEntity): void {
     $newsletter = new NewsletterEntity();
     $newsletter->setSubject('Subject');
     $newsletter->setType(NewsletterEntity::TYPE_NOTIFICATION);
@@ -176,14 +176,14 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($newsletterSegment);
   }
 
-  private function cleanup() {
+  private function cleanup(): void {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);
     $this->truncateEntity(NewsletterEntity::class);
     $this->truncateEntity(NewsletterSegmentEntity::class);
   }
 
-  public function _after() {
+  public function _after(): void {
     parent::_after();
     $this->cleanup();
   }

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -19,7 +19,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
   /** @var FilterDataMapper */
   private $mapper;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $wp = $this->makeEmpty(WPFunctions::class, [
       'hasFilter' => false,
@@ -27,28 +27,28 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper = new FilterDataMapper($wp);
   }
 
-  public function testItChecksFiltersArePresent() {
+  public function testItChecksFiltersArePresent(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Filters are missing');
     $this->expectExceptionCode(InvalidFilterException::MISSING_FILTER);
     $this->mapper->map([]);
   }
 
-  public function testItChecksFilterTypeIsPresent() {
+  public function testItChecksFilterTypeIsPresent(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Segment type is not set');
     $this->expectExceptionCode(InvalidFilterException::MISSING_TYPE);
     $this->mapper->map(['filters' => [['someFilter']]]);
   }
 
-  public function testItChecksFilterTypeIsValid() {
+  public function testItChecksFilterTypeIsValid(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Invalid type');
     $this->expectExceptionCode(InvalidFilterException::INVALID_TYPE);
     $this->mapper->map(['filters' => [['segmentType' => 'noexistent']]]);
   }
 
-  public function testItMapsEmailFilter() {
+  public function testItMapsEmailFilter(): void {
     $data = ['filters' => [[
         'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
         'action' => EmailAction::ACTION_OPENED,
@@ -71,7 +71,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItMapsEmailFilterForClicksWithoutLink() {
+  public function testItMapsEmailFilterForClicksWithoutLink(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailAction::ACTION_CLICKED,
@@ -93,7 +93,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItMapsEmailFilterForClicksWithLinks() {
+  public function testItMapsEmailFilterForClicksWithLinks(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailAction::ACTION_CLICKED,
@@ -118,7 +118,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItChecksOperatorForEmailFilterForClicksWithLinks() {
+  public function testItChecksOperatorForEmailFilterForClicksWithLinks(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailAction::ACTION_CLICKED,
@@ -132,7 +132,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map($data);
   }
 
-  public function testItChecksFilterEmailAction() {
+  public function testItChecksFilterEmailAction(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing action');
     $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
@@ -142,7 +142,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItChecksFilterEmailNewsletter() {
+  public function testItChecksFilterEmailNewsletter(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing newsletter');
     $this->expectExceptionCode(InvalidFilterException::MISSING_NEWSLETTER_ID);
@@ -152,7 +152,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItChecksFilterEmailActionIsSupported() {
+  public function testItChecksFilterEmailActionIsSupported(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Invalid email action');
     $this->expectExceptionCode(InvalidFilterException::INVALID_EMAIL_ACTION);
@@ -163,7 +163,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItMapsUserRoleFilter() {
+  public function testItMapsUserRoleFilter(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
       'wordpressRole' => ['editor'],
@@ -184,7 +184,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItChecksUserRoleFilterRole() {
+  public function testItChecksUserRoleFilterRole(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing role');
     $this->expectExceptionCode(InvalidFilterException::MISSING_ROLE);
@@ -193,7 +193,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItChecksSubscribedDateValue() {
+  public function testItChecksSubscribedDateValue(): void {
     $this->expectException(InvalidFilterException::class);
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
@@ -201,7 +201,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItCreatesSubscribedDate() {
+  public function testItCreatesSubscribedDate(): void {
     $filters = $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
       'action' => SubscriberSubscribedDate::TYPE,
@@ -222,7 +222,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItMapsWooCommerceCategory() {
+  public function testItMapsWooCommerceCategory(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceCategory::ACTION_CATEGORY,
@@ -245,7 +245,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItChecksWooCommerceAction() {
+  public function testItChecksWooCommerceAction(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing action');
     $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
@@ -255,7 +255,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItChecksWooCommerceCategoryId() {
+  public function testItChecksWooCommerceCategoryId(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing category');
     $this->expectExceptionCode(InvalidFilterException::MISSING_CATEGORY_ID);
@@ -266,7 +266,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItChecksWooCommerceCategoryOperator() {
+  public function testItChecksWooCommerceCategoryOperator(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing operator');
     $this->expectExceptionCode(InvalidFilterException::MISSING_OPERATOR);
@@ -278,7 +278,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItMapsWooCommerceProduct() {
+  public function testItMapsWooCommerceProduct(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceProduct::ACTION_PRODUCT,
@@ -301,7 +301,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItChecksWooCommerceProductId() {
+  public function testItChecksWooCommerceProductId(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing product');
     $this->expectExceptionCode(InvalidFilterException::MISSING_PRODUCT_ID);
@@ -311,7 +311,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItCreatesEmailOpens() {
+  public function testItCreatesEmailOpens(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailOpensAbsoluteCountAction::TYPE,
@@ -334,7 +334,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItMapsLinkClicksAny() {
+  public function testItMapsLinkClicksAny(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailActionClickAny::TYPE,
@@ -353,7 +353,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItCreatesEmailOpensWithOperator() {
+  public function testItCreatesEmailOpensWithOperator(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailOpensAbsoluteCountAction::TYPE,
@@ -377,7 +377,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItCreatesEmailOpensWithMissingOpens() {
+  public function testItCreatesEmailOpensWithMissingOpens(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailOpensAbsoluteCountAction::TYPE,
@@ -387,7 +387,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map($data);
   }
 
-  public function testItCreatesEmailOpensWithMissingDays() {
+  public function testItCreatesEmailOpensWithMissingDays(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailOpensAbsoluteCountAction::TYPE,
@@ -397,7 +397,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map($data);
   }
 
-  public function testItMapsWooCommerceNumberOfOrders() {
+  public function testItMapsWooCommerceNumberOfOrders(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS,
@@ -423,7 +423,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getData())->equals($expectedResult);
   }
 
-  public function testItRaisesExceptionWhenMappingWooCommerceNumberOfOrders() {
+  public function testItRaisesExceptionWhenMappingWooCommerceNumberOfOrders(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing required fields');
     $this->expectExceptionCode(InvalidFilterException::MISSING_NUMBER_OF_ORDERS_FIELDS);
@@ -434,7 +434,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]]]);
   }
 
-  public function testItMapsWooCommerceSubscription() {
+  public function testItMapsWooCommerceSubscription(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
       'action' => WooCommerceSubscription::ACTION_HAS_ACTIVE,
@@ -457,7 +457,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItChecksWooCommerceSubscriptionAction() {
+  public function testItChecksWooCommerceSubscriptionAction(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing action');
     $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
@@ -469,7 +469,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map($data);
   }
 
-  public function testItChecksWooCommerceSubscriptionProductIds() {
+  public function testItChecksWooCommerceSubscriptionProductIds(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing product');
     $this->expectExceptionCode(InvalidFilterException::MISSING_PRODUCT_ID);
@@ -481,7 +481,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map($data);
   }
 
-  public function testItChecksWooCommerceSubscriptionMissingOperator() {
+  public function testItChecksWooCommerceSubscriptionMissingOperator(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing product');
     $this->expectExceptionCode(InvalidFilterException::MISSING_PRODUCT_ID);
@@ -492,7 +492,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map($data);
   }
 
-  public function testItCreatesWooCommerceCustomerCountry() {
+  public function testItCreatesWooCommerceCustomerCountry(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceCountry::ACTION_CUSTOMER_COUNTRY,
@@ -514,7 +514,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     ]);
   }
 
-  public function testItRaisesExceptionCountryIsMissingForWooCommerceCustomerCountry() {
+  public function testItRaisesExceptionCountryIsMissingForWooCommerceCustomerCountry(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionMessage('Missing country');
     $this->expectExceptionCode(InvalidFilterException::MISSING_COUNTRY);


### PR DESCRIPTION
This PR removes the following PHPStan level 6 errors from `MailPoet\Segments\DynamicSegments` (first and second commit) and from `MailPoet\Segments\SegmentsRepository` (third commit)

```
(Method|Property|Function) has no (return )?type specified.
(Method|Function) has parameter with no type (specified)
```


To test you can modify the level6 exclusion rule on phpstan.neon file to this:


```
    # exclude level 6 errors (but keep them for Automation)
    - '/(Method|Property|Function) (?!(MailPoet\\Automation\\)|(MailPoet\\Segments\\DynamicSegments\\)|(MailPoet\\Segments\\SegmentsRepository)).*has no (return )?type specified/'
    - '/(Method|Function) (?!(MailPoet\\Automation\\)|(MailPoet\\Segments\\DynamicSegments\\)|(MailPoet\\Segments\\SegmentsRepository)).*has parameter (\$[_A-Z]{1}[_a-z]+)? with no type (specified)?/i'
```
and run `./do qa:phpstan`

There are too many errors to be handled in one PR, I am working on a second PR and will create a follow-up issue for the remaining errors.

[MAILPOET-3720]

[MAILPOET-3720]: https://mailpoet.atlassian.net/browse/MAILPOET-3720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ