### PR TITLE
Remove some PHPStan Level 6 errors - 2

### DIFF
--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -78,7 +78,7 @@ class WooCommerce {
     $this->connection = $connection;
   }
 
-  public function shouldShowWooCommerceSegment() {
+  public function shouldShowWooCommerceSegment(): bool {
     $isWoocommerceActive = $this->woocommerceHelper->isWooCommerceActive();
     $woocommerceUserExists = $this->subscribersRepository->woocommerceUserExists();
 
@@ -88,7 +88,7 @@ class WooCommerce {
     return true;
   }
 
-  public function synchronizeRegisteredCustomer($wpUserId, $currentFilter = null) {
+  public function synchronizeRegisteredCustomer(int $wpUserId, ?string $currentFilter = null): bool {
     $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
 
     $currentFilter = $currentFilter ?: $this->wp->currentFilter();
@@ -138,7 +138,7 @@ class WooCommerce {
     return true;
   }
 
-  public function synchronizeGuestCustomer($orderId) {
+  public function synchronizeGuestCustomer(int $orderId): void {
     $wcOrder = $this->woocommerceHelper->wcGetOrder($orderId);
 
     if (!$wcOrder instanceof \WC_Order) return;
@@ -151,7 +151,7 @@ class WooCommerce {
     $email = $this->insertSubscriberFromOrder($orderId, $status);
 
     if (empty($email)) {
-      return false;
+      return;
     }
     $subscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
 
@@ -226,7 +226,7 @@ class WooCommerce {
     return $charset1 === $charset2;
   }
 
-  private function markRegisteredCustomers() {
+  private function markRegisteredCustomers(): void {
     // Mark WP users having a customer role as WooCommerce subscribers
     global $wpdb;
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -551,7 +551,7 @@ class Import {
   }
 
   public function synchronizeWPUsers($wpUsers) {
-    return array_walk($wpUsers, [$this->wpSegment, 'synchronizeUser']);
+    return array_map([$this->wpSegment, 'synchronizeUser'], $wpUsers);
   }
 
   public function addSubscribersToSegments($subscribersIds, $segmentsIds) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/DynamicSegmentFilterRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/DynamicSegmentFilterRepositoryTest.php
@@ -16,7 +16,7 @@ class DynamicSegmentFilterRepositoryTest extends \MailPoetTest {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->cleanup();
     $this->dynamicSegmentFilterRepository = $this->diContainer->get(DynamicSegmentFilterRepository::class);
@@ -60,12 +60,12 @@ class DynamicSegmentFilterRepositoryTest extends \MailPoetTest {
     return $filter;
   }
 
-  private function cleanup() {
+  private function cleanup(): void {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 
-  public function _after() {
+  public function _after(): void {
     parent::_after();
     $this->cleanup();
   }

--- a/mailpoet/tests/integration/Segments/SegmentSaveControllerTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSaveControllerTest.php
@@ -15,14 +15,14 @@ class SegmentSaveControllerTest extends \MailPoetTest {
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->cleanup();
     $this->saveController = $this->diContainer->get(SegmentSaveController::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
   }
 
-  public function testItCanSaveASegment() {
+  public function testItCanSaveASegment(): void {
     $segmentData = [
       'name' => 'Segment one',
       'description' => 'Description',
@@ -34,7 +34,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     expect($segment->getType())->equals(SegmentEntity::TYPE_DEFAULT);
   }
 
-  public function testItDuplicatesSegment() {
+  public function testItDuplicatesSegment(): void {
     $segment = $this->createSegment('Segment two');
     $subscriber1 = $this->createSubscriber('subscribed@mailpoet.com');
     $subscriber2 = $this->createSubscriber('unsubscribed@mailpoet.com');
@@ -55,7 +55,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     expect($subscriberDuplicate2->getStatus())->equals($subscriberSegment2->getStatus());
   }
 
-  public function testItCheckDuplicateSegment() {
+  public function testItCheckDuplicateSegment(): void {
     $name = 'Test name';
     $this->createSegment($name);
     $segmentData = [
@@ -99,7 +99,7 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     return $subscriberSegment;
   }
 
-  private function cleanup() {
+  private function cleanup(): void {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SubscriberSegmentEntity::class);

--- a/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
@@ -15,7 +15,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
   /** @var SegmentsSimpleListRepository */
   private $segmentsListRepository;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $segmentRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->cleanup();
@@ -51,7 +51,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     $this->segmentsListRepository = $this->diContainer->get(SegmentsSimpleListRepository::class);
   }
 
-  public function testItReturnsCorrectlyFormattedOutput() {
+  public function testItReturnsCorrectlyFormattedOutput(): void {
     [$list] = $this->segmentsListRepository->getListWithAssociatedSubscribersCounts();
     expect($list['id'])->string();
     expect($list['name'])->string();
@@ -59,7 +59,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     expect($list['subscribers'])->int();
   }
 
-  public function testItReturnsSegmentsWithSubscribedSubscribersCount() {
+  public function testItReturnsSegmentsWithSubscribedSubscribersCount(): void {
     $segments = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts();
     expect($segments)->count(5);
     // Default 1
@@ -79,7 +79,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     expect($segments[4]['subscribers'])->equals(1);
   }
 
-  public function testItReturnsSegmentsWithSubscribedSubscribersCountFilteredBySegmentType() {
+  public function testItReturnsSegmentsWithSubscribedSubscribersCountFilteredBySegmentType(): void {
     $segments = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts([SegmentEntity::TYPE_DEFAULT, SegmentEntity::TYPE_WP_USERS]);
     expect($segments)->count(3);
     // Default 1
@@ -93,7 +93,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     expect($segments[2]['subscribers'])->equals(1);
   }
 
-  public function testItReturnsSegmentsWithAssociatedSubscribersCount() {
+  public function testItReturnsSegmentsWithAssociatedSubscribersCount(): void {
     $segments = $this->segmentsListRepository->getListWithAssociatedSubscribersCounts();
     expect($segments)->count(5);
     // Default 1
@@ -113,7 +113,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     expect($segments[4]['subscribers'])->equals(1);
   }
 
-  public function testItCanAddSegmentForSubscribersWithoutList() {
+  public function testItCanAddSegmentForSubscribersWithoutList(): void {
     $segments = $this->segmentsListRepository->getListWithAssociatedSubscribersCounts();
     $segments = $this->segmentsListRepository->addVirtualSubscribersWithoutListSegment($segments);
     expect($segments)->count(6);
@@ -154,14 +154,14 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     return $segment;
   }
 
-  private function cleanup() {
+  private function cleanup(): void {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SubscriberSegmentEntity::class);
     $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 
-  public function _after() {
+  public function _after(): void {
     parent::_after();
     $this->cleanup();
   }

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -21,6 +21,7 @@ use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Idiorm\ORM;
 
 class WPTest extends \MailPoetTest {
+  /** @var array<int> */
   private $userIds = [];
 
   /** @var SettingsController */
@@ -29,7 +30,7 @@ class WPTest extends \MailPoetTest {
   /** @var WP */
   private $wpSegment;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->settings = $this->diContainer->get(SettingsController::class);
     $this->wpSegment = $this->diContainer->get(WP::class);
@@ -38,7 +39,7 @@ class WPTest extends \MailPoetTest {
     $this->cleanData();
   }
 
-  public function testSynchronizeUserKeepsStatusOfOldUser() {
+  public function testSynchronizeUserKeepsStatusOfOldUser(): void {
     $randomNumber = rand();
     $id = $this->insertUser($randomNumber);
     $subscriber = Subscriber::createOrUpdate([
@@ -51,7 +52,7 @@ class WPTest extends \MailPoetTest {
     expect($dbSubscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
   }
 
-  public function testSynchronizeUserKeepsStatusOfOldSubscriber() {
+  public function testSynchronizeUserKeepsStatusOfOldSubscriber(): void {
     $randomNumber = rand();
     $subscriber = Subscriber::createOrUpdate([
       'email' => 'user-sync-test' . $randomNumber . '@example.com',
@@ -64,7 +65,7 @@ class WPTest extends \MailPoetTest {
     expect($dbSubscriber->status)->equals($subscriber->status);
   }
 
-  public function testSynchronizeUserStatusIsSubscribedForNewUserWithSignUpConfirmationDisabled() {
+  public function testSynchronizeUserStatusIsSubscribedForNewUserWithSignUpConfirmationDisabled(): void {
     $this->settings->set('signup_confirmation', ['enabled' => '0']);
     $randomNumber = rand();
     $id = $this->insertUser($randomNumber);
@@ -73,7 +74,7 @@ class WPTest extends \MailPoetTest {
     expect($wpSubscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
   }
 
-  public function testSynchronizeUserStatusIsUnconfirmedForNewUserWithSignUpConfirmationEnabled() {
+  public function testSynchronizeUserStatusIsUnconfirmedForNewUserWithSignUpConfirmationEnabled(): void {
     $this->settings->set('signup_confirmation', ['enabled' => '1']);
     $randomNumber = rand();
     $id = $this->insertUser($randomNumber);
@@ -82,7 +83,7 @@ class WPTest extends \MailPoetTest {
     expect($wpSubscriber->status)->equals(Subscriber::STATUS_UNCONFIRMED);
   }
 
-  public function testSynchronizeUsersStatusIsSubscribedForNewUsersWithSignUpConfirmationDisabled() {
+  public function testSynchronizeUsersStatusIsSubscribedForNewUsersWithSignUpConfirmationDisabled(): void {
     $this->settings->set('signup_confirmation', ['enabled' => '0']);
     $this->insertUser();
     $this->insertUser();
@@ -93,7 +94,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribers[1]->status)->equals(Subscriber::STATUS_SUBSCRIBED);
   }
 
-  public function testSynchronizeUsersStatusIsUnconfirmedForNewUsersWithSignUpConfirmationEnabled() {
+  public function testSynchronizeUsersStatusIsUnconfirmedForNewUsersWithSignUpConfirmationEnabled(): void {
     $this->settings->set('signup_confirmation', ['enabled' => '1']);
     $this->insertUser();
     $this->insertUser();
@@ -104,7 +105,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribers[1]->status)->equals(Subscriber::STATUS_UNCONFIRMED);
   }
 
-  public function testItSendsConfirmationEmailWhenSignupConfirmationAndSubscribeOnRegisterEnabled() {
+  public function testItSendsConfirmationEmailWhenSignupConfirmationAndSubscribeOnRegisterEnabled(): void {
     $registration = $this->diContainer->get(Registration::class);
     $this->settings->set('sender', [
       'address' => 'sender@mailpoet.com',
@@ -162,7 +163,7 @@ class WPTest extends \MailPoetTest {
     expect($wpSubscriber->status)->equals(Subscriber::STATUS_UNCONFIRMED);
   }
 
-  public function testItSynchronizeNewUsers() {
+  public function testItSynchronizeNewUsers(): void {
     $this->insertUser();
     $this->insertUser();
     $this->wpSegment->synchronizeUsers();
@@ -172,7 +173,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribersCount)->equals(3);
   }
 
-  public function testItSynchronizesPresubscribedUsers() {
+  public function testItSynchronizesPresubscribedUsers(): void {
     $randomNumber = 12345;
     $subscriber = Subscriber::createOrUpdate([
       'email' => 'user-sync-test' . $randomNumber . '@example.com',
@@ -186,7 +187,7 @@ class WPTest extends \MailPoetTest {
     expect($wpSubscriber->status)->equals(Subscriber::STATUS_SUBSCRIBED);
   }
 
-  public function testItSynchronizeEmails() {
+  public function testItSynchronizeEmails(): void {
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
     $this->updateWPUserEmail($id, 'user-sync-test-xx@email.com');
@@ -195,7 +196,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->email)->equals('user-sync-test-xx@email.com');
   }
 
-  public function testRemovesUsersWithEmptyEmailsFromSunscribersDuringSynchronization() {
+  public function testRemovesUsersWithEmptyEmailsFromSunscribersDuringSynchronization(): void {
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
     $this->updateWPUserEmail($id, '');
@@ -204,7 +205,7 @@ class WPTest extends \MailPoetTest {
     $this->deleteWPUser($id);
   }
 
-  public function testRemovesUsersWithInvalidEmailsFromSunscribersDuringSynchronization() {
+  public function testRemovesUsersWithInvalidEmailsFromSunscribersDuringSynchronization(): void {
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
     $this->updateWPUserEmail($id, 'ivalid.@email.com');
@@ -213,7 +214,7 @@ class WPTest extends \MailPoetTest {
     $this->deleteWPUser($id);
   }
 
-  public function testItDoesNotSynchronizeEmptyEmailsForNewUsers() {
+  public function testItDoesNotSynchronizeEmptyEmailsForNewUsers(): void {
     $id = $this->insertUser();
     $this->updateWPUserEmail($id, '');
     $this->wpSegment->synchronizeUsers();
@@ -222,7 +223,7 @@ class WPTest extends \MailPoetTest {
     $this->deleteWPUser($id);
   }
 
-  public function testItSynchronizeFirstNames() {
+  public function testItSynchronizeFirstNames(): void {
     $firstName = 'Very long name over 255 characters lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum';
     $trucantedFirstName = substr($firstName, 0, 255);
 
@@ -234,7 +235,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->firstName)->equals($trucantedFirstName);
   }
 
-  public function testItSynchronizeLastNames() {
+  public function testItSynchronizeLastNames(): void {
     $lastName = 'Very long name over 255 characters lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum';
     $trucantedLastName = substr($lastName, 0, 255);
 
@@ -246,7 +247,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->lastName)->equals($trucantedLastName);
   }
 
-  public function testItSynchronizeFirstNamesUsingDisplayName() {
+  public function testItSynchronizeFirstNamesUsingDisplayName(): void {
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
     $this->updateWPUserDisplayName($id, 'First name');
@@ -255,7 +256,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->firstName)->equals('First name');
   }
 
-  public function testItSynchronizeFirstNamesFromMetaNotDisplayName() {
+  public function testItSynchronizeFirstNamesFromMetaNotDisplayName(): void {
     $id = $this->insertUser();
     update_user_meta((int)$id, 'first_name', 'First name');
     $this->updateWPUserDisplayName($id, 'display_name');
@@ -264,7 +265,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->firstName)->equals('First name');
   }
 
-  public function testItSynchronizeSegment() {
+  public function testItSynchronizeSegment(): void {
     $this->insertUser();
     $this->insertUser();
     $this->insertUser();
@@ -273,7 +274,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribers->count())->equals(3);
   }
 
-  public function testItDoesntRemoveUsersFromTrash() {
+  public function testItDoesntRemoveUsersFromTrash(): void {
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
     $subscriber = Subscriber::where("wp_user_id", $id)->findOne();
@@ -284,7 +285,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->deletedAt)->notNull();
   }
 
-  public function testItSynchronizesDeletedWPUsersUsingHooks() {
+  public function testItSynchronizesDeletedWPUsersUsingHooks(): void {
     $id = $this->insertUser();
     $this->insertUser();
     $this->wpSegment->synchronizeUsers();
@@ -295,7 +296,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribersCount)->equals(1);
   }
 
-  public function testItSynchronizesNewUsersToDisabledWPSegmentAsUnconfirmedAndTrashed() {
+  public function testItSynchronizesNewUsersToDisabledWPSegmentAsUnconfirmedAndTrashed(): void {
     $this->disableWpSegment();
     $this->settings->set('signup_confirmation.enabled', '1');
     $id = $this->insertUser();
@@ -315,7 +316,7 @@ class WPTest extends \MailPoetTest {
     expect($deletedAt2->timestamp)->equals(Carbon::now()->timestamp, 1);
   }
 
-  public function testItRemovesOrphanedSubscribers() {
+  public function testItRemovesOrphanedSubscribers(): void {
     $this->insertUser();
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
@@ -325,7 +326,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribers->count())->equals(1);
   }
 
-  public function testItDoesntDeleteNonWPData() {
+  public function testItDoesntDeleteNonWPData(): void {
     $this->insertUser();
     // wp_user_id is null
     $subscriber = Subscriber::create();
@@ -364,7 +365,7 @@ class WPTest extends \MailPoetTest {
     $subscriber3->delete();
   }
 
-  public function testItRemovesSubscribersInWPSegmentWithoutWPId() {
+  public function testItRemovesSubscribersInWPSegmentWithoutWPId(): void {
     $subscriber = Subscriber::create();
     $subscriber->hydrate([
       'first_name' => 'Mike',
@@ -386,7 +387,7 @@ class WPTest extends \MailPoetTest {
     expect($subscribersCount)->equals(0);
   }
 
-  public function testItRemovesSubscribersInWPSegmentWithoutEmail() {
+  public function testItRemovesSubscribersInWPSegmentWithoutEmail(): void {
     $id = $this->insertUser();
     $this->updateWPUserEmail($id, '');
     $subscriber = Subscriber::create();
@@ -411,7 +412,7 @@ class WPTest extends \MailPoetTest {
     expect($dbSubscriber)->isEmpty();
   }
 
-  public function testItAddsNewUserToDisabledWpSegmentAsUnconfirmedAndTrashed() {
+  public function testItAddsNewUserToDisabledWpSegmentAsUnconfirmedAndTrashed(): void {
     $this->disableWpSegment();
     $id = $this->insertUser();
     $wp = Stub::make(
@@ -435,7 +436,7 @@ class WPTest extends \MailPoetTest {
     expect($deletedAt->timestamp)->equals(Carbon::now()->timestamp, 1);
   }
 
-  public function testItAddsNewUserWhoUncheckedOptInOnCheckoutPageAsUnsubscribed() {
+  public function testItAddsNewUserWhoUncheckedOptInOnCheckoutPageAsUnsubscribed(): void {
     $id = $this->insertUser();
     $wp = Stub::make(
       $this->diContainer->get(Functions::class),
@@ -456,7 +457,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber->status)->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItDoesNotSendConfirmationEmailForNewUserWhenWPSegmentIsDisabledOnRegisterEnabled() {
+  public function testItDoesNotSendConfirmationEmailForNewUserWhenWPSegmentIsDisabledOnRegisterEnabled(): void {
     $this->disableWpSegment();
     $this->settings->set('sender', [
       'address' => 'sender@mailpoet.com',
@@ -485,7 +486,7 @@ class WPTest extends \MailPoetTest {
     expect($wpSubscriber->countConfirmations)->equals(0);
   }
 
-  public function testItDoesNotTrashNewUsersWhoHaveSomeSegmentsToDisabledWPSegment() {
+  public function testItDoesNotTrashNewUsersWhoHaveSomeSegmentsToDisabledWPSegment(): void {
     $this->disableWpSegment();
     $randomNumber = rand();
     $id = $this->insertUser($randomNumber);
@@ -519,7 +520,7 @@ class WPTest extends \MailPoetTest {
     expect($subscriber1->deletedAt)->null();
   }
 
-  public function testItDoesNotTrashNewUsersWhoIsWooCustomerToDisabledWPSegment() {
+  public function testItDoesNotTrashNewUsersWhoIsWooCustomerToDisabledWPSegment(): void {
     $this->disableWpSegment();
     $randomNumber = rand();
     $id = $this->insertUser($randomNumber);
@@ -555,12 +556,12 @@ class WPTest extends \MailPoetTest {
     remove_role('customer');
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanData();
     Carbon::setTestNow();
   }
 
-  private function cleanData() {
+  private function cleanData(): void {
     ORM::raw_execute('TRUNCATE ' . Segment::$_table);
     ORM::raw_execute('TRUNCATE ' . SubscriberSegment::$_table);
     global $wpdb;
@@ -592,7 +593,7 @@ class WPTest extends \MailPoetTest {
     ', Subscriber::$_table));
   }
 
-  private function getSubscribersCount($a = null) {
+  private function getSubscribersCount($a = null): int {
     return Subscriber::whereLike("email", "user-sync-test%")->count();
   }
 
@@ -601,9 +602,10 @@ class WPTest extends \MailPoetTest {
    * Those tests are testing user synchronisation, so we need data in wp_users table which has not been synchronised to
    * mailpoet database yet. We cannot use wp_insert_user functions because they would do the sync on insert.
    *
-   * @return string
+   * @param int|null $number
+   * @return int
    */
-  private function insertUser($number = null) {
+  private function insertUser(?int $number = null): int {
     global $wpdb;
     $db = ORM::getDb();
     $numberSql = !is_null($number) ? (int)$number : 'rand()';
@@ -620,8 +622,8 @@ class WPTest extends \MailPoetTest {
     if (!is_string($id)) {
       throw new \RuntimeException('Unexpected error when creating WP user.');
     }
-    $this->userIds[] = $id;
-    return $id;
+    $this->userIds[] =  (int)$id;
+    return (int)$id;
   }
 
   private function getUser(int $id): array {
@@ -635,7 +637,7 @@ class WPTest extends \MailPoetTest {
     return $user;
   }
 
-  private function updateWPUserEmail($id, $email) {
+  private function updateWPUserEmail(int $id, string $email): void {
     global $wpdb;
     $db = ORM::getDb();
     $db->exec(sprintf('
@@ -647,7 +649,7 @@ class WPTest extends \MailPoetTest {
     ', $wpdb->users, $email, $id));
   }
 
-  private function updateWPUserDisplayName($id, $name) {
+  private function updateWPUserDisplayName(int $id, string $name): void {
     global $wpdb;
     $db = ORM::getDb();
     $db->exec(sprintf('
@@ -659,7 +661,7 @@ class WPTest extends \MailPoetTest {
     ', $wpdb->users, $name, $id));
   }
 
-  private function deleteWPUser($id) {
+  private function deleteWPUser(int $id): void {
     global $wpdb;
     $db = ORM::getDb();
     $db->exec(sprintf('
@@ -670,14 +672,14 @@ class WPTest extends \MailPoetTest {
     ', $wpdb->users, $id));
   }
 
-  private function clearEmail($subscriber) {
+  private function clearEmail(Subscriber $subscriber): void {
     ORM::raw_execute('
       UPDATE ' . MP_SUBSCRIBERS_TABLE . '
       SET `email` = "" WHERE `id` = ' . $subscriber->id
     );
   }
 
-  private function disableWpSegment() {
+  private function disableWpSegment(): void {
     $segment = Segment::getWPSegment();
     $segment->deletedAt = Carbon::now();
     $segment->save();

--- a/mailpoet/tests/integration/Segments/WPTestUser.php
+++ b/mailpoet/tests/integration/Segments/WPTestUser.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Segments;
 
 class WPTestUser extends \WP_User {
+  /** @var int */
   public $orderId;
 
   /**
@@ -11,7 +12,7 @@ class WPTestUser extends \WP_User {
    * for cases, where we do not want to trigger the synchronization but just want to
    * assign a role to a user.
    */
-  public function add_role($role)
+  public function add_role($role): void
   {
     if (empty($role)) {
       return;

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -18,12 +18,15 @@ use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WooCommerce\Helper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
+use PHPUnit\Framework\MockObject\MockObject;
 
 require_once('WPTestUser.php');
 
 class WooCommerceTest extends \MailPoetTest {
+  /** @var bool */
   public $customerRoleAdded;
 
+  /** @var string[] */
   private $userEmails = [];
 
   /** @var WooCommerceSegment */
@@ -41,7 +44,7 @@ class WooCommerceTest extends \MailPoetTest {
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentsRepository;
 
-  public function _before() {
+  public function _before(): void {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscriberSegmentsRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
@@ -51,7 +54,7 @@ class WooCommerceTest extends \MailPoetTest {
     $this->addCustomerRole();
   }
 
-  public function testItSynchronizesNewRegisteredCustomer() {
+  public function testItSynchronizesNewRegisteredCustomer(): void {
     $firstName = 'Test First';
     $lastName = 'Test Last';
     $user = $this->insertRegisteredCustomerWithOrder(null, ['first_name' => $firstName, 'last_name' => $lastName]);
@@ -76,7 +79,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getDeletedAt())->equals(null);
   }
 
-  public function testItSynchronizesUpdatedRegisteredCustomer() {
+  public function testItSynchronizesUpdatedRegisteredCustomer(): void {
     $firstName = 'Test First';
     $lastName = 'Test Last';
     $user = $this->insertRegisteredCustomerWithOrder(null, ['first_name' => $firstName, 'last_name' => $lastName]);
@@ -101,7 +104,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED); // no overriding
   }
 
-  public function testItSynchronizesDeletedRegisteredCustomer() {
+  public function testItSynchronizesDeletedRegisteredCustomer(): void {
     $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
     $user = $this->insertRegisteredCustomer();
     $subscriber = $this->createSubscriber(
@@ -119,7 +122,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($this->subscriberSegmentsRepository->findOneById($association->getId()))->notEmpty();
   }
 
-  public function testItSynchronizesNewGuestCustomer() {
+  public function testItSynchronizesNewGuestCustomer(): void {
     $this->settings->set('signup_confirmation', ['enabled' => true]);
     $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => false]);
     $guest = $this->insertGuestCustomer();
@@ -135,7 +138,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getSource())->equals(Source::WOOCOMMERCE_USER);
   }
 
-  public function testItSynchronizesNewGuestCustomerWithDoubleOptinDisabled() {
+  public function testItSynchronizesNewGuestCustomerWithDoubleOptinDisabled(): void {
     $this->settings->set('signup_confirmation', ['enabled' => false]);
     $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => false]);
     $this->settings->resetCache();
@@ -152,7 +155,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getSource())->equals(Source::WOOCOMMERCE_USER);
   }
 
-  public function testItSynchronizesNewGuestCustomerWithOptinCheckoutEnabled() {
+  public function testItSynchronizesNewGuestCustomerWithOptinCheckoutEnabled(): void {
     $this->settings->set('signup_confirmation', ['enabled' => false]);
     $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => true]);
     $this->settings->resetCache();
@@ -169,7 +172,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getSource())->equals(Source::WOOCOMMERCE_USER);
   }
 
-  public function testItSynchronizesCustomers() {
+  public function testItSynchronizesCustomers(): void {
     $this->settings->set('signup_confirmation', ['enabled' => true]);
     $this->settings->set('mailpoet_subscribe_old_woocommerce_customers', ['dummy' => '1', 'enabled' => '1']);
     $user = $this->insertRegisteredCustomer();
@@ -188,7 +191,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getSource())->equals(Source::WOOCOMMERCE_USER);
   }
 
-  public function testItSynchronizesCustomersInBatches() {
+  public function testItSynchronizesCustomersInBatches(): void {
     $user1 = $this->insertGuestCustomer();
     $user2 = $this->insertGuestCustomer();
     $user3 = $this->insertGuestCustomer();
@@ -215,7 +218,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscribersCount)->equals(3);
   }
 
-  public function testItSynchronizesNewCustomers() {
+  public function testItSynchronizesNewCustomers(): void {
     $this->insertRegisteredCustomer();
     $this->insertGuestCustomer();
     $this->wooCommerce->synchronizeCustomers();
@@ -226,7 +229,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscribersCount)->equals(4);
   }
 
-  public function testItSynchronizesPresubscribedRegisteredCustomers() {
+  public function testItSynchronizesPresubscribedRegisteredCustomers(): void {
     $randomNumber = 12345;
     $subscriber = $this->createSubscriber(
       'Mike',
@@ -247,7 +250,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($wpSubscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItSynchronizesPresubscribedGuestCustomers() {
+  public function testItSynchronizesPresubscribedGuestCustomers(): void {
     $randomNumber = 12345;
     $subscriber = $this->createSubscriber(
       'Mike',
@@ -268,7 +271,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($wpSubscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItDoesNotSynchronizeEmptyEmailsForNewUsers() {
+  public function testItDoesNotSynchronizeEmptyEmailsForNewUsers(): void {
     $guest = $this->insertGuestCustomer();
     update_post_meta($guest['order_id'], '_billing_email', '');
     $this->wooCommerce->synchronizeCustomers();
@@ -277,7 +280,7 @@ class WooCommerceTest extends \MailPoetTest {
     $this->deleteOrder($guest['order_id']);
   }
 
-  public function testItDoesNotSynchronizeInvalidEmailsForNewUsers() {
+  public function testItDoesNotSynchronizeInvalidEmailsForNewUsers(): void {
     $guest = $this->insertGuestCustomer();
     $invalidEmail = 'ivalid.@email.com';
     update_post_meta($guest['order_id'], '_billing_email', $invalidEmail);
@@ -287,7 +290,7 @@ class WooCommerceTest extends \MailPoetTest {
     $this->deleteOrder($guest['order_id']);
   }
 
-  public function testItSynchronizesFirstNamesForRegisteredCustomers() {
+  public function testItSynchronizesFirstNamesForRegisteredCustomers(): void {
     $user = $this->insertRegisteredCustomerWithOrder(null, ['first_name' => '']);
     $this->wooCommerce->synchronizeCustomers();
     update_post_meta($user->orderId, '_billing_first_name', 'First name');
@@ -298,7 +301,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getFirstName())->equals('First name (newer)');
   }
 
-  public function testItSynchronizesLastNamesForRegisteredCustomers() {
+  public function testItSynchronizesLastNamesForRegisteredCustomers(): void {
     $user = $this->insertRegisteredCustomerWithOrder(null, ['last_name' => '']);
     $this->wooCommerce->synchronizeCustomers();
     update_post_meta($user->orderId, '_billing_last_name', 'Last name');
@@ -309,7 +312,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getLastName())->equals('Last name (newer)');
   }
 
-  public function testItSynchronizesFirstNamesForGuestCustomers() {
+  public function testItSynchronizesFirstNamesForGuestCustomers(): void {
     $guest = $this->insertGuestCustomer(null, ['first_name' => '']);
     $this->wooCommerce->synchronizeCustomers();
     update_post_meta($guest['order_id'], '_billing_first_name', 'First name');
@@ -320,7 +323,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getFirstName())->equals('First name (newer)');
   }
 
-  public function testItSynchronizesLastNamesForGuestCustomers() {
+  public function testItSynchronizesLastNamesForGuestCustomers(): void {
     $guest = $this->insertGuestCustomer(null, ['last_name' => '']);
     $this->wooCommerce->synchronizeCustomers();
     update_post_meta($guest['order_id'], '_billing_last_name', 'Last name');
@@ -331,7 +334,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getLastName())->equals('Last name (newer)');
   }
 
-  public function testItSynchronizesSegment() {
+  public function testItSynchronizesSegment(): void {
     $this->insertRegisteredCustomer();
     $this->insertRegisteredCustomer();
     $this->insertGuestCustomer();
@@ -341,7 +344,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscribers)->count(4);
   }
 
-  public function testItDoesntRemoveRegisteredCustomersFromTrash() {
+  public function testItDoesntRemoveRegisteredCustomersFromTrash(): void {
     $user = $this->insertRegisteredCustomer();
     $this->wooCommerce->synchronizeCustomers();
     $subscriber = $this->subscribersRepository->findOneBy([
@@ -360,7 +363,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getDeletedAt())->notNull();
   }
 
-  public function testItDoesntRemoveGuestCustomersFromTrash() {
+  public function testItDoesntRemoveGuestCustomersFromTrash(): void {
     $guest = $this->insertGuestCustomer();
     $this->wooCommerce->synchronizeCustomers();
     $subscriber = $this->subscribersRepository->findOneBy([
@@ -379,7 +382,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriber->getDeletedAt())->notNull();
   }
 
-  public function testItRemovesOrphanedSubscribers() {
+  public function testItRemovesOrphanedSubscribers(): void {
     $this->insertRegisteredCustomer();
     $this->insertGuestCustomer();
     $user = $this->insertRegisteredCustomerWithOrder();
@@ -393,7 +396,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscribers)->count(2);
   }
 
-  public function testItDoesntDeleteNonWCData() {
+  public function testItDoesntDeleteNonWCData(): void {
     $this->insertRegisteredCustomer();
     $this->insertGuestCustomer();
     // WP user
@@ -432,7 +435,7 @@ class WooCommerceTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testItUnsubscribesSubscribersWithoutWCFlagFromWCSegment() {
+  public function testItUnsubscribesSubscribersWithoutWCFlagFromWCSegment(): void {
     $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
     $subscriber = $this->createSubscriber(
       'Mike',
@@ -447,7 +450,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($this->subscriberSegmentsRepository->findOneById($association->getId()))->isEmpty();
   }
 
-  public function testItUnsubscribesSubscribersWithoutEmailFromWCSegment() {
+  public function testItUnsubscribesSubscribersWithoutEmailFromWCSegment(): void {
     $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
     $subscriber = $this->createSubscriber(
       'Mike',
@@ -465,7 +468,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($this->subscriberSegmentsRepository->findOneById($association->getId()))->isEmpty();
   }
 
-  public function testItSetGlobalStatusUnsubscribedForUsersUnsyncedFromWooCommerceSegment() {
+  public function testItSetGlobalStatusUnsubscribedForUsersUnsyncedFromWooCommerceSegment(): void {
     $guest = $this->insertGuestCustomer();
     $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
     $subscriber = $this->createSubscriber(
@@ -485,7 +488,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriberAfterUpdate->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItDoesntSetGlobalStatusUnsubscribedIfUserHasMoreLists() {
+  public function testItDoesntSetGlobalStatusUnsubscribedIfUserHasMoreLists(): void {
     $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
     $guest = $this->insertGuestCustomer();
     $subscriber = $this->createSubscriber(
@@ -514,7 +517,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($subscriberAfterUpdate->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
-  public function testItSubscribesSubscribersToWCListWhenSettingIsEnabled() {
+  public function testItSubscribesSubscribersToWCListWhenSettingIsEnabled(): void {
     $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
     $user1 = $this->insertRegisteredCustomer();
     $user2 = $this->insertRegisteredCustomer();
@@ -560,7 +563,7 @@ class WooCommerceTest extends \MailPoetTest {
     expect($association2AfterUpdate->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItUnsubscribesSubscribersFromWCListWhenSettingIsDisabled() {
+  public function testItUnsubscribesSubscribersFromWCListWhenSettingIsDisabled(): void {
     $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
     $user1 = $this->insertRegisteredCustomer();
     $user2 = $this->insertRegisteredCustomer();
@@ -605,25 +608,25 @@ class WooCommerceTest extends \MailPoetTest {
     expect($association2AfterUpdate->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->cleanData();
     $this->removeCustomerRole();
   }
 
-  private function addCustomerRole() {
+  private function addCustomerRole(): void {
     if (!get_role('customer')) {
       add_role('customer', 'Customer');
       $this->customerRoleAdded = true;
     }
   }
 
-  private function removeCustomerRole() {
+  private function removeCustomerRole(): void {
     if (!empty($this->customerRoleAdded)) {
       remove_role('customer');
     }
   }
 
-  private function cleanData() {
+  private function cleanData(): void {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
     $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
@@ -693,7 +696,7 @@ class WooCommerceTest extends \MailPoetTest {
    *
    * @return WPTestUser
    */
-  private function insertRegisteredCustomer($number = null, $firstName = null, $lastName = null) {
+  private function insertRegisteredCustomer(?int $number = null, ?string $firstName = null, ?string $lastName = null): WPTestUser {
     global $wpdb;
     $connection = $this->entityManager->getConnection();
     $numberSql = !is_null($number) ? (int)$number : mt_rand();
@@ -741,7 +744,7 @@ class WooCommerceTest extends \MailPoetTest {
   /**
    * A guest customer is whose data is only contained in an order
    */
-  private function insertGuestCustomer($number = null, array $data = null) {
+  private function insertGuestCustomer(?int $number = null, ?array $data = null): array {
     $number = !is_null($number) ? (int)$number : mt_rand();
     // add order
     $guest = [
@@ -754,7 +757,7 @@ class WooCommerceTest extends \MailPoetTest {
     return $guest;
   }
 
-  private function insertRegisteredCustomerWithOrder($number = null, array $data = null) {
+  private function insertRegisteredCustomerWithOrder(?int $number = null, array $data = null): WPTestUser {
     $number = !is_null($number) ? (int)$number : mt_rand();
     $data = is_array($data) ? $data : [];
     $user = $this->insertRegisteredCustomer($number, $data['first_name'] ?? null, $data['last_name'] ?? null);
@@ -764,7 +767,11 @@ class WooCommerceTest extends \MailPoetTest {
     return $user;
   }
 
-  private function createOrder($data) {
+  /**
+   * @param array $data
+   * @return int
+   */
+  private function createOrder(array $data): int {
     $orderData = [
       'post_type' => 'shop_order',
       'meta_input' => [
@@ -777,10 +784,11 @@ class WooCommerceTest extends \MailPoetTest {
       $orderData['meta_input']['_customer_user'] = (int)$data['user_id'];
     }
     $id = wp_insert_post($orderData);
+    $this->assertIsInt($id);
     return $id;
   }
 
-  private function deleteOrder(int $id) {
+  private function deleteOrder(int $id): void {
     global $wpdb;
     $connection = $this->entityManager->getConnection();
     $connection->executeQuery("
@@ -805,7 +813,11 @@ class WooCommerceTest extends \MailPoetTest {
     );
   }
 
-  private function getWooCommerce($wooHelperMock = null): WooCommerceSegment {
+  private function getWooCommerce(?MockObject $wooHelperMock = null): WooCommerceSegment {
+    if ($wooHelperMock) {
+      $this->assertInstanceOf(Helper::class, $wooHelperMock);
+    }
+
     return new WooCommerceSegment(
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(WPFunctions::class),

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -24,7 +24,7 @@ require_once('WPTestUser.php');
 
 class WooCommerceTest extends \MailPoetTest {
   /** @var bool */
-  public $customerRoleAdded;
+  public $customerRoleAdded = false;
 
   /** @var string[] */
   private $userEmails = [];
@@ -621,7 +621,7 @@ class WooCommerceTest extends \MailPoetTest {
   }
 
   private function removeCustomerRole(): void {
-    if (!empty($this->customerRoleAdded)) {
+    if ($this->customerRoleAdded) {
       remove_role('customer');
     }
   }


### PR DESCRIPTION
Testing instructions for GlobalStep:
1. Go to MailPoet > Lists > Segment tab
2. Please perform some testing around segments to ensure there are no issues

 ---- 

This continues the work from https://github.com/mailpoet/mailpoet/pull/4138
It can be merged separately.

This PR removes some of the following PHPStan level 6 errors from MailPoet\Segments:

To test you can modify the level6 exclusion rule on phpstan.neon file to this:

    # exclude level 6 errors (but keep them for Automation)
    - '/(Method|Property|Function) (?!(MailPoet\\Automation\\)|(MailPoet\\Segments\\)|(MailPoet\\Test\\Segments\\)).*has no (return )?type specified/'
    - '/(Method|Function) (?!(MailPoet\\Automation\\)|(MailPoet\\Segments\\)|(MailPoet\\Test\\Segments\\)).*has parameter (\$[_A-Z]{1}[_a-z]+)? with no type (specified)?/i'


run `./do qa:phpstan` and check that the committed files throw no errors.

[MAILPOET-3720](https://mailpoet.atlassian.net/browse/MAILPOET-3720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

There are too many errors to fix in a couple of PRs. I will continue working on this and try to fix as many as possible before my sabbatical :) 