### PR TITLE
Fix form editor crash with old "below_post" value [MAILPOET-4381]

### DIFF
--- a/mailpoet/assets/js/src/form_editor/store/store.ts
+++ b/mailpoet/assets/js/src/form_editor/store/store.ts
@@ -57,6 +57,12 @@ export const initStore = () => {
           `mailpoet_form_preview_settings${formData.id}`,
         ),
       );
+
+      // Back compatibility - "below_post" was renamed to "below_posts"
+      // but local storage can have the old value, let's normalize it.
+      if (previewSettings.formType === 'below_post') {
+        previewSettings.formType = 'below_posts';
+      }
     } catch (e) {
       // We just keep it null
     }


### PR DESCRIPTION
[MAILPOET-4381]

**Testing:**
1. Install production's build (you can delete the existing MailPoet plugin and search plugins for MailPoet to install it
2. Create a new form and in editor click to preview it as `below pages` (check below screenshot as example)
<img width="387" alt="Screen Shot 2022-05-19 at 9 21 44" src="https://user-images.githubusercontent.com/141436/169235433-d2c24512-13fa-4d78-b6aa-61ab089bd103.png">

2. Save the form and go back to Forms
3. Install the build from this PR
4. Go to edit the same form, it should not crash, and in the preview screen the `below pages` option should be pre-checked.

[MAILPOET-4381]: https://mailpoet.atlassian.net/browse/MAILPOET-4381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ