### PR TITLE
Remove some PHPStan Level 6 errors - 3

### DIFF
--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -21,16 +21,27 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class Import {
+  /** @var array */
   public $subscribersData;
+  /** @var array */
   public $segmentsIds;
+  /** @var string */
   public $newSubscribersStatus;
+  /** @var string */
   public $existingSubscribersStatus;
+  /** @var bool */
   public $updateSubscribers;
+  /** @var array */
   public $subscribersFields;
+  /** @var array */
   public $subscribersCustomFields;
+  /** @var int */
   public $subscribersCount;
+  /** @var Carbon */
   public $createdAt;
+  /** @var Carbon */
   public $updatedAt;
+  /** @var array */
   public $requiredSubscribersFields;
   const DB_QUERY_CHUNK_SIZE = 100;
   const STATUS_DONT_UPDATE = 'dont_update';
@@ -81,7 +92,7 @@ class Import {
     $this->subscribersCustomFields = $this->getCustomSubscribersFields(
       array_keys($data['columns'])
     );
-    $this->subscribersCount = count(reset($this->subscribersData));
+    $this->subscribersCount = (reset($this->subscribersData) === false) ? 0 : count(reset($this->subscribersData));
     $this->createdAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $this->updatedAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp') + 1);
     $this->requiredSubscribersFields = [
@@ -92,7 +103,7 @@ class Import {
     ];
   }
 
-  public function validateImportData($data) {
+  public function validateImportData(array $data): void {
     $requiredDataFields = [
       'subscribers',
       'columns',
@@ -112,7 +123,11 @@ class Import {
     }
   }
 
-  public function process() {
+  /**
+   * @return array{created: int, updated:int, segments: array, added_to_segment_with_welcome_notification:bool}
+   * @throws \Exception
+   */
+  public function process(): array {
     // validate data based on field validation rules
     $subscribersData = $this->validateSubscribersData($this->subscribersData);
     if (!$subscribersData) {
@@ -179,15 +194,19 @@ class Import {
         false;
 
     return [
-      'created' => count($createdSubscribers),
-      'updated' => count($updatedSubscribers),
+      'created' => is_array($createdSubscribers) ? count($createdSubscribers) : 0,
+      'updated' => is_array($updatedSubscribers) ? count($updatedSubscribers) : 0,
       'segments' => $segments,
       'added_to_segment_with_welcome_notification' =>
         ($welcomeNotificationsInSegments) ? true : false,
     ];
   }
 
-  public function validateSubscribersData($subscribersData) {
+  /**
+   * @param array $subscribersData
+   * @return false|array
+   */
+  public function validateSubscribersData(array $subscribersData) {
     $invalidRecords = [];
     $validator = new ModelValidator();
     foreach ($subscribersData as $column => &$data) {
@@ -295,7 +314,7 @@ class Import {
     return $dateTimeDates;
   }
 
-  public function transformSubscribersData($subscribers, $columns) {
+  public function transformSubscribersData(array $subscribers, array $columns): array {
     $transformedSubscribers = [];
     foreach ($columns as $column => $data) {
       $transformedSubscribers[$column] = array_column($subscribers, $data['index']);
@@ -303,7 +322,11 @@ class Import {
     return $transformedSubscribers;
   }
 
-  public function splitSubscribersData($subscribersData) {
+  /**
+   * @param array $subscribersData
+   * @return array{array|false,array,array|false}
+   */
+  public function splitSubscribersData(array $subscribersData): array {
     // $subscribers_data is an two-dimensional associative array
     // of all subscribers being imported: [field => [value1, value2], field => [value1, value2], ...]
     $tempExistingSubscribers = [];
@@ -347,7 +370,7 @@ class Import {
     ];
   }
 
-  public function deleteExistingTrashedSubscribers($subscribersData) {
+  public function deleteExistingTrashedSubscribers(array $subscribersData): void {
     $existingTrashedRecords = array_filter(
       array_map(function($subscriberEmails) {
         return $this->subscriberRepository->findIdsOfDeletedByEmails($subscriberEmails);
@@ -362,14 +385,20 @@ class Import {
     }
   }
 
-  public function addMissingRequiredFields($subscribers) {
+  public function addMissingRequiredFields(array $subscribers): array {
     foreach (array_keys($this->requiredSubscribersFields) as $requiredField) {
       $subscribers = $this->addField($subscribers, $requiredField, $this->requiredSubscribersFields[$requiredField]);
     }
     return $subscribers;
   }
 
-  private function addField($subscribers, $fieldName, $fieldValue) {
+  /**
+   * @param array $subscribers
+   * @param mixed $fieldName
+   * @param mixed $fieldValue
+   * @return array
+   */
+  private function addField(array $subscribers, $fieldName, $fieldValue): array {
     if (in_array($fieldName, $subscribers['fields'])) return $subscribers;
 
     $subscribersCount = count($subscribers['data'][key($subscribers['data'])]);
@@ -384,7 +413,7 @@ class Import {
     return $subscribers;
   }
 
-  private function setSubscriptionStatusToDefault($subscribersData, $defaultStatus) {
+  private function setSubscriptionStatusToDefault(array $subscribersData, string $defaultStatus): array {
     if (!in_array('status', $subscribersData['fields'])) return $subscribersData;
     $subscribersData['data']['status'] = array_map(function() use ($defaultStatus) {
       return $defaultStatus;
@@ -401,7 +430,7 @@ class Import {
     return $subscribersData;
   }
 
-  private function setSource($subscribersData) {
+  private function setSource(array $subscribersData): array {
     $subscribersCount = count($subscribersData['data'][key($subscribersData['data'])]);
     $subscribersData['fields'][] = 'source';
     $subscribersData['data']['source'] = array_fill(
@@ -412,7 +441,7 @@ class Import {
     return $subscribersData;
   }
 
-  private function setLinkToken($subscribersData) {
+  private function setLinkToken(array $subscribersData): array {
     $subscribersCount = count($subscribersData['data'][key($subscribersData['data'])]);
     $subscribersData['fields'][] = 'link_token';
     $subscribersData['data']['link_token'] = array_map(
@@ -423,7 +452,7 @@ class Import {
     return $subscribersData;
   }
 
-  public function getSubscribersFields($subscribersFields) {
+  public function getSubscribersFields(array $subscribersFields): array {
     return array_values(
       array_filter(
         array_map(function($field) {
@@ -433,7 +462,11 @@ class Import {
     );
   }
 
-  public function getCustomSubscribersFields($subscribersFields) {
+  /**
+   * @param array $subscribersFields
+   * @return int[]
+   */
+  public function getCustomSubscribersFields(array $subscribersFields): array {
     return array_values(
       array_filter(
         array_map(function($field) {
@@ -447,7 +480,7 @@ class Import {
     string $action,
     array $subscribersData,
     array $subscribersCustomFields = []
-  ) {
+  ): ?array {
     $subscribersCount = count($subscribersData['data'][key($subscribersData['data'])]);
     $subscribers = array_map(function($index) use ($subscribersData) {
       return array_map(function($field) use ($index, $subscribersData) {
@@ -500,7 +533,7 @@ class Import {
     array $createdOrUpdatedSubscribers,
     array $subscribersData,
     array $subscribersCustomFieldsIds
-  ) {
+  ): void {
     // check if custom fields exist in the database
     $subscribersCustomFieldsIds = array_map(function(CustomFieldEntity $customField): int {
       return (int)$customField->getId();
@@ -550,11 +583,15 @@ class Import {
     }
   }
 
-  public function synchronizeWPUsers($wpUsers) {
+  /**
+   * @param int[] $wpUsers
+   * @return array
+   */
+  public function synchronizeWPUsers(array $wpUsers): array {
     return array_map([$this->wpSegment, 'synchronizeUser'], $wpUsers);
   }
 
-  public function addSubscribersToSegments($subscribersIds, $segmentsIds) {
+  public function addSubscribersToSegments(array $subscribersIds, array $segmentsIds): void {
     $columns = [
       'subscriber_id',
       'segment_id',

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -41,7 +41,7 @@ class Import {
   public $createdAt;
   /** @var Carbon */
   public $updatedAt;
-  /** @var array */
+  /** @var array<string, mixed> */
   public $requiredSubscribersFields;
   const DB_QUERY_CHUNK_SIZE = 100;
   const STATUS_DONT_UPDATE = 'dont_update';
@@ -394,11 +394,11 @@ class Import {
 
   /**
    * @param array $subscribers
-   * @param mixed $fieldName
+   * @param string $fieldName
    * @param mixed $fieldValue
    * @return array
    */
-  private function addField(array $subscribers, $fieldName, $fieldValue): array {
+  private function addField(array $subscribers, string $fieldName, $fieldValue): array {
     if (in_array($fieldName, $subscribers['fields'])) return $subscribers;
 
     $subscribersCount = count($subscribers['data'][key($subscribers['data'])]);

--- a/mailpoet/lib/Subscribers/ImportExport/Import/MailChimp.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/MailChimp.php
@@ -20,7 +20,7 @@ class MailChimp {
   private $mapper;
 
   public function __construct(
-    $apiKey
+    string $apiKey
   ) {
     $this->apiKey = $this->getAPIKey($apiKey);
     $this->maxPostSize = (int)Helpers::getMaxPostSize('bytes');
@@ -58,7 +58,7 @@ class MailChimp {
     return $lists;
   }
 
-  public function getSubscribers($lists = []): array {
+  public function getSubscribers(array $lists = []): array {
     if (!$this->apiKey || !$this->dataCenter) {
       $this->throwException('API');
     }
@@ -111,13 +111,21 @@ class MailChimp {
     ];
   }
 
+  /**
+   * @param string|false $apiKey
+   * @return false|string
+   */
   public function getDataCenter($apiKey) {
     if (!$apiKey) return false;
     $apiKeyParts = explode('-', $apiKey);
     return end($apiKeyParts);
   }
 
-  public function getAPIKey($apiKey) {
+  /**
+   * @param string $apiKey
+   * @return false|string
+   */
+  public function getAPIKey(string $apiKey) {
     return (preg_match(self::API_KEY_REGEX, $apiKey)) ? $apiKey : false;
   }
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -20,11 +20,15 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class ImportTest extends \MailPoetTest {
+  /** @var array */
   public $subscribersCustomFields;
+  /** @var array */
   public $subscribersData;
   /** @var Import */
   public $import;
+  /** @var array */
   public $subscribersFields;
+  /** @var array */
   public $testData;
   /** @var SegmentEntity */
   public $segment1;
@@ -55,7 +59,7 @@ class ImportTest extends \MailPoetTest {
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
-  public function _before() {
+  public function _before(): void {
     $this->wpSegment = $this->diContainer->get(WP::class);
     $this->customFieldsRepository = $this->diContainer->get(CustomFieldsRepository::class);
     $this->importExportRepository = $this->diContainer->get(ImportExportRepository::class);
@@ -129,7 +133,7 @@ class ImportTest extends \MailPoetTest {
     );
   }
 
-  public function testItConstructs() {
+  public function testItConstructs(): void {
     expect(is_array($this->import->subscribersData))->true();
     expect($this->import->segmentsIds)->equals($this->testData['segments']);
     expect(is_array($this->import->subscribersFields))->true();
@@ -139,7 +143,7 @@ class ImportTest extends \MailPoetTest {
     expect($this->import->updatedAt)->notEmpty();
   }
 
-  public function testItChecksForRequiredDataFields() {
+  public function testItChecksForRequiredDataFields(): void {
     $data = $this->testData;
     // exception should be thrown when one or more fields do not exist
     unset($data['timestamp']);
@@ -153,7 +157,7 @@ class ImportTest extends \MailPoetTest {
     $this->import->validateImportData($this->testData);
   }
 
-  public function testItValidatesColumnNames() {
+  public function testItValidatesColumnNames(): void {
     $data = $this->testData;
     $data['columns']['test) values ((ExtractValue(1,CONCAT(0x5c, (SELECT version())))))%23'] = true;
     try {
@@ -164,13 +168,14 @@ class ImportTest extends \MailPoetTest {
     }
   }
 
-  public function testItValidatesSubscribersEmail() {
+  public function testItValidatesSubscribersEmail(): void {
     // invalid email is removed from data object
     $data['email'] = [
       'àdam@smîth.com',
       'jane@doe.com',
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['email'])->count(1);
     expect($result['email'][0])->equals('jane@doe.com');
 
@@ -183,7 +188,7 @@ class ImportTest extends \MailPoetTest {
     expect($result)->equals($data);
   }
 
-  public function testItValidatesSubscribersConfirmedAt() {
+  public function testItValidatesSubscribersConfirmedAt(): void {
     // required email column
     $data['email'] = [
       'adam@smith.com',
@@ -195,6 +200,7 @@ class ImportTest extends \MailPoetTest {
       '2019-05-31 18:42:35',
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['confirmed_at'])->count(1);
     expect($result['confirmed_at'][0])->equals('2019-05-31 18:42:35');
 
@@ -204,13 +210,14 @@ class ImportTest extends \MailPoetTest {
       '2015-10-13T16:19:20-04:00',
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['confirmed_at'])->equals([
       '2020-09-17 11:11:11',
       '2015-10-13 16:19:20',
     ]);
   }
 
-  public function testItValidatesSubscribersConfirmedIP() {
+  public function testItValidatesSubscribersConfirmedIP(): void {
     // required email column
     $data['email'] = [
       'adam@smith.com',
@@ -222,6 +229,7 @@ class ImportTest extends \MailPoetTest {
       '192.68.69.32',
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['confirmed_ip'])->count(2);
     expect($result['confirmed_ip'][0])->isEmpty();
     expect($result['confirmed_ip'][1])->equals('192.68.69.32');
@@ -232,6 +240,7 @@ class ImportTest extends \MailPoetTest {
       '192.68.69.32',
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['confirmed_ip'])->count(2);
     expect($result['confirmed_ip'][0])->isEmpty();
     expect($result['confirmed_ip'][1])->equals('192.68.69.32');
@@ -242,6 +251,7 @@ class ImportTest extends \MailPoetTest {
       '192.68.69.32',
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['confirmed_ip'])->count(2);
     expect($result['confirmed_ip'][0])->isEmpty();
     expect($result['confirmed_ip'][1])->equals('192.68.69.32');
@@ -252,10 +262,11 @@ class ImportTest extends \MailPoetTest {
       '2001:0db8:85a3:08d3:1319:8a2e:0370:7334', //IPv6
     ];
     $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
     expect($result['confirmed_ip'])->equals($data['confirmed_ip']);
   }
 
-  public function testItThrowsErrorWhenNoValidSubscribersAreFoundDuringImport() {
+  public function testItThrowsErrorWhenNoValidSubscribersAreFoundDuringImport(): void {
     $data = [
       'subscribers' => [
         [
@@ -285,7 +296,7 @@ class ImportTest extends \MailPoetTest {
     }
   }
 
-  public function testItTransformsSubscribers() {
+  public function testItTransformsSubscribers(): void {
     $customField = $this->subscribersCustomFields[0];
     expect($this->import->subscribersData['first_name'][0])
       ->equals($this->testData['subscribers'][0][0]);
@@ -297,7 +308,7 @@ class ImportTest extends \MailPoetTest {
       ->equals($this->testData['subscribers'][0][3]);
   }
 
-  public function testItSplitsSubscribers() {
+  public function testItSplitsSubscribers(): void {
     $subscribersData = $this->subscribersData;
     $subscribersDataExisting = [
       [
@@ -344,6 +355,7 @@ class ImportTest extends \MailPoetTest {
     list($existingSubscribers, $newSubscribers, $wpUsers, ) = $this->import->splitSubscribersData(
       $subscribersData
     );
+    $this->assertIsArray($existingSubscribers);
     expect($existingSubscribers['email'][0])->equals($subscribersData['email'][2]);
     expect($existingSubscribers['email'][1])->equals($subscribersData['email'][3]);
     foreach ($newSubscribers as $field => $value) {
@@ -352,7 +364,7 @@ class ImportTest extends \MailPoetTest {
     expect($wpUsers)->equals([$subscribersDataExisting[0]['wp_user_id']]);
   }
 
-  public function testItAddsMissingRequiredFieldsToSubscribersObject() {
+  public function testItAddsMissingRequiredFieldsToSubscribersObject(): void {
     $data = [
       'subscribers' => [
         [
@@ -394,7 +406,7 @@ class ImportTest extends \MailPoetTest {
     expect($result['data']['created_at'][0])->equals($import->createdAt);
   }
 
-  public function testItGetsSubscriberFields() {
+  public function testItGetsSubscriberFields(): void {
     $data = [
       'one',
       'two',
@@ -408,7 +420,7 @@ class ImportTest extends \MailPoetTest {
       ]);
   }
 
-  public function testItGetsCustomSubscribersFields() {
+  public function testItGetsCustomSubscribersFields(): void {
     $data = [
       'one',
       'two',
@@ -418,7 +430,7 @@ class ImportTest extends \MailPoetTest {
     expect($fields)->equals([39]);
   }
 
-  public function testItAddsOrUpdatesSubscribers() {
+  public function testItAddsOrUpdatesSubscribers(): void {
     $subscribersData = [
       'data' => $this->subscribersData,
       'fields' => $this->subscribersFields,
@@ -442,7 +454,7 @@ class ImportTest extends \MailPoetTest {
       ->equals($subscribersData['data']['first_name'][1]);
   }
 
-  public function testItDeletesTrashedSubscribers() {
+  public function testItDeletesTrashedSubscribers(): void {
     $subscribersData = [
       'data' => $this->subscribersData,
       'fields' => $this->subscribersFields,
@@ -475,7 +487,7 @@ class ImportTest extends \MailPoetTest {
     expect(count($dbSubscribers))->equals(1);
   }
 
-  public function testItCreatesOrUpdatesCustomFields() {
+  public function testItCreatesOrUpdatesCustomFields(): void {
     $subscribersData = [
       'data' => $this->subscribersData,
       'fields' => $this->subscribersFields,
@@ -514,7 +526,7 @@ class ImportTest extends \MailPoetTest {
       ->equals($subscribersData['data'][$customField][1]);
   }
 
-  public function testItAddsSubscribersToSegments() {
+  public function testItAddsSubscribersToSegments(): void {
     $subscribersData = [
       'data' => $this->subscribersData,
       'fields' => $this->subscribersFields,
@@ -546,7 +558,7 @@ class ImportTest extends \MailPoetTest {
     }
   }
 
-  public function testItDeletesExistingTrashedSubscribers() {
+  public function testItDeletesExistingTrashedSubscribers(): void {
     $subscribersData = [
       'data' => $this->subscribersData,
       'fields' => $this->subscribersFields,
@@ -562,7 +574,7 @@ class ImportTest extends \MailPoetTest {
     );
   }
 
-  public function testItUpdatesSubscribers() {
+  public function testItUpdatesSubscribers(): void {
     $result = $this->import->process();
     expect($result['updated'])->equals(0);
     $result = $this->import->process();
@@ -572,7 +584,7 @@ class ImportTest extends \MailPoetTest {
     expect($result['updated'])->equals(0);
   }
 
-  public function testItDoesNotUpdateExistingSubscribersStatusWhenStatusColumnIsNotPresent() {
+  public function testItDoesNotUpdateExistingSubscribersStatusWhenStatusColumnIsNotPresent(): void {
     $subscriber = $this->createSubscriber(
       'Adam',
       'Smith',
@@ -586,7 +598,7 @@ class ImportTest extends \MailPoetTest {
     expect($updatedSubscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItImportsNewsSubscribersWithAllAdditionalParameters() {
+  public function testItImportsNewsSubscribersWithAllAdditionalParameters(): void {
     $data = $this->testData;
     $data['columns']['status'] = ['index' => 4];
     $data['subscribers'][0][] = 'unsubscribed';
@@ -613,7 +625,7 @@ class ImportTest extends \MailPoetTest {
     expect($lastSubscribed2->getTimestamp())->equals($this->testData['timestamp'], 1);
   }
 
-  public function testItDoesNotUpdateExistingSubscribersLastSubscribedAtWhenItIsPresent() {
+  public function testItDoesNotUpdateExistingSubscribersLastSubscribedAtWhenItIsPresent(): void {
     $data = $this->testData;
     $data['columns']['last_subscribed_at'] = ['index' => 4];
     $data['subscribers'][0][] = '2018-12-12 12:12:00';
@@ -635,7 +647,7 @@ class ImportTest extends \MailPoetTest {
     expect($updatedSubscriber->getLastSubscribedAt())->equals(Carbon::createFromFormat('Y-m-d H:i:s', '2017-12-12 12:12:00'));
   }
 
-  public function testItSynchronizesWpUsers() {
+  public function testItSynchronizesWpUsers(): void {
     $this->tester->createWordPressUser('mary@jane.com', 'editor');
     $beforeImport = $this->subscriberRepository->findOneBy(['email' => 'mary@jane.com']);
     assert($beforeImport instanceof SubscriberEntity);
@@ -651,7 +663,7 @@ class ImportTest extends \MailPoetTest {
     $this->tester->deleteWordPressUser('mary@jane.com');
   }
 
-  public function testItDoesUpdateStatusExistingSubscriberWhenExistingSubscribersStatusIsSet() {
+  public function testItDoesUpdateStatusExistingSubscriberWhenExistingSubscribersStatusIsSet(): void {
     $data = $this->testData;
     $data['existingSubscribersStatus'] = SubscriberEntity::STATUS_SUBSCRIBED;
     $lastSubscribedAt = Carbon::createFromFormat('Y-m-d H:i:s', '2020-08-08 08:08:00');
@@ -672,7 +684,7 @@ class ImportTest extends \MailPoetTest {
     expect($updatedSubscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
-  public function testItDoesStatusNewSubscriberWhenNewSubscribersStatusIsSet() {
+  public function testItDoesStatusNewSubscriberWhenNewSubscribersStatusIsSet(): void {
     $data = $this->testData;
     $data['newSubscribersStatus'] = SubscriberEntity::STATUS_UNSUBSCRIBED;
     $import = $this->createImportInstance($data);
@@ -685,7 +697,7 @@ class ImportTest extends \MailPoetTest {
     expect($newSubscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
   }
 
-  public function testItRunsImport() {
+  public function testItRunsImport(): void {
     $result = $this->import->process();
     expect($result['created'])->equals(2);
     $subscriber = $this->subscriberRepository->findOneBy(['email' => 'mary@jane.com']);
@@ -710,7 +722,7 @@ class ImportTest extends \MailPoetTest {
     }
   }
 
-  public function testItImportsSubscribersWithCustomFormat() {
+  public function testItImportsSubscribersWithCustomFormat(): void {
     WPFunctions::set(Stub::make(new WPFunctions, [
       'getOption' => 'd/m/Y',
     ]));
@@ -735,7 +747,7 @@ class ImportTest extends \MailPoetTest {
     WPFunctions::set(new WPFunctions());
   }
 
-  public function testItOnlyAppliesCustomFormatToSitesWithCustomFormat() {
+  public function testItOnlyAppliesCustomFormatToSitesWithCustomFormat(): void {
     WPFunctions::set(Stub::make(new WPFunctions, [
       'getOption' => 'm/d/Y',
     ]));
@@ -812,7 +824,7 @@ class ImportTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  public function _after() {
+  public function _after(): void {
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(SubscriberSegmentEntity::class);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
@@ -23,7 +23,7 @@ class MailChimpTest extends \MailPoetTest {
     $this->lists = explode(",", (string)getenv('WP_TEST_IMPORT_MAILCHIMP_LISTS'));
   }
 
-  public function _before() {
+  public function _before(): void {
     WPFunctions::set(Stub::make(new WPFunctions, [
       '__' => function ($value) {
         return $value;
@@ -31,7 +31,7 @@ class MailChimpTest extends \MailPoetTest {
     ]));
   }
 
-  public function testItCanGetAPIKey() {
+  public function testItCanGetAPIKey(): void {
     $validApiKeyFormat = '12345678901234567890123456789012-ab1';
     // key must consist of two parts separated by hyphen
     expect($this->mailchimp->getAPIKey('invalid_api_key_format'))->false();
@@ -49,14 +49,14 @@ class MailChimpTest extends \MailPoetTest {
       ->equals($validApiKeyFormat);
   }
 
-  public function testItCanGetDatacenter() {
+  public function testItCanGetDatacenter(): void {
     $validApiKeyFormat = '12345678901234567890123456789012-ab1';
     $dataCenter = 'ab1';
     expect($this->mailchimp->getDataCenter($validApiKeyFormat))
       ->equals($dataCenter);
   }
 
-  public function testItFailsWithIncorrectAPIKey() {
+  public function testItFailsWithIncorrectAPIKey(): void {
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
 
     try {
@@ -69,7 +69,7 @@ class MailChimpTest extends \MailPoetTest {
     }
   }
 
-  public function testItCanGetLists() {
+  public function testItCanGetLists(): void {
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
     try {
       $lists = $this->mailchimp->getLists();
@@ -81,7 +81,7 @@ class MailChimpTest extends \MailPoetTest {
     expect($lists[0]['name'])->notEmpty();
   }
 
-  public function testItFailsWithIncorrectLists() {
+  public function testItFailsWithIncorrectLists(): void {
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
 
     try {
@@ -99,7 +99,7 @@ class MailChimpTest extends \MailPoetTest {
     }
   }
 
-  public function testItCanGetSubscribers() {
+  public function testItCanGetSubscribers(): void {
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
 
     try {
@@ -115,7 +115,7 @@ class MailChimpTest extends \MailPoetTest {
     expect($subscribers['subscribersCount'])->equals(1);
   }
 
-  public function testItFailsWhenSubscribersDataTooLarge() {
+  public function testItFailsWhenSubscribersDataTooLarge(): void {
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
     $mailchimp = clone($this->mailchimp);
     $mailchimp->maxPostSize = 10;
@@ -177,7 +177,7 @@ class MailChimpTest extends \MailPoetTest {
     expect($this->mailchimp->isSubscriberAllowed($subscribed))->true();
   }
 
-  public function _after() {
+  public function _after(): void {
     WPFunctions::set(new WPFunctions);
   }
 }


### PR DESCRIPTION
This continues the work from https://github.com/mailpoet/mailpoet/pull/4141 and https://github.com/mailpoet/mailpoet/pull/4138

It can be merged separately.

This PR removes some of the following PHPStan level 6 errors from Subscribers\ImportExport\Import:

To test you can modify the level6 exclusion rule on phpstan.neon file to this:

```
    # exclude level 6 errors (but keep them for Automation)
    - '/(Method|Property|Function) (?!(MailPoet\\Automation\\)|(MailPoet\\Test\\Subscribers\\ImportExport\\Import\\)|(MailPoet\\Subscribers\\ImportExport\\Import\\)).*has no (return )?type specified/'
    - '/(Method|Function) (?!(MailPoet\\Automation\\)|(MailPoet\\Subscribers\\ImportExport\\Import\\)|(MailPoet\\Test\\Subscribers\\ImportExport\\Import\\)).*has parameter (\$[_A-Z]{1}[_a-z]+)? with no type (specified)?/i'

```
run ./do qa:phpstan and check there are no errors.

[MAILPOET-3720](https://mailpoet.atlassian.net/browse/MAILPOET-3720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

There are still many errors left, once the three PRs are merged, I will update the ticket with the errors removed and move it back to ready for development.