### PR TITLE
Verify that new email is unique when editing a subscriber MAILPOET-4259

### DIFF
--- a/mailpoet/lib/API/JSON/v1/ImportExport.php
+++ b/mailpoet/lib/API/JSON/v1/ImportExport.php
@@ -2,11 +2,11 @@
 
 namespace MailPoet\API\JSON\v1;
 
-use InvalidArgumentException;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\ResponseBuilders\SegmentsResponseBuilder;
 use MailPoet\Config\AccessControl;
+use MailPoet\ConflictException;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Cron\Workers\WooCommerceSync;
 use MailPoet\CustomFields\CustomFieldsRepository;
@@ -109,7 +109,7 @@ class ImportExport extends APIEndpoint {
       return $this->badRequest([
         APIError::BAD_REQUEST => __('Please specify a name.', 'mailpoet'),
       ]);
-    } catch (InvalidArgumentException $exception) {
+    } catch (ConflictException $exception) {
       return $this->badRequest([
         APIError::BAD_REQUEST => __('Another record already exists. Please specify a different "name".', 'mailpoet'),
       ]);

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -152,6 +152,7 @@ class Subscribers extends APIEndpoint {
   /**
    * @param array $data
    * @return ErrorResponse|SuccessResponse
+   * @throws \Exception
    */
   public function save(array $data = []) {
     try {
@@ -162,11 +163,8 @@ class Subscribers extends APIEndpoint {
       return $this->badRequest([
         APIError::BAD_REQUEST => $conflictException->getMessage(),
       ]);
-    } catch (\Exception $unknownException) {
-      return $this->badRequest([
-        APIError::UNKNOWN => __('Saving subscriber failed.', 'mailpoet'),
-      ]);
-    }
+    };
+
     return $this->successResponse(
       $this->subscribersResponseBuilder->build($subscriber)
     );

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -2,7 +2,9 @@
 
 namespace MailPoet\Subscribers;
 
+use MailPoet\ConflictException;
 use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -69,8 +71,33 @@ class SubscriberSaveController {
     $this->wp = $wp;
   }
 
+  public function filterOutReservedColumns(array $subscriberData): array {
+    $reservedColumns = [
+      'id',
+      'wp_user_id',
+      'is_woocommerce_user',
+      'status',
+      'subscribed_ip',
+      'confirmed_ip',
+      'confirmed_at',
+      'created_at',
+      'updated_at',
+      'deleted_at',
+      'unconfirmed_data',
+    ];
+    return array_diff_key(
+      $subscriberData,
+      array_flip($reservedColumns)
+    );
+  }
+
+  /**
+   * @throws ConflictException
+   * @throws ValidationException
+   * @throws \Exception
+   */
   public function save(array $data): SubscriberEntity {
-    if (is_array($data) && !empty($data)) {
+    if (!empty($data)) {
       $data = $this->wp->stripslashesDeep($data);
     }
 
@@ -97,6 +124,10 @@ class SubscriberSaveController {
       );
     }
 
+    if (isset($data['email']) && $this->isNewEmail($data['email'], $oldSubscriber)) {
+      $this->verifyEmailIsUnique($data['email']);
+    }
+
     $subscriber = $this->createOrUpdate($data, $oldSubscriber);
 
     $this->updateCustomFields($data, $subscriber);
@@ -118,26 +149,6 @@ class SubscriberSaveController {
     }
 
     return $subscriber;
-  }
-
-  public function filterOutReservedColumns(array $subscriberData): array {
-    $reservedColumns = [
-      'id',
-      'wp_user_id',
-      'is_woocommerce_user',
-      'status',
-      'subscribed_ip',
-      'confirmed_ip',
-      'confirmed_at',
-      'created_at',
-      'updated_at',
-      'deleted_at',
-      'unconfirmed_data',
-    ];
-    return array_diff_key(
-      $subscriberData,
-      array_flip($reservedColumns)
-    );
   }
 
   private function getNonDefaultSubscribedSegments(array $data): array {
@@ -175,6 +186,9 @@ class SubscriberSaveController {
     return array_diff($data['segments'], $oldSegmentIds);
   }
 
+  /**
+   * @throws ValidationException
+   */
   public function createOrUpdate(array $data, ?SubscriberEntity $subscriber): SubscriberEntity {
     if (!$subscriber) {
       $subscriber = $this->createSubscriber();
@@ -202,6 +216,22 @@ class SubscriberSaveController {
     $this->subscribersRepository->flush();
 
     return $subscriber;
+  }
+
+  private function isNewEmail(string $email, ?SubscriberEntity $subscriber): bool {
+    if ($subscriber && ($subscriber->getEmail() === $email)) return false;
+    return true;
+  }
+
+  /**
+   * @throws ConflictException
+   */
+  private function verifyEmailIsUnique(string $email): void {
+    $existingSubscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
+    if ($existingSubscriber) {
+      $exceptionMessage = __(sprintf("A subscriber with E-mail '%s' already exists.", $email), 'mailpoet');
+      throw new ConflictException($exceptionMessage);
+    }
   }
 
   private function createSubscriber(): SubscriberEntity {

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -229,7 +229,7 @@ class SubscriberSaveController {
   private function verifyEmailIsUnique(string $email): void {
     $existingSubscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
     if ($existingSubscriber) {
-      $exceptionMessage = __(sprintf("A subscriber with E-mail '%s' already exists.", $email), 'mailpoet');
+      $exceptionMessage = __(sprintf('A subscriber with E-mail "%s" already exists.', $email), 'mailpoet');
       throw new ConflictException($exceptionMessage);
     }
   }

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -295,7 +295,7 @@ class SubscribersTest extends \MailPoetTest {
     $response = $this->endpoint->save($subscriberData);
     $this->assertInstanceOf(ErrorResponse::class, $response);
     expect($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
-    expect($response->errors[0]['message'])->equals("A subscriber with E-mail '{$this->subscriber1->getEmail()}' already exists.");
+    expect($response->errors[0]['message'])->equals('A subscriber with E-mail "' . $this->subscriber1->getEmail() . '" already exists.');
   }
 
   public function testItCanRemoveListsFromAnExistingSubscriber() {

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -99,7 +99,7 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
 
     $this->entityManager->clear();
     $this->expectException(ConflictException::class);
-    $this->expectExceptionMessage("A subscriber with E-mail '{$subscriber2->getEmail()}' already exists.");
+    $this->expectExceptionMessage('A subscriber with E-mail "' . $subscriber2->getEmail() . '" already exists.');
 
     $this->saveController->save($data);
   }


### PR DESCRIPTION
With this PR, it throws an exception and displays a friendlier message if the new email already exists.

To test:
- Go to MailPoet>Subscribers>Edit a subscriber
- Enter an email that already exists and click save
- Check you see the message: `A subscriber with E-mail '{$email}' already exists.` instead of the DB exception

When working on this issue I found a tiny bug and fixed it:
To test:
- Go to MailPoet>Subscribers>Import>Proceed>Paste data
- Enter data for 1 subscriber `mary@jane.com, mary, jane` (doesn't really matter) click next.
- Click on 'Create a new list', enter the name of a list that already exists.
- Check that instead of seeing `An unknown error has occurred` you see `Another record already exists. Please specify a different "name".`


[MAILPOET-4259]

[MAILPOET-4259]: https://mailpoet.atlassian.net/browse/MAILPOET-4259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ