### PR TITLE
HTML entities in WP_User properties MAILPOET-4241

### DIFF
--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -95,10 +95,10 @@ class WP {
       $subscriber = Subscriber::where('email', $wpUser->user_email)->findOne(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
     // get first name & last name
-    $firstName = $wpUser->first_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    $lastName = $wpUser->last_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $firstName = html_entity_decode($wpUser->first_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $lastName = html_entity_decode($wpUser->last_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     if (empty($wpUser->first_name) && empty($wpUser->last_name)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $firstName = $wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $firstName = html_entity_decode($wpUser->display_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
     $signupConfirmationEnabled = SettingsController::getInstance()->get('signup_confirmation.enabled');
     $status = $signupConfirmationEnabled ? Subscriber::STATUS_UNCONFIRMED : Subscriber::STATUS_SUBSCRIBED;

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -486,6 +486,50 @@ class WPTest extends \MailPoetTest {
     expect($wpSubscriber->countConfirmations)->equals(0);
   }
 
+  public function testItDecodesHtmlEntitesInFirstAndLastName(): void {
+    $args = [
+      'user_login' => 'html-entities',
+      'user_email' => 'user-sync-test-html-entities@example.com',
+      'first_name' => 'Family & friends',
+      'last_name' => 'Family & friends lastname',
+      'role' => 'subscriber',
+      'user_pass' => 'password',
+    ];
+    $userId = wp_insert_user($args);
+    assert(is_numeric($userId));
+    $subscriberRepository = $this->diContainer->get(SubscribersRepository::class);
+    $subscriber = $subscriberRepository->findOneBy(['email' => 'user-sync-test-html-entities@example.com']);
+    /**
+     * @var SubscriberEntity $subscriber
+     */
+    $firstName = $subscriber->getFirstName();
+    $this->assertEquals($args['first_name'], $subscriber->getFirstName());
+    $this->assertEquals($args['last_name'], $subscriber->getLastName());
+    wp_delete_user($userId);
+  }
+
+  public function testItDecodesHtmlEntitesInDisplayName(): void {
+    $args = [
+      'user_login' => 'entities-display-name',
+      'user_email' => 'user-sync-test-html-entities-display-name@example.com',
+      'first_name' => '',
+      'last_name' => '',
+      'display_name' => 'Family & Frieds',
+      'role' => 'subscriber',
+      'user_pass' => 'password',
+    ];
+
+    $userId = wp_insert_user($args);
+    assert(is_numeric($userId));
+    $subscriberRepository = $this->diContainer->get(SubscribersRepository::class);
+    $subscriber = $subscriberRepository->findOneBy(['email' => 'user-sync-test-html-entities-display-name@example.com']);
+    /**
+     * @var SubscriberEntity $subscriber
+     */
+    $this->assertEquals($args['display_name'], $subscriber->getFirstName());
+    wp_delete_user($userId);
+  }
+
   public function testItDoesNotTrashNewUsersWhoHaveSomeSegmentsToDisabledWPSegment(): void {
     $this->disableWpSegment();
     $randomNumber = rand();


### PR DESCRIPTION
Fixes [MAILPOET-4241]

Source of the reported problem in MAILPOET-4241 can be found here:

https://github.com/WordPress/WordPress/blob/f6412575c890bf651cdaa8a2d60365c19f0d4173/wp-includes/default-filters.php#L21-L25

[MAILPOET-4241]: https://mailpoet.atlassian.net/browse/MAILPOET-4241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Add a new WordPress user and make sure in the first name you've added & symbol (check Jira for more info)
2. Check in MailPoet > Subscribers how the name has shown
3. Check when receiving a newsletter with added `Hi [subscriber:firstname | default:Subscriber]` in the title or somewhere in the newsletter content