### PR TITLE
Fix flaky integration test AbandonedCartTest

### DIFF
--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -12,6 +12,7 @@ use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler;
+use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\Track\SubscriberActivityTracker;
@@ -48,6 +49,9 @@ class AbandonedCartTest extends \MailPoetTest {
   /** @var SubscriberActivityTracker&MockObject */
   private $subscriberActivityTrackerMock;
 
+  /** @var AutomaticEmailScheduler */
+  private $automaticEmailScheduler;
+
   public function _before() {
     $this->cleanup();
 
@@ -67,6 +71,8 @@ class AbandonedCartTest extends \MailPoetTest {
     ]);
     $this->wp = $wp;
     WPFunctions::set($this->wp);
+
+    $this->automaticEmailScheduler = new AutomaticEmailScheduler(new Scheduler($this->wp));
 
     $this->wooCommerceMock = $this->mockWooCommerceClass(WooCommerce::class, []);
     $this->wooCommerceCartMock = $this->mockWooCommerceClass(WC_Cart::class, ['is_empty', 'get_cart']);
@@ -263,7 +269,8 @@ class AbandonedCartTest extends \MailPoetTest {
 
   private function createAbandonedCartEmail() {
     $settings = $this->diContainer->get(SettingsController::class);
-    $automaticEmailScheduler = $this->diContainer->get(AutomaticEmailScheduler::class);
+    $automaticEmailScheduler = $this->automaticEmailScheduler;
+
     return $this->make(AbandonedCart::class, [
       'wp' => $this->wp,
       'wooCommerceHelper' => $this->wooCommerceHelperMock,


### PR DESCRIPTION
This PR fixes the flaky test errors on AbandonedCartTest when checking the scheduled time:

```
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'2022-05-02 16:13:24'
+'2022-05-02 16:13:25'
```

If you want to reproduce the test errors locally, you can add a `sleep(5);` after [$abandonedCartEmail->init();](https://github.com/mailpoet/mailpoet/blob/75eb7f6900dac5865f58b6040246106e8a516af2/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php#L167) on any test in the file that checks the scheduled time.

The PR changes the test so that `AutomaticEmailScheduler` uses the mocked `currentTime`

[MAILPOET-4286]

[MAILPOET-4286]: https://mailpoet.atlassian.net/browse/MAILPOET-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ