### PR TITLE
Temporarily removing test that sends emails to AWS

### DIFF
--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -255,13 +255,4 @@ class AmazonSESTest extends \MailPoetTest {
     expect($result['error'])->isInstanceOf(MailerError::class);
     expect($result['error']->getMessage())->stringContainsString('AmazonSES has returned an unknown error.');
   }
-
-  public function testItCanSend() {
-    if (getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') $this->markTestSkipped();
-    $result = $this->mailer->send(
-      $this->newsletter,
-      $this->subscriber
-    );
-    expect($result['response'])->true();
-  }
 }


### PR DESCRIPTION
We need to prevent sending from CI so that we are not blocked on AWS. We will revert
this commit when we find a proper fix.

[MAILPOET-4394]

[MAILPOET-4394]: https://mailpoet.atlassian.net/browse/MAILPOET-4394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ