### PR TITLE
Stop integration test from sending real email via AmazonSES MAILPOET-4394

### DIFF
--- a/mailpoet/lib/Mailer/MailerFactory.php
+++ b/mailpoet/lib/Mailer/MailerFactory.php
@@ -57,7 +57,8 @@ class MailerFactory {
           $sender,
           $replyTo,
           $returnPath,
-          new AmazonSESMapper()
+          new AmazonSESMapper(),
+          $this->wp
         );
         break;
       case Mailer::METHOD_MAILPOET:

--- a/mailpoet/lib/Mailer/Methods/AmazonSES.php
+++ b/mailpoet/lib/Mailer/Methods/AmazonSES.php
@@ -73,7 +73,8 @@ class AmazonSES extends PHPMailerMethod {
     $sender,
     $replyTo,
     $returnPath,
-    AmazonSESMapper $errorMapper
+    AmazonSESMapper $errorMapper,
+    WPFunctions $wp
   ) {
     $this->awsAccessKey = $accessKey;
     $this->awsSecretKey = $secretKey;
@@ -93,7 +94,7 @@ class AmazonSES extends PHPMailerMethod {
     $this->date = gmdate('Ymd\THis\Z');
     $this->dateWithoutTime = gmdate('Ymd');
     $this->errorMapper = $errorMapper;
-    $this->wp = new WPFunctions();
+    $this->wp = $wp;
     $this->blacklist = new BlacklistCheck();
     $this->mailer = $this->buildMailer();
   }

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -260,8 +260,6 @@ class AmazonSESTest extends \MailPoetTest {
   }
 
   public function testItCanSend() {
-    if (getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') $this->markTestSkipped();
-
     $mockedWp = $this->createMock(WPFunctions::class);
     /**
      * We don't want to send a real email through AmazonSES, thus mocking

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -23,6 +23,14 @@ if ((boolean)getenv('MULTISITE') === true) {
 }
 require_once($wpLoadFile);
 
+/**
+ * Setting env from .evn file
+ * Note that the following are override in the docker-compose file
+ * WP_ROOT, WP_ROOT_MULTISITE, WP_TEST_MULTISITE_SLUG
+ */
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__ . '/../..');
+$dotenv->load();
+
 $console = new \Codeception\Lib\Console\Output([]);
 $console->writeln('Loading WP core... (' . $wpLoadFile . ')');
 


### PR DESCRIPTION
Currently .env variables are not picked up for integration tests, this PR enables this.

[MAILPOET-4394]

[MAILPOET-4394]: https://mailpoet.atlassian.net/browse/MAILPOET-4394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ