### PR TITLE
Fix condition for authentication [MAILPOET-4398]

### DIFF
--- a/mailpoet/lib/Mailer/Methods/SMTP.php
+++ b/mailpoet/lib/Mailer/Methods/SMTP.php
@@ -59,7 +59,7 @@ class SMTP extends PHPMailerMethod {
     /** @phpstan-ignore-next-line - we cannot annotate the return type from a filter */
     $mailer->Timeout = $this->wp->applyFilters('mailpoet_mailer_smtp_connection_timeout', self::SMTP_CONNECTION_TIMEOUT); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-    if ($this->authentication) {
+    if ($this->authentication === 1) {
       $mailer->SMTPAuth = true; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       $mailer->Username = $this->login; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       $mailer->Password = $this->password; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods;
 
@@ -51,7 +51,7 @@ class SMTPTest extends \MailPoetTest {
     $this->mailer = new SMTP(
       $this->settings['host'],
       $this->settings['port'],
-      $this->settings['authentication'],
+      (int)$this->settings['authentication'],
       $this->settings['encryption'],
       $this->sender,
       $this->replyTo,


### PR DESCRIPTION
[MAILPOET-4398]

[MAILPOET-4398]: https://mailpoet.atlassian.net/browse/MAILPOET-4398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing instructions:
1. Go to MailPoet > Settings > Send with and set custom sending method (SMTP) and save it
2. Send a newsletter and make sure it has been sent
3. Subscribe to a form and make sure you have received confirmation email