### PR TITLE
Prepare repository to move from master to trunk [MAILPOET-3466]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ slack-fail-post-step: &slack-fail-post-step
   post-steps:
     - slack/notify:
         channel: mailpoet-dev-feeds
-        branch_pattern: 'master,release'
+        branch_pattern: 'trunk,release'
         event: fail
         custom: |
           {
@@ -64,11 +64,11 @@ anchors:
     environment:
       TZ: /usr/share/zoneinfo/Etc/UTC
 
-  only_master_and_release: &only_master_and_release
+  only_trunk_and_release: &only_trunk_and_release
     filters:
       branches:
         only:
-          - master
+          - trunk
           - release
 
   multisite_acceptance_config: &multisite_acceptance_config
@@ -76,7 +76,7 @@ anchors:
     requires:
       - unit_tests
       - static_analysis_php8
-    <<: *only_master_and_release
+    <<: *only_trunk_and_release
 
 executors:
   wpcli_php_oldest:
@@ -577,7 +577,7 @@ workflows:
           name: acceptance_tests_multisite
       - integration_tests:
           <<: *slack-fail-post-step
-          <<: *only_master_and_release
+          <<: *only_trunk_and_release
           multisite: 1
           name: integration_tests_multisite
           requires:
@@ -601,7 +601,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [master]
+    branches: [trunk]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [trunk]
   schedule:
     - cron: '0 17 * * 4'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@
 
 ## Git flow
 
-- Do not commit to master.
+- Do not commit to trunk.
 - Open a short-living feature branch.
 - Open a pull request.
 - Add Jira issue reference in the title of the Pull Request.
@@ -53,4 +53,4 @@
 
 MailPoet used to use [IdiORM](https://github.com/j4mie/idiorm) as its object-relational mapper (ORM), but the project was abandoned a while ago, so we started a migration to [Doctrine](https://www.doctrine-project.org/). This is a significant effort that has been going on for quite some time. Although you will still see parts of the code that use IdioORM, we ask that all new code be added using Doctrine instead.
 
-All IdioORM models live in [mailpoet/lib/Models](https://github.com/mailpoet/mailpoet/tree/master/mailpoet/lib/Models), should be considered deprecated and shouldn't be used by new code. We are moving everything to Doctrine entities and some auxiliary code when needed. You can find Doctrine entities in [mailpoet/lib/Entities](https://github.com/mailpoet/mailpoet/tree/master/mailpoet/lib/Entities).
+All IdioORM models live in [mailpoet/lib/Models](https://github.com/mailpoet/mailpoet/tree/trunk/mailpoet/lib/Models), should be considered deprecated and shouldn't be used by new code. We are moving everything to Doctrine entities and some auxiliary code when needed. You can find Doctrine entities in [mailpoet/lib/Entities](https://github.com/mailpoet/mailpoet/tree/trunk/mailpoet/lib/Entities).

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -745,10 +745,10 @@ class RoboFile extends \Robo\Tasks {
       $this->yell('Please make sure your working directory is clean before running release.', 40, 'red');
       exit(1);
     }
-    // checkout master and pull from remote
+    // checkout trunk and pull from remote
     $this->taskGitStack()
       ->stopOnFail()
-      ->checkout('master')
+      ->checkout('trunk')
       ->exec('git pull --ff-only')
       ->run();
     // make sure release branch doesn't exist on github

--- a/mailpoet/tasks/release/GitHubController.php
+++ b/mailpoet/tasks/release/GitHubController.php
@@ -44,7 +44,7 @@ class GitHubController {
       'json' => [
         'title' => 'Release ' . $version,
         'head' => self::RELEASE_SOURCE_BRANCH,
-        'base' => 'master',
+        'base' => 'trunk',
       ],
     ]);
     $response = json_decode($response->getBody()->getContents(), true);
@@ -69,7 +69,7 @@ class GitHubController {
       'query' => [
         'state' => 'all',
         'head' => self::RELEASE_SOURCE_BRANCH,
-        'base' => 'master',
+        'base' => 'trunk',
         'direction' => 'desc',
       ],
     ]);

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -13,7 +13,7 @@ class CheckSkippedTestsExtension extends Extension {
   public function checkErrorsAfterTests(SuiteEvent $e) {
     $branch = getenv('CIRCLE_BRANCH');
     $skipped = $e->getResult()->skipped();
-    if (in_array($branch, ['master', 'release']) && (count($skipped) !== 0)) {
+    if (in_array($branch, ['trunk', 'release']) && (count($skipped) !== 0)) {
       throw new \PHPUnit\Framework\ExpectationFailedException("Failed, Cannot skip tests on branch $branch.");
     }
   }

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -163,7 +163,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 
   public static function markTestSkipped(string $message = ''): void {
     $branchName = getenv('CIRCLE_BRANCH');
-    if ($branchName === 'master' || $branchName === 'release') {
+    if ($branchName === 'trunk' || $branchName === 'release') {
       self::fail('Cannot skip tests on this branch.');
     } else {
       parent::markTestSkipped($message);


### PR DESCRIPTION
This PR prepares this repository to move from master to trunk as the default branch. It updates the CircleCI configuration, the release script, and a few other places where there was a direct reference to the master branch.

In the Jira ticket there is more information about the whole migration process.

[MAILPOET-3466]

[MAILPOET-3466]: https://mailpoet.atlassian.net/browse/MAILPOET-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ