### PR TITLE
Focusable checkbox and radio components

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing.scss
@@ -396,14 +396,12 @@ a.mailpoet-listing-title {
 
   .mailpoet-form-checkbox-control {
     margin-right: 0;
-    opacity: 1;
   }
 
   thead &,
-  tr:hover &,
-  input:checked + {
+  tr:hover & {
     .mailpoet-form-checkbox-control {
-      opacity: 1;
+      border: 2px solid $color-input-border;
     }
   }
 }

--- a/mailpoet/assets/css/src/components-plugin/_listing.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing.scss
@@ -396,7 +396,7 @@ a.mailpoet-listing-title {
 
   .mailpoet-form-checkbox-control {
     margin-right: 0;
-    opacity: 0;
+    opacity: 1;
   }
 
   thead &,

--- a/mailpoet/assets/css/src/generic/_forms-checkbox.scss
+++ b/mailpoet/assets/css/src/generic/_forms-checkbox.scss
@@ -8,10 +8,22 @@
   vertical-align: middle;
 
   input {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
     height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
     position: absolute;
-    visibility: hidden;
     width: 1px;
+    word-wrap: normal !important;
+
+    &:focus {
+      ~ .mailpoet-form-checkbox-control {
+        border: 2px solid $color-input-border;
+      }
+    }
   }
 
   &.mailpoet-full-width + .mailpoet-form-checkbox.mailpoet-full-width { margin-top: $grid-gap; }

--- a/mailpoet/assets/css/src/generic/_forms-radio.scss
+++ b/mailpoet/assets/css/src/generic/_forms-radio.scss
@@ -8,10 +8,22 @@
   vertical-align: middle;
 
   input {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
     height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
     position: absolute;
-    visibility: hidden;
     width: 1px;
+    word-wrap: normal !important;
+
+    &:focus {
+      ~ .mailpoet-form-radio-control {
+        border: 2px solid $color-input-border;
+      }
+    }
   }
 
   &.mailpoet-full-width + .mailpoet-form-radio.mailpoet-full-width { margin-top: $grid-gap; }


### PR DESCRIPTION
This PR changes the way the components are hidden, using now the properties from the class `.screen-reader-text`
We also display the checkboxes in the list, for consistency with other WP screens and change the CSS when the components are focused.

To test the checkboxes:
- Go to MailPoet > settings  or MailPoet > Emails and check that you can move to the checkboxes using the keyboard
- Check that the border changes when in focus
To test the radio buttons:
- Go to MailPoet > Settings > Advanced and check that you can move to the radio buttons using the keyboard
- Check the border changes when in focus

[MAILPOET-3332]

[MAILPOET-3332]: https://mailpoet.atlassian.net/browse/MAILPOET-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ