### PR TITLE
Add label to text input fields on form

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -520,3 +520,38 @@ h2.mailpoet-heading {
     font-size: 85%;
   }
 }
+
+// screen-reader-text CSS class only exists within the WordPress environment
+// the class does not exist when using iFrame forms due to these being used outside WordPress
+// prefixing with mailpoet-* to not interfere with the default WordPress screen-reader-text class
+.mailpoet-screen-reader-text {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  word-wrap: normal !important;
+}
+
+.mailpoet-screen-reader-text:focus {
+  background-color: #ddd;
+  clip: auto !important;
+  -webkit-clip-path: none;
+  clip-path: none;
+  color: #444;
+  display: block;
+  font-size: 1em;
+  height: auto;
+  line-height: normal;
+  padding: 15px 23px 14px;
+  right: 5px;
+  text-decoration: none;
+  top: 5px;
+  width: auto;
+  z-index: 100000;
+}

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -104,28 +104,39 @@ class BlockRendererHelper {
 
   public function renderLabel(array $block, array $formSettings): string {
     $html = '';
+    $forId = '';
+
     if (
       isset($block['params']['hide_label'])
       && $block['params']['hide_label']
     ) {
       return $html;
     }
-    if (
-      isset($block['params']['label_within'])
-      && $block['params']['label_within']
-    ) {
-      return $html;
-    }
+
     $automationId = null;
     if (in_array($block['id'], ['email', 'last_name', 'first_name'], true)) {
       $automationId = 'data-automation-id="form_' . $block['id'] . '_label" ';
+      if (isset($formSettings['id'])) {
+        $forId = 'for="form_' . $block['id'] . '_' . $formSettings['id'] . '" ';
+      }
     }
+
     if (
       isset($block['params']['label'])
       && strlen(trim($block['params']['label'])) > 0
     ) {
+      $labelClass = 'class="mailpoet_' . $block['type'] . '_label" ';
+
+      if (
+        isset($block['params']['label_within'])
+        && $block['params']['label_within']
+      ) {
+        $labelClass = 'class="screen-reader-text" ';
+      }
+
       $html .= '<label '
-        . 'class="mailpoet_' . $block['type'] . '_label" '
+        . $forId
+        . $labelClass
         . $this->renderFontStyle($formSettings, $block['styles'] ?? [])
         . ($automationId ?? '')
         . '>';

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -116,9 +116,10 @@ class BlockRendererHelper {
     $automationId = null;
     if (in_array($block['id'], ['email', 'last_name', 'first_name'], true)) {
       $automationId = 'data-automation-id="form_' . $block['id'] . '_label" ';
-      if (isset($formSettings['id'])) {
-        $forId = 'for="form_' . $block['id'] . '_' . $formSettings['id'] . '" ';
-      }
+    }
+
+    if (isset($formSettings['id'])) {
+      $forId = 'for="form_' . $block['id'] . '_' . $formSettings['id'] . '" ';
     }
 
     if (

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -132,7 +132,7 @@ class BlockRendererHelper {
         isset($block['params']['label_within'])
         && $block['params']['label_within']
       ) {
-        $labelClass = 'class="screen-reader-text" ';
+        $labelClass = 'class="mailpoet-screen-reader-text" ';
       }
 
       $html .= '<label '

--- a/mailpoet/lib/Form/Block/Text.php
+++ b/mailpoet/lib/Form/Block/Text.php
@@ -34,6 +34,7 @@ class Text {
   public function render(array $block, array $formSettings): string {
     $type = 'text';
     $automationId = ' ';
+    $id = '';
     $autocomplete = 'on';
     if ($block['id'] === 'email') {
       $type = 'email';
@@ -41,19 +42,25 @@ class Text {
     }
 
     if (in_array($block['id'], ['email', 'last_name', 'first_name'], true)) {
+
       $automationId = 'data-automation-id="form_' . $this->wp->escAttr($block['id']) . '" ';
+
+      if (isset($formSettings['id'])) {
+        $id = 'id="form_' . $this->wp->escAttr($block['id']) . '_' . $this->wp->escAttr($formSettings['id']) . '" ';
+      }
     }
 
     $styles = $this->inputStylesRenderer->renderForTextInput($block['styles'] ?? [], $formSettings);
 
     $name = $this->rendererHelper->getFieldName($block);
 
-    $html = '';
-    $html .= $this->inputStylesRenderer->renderPlaceholderStyles($block, 'input[name="data[' . $name . ']"]');
+    $html = $this->inputStylesRenderer->renderPlaceholderStyles($block, 'input[name="data[' . $name . ']"]');
 
     $html .= $this->rendererHelper->renderLabel($block, $formSettings);
 
     $html .= '<input type="' . $type . '" autocomplete="' . $autocomplete . '" class="mailpoet_text" ';
+
+    $html .= $id;
 
     $html .= 'name="data[' . $name . ']" ';
 

--- a/mailpoet/lib/Form/Block/Text.php
+++ b/mailpoet/lib/Form/Block/Text.php
@@ -42,12 +42,11 @@ class Text {
     }
 
     if (in_array($block['id'], ['email', 'last_name', 'first_name'], true)) {
-
       $automationId = 'data-automation-id="form_' . $this->wp->escAttr($block['id']) . '" ';
+    }
 
-      if (isset($formSettings['id'])) {
-        $id = 'id="form_' . $this->wp->escAttr($block['id']) . '_' . $this->wp->escAttr($formSettings['id']) . '" ';
-      }
+    if (isset($formSettings['id'])) {
+      $id = 'id="form_' . $this->wp->escAttr($block['id']) . '_' . $this->wp->escAttr($formSettings['id']) . '" ';
     }
 
     $styles = $this->inputStylesRenderer->renderForTextInput($block['styles'] ?? [], $formSettings);

--- a/mailpoet/lib/Form/BlocksRenderer.php
+++ b/mailpoet/lib/Form/BlocksRenderer.php
@@ -101,6 +101,9 @@ class BlocksRenderer {
 
   public function renderBlock(array $block, array $formSettings, ?int $formId): string {
     $html = '';
+    if ($formId) {
+      $formSettings['id'] = $formId;
+    }
     switch ($block['type']) {
       case FormEntity::HTML_BLOCK_TYPE:
         $html .= $this->html->render($block, $formSettings);


### PR DESCRIPTION
This PR adds `<label>` to text input fields in the forms for email, last name, and first name, in the front end.

If the text form has a placeholder, the label is not visible using the class `.screen-reader-text`
The forms also have a unique ID to use on the `for` attribute on the label.

To test, create a subscription form that is displayed on the front end.
Inspect the form and check that:
- The text inputs have a unique id
- Each text input has a label with a `for` attribute using the input id
- Labels on text input fields with placeholders use the class `.screen-reader-text`

[MAILPOET-4312]

[MAILPOET-4312]: https://mailpoet.atlassian.net/browse/MAILPOET-4312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ