### PR TITLE
do not override status when wp user list is deleted

### DIFF
--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -145,7 +145,6 @@ class WP {
     // or who are not WooCommerce customers at the same time since customers are added to the WooCommerce list
     if ($addingNewUserToDisabledWPSegment && !$otherActiveSegments && !$isWooCustomer) {
       $data['deleted_at'] = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
-      $data['status'] = SubscriberEntity::STATUS_UNCONFIRMED;
     }
 
     $subscriber = Subscriber::createOrUpdate($data);


### PR DESCRIPTION
this lead to confirmation email being sent even though
the user did not choose to be subscribed to any newsletter