### PR TITLE
Update CircleCI API [MAILPOET-4399]

### DIFF
--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -77,7 +77,10 @@ class CircleCiController {
 
     // ensure we're downloading latest revision on given branch
     $latestRevision = $this->githubController->getLatestCommitRevisionOnBranch(self::RELEASE_BRANCH);
-    if ($latestRevision === null || $latestPipelineRevision !== $latestRevision) {
+    if ($latestRevision === null) {
+      throw new \Exception("Couldn't find a Github revision for " . self::RELEASE_BRANCH . ". Does the branch exist?");
+    }
+    if ($latestPipelineRevision !== $latestRevision) {
       throw new \Exception(
         "Found latest pipeline run from revision '$latestPipelineRevision' but the latest one on Github is '$latestRevision'"
       );

--- a/mailpoet/tasks/release/GitHubController.php
+++ b/mailpoet/tasks/release/GitHubController.php
@@ -142,7 +142,7 @@ class GitHubController {
       $response = $this->httpClient->get('commits/' . urlencode($branch));
       $data = json_decode($response->getBody()->getContents(), true);
     } catch (ClientException $e) {
-      if ($e->getCode() === 404) {
+      if ($e->getCode() === 404 || $e->getCode() === 422) {
         return null;
       }
       throw $e;


### PR DESCRIPTION
The [v2 API](https://circleci.com/docs/api/v2/) seems to be better organized but it requires doing more requests to get the latest release job.

### Testing
When there is no release branch on Github and there is no successful release build the command will fail.
You can test the functionality on the other branch (that is on Github and has the latest successful build on Circle CI) by changing `MailPoetTasks\Release\CircleCiController::RELEASE_BRANCH` constant to your testing branch.

[MAILPOET-4399]

[MAILPOET-4399]: https://mailpoet.atlassian.net/browse/MAILPOET-4399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ