### PR TITLE
Fix badge alignment in React selects [MAILPOET-4057]

### DIFF
--- a/mailpoet/assets/css/src/generic/_forms-select.scss
+++ b/mailpoet/assets/css/src/generic/_forms-select.scss
@@ -134,8 +134,9 @@
   background: $color-tertiary-light !important;
 }
 
-.mailpoet-form-react-select-option > span {
-  vertical-align: middle;
+.mailpoet-form-react-select-option {
+  display: flex;
+  align-items: center;
 }
 
 .mailpoet-form-react-select-tag {

--- a/mailpoet/assets/css/src/generic/_forms-select.scss
+++ b/mailpoet/assets/css/src/generic/_forms-select.scss
@@ -135,7 +135,7 @@
 }
 
 .mailpoet-form-react-select-option > span {
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .mailpoet-form-react-select-tag {


### PR DESCRIPTION
Badges inside react selects are currently top aligned, sometimes appearing cut off. This PR reverts to aligning them in the middle vertically.

## Current
<img width="409" alt="Screen Shot 2022-06-03 at 12 51 37 PM" src="https://user-images.githubusercontent.com/8656640/171919299-8ef71f6a-54e9-40a8-8134-10590f37c339.png">

## After PR
<img width="415" alt="Screen Shot 2022-06-03 at 12 52 13 PM" src="https://user-images.githubusercontent.com/8656640/171919351-03670f5f-5fc9-43c9-bbca-57a4ea1a09bf.png">

I believe the issue was introduced in eecbeebafd39798d22b271fe4286d3fafaafca1f as part of MAILPOET-3997. It's unclear to me why it was necessary to change the vertical alignment for that PR. MAILPOET-3997 was a ticket to standardize the size of react selects, and changing the vertical alignment back to `middle` doesn't seem to affect the size of react selects that I can see. Maybe it has an effect when there is a certain amount or type of content in the select, or for certain browsers? @NeosinneR do you happen to remember?

MAILPOET-4057

Testing instructions
1. Check the badges and checkboxes, alignment should be fine now..
2. You can check those in Segments, Forms, Newsletters..