### PR TITLE
Clear WP cache after restoring DB backup for Acceptance Tests [MAILPOET-4403]

### DIFF
--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -79,6 +79,12 @@ class CleanupExtension extends Extension {
 
     // cleanup EntityManager for data factories that are using it
     ContainerWrapper::getInstance()->get(EntityManager::class)->clear();
+    
+    // Without clearing the cache WordPress will think data exist that doesn't, e.g. users created in previous tests
+    global $wp_object_cache;
+    if ($wp_object_cache) {
+      $wp_object_cache->flush();
+    }
   }
 
   private function createDsnConnectionString() {


### PR DESCRIPTION
Some acceptance tests were failing when run together in the same batch, making them flaky, like [this one](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/10181/workflows/c7a4ab5e-8602-48f5-a773-6f37e20d5be0/jobs/181806/tests).

In this case, user creation was failing because WordPress thought there was already a user with that username. The same username was in fact used in a previous test, which added the user's information to WordPress's in-memory cache. When checking for the existence of a user, WordPress checks the cache first before going to the database. So even though we're restoring a database backup before each test, WordPress still thought the previous user existed because they exist in the cache.

This PR ensures that the WordPress cache is cleared after restoring the database. It fixed this specific issue for me locally and I'm hopeful that it might fix any other tests that are failing due to cached data bleeding over from one test to another.

[MAILPOET-4403](https://mailpoet.atlassian.net/browse/MAILPOET-4403)