### PR TITLE
Handle exceptions for inaccessible cron URL in admin [MAILPOET-4406]

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -43,13 +43,19 @@ class Help {
 
   public function render() {
     $systemInfoData = $this->helpscoutBeacon->getData(true);
-    $cronPingResponse = $this->cronHelper->pingDaemon();
+    try {
+      $cronPingUrl = $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING);
+      $cronPingResponse = $this->cronHelper->pingDaemon();
+    } catch (\Exception $e) {
+      $cronPingResponse = __('Can‘t generate cron URL.', 'mailpoet') . ' (' . $e->getMessage() . ')';
+      $cronPingUrl = $cronPingResponse;
+    }
 
     $mailerLog = MailerLog::getMailerLog();
     $mailerLog['sent'] = MailerLog::sentSince();
     $systemStatusData = [
       'cron' => [
-        'url' => $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING),
+        'url' => $cronPingUrl,
         'isReachable' => $this->cronHelper->validatePingResponse($cronPingResponse),
         'pingResponse' => $cronPingResponse,
       ],

--- a/mailpoet/lib/Cron/CronHelper.php
+++ b/mailpoet/lib/Cron/CronHelper.php
@@ -187,7 +187,9 @@ class CronHelper {
   public function getSiteUrl($siteUrl = false) {
     // additional check for some sites running inside a virtual machine or behind
     // proxy where there could be different ports (e.g., host:8080 => guest:80)
-    $siteUrl = ($siteUrl) ? $siteUrl : WPFunctions::get()->homeUrl();
+    if (!$siteUrl) {
+      $siteUrl = defined('MAILPOET_CRON_SITE_URL') ? MAILPOET_CRON_SITE_URL : $this->wp->homeUrl();
+    }
     $parsedUrl = parse_url($siteUrl);
     if (!is_array($parsedUrl)) {
       throw new \Exception(__('Site URL is unreachable.', 'mailpoet'));

--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -44,9 +44,14 @@ class Beacon {
     }
 
     $cronHelper = ContainerWrapper::getInstance()->get(CronHelper::class);
-    $cronPingUrl = $cronHelper->getCronUrl(
-      CronDaemon::ACTION_PING
-    );
+    try {
+      $cronPingUrl = $cronHelper->getCronUrl(
+        CronDaemon::ACTION_PING
+      );
+    } catch (\Exception $e) {
+      $cronPingUrl = __('Can‘t generate cron URL.', 'mailpoet') . ' (' . $e->getMessage() . ')';
+    }
+
     return [
       'name' => $currentUser->display_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       'email' => $sender['address'],


### PR DESCRIPTION
This PR adds handling of exceptions coming from CronHelper::getSiteUrl in the WP admin interface. 

It also adds the possibility to override the value of the site URL used for the cron job via a PHP constant  `MAILPOET_CRON_SITE_URL`.

Please read the related [issue](https://github.com/mailpoet/mailpoet/issues/4173) for more details.

Closes #4173 
[MAILPOET-4406]

[MAILPOET-4406]: https://mailpoet.atlassian.net/browse/MAILPOET-4406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ