### PR TITLE
Link segment badges to filtered subscribers page [MAILPOET-4244]

### DIFF
--- a/mailpoet/assets/css/src/components/_tooltips.scss
+++ b/mailpoet/assets/css/src/components/_tooltips.scss
@@ -3,6 +3,7 @@
   box-shadow: 0 2px 4px 0 rgba(229, 233, 248, .4), 0 5px 30px 0 $color-tertiary-light;
   max-width: 400px;
   padding: $grid-gap-half;
+  z-index: 9990; // Allow tooltip to display over #adminmenuwrap (lefthand menu) core style
 
   &.show {
     opacity: 1;

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 import { Tag } from './tag';
+import { Tooltip } from '../tooltip/tooltip';
+import { MailPoet } from '../../mailpoet';
 
 type Segment = {
   name: string;
@@ -18,21 +20,36 @@ function Tags({ children, dimension, segments, strings }: Props) {
     <div className="mailpoet-tags">
       {children}
       {segments &&
-        segments.map((segment) =>
-          segment.id ? (
-            <a
-              href={`admin.php?page=mailpoet-subscribers#/filter[segment=${segment.id}]`}
-            >
-              <Tag key={segment.name} dimension={dimension} variant="list">
-                {segment.name}
-              </Tag>
-            </a>
-          ) : (
+        segments.map((segment) => {
+          const tag = (
             <Tag key={segment.name} dimension={dimension} variant="list">
               {segment.name}
             </Tag>
-          ),
-        )}
+          );
+          if (!segment.id) {
+            return tag;
+          }
+          const randomId = Math.random().toString(36).substring(2, 15);
+          const tooltipId = `segment-tooltip-${randomId}`;
+
+          return (
+            <div key={randomId}>
+              <Tooltip id={tooltipId} place="top">
+                {MailPoet.I18n.t('viewFilteredSubscribersMessage').replace(
+                  '%1$s',
+                  segment.name,
+                )}
+              </Tooltip>
+              <a
+                data-tip=""
+                data-for={tooltipId}
+                href={`admin.php?page=mailpoet-subscribers#/filter[segment=${segment.id}]`}
+              >
+                {tag}
+              </a>
+            </div>
+          );
+        })}
       {strings &&
         strings.map((string) => (
           <Tag key={string} dimension={dimension} variant="list">

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -3,6 +3,7 @@ import { Tag } from './tag';
 
 type Segment = {
   name: string;
+  id?: string;
 };
 
 type Props = {
@@ -17,11 +18,21 @@ function Tags({ children, dimension, segments, strings }: Props) {
     <div className="mailpoet-tags">
       {children}
       {segments &&
-        segments.map((segment) => (
-          <Tag key={segment.name} dimension={dimension} variant="list">
-            {segment.name}
-          </Tag>
-        ))}
+        segments.map((segment) =>
+          segment.id ? (
+            <a
+              href={`admin.php?page=mailpoet-subscribers#/filter[segment=${segment.id}]`}
+            >
+              <Tag key={segment.name} dimension={dimension} variant="list">
+                {segment.name}
+              </Tag>
+            </a>
+          ) : (
+            <Tag key={segment.name} dimension={dimension} variant="list">
+              {segment.name}
+            </Tag>
+          ),
+        )}
       {strings &&
         strings.map((string) => (
           <Tag key={string} dimension={dimension} variant="list">

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_type.ts
@@ -2,7 +2,7 @@ export type NewsletterType = {
   id: string;
   total_sent: number;
   subject: string;
-  segments: { name: string }[];
+  segments: { name: string; id?: string }[];
   queue: {
     scheduled_at: string;
     created_at: string;

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -271,9 +271,6 @@ class SubscriberListingRepository extends ListingRepository {
       } else {
         $count = $this->subscribersCountsController->getSegmentStatisticsCount($segment);
       }
-      if (!$count[$key]) {
-        continue;
-      }
 
       $segmentList[] = [
         'label' => sprintf('%s (%s)', $segment->getName(), number_format((float)$count[$key])),

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -99,6 +99,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'youCanDisableWPUsersList': __('If you do not send emails to your WordPress Users list, you can [link]disable it[/link] to lower your number of subscribers.'),
   'upgradeNow': __('Upgrade Now'),
   'refreshMySubscribers': __('I’ve upgraded my subscription, refresh subscriber limit'),
+  'viewFilteredSubscribersMessage': __('View everyone subscribed to "%1$s"'),
 
   'emailVolumeLimitNoticeTitle': __('Congratulations, you sent more than [emailVolumeLimit] emails this month!'),
   'youReachedEmailVolumeLimit': __('You have sent more emails this month than your MailPoet plan includes ([emailVolumeLimit]), and sending has been temporarily paused.'),


### PR DESCRIPTION
This PR turns segment badges into clickable links that take a user to the "All Subscribers" page with that segment selected.

Hovering over a badge reveals a tooltip telling the user what will happen if they click.

<img width="448" alt="image" src="https://user-images.githubusercontent.com/8656640/172673704-fac52e55-49ee-46a5-b1c8-ab9e7c0b4ec2.png">

![image](https://user-images.githubusercontent.com/8656640/172674208-3a09b43e-eced-4fc3-8535-e95eedee0bf9.png)

This PR also tweaks the logic for which segments are included in the dropdown on subscribers listing pages to include segments where the calculated subscriber count is 0. This is to ensure that the segment a user clicks on will definitely show up selected in the dropdown.

This change should affect segment badges anywhere they appear in the UI, including:

- Emails (all tabs + statistics page)
-- Note: Badges on the stats page will not work right now if the premium plugin is activated. I have a PR for the premium plugin here: https://github.com/mailpoet/mailpoet-premium/pull/585
- Forms (listing page)
- Subscribers

MAILPOET-4244