### PR TITLE
Warn when unauthorized email set as from email [MAILPOET-4253]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -123,4 +123,5 @@ interface Window {
   MailPoetForm?: {
     ajax_url: string;
   };
+  mailpoet_authorized_emails?: string[];
 }

--- a/mailpoet/assets/js/src/settings/pages/basics/default_sender.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/default_sender.tsx
@@ -1,22 +1,45 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Label, Inputs } from 'settings/components';
 import { isEmail, t, onChange, setLowercaseValue } from 'common/functions';
 import { Input } from 'common/form/input/input';
 import { useSetting, useSelector, useAction } from 'settings/store/hooks';
 import { SenderEmailAddressWarning } from 'common/sender_email_address_warning.jsx';
+import ReactStringReplace from 'react-string-replace';
 
 export function DefaultSender() {
   const isMssActive = useSelector('isMssActive')();
   const [senderName, setSenderName] = useSetting('sender', 'name');
   const [senderEmail, setSenderEmail] = useSetting('sender', 'address');
+  const [isAuthorized, setIsAuthorized] = useState(true);
   const [replyToName, setReplyToName] = useSetting('reply_to', 'name');
   const [replyToEmail, setReplyToEmail] = useSetting('reply_to', 'address');
   const setErrorFlag = useAction('setErrorFlag');
   const invalidSenderEmail = senderEmail && !isEmail(senderEmail);
   const invalidReplyToEmail = replyToEmail && !isEmail(replyToEmail);
+
+  const isAuthorizedEmail = (email: string) => {
+    if (!isMssActive) {
+      return;
+    }
+    setIsAuthorized(window.mailpoet_authorized_emails.includes(email));
+  };
+  const updateSenderEmailController = (email: string) => {
+    setIsAuthorized(true);
+    setSenderEmail(email);
+  };
   useEffect(() => {
-    setErrorFlag(invalidSenderEmail || invalidReplyToEmail);
-  }, [invalidReplyToEmail, invalidSenderEmail, setErrorFlag]);
+    setErrorFlag(
+      invalidSenderEmail ||
+        invalidReplyToEmail ||
+        (!isAuthorized && isMssActive),
+    );
+  }, [
+    invalidReplyToEmail,
+    invalidSenderEmail,
+    setErrorFlag,
+    isAuthorized,
+    isMssActive,
+  ]);
   return (
     <>
       <Label
@@ -43,9 +66,27 @@ export function DefaultSender() {
           placeholder="from@mydomain.com"
           data-automation-id="from-email-field"
           value={senderEmail}
-          onChange={onChange(setLowercaseValue(setSenderEmail))}
+          onChange={onChange(setLowercaseValue(updateSenderEmailController))}
+          onBlur={onChange(isAuthorizedEmail)}
         />
         <br />
+        {!isAuthorized && (
+          <span className="mailpoet_error_item mailpoet_error">
+            {ReactStringReplace(
+              t('youNeedToAuthorizeTheEmail'),
+              '[email]',
+              () => senderEmail,
+            )}{' '}
+            <a
+              className="mailpoet-link"
+              href={`https://account.mailpoet.com/authorization?email=${senderEmail}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('authorizeMyEmail')}
+            </a>
+          </span>
+        )}
         {invalidSenderEmail && (
           <span className="mailpoet_error_item mailpoet_error">
             {t('invalidEmail')}

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -7,6 +7,7 @@ use MailPoet\API\JSON\v1\Premium;
 use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Services\Bridge;
 use MailPoet\Settings\Hosts;
 use MailPoet\Settings\Pages;
 use MailPoet\Settings\SettingsController;
@@ -41,6 +42,9 @@ class Settings {
   /** @var SegmentsSimpleListRepository */
   private $segmentsListRepository;
 
+  /** @var Bridge */
+  private $bridge;
+
   public function __construct(
     PageRenderer $pageRenderer,
     SettingsController $settings,
@@ -49,7 +53,8 @@ class Settings {
     ServicesChecker $servicesChecker,
     Installation $installation,
     Captcha $captcha,
-    SegmentsSimpleListRepository $segmentsListRepository
+    SegmentsSimpleListRepository $segmentsListRepository,
+    Bridge $bridge
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->settings = $settings;
@@ -59,6 +64,7 @@ class Settings {
     $this->installation = $installation;
     $this->captcha = $captcha;
     $this->segmentsListRepository = $segmentsListRepository;
+    $this->bridge = $bridge;
   }
 
   public function render() {
@@ -90,6 +96,7 @@ class Settings {
         'plugin' => dirname(dirname(dirname(__DIR__))),
       ],
       'built_in_captcha_supported' => $this->captcha->isSupported(),
+      'authorized_emails' => $this->bridge->getAuthorizedEmailAddresses(),
     ];
 
     $data['is_new_user'] = $this->installation->isNewInstallation();

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -67,7 +67,7 @@ class AuthorizedEmailsController {
 
     $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses();
     // Keep previous check result for an invalid response from API
-    if ($authorizedEmails === false) {
+    if (!$authorizedEmails) {
       return null;
     }
     $authorizedEmails = array_map('strtolower', $authorizedEmails);

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -118,10 +118,11 @@ class Bridge {
     return $this->api;
   }
 
-  public function getAuthorizedEmailAddresses() {
-    return $this
+  public function getAuthorizedEmailAddresses(): array {
+    $data = $this
       ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
       ->getAuthorizedEmailAddresses();
+    return $data ? $data['authorized'] : [];
   }
 
   public function checkMSSKey($apiKey) {

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -6,7 +6,8 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\WP\Functions as WPFunctions;
 use WP_Error;
 
-class API {
+class
+API {
   const SENDING_STATUS_OK = 'ok';
   const SENDING_STATUS_CONNECTION_ERROR = 'connection_error';
   const SENDING_STATUS_SEND_ERROR = 'send_error';
@@ -36,7 +37,7 @@ class API {
   public $urlMessages = 'https://bridge.mailpoet.com/api/v0/messages';
   public $urlBounces = 'https://bridge.mailpoet.com/api/v0/bounces/search';
   public $urlStats = 'https://bridge.mailpoet.com/api/v0/stats';
-  public $urlAuthorizedEmailAddresses = 'https://bridge.mailpoet.com/api/v0/authorized_email_addresses';
+  public $urlAuthorizedEmailAddresses = 'https://bridge.mailpoet.com/api/v1/authorized_email_address';
 
   public function __construct(
     $apiKey,
@@ -166,16 +167,17 @@ class API {
     return $isSuccess;
   }
 
-  public function getAuthorizedEmailAddresses() {
+  public function getAuthorizedEmailAddresses(): ?array {
     $result = $this->request(
       $this->urlAuthorizedEmailAddresses,
       null,
       'GET'
     );
-    if ($this->wp->wpRemoteRetrieveResponseCode($result) === 200) {
-      return json_decode($this->wp->wpRemoteRetrieveBody($result), true);
+    if ($this->wp->wpRemoteRetrieveResponseCode($result) !== 200) {
+      return null;
     }
-    return false;
+    $data = json_decode($this->wp->wpRemoteRetrieveBody($result), true);
+    return is_array($data) ? $data : null;
   }
 
   public function setKey($apiKey) {

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -6,8 +6,7 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\WP\Functions as WPFunctions;
 use WP_Error;
 
-class
-API {
+class API {
   const SENDING_STATUS_OK = 'ok';
   const SENDING_STATUS_CONNECTION_ERROR = 'connection_error';
   const SENDING_STATUS_SEND_ERROR = 'send_error';

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -2,7 +2,9 @@
 
 namespace MailPoet\Test\DataFactories;
 
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 
@@ -10,8 +12,11 @@ class Settings {
   /** @var SettingsController */
   private $settings;
 
+  private $authorizedEmailsController;
+
   public function __construct() {
     $this->settings = SettingsController::getInstance();
+    $this->authorizedEmailsController = ContainerWrapper::getInstance()->get(AuthorizedEmailsController::class);
     $this->settings->resetCache();
   }
 
@@ -100,6 +105,7 @@ class Settings {
     $this->settings->set('mta.mailpoet_api_key', $mailPoetSendingKey);
     $this->settings->set('mta.mailpoet_api_key_state.state', 'valid');
     $this->settings->set('mta.mailpoet_api_key_state.code', 200);
+    $this->authorizedEmailsController->checkAuthorizedEmailAddresses();
     return $this;
   }
 

--- a/mailpoet/tests/acceptance/Settings/AuthorizedEmailAddressesValidationCest.php
+++ b/mailpoet/tests/acceptance/Settings/AuthorizedEmailAddressesValidationCest.php
@@ -49,7 +49,7 @@ class AuthorizedEmailAddressesValidationCest {
     $i->reloadPage();
     $i->cantSee($errorMessagePrefix);
   }
-/*
+
   public function authorizedEmailsInNewslettersValidation(\AcceptanceTester $i) {
     $subject = 'Subject Unauthorized Welcome Email';
     (new Newsletter())->withSubject($subject)
@@ -102,5 +102,4 @@ class AuthorizedEmailAddressesValidationCest {
     $i->click('Send');
     $i->waitForElement('.parsley-invalidFromAddress');
   }
-*/
 }

--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -5,6 +5,7 @@
 
   <script type="text/javascript">
     <% autoescape 'js' %>
+      var mailpoet_authorized_emails = <%= json_encode(authorized_emails) %>;
       var mailpoet_woocommerce_active = <%= json_encode(is_woocommerce_active == true) %>;
       var mailpoet_members_plugin_active = <%= json_encode(is_members_plugin_active == true) %>;
       var mailpoet_is_new_user = <%= json_encode(is_new_user == true) %>;
@@ -99,6 +100,8 @@
     'readGuide': __('Read our guide'),
 
     'invalidEmail': __('Invalid email address'),
+    'youNeedToAuthorizeTheEmail': __('You need to authorize the email address [email] to be able to send with it.'),
+    'authorizeMyEmail': __('Authorize my email address'),
 
     'enableSignupConfTitle': __('Enable sign-up confirmation'),
     'enableSignupConfDescription': __("If you enable this option, your subscribers will first receive a confirmation email after they subscribe. Once they confirm their subscription (via this email), they will be marked as 'confirmed' and will begin to receive your email newsletters."),


### PR DESCRIPTION
Fixes [MAILPOET-4253]

How To Test:
* Activate MSS sending method
* Change your from address in the Basic tab
* When your email is not authorized a message should appear once you leave the from address input field and you shouldn't be able to save
* When your email is authorized no message should appear once you leave the from address input field and you should be able to save
![image](https://user-images.githubusercontent.com/6458412/172776424-937f7722-f6b7-46e7-a194-e9f9efed13d9.png)



[MAILPOET-4253]: https://mailpoet.atlassian.net/browse/MAILPOET-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ