### PR TITLE
Use WP 6.0 when running the acceptance tests

### DIFF
--- a/mailpoet/lib/PostEditorBlocks/MarketingOptinBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/MarketingOptinBlock.php
@@ -86,11 +86,14 @@ class MarketingOptinBlock implements IntegrationInterface {
    */
   private function registerEditorTranslations() {
     $handle = 'mailpoet-marketing-optin-block-editor-script';
-    $editorTranslations = $this->wp->getWpScripts()->print_translations($handle, false);
-    // mailpoet-marketing-optin-block-editor-script is not enqueued
-    if ($editorTranslations === false) {
-      return;
-    }
+    $editorTranslations = <<<JS
+( function( domain, translations ) {
+	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
+	localeData[""].domain = domain;
+	wp.i18n.setLocaleData( localeData, domain );
+} )( "mailpoet", { "locale_data": { "messages": { "": {} } } } );
+JS;
+
     $translations = [
       '' => ['domain' => 'messages'],
       'marketing-opt-in-label' => [__('Marketing opt-in', 'mailpoet')],

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-5.9_php8.0_20220127.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.0_php8.0_20220609.1}
     depends_on:
       - smtp
       - mysql


### PR DESCRIPTION
Just bumping the WP version used in the acceptance tests to the latest version.

**Testing instructions**
- Check that the acceptance tests are using WP 6.0 and that they are passing.

[MAILPOET-4297]

[MAILPOET-4297]: https://mailpoet.atlassian.net/browse/MAILPOET-4297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ