### PR TITLE
Update documentation on how to run the dev environment with different PHP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To switch the environment to PHP 7.4/8.0:
    wordpress:
      build:
        context: .
-       dockerfile: docker/php74/Dockerfile # OR docker/php80/Dockerfile
+       dockerfile: dev/php74/Dockerfile # OR dev/php80/Dockerfile
    ```
 
 2. Run `docker-compose build wordpress`.


### PR DESCRIPTION
Since mailpoet-dev-env was deprecated and the mono repo was created, the directory that contains the docker files is `dev` instead `docker`. This PR updates the documentation on how to run the dev env with different PHP versions to reflect this change.