### PR TITLE
Do not autoreload twig templates [MAILPOET-4439]

### DIFF
--- a/mailpoet/lib/Config/Renderer.php
+++ b/mailpoet/lib/Config/Renderer.php
@@ -27,7 +27,7 @@ class Renderer {
       [
         'cache' => new TwigFileSystemCache($cachePath),
         'debug' => $this->debuggingEnabled,
-        'auto_reload' => true,
+        'auto_reload' => false,
       ]
     );
 

--- a/mailpoet/lib/Config/Renderer.php
+++ b/mailpoet/lib/Config/Renderer.php
@@ -18,7 +18,8 @@ class Renderer {
   public function __construct(
     bool $debuggingEnabled,
     string $cachePath,
-    TwigFileSystem $fileSystem
+    TwigFileSystem $fileSystem,
+    bool $autoReload = false
   ) {
     $this->debuggingEnabled = $debuggingEnabled;
     $this->cachePath = $cachePath;
@@ -27,7 +28,7 @@ class Renderer {
       [
         'cache' => new TwigFileSystemCache($cachePath),
         'debug' => $this->debuggingEnabled,
-        'auto_reload' => false,
+        'auto_reload' => $autoReload,
       ]
     );
 

--- a/mailpoet/lib/Config/RendererFactory.php
+++ b/mailpoet/lib/Config/RendererFactory.php
@@ -12,10 +12,12 @@ class RendererFactory {
   public function getRenderer() {
     if (!$this->renderer) {
       $debugging = WP_DEBUG;
+      $autoReload = defined('MAILPOET_DEVELOPMENT') && MAILPOET_DEVELOPMENT;
       $this->renderer = new Renderer(
         $debugging,
         Env::$cachePath,
-        new TwigFileSystem(Env::$viewsPath)
+        new TwigFileSystem(Env::$viewsPath),
+        $autoReload
       );
     }
     return $this->renderer;

--- a/mailpoet/mailpoet_initializer.php
+++ b/mailpoet/mailpoet_initializer.php
@@ -53,6 +53,7 @@ if (WP_DEBUG && PHP_VERSION_ID >= 70100 && file_exists($tracyPath)) {
     session_start();
     Debugger::enable(Debugger::DEVELOPMENT);
   }
+  define('MAILPOET_DEVELOPMENT', true);
 }
 
 define('MAILPOET_VERSION', $mailpoetPlugin['version']);


### PR DESCRIPTION
Fixes [MAILPOET-4439]

Set to true auto_reload will attempt to overwrite existing files, which is to be avoided.

Current state:
When you download the plugin, you can see how, after loading some twig templates, the template files are regenerated and the owner etc. of those files change.

A useful breakpoint for xDebug would be vendor-prefixed/twig/twig/src/Environment.phpL151. You see how because of `isAutoReload()` you skip L153, which then produces a write in L159. This produces errors, when the directory/file is not writeable.

Solution:
This PR sets `auto_reload` to `false` which then does not produce the attempted write.

[MAILPOET-4439]: https://mailpoet.atlassian.net/browse/MAILPOET-4439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ