### PR TITLE
Use original WordPress Mailer as fallback for transactional mailer [MAILPOET-4254]

### DIFF
--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -120,7 +120,7 @@ class Settings {
     return $this;
   }
 
-  public function withMisconfiguredSendingMethodSmtpMailhog() {
+  public function withMisconfiguredSendingMethodSmtp() {
     $this->withSendingMethodSmtpMailhog();
     $this->settings->set('mta.host', 'unknown_server');
   }

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -120,6 +120,11 @@ class Settings {
     return $this;
   }
 
+  public function withMisconfiguredSendingMethodSmtpMailhog() {
+    $this->withSendingMethodSmtpMailhog();
+    $this->settings->set('mta.host', 'unknown_server');
+  }
+
   public function withSendingMethodSmtpMailhog() {
     $this->settings->set('mta_group', 'smtp');
     $this->settings->set('mta.method', Mailer::METHOD_SMTP);

--- a/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
+++ b/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
@@ -9,8 +9,10 @@ class TransactionalEmailsCest {
   public function sendTransactionalEmailFallback(\AcceptanceTester $i) {
     $i->wantTo('Check that transactional email are sent even when MailPoet sending doesn‘t send');
     $settings = new Settings();
+    $i->wantTo('Setup MailPoet to send transactional emails but having misconfigured SMTP settings.');
     $settings->withMisconfiguredSendingMethodSmtpMailhog();
     $settings->withTransactionEmailsViaMailPoet();
+    $i->wantTo('Create a new WP user and make sure transactional email were received');
     $i->cli(['user', 'create', 'john_doe', 'john_doe@example.com', '--send-email']);
     $i->amOnMailboxAppPage();
     $i->checkEmailWasReceived('New User Registration');

--- a/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
+++ b/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
@@ -10,7 +10,7 @@ class TransactionalEmailsCest {
     $i->wantTo('Check that transactional email are sent even when MailPoet sending doesn‘t send');
     $settings = new Settings();
     $i->wantTo('Setup MailPoet to send transactional emails but having misconfigured SMTP settings.');
-    $settings->withMisconfiguredSendingMethodSmtpMailhog();
+    $settings->withMisconfiguredSendingMethodSmtp();
     $settings->withTransactionEmailsViaMailPoet();
     $i->wantTo('Create a new WP user and make sure transactional email were received');
     $i->cli(['user', 'create', 'john_doe', 'john_doe@example.com', '--send-email']);

--- a/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
+++ b/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Settings;
+
+class TransactionalEmailsCest {
+
+  public function sendTransactionalEmailFallback(\AcceptanceTester $i) {
+    $i->wantTo('Check that transactional email are sent even when MailPoet sending doesn‘t send');
+    $settings = new Settings();
+    $settings->withMisconfiguredSendingMethodSmtpMailhog();
+    $i->cli(['user', 'create', 'john_doe', 'john_doe@example.com', '--send-email']);
+    $i->amOnMailboxAppPage();
+    $i->checkEmailWasReceived('New User Registration');
+    $i->checkEmailWasReceived('Login Details');
+  }
+}

--- a/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
+++ b/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
@@ -10,6 +10,7 @@ class TransactionalEmailsCest {
     $i->wantTo('Check that transactional email are sent even when MailPoet sending doesn‘t send');
     $settings = new Settings();
     $settings->withMisconfiguredSendingMethodSmtpMailhog();
+    $settings->withTransactionEmailsViaMailPoet();
     $i->cli(['user', 'create', 'john_doe', 'john_doe@example.com', '--send-email']);
     $i->amOnMailboxAppPage();
     $i->checkEmailWasReceived('New User Registration');


### PR DESCRIPTION
This PR changes the fallback method for transactional emails when they are set to be sent using MailPoet. 
Prior to this change, we used PHPMailer with the default configuration as the fallback. Now we use PHPMailer as configured within the wp_mail function.

The problem it fixes is that on some hosts it is not possible to send with the PHP mail function which is used as default in PHPMailer and it is more likely that the WP PHPMailer would work.

### Testing instructions
1) Setup a WP site and make sure transactional emails work even without MailPoet (e.g., add a new WP user, create new Woo order).
2) Install MailPoet and set transactional emails to be sent via MailPoet (Settings > Advanced > The current sending method)
3) Misconfigure MailPoet sending settings so that it doesn't send (e.g. use an invalid API key or use SMTP with no existing host)
4) Make some action that triggers transactional email (e.g., add a new WP user, create new Woo order).
5) Verify that you received the email even when MailPoet is misconfigured

Also, it might be a good idea to test on an Atomic site, because that's where the issue was discovered.

[MAILPOET-4254]

[MAILPOET-4254]: https://mailpoet.atlassian.net/browse/MAILPOET-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ