### PR TITLE
Introduce automation email type [MAILPOET-4432]

### DIFF
--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -23,6 +23,7 @@ use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
 class NewsletterEntity {
   // types
   const TYPE_AUTOMATIC = 'automatic';
+  const TYPE_AUTOMATION = 'automation';
   const TYPE_STANDARD = 'standard';
   const TYPE_WELCOME = 'welcome';
   const TYPE_NOTIFICATION = 'notification';

--- a/mailpoet/lib/Models/Newsletter.php
+++ b/mailpoet/lib/Models/Newsletter.php
@@ -44,6 +44,7 @@ use MailPoet\WP\Functions as WPFunctions;
 class Newsletter extends Model {
   public static $_table = MP_NEWSLETTERS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
   const TYPE_AUTOMATIC = NewsletterEntity::TYPE_AUTOMATIC;
+  const TYPE_AUTOMATION = NewsletterEntity::TYPE_AUTOMATION;
   const TYPE_STANDARD = NewsletterEntity::TYPE_STANDARD;
   const TYPE_WELCOME = NewsletterEntity::TYPE_WELCOME;
   const TYPE_NOTIFICATION = NewsletterEntity::TYPE_NOTIFICATION;

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -122,6 +122,7 @@ class NewsletterSaveController {
     }
 
     $newsletter = isset($data['id']) ? $this->getNewsletter($data) : $this->createNewsletter($data);
+    $data = $this->sanitizeAutomationEmailData($data, $newsletter);
     $oldSenderAddress = $newsletter->getSenderAddress();
 
     $this->updateNewsletter($newsletter, $data);
@@ -151,6 +152,14 @@ class NewsletterSaveController {
     $this->updateQueue($newsletter, $newsletterModel, $data['options'] ?? []);
     $this->authorizedEmailsController->onNewsletterSenderAddressUpdate($newsletter, $oldSenderAddress);
     return $newsletter;
+  }
+
+  private function sanitizeAutomationEmailData(array $data, NewsletterEntity $newsletter): array {
+    if ($newsletter->getType() !== NewsletterEntity::TYPE_AUTOMATION) {
+      return $data;
+    }
+    $data['segments'] = [];
+    return $data;
   }
 
   public function duplicate(NewsletterEntity $newsletter): NewsletterEntity {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -406,6 +406,18 @@ class NewslettersTest extends \MailPoetTest {
     expect($response->errors[0]['message'])->equals('Please specify a type.');
   }
 
+  public function testItCanCreateAnAutomationNewsletter() {
+    $data = [
+      'subject' => 'My Automation newsletter',
+      'type' => NewsletterEntity::TYPE_AUTOMATION,
+    ];
+    $response = $this->endpoint->create($data);
+    expect($response->status)->equals(APIResponse::STATUS_OK);
+    $newsletter = $this->newsletterRepository->findOneBy(['subject' => 'My Automation newsletter']);
+    assert($newsletter instanceof NewsletterEntity);
+    expect($response->data)->equals($this->newslettersResponseBuilder->build($newsletter));
+  }
+
   public function testItHasDefaultSenderAfterCreate() {
     $data = [
       'subject' => 'My First Newsletter',

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -43,6 +43,10 @@ class SendingQueueTest extends \MailPoetTest {
     ]);
   }
 
+  public function testItDoesNotScheduleAutomationEmailsWithTheSendingQueue() {
+
+  }
+
   public function testItCreatesNewScheduledSendingQueueTask() {
     $newsletter = $this->newsletter;
     $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -43,10 +43,6 @@ class SendingQueueTest extends \MailPoetTest {
     ]);
   }
 
-  public function testItDoesNotScheduleAutomationEmailsWithTheSendingQueue() {
-
-  }
-
   public function testItCreatesNewScheduledSendingQueueTask() {
     $newsletter = $this->newsletter;
     $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -243,6 +243,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
       NewsletterEntity::TYPE_STANDARD, // should be returned
       NewsletterEntity::TYPE_WELCOME,
       NewsletterEntity::TYPE_AUTOMATIC,
+      NewsletterEntity::TYPE_AUTOMATION,
       NewsletterEntity::TYPE_NOTIFICATION,
       NewsletterEntity::TYPE_NOTIFICATION_HISTORY, // should be returned
       NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
@@ -258,7 +259,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     end($newsletters)->setDeletedAt(new Carbon());
     $this->entityManager->flush();
 
-    expect($this->repository->findAll())->count(7);
+    expect($this->repository->findAll())->count(8);
 
     // archives return only:
     // 1. STANDARD and NOTIFICATION HISTORY newsletters
@@ -269,7 +270,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     expect($results)->count(2);
     expect($results[0]->getId())->equals($newsletters[1]->getId());
     expect($results[0]->getType())->equals(NewsletterEntity::TYPE_STANDARD);
-    expect($results[1]->getId())->equals($newsletters[5]->getId());
+    expect($results[1]->getId())->equals($newsletters[6]->getId());
     expect($results[1]->getType())->equals(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
   }
 

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -201,6 +201,26 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     expect($segment->getName())->equals('Segment 1');
   }
 
+
+  public function testItDoesNotSaveSegmentsForAutomationEmails() {
+    $segment = new SegmentEntity('Segment 1', SegmentEntity::TYPE_DEFAULT, 'Segment 1 description');
+    $this->entityManager->persist($segment);
+    $this->entityManager->flush();
+    $fakeSegmentId = 1;
+
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletterData = [
+      'id' => $newsletter->getId(),
+      'segments' => [
+        ['id' => $segment->getId()],
+        $fakeSegmentId,
+      ],
+    ];
+
+    $newsletter = $this->saveController->save($newsletterData);
+    expect(count($newsletter->getNewsletterSegments()))->equals(0);
+  }
+
   public function testItDeletesSendingQueueAndSetsNewsletterStatusToDraftWhenItIsUnscheduled() {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SCHEDULED);
 


### PR DESCRIPTION
Fixes [MAILPOET-4432]

This PR introduces a new email type "automation".
I had a look for more tests, which might need extension but didn't really find a lot.

[MAILPOET-4432]: https://mailpoet.atlassian.net/browse/MAILPOET-4432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ