### PR TITLE
Introduce a SubjectFactory [MAILPOET-4449]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Exceptions/UnexpectedSubjectType.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/UnexpectedSubjectType.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Exceptions;
+
+class UnexpectedSubjectType extends RuntimeException {
+
+
+}

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\Workflows\Action;
+use MailPoet\Automation\Engine\Workflows\SubjectFactory;
 use MailPoet\Automation\Engine\Workflows\Trigger;
 
 class Registry {
@@ -11,6 +12,9 @@ class Registry {
 
   /** @var array<string, Action> */
   private $actions = [];
+
+  /** @var array<SubjectFactory> */
+  private $subjectFactories = [];
 
   public function addTrigger(Trigger $trigger): void {
     $key = $trigger->getKey();
@@ -44,5 +48,14 @@ class Registry {
   /** @return array<string, Action> */
   public function getActions(): array {
     return $this->actions;
+  }
+
+  public function addSubjectFactory(SubjectFactory $factory): void {
+      $this->subjectFactories[] = $factory;
+  }
+
+  /** @return SubjectFactory[] */
+  public function getSubjectFactories(): array {
+    return $this->subjectFactories;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -3,6 +3,9 @@
 namespace MailPoet\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Utils\Json;
+use MailPoet\Automation\Engine\Workflows\Subject;
 use MailPoet\Automation\Engine\Workflows\WorkflowRun;
 use wpdb;
 
@@ -13,10 +16,16 @@ class WorkflowRunStorage {
   /** @var wpdb */
   private $wpdb;
 
-  public function __construct() {
+  /** @var Registry  */
+  private $registry;
+
+  public function __construct(
+    Registry $registry
+  ) {
     global $wpdb;
     $this->table = $wpdb->prefix . 'mailpoet_automation_workflow_runs';
     $this->wpdb = $wpdb;
+    $this->registry = $registry;
   }
 
   public function createWorkflowRun(WorkflowRun $workflowRun): int {
@@ -31,7 +40,36 @@ class WorkflowRunStorage {
     $table = esc_sql($this->table);
     $query = (string)$this->wpdb->prepare("SELECT * FROM $table WHERE id = %d", $id);
     $data = $this->wpdb->get_row($query, ARRAY_A);
-    return $data ? WorkflowRun::fromArray((array)$data) : null;
+    if (!is_array($data) || empty($data)) {
+      return null;
+    }
+    $data['subjects'] = isset($data['subjects']) ? $this->createSubjects(Json::decode($data['subjects'])) : [];
+    return WorkflowRun::fromArray($data);
+  }
+
+  /**
+   * @param array $rawSubjects
+   * @return Subject[]
+   */
+  private function createSubjects(array $rawSubjects): array {
+    $subjects = [];
+    $subjectFactories = $this->registry->getSubjectFactories();
+    foreach ($rawSubjects as $subjectKey => $subjectData) {
+      foreach ($subjectFactories as $factory) {
+        if (!$factory->canHandle($subjectKey)) {
+          continue;
+        }
+        try {
+          $subject = $factory->forKey($subjectKey);
+          $subject->load($subjectData);
+          $subjects[] = $subject;
+        } catch (Exceptions\UnexpectedSubjectType $error) {
+          continue;
+        }
+        break;
+      }
+    }
+    return $subjects;
   }
 
   public function updateStatus(int $id, string $status): void {

--- a/mailpoet/lib/Automation/Engine/Workflows/SubjectFactory.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/SubjectFactory.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedSubjectType;
+
+interface SubjectFactory {
+  public function canHandle(string $key): bool;
+
+  /**
+   * @param string $key
+   * @return Subject
+   * @throws UnexpectedSubjectType
+   */
+  public function forKey(string $key): Subject;
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/WorkflowRun.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/WorkflowRun.php
@@ -97,7 +97,8 @@ class WorkflowRun {
   }
 
   public static function fromArray(array $data): self {
-    $workflowRun = new WorkflowRun((int)$data['workflow_id'], $data['trigger_key'], Json::decode($data['subjects']));
+
+    $workflowRun = new WorkflowRun((int)$data['workflow_id'], $data['trigger_key'], $data['subjects']);
     $workflowRun->id = (int)$data['id'];
     $workflowRun->status = $data['status'];
     $workflowRun->createdAt = $data['created_at'];

--- a/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
@@ -5,25 +5,32 @@ namespace MailPoet\Automation\Integrations\MailPoet;
 use MailPoet\Automation\Engine\Integration;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendWelcomeEmailAction;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\MailPoetSubjectFactory;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger;
 
 class MailPoetIntegration implements Integration {
   /** @var SegmentSubscribedTrigger */
   private $segmentSubscribedTrigger;
-  
+
   /** @var SendWelcomeEmailAction */
   private $sendWelcomeEmailAction;
-  
+
+  /** @var MailPoetSubjectFactory */
+  private $subjectFactory;
+
   public function __construct(
-    SegmentSubscribedTrigger $segmentSubscribedTrigger, 
-    SendWelcomeEmailAction $sendWelcomeEmailAction
+    SegmentSubscribedTrigger $segmentSubscribedTrigger,
+    SendWelcomeEmailAction $sendWelcomeEmailAction,
+    MailPoetSubjectFactory $subjectFactory
   ) {
     $this->segmentSubscribedTrigger = $segmentSubscribedTrigger;
     $this->sendWelcomeEmailAction = $sendWelcomeEmailAction;
+    $this->subjectFactory = $subjectFactory;
   }
 
   public function register(Registry $registry): void {
     $registry->addTrigger($this->segmentSubscribedTrigger);
     $registry->addAction($this->sendWelcomeEmailAction);
+    $registry->addSubjectFactory($this->subjectFactory);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/MailPoetSubjectFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/MailPoetSubjectFactory.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Subjects;
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedSubjectType;
+use MailPoet\Automation\Engine\Workflows\Subject;
+use MailPoet\Automation\Engine\Workflows\SubjectFactory;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+
+class MailPoetSubjectFactory implements SubjectFactory {
+
+
+  private $segmentsRepository;
+
+  private $subscribersRepository;
+
+  public function __construct(
+    SegmentsRepository $segmentsRepository,
+    SubscribersRepository $subscribersRepository
+  ) {
+    $this->segmentsRepository = $segmentsRepository;
+    $this->subscribersRepository = $subscribersRepository;
+  }
+
+  public function canHandle(string $key): bool {
+    return in_array($key, ['mailpoet:segment', 'mailpoet:subscriber'], true);
+  }
+
+  public function forKey(string $key): Subject {
+    if ($key === 'mailpoet:segment') {
+      return new SegmentSubject($this->segmentsRepository);
+    }
+    if ($key === 'mailpoet:subscriber') {
+      return new SubscriberSubject($this->subscribersRepository);
+    }
+    throw new UnexpectedSubjectType("Can not handle $key");
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -132,6 +132,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject::class)->setPublic(true)->setShared(false);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Subjects\MailPoetSubjectFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\WorkflowBuilder::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Actions\SendWelcomeEmailAction::class)->setPublic(true);

--- a/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunStorageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace MailPoet\Test\Automation\Engine\Storage;
+
+use MailPoet\Automation\Engine\Storage\WorkflowRunStorage;
+use MailPoet\Automation\Engine\Workflows\WorkflowRun;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+
+class WorkflowRunStorageTest extends \MailPoetTest
+{
+
+  /** @var WorkflowRunStorage */
+  private $testee;
+
+  /** @var SegmentsRepository */
+  private $segmentRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  public function _before() {
+    $this->testee = $this->diContainer->get(WorkflowRunStorage::class);
+    $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+  }
+
+  public function testItGeneratesSubjectsWhenCreatingTheWorkflowRun() {
+    $segment = new SegmentEntity('testItGeneratesSubjectsWhenCreatingTheWorkflowRun', SegmentEntity::TYPE_DEFAULT, '');
+    $this->segmentRepository->persist($segment);
+    $this->segmentRepository->flush();
+    $segment = $this->segmentRepository->findOneBy(['name' => 'testItGeneratesSubjectsWhenCreatingTheWorkflowRun']);
+    $segmentSubject = $this->diContainer->get(SegmentSubject::class);
+    /** @var SegmentEntity $segment */
+    $segmentSubject->load(['segment_id' => $segment->getId()]);
+
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail('test@example.com');
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'test@example.com']);
+    $subscriberSubject = $this->diContainer->get(SubscriberSubject::class);
+    /** @var SubscriberEntity $subscriber */
+    $subscriberSubject->load(['subscriber_id' => $subscriber->getId()]);
+
+    $workflowRun = new WorkflowRun(1, 'triggerKey', [$subscriberSubject, $segmentSubject]);
+    $workflowId = $this->testee->createWorkflowRun($workflowRun);
+    $workflowRunFromStorage = $this->testee->getWorkflowRun($workflowId);
+    $this->assertInstanceOf(WorkflowRun::class, $workflowRunFromStorage);
+    /** @var WorkflowRun $workflowRunFromStorage */
+    $subjects = $workflowRunFromStorage->getSubjects();
+
+    $this->assertCount(2, $subjects);
+    $this->assertInstanceOf(SubscriberSubject::class, $subjects[0]);
+    $this->assertEquals($subscriber->getId(), $subjects[0]->pack()['subscriber_id']);
+    $this->assertInstanceOf(SegmentSubject::class, $subjects[1]);
+    $this->assertEquals($segment->getId(), $subjects[1]->pack()['segment_id']);
+  }
+}


### PR DESCRIPTION
Fixes [MAILPOET-4449]

Depending on a specific integration, different subjects might exist for a WorkflowRun. This commit introduces the concept of a SubjectFactory, which can be registered by an integration and return a Subject depending on a given key.

The `Registry` with which integrations can register actions and triggers is used to also register a `SubjectFactory`. Such a factory returns an empty `Subject` for a given key, which the caller then can load. I use the `WorkflowRunStorage` as a caller. Here the subjects are instantiated. I do not really like this location, as it means, it spills over the knowledge on how to construct a subject. So far the storage just had to have an array of `$data`, now it needs to now that this array contains a `subject` property, which is a JSON encoded string, knowledge which resided only in the WorkflowRun so far, as encoding and decoding where done here. On the other hand I didn't want to inject the Registry or the existing SubjectFactories into the WorkflowRun itself, but that would be an alternative in my mind. Maybe something like
```
public static function fromArray(array $data, SubjectFactory ...$factories) : self { ... }
```

The `MailPoetIntegration` shows how such a factory can be registered and the `MailPoetSubjectFactory` how it could work.

I added an integration test, which demonstrates, how this integration is supposed to work. It creates a new workflow with a SegmentSubject and a SubscriberSubject and stores it in the database. Afterwards we test, if the subjects are correctly returned when fetched from the database.


[MAILPOET-4449]: https://mailpoet.atlassian.net/browse/MAILPOET-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ