### PR TITLE
Fix auth error with Circle CI - MAILPOET-4436

### DIFF
--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -37,7 +37,7 @@ class CircleCiController {
     $circleCiProject = $project === self::PROJECT_MAILPOET ? 'mailpoet' : 'mailpoet-premium';
     $this->zipFilename = $project === self::PROJECT_MAILPOET ? self::FREE_ZIP_FILENAME : self::PREMIUM_ZIP_FILENAME;
     $this->httpClient = new Client([
-      'auth' => [null, $token],
+      'auth' => [$token, null],
       'headers' => [
         'Accept' => 'application/json',
       ],


### PR DESCRIPTION
CircleCI HTTP basic authentication (basic_auth) requires the circle-token to be the username and the password should be empty.

[MAILPOET-4436](https://mailpoet.atlassian.net/browse/MAILPOET-4436)