### PR TITLE
Add tagging subscribers on the edit page [MAILPOET-4440]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -219,6 +219,7 @@ progress::-moz-progress-bar {
   }
 }
 
+// We need to hide the label because it doesn't fit to our form design, and it's added automatically by Gutenberg component
 .mailpoet-form-field-tags label.components-form-token-field__label {
   display: none;
 }

--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -218,3 +218,7 @@ progress::-moz-progress-bar {
     font-style: italic;
   }
 }
+
+.mailpoet-form-field-tags label.components-form-token-field__label {
+  display: none;
+}

--- a/mailpoet/assets/css/src/generic/_forms-token-field.scss
+++ b/mailpoet/assets/css/src/generic/_forms-token-field.scss
@@ -7,9 +7,19 @@
   max-width: 100%;
   min-height: $form-control-height;
   min-width: 0;
-  padding: 0;
-  position: relative;
-  text-align: left;
-  vertical-align: top;
   width: $grid-column;
+  // To align the left padding with the other inputs
+  input[type=text].components-form-token-field__input {
+    margin-left: 0;
+    padding-left: 8px;
+  }
+  // For better fit when the last item is active
+  li:last-child {
+    border-radius: 0 0 $form-control-border-radius $form-control-border-radius;
+  }
+  // Resetting is-active because other input doesn't support it
+  &.components-form-token-field__input-container.is-active {
+    box-shadow: none;
+    outline: 0;
+  }
 }

--- a/mailpoet/assets/css/src/generic/_forms-token-field.scss
+++ b/mailpoet/assets/css/src/generic/_forms-token-field.scss
@@ -1,0 +1,15 @@
+.mailpoet-form-token-field {
+  background: $color-input-background;
+  border: 1px solid $color-input-border !important;
+  border-radius: $form-control-border-radius !important;
+  box-sizing: border-box;
+  display: inline-flex;
+  max-width: 100%;
+  min-height: $form-control-height;
+  min-width: 0;
+  padding: 0;
+  position: relative;
+  text-align: left;
+  vertical-align: top;
+  width: $grid-column;
+}

--- a/mailpoet/assets/css/src/mailpoet-admin.scss
+++ b/mailpoet/assets/css/src/mailpoet-admin.scss
@@ -3,3 +3,8 @@
 
 @import 'components-admin/menu';
 @import 'components-admin/3rd-party-plugins/members';
+
+// Generic
+// 3rd-party styles, can be overwritten.
+
+@import '../../../node_modules/@wordpress/components/build-style/style';

--- a/mailpoet/assets/css/src/mailpoet-admin.scss
+++ b/mailpoet/assets/css/src/mailpoet-admin.scss
@@ -3,8 +3,3 @@
 
 @import 'components-admin/menu';
 @import 'components-admin/3rd-party-plugins/members';
-
-// Generic
-// 3rd-party styles, can be overwritten.
-
-@import '../../../node_modules/@wordpress/components/build-style/style';

--- a/mailpoet/assets/css/src/mailpoet-form-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-form-editor.scss
@@ -17,7 +17,6 @@
 
 @import '../../../node_modules/@wordpress/interface/build-style/style';
 @import '../../../node_modules/@wordpress/editor/build-style/style';
-@import '../../../node_modules/@wordpress/components/build-style/style';
 @import '../../../node_modules/@wordpress/edit-post/build-style/style';
 @import '../../../node_modules/@wordpress/edit-post/build-style/classic';
 @import '../../../node_modules/@wordpress/block-editor/build-style/style';

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -21,6 +21,7 @@
 // 3rd party styles
 
 @import '../../../node_modules/select2/dist/css/select2';
+@import '../../../node_modules/@wordpress/components/build-style/style';
 
 // Generic
 

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -35,6 +35,7 @@
 @import 'generic/forms-select2';
 @import 'generic/forms-textarea';
 @import 'generic/forms-toggle';
+@import 'generic/forms-token-field';
 @import 'generic/forms-yesno';
 @import 'generic/grid';
 @import 'generic/helpers'; // must be the last

--- a/mailpoet/assets/js/src/common/form/tokenField/_stories/tokenField.tsx
+++ b/mailpoet/assets/js/src/common/form/tokenField/_stories/tokenField.tsx
@@ -1,0 +1,32 @@
+import { action } from '_storybook/action';
+import { FormTokenField } from '@wordpress/components';
+import { TokenField } from '../tokenField';
+import { Heading } from '../../../typography/heading/heading';
+import { Grid } from '../../../grid';
+
+export default {
+  title: 'Form',
+  component: TokenField,
+};
+
+const suggestedValues = ['Option 1', 'Option 3', 'Option 4'];
+
+const selectedValues: FormTokenField.Value[] = [{ value: 'Option 2' }];
+
+export function TokenFields() {
+  return (
+    <>
+      <Heading level={3}>Token Fields</Heading>
+      <Grid.Column dimension="small">
+        <Grid.SpaceBetween>
+          <TokenField
+            onChange={action('onChange')}
+            suggestedValues={suggestedValues}
+            selectedValues={selectedValues}
+            label="Add Option"
+          />
+        </Grid.SpaceBetween>
+      </Grid.Column>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/common/form/tokenField/tokenField.tsx
+++ b/mailpoet/assets/js/src/common/form/tokenField/tokenField.tsx
@@ -1,0 +1,42 @@
+import { FormTokenField } from '@wordpress/components';
+
+type Event = {
+  value: readonly FormTokenField.Value[] | string[];
+  name: string;
+};
+
+type Props = {
+  id?: string;
+  label?: string;
+  name?: string;
+  placeholder?: string;
+  onChange: (event: Event) => void;
+  selectedValues?: FormTokenField.Value[];
+  suggestedValues?: readonly string[];
+};
+
+export function TokenField({
+  id,
+  label,
+  name,
+  placeholder,
+  selectedValues,
+  suggestedValues,
+  onChange,
+}: Props) {
+  const args = {
+    id,
+    label,
+    name,
+    placeholder,
+    className: 'mailpoet-form-token-field',
+  };
+  return (
+    <FormTokenField
+      {...args}
+      value={selectedValues}
+      suggestions={suggestedValues}
+      onChange={(tokens) => onChange({ value: tokens, name })}
+    />
+  );
+}

--- a/mailpoet/assets/js/src/common/form/tokenField/tokenField.tsx
+++ b/mailpoet/assets/js/src/common/form/tokenField/tokenField.tsx
@@ -1,4 +1,5 @@
 import { FormTokenField } from '@wordpress/components';
+import { find, last, slice } from 'lodash';
 
 type Event = {
   value: readonly FormTokenField.Value[] | string[];
@@ -31,12 +32,31 @@ export function TokenField({
     placeholder,
     className: 'mailpoet-form-token-field',
   };
+
+  const handleSave = (
+    tokens: readonly FormTokenField.Value[],
+    onChangeCallback,
+  ) => {
+    // Check if the newest value is already in tokens
+    const values = slice(tokens, 0, tokens.length - 1);
+    const newValue = last(tokens);
+    const newTag = newValue ? newValue.toString() : '';
+    const newTagExists = find(
+      values,
+      (location: string) => location.toLowerCase() === newTag.toLowerCase(),
+    );
+    if (newTag && !newTagExists) {
+      values.push(newValue);
+    }
+    onChangeCallback({ value: values, name });
+  };
+
   return (
     <FormTokenField
       {...args}
       value={selectedValues}
       suggestions={suggestedValues}
-      onChange={(tokens) => onChange({ value: tokens, name })}
+      onChange={(tokens) => handleSave(tokens, onChange)}
     />
   );
 }

--- a/mailpoet/assets/js/src/form/fields/field.jsx
+++ b/mailpoet/assets/js/src/form/fields/field.jsx
@@ -10,6 +10,7 @@ import { FormFieldCheckbox } from 'form/fields/checkbox.jsx';
 import { Selection } from 'form/fields/selection.jsx';
 import { FormFieldDate } from 'form/fields/date.jsx';
 import { Heading } from 'common/typography/heading/heading';
+import { FormFieldTokenField } from 'form/fields/tokenField';
 
 class FormField extends Component {
   renderField = (data) => {
@@ -126,6 +127,18 @@ class FormField extends Component {
             item={data.item}
             automationId={data.automationId}
             inline={data.inline}
+            description={data.description}
+          />
+        );
+        break;
+
+      case 'tokenField':
+        field = (
+          <FormFieldTokenField
+            onValueChange={data.onValueChange}
+            field={data.field}
+            item={data.item}
+            automationId={data.automationId}
             description={data.description}
           />
         );

--- a/mailpoet/assets/js/src/form/fields/tokenField.tsx
+++ b/mailpoet/assets/js/src/form/fields/tokenField.tsx
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import { TokenField } from 'common/form/tokenField/tokenField';
+
+function getItems(endpoint: string) {
+  let items = [];
+  if (typeof window[`mailpoet_${endpoint}`] !== 'undefined') {
+    items = window[`mailpoet_${endpoint}`];
+  }
+
+  return items;
+}
+
+function FormFieldTokenField(props) {
+  const selectedValues = Array.isArray(props.item[props.field.name])
+    ? props.item[props.field.name].map((item) => props.field.getName(item))
+    : [];
+
+  let suggestedValues = [];
+  if (props.field.endpoint) {
+    const items = getItems(String(props.field.endpoint));
+    suggestedValues = items.map((item) => props.field.getName(item));
+  } else if (props.field.suggestedValues) {
+    suggestedValues = props.field.suggestedValues;
+  }
+
+  return (
+    <TokenField
+      label={props.field.label}
+      name={props.field.name}
+      placeholder={props.field.placeholder}
+      selectedValues={selectedValues}
+      suggestedValues={suggestedValues}
+      onChange={props.onValueChange}
+    />
+  );
+}
+
+FormFieldTokenField.propTypes = {
+  onValueChange: PropTypes.func,
+  item: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  field: PropTypes.shape({
+    name: PropTypes.string,
+    label: PropTypes.string,
+    suggestedValues: PropTypes.arrayOf(PropTypes.string),
+    placeholder: PropTypes.string,
+    getName: PropTypes.func,
+  }).isRequired,
+};
+
+export { FormFieldTokenField };

--- a/mailpoet/assets/js/src/form/form.jsx
+++ b/mailpoet/assets/js/src/form/form.jsx
@@ -145,7 +145,10 @@ class FormComponent extends Component {
   };
 
   handleValueChange = (e) => {
-    const { name, value } = e.target;
+    // Because we need to support events that don't have the original event we need to check that the property target exists
+    const { name, value } = Object.prototype.hasOwnProperty.call(e, 'target')
+      ? e.target
+      : e;
     if (this.props.onChange) {
       return this.props.onChange(e);
     }

--- a/mailpoet/assets/js/src/subscribers/form.jsx
+++ b/mailpoet/assets/js/src/subscribers/form.jsx
@@ -110,6 +110,17 @@ const fields = [
       return label;
     },
   },
+  {
+    name: 'tags',
+    label: MailPoet.I18n.t('tags'),
+    type: 'tokenField',
+    placeholder: MailPoet.I18n.t('addNewTag'),
+    suggestedValues: [],
+    endpoint: 'tags',
+    getName: function getName(tag) {
+      return Object.prototype.hasOwnProperty.call(tag, 'name') ? tag.name : tag;
+    },
+  },
 ];
 
 const customFields = window.mailpoet_custom_fields || [];

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -92,6 +92,7 @@ class SubscribersResponseBuilder {
       'count_confirmations' => $subscriberEntity->getConfirmationsCount(),
       'unsubscribe_token' => $subscriberEntity->getUnsubscribeToken(),
       'link_token' => $subscriberEntity->getLinkToken(),
+      'tags' => $this->buildTags($subscriberEntity),
     ];
 
     return $this->buildCustomFields($subscriberEntity, $data);
@@ -151,6 +152,25 @@ class SubscribersResponseBuilder {
       }
     }
     return $data;
+  }
+
+  private function buildTags(SubscriberEntity $subscriber): array {
+    $result = [];
+    foreach ($subscriber->getSubscriberTags() as $subscriberTag) {
+      $tag = $subscriberTag->getTag();
+      if (!$tag) {
+        continue;
+      }
+      $result[] = [
+        'id' => $subscriberTag->getId(),
+        'subscriber_id' => (string)$subscriber->getId(),
+        'tag_id' => (string)$tag->getId(),
+        'created_at' => ($createdAt = $subscriberTag->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
+        'updated_at' => $subscriberTag->getUpdatedAt()->format(self::DATE_FORMAT),
+        'name' => $tag->getName(),
+      ];
+    }
+    return $result;
   }
 
   /**

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -76,9 +76,6 @@ class Subscribers {
   }
 
   public function render() {
-    // Gutenberg components styles
-    $this->wp->wpEnqueueStyle('wp-components');
-
     $installer = new Installer(Installer::PREMIUM_PLUGIN_SLUG);
     $pluginInformation = $installer->retrievePluginInformation();
 

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -69,6 +69,9 @@ class Subscribers {
   }
 
   public function render() {
+    // Gutenberg components styles
+    $this->wp->wpEnqueueStyle('wp-components');
+
     $installer = new Installer(Installer::PREMIUM_PLUGIN_SLUG);
     $pluginInformation = $installer->retrievePluginInformation();
 

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -6,6 +6,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
+use MailPoet\Entities\TagEntity;
 use MailPoet\Form\Block;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Models\CustomField;
@@ -13,6 +14,7 @@ use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Tags\TagRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
@@ -40,6 +42,9 @@ class Subscribers {
   /** @var SegmentsSimpleListRepository */
   private $segmentsListRepository;
 
+  /** @var TagRepository */
+  private $tagRepository;
+
   /** @var TransientCache */
   private $transientCache;
 
@@ -54,6 +59,7 @@ class Subscribers {
     ServicesChecker $servicesChecker,
     Block\Date $dateBlock,
     SegmentsSimpleListRepository $segmentsListRepository,
+    TagRepository $tagRepository,
     TransientCache $transientCache,
     TrackingConfig $trackingConfig
   ) {
@@ -64,6 +70,7 @@ class Subscribers {
     $this->dateBlock = $dateBlock;
     $this->servicesChecker = $servicesChecker;
     $this->segmentsListRepository = $segmentsListRepository;
+    $this->tagRepository = $tagRepository;
     $this->transientCache = $transientCache;
     $this->trackingConfig = $trackingConfig;
   }
@@ -79,6 +86,13 @@ class Subscribers {
 
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('subscribers');
     $data['segments'] = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts();
+
+    $data['tags'] = array_map(function (TagEntity $tag): array {
+      return [
+        'id' => $tag->getId(),
+        'name' => $tag->getName(),
+      ];
+    }, $this->tagRepository->findAll());
 
     $data['custom_fields'] = array_map(function($field) {
       $field['params'] = unserialize($field['params']);

--- a/mailpoet/lib/Config/AssetsLoader.php
+++ b/mailpoet/lib/Config/AssetsLoader.php
@@ -18,9 +18,16 @@ class AssetsLoader {
   }
 
   public function loadStyles(): void {
+    // MailPoet plugin style should be loaded on all mailpoet sites
+    if (isset($_GET['page']) && strpos($_GET['page'], 'mailpoet-') === 0 ) {
+      $this->enqueueStyle('mailpoet-plugin', [
+        'forms', // To prevent conflict in CSS with WP forms we need to add dependency
+        'buttons',
+      ]);
+    }
     if (isset($_GET['page']) && $_GET['page'] === 'mailpoet-form-editor') {
-      // Because 3rd styles were moved into admin styles, the dependency guarantees correct overriding
-      $this->enqueueStyle('mailpoet-form-editor', ['mailpoet-admin-global']);
+      // Form-editor CSS has to be loaded after plugin style because it contains @wordpress/components dependency
+      $this->enqueueStyle('mailpoet-form-editor', ['mailpoet-plugin']);
       $this->enqueueStyle('mailpoet-public');
     }
   }

--- a/mailpoet/lib/Config/AssetsLoader.php
+++ b/mailpoet/lib/Config/AssetsLoader.php
@@ -19,15 +19,17 @@ class AssetsLoader {
 
   public function loadStyles(): void {
     if (isset($_GET['page']) && $_GET['page'] === 'mailpoet-form-editor') {
-      $this->enqueueStyle('mailpoet-form-editor');
+      // Because 3rd styles were moved into admin styles, the dependency guarantees correct overriding
+      $this->enqueueStyle('mailpoet-form-editor', ['mailpoet-admin-global']);
       $this->enqueueStyle('mailpoet-public');
     }
   }
 
-  private function enqueueStyle(string $name): void {
+  private function enqueueStyle(string $name, array $deps = []): void {
     $this->wp->wpEnqueueStyle(
       $name,
-      Env::$assetsUrl . '/dist/css/' . $this->renderer->getCssAsset("{$name}.css")
+      Env::$assetsUrl . '/dist/css/' . $this->renderer->getCssAsset("{$name}.css"),
+      $deps
     );
   }
 }

--- a/mailpoet/lib/Config/Migrator.php
+++ b/mailpoet/lib/Config/Migrator.php
@@ -72,6 +72,8 @@ class Migrator {
       'feature_flags',
       'dynamic_segment_filters',
       'user_agents',
+      'tags',
+      'subscriber_tag',
     ];
   }
 
@@ -632,6 +634,33 @@ class Migrator {
       'created_at timestamp NULL,',
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
       'PRIMARY KEY (id)',
+    ];
+    return $this->sqlify(__FUNCTION__, $attributes);
+  }
+
+  public function tags(): string {
+    $attributes = [
+      'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
+      'name varchar(255) NOT NULL,',
+      'description text NOT NULL DEFAULT "",',
+      'created_at timestamp NULL,', // must be NULL, see comment at the top
+      'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
+      'PRIMARY KEY (id),',
+      'UNIQUE KEY name (name)',
+    ];
+    return $this->sqlify(__FUNCTION__, $attributes);
+  }
+
+  public function subscriberTag(): string {
+    $attributes = [
+      'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
+      'subscriber_id int(11) unsigned NOT NULL,',
+      'tag_id int(11) unsigned NOT NULL,',
+      'created_at timestamp NULL,', // must be NULL, see comment at the top
+      'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
+      'PRIMARY KEY (id),',
+      'UNIQUE KEY subscriber_tag (subscriber_id, tag_id),',
+      'KEY tag_id (tag_id)',
     ];
     return $this->sqlify(__FUNCTION__, $attributes);
   }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -317,6 +317,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\SubscriberIPsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSegmentRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\SubscriberTagRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberCustomFieldRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSubscribeController::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -469,6 +469,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoetVendor\csstidy::class)->setClass(\MailPoetVendor\csstidy::class);
     // Cache
     $container->autowire(\MailPoet\Cache\TransientCache::class)->setPublic(true);
+    // Tags
+    $container->autowire(\MailPoet\Tags\TagRepository::class)->setPublic(true);
     return $container;
   }
 

--- a/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
@@ -29,7 +29,7 @@ class NewsletterOptionFieldEntity {
   public const NAME_SEGMENT = 'segment';
   public const NAME_SEND_TO = 'sendTo';
   public const NAME_TIME_OF_DAY = 'timeOfDay';
-  public const NAME_WEK_DAY = 'weekDay';
+  public const NAME_WEEK_DAY = 'weekDay';
 
   use AutoincrementedIdTrait;
   use CreatedAtTrait;

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -168,9 +168,16 @@ class SubscriberEntity {
    */
   private $subscriberCustomFields;
 
+  /**
+   * @ORM\OneToMany(targetEntity="MailPoet\Entities\SubscriberTagEntity", mappedBy="subscriber", orphanRemoval=true)
+   * @var Collection<int, SubscriberTagEntity>
+   */
+  private $subscriberTags;
+
   public function __construct() {
     $this->subscriberSegments = new ArrayCollection();
     $this->subscriberCustomFields = new ArrayCollection();
+    $this->subscriberTags = new ArrayCollection();
   }
 
   /**
@@ -444,6 +451,13 @@ class SubscriberEntity {
    */
   public function getSubscriberCustomFields() {
     return $this->subscriberCustomFields;
+  }
+
+  /**
+   * @return Collection<int, SubscriberTagEntity>
+   */
+  public function getSubscriberTags() {
+    return $this->subscriberTags;
   }
 
   /**

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -10,6 +10,7 @@ use MailPoet\Doctrine\EntityTraits\UpdatedAtTrait;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\Common\Collections\ArrayCollection;
 use MailPoetVendor\Doctrine\Common\Collections\Collection;
+use MailPoetVendor\Doctrine\Common\Collections\Criteria;
 use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
 use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
 
@@ -458,6 +459,13 @@ class SubscriberEntity {
    */
   public function getSubscriberTags() {
     return $this->subscriberTags;
+  }
+
+  public function getSubscriberTag(TagEntity $tag): ?SubscriberTagEntity {
+    $criteria = Criteria::create()
+      ->where(Criteria::expr()->eq('tag', $tag))
+      ->setMaxResults(1);
+    return $this->getSubscriberTags()->matching($criteria)->first() ?: null;
   }
 
   /**

--- a/mailpoet/lib/Entities/SubscriberTagEntity.php
+++ b/mailpoet/lib/Entities/SubscriberTagEntity.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+use MailPoet\Doctrine\EntityTraits\AutoincrementedIdTrait;
+use MailPoet\Doctrine\EntityTraits\CreatedAtTrait;
+use MailPoet\Doctrine\EntityTraits\SafeToOneAssociationLoadTrait;
+use MailPoet\Doctrine\EntityTraits\UpdatedAtTrait;
+use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="subscriber_tag")
+ */
+class SubscriberTagEntity {
+  use AutoincrementedIdTrait;
+  use CreatedAtTrait;
+  use UpdatedAtTrait;
+  use SafeToOneAssociationLoadTrait;
+
+  /**
+   * @ORM\ManyToOne(targetEntity="MailPoet\Entities\TagEntity")
+   * @var TagEntity|null
+   */
+  private $tag;
+
+  /**
+   * @ORM\ManyToOne(targetEntity="MailPoet\Entities\SubscriberEntity", inversedBy="subscriberTags")
+   * @var SubscriberEntity|null
+   */
+  private $subscriber;
+
+  public function __construct(
+    TagEntity $tag,
+    SubscriberEntity $subscriber
+  ) {
+    $this->tag = $tag;
+    $this->subscriber = $subscriber;
+  }
+
+  public function getTag(): ?TagEntity {
+    $this->safelyLoadToOneAssociation('tag');
+    return $this->tag;
+  }
+
+  public function getSubscriber(): ?SubscriberEntity {
+    $this->safelyLoadToOneAssociation('subscriber');
+    return $this->subscriber;
+  }
+}

--- a/mailpoet/lib/Entities/TagEntity.php
+++ b/mailpoet/lib/Entities/TagEntity.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+use MailPoet\Doctrine\EntityTraits\AutoincrementedIdTrait;
+use MailPoet\Doctrine\EntityTraits\CreatedAtTrait;
+use MailPoet\Doctrine\EntityTraits\UpdatedAtTrait;
+use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
+use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="tags")
+ */
+class TagEntity {
+  use AutoincrementedIdTrait;
+  use CreatedAtTrait;
+  use UpdatedAtTrait;
+
+  /**
+   * @ORM\Column(type="string")
+   * @Assert\NotBlank()
+   * @var string
+   */
+  private $name;
+
+  /**
+   * @ORM\Column(type="string")
+   * @var string
+   */
+  private $description;
+
+  public function __construct(
+    string $name,
+    string $description = ''
+  ) {
+    $this->name = $name;
+    $this->description = $description;
+  }
+
+  public function getName(): string {
+    return $this->name;
+  }
+
+  public function setName(string $name): void {
+    $this->name = $name;
+  }
+
+  public function getDescription(): string {
+    return $this->description;
+  }
+
+  public function setDescription(string $description): void {
+    $this->description = $description;
+  }
+}

--- a/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
@@ -137,7 +137,7 @@ class PostNotificationScheduler {
     $timeOfDayOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_TIME_OF_DAY);
     $hour = $timeOfDayOption ? (int)$timeOfDayOption->getValue() / self::SECONDS_IN_HOUR : null;
 
-    $weekDayOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_WEK_DAY);
+    $weekDayOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_WEEK_DAY);
     $weekDay = $weekDayOption ? $weekDayOption->getValue() : null;
 
     $monthDayOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_MONTH_DAY);

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -298,10 +298,7 @@ class SubscriberSaveController {
   private function updateTags(array $data, SubscriberEntity $subscriber): void {
     foreach ($subscriber->getSubscriberTags() as $subscriberTag) {
       $tag = $subscriberTag->getTag();
-      if (!$tag) {
-        continue;
-      }
-      if (!in_array($tag->getName(), $data['tags'], true)) {
+      if (!$tag || !in_array($tag->getName(), $data['tags'], true)) {
         $subscriber->getSubscriberTags()->removeElement($subscriberTag);
       }
     }

--- a/mailpoet/lib/Subscribers/SubscriberTagRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberTagRepository.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Doctrine\Repository;
+use MailPoet\Entities\SubscriberTagEntity;
+
+/**
+ * @extends Repository<SubscriberTagEntity>
+ */
+class SubscriberTagRepository extends Repository {
+  protected function getEntityClassName() {
+    return SubscriberTagEntity::class;
+  }
+}

--- a/mailpoet/lib/Tags/TagRepository.php
+++ b/mailpoet/lib/Tags/TagRepository.php
@@ -12,4 +12,24 @@ class TagRepository extends Repository {
   protected function getEntityClassName() {
     return TagEntity::class;
   }
+
+  public function createOrUpdate(array $data = []): TagEntity {
+    if (!$data['name']) {
+      throw new \InvalidArgumentException('Missing name');
+    }
+    $tag = $this->findOneBy([
+      'name' => $data['name'],
+    ]);
+    if (!$tag) {
+      $tag = new TagEntity($data['name']);
+      $this->persist($tag);
+    }
+
+    try {
+      $this->flush();
+    } catch (\Exception $e) {
+      throw new \RuntimeException("Error when saving tag " . $data['name']);
+    }
+    return $tag;
+  }
 }

--- a/mailpoet/lib/Tags/TagRepository.php
+++ b/mailpoet/lib/Tags/TagRepository.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags;
+
+use MailPoet\Doctrine\Repository;
+use MailPoet\Entities\TagEntity;
+
+/**
+ * @extends Repository<TagEntity>
+ */
+class TagRepository extends Repository {
+  protected function getEntityClassName() {
+    return TagEntity::class;
+  }
+}

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -6,6 +6,8 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\SubscriberTagEntity;
+use MailPoet\Entities\TagEntity;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use DateTimeInterface;
 
@@ -17,12 +19,16 @@ class Subscriber {
   /** @var SegmentEntity[] */
   private $segments;
 
+  /** @var TagEntity[] */
+  private $tags;
+
   public function __construct() {
     $this->data = [
       'email' => bin2hex(random_bytes(7)) . '@example.com', // phpcs:ignore
       'status' => SubscriberEntity::STATUS_SUBSCRIBED,
     ];
     $this->segments = [];
+    $this->tags = [];
   }
 
   /**
@@ -114,6 +120,18 @@ class Subscriber {
   }
 
   /**
+   * @param TagEntity[] $tags
+   * @return $this
+   */
+  public function withTags(array $tags) {
+    $this->tags = [];
+    foreach ($tags as $tag) {
+      $this->tags[$tag->getId()] = $tag;
+    }
+    return $this;
+  }
+
+  /**
    * @param DateTimeInterface $createdAt
    * @return $this
    */
@@ -145,6 +163,12 @@ class Subscriber {
       $subscriberSegment = new SubscriberSegmentEntity($segment, $subscriber, 'subscribed');
       $subscriber->getSubscriberSegments()->add($subscriberSegment);
       $entityManager->persist($subscriberSegment);
+    }
+
+    foreach ($this->tags as $tag) {
+      $subscriberTag = new SubscriberTagEntity($tag, $subscriber);
+      $subscriber->getSubscriberTags()->add($subscriberTag);
+      $entityManager->persist($subscriberTag);
     }
 
     $entityManager->flush();

--- a/mailpoet/tests/DataFactories/Tag.php
+++ b/mailpoet/tests/DataFactories/Tag.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Tags\TagRepository;
+
+class Tag {
+  /** @var array */
+  private $data;
+
+  /** @var TagRepository */
+  private $tagRepository;
+
+  public function __construct() {
+    $this->tagRepository = ContainerWrapper::getInstance()->get(TagRepository::class);
+    $this->data = [
+      'name' => 'Tag' . bin2hex(random_bytes(7)),
+    ];
+  }
+
+  /**
+   * @return $this
+   */
+  public function withName(string $name) {
+    return $this->update('name', $name);
+  }
+
+  public function create(): TagEntity {
+    $tag = new TagEntity($this->data['name']);
+    $this->tagRepository->persist($tag);
+    $this->tagRepository->flush();
+    return $tag;
+  }
+
+  /**
+   * @return $this
+   */
+  private function update(string $item, $value) {
+    $data = $this->data;
+    $data[$item] = $value;
+    $new = clone $this;
+    $new->data = $data;
+    return $new;
+  }
+}

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Codeception\Util\Locator;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
@@ -192,15 +193,21 @@ class ManageSubscribersCest {
     $i->fillField(['name' => 'first_name'], 'EditedNew');
     $i->fillField(['name' => 'last_name'], 'EditedGlobalUser');
     $i->selectOption('[data-automation-id="subscriber-status"]', 'Unsubscribed');
+    // we cannot use data-automation attribute because this input is based on guttenberg component
+    $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag,'); // the comma separates the tag
     $i->click('Save');
     $i->waitForElementVisible('[data-automation-id="listing_item_1"]');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
     $i->waitForText('Subscriber');
     $i->seeOptionIsSelected('[data-automation-id="subscriber-status"]', 'Unsubscribed');
     $i->see('Unsubscribed at', $unsubscribedMessage);
+    // tag is visible
+    $i->see('My tag');
     $i->selectOptionInSelect2('Cooking');
     $i->selectOptionInSelect2('Camping');
     $i->selectOption('[data-automation-id="subscriber-status"]', 'Subscribed');
+    // remove tag
+    $i->click(Locator::firstElement('.mailpoet-form-field-tags button[aria-label="Remove item"]'));
     $i->click('Save');
     $i->waitForElementVisible('[data-automation-id="listing_item_1"]');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
@@ -208,6 +215,9 @@ class ManageSubscribersCest {
     $i->seeSelectedInSelect2('Cooking');
     $i->seeSelectedInSelect2('Camping');
     $i->seeOptionIsSelected('[data-automation-id="subscriber-status"]', 'Subscribed');
+    // check that tag is removed
+    $i->seeInField('.mailpoet-form-field-tags input[type="text"]', '');
+    $i->dontSee('My tag');
   }
 
   public function inactiveSubscribers(\AcceptanceTester $i) {

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\JSON\ResponseBuilders;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\SubscriberTagEntity;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Subscribers\Source;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Test\DataFactories\Tag as TagFactory;
+
+class SubscribersResponseBuilderTest extends \MailPoetTest {
+
+  /** @var SubscribersResponseBuilder */
+  private $responseBuilder;
+
+  /** @var SegmentEntity */
+  private $segment;
+
+  /** @var \MailPoet\Entities\TagEntity */
+  private $tag;
+
+  /** @var SubscriberEntity */
+  private $subscriber1;
+
+  /** @var SubscriberEntity */
+  private $subscriber2;
+
+  public function _before() {
+    parent::_before();
+    $this->responseBuilder = $this->diContainer->get(SubscribersResponseBuilder::class);
+
+    $this->segment = (new SegmentFactory())
+      ->withName('My Segment')
+      ->withType(SegmentEntity::TYPE_DEFAULT)
+      ->create();
+
+    $this->tag = (new TagFactory())
+      ->withName('My Tag')
+      ->create();
+
+    $this->subscriber1 = (new SubscriberFactory())
+      ->withFirstName('First')
+      ->withLastName('Last')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withIsWooCommerceUser()
+      ->withSource(Source::FORM)
+      ->withWpUserId(1)
+      ->withSegments([$this->segment])
+      ->withTags([$this->tag])
+      ->create();
+
+    $this->subscriber2 = (new SubscriberFactory())
+      ->withFirstName('Second')
+      ->withLastName('Last')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withIsWooCommerceUser()
+      ->withWpUserId(2)
+      ->withSegments([$this->segment])
+      ->create();
+  }
+
+  public function testItBuildsResponse(): void {
+    $subscriber = $this->subscriber1;
+    $response = $this->responseBuilder->build($subscriber);
+
+    $this->assertEquals($subscriber->getId(), $response['id']);
+    $this->assertEquals($subscriber->getFirstName(), $response['first_name']);
+    $this->assertEquals($subscriber->getLastName(), $response['last_name']);
+    $this->assertEquals($subscriber->getEmail(), $response['email']);
+    $this->assertEquals($subscriber->getWpUserId(), $response['wp_user_id']);
+    $this->assertEquals($subscriber->getIsWoocommerceUser(), $response['is_woocommerce_user']);
+    $this->assertEquals($subscriber->getStatus(), $response['status']);
+    $this->assertEquals($subscriber->getSource(), $response['source']);
+    $this->assertArrayHasKey('created_at', $response);
+    $this->assertArrayHasKey('updated_at', $response);
+    $this->assertArrayHasKey('deleted_at', $response);
+    $this->assertArrayHasKey('subscribed_ip', $response);
+    $this->assertArrayHasKey('confirmed_ip', $response);
+    $this->assertArrayHasKey('confirmed_at', $response);
+    $this->assertArrayHasKey('last_subscribed_at', $response);
+    $this->assertArrayHasKey('unconfirmed_data', $response);
+    $this->assertArrayHasKey('count_confirmations', $response);
+    $this->assertArrayHasKey('unsubscribe_token', $response);
+    $this->assertArrayHasKey('link_token', $response);
+    // check subscriptions
+    $this->assertCount(0, $response['unsubscribes']);
+    $this->checkSubscription($response, $subscriber);
+    // check tags
+    $tag = reset($response['tags']);
+    $this->assertCount(1, $response['tags']);
+    $this->assertEquals($subscriber->getId(), $tag['subscriber_id']);
+    $this->assertEquals($this->tag->getId(), $tag['tag_id']);
+    $this->assertEquals($this->tag->getName(), $tag['name']);
+    $this->assertArrayHasKey('created_at', $tag);
+    $this->assertArrayHasKey('updated_at', $tag);
+  }
+
+  public function testItBuildsListingResponse(): void {
+//    'email' => $subscriber->getEmail(),
+//    'first_name' => $subscriber->getFirstName(),
+//    'last_name' => $subscriber->getLastName(),
+//    'subscriptions' => $this->buildSubscriptions($subscriber),
+//    'status' => $subscriber->getStatus(),
+//    'wp_user_id' => $subscriber->getWpUserId(),
+//    'is_woocommerce_user' => $subscriber->getIsWoocommerceUser(),
+    $subscribers = [
+      $this->subscriber1,
+      $this->subscriber2,
+    ];
+    $response = $this->responseBuilder->buildForListing($subscribers);
+
+    $this->assertCount(2, $response);
+    foreach ($subscribers as $key => $subscriber) {
+      $item = $response[$key];
+      $this->assertEquals($subscriber->getId(), $item['id']);
+      $this->assertEquals($subscriber->getFirstName(), $item['first_name']);
+      $this->assertEquals($subscriber->getLastName(), $item['last_name']);
+      $this->assertEquals($subscriber->getEmail(), $item['email']);
+      $this->assertEquals($subscriber->getWpUserId(), $item['wp_user_id']);
+      $this->assertEquals($subscriber->getIsWoocommerceUser(), $item['is_woocommerce_user']);
+      $this->assertEquals($subscriber->getStatus(), $item['status']);
+      $this->assertArrayHasKey('created_at', $item);
+      $this->assertArrayHasKey('count_confirmations', $item);
+      $this->assertArrayHasKey('engagement_score', $item);
+      // check subscriptions
+      $this->checkSubscription($item, $subscriber);
+    }
+  }
+
+  private function checkSubscription(array $responseItem, SubscriberEntity $subscriber): void {
+    $this->assertCount(1, $responseItem['subscriptions']);
+    $subscription = reset($responseItem['subscriptions']);
+    $this->assertEquals($subscriber->getId(), $subscription['subscriber_id']);
+    $this->assertEquals($this->segment->getId(), $subscription['segment_id']);
+    $this->assertEquals(SubscriberEntity::STATUS_SUBSCRIBED, $subscription['status']);
+    $this->assertArrayHasKey('created_at', $subscription);
+    $this->assertArrayHasKey('updated_at', $subscription);
+  }
+
+  protected function _after() {
+    $this->truncateEntity(SegmentEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SubscriberSegmentEntity::class);
+    $this->truncateEntity(TagEntity::class);
+    $this->truncateEntity(SubscriberTagEntity::class);
+  }
+
+
+}

--- a/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
@@ -150,7 +150,7 @@ class PostNotificationTest extends \MailPoetTest {
       NewsletterOptionFieldEntity::NAME_INTERVAL_TYPE => PostNotificationScheduler::INTERVAL_DAILY,
       NewsletterOptionFieldEntity::NAME_MONTH_DAY => null,
       NewsletterOptionFieldEntity::NAME_NTH_WEEK_DAY => null,
-      NewsletterOptionFieldEntity::NAME_WEK_DAY => null,
+      NewsletterOptionFieldEntity::NAME_WEEK_DAY => null,
       NewsletterOptionFieldEntity::NAME_TIME_OF_DAY => 50400, // 2 p.m.
       NewsletterOptionFieldEntity::NAME_SCHEDULE => '* * * * *',
     ]);
@@ -172,7 +172,7 @@ class PostNotificationTest extends \MailPoetTest {
       NewsletterOptionFieldEntity::NAME_INTERVAL_TYPE => PostNotificationScheduler::INTERVAL_WEEKLY,
       NewsletterOptionFieldEntity::NAME_MONTH_DAY => null,
       NewsletterOptionFieldEntity::NAME_NTH_WEEK_DAY => null,
-      NewsletterOptionFieldEntity::NAME_WEK_DAY => Carbon::TUESDAY,
+      NewsletterOptionFieldEntity::NAME_WEEK_DAY => Carbon::TUESDAY,
       NewsletterOptionFieldEntity::NAME_TIME_OF_DAY => 50400, // 2 p.m.
       NewsletterOptionFieldEntity::NAME_SCHEDULE => '* * * * *',
     ]);
@@ -194,7 +194,7 @@ class PostNotificationTest extends \MailPoetTest {
       NewsletterOptionFieldEntity::NAME_INTERVAL_TYPE => PostNotificationScheduler::INTERVAL_MONTHLY,
       NewsletterOptionFieldEntity::NAME_MONTH_DAY => 19,
       NewsletterOptionFieldEntity::NAME_NTH_WEEK_DAY => null,
-      NewsletterOptionFieldEntity::NAME_WEK_DAY => null,
+      NewsletterOptionFieldEntity::NAME_WEEK_DAY => null,
       NewsletterOptionFieldEntity::NAME_TIME_OF_DAY => 50400, // 2 p.m.
       NewsletterOptionFieldEntity::NAME_SCHEDULE => '* * * * *',
     ]);
@@ -215,7 +215,7 @@ class PostNotificationTest extends \MailPoetTest {
       NewsletterOptionFieldEntity::NAME_INTERVAL_TYPE => PostNotificationScheduler::INTERVAL_NTHWEEKDAY,
       NewsletterOptionFieldEntity::NAME_MONTH_DAY => null,
       NewsletterOptionFieldEntity::NAME_NTH_WEEK_DAY => 'L', // L = last
-      NewsletterOptionFieldEntity::NAME_WEK_DAY => Carbon::SATURDAY,
+      NewsletterOptionFieldEntity::NAME_WEEK_DAY => Carbon::SATURDAY,
       NewsletterOptionFieldEntity::NAME_TIME_OF_DAY => 50400, // 2 p.m.
       NewsletterOptionFieldEntity::NAME_SCHEDULE => '* * * * *',
     ]);
@@ -236,7 +236,7 @@ class PostNotificationTest extends \MailPoetTest {
       NewsletterOptionFieldEntity::NAME_INTERVAL_TYPE => PostNotificationScheduler::INTERVAL_IMMEDIATELY,
       NewsletterOptionFieldEntity::NAME_MONTH_DAY => null,
       NewsletterOptionFieldEntity::NAME_NTH_WEEK_DAY => null,
-      NewsletterOptionFieldEntity::NAME_WEK_DAY => null,
+      NewsletterOptionFieldEntity::NAME_WEEK_DAY => null,
       NewsletterOptionFieldEntity::NAME_TIME_OF_DAY => null,
       NewsletterOptionFieldEntity::NAME_SCHEDULE => '* * * * *',
     ]);

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -44,6 +44,10 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
       'confirmed_ip' => '192.168.1.32',
       'subscribed_ip' => '192.168.1.16',
       'wp_user_id' => 7,
+      'tags' => [
+        'First',
+        'Second',
+      ]
     ];
 
     $subscriber = $this->saveController->save($data);
@@ -62,6 +66,7 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     expect($subscriber->getLastSubscribedAt())->notNull();
     expect($subscriber->getSegments())->count(2);
     expect($subscriber->getSubscriberSegments())->count(2);
+    expect($subscriber->getSubscriberTags())->count(2);
   }
 
   public function testItCanUpdateASubscriber(): void {
@@ -75,6 +80,9 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
       'segments' => [
         $segmentOne->getId(),
       ],
+      'tags' => [
+        'First',
+      ],
     ];
 
     $this->entityManager->clear();
@@ -86,6 +94,7 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     expect($subscriber->getLastSubscribedAt())->notNull();
     expect($subscriber->getSegments())->count(1);
     expect($subscriber->getSubscriberSegments())->count(1);
+    expect($subscriber->getSubscriberTags())->count(1);
   }
 
   public function testItThrowsExceptionWhenUpdatingSubscriberEmailIfNotUnique(): void {

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -6,6 +6,7 @@ use MailPoet\ConflictException;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -95,6 +96,23 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     expect($subscriber->getSegments())->count(1);
     expect($subscriber->getSubscriberSegments())->count(1);
     expect($subscriber->getSubscriberTags())->count(1);
+    // Check exact tag name
+    $tagNames = array_values(array_map(function (SubscriberTagEntity $subscriberTag): string {
+      return ($tag = $subscriberTag->getTag()) ? $tag->getName() : '';
+    }, $subscriber->getSubscriberTags()->toArray()));
+    expect($data['tags'])->equals($tagNames);
+
+    // Test updating tags
+    $data['tags'] = [
+      'Second',
+      'Third',
+    ];
+    $subscriber = $this->saveController->save($data);
+    expect($subscriber->getSubscriberTags())->count(2);
+    $tagNames = array_values(array_map(function (SubscriberTagEntity $subscriberTag): string {
+      return ($tag = $subscriberTag->getTag()) ? $tag->getName() : '';
+    }, $subscriber->getSubscriberTags()->toArray()));
+    expect($data['tags'])->equals($tagNames);
   }
 
   public function testItThrowsExceptionWhenUpdatingSubscriberEmailIfNotUnique(): void {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -41,11 +41,6 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
 </div>
 <% endblock %>
 
-<!-- stylesheets -->
-<%= stylesheet(
-  'mailpoet-plugin.css'
-)%>
-
 <%= do_action('mailpoet_styles_admin_after') %>
 
 <% block after_css %><% endblock %>

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -8,6 +8,7 @@
     var mailpoet_listing_per_page = <%= items_per_page %>;
     var mailpoet_segments = <%= json_encode(segments) %>;
     var mailpoet_custom_fields = <%= json_encode(custom_fields) %>;
+    var mailpoet_tags = <%= json_encode(tags) %>;
     var mailpoet_month_names = <%= json_encode(month_names) %>;
     var mailpoet_date_formats = <%= json_encode(date_formats) %>;
     var mailpoet_premium_active = <%= json_encode(premium_plugin_active) %>;

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -172,6 +172,8 @@
 
     'subscribersCountWereCalculatedWithMinutesAgo': __('Lists and Segments subscribers counts were calculated <abbr>{$mins} minutes ago</abbr>'),
     'recalculateNow': __('Recalculate now'),
+    'tags': __('Tags'),
+    'addNewTag': __('Add new tag'),
   }) %>
 <% endblock %>
 


### PR DESCRIPTION
This is the first pull request to add a new tag management feature.

**How to test**
1. Create/Edit a subscriber in the administration
2. Add/Remove tags
3. Check that tags are stored properly

Note: This PR contains a DB Migration. You need to run it before testing (e.g. deactivate and activate the plugin).

[MAILPOET-4440]

[MAILPOET-4440]: https://mailpoet.atlassian.net/browse/MAILPOET-4440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ