### PR TITLE
Fix acceptance test for transactional emails [MAILPOET-4455]

### DIFF
--- a/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
+++ b/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
@@ -13,7 +13,7 @@ class TransactionalEmailsCest {
     $settings->withMisconfiguredSendingMethodSmtp();
     $settings->withTransactionEmailsViaMailPoet();
     $i->wantTo('Create a new WP user and make sure transactional email were received');
-    $i->cli(['user', 'create', 'john_doe', 'john_doe@example.com', '--send-email']);
+    $i->cli(['user', 'create', 'johndoe', 'john_doe@example.com', '--send-email']);
     $i->amOnMailboxAppPage();
     $i->checkEmailWasReceived('New User Registration');
     $i->checkEmailWasReceived('Login Details');


### PR DESCRIPTION
Fixes error: Error: Usernames can only contain lowercase letters (a-z) and numbers.

[MAILPOET-4455]


[MAILPOET-4455]: https://mailpoet.atlassian.net/browse/MAILPOET-4455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ