### PR TITLE
Add robots meta tag with noindex/nofollow to preview newsletter page [MAILPOET-4263]

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -96,6 +96,7 @@ class Renderer {
       $content = $this->addMailpoetLogoContentBlock($content, $styles);
     }
 
+    $metaRobots = $preview ? '<meta name="robots" content="noindex, follow" />' : '';
     $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingTask);
     $renderedBody = $this->renderBody($newsletter, $content);
     $renderedStyles = $this->renderStyles($styles);
@@ -104,6 +105,7 @@ class Renderer {
     $template = $this->injectContentIntoTemplate(
       (string)file_get_contents(dirname(__FILE__) . '/' . self::NEWSLETTER_TEMPLATE),
       [
+        $metaRobots,
         htmlspecialchars($subject ?: $newsletter->getSubject()),
         $renderedStyles,
         $customFontsLinks,

--- a/mailpoet/lib/Newsletter/Renderer/Template.html
+++ b/mailpoet/lib/Newsletter/Renderer/Template.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="format-detection" content="telephone=no">
+    {{newsletter_meta_robots}}
     <title>{{newsletter_subject}}</title>
     <style type="text/css">
         html, body {


### PR DESCRIPTION
This PR adds a `<meta name="robots" content="noindex, follow" />` tag to the newsletter page when in preview mode to prevent it from being indexed by search engines.

**How to test this PR**
- When editing a newsletter, click "Preview" and then "Open in new tab". Check the HTML and verify that it contains the above mentioned tag.
- Send a newsletter and check that its HTML do not contain the above mentioned tag.

[MAILPOET-4263]

[MAILPOET-4263]: https://mailpoet.atlassian.net/browse/MAILPOET-4263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ