### PR TITLE
Fix: don't run the code to enable third party libraries for new installs [MAILPOET-4285]

### DIFF
--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -314,12 +314,6 @@ class Populator {
     }
     // reset mailer log
     MailerLog::resetMailerLog();
-
-    $thirdPartyScriptsEnabled = $this->settings->get('3rd_party_libs');
-    if (is_null($thirdPartyScriptsEnabled)) {
-      // keep loading 3rd party libraries for existing users so the functionality is not broken
-      $this->settings->set('3rd_party_libs.enabled', '1');
-    }
   }
 
   private function createDefaultUsersFlags() {


### PR DESCRIPTION
This PR fixes the logic of the code that enables third-party libraries by default. It was meant to enable those libraries only for existing installs when the code was introduced in cfae75360193af457d66fb64c806ef30048a5c63 to avoid breaking functionality. But due to a bug, it was also enabling those libraries for new installs.

To fix this issue, this PR moves the code to the Migrator class and makes sure it is only executed for existing installs and only once when doing a version update by using a version check.

**How to test this PR**
- Check that third-party libraries are not enabled for new installs if the user skips the onboarding wizard (see screencast in the Jira ticket).
- Check that third-party libraries are enabled for installs updating from a version before the setting existed (the easiest way to test this is probably to run an older version of MailPoet, delete the setting `3rd_party_libs`, and then perform an update).

[MAILPOET-4285]

[MAILPOET-4285]: https://mailpoet.atlassian.net/browse/MAILPOET-4285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ