### PR TITLE
Bundle automation editor styles for now [MAILPOET-4451]

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-automation-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-editor.scss
@@ -1,3 +1,7 @@
+@import '../../../node_modules/@wordpress/components/build-style/style';
+@import '../../../node_modules/@wordpress/interface/build-style/style';
+@import '../../../node_modules/@wordpress/edit-site/build-style/style';
+@import '../../../node_modules/@wordpress/block-editor/build-style/style'; // for inserter styles
 @import './components-automation-editor/add-step-button';
 @import './components-automation-editor/empty-workflow';
 @import './components-automation-editor/separator';

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -30,11 +30,6 @@ class AutomationEditor {
   }
 
   public function render() {
-    // Gutenberg styles
-    $this->wp->wpEnqueueStyle('wp-edit-site');
-    $this->wp->wpEnqueueStyle('wp-format-library');
-    $this->wp->wpEnqueueMedia();
-
     $id = isset($_GET['id']) ? (int)$_GET['id'] : null;
 
     $workflow = $id ? $this->workflowStorage->getWorkflow($id) : null;

--- a/mailpoet/package-lock.json
+++ b/mailpoet/package-lock.json
@@ -23,6 +23,7 @@
         "@wordpress/data": "^6.4.1",
         "@wordpress/data-controls": "^2.9.0",
         "@wordpress/edit-post": "^6.1.1",
+        "@wordpress/edit-site": "^4.1.0",
         "@wordpress/editor": "^12.3.1",
         "@wordpress/element": "^4.2.1",
         "@wordpress/escape-html": "^2.4.1",
@@ -14045,6 +14046,83 @@
         "react-dom": "^17.0.0"
       }
     },
+    "node_modules/@wordpress/edit-site": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-site/-/edit-site-4.1.0.tgz",
+      "integrity": "sha512-PSZKt4PcZeNHcsQCJL/kwHhtPR3oBEkt+nrXt5kQMYRQzMiSo/8rcxIlT0RvuqM3ieGlPY8iFEWIBHDEUD8zhw==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.4.0",
+        "@wordpress/api-fetch": "^6.1.0",
+        "@wordpress/block-editor": "^8.3.0",
+        "@wordpress/block-library": "^7.1.0",
+        "@wordpress/blocks": "^11.3.0",
+        "@wordpress/components": "^19.6.0",
+        "@wordpress/compose": "^5.2.0",
+        "@wordpress/core-data": "^4.2.0",
+        "@wordpress/data": "^6.4.0",
+        "@wordpress/deprecated": "^3.4.0",
+        "@wordpress/editor": "^12.3.0",
+        "@wordpress/element": "^4.2.0",
+        "@wordpress/hooks": "^3.4.0",
+        "@wordpress/html-entities": "^3.4.0",
+        "@wordpress/i18n": "^4.4.0",
+        "@wordpress/icons": "^8.0.0",
+        "@wordpress/interface": "^4.3.0",
+        "@wordpress/keyboard-shortcuts": "^3.2.0",
+        "@wordpress/keycodes": "^3.4.0",
+        "@wordpress/media-utils": "^3.2.0",
+        "@wordpress/notices": "^3.4.0",
+        "@wordpress/plugins": "^4.2.0",
+        "@wordpress/preferences": "^1.0.0-prerelease",
+        "@wordpress/reusable-blocks": "^3.2.0",
+        "@wordpress/style-engine": "^0.3.0",
+        "@wordpress/url": "^3.5.0",
+        "@wordpress/viewport": "^4.2.0",
+        "classnames": "^2.3.1",
+        "downloadjs": "^1.4.7",
+        "history": "^5.1.0",
+        "lodash": "^4.17.21",
+        "react-autosize-textarea": "^7.1.0",
+        "rememo": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/edit-site/node_modules/@wordpress/preferences": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-1.3.0.tgz",
+      "integrity": "sha512-2ACfz6LkQY2oAcEgTVpkfpasywo/nSmN5jbpT2gNoF/W/RCFBso+VDyuLsfpJ1INbbq+6pPKLccLBWYAvwuFdA==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.7.0",
+        "@wordpress/components": "^19.9.0",
+        "@wordpress/data": "^6.7.0",
+        "@wordpress/i18n": "^4.7.0",
+        "@wordpress/icons": "^8.3.0",
+        "classnames": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
+    },
+    "node_modules/@wordpress/edit-site/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/@wordpress/editor": {
       "version": "12.3.1",
       "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-12.3.1.tgz",
@@ -20730,6 +20808,11 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
+    },
+    "node_modules/downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "node_modules/downshift": {
       "version": "6.1.3",
@@ -53338,6 +53421,71 @@
         }
       }
     },
+    "@wordpress/edit-site": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-site/-/edit-site-4.1.0.tgz",
+      "integrity": "sha512-PSZKt4PcZeNHcsQCJL/kwHhtPR3oBEkt+nrXt5kQMYRQzMiSo/8rcxIlT0RvuqM3ieGlPY8iFEWIBHDEUD8zhw==",
+      "requires": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.4.0",
+        "@wordpress/api-fetch": "^6.1.0",
+        "@wordpress/block-editor": "^8.3.0",
+        "@wordpress/block-library": "^7.1.0",
+        "@wordpress/blocks": "^11.3.0",
+        "@wordpress/components": "^19.6.0",
+        "@wordpress/compose": "^5.2.0",
+        "@wordpress/core-data": "^4.2.0",
+        "@wordpress/data": "^6.4.0",
+        "@wordpress/deprecated": "^3.4.0",
+        "@wordpress/editor": "^12.3.0",
+        "@wordpress/element": "^4.2.0",
+        "@wordpress/hooks": "^3.4.0",
+        "@wordpress/html-entities": "^3.4.0",
+        "@wordpress/i18n": "^4.4.0",
+        "@wordpress/icons": "^8.0.0",
+        "@wordpress/interface": "^4.3.0",
+        "@wordpress/keyboard-shortcuts": "^3.2.0",
+        "@wordpress/keycodes": "^3.4.0",
+        "@wordpress/media-utils": "^3.2.0",
+        "@wordpress/notices": "^3.4.0",
+        "@wordpress/plugins": "^4.2.0",
+        "@wordpress/preferences": "^1.0.0-prerelease",
+        "@wordpress/reusable-blocks": "^3.2.0",
+        "@wordpress/style-engine": "^0.3.0",
+        "@wordpress/url": "^3.5.0",
+        "@wordpress/viewport": "^4.2.0",
+        "classnames": "^2.3.1",
+        "downloadjs": "^1.4.7",
+        "history": "^5.1.0",
+        "lodash": "^4.17.21",
+        "react-autosize-textarea": "^7.1.0",
+        "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/preferences": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-1.3.0.tgz",
+          "integrity": "sha512-2ACfz6LkQY2oAcEgTVpkfpasywo/nSmN5jbpT2gNoF/W/RCFBso+VDyuLsfpJ1INbbq+6pPKLccLBWYAvwuFdA==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/a11y": "^3.7.0",
+            "@wordpress/components": "^19.9.0",
+            "@wordpress/data": "^6.7.0",
+            "@wordpress/i18n": "^4.7.0",
+            "@wordpress/icons": "^8.3.0",
+            "classnames": "^2.3.1"
+          }
+        },
+        "history": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+          "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+          "requires": {
+            "@babel/runtime": "^7.7.6"
+          }
+        }
+      }
+    },
     "@wordpress/editor": {
       "version": "12.3.1",
       "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-12.3.1.tgz",
@@ -58529,6 +58677,11 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
+    },
+    "downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "downshift": {
       "version": "6.1.3",

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -53,6 +53,7 @@
     "@wordpress/data": "^6.4.1",
     "@wordpress/data-controls": "^2.9.0",
     "@wordpress/edit-post": "^6.1.1",
+    "@wordpress/edit-site": "^4.1.0",
     "@wordpress/editor": "^12.3.1",
     "@wordpress/element": "^4.2.1",
     "@wordpress/escape-html": "^2.4.1",


### PR DESCRIPTION
We need to use older @wordpress/edit-site package (version 4.1.0)
to be compatible with the current @wordpress/edit-post (version 6.1.1).

[MAILPOET-4451]

[MAILPOET-4451]: https://mailpoet.atlassian.net/browse/MAILPOET-4451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ