### PR TITLE
Add missing re_engagement type to newsletter meta info

### DIFF
--- a/mailpoet/lib/Mailer/MetaInfo.php
+++ b/mailpoet/lib/Mailer/MetaInfo.php
@@ -36,7 +36,7 @@ class MetaInfo {
   }
 
   public function getNewsletterMetaInfo($newsletter, Subscriber $subscriber) {
-    $type = 'unknown';
+    $type = $newsletter->type ?? 'unknown';
     switch ($newsletter->type) {
       case Newsletter::TYPE_AUTOMATIC:
         $group = isset($newsletter->options['group']) ? $newsletter->options['group'] : 'unknown';

--- a/mailpoet/lib/Models/Newsletter.php
+++ b/mailpoet/lib/Models/Newsletter.php
@@ -50,6 +50,7 @@ class Newsletter extends Model {
   const TYPE_NOTIFICATION = NewsletterEntity::TYPE_NOTIFICATION;
   const TYPE_NOTIFICATION_HISTORY = NewsletterEntity::TYPE_NOTIFICATION_HISTORY;
   const TYPE_WC_TRANSACTIONAL_EMAIL = NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL;
+  const TYPE_RE_ENGAGEMENT = NewsletterEntity::TYPE_RE_ENGAGEMENT;
   // standard newsletters
   const STATUS_DRAFT = NewsletterEntity::STATUS_DRAFT;
   const STATUS_SCHEDULED = NewsletterEntity::STATUS_SCHEDULED;

--- a/mailpoet/tests/integration/Mailer/MetaInfoTest.php
+++ b/mailpoet/tests/integration/Mailer/MetaInfoTest.php
@@ -182,6 +182,63 @@ class MetaInfoTest extends \MailPoetTest {
     ]);
   }
 
+  public function testItGetsMetaInfoForReEngagement() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate([
+      'status' => 'subscribed',
+      'source' => 'form',
+    ]);
+    $newsletter1 = (object)[
+      'type' => Newsletter::TYPE_RE_ENGAGEMENT,
+    ];
+    $newsletter2 = (object)[
+      'type' => Newsletter::TYPE_RE_ENGAGEMENT,
+    ];
+    expect($this->meta->getNewsletterMetaInfo($newsletter1, $subscriber))->equals([
+      'email_type' => 're_engagement',
+      'subscriber_status' => 'subscribed',
+      'subscriber_source' => 'form',
+    ]);
+    expect($this->meta->getNewsletterMetaInfo($newsletter2, $subscriber))->equals([
+      'email_type' => 're_engagement',
+      'subscriber_status' => 'subscribed',
+      'subscriber_source' => 'form',
+    ]);
+  }
+
+  public function testItGetsMetaInfoForRandomType() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate([
+      'status' => 'subscribed',
+      'source' => 'form',
+    ]);
+    $newsletter1 = (object)[
+      'type' => "random",
+    ];
+
+    expect($this->meta->getNewsletterMetaInfo($newsletter1, $subscriber))->equals([
+      'email_type' => 'random',
+      'subscriber_status' => 'subscribed',
+      'subscriber_source' => 'form',
+    ]);
+  }
+
+  public function testItGetsMetaInfoForUnknownType() {
+    $subscriber = Subscriber::create();
+    $subscriber->hydrate([
+      'status' => 'subscribed',
+      'source' => 'form',
+    ]);
+    $newsletter1 = (object)[
+      'type' => null
+    ];
+    expect($this->meta->getNewsletterMetaInfo($newsletter1, $subscriber))->equals([
+      'email_type' => 'unknown',
+      'subscriber_status' => 'subscribed',
+      'subscriber_source' => 'form',
+    ]);
+  }
+
   public function _after() {
     Subscriber::deleteMany();
   }


### PR DESCRIPTION
Fixes [MAILPOET-4393]

This PR:
- Adds missing type for re-engagement to Newsletter model to help with retiring of newsletterEntity 
- Defaults metaInfor->email_type to the newsletter::type, this fixes the issue of not having the re_engagement type passed to the bridge as well.

Please check [the thread](https://a8c.slack.com/archives/C01GHD08ULT/p1653386562661139) for more context

[MAILPOET-4393]: https://mailpoet.atlassian.net/browse/MAILPOET-4393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ