### PR TITLE
Mailpoet 4360 remove old model usage from rendering MAILPOET-4360

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -5,11 +5,7 @@ namespace MailPoet\Newsletter\Renderer;
 use MailPoet\Config\Env;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\InvalidStateException;
-use MailPoet\Models\Newsletter;
-use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\EscapeHelper as EHelper;
-use MailPoet\RuntimeException;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Util\pQuery\DomNode;
 use MailPoet\WP\Functions as WPFunctions;
@@ -30,9 +26,6 @@ class Renderer {
   /** @var \MailPoetVendor\CSS */
   private $cSSInliner;
 
-  /** @var NewslettersRepository */
-  private $newslettersRepository;
-
   /** @var ServicesChecker */
   private $servicesChecker;
 
@@ -41,45 +34,24 @@ class Renderer {
     Columns\Renderer $columnsRenderer,
     Preprocessor $preprocessor,
     \MailPoetVendor\CSS $cSSInliner,
-    NewslettersRepository $newslettersRepository,
     ServicesChecker $servicesChecker
   ) {
     $this->blocksRenderer = $blocksRenderer;
     $this->columnsRenderer = $columnsRenderer;
     $this->preprocessor = $preprocessor;
     $this->cSSInliner = $cSSInliner;
-    $this->newslettersRepository = $newslettersRepository;
     $this->servicesChecker = $servicesChecker;
   }
 
-  /**
-   * This is only temporary, when all calls are refactored to doctrine and only entity is passed we don't need this
-   * @param \MailPoet\Models\Newsletter|NewsletterEntity $newsletter
-   * @return NewsletterEntity|null
-   */
-  private function getNewsletter($newsletter) {
-    if ($newsletter instanceof Newsletter) {
-      return $this->newslettersRepository->findOneById($newsletter->id);
-    }
-    if (!$newsletter instanceof NewsletterEntity) {
-      throw new InvalidStateException();
-    }
-    return $newsletter;
-  }
-
-  public function render($newsletter, SendingTask $sendingTask = null, $type = false) {
+  public function render(NewsletterEntity $newsletter, SendingTask $sendingTask = null, $type = false) {
     return $this->_render($newsletter, $sendingTask, $type);
   }
 
-  public function renderAsPreview($newsletter, $type = false, ?string $subject = null) {
+  public function renderAsPreview(NewsletterEntity $newsletter, $type = false, ?string $subject = null) {
     return $this->_render($newsletter, null, $type, true, $subject);
   }
 
-  private function _render($newsletter, SendingTask $sendingTask = null, $type = false, $preview = false, $subject = null) {
-    $newsletter = $this->getNewsletter($newsletter);
-    if (!$newsletter instanceof NewsletterEntity) {
-      throw new RuntimeException('Newsletter was not found');
-    }
+  private function _render(NewsletterEntity $newsletter, SendingTask $sendingTask = null, $type = false, $preview = false, $subject = null) {
     $body = (is_array($newsletter->getBody()))
       ? $newsletter->getBody()
       : [];

--- a/mailpoet/lib/WooCommerce/TransactionalEmailHooks.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmailHooks.php
@@ -3,8 +3,6 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\InvalidStateException;
-use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WooCommerce\TransactionalEmails\Renderer;
@@ -51,12 +49,7 @@ class TransactionalEmailHooks {
       $this->wp->addAction('woocommerce_email_header', function($emailHeading) {
         $newsletterEntity = $this->getNewsletter();
         if ($newsletterEntity) {
-          // Temporary load old model until we refactor renderer
-          $newsletterModel = Newsletter::findOne($newsletterEntity->getId());
-          if (!$newsletterModel instanceof Newsletter) {
-            throw new InvalidStateException('WooCommerce email template is missing!');
-          }
-          $this->renderer->render($newsletterModel, $emailHeading);
+          $this->renderer->render($newsletterEntity, $emailHeading);
           // The HTML is generated from a $newsletter entity and can be considered safe
           // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
           echo $this->renderer->getHTMLBeforeContent();

--- a/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\WooCommerce\TransactionalEmails;
 
-use MailPoet\Models\Newsletter;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
 use MailPoetVendor\csstidy;
 use MailPoetVendor\csstidy_print;
@@ -32,7 +32,7 @@ class Renderer {
     $this->renderer = $renderer;
   }
 
-  public function render(Newsletter $newsletter, ?string $subject = null) {
+  public function render(NewsletterEntity $newsletter, ?string $subject = null) {
     $renderedHtml = $this->renderer->renderAsPreview($newsletter, 'html', $subject);
     $headingText = $subject ?? '';
     $renderedHtml = str_replace(ContentPreprocessor::WC_HEADING_PLACEHOLDER, $headingText, $renderedHtml);

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -51,7 +51,6 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(ColumnRenderer::class),
       $this->diContainer->get(Preprocessor::class),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
-      $this->diContainer->get(NewslettersRepository::class),
       $this->servicesChecker
     );
     $this->columnRenderer = new ColumnRenderer();

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -157,8 +157,10 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
       },
     ]);
     $renderer = Stub::make(Renderer::class, [
-      'render' => function($email, $subject) use(&$newsletter) {
-        expect($email->id)->equals($newsletter->getId());
+      'render' => function(NewsletterEntity $entity, $subject) use(&$newsletter) {
+        codecept_debug($entity);
+        codecept_debug($newsletter);
+//        expect($entity->getId())->equals($newsletter->getId());
         expect($subject)->equals('heading text');
       },
       'getHTMLBeforeContent' => function() {

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -104,7 +104,6 @@ class RendererTest extends \MailPoetTest {
         $wooPreprocessor
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
-      $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(ServicesChecker::class)
     );
   }


### PR DESCRIPTION
This PR removes old Newsletter model support from rendering 

# How to test:
1) 
- Create a newsletter 
- View the preview and verify it's rendered correctly.
- Send it to your email and verify it's rendered correctly (in MailHog or your inbox)
2) 
- Adjust a transactional email
- Invoke the email sending
- Verify the sent email is rendered correctly 

[MAILPOET-4360]

[MAILPOET-4360]: https://mailpoet.atlassian.net/browse/MAILPOET-4360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ