### PR TITLE
Feat/let users authorise their email addresses in the plugin - MAILPOET-4300

### DIFF
--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -122,6 +122,8 @@ function AuthorizeSenderEmailModal({
       return null;
     }
 
+    clearCurrentInterval(setIntervalId.current);
+
     makeApiRequest(senderEmailAddress)
       .then((res) => {
         const response = Boolean(res?.data);
@@ -130,6 +132,16 @@ function AuthorizeSenderEmailModal({
         if (response) {
           // if pending or already authorized perform the check ahead
           executeAction();
+
+          // start polling on success response
+          setIntervalStopTime.current = moment()
+            .add(STOP_POLLING_AFTER, 'hours')
+            .valueOf();
+
+          setIntervalId.current = setInterval(
+            executeAction,
+            1000 * SET_INTERVAL_SECONDS,
+          );
         }
       })
       .catch(() => {
@@ -137,15 +149,7 @@ function AuthorizeSenderEmailModal({
         setShowLoader(false);
       });
 
-    clearCurrentInterval(setIntervalId.current);
-    setIntervalStopTime.current = moment()
-      .add(STOP_POLLING_AFTER, 'hours')
-      .valueOf();
-
-    const invervalID = setInterval(executeAction, 1000 * SET_INTERVAL_SECONDS);
-    setIntervalId.current = invervalID;
-
-    return () => clearCurrentInterval(invervalID);
+    return () => clearCurrentInterval(setIntervalId.current);
   }, [senderEmailAddress]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (

--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import ReactStringReplace from 'react-string-replace';
+import PropTypes from 'prop-types';
+import { MailPoet } from 'mailpoet';
+import { Modal } from 'common/modal/modal';
+import { Loader } from 'common';
+
+type ApiActionType = 'create' | 'confirm';
+
+/**
+ * @param {string} email - Email address
+ * @param {ApiActionType} type - action type
+ * @returns {Promise}
+ */
+const makeApiRequest = (email: string, type: ApiActionType = 'create') =>
+  MailPoet.Ajax.post({
+    api_version: MailPoet.apiVersion,
+    endpoint: 'settings',
+    action:
+      type === 'create'
+        ? 'authorizeSenderEmailAddress'
+        : 'confirmSenderEmailAddressIsAuthorized',
+    data: {
+      email,
+    },
+  });
+
+type Props = {
+  senderEmail: string;
+  onRequestClose: () => void;
+};
+
+function AuthorizeSenderEmailModal({ senderEmail, onRequestClose }: Props) {
+  const [apiResponseType, setApiResponseType] = useState<boolean>(null);
+
+  const senderEmailAddress = String(senderEmail).toLowerCase();
+
+  useEffect(() => {
+    if (!senderEmailAddress) {
+      return;
+    }
+
+    makeApiRequest(senderEmailAddress)
+      .then((res) => {
+        setApiResponseType(Boolean(res?.data));
+      })
+      .catch(() => {
+        setApiResponseType(false);
+      });
+  }, [senderEmailAddress]);
+
+  return (
+    <Modal
+      title={MailPoet.I18n.t('authorizeSenderEmailModalTitle').replace(
+        '[senderEmail]',
+        senderEmailAddress,
+      )}
+      onRequestClose={onRequestClose}
+      contentClassName="authorize-sender-email-modal"
+    >
+      {apiResponseType && (
+        <p>
+          {ReactStringReplace(
+            MailPoet.I18n.t('authorizeSenderEmailModalDescription'),
+            /\[bold\](.*?)\[\/bold\]/g,
+            (match, i) => (
+              <strong key={i}>{match}</strong>
+            ),
+          )}
+        </p>
+      )}
+
+      {apiResponseType === false && (
+        <p>{MailPoet.I18n.t('authorizeSenderEmailMessageError')}</p>
+      )}
+
+      <Loader size={64} />
+    </Modal>
+  );
+}
+
+AuthorizeSenderEmailModal.propTypes = {
+  senderEmail: PropTypes.string.isRequired,
+};
+
+export { AuthorizeSenderEmailModal };

--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal';
 import { Button, Loader } from 'common';
+import { isErrorResponse, ErrorResponse } from 'ajax';
 
 const SET_INTERVAL_SECONDS = 15;
 
@@ -77,6 +78,7 @@ function AuthorizeSenderEmailModal({
 }: Props) {
   const [createEmailApiResponse, setCreateEmailApiResponse] =
     useState<boolean>(null);
+  const [createEmailApiError, setCreateEmailApiError] = useState('');
   const [confirmEmailApiResponse, setConfirmEmailApiResponse] =
     useState<boolean>(null);
   const [showLoader, setShowLoader] = useState<boolean>(true);
@@ -144,7 +146,13 @@ function AuthorizeSenderEmailModal({
           );
         }
       })
-      .catch(() => {
+      .catch((e: ErrorResponse) => {
+        const error =
+          isErrorResponse(e) && e.errors[0] && e.errors[0].message
+            ? e.errors[0].message
+            : '';
+        setCreateEmailApiError(error);
+
         setCreateEmailApiResponse(false);
         setShowLoader(false);
       });
@@ -173,7 +181,10 @@ function AuthorizeSenderEmailModal({
         </p>
       )}
       {createEmailApiResponse === false && (
-        <p>{MailPoet.I18n.t('authorizeSenderEmailMessageError')}</p>
+        <>
+          <strong> {createEmailApiError} </strong>
+          <p>{MailPoet.I18n.t('authorizeSenderEmailMessageError')}</p>
+        </>
       )}
 
       {showLoader && <Loader size={64} />}

--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -128,7 +128,7 @@ function AuthorizeSenderEmailModal({
 
     makeApiRequest(senderEmailAddress)
       .then((res) => {
-        const response = Boolean(res?.data);
+        const response = Boolean(res?.data?.status);
         setCreateEmailApiResponse(response);
         setShowLoader(response);
         if (response) {

--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -1,9 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactStringReplace from 'react-string-replace';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal';
-import { Loader } from 'common';
+import { Button, Loader } from 'common';
+
+const SET_INTERVAL_SECONDS = 15;
+
+const STOP_POLLING_AFTER = 2; // hours
 
 type ApiActionType = 'create' | 'confirm';
 
@@ -31,22 +36,75 @@ type Props = {
 };
 
 function AuthorizeSenderEmailModal({ senderEmail, onRequestClose }: Props) {
-  const [apiResponseType, setApiResponseType] = useState<boolean>(null);
+  const [createEmailApiResponse, setCreateEmailApiResponse] =
+    useState<boolean>(null);
+  const [confirmEmailApiResponse, setConfirmEmailApiResponse] =
+    useState<boolean>(null);
+  const [showLoader, setShowLoader] = useState<boolean>(true);
+  const setIntervalId = useRef<NodeJS.Timeout>();
+  const setIntervalStopTime = useRef<number>();
 
   const senderEmailAddress = String(senderEmail).toLowerCase();
 
   useEffect(() => {
     if (!senderEmailAddress) {
-      return;
+      return null;
     }
+
+    const clearCurrentInterval = (intervalID: NodeJS.Timeout) => {
+      clearInterval(intervalID);
+    };
+
+    const executeAction = () => {
+      const currentIntervalId = setIntervalId.current;
+      const currentIntervalStopTime = setIntervalStopTime.current;
+
+      if (currentIntervalStopTime && Date.now() >= currentIntervalStopTime) {
+        // stop polling after 2 hours
+        clearCurrentInterval(currentIntervalId);
+        return;
+      }
+
+      makeApiRequest(senderEmailAddress, 'confirm')
+        .then((res) => {
+          const response = Boolean(res?.data?.isAuthorized);
+
+          if (response) {
+            clearCurrentInterval(currentIntervalId);
+            setCreateEmailApiResponse(null);
+            setShowLoader(false);
+            setConfirmEmailApiResponse(true);
+          }
+        })
+        .catch(() => {
+          //
+        });
+    };
 
     makeApiRequest(senderEmailAddress)
       .then((res) => {
-        setApiResponseType(Boolean(res?.data));
+        const response = Boolean(res?.data);
+        setCreateEmailApiResponse(response);
+        setShowLoader(response);
+        if (response) {
+          // if pending or already authorized perform the check ahead
+          executeAction();
+        }
       })
       .catch(() => {
-        setApiResponseType(false);
+        setCreateEmailApiResponse(false);
+        setShowLoader(false);
       });
+
+    clearCurrentInterval(setIntervalId.current);
+    setIntervalStopTime.current = moment()
+      .add(STOP_POLLING_AFTER, 'hours')
+      .valueOf();
+
+    const invervalID = setInterval(executeAction, 1000 * SET_INTERVAL_SECONDS);
+    setIntervalId.current = invervalID;
+
+    return () => clearCurrentInterval(invervalID);
   }, [senderEmailAddress]);
 
   return (
@@ -58,7 +116,7 @@ function AuthorizeSenderEmailModal({ senderEmail, onRequestClose }: Props) {
       onRequestClose={onRequestClose}
       contentClassName="authorize-sender-email-modal"
     >
-      {apiResponseType && (
+      {createEmailApiResponse && (
         <p>
           {ReactStringReplace(
             MailPoet.I18n.t('authorizeSenderEmailModalDescription'),
@@ -69,12 +127,21 @@ function AuthorizeSenderEmailModal({ senderEmail, onRequestClose }: Props) {
           )}
         </p>
       )}
-
-      {apiResponseType === false && (
+      {createEmailApiResponse === false && (
         <p>{MailPoet.I18n.t('authorizeSenderEmailMessageError')}</p>
       )}
 
-      <Loader size={64} />
+      {showLoader && <Loader size={64} />}
+
+      {confirmEmailApiResponse && (
+        <>
+          <p>{MailPoet.I18n.t('authorizeSenderEmailMessageSuccess')}</p>
+          <Button onClick={onRequestClose} className="button-on-top">
+            {' '}
+            {MailPoet.I18n.t('close')}{' '}
+          </Button>
+        </>
+      )}
     </Modal>
   );
 }

--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -84,10 +84,13 @@ function AuthorizeSenderEmailModal({
   const [showLoader, setShowLoader] = useState<boolean>(true);
   const setIntervalId = useRef<NodeJS.Timeout>();
   const setIntervalStopTime = useRef<number>();
+  const modalIsOpened = useRef<boolean>(false);
 
   const senderEmailAddress = String(senderEmail).toLowerCase();
 
   const executeAction = () => {
+    if (!modalIsOpened.current) return; // do nothing if modal is not opened
+
     const currentIntervalId = setIntervalId.current;
     const currentIntervalStopTime = setIntervalStopTime.current;
 
@@ -124,10 +127,14 @@ function AuthorizeSenderEmailModal({
       return null;
     }
 
+    modalIsOpened.current = true;
+
     clearCurrentInterval(setIntervalId.current);
 
     makeApiRequest(senderEmailAddress)
       .then((res) => {
+        if (!modalIsOpened.current) return; // do nothing if modal is not opened
+
         const response = Boolean(res?.data?.status);
         setCreateEmailApiResponse(response);
         setShowLoader(response);
@@ -147,6 +154,8 @@ function AuthorizeSenderEmailModal({
         }
       })
       .catch((e: ErrorResponse) => {
+        if (!modalIsOpened.current) return; // do nothing if modal is not opened
+
         const error =
           isErrorResponse(e) && e.errors[0] && e.errors[0].message
             ? e.errors[0].message
@@ -157,7 +166,10 @@ function AuthorizeSenderEmailModal({
         setShowLoader(false);
       });
 
-    return () => clearCurrentInterval(setIntervalId.current);
+    return () => {
+      modalIsOpened.current = false;
+      clearCurrentInterval(setIntervalId.current);
+    };
     /**
      * I'm using eslint-disable-line react-hooks/exhaustive-deps here to fix eslint warning.
      *

--- a/mailpoet/assets/js/src/common/functions/index.ts
+++ b/mailpoet/assets/js/src/common/functions/index.ts
@@ -2,3 +2,4 @@ export * from './change_handlers';
 export * from './t';
 export * from './is_email';
 export * from './set_lowercase_value';
+export * from './parsley_helper_functions';

--- a/mailpoet/assets/js/src/common/functions/parsley_helper_functions.ts
+++ b/mailpoet/assets/js/src/common/functions/parsley_helper_functions.ts
@@ -1,0 +1,84 @@
+import jQuery from 'jquery';
+
+/**
+ * Parsely Helper functions
+ * @see http://parsleyjs.org/doc/index.html
+ */
+
+/**
+ * Alias to Parsely isValid method
+ *
+ * Check if the field is valid or not. Does not affect UI nor fires events.
+ *
+ * @param {string} domElementSelector jQuery DOM Selector
+ * @returns {boolean|null} true if all ok or null if some validations are still pending
+ */
+export const isFieldValid = (domElementSelector: string) =>
+  jQuery(domElementSelector).parsley().isValid();
+
+/**
+ * Alias to Parsely validate method
+ *
+ * Validate Field. Fires events and affects UI.
+ *
+ * @param {string} domElementSelector jQuery DOM Selector
+ * @returns {boolean|null} true if all ok or null if some validations are still pending
+ */
+export const validateField = (domElementSelector: string) =>
+  jQuery(domElementSelector).parsley().validate();
+
+/**
+ * Check if an Error message with this fieldName already exist on the DOM
+ * @param {string} parsleyFieldName Parsely Error name
+ * @returns {boolean}
+ */
+export const doesErrorFieldExist = (parsleyFieldName: string) =>
+  !!jQuery(document).find(`.parsley-${parsleyFieldName}`).length;
+
+/**
+ * Alias to Parsely addError and updateError methods
+ *
+ * If an Error message with this fieldName already exist on the DOM, Update the Error message
+ * else
+ * Create a new Error message
+ * @param {string} domElementSelector jQuery DOM Selector
+ * @param {string} parsleyFieldName Parsely Error name
+ * @param {string} errorMessage
+ */
+export const addOrUpdateError = (
+  domElementSelector: string,
+  parsleyFieldName: string,
+  errorMessage: string,
+) => {
+  if (doesErrorFieldExist(parsleyFieldName)) {
+    jQuery(domElementSelector).parsley().updateError(parsleyFieldName, {
+      message: errorMessage,
+      updateClass: true,
+    });
+  } else {
+    jQuery(domElementSelector).parsley().addError(parsleyFieldName, {
+      message: errorMessage,
+      updateClass: true,
+    });
+  }
+};
+
+/**
+ * Alias to Parsely removeError method
+ *
+ * Remove an already present error message.
+ *
+ * @param {string} domElementSelector jQuery DOM Selector
+ * @param {string} parsleyFieldName Parsely Error name
+ * @returns
+ */
+export const removeError = (
+  domElementSelector: string,
+  parsleyFieldName: string,
+) => {
+  if (!doesErrorFieldExist(parsleyFieldName)) return; // do nothing if error message does not exist
+
+  jQuery(domElementSelector)
+    .parsley()
+    .removeError(parsleyFieldName, { updateClass: true });
+};

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
+import { AuthorizeSenderEmailModal } from 'common/authorize_sender_email_modal';
 
 const userHostDomain = window.location.hostname.replace('www.', '');
 const suggestedEmailAddress = `contact@${userHostDomain}`;
@@ -10,24 +12,42 @@ function SenderEmailAddressWarning({
   mssActive,
   isEmailAuthorized,
 }) {
+  const [showAuthorizedEmailModel, setAuthorizedEmailModel] = useState(false);
+
+  const loadModal = (event) => {
+    event.preventDefault();
+    setAuthorizedEmailModel(true);
+  };
+
   if (mssActive) {
     if (!isEmailAuthorized) {
       return (
-        <p className="sender_email_address_warning">
-          {ReactStringReplace(
-            MailPoet.I18n.t('youNeedToAuthorizeTheEmail'),
-            '[email]',
-            () => emailAddress,
-          )}{' '}
-          <a
-            className="mailpoet-link"
-            href={`https://account.mailpoet.com/authorization?email=${emailAddress}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {MailPoet.I18n.t('authorizeMyEmail')}
-          </a>
-        </p>
+        <>
+          {showAuthorizedEmailModel && (
+            <AuthorizeSenderEmailModal
+              senderEmail={emailAddress}
+              onRequestClose={() => {
+                setAuthorizedEmailModel(false);
+              }}
+            />
+          )}
+          <p className="sender_email_address_warning">
+            {ReactStringReplace(
+              MailPoet.I18n.t('youNeedToAuthorizeTheEmail'),
+              '[email]',
+              () => emailAddress,
+            )}{' '}
+            <a
+              className="mailpoet-link"
+              href="#"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={loadModal}
+            >
+              {MailPoet.I18n.t('authorizeMyEmail')}
+            </a>
+          </p>
+        </>
       );
     }
     return null;

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -12,24 +12,24 @@ function SenderEmailAddressWarning({
   mssActive,
   isEmailAuthorized,
 }) {
-  const [showAuthorizedEmailModel, setShowAuthorizedEmailModel] =
+  const [showAuthorizedEmailModal, setShowAuthorizedEmailModal] =
     useState(false);
   const [authorizedEmailAddress, setAuthorizedEmailAddress] = useState('');
 
   const loadModal = (event) => {
     event.preventDefault();
-    setShowAuthorizedEmailModel(true);
+    setShowAuthorizedEmailModal(true);
   };
 
   if (mssActive) {
     if (!isEmailAuthorized) {
       return (
         <>
-          {showAuthorizedEmailModel && (
+          {showAuthorizedEmailModal && (
             <AuthorizeSenderEmailModal
               senderEmail={emailAddress}
               onRequestClose={() => {
-                setShowAuthorizedEmailModel(false);
+                setShowAuthorizedEmailModal(false);
               }}
               setAuthorizedAddress={setAuthorizedEmailAddress}
             />

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -33,7 +33,8 @@ function SenderEmailAddressWarning({
               setAuthorizedAddress={setAuthorizedEmailAddress}
             />
           )}
-          {authorizedEmailAddress ? null : (
+          {authorizedEmailAddress &&
+          authorizedEmailAddress === emailAddress ? null : (
             <p className="sender_email_address_warning">
               {ReactStringReplace(
                 MailPoet.I18n.t('youNeedToAuthorizeTheEmail'),

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -12,12 +12,13 @@ function SenderEmailAddressWarning({
   mssActive,
   isEmailAuthorized,
 }) {
-  const [showAuthorizedEmailModel, setAuthorizedEmailModel] = useState(false);
+  const [showAuthorizedEmailModel, setShowAuthorizedEmailModel] =
+    useState(false);
   const [authorizedEmailAddress, setAuthorizedEmailAddress] = useState('');
 
   const loadModal = (event) => {
     event.preventDefault();
-    setAuthorizedEmailModel(true);
+    setShowAuthorizedEmailModel(true);
   };
 
   if (mssActive) {
@@ -28,7 +29,7 @@ function SenderEmailAddressWarning({
             <AuthorizeSenderEmailModal
               senderEmail={emailAddress}
               onRequestClose={() => {
-                setAuthorizedEmailModel(false);
+                setShowAuthorizedEmailModel(false);
               }}
               setAuthorizedAddress={setAuthorizedEmailAddress}
             />

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -13,6 +13,7 @@ function SenderEmailAddressWarning({
   isEmailAuthorized,
 }) {
   const [showAuthorizedEmailModel, setAuthorizedEmailModel] = useState(false);
+  const [authorizedEmailAddress, setAuthorizedEmailAddress] = useState('');
 
   const loadModal = (event) => {
     event.preventDefault();
@@ -29,24 +30,27 @@ function SenderEmailAddressWarning({
               onRequestClose={() => {
                 setAuthorizedEmailModel(false);
               }}
+              setAuthorizedAddress={setAuthorizedEmailAddress}
             />
           )}
-          <p className="sender_email_address_warning">
-            {ReactStringReplace(
-              MailPoet.I18n.t('youNeedToAuthorizeTheEmail'),
-              '[email]',
-              () => emailAddress,
-            )}{' '}
-            <a
-              className="mailpoet-link"
-              href="#"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={loadModal}
-            >
-              {MailPoet.I18n.t('authorizeMyEmail')}
-            </a>
-          </p>
+          {authorizedEmailAddress ? null : (
+            <p className="sender_email_address_warning">
+              {ReactStringReplace(
+                MailPoet.I18n.t('youNeedToAuthorizeTheEmail'),
+                '[email]',
+                () => emailAddress,
+              )}{' '}
+              <a
+                className="mailpoet-link"
+                href="#"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={loadModal}
+              >
+                {MailPoet.I18n.t('authorizeMyEmail')}
+              </a>
+            </p>
+          )}
         </>
       );
     }

--- a/mailpoet/assets/js/src/common/set_from_address_modal.tsx
+++ b/mailpoet/assets/js/src/common/set_from_address_modal.tsx
@@ -7,6 +7,7 @@ import { GlobalContext } from 'context';
 import { noop } from 'lodash';
 import { ErrorResponse, isErrorResponse } from '../ajax';
 import { AuthorizeSenderEmailModal } from './authorize_sender_email_modal';
+import { Button } from './button/button';
 
 /**
  * @param {string|null} address
@@ -86,6 +87,7 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
     useState(false);
   const [showAuthorizedEmailErrorMessage, setShowAuthorizedEmailErrorMessage] =
     useState(false);
+  const [loading, setLoading] = useState(false);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { notices } = useContext<any>(GlobalContext);
 
@@ -163,10 +165,9 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
           )}
       </p>
 
-      <input
-        className="button button-primary"
+      <Button
+        withSpinner={loading}
         type="submit"
-        value={MailPoet.I18n.t('setFromAddressModalSave')}
         onClick={async () => {
           const addressValidator = jQuery(
             '#mailpoet-set-from-address-modal-input',
@@ -179,12 +180,15 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
             return;
           }
           try {
+            setLoading(true);
             await handleSave(address);
+            setLoading(false);
             setAuthorizedAddress(address);
             onRequestClose();
             removeUnauthorizedEmailNotices();
             notices.success(getSuccessMessage(), { timeout: false });
           } catch (e) {
+            setLoading(false);
             const error =
               isErrorResponse(e) && e.errors[0] ? e.errors[0] : null;
             if (error.error === 'unauthorized') {
@@ -197,7 +201,9 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
             addressValidator.addError('saveError', { message });
           }
         }}
-      />
+      >
+        {MailPoet.I18n.t('setFromAddressModalSave')}
+      </Button>
     </Modal>
   );
 }

--- a/mailpoet/assets/js/src/common/set_from_address_modal.tsx
+++ b/mailpoet/assets/js/src/common/set_from_address_modal.tsx
@@ -31,7 +31,7 @@ const getErrorMessage = (
   }
 
   if (error.error === 'unauthorized') {
-    return ' ';
+    return '';
   }
 
   return error.message || MailPoet.I18n.t('setFromAddressEmailUnknownError');
@@ -83,7 +83,7 @@ type Props = {
 
 function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
   const [address, setAddress] = useState<string>();
-  const [showAuthorizedEmailModel, setShowAuthorizedEmailModel] =
+  const [showAuthorizedEmailModal, setShowAuthorizedEmailModal] =
     useState(false);
   const [showAuthorizedEmailErrorMessage, setShowAuthorizedEmailErrorMessage] =
     useState(false);
@@ -97,11 +97,11 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
       onRequestClose={onRequestClose}
       contentClassName="set-from-address-modal"
     >
-      {showAuthorizedEmailModel && (
+      {showAuthorizedEmailModal && (
         <AuthorizeSenderEmailModal
           senderEmail={address}
           onRequestClose={() => {
-            setShowAuthorizedEmailModel(false);
+            setShowAuthorizedEmailModal(false);
           }}
           setAuthorizedAddress={(emailAddres) => {
             setAuthorizedAddress(emailAddres);
@@ -151,10 +151,12 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
             (string, index) => (
               <a
                 key={index}
-                href={`https://account.mailpoet.com/authorization?email=${address}`}
+                href={`https://account.mailpoet.com/authorization?email=${encodeURIComponent(
+                  address,
+                )}`}
                 onClick={(event) => {
                   event.preventDefault();
-                  setShowAuthorizedEmailModel(true);
+                  setShowAuthorizedEmailModal(true);
                 }}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -198,7 +200,9 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
               setShowAuthorizedEmailErrorMessage(true);
             }
             const message = getErrorMessage(error);
-            addressValidator.addError('saveError', { message });
+            if (message) {
+              addressValidator.addError('saveError', { message });
+            }
           }
         }}
       >

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -180,7 +180,7 @@ class NewsletterSendComponent extends Component {
       (match) =>
         `<a href="https://account.mailpoet.com/authorization?email=${encodeURIComponent(
           fromAddress,
-        )}" target="_blank" rel="noopener noreferrer">${match}</a>`,
+        )}" target="_blank" class="mailpoet-js-button-authorize-email" data-email="${fromAddress}" rel="noopener noreferrer">${match}</a>`,
     );
     jQuery('#field_sender_address')
       .parsley()

--- a/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
@@ -1,51 +1,95 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactStringReplace from 'react-string-replace';
+import { MailPoet } from 'mailpoet';
 import { FormFieldText } from 'form/fields/text.jsx';
 import { SenderEmailAddressWarning } from 'common/sender_email_address_warning.jsx';
+import {
+  isFieldValid,
+  addOrUpdateError,
+  removeError,
+  validateField,
+} from 'common/functions/parsley_helper_functions';
 
 class SenderField extends Component {
   constructor(props) {
     super(props);
     this.state = {
       emailAddress: props.item.sender_address,
-      isEmailAuthorized: this.isEmailAddressAuthorized(
-        props.item.sender_address,
-      ),
     };
     this.onChange = this.onChange.bind(this);
     this.onBlur = this.onBlur.bind(this);
+
+    const fieldId = props.field.id || `field_${props.field.name}`;
+    this.domElementSelector = `#${fieldId}`;
+    this.parsleyFieldName = 'invalidFromAddress';
   }
 
   onChange(event) {
+    const emailAddress = event.target.value.toLowerCase();
     this.setState({
-      emailAddress: event.target.value.toLowerCase(),
-      isEmailAuthorized: true, // hide email address warning when user is typing
+      emailAddress,
     });
     this.props.onValueChange({
       ...event,
       target: {
         ...event.target,
         name: event.target.name,
-        value: event.target.value.toLowerCase(),
+        value: emailAddress,
       },
     });
+    // hide email address warning when user is typing
+    removeError(this.domElementSelector, this.parsleyFieldName);
   }
 
-  onBlur(event) {
-    const emailAddress = event.target.value.toLowerCase();
+  onBlur() {
+    const emailAddress = this.state.emailAddress;
     const emailAddressIsAuthorized =
-      event.target.value.length >= 3
-        ? this.isEmailAddressAuthorized(emailAddress)
-        : true;
+      this.isEmailAddressAuthorized(emailAddress);
 
-    this.setState({
-      isEmailAuthorized: emailAddressIsAuthorized,
-      emailAddress,
-    });
+    this.showSenderFieldError(emailAddressIsAuthorized, emailAddress);
   }
 
   isEmailAddressAuthorized = (email) =>
-    window.mailpoet_authorized_emails.includes(email);
+    (window.mailpoet_authorized_emails || []).includes(email);
+
+  showInvalidFromAddressError = (emailAddress) => {
+    const fromAddress = emailAddress;
+    let errorMessage = ReactStringReplace(
+      MailPoet.I18n.t('newsletterInvalidFromAddress'),
+      '%1$s',
+      () => fromAddress,
+    );
+    errorMessage = ReactStringReplace(
+      errorMessage,
+      /\[link\](.*?)\[\/link\]/g,
+      (match) =>
+        `<a href="https://account.mailpoet.com/authorization?email=${encodeURIComponent(
+          fromAddress,
+        )}" target="_blank" class="mailpoet-js-button-authorize-email" data-email="${fromAddress}" rel="noopener noreferrer">${match}</a>`,
+    );
+
+    addOrUpdateError(
+      this.domElementSelector,
+      this.parsleyFieldName,
+      errorMessage.join(''),
+    );
+  };
+
+  showSenderFieldError = (emailAddressIsAuthorized, emailAddress) => {
+    if (!window.mailpoet_mss_active) return;
+
+    removeError(this.domElementSelector, this.parsleyFieldName);
+
+    if (!isFieldValid(this.domElementSelector)) {
+      validateField(this.domElementSelector);
+      return;
+    }
+
+    if (!emailAddressIsAuthorized) {
+      this.showInvalidFromAddressError(emailAddress);
+    }
+  };
 
   render() {
     return (
@@ -59,11 +103,11 @@ class SenderField extends Component {
           onValueChange={this.onChange}
           onBlurEvent={this.onBlur}
         />
-        <div className="regular-text" style={{ marginTop: '2.5rem' }}>
+
+        <div className="regular-text">
           <SenderEmailAddressWarning
             emailAddress={this.state.emailAddress}
             mssActive={window.mailpoet_mss_active}
-            isEmailAuthorized={this.state.isEmailAuthorized}
           />
         </div>
       </>

--- a/mailpoet/assets/js/src/sending-paused-notices-authorize-email.tsx
+++ b/mailpoet/assets/js/src/sending-paused-notices-authorize-email.tsx
@@ -3,11 +3,23 @@ import { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { AuthorizeSenderEmailModal } from 'common/authorize_sender_email_modal';
 
-const performActionOnModalClose = () => {
+/**
+ * Perform action after the email has been successfully Authorized
+ */
+const performSuccessActionOnModalClose = () => {
   // if in Settings, reload page, so the new saved FROM address is loaded
   const isInSettings = window.location.href.includes('?page=mailpoet-settings');
+
+  const isInNewsletterSendPage = window.location.href.includes(
+    '?page=mailpoet-newsletters#/send',
+  );
+
   if (isInSettings) {
     window.location.reload();
+  } else if (isInNewsletterSendPage) {
+    jQuery('#field_sender_address')
+      .parsley()
+      .removeError('invalidFromAddress', { updateClass: true });
   }
 };
 
@@ -15,17 +27,24 @@ function AuthorizeSenderEmailApp() {
   const [showModal, setShowModal] = useState(''); // used to hold the email address as well
 
   useEffect(() => {
+    const performAction = (e) => {
+      e.preventDefault();
+      const email = String(e?.target?.dataset?.email || '');
+      setShowModal(email);
+    };
     // use jQuery since some of the targeted notices are added to the DOM using the old
     // jQuery-based notice implementation which doesn't trigger pure-JS added listeners
     jQuery(($) => {
       $(document).on(
         'click',
         '.notice .mailpoet-js-button-authorize-email',
-        (e) => {
-          e.preventDefault();
-          const email = String(e?.target?.dataset?.email || '');
-          setShowModal(email);
-        },
+        performAction,
+      );
+
+      $(document).on(
+        'click',
+        '.parsley-errors-list .mailpoet-js-button-authorize-email',
+        performAction,
       );
     });
   }, []);
@@ -38,7 +57,7 @@ function AuthorizeSenderEmailApp() {
           onRequestClose={() => {
             setShowModal('');
           }}
-          setAuthorizedAddress={performActionOnModalClose}
+          setAuthorizedAddress={performSuccessActionOnModalClose}
         />
       )}
     </>

--- a/mailpoet/assets/js/src/sending-paused-notices-authorize-email.tsx
+++ b/mailpoet/assets/js/src/sending-paused-notices-authorize-email.tsx
@@ -1,0 +1,55 @@
+import jQuery from 'jquery';
+import { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { AuthorizeSenderEmailModal } from 'common/authorize_sender_email_modal';
+
+const performActionOnModalClose = () => {
+  // if in Settings, reload page, so the new saved FROM address is loaded
+  const isInSettings = window.location.href.includes('?page=mailpoet-settings');
+  if (isInSettings) {
+    window.location.reload();
+  }
+};
+
+function AuthorizeSenderEmailApp() {
+  const [showModal, setShowModal] = useState(''); // used to hold the email address as well
+
+  useEffect(() => {
+    // use jQuery since some of the targeted notices are added to the DOM using the old
+    // jQuery-based notice implementation which doesn't trigger pure-JS added listeners
+    jQuery(($) => {
+      $(document).on(
+        'click',
+        '.notice .mailpoet-js-button-authorize-email',
+        (e) => {
+          e.preventDefault();
+          const email = String(e?.target?.dataset?.email || '');
+          setShowModal(email);
+        },
+      );
+    });
+  }, []);
+
+  return (
+    <>
+      {showModal && (
+        <AuthorizeSenderEmailModal
+          senderEmail={showModal}
+          onRequestClose={() => {
+            setShowModal('');
+          }}
+          setAuthorizedAddress={performActionOnModalClose}
+        />
+      )}
+    </>
+  );
+}
+
+// nothing is actually rendered to the container because the <Modal> component uses
+// ReactDOM.createPortal() but we need an element as a React root on all pages
+const container = document.getElementById(
+  'mailpoet_authorize_sender_email_modal',
+);
+if (container) {
+  ReactDOM.render(<AuthorizeSenderEmailApp />, container);
+}

--- a/mailpoet/assets/js/src/webpack_admin_index.jsx
+++ b/mailpoet/assets/js/src/webpack_admin_index.jsx
@@ -16,3 +16,4 @@ import 'experimental_features/experimental_features.jsx'; // side effect - rende
 import 'logs/logs'; // side effect - renders ReactDOM to document
 import 'sending-paused-notices-fix-button.tsx'; // side effect - renders ReactDOM to document
 import 'sending-paused-notices-resume-button.ts'; // side effect - executes on doc ready, adds events
+import 'sending-paused-notices-authorize-email.tsx'; // side effect - renders ReactDOM to document

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -198,7 +198,7 @@ class Settings extends APIEndpoint {
   }
 
   /**
-   * Makes POST request to Bridge endpoint to add email to user email authorization list
+   * Create POST request to Bridge endpoint to add email to user email authorization list
    */
   public function authorizeSenderEmailAddress($data = []) {
     $emailAddress = $data['email'] ?? null;

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -219,7 +219,7 @@ class Settings extends APIEndpoint {
         $e->getMessage() === AuthorizedEmailsController::AUTHORIZED_EMAIL_ERROR_PENDING_CONFIRMATION
       ) {
         // return true if the email is already authorized or pending confirmation
-        $response = true;
+        $response = ['status' => true];
       } else {
         return $this->badRequest([
           APIError::BAD_REQUEST => WPFunctions::get()->__($e->getMessage(), 'mailpoet'),

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -64,11 +64,11 @@ class AuthorizedEmailsController {
     $this->settings->set(self::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, null);
   }
 
-  public function getAllAuthorizedEmailAddress() {
+  public function getAllAuthorizedEmailAddress(): array {
     return $this->bridge->getAuthorizedEmailAddresses(self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_ALL);
   }
 
-  public function createAuthorizedEmailAddress(string $email) {
+  public function createAuthorizedEmailAddress(string $email): array {
     $allEmails = $this->getAllAuthorizedEmailAddress();
 
     $authorizedEmails = isset($allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED]) ? $allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED] : [];
@@ -87,9 +87,8 @@ class AuthorizedEmailsController {
 
     $finalData = $this->bridge->createAuthorizedEmailAddress($email);
 
-    if (!is_bool($finalData) && is_array($finalData)) {
-      $errorMessage = isset($finalData['error']) ? $finalData['error'] : ' ';
-      throw new \InvalidArgumentException($errorMessage);
+    if ($finalData && isset($finalData['error'])) {
+      throw new \InvalidArgumentException($finalData['error']);
     }
 
     return $finalData;

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -87,6 +87,11 @@ class AuthorizedEmailsController {
 
     $finalData = $this->bridge->createAuthorizedEmailAddress($email);
 
+    if (!is_bool($finalData) && is_array($finalData)) {
+      $errorMessage = isset($finalData['error']) ? $finalData['error'] : ' ';
+      throw new \InvalidArgumentException($errorMessage);
+    }
+
     return $finalData;
   }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -45,7 +45,7 @@ class AuthorizedEmailsController {
   }
 
   public function setFromEmailAddress(string $address) {
-    $authorizedEmails = array_map('strtolower', $this->bridge->getAuthorizedEmailAddresses() ?: []);
+    $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses() ?: [];
     $isAuthorized = $this->validateAuthorizedEmail($authorizedEmails, $address);
     if (!$isAuthorized) {
       throw new \InvalidArgumentException("Email address '$address' is not authorized");
@@ -71,14 +71,14 @@ class AuthorizedEmailsController {
   public function createAuthorizedEmailAddress(string $email) {
     $allEmails = $this->getAllAuthorizedEmailAddress();
 
-    $authorizedEmails = array_map('strtolower', $allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED]);
+    $authorizedEmails = isset($allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED]) ? $allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED] : [];
     $isAuthorized = $this->validateAuthorizedEmail($authorizedEmails, $email);
 
     if ($isAuthorized) {
       throw new \InvalidArgumentException(self::AUTHORIZED_EMAIL_ERROR_ALREADY_AUTHORIZED);
     }
 
-    $pendingEmails = array_map('strtolower', $allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_PENDING]);
+    $pendingEmails = isset($allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_PENDING]) ? $allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_PENDING] : [];
     $isPending = $this->validateAuthorizedEmail($pendingEmails, $email);
 
     if ($isPending) {
@@ -96,7 +96,7 @@ class AuthorizedEmailsController {
   }
 
   public function isEmailAddressAuthorized(string $email): bool {
-    $authorizedEmails = array_map('strtolower', $this->bridge->getAuthorizedEmailAddresses() ?: []);
+    $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses() ?: [];
     return $this->validateAuthorizedEmail($authorizedEmails, $email);
   }
 
@@ -197,7 +197,8 @@ class AuthorizedEmailsController {
     }
   }
 
-  private function validateAuthorizedEmail($authorizedEmails, $email) {
-    return in_array(strtolower($email), $authorizedEmails, true);
+  private function validateAuthorizedEmail($authorizedEmails = [], $email = '') {
+    $lowercaseAuthorizedEmails = array_map('strtolower', $authorizedEmails);
+    return in_array(strtolower($email), $lowercaseAuthorizedEmails, true);
   }
 }

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -125,7 +125,7 @@ class Bridge {
     if ($data && $type === 'all') {
       return $data;
     }
-    return $data && isset($data[$type]) ? $data[$type] : [];
+    return isset($data[$type]) ? $data[$type] : [];
   }
 
   /**

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -130,9 +130,10 @@ class Bridge {
 
   /**
    * Create Authorized Email Address
-   * Return true if done, false for errors
+   *
+   * returns true if done or an array of error messages
    */
-  public function createAuthorizedEmailAddress(string $emailAdress): bool {
+  public function createAuthorizedEmailAddress(string $emailAdress) {
     $data = $this
     ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
     ->createAuthorizedEmailAddress($emailAdress);

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -125,7 +125,7 @@ class Bridge {
     if ($data && $type === 'all') {
       return $data;
     }
-    return $data ? $data[$type] : [];
+    return $data && isset($data[$type]) ? $data[$type] : [];
   }
 
   /**

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -130,8 +130,6 @@ class Bridge {
 
   /**
    * Create Authorized Email Address
-   *
-   * returns true if done or an array of error messages
    */
   public function createAuthorizedEmailAddress(string $emailAdress) {
     $data = $this

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -118,11 +118,26 @@ class Bridge {
     return $this->api;
   }
 
-  public function getAuthorizedEmailAddresses(): array {
+  public function getAuthorizedEmailAddresses($type = 'authorized'): array {
     $data = $this
       ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
       ->getAuthorizedEmailAddresses();
-    return $data ? $data['authorized'] : [];
+    if ($data && $type === 'all') {
+      return $data;
+    }
+    return $data ? $data[$type] : [];
+  }
+
+  /**
+   * Create Authorized Email Address
+   * Return true if done, false for errors
+   */
+  public function createAuthorizedEmailAddress(string $emailAdress): bool {
+    $data = $this
+    ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
+    ->createAuthorizedEmailAddress($emailAdress);
+
+    return $data;
   }
 
   public function checkMSSKey($apiKey) {

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -193,7 +193,7 @@ class API {
     if (!$isSuccess) {
       $logData = [
         'code' => $code,
-        'error' => is_wp_error($result) ? $result->get_error_message() : null,
+        'error' => is_wp_error($result) ? $result->get_error_message() : $this->wp->wpRemoteRetrieveBody($result),
       ];
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('CreateAuthorizedEmailAddress API call failed.', $logData);
     }

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -184,11 +184,11 @@ class API {
    * Create Authorized Email Address
    *
    * returns true if done or an array of error messages
-   * @param string $emailAdress
+   * @param string $emailAddress
    * @return bool|array
    */
-  public function createAuthorizedEmailAddress(string $emailAdress) {
-    $body = ['email' => $emailAdress];
+  public function createAuthorizedEmailAddress(string $emailAddress) {
+    $body = ['email' => $emailAddress];
     $result = $this->request(
       $this->urlAuthorizedEmailAddresses,
       $body

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -15,6 +15,7 @@ class API {
 
   const RESPONSE_CODE_KEY_INVALID = 401;
   const RESPONSE_CODE_STATS_SAVED = 204;
+  const RESPONSE_CODE_CREATED = 201;
   const RESPONSE_CODE_INTERNAL_SERVER_ERROR = 500;
   const RESPONSE_CODE_BAD_GATEWAY = 502;
   const RESPONSE_CODE_TEMPORARY_UNAVAILABLE = 503;
@@ -177,6 +178,27 @@ class API {
     }
     $data = json_decode($this->wp->wpRemoteRetrieveBody($result), true);
     return is_array($data) ? $data : null;
+  }
+
+  public function createAuthorizedEmailAddress(string $emailAdress): bool {
+    $body = ['email' => $emailAdress];
+    $result = $this->request(
+      $this->urlAuthorizedEmailAddresses,
+      $body
+    );
+
+    $code = $this->wp->wpRemoteRetrieveResponseCode($result);
+    $isSuccess = $code === self::RESPONSE_CODE_CREATED;
+
+    if (!$isSuccess) {
+      $logData = [
+        'code' => $code,
+        'error' => is_wp_error($result) ? $result->get_error_message() : null,
+      ];
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('CreateAuthorizedEmailAddress API call failed.', $logData);
+    }
+
+    return $isSuccess;
   }
 
   public function setKey($apiKey) {

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -183,11 +183,11 @@ class API {
   /**
    * Create Authorized Email Address
    *
-   * returns true if done or an array of error messages
+   * returns ['status' => true] if done or an array of error messages ['error' => $errorBody, 'status' => false]
    * @param string $emailAddress
-   * @return bool|array
+   * @return array
    */
-  public function createAuthorizedEmailAddress(string $emailAddress) {
+  public function createAuthorizedEmailAddress(string $emailAddress): array {
     $body = ['email' => $emailAddress];
     $result = $this->request(
       $this->urlAuthorizedEmailAddresses,
@@ -204,12 +204,15 @@ class API {
         'error' => is_wp_error($result) ? $result->get_error_message() : $errorBody,
       ];
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('CreateAuthorizedEmailAddress API call failed.', $logData);
+
       $errorResponseData = json_decode($errorBody, true);
       $fallbackError = sprintf($this->wp->__('An error has happened while performing a request, the server has responded with response code %d'), $code);
-      return is_array($errorResponseData) ? $errorResponseData : ['error' => $fallbackError];
+
+      $errorData = is_array($errorResponseData) && isset($errorResponseData['error']) ? $errorResponseData['error'] : $fallbackError;
+      return ['error' => $errorData, 'status' => false];
     }
 
-    return $isSuccess;
+    return ['status' => $isSuccess];
   }
 
   public function setKey($apiKey) {

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
@@ -63,7 +63,7 @@ class UnauthorizedEmailNotice {
 
   private function getAuthorizeEmailButton($validationError) {
     $email = $this->wp->escAttr($validationError['invalid_sender_address']);
-    $button = '<a target="_blank" href="https://account.mailpoet.com/authorization?email=' . $email . '" class="button button-primary">' . $this->wp->__('Authorize this email address', 'mailpoet') . '</a>';
+    $button = '<a target="_blank" href="https://account.mailpoet.com/authorization?email=' . $email . '" class="button button-primary mailpoet-js-button-authorize-email" data-email="' . $email . '">' . $this->wp->__('Authorize this email address', 'mailpoet') . '</a>';
     return $button;
   }
 

--- a/mailpoet/tests/acceptance/Settings/AuthorizedEmailAddressesValidationCest.php
+++ b/mailpoet/tests/acceptance/Settings/AuthorizedEmailAddressesValidationCest.php
@@ -99,8 +99,8 @@ class AuthorizedEmailAddressesValidationCest {
     $i->waitForText('Sender');
     $i->fillField('[name="sender_address"]', 'unauthorized@email.com');
     $i->selectOptionInSelect2('WordPress Users');
+    $i->waitForElement('.parsley-invalidFromAddress'); // see new email unauthorized error on input blur
     $i->click('Send');
-    $i->waitForElement('.sender_email_address_warning'); // see new email unauthorized error
     $i->waitForElement('.parsley-invalidFromAddress');
   }
 }

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -264,14 +264,15 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       'pending' => ['pending@email.com'],
       'authorized' => ['authorized@email.com']
     ];
+    $response = ['status' => true];
     $bridgeMock = $this->make(Bridge::class, [
       'getAuthorizedEmailAddresses' => Expected::once($array),
-      'createAuthorizedEmailAddress' => Expected::once(true)
+      'createAuthorizedEmailAddress' => Expected::once($response)
     ]);
     $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository);
     $result = $controller->createAuthorizedEmailAddress('new-authorized@email.com');
-    expect($result)->equals(true);
+    expect($result)->equals($response);
   }
 
   public function testItThrowsAnExceptionForReturnedArrayForCreateNewAuthorizedEmailAddress() {

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -283,6 +283,56 @@ class BridgeTest extends \MailPoetTest {
     $wp->removeFilter('mailpoet_bridge_api_request_timeout', $filter);
   }
 
+  public function testItReturnsOnlyAuthorizedEmails() {
+    $array = [
+      'pending' => ['pending@email.com'],
+      'authorized' => ['authorized@email.com'],
+      'main' => 'main@email.com'
+    ];
+    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => $array], $this);
+    $this->bridge->api = $api;
+
+    $result = $this->bridge->getAuthorizedEmailAddresses();
+    expect($result)->same(['authorized@email.com']);
+  }
+
+  public function testItReturnsAllUserEmails() {
+    $array = [
+      'pending' => ['pending@email.com'],
+      'authorized' => ['authorized@email.com'],
+      'main' => 'main@email.com'
+    ];
+    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => $array], $this);
+    $this->bridge->api = $api;
+
+    $result = $this->bridge->getAuthorizedEmailAddresses('all');
+    expect($result)->same($array);
+  }
+
+  public function testItReturnsAnEmptyArrayIfNoEmailForAllParam() {
+    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => []], $this);
+    $this->bridge->api = $api;
+
+    $result = $this->bridge->getAuthorizedEmailAddresses('all');
+    expect($result)->same([]);
+  }
+
+  public function testItReturnsAnEmptyArrayIfNoEmailForAuthorizedParam() {
+    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => []], $this);
+    $this->bridge->api = $api;
+
+    $result = $this->bridge->getAuthorizedEmailAddresses();
+    expect($result)->same([]);
+  }
+
+  public function testItReturnsAnEmptyArrayIfNoNullForAuthorizedParam() {
+    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => null], $this);
+    $this->bridge->api = $api;
+
+    $result = $this->bridge->getAuthorizedEmailAddresses();
+    expect($result)->same([]);
+  }
+
   private function setMailPoetSendingMethod() {
     $this->settings->set(
       Mailer::MAILER_CONFIG_SETTING_NAME,

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -35,6 +35,9 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   <!-- Set FROM address modal React root -->
   <div id="mailpoet_set_from_address_modal"></div>
 
+  <!-- Set Authorize sender email React root -->
+  <div id="mailpoet_authorize_sender_email_modal"></div>
+
   <!-- title block -->
   <% block title %><% endblock %>
   <!-- content block -->

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -120,6 +120,11 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'reviewRequestRateUsNow': _x('Rate us now', 'Review our plugin on WordPress.org.'),
   'reviewRequestNotNow': __('Not now'),
 
+  'authorizeSenderEmailModalTitle': __('Authorizing your email address: [senderEmail]', 'mailpoet'),
+  'authorizeSenderEmailModalDescription': __('Check your inbox now to confirm your email address. Please find the email with the subject: [bold]"email address to authorize"[/bold]', 'mailpoet'),
+  'authorizeSenderEmailMessageSuccess': __('The email address has been authorized. You can now send emails using this address with MailPoet.', 'mailpoet'),
+  'authorizeSenderEmailMessageError': __('An error occured when performing the request. Please try again later', 'mailpoet'),
+
   'sent': __('Sent'),
   'notSentYet': __('Not sent yet!'),
 


### PR DESCRIPTION
[MAILPOET-4300](https://mailpoet.atlassian.net/browse/MAILPOET-4300)

Please start reviewing from https://github.com/mailpoet/mailpoet/commit/4198bade172d6214f7360149eb02d52163358710

Depends on https://github.com/mailpoet/mailpoet/pull/4216

Testing:
* Test anywhere with links to MP Shop Email authorization page e.g. `/authorization?email=NEW_EMAIL`
* Confirm you can add a new email
* Confirm you get the confirmation email
* Confirm after clicking on the confirmation email and waiting for some seconds, the modal window update with new messages
* Confirm you can use the new email for sending newsletters