### PR TITLE
Add tags dynamic filter [PREMIUM-196]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -23,6 +23,7 @@ import {
   SubscribedToList,
   validateSubscribedToList,
 } from './subscriber_subscribed_to_list';
+import { SubscriberTag, validateSubscriberTag } from './subscriber_tag';
 
 export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
   if (
@@ -42,6 +43,9 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
   }
   if (formItems.action === SubscriberActionTypes.SUBSCRIBED_TO_LIST) {
     return validateSubscribedToList(formItems);
+  }
+  if (formItems.action === SubscriberActionTypes.SUBSCRIBER_TAG) {
+    return validateSubscriberTag(formItems);
   }
   if (!formItems.operator || !formItems.value) {
     return false;
@@ -87,6 +91,11 @@ export const SubscriberSegmentOptions = [
     group: SegmentTypes.WordPressRole,
   },
   {
+    value: SubscriberActionTypes.SUBSCRIBER_TAG,
+    label: MailPoet.I18n.t('subscriberTag'),
+    group: SegmentTypes.WordPressRole,
+  },
+  {
     value: SubscriberActionTypes.WORDPRESS_ROLE,
     label: MailPoet.I18n.t('segmentsSubscriber'),
     group: SegmentTypes.WordPressRole,
@@ -99,6 +108,7 @@ const componentsMap = {
   [SubscriberActionTypes.SUBSCRIBED_DATE]: SubscribedDateFields,
   [SubscriberActionTypes.MAILPOET_CUSTOM_FIELD]: MailPoetCustomFields,
   [SubscriberActionTypes.SUBSCRIBED_TO_LIST]: SubscribedToList,
+  [SubscriberActionTypes.SUBSCRIBER_TAG]: SubscriberTag,
 };
 
 type Props = {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_tag.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_tag.tsx
@@ -1,0 +1,26 @@
+import { Hooks } from 'wp-js-hooks';
+
+import { WordpressRoleFormItem } from '../types';
+import { DynamicSegmentsPremiumBanner } from '../premium_banner';
+
+export function validateSubscriberTag(
+  formItems: WordpressRoleFormItem,
+): boolean {
+  return Hooks.applyFilters(
+    'mailpoet_dynamic_segments_filter_subscriber_tag_validate',
+    false,
+    formItems,
+  );
+}
+
+type Props = {
+  filterIndex: number;
+};
+
+export function SubscriberTag({ filterIndex }: Props): JSX.Element {
+  return Hooks.applyFilters(
+    'mailpoet_dynamic_segments_filter_subscriber_tag',
+    <DynamicSegmentsPremiumBanner />,
+    filterIndex,
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -7,6 +7,7 @@ import {
   StateType,
   StaticSegment,
   SubscriberCount,
+  Tag,
   WindowCustomFields,
   WindowEditableRoles,
   WindowMembershipPlans,
@@ -44,6 +45,7 @@ export const getStaticSegmentsList = (state: StateType): StaticSegment[] =>
   state.staticSegmentsList;
 export const getSubscriberCount = (state: StateType): SubscriberCount =>
   state.subscriberCount;
+export const getTags = (state: StateType): Tag[] => state.tags;
 export const getSegmentFilter = (
   state: StateType,
   index: number,

--- a/mailpoet/assets/js/src/segments/dynamic/store/store.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/store.ts
@@ -34,6 +34,7 @@ export const createStore = (): void => {
     wooCurrencySymbol: window.mailpoet_woocommerce_currency_symbol,
     wooCountries: window.mailpoet_woocommerce_countries,
     customFieldsList: window.mailpoet_custom_fields,
+    tags: window.mailpoet_tags,
     segment: {
       filters_connect: SegmentConnectTypes.AND,
       filters: [

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -22,6 +22,7 @@ export enum SubscriberActionTypes {
   SUBSCRIBED_DATE = 'subscribedDate',
   SUBSCRIBER_SCORE = 'subscriberScore',
   SUBSCRIBED_TO_LIST = 'subscribedToList',
+  SUBSCRIBER_TAG = 'subscriberTag',
 }
 
 export enum SegmentConnectTypes {
@@ -68,6 +69,7 @@ export interface WordpressRoleFormItem extends FormItem {
   custom_field_type?: string;
   date_type?: string;
   segments?: number[];
+  tags?: number[];
 }
 
 export interface WooCommerceFormItem extends FormItem {
@@ -189,6 +191,7 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_can_use_woocommerce_subscriptions: boolean;
   mailpoet_woocommerce_currency_symbol: string;
   mailpoet_static_segments_list: StaticSegment[];
+  mailpoet_tags: Tag[];
 }
 
 export interface StateType {
@@ -208,6 +211,7 @@ export interface StateType {
   errors: string[];
   allAvailableFilters: GroupFilterValue[];
   staticSegmentsList: StaticSegment[];
+  tags: Tag[];
 }
 
 export enum Actions {
@@ -238,3 +242,8 @@ export interface SetSubscriberCountActionType extends ActionType {
 export interface SetErrorsActionType extends ActionType {
   errors: string[];
 }
+
+export type Tag = {
+  id: number;
+  name: string;
+};

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -11,12 +11,14 @@ use MailPoet\Config\ServicesChecker;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\TagEntity;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Segments\SegmentDependencyValidator;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
+use MailPoet\Tags\TagRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\AutocompletePostListLoader as WPPostListLoader;
@@ -67,6 +69,9 @@ class Segments {
   /** @var NewslettersResponseBuilder */
   private $newslettersResponseBuilder;
 
+  /** @var TagRepository */
+  private $tagRepository;
+
   /** @var TrackingConfig */
   private $trackingConfig;
 
@@ -84,6 +89,7 @@ class Segments {
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
     NewslettersResponseBuilder $newslettersResponseBuilder,
+    TagRepository $tagRepository,
     TrackingConfig $trackingConfig,
     TransientCache $transientCache
   ) {
@@ -100,6 +106,7 @@ class Segments {
     $this->transientCache = $transientCache;
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
+    $this->tagRepository = $tagRepository;
     $this->trackingConfig = $trackingConfig;
     $this->newslettersResponseBuilder = $newslettersResponseBuilder;
   }
@@ -159,6 +166,12 @@ class Segments {
       ];
     }
 
+    $data['tags'] = array_map(function (TagEntity $tag): array {
+      return [
+        'id' => $tag->getId(),
+        'name' => $tag->getName(),
+      ];
+    }, $this->tagRepository->findBy([], ['name' => 'ASC']));
 
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -353,6 +353,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberScore::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberSegment::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberTag::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\UserRole::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -11,6 +11,7 @@ use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberScore;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSegment;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
+use MailPoet\Segments\DynamicSegments\Filters\SubscriberTag;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
@@ -124,6 +125,16 @@ class FilterDataMapper {
       if (!empty($data['date_type'])) $filterData['date_type'] = $data['date_type'];
       if (!empty($data['operator'])) $filterData['operator'] = $data['operator'];
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], $filterData);
+    }
+    if ($data['action'] === SubscriberTag::TYPE) {
+      if (empty($data['tags'])) throw new InvalidFilterException('Missing tags', InvalidFilterException::MISSING_VALUE);
+      return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
+        'tags' => array_map(function ($tagId) {
+          return intval($tagId);
+        }, $data['tags']),
+        'operator' => $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY,
+        'connect' => $data['connect'],
+      ]);
     }
     if (empty($data['wordpressRole'])) throw new InvalidFilterException('Missing role', InvalidFilterException::MISSING_ROLE);
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -13,6 +13,7 @@ use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberScore;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSegment;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
+use MailPoet\Segments\DynamicSegments\Filters\SubscriberTag;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
@@ -65,6 +66,9 @@ class FilterFactory {
   /** @var SubscriberSegment */
   private $subscriberSegment;
 
+  /** @var SubscriberTag */
+  private $subscriberTag;
+
   /** @var EmailActionClickAny */
   private $emailActionClickAny;
 
@@ -83,6 +87,7 @@ class FilterFactory {
     WooCommerceSubscription $wooCommerceSubscription,
     SubscriberSubscribedDate $subscriberSubscribedDate,
     SubscriberScore $subscriberScore,
+    SubscriberTag $subscriberTag,
     SubscriberSegment $subscriberSegment
   ) {
     $this->emailAction = $emailAction;
@@ -97,6 +102,7 @@ class FilterFactory {
     $this->wooCommerceTotalSpent = $wooCommerceTotalSpent;
     $this->subscriberSubscribedDate = $subscriberSubscribedDate;
     $this->subscriberScore = $subscriberScore;
+    $this->subscriberTag = $subscriberTag;
     $this->mailPoetCustomFields = $mailPoetCustomFields;
     $this->subscriberSegment = $subscriberSegment;
     $this->emailActionClickAny = $emailActionClickAny;
@@ -124,7 +130,7 @@ class FilterFactory {
 
   /**
    * @param ?string $action
-   * @return MailPoetCustomFields|SubscriberScore|SubscriberSegment|SubscriberSubscribedDate|UserRole
+   * @return MailPoetCustomFields|SubscriberScore|SubscriberSegment|SubscriberSubscribedDate|UserRole|SubscriberTag
    */
   private function userRole(?string $action) {
     if ($action === SubscriberSubscribedDate::TYPE) {
@@ -135,6 +141,8 @@ class FilterFactory {
       return $this->mailPoetCustomFields;
     } elseif ($action === SubscriberSegment::TYPE) {
       return $this->subscriberSegment;
+    } elseif ($action === SubscriberTag::TYPE) {
+      return $this->subscriberTag;
     }
     return $this->userRole;
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class SubscriberTag implements Filter {
+  const TYPE = 'subscriberTag';
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $this->wp->applyFilters('mailpoet_dynamic_segments_filter_subscriber_tag_apply', $queryBuilder, $filter);
+    return $queryBuilder;
+  }
+}

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -200,6 +200,8 @@
     'woocommerceSubscriptions': _x('WooCommerce Subscriptions', 'Dynamic segment creation: User selects this to use any WooCommerce Subscriptions filters'),
     'selectWooSubscription': __('Search subscriptions'),
     'searchLists': __('Search lists'),
+    'subscriberTag': _x('tag', 'Subscriber tag'),
+    'searchTags': _x('Search tags'),
 
     'anyOf': __('any of'),
     'allOf': __('all of'),

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -25,6 +25,7 @@
     var mailpoet_subscribers_count = <%= subscriber_count %>;
     var mailpoet_custom_fields = <%= json_encode(custom_fields) %>;
     var mailpoet_static_segments_list = <%= json_encode(static_segments_list) %>;
+    var mailpoet_tags = <%= json_encode(tags) %>;
     var mailpoet_has_premium_support = <%= has_premium_support ? 'true' : 'false' %>;
     var mailpoet_premium_link = <%= json_encode(link_premium) %>;
     var wordpress_editable_roles_list = <%= json_encode(wordpress_editable_roles_list)  %>;

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -181,6 +181,48 @@ const baseConfig = {
         ],
       },
       {
+        include: path.resolve(__dirname, 'assets/js/src/common/grid/index.tsx'),
+        use: [
+          {
+            loader: 'expose-loader',
+            options: {
+              exposes: `${globalPrefix}.CommonGrid`,
+            },
+          },
+          'babel-loader',
+        ],
+      },
+      {
+        include: path.resolve(
+          __dirname,
+          'assets/js/src/common/form/select/select.tsx',
+        ),
+        use: [
+          {
+            loader: 'expose-loader',
+            options: {
+              exposes: `${globalPrefix}.CommonFormSelect`,
+            },
+          },
+          'babel-loader',
+        ],
+      },
+      {
+        include: path.resolve(
+          __dirname,
+          'assets/js/src/common/form/react_select/react_select.tsx',
+        ),
+        use: [
+          {
+            loader: 'expose-loader',
+            options: {
+              exposes: `${globalPrefix}.CommonFormReactSelect`,
+            },
+          },
+          'babel-loader',
+        ],
+      },
+      {
         include: path.resolve(
           __dirname,
           'assets/js/src/segments/dynamic/types.ts',
@@ -277,6 +319,9 @@ const adminConfig = {
       'help-tooltip.jsx',
       'listing/index.ts',
       'common/index.ts',
+      'common/grid/index.tsx',
+      'common/form/select/select.tsx',
+      'common/form/react_select/react_select.tsx',
       'wp-data-hooks.js',
       'segments/dynamic/types.ts',
     ],


### PR DESCRIPTION
Please start reviewing from https://github.com/mailpoet/mailpoet/commit/789e91413254c917aff3a690a420e42a952e14da

Depends on https://github.com/mailpoet/mailpoet/pull/4214

**How to test**:

1. Install the free plugin and the premium from https://github.com/mailpoet/mailpoet-premium/pull/596
2. Assign a tag to several subscribers
3. Create a new dynamic segment with tags - check if the count is correct
4. Try to deactivate the premium plugin
    a. it shouldn't be possible to view a count of subscribers or to edit the segment
    b. the new tag filter should be visible in the select, but it shouldn't be possible to use

[PREMIUM-196]

[PREMIUM-196]: https://mailpoet.atlassian.net/browse/PREMIUM-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ