### PR TITLE
Remove old model usage from MailPoet\Newsletter\Shortcodes\Categories\Link [MAILPOET-4361]

### DIFF
--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -138,14 +138,11 @@ class NewslettersResponseBuilder {
         ? $statistics->asArray()
         : false,
       'preview_url' => $this->newsletterUrl->getViewInBrowserUrl(
-        (object)[
-          'id' => $newsletter->getId(),
-          'hash' => $newsletter->getHash(),
-        ],
+        $newsletter,
         null,
         in_array($newsletter->getStatus(), [NewsletterEntity::STATUS_SENT, NewsletterEntity::STATUS_SENDING], true)
           ? $latestQueue
-          : false
+          : null
       ),
     ];
 

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -399,13 +399,7 @@ class Newsletters extends APIEndpoint {
 
   private function getViewInBrowserUrl(NewsletterEntity $newsletter): string {
     $this->fixMissingHash([$newsletter]); // Fix for MAILPOET-3275. Remove after May 2021
-    $url = $this->newsletterUrl->getViewInBrowserUrl(
-      (object)[
-        'id' => $newsletter->getId(),
-        'hash' => $newsletter->getHash(),
-      ]
-    );
-
+    $url = $this->newsletterUrl->getViewInBrowserUrl($newsletter);
     // strip protocol to avoid mix content error
     return preg_replace('/^https?:/i', '', $url);
   }

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -18,7 +18,6 @@ use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Pages;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class Shortcodes {
   /** @var Pages */
@@ -39,9 +38,6 @@ class Shortcodes {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
-  /** @var EntityManager */
-  private $entityManager;
-
   /** @var Date */
   private $dateCategory;
 
@@ -61,7 +57,6 @@ class Shortcodes {
     SubscribersRepository $subscribersRepository,
     NewsletterUrl $newsletterUrl,
     NewslettersRepository $newslettersRepository,
-    EntityManager $entityManager,
     Date $dateCategory,
     Link $linkCategory,
     Newsletter $newsletterCategory,
@@ -73,7 +68,6 @@ class Shortcodes {
     $this->subscribersRepository = $subscribersRepository;
     $this->newsletterUrl = $newsletterUrl;
     $this->newslettersRepository = $newslettersRepository;
-    $this->entityManager = $entityManager;
     $this->dateCategory = $dateCategory;
     $this->linkCategory = $linkCategory;
     $this->newsletterCategory = $newsletterCategory;
@@ -235,7 +229,7 @@ class Shortcodes {
     $shortcodeProcessor->setQueue($queue);
     return '<a href="' . esc_attr($previewUrl) . '" target="_blank" title="'
       . esc_attr(__('Preview in a new tab', 'mailpoet')) . '">'
-      . esc_attr((string)$shortcodeProcessor->replace($queue->getNewsletterRenderedSubject())) .
+      . esc_attr((string)$shortcodeProcessor->replace($queue ? $queue->getNewsletterRenderedSubject() : '')) .
       '</a>';
   }
 }

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -172,7 +172,6 @@ class Shortcodes {
     $newsletters = $this->newslettersRepository->getArchives($segmentIds);
 
     $subscriber = $this->subscribersRepository->getCurrentWPUser();
-    $subscriber = $subscriber ? Subscriber::findOne($subscriber->getId()) : null;
 
     if (empty($newsletters)) {
       return $this->wp->applyFilters(
@@ -216,7 +215,7 @@ class Shortcodes {
     );
   }
 
-  public function renderArchiveSubject(NewsletterEntity $newsletter, $subscriber, SendingQueueEntity $queue) {
+  public function renderArchiveSubject(NewsletterEntity $newsletter, ?SubscriberEntity $subscriber, ?SendingQueueEntity $queue) {
     $previewUrl = $this->newsletterUrl->getViewInBrowserUrl($newsletter, $subscriber, $queue);
     /**
      * An ugly workaround to make sure state is not shared via NewsletterShortcodes service
@@ -230,15 +229,9 @@ class Shortcodes {
       $this->subscriberCategory,
       $this->wp
     );
+
     $shortcodeProcessor->setNewsletter($newsletter);
-
-    if (is_object($subscriber) && !is_a($subscriber, SubscriberEntity::class) && !empty($subscriber->id)) {
-      $subscriberEntity = $this->entityManager->find(SubscriberEntity::class, $subscriber->id);
-    } else {
-      $subscriberEntity = new SubscriberEntity();
-    }
-
-    $shortcodeProcessor->setSubscriber($subscriberEntity);
+    $shortcodeProcessor->setSubscriber($subscriber ?? new SubscriberEntity());
     $shortcodeProcessor->setQueue($queue);
     return '<a href="' . esc_attr($previewUrl) . '" target="_blank" title="'
       . esc_attr(__('Preview in a new tab', 'mailpoet')) . '">'

--- a/mailpoet/lib/Models/StatisticsNewsletters.php
+++ b/mailpoet/lib/Models/StatisticsNewsletters.php
@@ -4,6 +4,7 @@ namespace MailPoet\Models;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
@@ -37,7 +38,7 @@ class StatisticsNewsletters extends Model {
     );
   }
 
-  public static function getAllForSubscriber(Subscriber $subscriber) {
+  public static function getAllForSubscriber(SubscriberEntity $subscriber) {
     $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
 
     return static::tableAlias('statistics')
@@ -55,7 +56,7 @@ class StatisticsNewsletters extends Model {
         'statistics.newsletter_id = opens.newsletter_id AND statistics.subscriber_id = opens.subscriber_id',
         'opens'
       )
-      ->where('statistics.subscriber_id', $subscriber->id())
+      ->where('statistics.subscriber_id', $subscriber->getId())
       ->orderByAsc('newsletter_id');
   }
 }

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -6,7 +6,6 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\SendingQueue;
-use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
@@ -49,7 +48,6 @@ class Link implements CategoryInterface {
     bool $wpUserPreview = false
   ): ?string {
     $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
-    $subscriberModel = $this->getSubscriberModel($subscriber);
     $queueModel = $this->getQueueModel($queue);
 
     switch ($shortcodeDetails['action']) {
@@ -80,7 +78,7 @@ class Link implements CategoryInterface {
       case 'newsletter_view_in_browser_url':
         $url = $this->newsletterUrl->getViewInBrowserUrl(
           $newsletter,
-          $wpUserPreview ? null : $subscriberModel,
+          $wpUserPreview ? null : $subscriber,
           $queueModel,
           $wpUserPreview
         );
@@ -122,7 +120,6 @@ class Link implements CategoryInterface {
     SendingQueueEntity $queue = null,
     $wpUserPreview = false
   ): ?string {
-    $subscriberModel = $this->getSubscriberModel($subscriber);
     $queueModel = $this->getQueueModel($queue);
     $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
     switch ($shortcodeAction) {
@@ -138,7 +135,7 @@ class Link implements CategoryInterface {
       case 'newsletter_view_in_browser_url':
         $url = $this->newsletterUrl->getViewInBrowserUrl(
           $newsletter,
-          $subscriberModel,
+          $subscriber,
           $queueModel,
           false
         );
@@ -170,14 +167,6 @@ class Link implements CategoryInterface {
     if ($queue instanceof SendingQueueEntity) {
       return $queue->getId();
     }
-    return null;
-  }
-
-  // temporary function until Links are refactored to Doctrine
-  private function getSubscriberModel(SubscriberEntity $subscriber = null): ?SubscriberModel {
-    if (!$subscriber) return null;
-    $subscriberModel = SubscriberModel::where('id', $subscriber->getId())->findOne();
-    if ($subscriberModel) return $subscriberModel;
     return null;
   }
 

--- a/mailpoet/lib/Newsletter/Url.php
+++ b/mailpoet/lib/Newsletter/Url.php
@@ -20,9 +20,9 @@ class Url {
   }
 
   public function getViewInBrowserUrl(
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    $queue = false,
+    ?NewsletterEntity $newsletter,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     bool $preview = true
   ) {
     $data = $this->createUrlDataObject($newsletter, $subscriber, $queue, $preview);
@@ -33,15 +33,15 @@ class Url {
     );
   }
 
-  public function createUrlDataObject(NewsletterEntity $newsletter = null, SubscriberEntity $subscriber = null, $queue, $preview) {
+  public function createUrlDataObject(
+    ?NewsletterEntity $newsletter,
+    ?SubscriberEntity $subscriber,
+    ?SendingQueueEntity $queue,
+    bool $preview
+  ) {
     $newsletterId = $newsletter && $newsletter->getId() ? $newsletter->getId() : 0;
     $newsletterHash = $newsletter && $newsletter->getHash() ? $newsletter->getHash() : 0;
-
-    if ($queue instanceof SendingQueueEntity) {
-      $sendingQueueId = (!empty($queue->getId())) ? (int)$queue->getId() : 0;
-    } else {
-      $sendingQueueId = (!empty($queue->id)) ? (int)$queue->id : 0;
-    }
+    $sendingQueueId = $queue && $queue->getId() ? $queue->getId() : 0;
 
     return [
       $newsletterId,

--- a/mailpoet/lib/Newsletter/Url.php
+++ b/mailpoet/lib/Newsletter/Url.php
@@ -27,7 +27,7 @@ class Url {
   }
 
   public function getViewInBrowserUrl(
-    $newsletter,
+    NewsletterEntity $newsletter = null,
     $subscriber = false,
     $queue = false,
     bool $preview = true
@@ -46,14 +46,9 @@ class Url {
     );
   }
 
-  public function createUrlDataObject($newsletter, $subscriber, $queue, $preview) {
-    if ($newsletter instanceof NewsletterEntity) {
-      $newsletterId = (!empty($newsletter->getId())) ? (int)$newsletter->getId() : 0;
-      $newsletterHash = (!empty($newsletter->getHash())) ? $newsletter->getHash() : 0;
-    } else {
-      $newsletterId = (!empty($newsletter->id)) ? (int)$newsletter->id : 0;
-      $newsletterHash = (!empty($newsletter->hash)) ? $newsletter->hash : 0;
-    }
+  public function createUrlDataObject(NewsletterEntity $newsletter = null, $subscriber, $queue, $preview) {
+    $newsletterId = $newsletter && $newsletter->getId() ? $newsletter->getId() : 0;
+    $newsletterHash = $newsletter && $newsletter->getHash() ? $newsletter->getHash() : 0;
 
     if ($queue instanceof SendingQueueEntity) {
       $sendingQueueId = (!empty($queue->getId())) ? (int)$queue->getId() : 0;

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -78,8 +78,8 @@ class ViewInBrowserRenderer {
     }
     $this->prepareShortcodes(
       $newsletter,
-      $subscriber ?: false,
-      $queue ?: false,
+      $subscriber,
+      $queue,
       $wpUserPreview
     );
     $renderedNewsletter = $this->shortcodes->replace($newsletterBody);
@@ -93,19 +93,15 @@ class ViewInBrowserRenderer {
     return $renderedNewsletter;
   }
 
-  private function prepareShortcodes($newsletter, $subscriber, $queue, $wpUserPreview) {
-    if ($queue instanceof SendingQueueEntity) {
-      $this->shortcodes->setQueue($queue);
-    }
-
-    if ($newsletter instanceof NewsletterEntity) {
-      $this->shortcodes->setNewsletter($newsletter);
-    }
-
+  private function prepareShortcodes(
+    NewsletterEntity $newsletter,
+    ?SubscriberEntity $subscriber,
+    ?SendingQueueEntity $queue,
+    bool $wpUserPreview
+  ) {
+    $this->shortcodes->setQueue($queue);
+    $this->shortcodes->setNewsletter($newsletter);
     $this->shortcodes->setWpUserPreview($wpUserPreview);
-
-    if ($subscriber instanceof SubscriberEntity) {
-      $this->shortcodes->setSubscriber($subscriber);
-    }
+    $this->shortcodes->setSubscriber($subscriber);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -66,12 +66,7 @@ class SendPreviewControllerTest extends \MailPoetTest {
         function ($newsletter, $subscriber, $extraParams) {
           $unsubscribeLink = $this->subscriptionUrlFactory->getConfirmUnsubscribeUrl(null);
           $manageLink = $this->subscriptionUrlFactory->getManageUrl(null);
-          $viewInBrowserLink = $this->newsletterUrl->getViewInBrowserUrl(
-            (object)[
-              'id' => $this->newsletter->getId(),
-              'hash' => $this->newsletter->getHash(),
-            ]
-          );
+          $viewInBrowserLink = $this->newsletterUrl->getViewInBrowserUrl($this->newsletter);
           $mailerMetaInfo = new MetaInfo;
 
           expect(is_array($newsletter))->true();

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -36,7 +36,7 @@ class SendPreviewControllerTest extends \MailPoetTest {
     $this->subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
     $newsletter = new NewsletterEntity();
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
-    $newsletter->setSubject('My Standard Newsletter');
+    $newsletter->setSubject('My Standard Newsletter SendPreviewControllerTest');
     $newsletter->setPreheader('preheader');
     $newsletter->setBody(json_decode(Fixtures::get('newsletter_body_template'), true));
     $newsletter->setHash(Security::generateHash());
@@ -86,13 +86,15 @@ class SendPreviewControllerTest extends \MailPoetTest {
 
     $mailerFactory = $this->createMock(MailerFactory::class);
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
+    $shortcodes = $this->diContainer->get(Shortcodes::class);
+    $shortcodes->setQueue(null);
     $sendPreviewController = new SendPreviewController(
       $mailerFactory,
       new MetaInfo(),
       $this->diContainer->get(Renderer::class),
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(Shortcodes::class)
+      $shortcodes
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\Newsletter as NewsletterModel;
 use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
@@ -352,7 +351,6 @@ class ShortcodesTest extends \MailPoetTest {
     $shortcodesObject = $this->shortcodesObject;
     $shortcodesObject->setWpUserPreview(true);
     $shortcodesObject->setSubscriber(null);
-    $newsletterModel = NewsletterModel::where('id', $this->newsletter->getId())->findOne();
     $shortcodes = [
       '[link:subscription_unsubscribe_url]',
       '[link:subscription_instant_unsubscribe_url]',
@@ -363,7 +361,7 @@ class ShortcodesTest extends \MailPoetTest {
       $this->subscriptionUrlFactory->getConfirmUnsubscribeUrl(null),
       $this->subscriptionUrlFactory->getUnsubscribeUrl(null),
       $this->subscriptionUrlFactory->getManageUrl(null),
-      $this->newsletterUrl->getViewInBrowserUrl($newsletterModel),
+      $this->newsletterUrl->getViewInBrowserUrl($this->newsletter),
     ];
     $result = $shortcodesObject->process($shortcodes);
     // hash is returned

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporterTest.php
@@ -8,7 +8,9 @@ use MailPoet\Models\Newsletter;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsNewsletters;
 use MailPoet\Models\Subscriber;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Url;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -17,9 +19,17 @@ class NewslettersExporterTest extends \MailPoetTest {
   /** @var NewslettersExporter */
   private $exporter;
 
+  /*** @var SubscribersRepository */
+  private $subscribersRepository;
+
   public function _before() {
     parent::_before();
-    $this->exporter = new NewslettersExporter($this->diContainer->get(Url::class));
+    $this->subscribersRepository =  $this->diContainer->get(SubscribersRepository::class);
+    $this->exporter = new NewslettersExporter(
+      $this->diContainer->get(Url::class),
+      $this->subscribersRepository,
+      $this->diContainer->get(NewslettersRepository::class)
+    );
   }
 
   public function testExportWorksWhenSubscriberNotFound() {

--- a/mailpoet/tests/integration/Tasks/StateTest.php
+++ b/mailpoet/tests/integration/Tasks/StateTest.php
@@ -6,6 +6,7 @@ use MailPoet\Cron\Workers\SendingQueue\Migration;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Url;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Tasks\State;
@@ -19,7 +20,8 @@ class StateTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->tasksState = new State(
-      $this->diContainer->get(Url::class)
+      $this->diContainer->get(Url::class),
+      $this->diContainer->get(SendingQueuesRepository::class)
     );
   }
 


### PR DESCRIPTION
This PR removes old models from newsletter shortcode-link related files.

- The files using MailPoet\Newsletter\Shortcodes\Categories\Link where adjusted so that they are not using the old models either.
- Down the line NewslettersExporter had to get adjusted as well.
- Test where adjusted as well.

[MAILPOET-4361]

[MAILPOET-4361]: https://mailpoet.atlassian.net/browse/MAILPOET-4361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ