### PR TITLE
Expose test db port to local dev machine

### DIFF
--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -104,6 +104,8 @@ services:
       MYSQL_PASSWORD: wordpress
     volumes:
       - /dev/shm:/dev/shm
+    ports:
+      - 4401:3306
 
   chrome:
     environment:


### PR DESCRIPTION
A not very common db port number is used so that it won’t
easily conflict with other possible instances of database

[MAILPOET-4468]

[MAILPOET-4468]: https://mailpoet.atlassian.net/browse/MAILPOET-4468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ