### PR TITLE
Replace Paris models with Doctrine in SubscriberPersonalDataEraser [MAILPOET-4349]

### DIFF
--- a/mailpoet/lib/Config/PersonalDataErasers.php
+++ b/mailpoet/lib/Config/PersonalDataErasers.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Config;
 
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Subscribers\SubscriberPersonalDataEraser;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -13,7 +14,7 @@ class PersonalDataErasers {
   public function registerSubscriberEraser($erasers) {
     $erasers['mailpet-subscriber'] = [
       'eraser_friendly_name' => WPFunctions::get()->__('MailPoet Subscribers', 'mailpoet'),
-      'callback' => [new SubscriberPersonalDataEraser(), 'erase'],
+      'callback' => [ContainerWrapper::getInstance()->get(SubscriberPersonalDataEraser::class), 'erase'],
     ];
 
     return $erasers;

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -321,6 +321,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\SubscriberListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSegmentRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberCustomFieldRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\SubscriberPersonalDataEraser::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSubscribeController::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ImportExport\ImportExportRepository::class)->setPublic(true);

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -123,6 +123,30 @@ class Subscriber {
   }
 
   /**
+   * @return $this
+   */
+  public function withSubscribedIp(string $subscribedIp) {
+    $this->data['subscribedIp'] = $subscribedIp;
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function withConfirmedIp(string $confirmedIp) {
+    $this->data['confirmedIp'] = $confirmedIp;
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function withUnconfirmedData(string $unconfirmedData) {
+    $this->data['unconfirmedData'] = $unconfirmedData;
+    return $this;
+  }
+
+  /**
    * @throws \Exception
    */
   public function create(): SubscriberEntity {
@@ -136,6 +160,9 @@ class Subscriber {
     if (isset($this->data['first_name'])) $subscriber->setFirstName($this->data['first_name']);
     if (isset($this->data['is_woocommerce_user'])) $subscriber->setIsWoocommerceUser($this->data['is_woocommerce_user']);
     if (isset($this->data['wp_user_id'])) $subscriber->setWpUserId($this->data['wp_user_id']);
+    if (isset($this->data['subscribedIp'])) $subscriber->setSubscribedIp($this->data['subscribedIp']);
+    if (isset($this->data['confirmedIp'])) $subscriber->setConfirmedIp($this->data['confirmedIp']);
+    if (isset($this->data['unconfirmedData'])) $subscriber->setUnconfirmedData($this->data['unconfirmedData']);
     if (isset($this->data['source'])) {
       $subscriber->setSource($this->data['source']);
     }


### PR DESCRIPTION
**How to test this PR**

Check that anonymizing MailPoet specific data for subscribers still works as expected when the WP Erase Personal Data tool (`/wp-admin/erase-personal-data.php`) is used.

[MAILPOET-4349]

[MAILPOET-4349]: https://mailpoet.atlassian.net/browse/MAILPOET-4349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ