### PR TITLE
Fix nofollow tag in the preview newsletter page

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -96,7 +96,7 @@ class Renderer {
       $content = $this->addMailpoetLogoContentBlock($content, $styles);
     }
 
-    $metaRobots = $preview ? '<meta name="robots" content="noindex, follow" />' : '';
+    $metaRobots = $preview ? '<meta name="robots" content="noindex, nofollow" />' : '';
     $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingTask);
     $renderedBody = $this->renderBody($newsletter, $content);
     $renderedStyles = $this->renderStyles($styles);


### PR DESCRIPTION
Commit 1a9b2ed798c68b818328eda1293ca8ee174b37f9 added a `follow` tag to the preview newsletter page by mistake. The intention was to add a `nofollow` tag. This PR fixes it.

[MAILPOET-4263]

[MAILPOET-4263]: https://mailpoet.atlassian.net/browse/MAILPOET-4263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ