### PR TITLE
Remove the deprecated filters mailpoet_archive_date and mailpoet_archive_subject [MAILPOET-4470]

### DIFF
--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -103,27 +103,7 @@ class Shortcodes {
     $this->wp->addFilter('mailpoet_archive_email_subject', [
       $this, 'renderArchiveSubject',
     ], 2, 3);
-
-    // This deprecated notice can be removed after 2022-06-01
-    if ($this->wp->hasFilter('mailpoet_archive_date')) {
-      $this->wp->deprecatedHook(
-        'mailpoet_archive_date',
-        '3.69.2',
-        'mailpoet_archive_email_processed_date',
-        __('Please note that mailpoet_archive_date no longer runs and that the list of parameters of the new filter is different.', 'mailpoet')
-      );
-    }
-
-    // This deprecated notice can be removed after 2022-06-01
-    if ($this->wp->hasFilter('mailpoet_archive_subject')) {
-      $this->wp->deprecatedHook(
-        'mailpoet_archive_subject',
-        '3.69.2',
-        'mailpoet_archive_email_subject',
-        __('Please note that mailpoet_archive_subject no longer runs and that the list of parameters of the new filter is different.', 'mailpoet')
-      );
-    }
-
+    
     // initialize subscription pages data
     $this->subscriptionPages->init();
     // initialize subscription management shortcodes


### PR DESCRIPTION
Those two filters were deprecated over six months ago and were scheduled to be removed last month.

[MAILPOET-4470]

[MAILPOET-4470]: https://mailpoet.atlassian.net/browse/MAILPOET-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ