### PR TITLE
Replace old model usage in AdminPages with a doctrine code [MAILPOET-4339]

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Forms.php
+++ b/mailpoet/lib/AdminPages/Pages/Forms.php
@@ -3,8 +3,9 @@
 namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\API\JSON\ResponseBuilders\SegmentsResponseBuilder;
 use MailPoet\Listing\PageLimit;
-use MailPoet\Models\Segment;
+use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\Util\Installation;
@@ -30,12 +31,20 @@ class Forms {
   /** @var SettingsController */
   private $settings;
 
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var SegmentsResponseBuilder */
+  private $segmentsResponseBuilder;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
     Installation $installation,
     SettingsController $settings,
     UserFlagsController $userFlags,
+    SegmentsRepository $segmentsRepository,
+    SegmentsResponseBuilder $segmentsResponseBuilder,
     WPFunctions $wp
   ) {
     $this->pageRenderer = $pageRenderer;
@@ -44,12 +53,14 @@ class Forms {
     $this->userFlags = $userFlags;
     $this->wp = $wp;
     $this->settings = $settings;
+    $this->segmentsRepository = $segmentsRepository;
+    $this->segmentsResponseBuilder = $segmentsResponseBuilder;
   }
 
   public function render() {
     $data = [];
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('forms');
-    $data['segments'] = Segment::findArray();
+    $data['segments'] = $this->segmentsResponseBuilder->buildForListing($this->segmentsRepository->findAll());
     $data['is_new_user'] = $this->installation->isNewInstallation();
 
     $data = $this->getNPSSurveyData($data);

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -8,9 +8,10 @@ use MailPoet\Config\Env;
 use MailPoet\Config\Installer;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Listing\PageLimit;
-use MailPoet\Models\Newsletter;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\NewsletterTemplates\NewsletterTemplatesRepository;
 use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Services\Bridge;
@@ -69,6 +70,9 @@ class Newsletters {
   /** @var SegmentsSimpleListRepository */
   private $segmentsListRepository;
 
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
   /** @var TrackingConfig */
   private $trackingConfig;
 
@@ -90,6 +94,7 @@ class Newsletters {
     WPPostListLoader $wpPostListLoader,
     AutomaticEmails $automaticEmails,
     SegmentsSimpleListRepository $segmentsListRepository,
+    NewslettersRepository $newslettersRepository,
     TrackingConfig $trackingConfig,
     Bridge $bridge
   ) {
@@ -108,6 +113,7 @@ class Newsletters {
     $this->wpPostListLoader = $wpPostListLoader;
     $this->segmentsListRepository = $segmentsListRepository;
     $this->trackingConfig = $trackingConfig;
+    $this->newslettersRepository = $newslettersRepository;
     $this->bridge = $bridge;
   }
 
@@ -158,7 +164,7 @@ class Newsletters {
     $data['is_woocommerce_active'] = $this->woocommerceHelper->isWooCommerceActive();
     $data['is_mailpoet_update_available'] = array_key_exists(Env::$pluginPath, $this->wp->getPluginUpdates());
     $data['subscriber_count'] = $this->subscribersFeature->getSubscribersCount();
-    $data['newsletters_count'] = Newsletter::count();
+    $data['newsletters_count'] = $this->newslettersRepository->countBy([]);
     $data['mailpoet_feature_flags'] = $this->featuresController->getAllFlags();
     $data['transactional_emails_opt_in_notice_dismissed'] = $this->userFlags->get('transactional_emails_opt_in_notice_dismissed');
     $data['has_premium_support'] = $this->subscribersFeature->hasPremiumSupport();
@@ -179,7 +185,7 @@ class Newsletters {
     $data['woocommerce_optin_on_checkout'] = $this->settings->get('woocommerce.optin_on_checkout.enabled', false);
 
     $data['is_new_user'] = $this->installation->isNewInstallation();
-    $data['sent_newsletters_count'] = (int)Newsletter::where('status', Newsletter::STATUS_SENT)->count();
+    $data['sent_newsletters_count'] = $this->newslettersRepository->countBy(['status' => NewsletterEntity::STATUS_SENT]);
     $data['woocommerce_transactional_email_id'] = $this->settings->get(TransactionalEmails::SETTING_EMAIL_ID);
     $data['display_detailed_stats'] = Installer::getPremiumStatus()['premium_plugin_initialized'];
     $data['newsletters_templates_recently_sent_count'] = $this->newsletterTemplatesRepository->getRecentlySentCount();

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -422,6 +422,24 @@ class NewslettersRepository extends Repository {
     return $result;
   }
 
+  /**
+   * Returns standard newsletters ordered by sentAt
+   * @return NewsletterEntity[]
+   */
+  public function getStandardNewsletterList(): array {
+    return $this->entityManager->createQueryBuilder()
+      ->select('n')
+      ->addSelect('CASE WHEN n.sentAt IS NULL THEN 1 ELSE 0 END as HIDDEN sent_at_is_null')
+      ->from(NewsletterEntity::class, 'n')
+      ->where('n.type = :typeStandard')
+      ->andWhere('n.deletedAt IS NULL')
+      ->orderBy('sent_at_is_null', 'DESC')
+      ->addOrderBy('n.sentAt', 'DESC')
+      ->setParameter('typeStandard', NewsletterEntity::TYPE_STANDARD)
+      ->getQuery()
+      ->getResult();
+  }
+
   public function prefetchOptions(array $newsletters) {
     $this->entityManager->createQueryBuilder()
       ->select('PARTIAL n.{id}, o, opf')

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
@@ -46,6 +46,7 @@ class EditorUpdateNewFormCest {
     $i->waitForElement('[data-automation-id="template_selection_list"]');
     $i->click('[data-automation-id="select_template_template_1_popup"]');
     $i->waitForElement('[data-automation-id="form_title_input"]');
+    $i->clearField('[data-automation-id="form_title_input"]'); // Clear field due to flakiness
     $i->fillField('[data-automation-id="form_title_input"]', $formName);
     // Try saving form without selected list
     $i->click('[data-automation-id="form_save_button"]');


### PR DESCRIPTION
[MAILPOET-4339]

This pull request removes old model usage from four admin pages:
- Forms - rendering segments
- Newsletters - rendering count of newsletters
- Segments - rendering newsletters
- Subscribers - rendering custom fields

[MAILPOET-4339]: https://mailpoet.atlassian.net/browse/MAILPOET-4339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ