### PR TITLE
Refactor MailPoet\Config\Shortcodes to Doctrine [MAILPOET-4307]

### DIFF
--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -57,7 +57,7 @@ class ShortcodesTest extends \MailPoetTest {
       switch ($filterName) {
         case 'mailpoet_archive_date':
           return $shortcodes->renderArchiveDate($args[0]);
-        case 'mailpoet_archive_subject':
+        case 'mailpoet_archive_subject_line':
           return $shortcodes->renderArchiveSubject($args[0], $args[1], $args[2]);
       }
       return '';
@@ -90,7 +90,7 @@ class ShortcodesTest extends \MailPoetTest {
       switch ($filterName) {
         case 'mailpoet_archive_date':
           return $shortcodes->renderArchiveDate($args[0]);
-        case 'mailpoet_archive_subject':
+        case 'mailpoet_archive_subject_line':
           return $shortcodes->renderArchiveSubject($args[0], $args[1], $args[2]);
       }
       return '';
@@ -124,7 +124,7 @@ class ShortcodesTest extends \MailPoetTest {
       switch ($filterName) {
         case 'mailpoet_archive_date':
           return $shortcodes->renderArchiveDate($args[0]);
-        case 'mailpoet_archive_subject':
+        case 'mailpoet_archive_subject_line':
           return $shortcodes->renderArchiveSubject($args[0], $args[1], $args[2]);
       }
       return '';


### PR DESCRIPTION
This PR replaces all models with Doctrine entities and repositories in the classes MailPoet\Config\Shortcodes and \MailPoet\Config\ShortcodesTest. 

In the process, it was necessary to change the type of a parameter passed to a WP filter. To avoid fatal errors for users that might be using this filter, a new filter was created, and the old filter was deprecated. A similar process already happened for this same filter (unfortunately) about six months ago. See more information about the discussion that lead to the decision to create a new filter here: https://github.com/mailpoet/mailpoet/pull/3665

**How to test this PR**

Check that the following shortcodes are still working and their behavior is exactly the same as it was before the changes proposed here: mailpoet_subscribers_count and mailpoet_archive

[MAILPOET-4307]

[MAILPOET-4307]: https://mailpoet.atlassian.net/browse/MAILPOET-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ