### PR TITLE
Fix CSS property order [MAILPOET-4057]

### DIFF
--- a/mailpoet/assets/css/src/generic/_forms-select.scss
+++ b/mailpoet/assets/css/src/generic/_forms-select.scss
@@ -135,8 +135,8 @@
 }
 
 .mailpoet-form-react-select-option {
-  display: flex;
   align-items: center;
+  display: flex;
 }
 
 .mailpoet-form-react-select-tag {

--- a/mailpoet/assets/css/src/mailpoet-automation-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-editor.scss
@@ -2,6 +2,7 @@
 @import '../../../node_modules/@wordpress/interface/build-style/style';
 @import '../../../node_modules/@wordpress/edit-site/build-style/style';
 @import '../../../node_modules/@wordpress/block-editor/build-style/style'; // for inserter styles
+@import 'settings/colors';
 @import './components-automation-editor/add-step-button';
 @import './components-automation-editor/empty-workflow';
 @import './components-automation-editor/separator';


### PR DESCRIPTION
For some reason this issue wasn't caught by our automated checks. I believe it may be because we're running `stylelint --fix` during the [build process](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/10505/workflows/58898567-a681-456c-9f6f-21b73b276fe9/jobs/185396), which would automatically fix this.

MAILPOET-4057