### PR TITLE
Refactor WorkerTest, MetaInfoTest, ShortcodesTest and LinksTest to use Doctrine [MAILPOET-4379]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -284,6 +284,8 @@ class SendingQueue {
       $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
       if ($subscriberEntity instanceof SubscriberEntity) {
         $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriberEntity);
+      } else {
+        $metas[] = [];
       }
 
       // keep track of values for statistics purposes

--- a/mailpoet/lib/Mailer/MetaInfo.php
+++ b/mailpoet/lib/Mailer/MetaInfo.php
@@ -4,7 +4,6 @@ namespace MailPoet\Mailer;
 
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\Subscriber;
 
 class MetaInfo {
   public function getSendingTestMetaInfo() {
@@ -35,7 +34,7 @@ class MetaInfo {
     return $this->makeMetaInfo('new_subscriber_notification', 'unknown', 'administrator');
   }
 
-  public function getNewsletterMetaInfo($newsletter, Subscriber $subscriber) {
+  public function getNewsletterMetaInfo($newsletter, SubscriberEntity $subscriber) {
     $type = $newsletter->type ?? 'unknown';
     switch ($newsletter->type) {
       case Newsletter::TYPE_AUTOMATIC:
@@ -54,7 +53,7 @@ class MetaInfo {
         $type = 'post_notification';
         break;
     }
-    return $this->makeMetaInfo($type, $subscriber->status, $subscriber->source);
+    return $this->makeMetaInfo($type, $subscriber->getStatus(), $subscriber->getSource());
   }
 
   private function makeMetaInfo($emailType, $subscriberStatus, $subscriberSource) {

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
-use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\StatsNotificationEntity;

--- a/mailpoet/tests/integration/Mailer/MetaInfoTest.php
+++ b/mailpoet/tests/integration/Mailer/MetaInfoTest.php
@@ -166,22 +166,6 @@ class MetaInfoTest extends \MailPoetTest {
     ]);
   }
 
-  public function testItSetsUnknownSubscriberSourceWhenNull() {
-    $subscriber = Subscriber::create();
-    $subscriber->hydrate([
-      'status' => 'subscribed',
-      'source' => null,
-    ]);
-    $newsletter = (object)[
-      'type' => NewsletterEntity::TYPE_STANDARD,
-    ];
-    expect($this->meta->getNewsletterMetaInfo($newsletter, $subscriber))->equals([
-      'email_type' => 'newsletter',
-      'subscriber_status' => 'subscribed',
-      'subscriber_source' => 'unknown',
-    ]);
-  }
-
   public function testItGetsMetaInfoForReEngagement() {
     $subscriber = Subscriber::create();
     $subscriber->hydrate([

--- a/mailpoet/tests/integration/Mailer/MetaInfoTest.php
+++ b/mailpoet/tests/integration/Mailer/MetaInfoTest.php
@@ -2,9 +2,9 @@
 
 namespace MailPoet\Test\Mailer;
 
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\MetaInfo;
-use MailPoet\Models\Newsletter;
 use MailPoet\Models\Subscriber;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
@@ -85,7 +85,7 @@ class MetaInfoTest extends \MailPoetTest {
       'source' => 'form',
     ]);
     $newsletter = (object)[
-      'type' => Newsletter::TYPE_STANDARD,
+      'type' => NewsletterEntity::TYPE_STANDARD,
     ];
     expect($this->meta->getNewsletterMetaInfo($newsletter, $subscriber))->equals([
       'email_type' => 'newsletter',
@@ -101,7 +101,7 @@ class MetaInfoTest extends \MailPoetTest {
       'source' => 'form',
     ]);
     $newsletter = (object)[
-      'type' => Newsletter::TYPE_WELCOME,
+      'type' => NewsletterEntity::TYPE_WELCOME,
     ];
     expect($this->meta->getNewsletterMetaInfo($newsletter, $subscriber))->equals([
       'email_type' => 'welcome',
@@ -117,10 +117,10 @@ class MetaInfoTest extends \MailPoetTest {
       'source' => 'form',
     ]);
     $newsletter1 = (object)[
-      'type' => Newsletter::TYPE_NOTIFICATION,
+      'type' => NewsletterEntity::TYPE_NOTIFICATION,
     ];
     $newsletter2 = (object)[
-      'type' => Newsletter::TYPE_NOTIFICATION_HISTORY,
+      'type' => NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
     ];
     expect($this->meta->getNewsletterMetaInfo($newsletter1, $subscriber))->equals([
       'email_type' => 'post_notification',
@@ -141,14 +141,14 @@ class MetaInfoTest extends \MailPoetTest {
       'source' => 'form',
     ]);
     $newsletter1 = (object)[
-      'type' => Newsletter::TYPE_AUTOMATIC,
+      'type' => NewsletterEntity::TYPE_AUTOMATIC,
       'options' => [
         'group' => 'woocommerce',
         'event' => 'woocommerce_first_purchase',
       ],
     ];
     $newsletter2 = (object)[
-      'type' => Newsletter::TYPE_AUTOMATIC,
+      'type' => NewsletterEntity::TYPE_AUTOMATIC,
       'options' => [
         'group' => 'woocommerce',
         'event' => 'woocommerce_purchased_in_category',
@@ -173,7 +173,7 @@ class MetaInfoTest extends \MailPoetTest {
       'source' => null,
     ]);
     $newsletter = (object)[
-      'type' => Newsletter::TYPE_STANDARD,
+      'type' => NewsletterEntity::TYPE_STANDARD,
     ];
     expect($this->meta->getNewsletterMetaInfo($newsletter, $subscriber))->equals([
       'email_type' => 'newsletter',


### PR DESCRIPTION
Most of the changes proposed in this PR are fairly straightforward and only affect a few integration test classes. The only exception is the commit that refactors MetaInfoTest. While refactoring this class, it was necessary to change the signature of \MailPoet\Mailer\MetaInfo::getNewsletterMetaInfo() which also meant changing \MailPoet\Cron\Workers\SendingQueue\SendingQueue::processQueue() and its test class. See the message in the commit a31a35265a4441b2d0b835d25644de03dbeab10c for more information.

Since there are changes here to a method related to sending, it is probably a good idea to check that this part is still working as expected.

[MAILPOET-4379]

[MAILPOET-4379]: https://mailpoet.atlassian.net/browse/MAILPOET-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ