### PR TITLE
Mailpoet 4348 refactor personal data exporters to doctrine s

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -102,6 +102,9 @@ class Initializer {
   /** @var FeaturesController */
   private $featuresController;
 
+  /*** @var PersonalDataExporters */
+  private $personalDataExporters;
+
   const INITIALIZED = 'MAILPOET_INITIALIZED';
 
   public function __construct(
@@ -129,7 +132,8 @@ class Initializer {
     AssetsLoader $assetsLoader,
     Engine $automationEngine,
     MailPoetIntegration $automationMailPoetIntegration,
-    FeaturesController $featuresController
+    FeaturesController $featuresController,
+    PersonalDataExporters $personalDataExporters
   ) {
     $this->rendererFactory = $rendererFactory;
     $this->accessControl = $accessControl;
@@ -156,6 +160,7 @@ class Initializer {
     $this->automationEngine = $automationEngine;
     $this->automationMailPoetIntegration = $automationMailPoetIntegration;
     $this->featuresController = $featuresController;
+    $this->personalDataExporters = $personalDataExporters;
   }
 
   public function init() {
@@ -387,8 +392,7 @@ class Initializer {
   }
 
   public function setupPersonalDataExporters() {
-    $exporters = new PersonalDataExporters();
-    $exporters->init();
+    $this->personalDataExporters->init();
   }
 
   public function setupPersonalDataErasers() {

--- a/mailpoet/lib/Config/PersonalDataExporters.php
+++ b/mailpoet/lib/Config/PersonalDataExporters.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Config;
 
+use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterClicksExporter;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterOpensExporter;
@@ -15,11 +16,18 @@ class PersonalDataExporters {
 
   /*** @var SubscribersRepository */
   private $subscribersRepository;
+
+  /**
+   * @var CustomFieldsRepository
+   */
+  private $customFieldsRepository;
   
   public function __construct(
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    CustomFieldsRepository $customFieldsRepository
   ) {
     $this->subscribersRepository = $subscribersRepository;
+    $this->customFieldsRepository = $customFieldsRepository;
   }
 
   public function init() {
@@ -41,7 +49,7 @@ class PersonalDataExporters {
   public function registerSubscriberExporter($exporters) {
     $exporters[] = [
       'exporter_friendly_name' => WPFunctions::get()->__('MailPoet Subscriber Data', 'mailpoet'),
-      'callback' => [new SubscriberExporter(), 'export'],
+      'callback' => [new SubscriberExporter($this->subscribersRepository, $this->customFieldsRepository), 'export'],
     ];
     return $exporters;
   }

--- a/mailpoet/lib/Config/PersonalDataExporters.php
+++ b/mailpoet/lib/Config/PersonalDataExporters.php
@@ -8,9 +8,20 @@ use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewsletterOpensExpor
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\NewslettersExporter;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\SegmentsExporter;
 use MailPoet\Subscribers\ImportExport\PersonalDataExporters\SubscriberExporter;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class PersonalDataExporters {
+
+  /*** @var SubscribersRepository */
+  private $subscribersRepository;
+  
+  public function __construct(
+    SubscribersRepository $subscribersRepository
+  ) {
+    $this->subscribersRepository = $subscribersRepository;
+  }
+
   public function init() {
     WPFunctions::get()->addFilter('wp_privacy_personal_data_exporters', [$this, 'registerSubscriberExporter']);
     WPFunctions::get()->addFilter('wp_privacy_personal_data_exporters', [$this, 'registerSegmentsExporter']);
@@ -22,7 +33,7 @@ class PersonalDataExporters {
   public function registerSegmentsExporter($exporters) {
     $exporters[] = [
       'exporter_friendly_name' => WPFunctions::get()->__('MailPoet Lists', 'mailpoet'),
-      'callback' => [new SegmentsExporter(), 'export'],
+      'callback' => [new SegmentsExporter($this->subscribersRepository), 'export'],
     ];
     return $exporters;
   }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -162,6 +162,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->register(\MailPoet\Config\Renderer::class)
       ->setPublic(true)
       ->setFactory([new Reference(\MailPoet\Config\RendererFactory::class), 'getRenderer']);
+    $container->autowire(\MailPoet\Config\PersonalDataExporters::class)->setPublic(true);
     // Doctrine
     $container->autowire(\MailPoet\Doctrine\Annotations\AnnotationReaderProvider::class);
     $container->autowire(\MailPoet\Doctrine\ConfigurationFactory::class);

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporter.php
@@ -2,22 +2,43 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
-use MailPoet\Models\Subscriber;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\WP\DateTime;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SegmentsExporter {
-  public function export($email) {
+
+  /*** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  public function __construct(
+    SubscribersRepository $subscribersRepository
+  ) {
+    $this->subscribersRepository = $subscribersRepository;
+  }
+
+  /**
+   * @param string $email
+   * @return array(data: mixed[], done: boolean)
+   */
+  public function export(string $email): array {
     return [
-      'data' => $this->exportSubscriber(Subscriber::findOne(trim($email))),
+      'data' => $this->exportSubscriber($this->subscribersRepository->findOneBy(['email' => trim($email)])),
       'done' => true,
     ];
   }
 
-  private function exportSubscriber($subscriber) {
+  /**
+   * @param SubscriberEntity|null $subscriber
+   * @return mixed[]
+   */
+  private function exportSubscriber(?SubscriberEntity $subscriber): array {
     if (!$subscriber) return [];
 
     $result = [];
-    $segments = $subscriber->getAllSegmentNamesWithStatus();
+    $segments = $subscriber->getSubscriberSegments();
 
     foreach ($segments as $segment) {
       $result[] = $this->exportSegment($segment);
@@ -26,24 +47,28 @@ class SegmentsExporter {
     return $result;
   }
 
-  private function exportSegment($segment) {
+  /**
+   * @param SubscriberSegmentEntity $segment
+   * @return mixed[]
+   */
+  private function exportSegment(SubscriberSegmentEntity $segment): array {
     $segmentData = [];
     $segmentData[] = [
       'name' => WPFunctions::get()->__('List name', 'mailpoet'),
-      'value' => $segment['name'],
+      'value' => $segment->getSegment() ? $segment->getSegment()->getName() : '',
     ];
     $segmentData[] = [
       'name' => WPFunctions::get()->__('Subscription status', 'mailpoet'),
-      'value' => $segment['status'],
+      'value' => $segment->getStatus(),
     ];
     $segmentData[] = [
       'name' => WPFunctions::get()->__('Timestamp of the subscription (or last change of the subscription status)', 'mailpoet'),
-      'value' => $segment['updated_at'],
+      'value' => $segment->getUpdatedAt()->format(DateTime::DEFAULT_DATE_TIME_FORMAT),
     ];
     return [
       'group_id' => 'mailpoet-lists',
       'group_label' => WPFunctions::get()->__('MailPoet Mailing Lists', 'mailpoet'),
-      'item_id' => 'list-' . $segment['segment_id'],
+      'item_id' => 'list-' . ($segment->getSegment() ? $segment->getSegment()->getId() : ''),
       'data' => $segmentData,
     ];
   }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporterTest.php
@@ -9,6 +9,7 @@ use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsNewsletters;
 use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
@@ -28,7 +29,8 @@ class NewslettersExporterTest extends \MailPoetTest {
     $this->exporter = new NewslettersExporter(
       $this->diContainer->get(Url::class),
       $this->subscribersRepository,
-      $this->diContainer->get(NewslettersRepository::class)
+      $this->diContainer->get(NewslettersRepository::class),
+      $this->diContainer->get(NewsletterStatisticsRepository::class)
     );
   }
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporterTest.php
@@ -2,10 +2,12 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
-use MailPoet\Models\Segment;
-use MailPoet\Models\Subscriber;
-use MailPoet\Models\SubscriberSegment;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\WP\DateTime;
 
 class SegmentsExporterTest extends \MailPoetTest {
 
@@ -29,9 +31,7 @@ class SegmentsExporterTest extends \MailPoetTest {
   }
 
   public function testExportWorksForSubscriberWithNoSegments() {
-    Subscriber::createOrUpdate([
-      'email' => 'email.that@has.no.segments',
-    ]);
+    (new SubscriberFactory())->withEmail('email.that@has.no.segments')->create();
     $result = $this->exporter->export('email.that@has.no.segments');
     expect($result)->array();
     expect($result)->hasKey('data');
@@ -41,24 +41,25 @@ class SegmentsExporterTest extends \MailPoetTest {
   }
 
   public function testExportWorksForSubscriberWithSegments() {
-    $subscriber = Subscriber::createOrUpdate([
-      'email' => 'email.that@has.some.segments',
-    ]);
-    $segment1 = Segment::createOrUpdate(['name' => 'List 1']);
-    $segment2 = Segment::createOrUpdate(['name' => 'List 2']);
-    SubscriberSegment::createOrUpdate([
-      'subscriber_id' => $subscriber->id(),
-      'segment_id' => $segment1->id(),
-      'status' => Subscriber::STATUS_SUBSCRIBED,
-      'updated_at' => '2018-05-02 15:26:52',
-    ]);
-    SubscriberSegment::createOrUpdate([
-      'subscriber_id' => $subscriber->id(),
-      'segment_id' => $segment2->id(),
-      'status' => Subscriber::STATUS_UNSUBSCRIBED,
-      'updated_at' => '2018-05-02 15:26:00',
-    ]);
-    $result = $this->exporter->export('email.that@has.some.segments');
+    $subscriber = (new SubscriberFactory())->create();
+
+    $segment1 = (new SegmentFactory())->withName('List 1')->create();
+    $segment2 = (new SegmentFactory())->withName('List 2')->create();
+
+    $ss1 = new SubscriberSegmentEntity($segment1, $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->entityManager->persist($ss1);
+    $this->entityManager->flush();
+
+    $ss2 = new SubscriberSegmentEntity($segment2, $subscriber, SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->entityManager->persist($ss2);
+    $this->entityManager->flush();
+
+    /**
+     * Make Doctrine update SubscriberSegment collections
+     */
+    $this->entityManager->refresh($subscriber);
+
+    $result = $this->exporter->export($subscriber->getEmail());
     expect($result)->array();
     expect($result)->hasKey('data');
     expect($result)->hasKey('done');
@@ -66,21 +67,27 @@ class SegmentsExporterTest extends \MailPoetTest {
        [
         'group_id' => 'mailpoet-lists',
         'group_label' => 'MailPoet Mailing Lists',
-        'item_id' => 'list-' . $segment1->id(),
+        'item_id' => 'list-' . $segment1->getId(),
         'data' => [
              ['name' => 'List name', 'value' => 'List 1'],
              ['name' => 'Subscription status', 'value' => 'subscribed'],
-             ['name' => 'Timestamp of the subscription (or last change of the subscription status)', 'value' => '2018-05-02 15:26:52'],
+             [
+               'name' => 'Timestamp of the subscription (or last change of the subscription status)',
+               'value' => $ss1->getUpdatedAt()->format(DateTime::DEFAULT_DATE_TIME_FORMAT)
+             ],
           ],
        ],
        [
         'group_id' => 'mailpoet-lists',
         'group_label' => 'MailPoet Mailing Lists',
-        'item_id' => 'list-' . $segment2->id(),
+        'item_id' => 'list-' . $segment2->getId(),
         'data' => [
              ['name' => 'List name', 'value' => 'List 2'],
              ['name' => 'Subscription status', 'value' => 'unsubscribed'],
-             ['name' => 'Timestamp of the subscription (or last change of the subscription status)', 'value' => '2018-05-02 15:26:00'],
+             [
+               'name' => 'Timestamp of the subscription (or last change of the subscription status)',
+               'value' => $ss2->getUpdatedAt()->format(DateTime::DEFAULT_DATE_TIME_FORMAT)
+             ],
           ],
        ],
     ];

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporterTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
+use MailPoet\Subscribers\SubscribersRepository;
 
 class SegmentsExporterTest extends \MailPoetTest {
 
@@ -13,7 +14,9 @@ class SegmentsExporterTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->exporter = new SegmentsExporter();
+    $this->exporter = new SegmentsExporter(
+      $this->diContainer->get(SubscribersRepository::class)
+    );
   }
 
   public function testExportWorksWhenSubscriberNotFound() {

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporterTest.php
@@ -2,8 +2,10 @@
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
+use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Models\CustomField;
 use MailPoet\Models\Subscriber;
+use MailPoet\Subscribers\SubscribersRepository;
 
 class SubscriberExporterTest extends \MailPoetTest {
 
@@ -12,7 +14,10 @@ class SubscriberExporterTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->exporter = new SubscriberExporter();
+    $this->exporter = new SubscriberExporter(
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(CustomFieldsRepository::class)
+    );
   }
 
   public function testExportWorksWhenSubscriberNotFound() {


### PR DESCRIPTION
### How to test:

- Verify the data export works in `wp-admin/admin.php?page=mailpoet-export` and `wp-admin/export-personal-data.php`


[MAILPOET-4348]

[MAILPOET-4348]: https://mailpoet.atlassian.net/browse/MAILPOET-4348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ