### PR TITLE
Improve forms accessibility [MAILPOET-4471]

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -67,8 +67,11 @@ $form-line-height: 1.4;
 
 /* Reset fieldset styles in form for backward compatibility. */
 .mailpoet_paragraph {
-  fieldset {
+  fieldset,
+  legend {
+    background: transparent;
     border: 0;
+    color: inherit;
     margin: 0;
     padding: 0;
   }

--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -63,6 +63,12 @@ $form-line-height: 1.4;
   .mailpoet-has-font-size {
     line-height: $form-line-height;
   }
+
+  fieldset {
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .mailpoet_textarea {

--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -63,7 +63,10 @@ $form-line-height: 1.4;
   .mailpoet-has-font-size {
     line-height: $form-line-height;
   }
+}
 
+/* Reset fieldset styles in form for backward compatibility. */
+.mailpoet_paragraph {
   fieldset {
     border: 0;
     margin: 0;

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -34,7 +34,7 @@ class BlockRendererHelper {
       $rules['required'] = true;
       $rules['minlength'] = ModelValidator::EMAIL_MIN_LENGTH;
       $rules['maxlength'] = ModelValidator::EMAIL_MAX_LENGTH;
-      $rules['type-message'] = __('This value should be a valid email', 'mailpoet');
+      $rules['type-message'] = __('This value should be a valid email.', 'mailpoet');
     }
 
     if (($blockId === 'first_name') || ($blockId === 'last_name')) {

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -153,6 +153,37 @@ class BlockRendererHelper {
     return $html;
   }
 
+  public function renderLegend(array $block, array $formSettings): string {
+    $html = '';
+
+    if (
+      isset($block['params']['hide_label'])
+      && $block['params']['hide_label']
+    ) {
+      return $html;
+    }
+
+    if (
+      isset($block['params']['label'])
+      && strlen(trim($block['params']['label'])) > 0
+    ) {
+      // Use _label suffix for backward compatibility
+      $labelClass = 'class="mailpoet_' . $block['type'] . '_label" ';
+      $html .= '<legend '
+        . $labelClass
+        . $this->renderFontStyle($formSettings, $block['styles'] ?? [])
+        . '>';
+      $html .= htmlspecialchars($block['params']['label']);
+
+      if (isset($block['params']['required']) && $block['params']['required']) {
+        $html .= ' <span class="mailpoet_required">*</span>';
+      }
+
+      $html .= '</legend>';
+    }
+    return $html;
+  }
+
   public function renderFontStyle(array $formSettings, array $styles = []) {
     $rules = [];
     if (isset($formSettings['fontSize'])) {

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -34,7 +34,7 @@ class BlockRendererHelper {
       $rules['required'] = true;
       $rules['minlength'] = ModelValidator::EMAIL_MIN_LENGTH;
       $rules['maxlength'] = ModelValidator::EMAIL_MAX_LENGTH;
-      $rules['error-message'] = __('Please specify a valid email address.', 'mailpoet');
+      $rules['type-message'] = __('This value should be a valid email', 'mailpoet');
     }
 
     if (($blockId === 'first_name') || ($blockId === 'last_name')) {
@@ -58,6 +58,7 @@ class BlockRendererHelper {
 
     if (!empty($block['params']['required'])) {
       $rules['required'] = true;
+      $rules['errors-container'] = '.mailpoet_error_' . $blockId . '_' . $formId;
       $rules['required-message'] = __('This field is required.', 'mailpoet');
     }
 

--- a/mailpoet/lib/Form/Block/Checkbox.php
+++ b/mailpoet/lib/Form/Block/Checkbox.php
@@ -32,7 +32,8 @@ class Checkbox {
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
     $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
-    $html .= $this->rendererHelper->renderLabel($block, $formSettings);
+    $html .= '<fieldset>';
+    $html .= '<legend>' . $block['params']['label'] . '</legend>';
 
     $options = (!empty($block['params']['values'])
       ? $block['params']['values']
@@ -69,6 +70,8 @@ class Checkbox {
 
       $html .= '</label>';
     }
+
+    echo '</fieldset>';
 
     $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . ($formId ? '_' . $formId : '') . '"></span>';
 

--- a/mailpoet/lib/Form/Block/Checkbox.php
+++ b/mailpoet/lib/Form/Block/Checkbox.php
@@ -33,7 +33,7 @@ class Checkbox {
     $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
     $html .= '<fieldset>';
-    $html .= '<legend>' . $block['params']['label'] . '</legend>';
+    $html .= $this->rendererHelper->renderLegend($block, $formSettings);
 
     $options = (!empty($block['params']['values'])
       ? $block['params']['values']

--- a/mailpoet/lib/Form/Block/Checkbox.php
+++ b/mailpoet/lib/Form/Block/Checkbox.php
@@ -71,7 +71,7 @@ class Checkbox {
       $html .= '</label>';
     }
 
-    echo '</fieldset>';
+    $html .= '</fieldset>';
 
     $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . ($formId ? '_' . $formId : '') . '"></span>';
 

--- a/mailpoet/lib/Form/Block/Radio.php
+++ b/mailpoet/lib/Form/Block/Radio.php
@@ -33,7 +33,7 @@ class Radio {
     $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
     $html .= '<fieldset>';
-    $html .= '<legend>' . $block['params']['label'] . '</legend>';
+    $html .= $this->rendererHelper->renderLegend($block, $formSettings);
 
     $options = (!empty($block['params']['values'])
       ? $block['params']['values']

--- a/mailpoet/lib/Form/Block/Radio.php
+++ b/mailpoet/lib/Form/Block/Radio.php
@@ -32,7 +32,8 @@ class Radio {
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
     $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
-    $html .= $this->rendererHelper->renderLabel($block, $formSettings);
+    $html .= '<fieldset>';
+    $html .= '<legend>' . $block['params']['label'] . '</legend>';
 
     $options = (!empty($block['params']['values'])
       ? $block['params']['values']
@@ -72,6 +73,8 @@ class Radio {
       $html .= ' /> ' . $this->wp->escAttr($label);
       $html .= '</label>';
     }
+
+    $html .= '</fieldset>';
 
     $html .= '<span class="mailpoet_error_' . $block['id'] . ($formId ? '_' . $formId : '') . '"></span>';
 

--- a/mailpoet/lib/Form/Block/Segment.php
+++ b/mailpoet/lib/Form/Block/Segment.php
@@ -38,7 +38,10 @@ class Segment {
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
     $fieldValidation = $this->rendererHelper->getInputValidation($block, [], $formId);
 
-    $html .= $this->rendererHelper->renderLabel($block, $formSettings);
+    // Add fieldset around the checkboxes
+    $html .= '<fieldset>';
+
+    $html .= '<legend>' . $block['params']['label'] . '</legend>';
 
     $options = (!empty($block['params']['values'])
       ? $block['params']['values']
@@ -68,6 +71,9 @@ class Segment {
     }
 
     $html .= '<span class="mailpoet_error_' . $block['id'] . ($formId ? '_' . $formId : '') . '"></span>';
+
+    // End fieldset around checkboxes
+    $html .= '</fieldset>';
 
     return $this->wrapper->render($block, $html);
   }

--- a/mailpoet/lib/Form/Block/Segment.php
+++ b/mailpoet/lib/Form/Block/Segment.php
@@ -40,8 +40,7 @@ class Segment {
 
     // Add fieldset around the checkboxes
     $html .= '<fieldset>';
-
-    $html .= '<legend>' . $block['params']['label'] . '</legend>';
+    $html .= $this->rendererHelper->renderLegend($block, $formSettings);
 
     $options = (!empty($block['params']['values'])
       ? $block['params']['values']

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -96,7 +96,7 @@ class GutenbergFormBlockCest {
     $i->fillField('[data-automation-id="form_last_name"]', $this->lastName);
     $i->fillField('[data-automation-id="form_email"]', $this->firstName);
     $i->click('.mailpoet_submit');
-    $i->waitForText('Please specify a valid email address.');
+    $i->waitForText('This value should be a valid email.');
 
     $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
     $i->click('.mailpoet_submit');

--- a/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -60,6 +60,25 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
     expect($label)->equals('');
   }
 
+  public function testItShouldRenderLegend() {
+    $block = $this->block;
+    $label = $this->rendererHelper->renderLegend($block, []);
+    expect($label)->regExp('#<legend.*class="mailpoet_text_label".*>Input label</legend>#m');
+
+    $block['styles'] = ['bold' => '1'];
+    $label = $this->rendererHelper->renderLegend($block, []);
+    expect($label)->equals('<legend class="mailpoet_text_label" style="font-weight: bold;">Input label</legend>');
+
+    $block['params']['required'] = '1';
+    $block['styles'] = [];
+    $label = $this->rendererHelper->renderLegend($block, []);
+    expect($label)->equals('<legend class="mailpoet_text_label" >Input label <span class="mailpoet_required">*</span></legend>');
+
+    $block['params']['hide_label'] = '1';
+    $label = $this->rendererHelper->renderLegend($block, []);
+    expect($label)->equals('');
+  }
+
   public function testItShouldRenderPlaceholder() {
     $block = $this->block;
     $placeholder = $this->rendererHelper->renderInputPlaceholder($block);

--- a/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -99,13 +99,13 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
     expect($validation)->equals('');
 
     $block['params']['required'] = '1';
-    $validation = $this->rendererHelper->getInputValidation($block);
-    expect($validation)->equals('data-parsley-required="true" data-parsley-required-message="This field is required."');
+    $validation = $this->rendererHelper->getInputValidation($block, [], 2);
+    expect($validation)->equals('data-parsley-required="true" data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required-message="This field is required."');
 
     $block['params']['required'] = '0';
     $block['id'] = 'email';
     $validation = $this->rendererHelper->getInputValidation($block);
-    expect($validation)->equals('data-parsley-required="true" data-parsley-minlength="6" data-parsley-maxlength="150" data-parsley-error-message="Please specify a valid email address."');
+    expect($validation)->equals('data-parsley-required="true" data-parsley-minlength="6" data-parsley-maxlength="150" data-parsley-type-message="This value should be a valid email."');
 
     $block = $this->block;
     $block['params']['validate'] = 'phone';

--- a/mailpoet/tests/unit/Form/Block/CheckboxTest.php
+++ b/mailpoet/tests/unit/Form/Block/CheckboxTest.php
@@ -55,7 +55,7 @@ class CheckboxTest extends \MailPoetUnitTest {
   }
 
   public function testItShouldRenderCheckbox() {
-    $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->rendererHelperMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
     $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldValue')->willReturn('1');
@@ -68,7 +68,7 @@ class CheckboxTest extends \MailPoetUnitTest {
   }
 
   public function testItShouldRenderErrorContainerWithFormId() {
-    $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->rendererHelperMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
     $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldValue')->willReturn('1');

--- a/mailpoet/tests/unit/Form/Block/RadioTest.php
+++ b/mailpoet/tests/unit/Form/Block/RadioTest.php
@@ -60,7 +60,7 @@ class RadioTest extends \MailPoetUnitTest {
   }
 
   public function testItShouldRenderRadioInputs() {
-    $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->baseMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
     $this->baseMock->expects($this->once())->method('getInputValidation')->willReturn(' validation="1" ');
     $this->baseMock->expects($this->once())->method('getFieldValue')->willReturn('Radio 2');
@@ -81,7 +81,7 @@ class RadioTest extends \MailPoetUnitTest {
   }
 
   public function testItShouldRenderErrorContainerWithFormId() {
-    $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->baseMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
     $this->baseMock->expects($this->once())->method('getInputValidation')->willReturn(' validation="1" ');
     $this->baseMock->expects($this->once())->method('getFieldValue')->willReturn('Radio 2');

--- a/mailpoet/tests/unit/Form/Block/SegmentTest.php
+++ b/mailpoet/tests/unit/Form/Block/SegmentTest.php
@@ -64,7 +64,7 @@ class SegmentTest extends \MailPoetUnitTest {
   }
 
   public function testItShouldRenderSegments() {
-    $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->rendererHelperMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Segments');
     $this->segmentsRepositoryMock->expects($this->once())->method('findBy')->willReturn([
@@ -89,7 +89,7 @@ class SegmentTest extends \MailPoetUnitTest {
   }
 
   public function testItShouldRenderErrorContainerWithFormId(): void {
-    $this->rendererHelperMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->rendererHelperMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Segments');
     $this->segmentsRepositoryMock->expects($this->once())->method('findBy')->willReturn([


### PR DESCRIPTION
This PR was [originally submitted](https://github.com/mailpoet/mailpoet/pull/4204) by @simsekb.
I've recreated it because we still have the issue with public builds. I've also added a couple of additional fixes for issues that I missed when doing [the initial review on the original PR](https://github.com/mailpoet/mailpoet/pull/4204).

It changes two things:
1) Improves accessibility of radio buttons, list of segments, and checkboxes by grouping them in a fieldset (see [WAI grouping recommendations](https://www.w3.org/WAI/tutorials/forms/grouping/)). It affects forms that contain a list of segments block, radio buttons custom field block, or checkbox custom field block. It also affects the manage subscription form displayed on the manage subscription page. This PR also adds a CSS reset for fieldsets used inside MailPoets' forms, so the change should not affect the visual appearance of previously created forms.

2) Improves invalid email address error rendering. The error is now rendered next to the field and contains slightly different wording. `Please specify a valid email address.` > `This value should be a valid email.`

[MAILPOET-4471]

[MAILPOET-4471]: https://mailpoet.atlassian.net/browse/MAILPOET-4471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ