### PR TITLE
Shorten the max tag `name` from 255 to 191 chars [MAILPOET-4489]

### DIFF
--- a/mailpoet/lib/Config/Migrator.php
+++ b/mailpoet/lib/Config/Migrator.php
@@ -642,7 +642,7 @@ class Migrator {
   public function tags(): string {
     $attributes = [
       'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
-      'name varchar(255) NOT NULL,',
+      'name varchar(191) NOT NULL,',
       'description text NOT NULL DEFAULT "",',
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',


### PR DESCRIPTION
MySQL has maximum key lengths for indexes, and the number can vary based
 on storage engine and MySQL version. Using utf8mb4, the index would be
 255 * 4 = 1020 bytes long, exceeding the MyISAM maximum of 1000 bytes
 and the MySQL 5.6 maximum of 767 bytes.

 See Column Prefix Key Parts in the MySQL reference:
 https://dev.mysql.com/doc/refman/8.0/en/create-index.html

 By reducing this length to 191, we ensure that the maximum likely index
 length will be less than the 767 lower bound (191 * 4 = 764).

 MAILPOET-4489