### PR TITLE
Fix PHPMailer on WP 5.6 in acceptance tests [MAILPOET-4481]

### DIFF
--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -118,6 +118,10 @@ if [[ ! -d "/wp-core/wp-content/plugins/woo-gutenberg-products-block" ]]; then
   unzip -q -o "$WOOCOMMERCE_BLOCKS_ZIP" -d /wp-core/wp-content/plugins/
 fi
 
+# Install a fix plugin for PHPMailer on WP 5.6
+cp /project/tests/docker/codeception/wp-56-phpmailer-fix.php /wp-core/wp-content/plugins/wp-56-phpmailer-fix.php
+wp plugin activate wp-56-phpmailer-fix
+
 # activate all plugins which source code want to access in tests runtime
 wp plugin activate woocommerce
 wp plugin activate woocommerce-subscriptions

--- a/mailpoet/tests/docker/codeception/wp-56-phpmailer-fix.php
+++ b/mailpoet/tests/docker/codeception/wp-56-phpmailer-fix.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+Plugin Name: MailPoet Testing Fix: Use SMTP In PHPMailer on WP 5.6
+Version: 0.1
+*/
+
+add_action('phpmailer_init', 'mailpoet_test_phpmailer_use_smtp');
+
+function mailpoet_test_phpmailer_use_smtp($phpmailer) {
+    global $wp_version;
+
+    if (!getenv('CIRCLE_BRANCH') || !preg_match('/^5\.6/', $wp_version)) {
+      return;
+    }
+
+    $phpmailer->isSMTP();
+    $phpmailer->Host = 'mailhog';
+    $phpmailer->SMTPAuth = false;
+    $phpmailer->Port = 1025;
+    $phpmailer->Username = '';
+    $phpmailer->Password = '';
+}


### PR DESCRIPTION
[MAILPOET-4481]

Use SMTP in PHPMailer on WP 5.6 because its Docker container
has a misconfigured PHP `mail()` function (no sendmail or alternative set up).

[MAILPOET-4481]: https://mailpoet.atlassian.net/browse/MAILPOET-4481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ