### PR TITLE
 Release 3.92.1

### DIFF
--- a/mailpoet/lib/Config/Migrator.php
+++ b/mailpoet/lib/Config/Migrator.php
@@ -642,7 +642,7 @@ class Migrator {
   public function tags(): string {
     $attributes = [
       'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
-      'name varchar(255) NOT NULL,',
+      'name varchar(191) NOT NULL,',
       'description text NOT NULL DEFAULT "",',
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet 3 (New)
- * Version: 3.91.1
+ * Version: 3.92.0
  * Plugin URI: http://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -17,7 +17,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '3.91.1',
+  'version' => '3.92.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload.php',

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet 3 (New)
- * Version: 3.92.0
+ * Version: 3.92.1
  * Plugin URI: http://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -17,7 +17,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '3.92.0',
+  'version' => '3.92.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 5.6
 Tested up to: 6.0
-Stable tag: 3.91.1
+Stable tag: 3.92.0
 Requires PHP: 7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -218,6 +218,13 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 6. WooCommerce emails
 
 == Changelog ==
+
+= 3.92.0 - 2022-07-19 =
+* Added: show tags on Subscribers listing page;
+* Added: tagging subscribers on the edit page;
+* Added: the ability to authorise the email address in the plugin;
+* Improved: when sending with MailPoet Sending Service, show a warning when unauthorized email is used immediately before sending an email;
+* Improved: don't load 3rd-party libraries on new installations unless an active consent is given.
 
 = 3.91.1 - 2022-07-11 =
 * Updated: npm and composer dependencies;

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 5.6
 Tested up to: 6.0
-Stable tag: 3.92.0
+Stable tag: 3.92.1
 Requires PHP: 7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -218,6 +218,9 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 6. WooCommerce emails
 
 == Changelog ==
+
+= 3.92.1 - 2022-07-20 =
+* Fixed: A database table could not be created in some installations.
 
 = 3.92.0 - 2022-07-19 =
 * Added: show tags on Subscribers listing page;


### PR DESCRIPTION
This PR also contains the changes from 3.91.1 to 3.92.0 in the readme and mailpoet.php as I did not merge yesterdays release (and just closed it now, see #4255)

Nevertheless, the release is branched of the 3.92.0 tag and contains the changes of @johnolek in #4258 as cherry-pick