### PR TITLE
Add a link to the MailPoet settings page in the page that lists plugins [MAILPOET-4412]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -91,6 +91,7 @@ class Hooks {
     $this->setupPostNotifications();
     $this->setupWooCommerceSettings();
     $this->setupFooter();
+    $this->setupSettingsLinkInPluginPage();
   }
 
   public function initEarlyHooks() {
@@ -414,5 +415,20 @@ class Hooks {
 
   public function setFooter($text) {
     return '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">Give feedback</a>';
+  }
+
+  public function setupSettingsLinkInPluginPage() {
+    $this->wp->addFilter(
+      'plugin_action_links_' . Env::$pluginPath,
+      [$this, 'setSettingsLinkInPluginPage']
+    );
+  }
+
+  public function setSettingsLinkInPluginPage($actionLinks) {
+    $customLinks = [
+      'settings' => '<a href="' . $this->wp->adminUrl('admin.php?page=mailpoet-settings') . '" aria-label="' . esc_attr__( 'View MailPoet settings', 'mailpoet' ) . '">' . esc_html__( 'Settings', 'mailpoet' ) . '</a>',
+    ];
+
+    return array_merge($actionLinks, $customLinks);
   }
 }


### PR DESCRIPTION
@websupporter, I'm asking for your review as you mentioned in the ticket that it would be a good idea to create a test for this to prevent the same problem from happening again. Please correct me if I'm wrong, but my understanding is that the "Manage Plugin" button is only displayed when MailPoet is installed in the WP.com environment and we don't have an easy way to test MP using the WP.com interface. Because of that, I'm creating this PR without a test, but I'd be happy to create a test if still needed. Just creating an acceptance test to check that the "Settings" link works seemed unnecessary to me.

Also, I'm unsure if mailpoet/lib/Config/Hooks.php is the best file to add this hook, but it was the best that I could find.

[MAILPOET-4412]

[MAILPOET-4412]: https://mailpoet.atlassian.net/browse/MAILPOET-4412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ