### PR TITLE
Fix deprecation warnings coming from NewsletterOption model [MAILPOET-4511][MAILPOET-4354]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -635,6 +635,7 @@ class NewsletterSendComponent extends Component {
               variant="secondary"
               type="submit"
               automationId="email-save-draft"
+              isDisabled={this.state.loading}
             >
               {MailPoet.I18n.t('saveDraftAndClose')}
             </Button>
@@ -642,7 +643,7 @@ class NewsletterSendComponent extends Component {
               <Button
                 type="button"
                 onClick={this.handleResume}
-                isDisabled={sendingDisabled}
+                isDisabled={sendingDisabled || this.state.loading}
                 automationId="email-resume"
               >
                 {MailPoet.I18n.t('resume')}
@@ -652,7 +653,7 @@ class NewsletterSendComponent extends Component {
                 type="button"
                 onClick={this.handleSend}
                 {...sendButtonOptions}
-                isDisabled={sendingDisabled}
+                isDisabled={sendingDisabled || this.state.loading}
                 automationId="email-submit"
               >
                 {sendButtonOptions.value || MailPoet.I18n.t('send')}

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -144,11 +144,16 @@ class SendingQueue {
       'sending queue processing',
       ['task_id' => $queue->taskId]
     );
+
     $newsletter = $this->newsletterTask->getNewsletterFromQueue($queue);
-    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
-    if (!$newsletter || !$newsletterEntity) {
+    if (!$newsletter) {
       return;
     }
+    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
+    if (!$newsletterEntity) {
+      return;
+    }
+
     // pre-process newsletter (render, replace shortcodes/links, etc.)
     $newsletter = $this->newsletterTask->preProcessNewsletter($newsletter, $queue);
     if (!$newsletter) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -70,7 +70,7 @@ class SendingQueue {
 
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
-  
+
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
@@ -145,7 +145,8 @@ class SendingQueue {
       ['task_id' => $queue->taskId]
     );
     $newsletter = $this->newsletterTask->getNewsletterFromQueue($queue);
-    if (!$newsletter) {
+    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
+    if (!$newsletter || !$newsletterEntity) {
       return;
     }
     // pre-process newsletter (render, replace shortcodes/links, etc.)
@@ -160,11 +161,7 @@ class SendingQueue {
     }
     // clone the original object to be used for processing
     $_newsletter = (object)$newsletter->asArray();
-    $options = $newsletter->options()->findMany();
-    if (!empty($options)) {
-      $options = array_column($options, 'value', 'name');
-    }
-    $_newsletter->options = $options;
+    $_newsletter->options = $newsletterEntity->getOptionsAsArray();
     // configure mailer
     $this->mailerTask->configureMailer($newsletter);
     // get newsletter segments

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -443,6 +443,21 @@ class NewsletterEntity {
     return $option ?: null;
   }
 
+  /**
+   * @return array<string, mixed> Associative array of newsletter option values with option names as keys
+   */
+  public function getOptionsAsArray(): array {
+    $optionsArray = [];
+    foreach ($this->options as $option) {
+      $name = $option->getName();
+      if (!$name) {
+        continue;
+      }
+      $optionsArray[$name] = $option->getValue();
+    }
+    return $optionsArray;
+  }
+
   public function getOptionValue(string $name) {
     $option = $this->getOption($name);
     return $option ? $option->getValue() : null;

--- a/mailpoet/lib/Entities/NewsletterOptionEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionEntity.php
@@ -53,6 +53,17 @@ class NewsletterOptionEntity {
   }
 
   /**
+   * @return string|null
+   */
+  public function getName() {
+    $optionField = $this->getOptionField();
+    if ($optionField === null) {
+      return null;
+    }
+    return $optionField->getName();
+  }
+
+  /**
    * @param string|null $value
    */
   public function setValue($value) {

--- a/mailpoet/tests/acceptance/Newsletters/EditExistingNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditExistingNewsletterCest.php
@@ -20,6 +20,7 @@ class EditExistingNewsletterCest {
     $i->fillField($titleElement, $editedNewsletterTitle);
     $i->click('Next');
     $i->waitForElement('[data-automation-id="newsletter_send_form"]');
+    $i->waitForElementClickable('[data-automation-id="email-save-draft"]');
     $i->click('Save as draft and close');
     $i->amOnMailpoetPage('Emails');
     $i->waitForText($editedNewsletterTitle);

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -137,9 +137,6 @@ CONFIG+="define('WP_DEBUG_LOG', true);\n"
 CONFIG+="define('COOKIE_DOMAIN', \$_SERVER['HTTP_HOST']);\n"
 CONFIG+="define('DISABLE_WP_CRON', true);\n"
 
-# fix for WP CLI bug (https://core.trac.wordpress.org/ticket/44569)
-CONFIG+="if (!isset(\$_SERVER['SERVER_NAME'])) \$_SERVER['SERVER_NAME'] = '';\n"
-
 sed -i "s/define( *'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '')* );/$CONFIG/" /wp-core/wp-config.php
 
 # activate theme

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -135,13 +135,12 @@ CONFIG+="define('WP_DEBUG', true);\n"
 CONFIG+="define('WP_DEBUG_DISPLAY', true);\n"
 CONFIG+="define('WP_DEBUG_LOG', true);\n"
 CONFIG+="define('COOKIE_DOMAIN', \$_SERVER['HTTP_HOST']);\n"
-CONFIG+="define('WP_AUTO_UPDATE_CORE', false);\n"
 CONFIG+="define('DISABLE_WP_CRON', true);\n"
 
 # fix for WP CLI bug (https://core.trac.wordpress.org/ticket/44569)
 CONFIG+="if (!isset(\$_SERVER['SERVER_NAME'])) \$_SERVER['SERVER_NAME'] = '';\n"
 
-sed -i "s/define( *'WP_DEBUG', false *);/$CONFIG/" /wp-core/wp-config.php
+sed -i "s/define( *'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '')* );/$CONFIG/" /wp-core/wp-config.php
 
 # activate theme
 wp theme activate twentytwentyone

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -129,15 +129,12 @@ wp plugin activate woocommerce-memberships
 wp plugin activate woo-gutenberg-products-block
 fi # end of check for enabling extra plugins
 
-# add configuration
-CONFIG=''
-CONFIG+="define('WP_DEBUG', true);\n"
-CONFIG+="define('WP_DEBUG_DISPLAY', true);\n"
-CONFIG+="define('WP_DEBUG_LOG', true);\n"
-CONFIG+="define('COOKIE_DOMAIN', \$_SERVER['HTTP_HOST']);\n"
-CONFIG+="define('DISABLE_WP_CRON', true);\n"
-
-sed -i "s/define( *'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '')* );/$CONFIG/" /wp-core/wp-config.php
+# Set constants in wp-config.php
+wp config set WP_DEBUG true --raw
+wp config set WP_DEBUG_DISPLAY true --raw
+wp config set WP_DEBUG_LOG true --raw
+wp config set COOKIE_DOMAIN \$_SERVER[\'HTTP_HOST\'] --raw
+wp config set DISABLE_WP_CRON true --raw
 
 # activate theme
 wp theme activate twentytwentyone

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -189,8 +189,8 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItEnforcesExecutionLimitsBeforeQueueProcessing() {
-    $sendingQueueWorker = $this->make($this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class)),
+    $sendingQueueWorker = $this->make(
+      $this->getSendingQueueWorker(),
       [
         'processQueue' => Expected::never(),
         'enforceSendingAndExecutionLimits' => Expected::exactly(1, function() {
@@ -202,7 +202,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingThrottlingHandler,
       $this->statsNotificationsWorker,
       $this->loggerFactory,
-      $this->makeEmpty(NewslettersRepository::class),
+      $this->newslettersRepository,
       $this->cronHelper,
       $this->subscribersFinder,
       $this->segmentsRepository,
@@ -307,7 +307,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItEnforcesExecutionLimitsAfterQueueProcessing() {
     $sendingQueueWorker = $this->make(
-      $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class)),
+      $this->getSendingQueueWorker(),
       [
         'processQueue' => function() {
           // this function returns a queue object
@@ -320,7 +320,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingThrottlingHandler,
       $this->statsNotificationsWorker,
       $this->loggerFactory,
-      $this->makeEmpty(NewslettersRepository::class),
+      $this->newslettersRepository,
       $this->cronHelper,
       $this->subscribersFinder,
       $this->segmentsRepository,
@@ -781,7 +781,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class),
+      null,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],


### PR DESCRIPTION
By [deprecating NewsletterOption and NewsletterOptionField models ](https://github.com/mailpoet/mailpoet/pull/4223)we introduced a couple of deprecation warnings because they were still used in a couple of places.

This was not detected in acceptance tests because there was an issue in test configuration, and WP_DEBUG was disabled.
[WP_DEBUG affects error reporting in WordPress](https://github.com/WordPress/wordpress-develop/blob/6.0/src/wp-includes/load.php#L459-L479).

This PR fixes the deprecation warnings coming from two places in the plugin.  [MAILPOET-4511]

It also fixes the acceptance test configuration issue so that the acceptance test will start catching warnings etc. [MAILPOET-4354]

When I fixed the acceptance tests config, I also needed to fix EditExistingNewsletterCest.

[MAILPOET-4354]  [MAILPOET-4511]

[MAILPOET-4511]: https://mailpoet.atlassian.net/browse/MAILPOET-4511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4354]: https://mailpoet.atlassian.net/browse/MAILPOET-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4354]: https://mailpoet.atlassian.net/browse/MAILPOET-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4511]: https://mailpoet.atlassian.net/browse/MAILPOET-4511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ