### PR TITLE
Refactor AuthorizedEmailsController to Doctrine [MAILPOET-4347]

### DIFF
--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -464,6 +464,42 @@ class NewslettersRepository extends Repository {
       ->getResult();
   }
 
+  /**
+   * Returns a list of emails that are either scheduled standard emails
+   * or active automatic emails of the provided types.
+   *
+   * @param array $automaticEmailTypes
+   *
+   * @return array
+   */
+  public function getScheduledStandardEmailsAndActiveAutomaticEmails(array $automaticEmailTypes): array {
+    $queryBuilder = $this->entityManager->createQueryBuilder();
+
+    $newsletters = $queryBuilder
+      ->select('n')
+      ->from(NewsletterEntity::class, 'n')
+      ->orWhere(
+        $queryBuilder->expr()->andX(
+          $queryBuilder->expr()->eq('n.type', ':typeStandard'),
+          $queryBuilder->expr()->eq('n.status', ':statusScheduled')
+        )
+      )
+      ->orWhere(
+        $queryBuilder->expr()->andX(
+          $queryBuilder->expr()->in('n.type', ':automaticEmailTypes'),
+          $queryBuilder->expr()->eq('n.status', ':statusActive')
+        )
+      )
+      ->setParameter('typeStandard', NewsletterEntity::TYPE_STANDARD)
+      ->setParameter('statusScheduled', NewsletterEntity::STATUS_SCHEDULED)
+      ->setParameter('automaticEmailTypes', $automaticEmailTypes)
+      ->setParameter('statusActive', NewsletterEntity::STATUS_ACTIVE)
+      ->getQuery()
+      ->getResult();
+
+    return $newsletters;
+  }
+
   private function fetchChildrenIds(array $parentIds) {
     $ids = $this->entityManager->createQueryBuilder()->select('n.id')
       ->from(NewsletterEntity::class, 'n')

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -90,6 +90,11 @@ class Newsletter {
     return $this;
   }
 
+  public function withStatus($status) {
+    $this->data['status'] = $status;
+    return $this;
+  }
+
   public function withActiveStatus() {
     $this->data['status'] = NewsletterEntity::STATUS_ACTIVE;
     return $this;


### PR DESCRIPTION
The main change in this PR is replacing Paris with Doctrine in the code that runs a custom query that gets emails that are either standard and scheduled or automatic and active. To test that the resulting query is still the same I monitored the MySQL query log while executing one of the many tests in AuthorizedEmailsControllerTest.php that trigger the modified code and compared the results before and after the changes proposed here.

[MAILPOET-4347]

[MAILPOET-4347]: https://mailpoet.atlassian.net/browse/MAILPOET-4347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ