### PR TITLE
Track if MailPoet is installed via WooCommerce Onboarding Wizard [MAILPOET-4491]

### DIFF
--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -197,6 +197,8 @@ class Reporter {
       $result['Number of active WooCommerce purchased this product emails'] = $newsletters['product_purchased_emails_count'];
       $result['Number of active purchased in this category'] = $newsletters['product_purchased_in_category_emails_count'];
       $result['Number of active abandoned cart'] = $newsletters['abandoned_cart_emails_count'];
+
+      $result['Installed via WooCommerce onboarding wizard'] = $this->woocommerceHelper->wasMailPoetInstalledViaWooCommerceOnboardingWizard();
     }
     return $result;
   }

--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -8,6 +8,7 @@ use MailPoet\Router\Endpoints\CronDaemon;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Beacon {
@@ -20,14 +21,19 @@ class Beacon {
   /** @var SubscribersFeature */
   private $subscribersFeature;
 
+  /** @var WooCommerceHelper */
+  private $wooCommerceHelper;
+
   public function __construct(
     SettingsController $settings,
     WPFunctions $wp,
-    SubscribersFeature $subscribersFeature
+    SubscribersFeature $subscribersFeature,
+    WooCommerceHelper $wooCommerceHelper
   ) {
     $this->settings = $settings;
     $this->wp = $wp;
     $this->subscribersFeature = $subscribersFeature;
+    $this->wooCommerceHelper = $wooCommerceHelper;
   }
 
   public function getData($maskApiKey = false) {
@@ -88,6 +94,7 @@ class Beacon {
       'Bounce Email Address' => $this->settings->get('bounce.address'),
       'Total number of subscribers' => $this->subscribersFeature->getSubscribersCount(),
       'Plugin installed at' => $this->settings->get('installed_at'),
+      'Installed via WooCommerce onboarding wizard' => $this->wooCommerceHelper->wasMailPoetInstalledViaWooCommerceOnboardingWizard(),
     ];
   }
 

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\WP\Functions as WPFunctions;
+
 class Helper {
   public function isWooCommerceActive() {
     return class_exists('WooCommerce');
@@ -77,5 +80,22 @@ class Helper {
 
   public function getAllowedCountries(): array {
     return (new \WC_Countries)->get_allowed_countries() ?? [];
+  }
+
+  public function wasMailPoetInstalledViaWooCommerceOnboardingWizard(): bool {
+    $wp = ContainerWrapper::getInstance()->get(WPFunctions::class);
+    $installedViaWooCommerce = false;
+    $wooCommerceOnboardingProfile = $wp->getOption('woocommerce_onboarding_profile');
+
+    if (
+      !empty($wooCommerceOnboardingProfile)
+      && isset($wooCommerceOnboardingProfile['business_extensions'])
+      && is_array($wooCommerceOnboardingProfile['business_extensions'])
+      && in_array('mailpoet', $wooCommerceOnboardingProfile['business_extensions'])
+    ) {
+      $installedViaWooCommerce = true;
+    }
+
+    return $installedViaWooCommerce;
   }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -88,7 +88,7 @@ class Helper {
     $wooCommerceOnboardingProfile = $wp->getOption('woocommerce_onboarding_profile');
 
     if (
-      !empty($wooCommerceOnboardingProfile)
+      is_array($wooCommerceOnboardingProfile)
       && isset($wooCommerceOnboardingProfile['business_extensions'])
       && is_array($wooCommerceOnboardingProfile['business_extensions'])
       && in_array('mailpoet', $wooCommerceOnboardingProfile['business_extensions'])

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -25,12 +25,12 @@ class HelperTest extends \MailPoetTest {
   public function testGetDataMailPoetNotInstalledViaWooCommerceOnboardingWizard() {
     $this->assertFalse($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
 
-    $this->wp->addOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'another_plugin']]);
+    $this->wp->updateOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'another_plugin']]);
     $this->assertFalse($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
   }
 
   public function testGetDataMailPoetInstalledViaWooCommerceOnboardingWizard() {
-    $this->wp->addOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'mailpoet', 'another_plugin']]);
+    $this->wp->updateOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'mailpoet', 'another_plugin']]);
     $this->assertTrue($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class HelperTest extends \MailPoetTest {
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var Helper */
+  private $helper;
+
+  public function _before() {
+    parent::_before();
+
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+    $this->helper = $this->diContainer->get(Helper::class);
+  }
+
+  public function _after() {
+    $this->wp->deleteOption('woocommerce_onboarding_profile');
+  }
+
+  public function testGetDataMailPoetNotInstalledViaWooCommerceOnboardingWizard() {
+    $this->assertFalse($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
+
+    $this->wp->addOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'another_plugin']]);
+    $this->assertFalse($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
+  }
+
+  public function testGetDataMailPoetInstalledViaWooCommerceOnboardingWizard() {
+    $this->wp->addOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'mailpoet', 'another_plugin']]);
+    $this->assertTrue($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
+  }
+}


### PR DESCRIPTION
**How to test this PR**

- Check that the information about whether or not MP was installed via the WooCommerce Onboarding Wizard is displayed correctly on the System Info page: /wp-admin/admin.php?page=mailpoet-help#/systemInfo
- Check that the same information is also present in the data sent to Mixpanel. I used the following snippet to test that. There might be better ways to do the same.

```
add_action('init', function() {
  $reporter = \MailPoet\DI\ContainerWrapper::getInstance()->get(\MailPoet\Analytics\Reporter::class);
  var_dump($reporter->getData()); die;
});
```

See [this comment](https://mailpoet.atlassian.net/browse/MAILPOET-4491?focusedCommentId=22546) for more information on at which point of the WooCommerce onboarding wizard it is possible to install MailPoet.

[MAILPOET-4491]

[MAILPOET-4491]: https://mailpoet.atlassian.net/browse/MAILPOET-4491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ