### PR TITLE
Remove old model usage from the SubscriberLinkTokens worker [MAILPOET-4345]

### DIFF
--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -165,6 +165,16 @@ class Subscriber {
   }
 
   /**
+   * @param string $linkToken
+   *
+   * @return $this
+   */
+  public function withLinkToken(string $linkToken) {
+    $this->data['linkToken'] = $linkToken;
+    return $this;
+  }
+
+  /**
    * @throws \Exception
    */
   public function create(): SubscriberEntity {
@@ -183,6 +193,9 @@ class Subscriber {
     if (isset($this->data['unconfirmedData'])) $subscriber->setUnconfirmedData($this->data['unconfirmedData']);
     if (isset($this->data['source'])) {
       $subscriber->setSource($this->data['source']);
+    }
+    if (isset($this->data['linkToken'])) {
+      $subscriber->setLinkToken($this->data['linkToken']);
     }
     $entityManager->persist($subscriber);
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscriberLinkTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscriberLinkTokensTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class SubscriberLinkTokensTest extends \MailPoetTest {
+  /** @var SubscriberLinkTokens */
+  private $worker;
+
+  public function _before() {
+    parent::_before();
+    $this->worker = $this->diContainer->get(SubscriberLinkTokens::class);
+  }
+
+  public function testItCanSetLinkTokensWhenFieldIsNull() {
+    $linkToken = 'some link token';
+    $subscriberWithLinkToken = (new SubscriberFactory())->withLinkToken($linkToken)->create();
+    $subscriberWithoutLinkToken1 = (new SubscriberFactory())->create();
+    $subscriberWithoutLinkToken2 = (new SubscriberFactory())->create();
+
+    $this->assertNull($subscriberWithoutLinkToken1->getLinkToken());
+    $this->assertNull($subscriberWithoutLinkToken2->getLinkToken());
+
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
+
+    $this->entityManager->refresh($subscriberWithLinkToken);
+    $this->entityManager->refresh($subscriberWithoutLinkToken1);
+    $this->entityManager->refresh($subscriberWithoutLinkToken2);
+
+    $this->assertSame($linkToken, $subscriberWithLinkToken->getLinkToken());
+    $this->assertIsString($subscriberWithoutLinkToken1->getLinkToken());
+    $this->assertIsString($subscriberWithoutLinkToken2->getLinkToken());
+  }
+
+  public function _after(): void {
+    $this->truncateEntity(SubscriberEntity::class);
+  }
+}
+


### PR DESCRIPTION
A few things worth noting about this PR:

- There were no integration tests for SubscriberLinkTokens so I created a very basic test class with a single test.
- I also added a new method to the Subscriber data factory to be able to set the link_token when creating a subscriber.
- I used Doctrine to create a SQL query instead of using DQL as it seemed to me on a quick search that the SQL function MD5() is not available by default and it is not worth registering it as a custom function. Please let me know if I missed something and I should have taken a different approach.

[MAILPOET-4345]

[MAILPOET-4345]: https://mailpoet.atlassian.net/browse/MAILPOET-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ