### PR TITLE
Rename popup message over list/segment badges to 'View subscribers' [MAILPOET-4505]

### DIFF
--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -44,10 +44,7 @@ function Tags({
           return (
             <div key={randomId}>
               <Tooltip id={tooltipId} place="top">
-                {MailPoet.I18n.t('viewFilteredSubscribersMessage').replace(
-                  '%1$s',
-                  segment.name,
-                )}
+                {MailPoet.I18n.t('viewFilteredSubscribersMessage')}
               </Tooltip>
               <a
                 data-tip=""

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -102,7 +102,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'youCanDisableWPUsersList': __('If you do not send emails to your WordPress Users list, you can [link]disable it[/link] to lower your number of subscribers.'),
   'upgradeNow': __('Upgrade Now'),
   'refreshMySubscribers': __('I’ve upgraded my subscription, refresh subscriber limit'),
-  'viewFilteredSubscribersMessage': __('View everyone subscribed to "%1$s"'),
+  'viewFilteredSubscribersMessage': __('View subscribers'),
 
   'emailVolumeLimitNoticeTitle': __('Congratulations, you sent more than [emailVolumeLimit] emails this month!'),
   'youReachedEmailVolumeLimit': __('You have sent more emails this month than your MailPoet plan includes ([emailVolumeLimit]), and sending has been temporarily paused.'),


### PR DESCRIPTION
How to test this PR:

- Go to /wp-admin/admin.php?page=mailpoet-subscribers#/ and place the cursor over the name of one of the lists that a given subscriber subscribed to. The text in the popup should read "View subscribers" instead of "View everyone subscribed to LIST_NAME".

[MAILPOET-4505]

[MAILPOET-4505]: https://mailpoet.atlassian.net/browse/MAILPOET-4505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ