### PR TITLE
Fix type hint in fix-guzzle.php [PREMIUM-199]

### DIFF
--- a/mailpoet/tasks/fix-guzzle.php
+++ b/mailpoet/tasks/fix-guzzle.php
@@ -24,8 +24,8 @@ if (!file_exists($clientFilePath) || version_compare(phpversion(), '8.0.0') == -
 }
 $replacement = '
 // Updated by MailPoet
-function http_build_query($data, string $numeric_prefix = "", ?string $arg_separator = "&", int $encoding_type = PHP_QUERY_RFC1738) {
-  $prefix = empty($numeric_prefix) ? "" : $numeric_prefix; 
+function http_build_query($data, ?string $numeric_prefix = "", ?string $arg_separator = "&", int $encoding_type = PHP_QUERY_RFC1738) {
+  $prefix = empty($numeric_prefix) ? "" : $numeric_prefix;
   return \http_build_query($data, $numeric_prefix, $arg_separator, $encoding_type);
 }
 


### PR DESCRIPTION
[PREMIUM-199]

Without this fix the release command gives me an error:
```
ERROR: Uncaught TypeError: GuzzleHttp\http_build_query(): Argument #2 ($numeric_prefix) must be of type string, null given, called in /www/wp-content/plugins/mp3repo/mailpoet/vendor/guzzlehttp/guzzle/src/Client.php on line 452 and defined in /www/wp-content/plugins/mp3repo/mailpoet/vendor/guzzlehttp/guzzle/src/Client.php:28
```

[PREMIUM-199]: https://mailpoet.atlassian.net/browse/PREMIUM-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ