### PR TITLE
Fix bug when displaying email subjects in the system status page [MAILPOET-4508]

### DIFF
--- a/mailpoet/lib/Tasks/State.php
+++ b/mailpoet/lib/Tasks/State.php
@@ -87,7 +87,7 @@ class State {
   private function buildTaskData(ScheduledTask $task) {
     $queue = $newsletter = null;
     if ($task->type === Sending::TASK_TYPE) {
-      $queue = $this->sendingQueuesRepository->findOneById($task->id);
+      $queue = $this->sendingQueuesRepository->findOneBy(['task' => $task->id]);
       $newsletter = $queue ? $queue->getNewsletter() : null;
     }
     return [


### PR DESCRIPTION
The commit f44afbddf27cd9731d5b9ef6da399a11823906d1 introduced a bug when replacing Paris code with Doctrine code in lib/Tasks/State.php. This bug was causing the system status page to display "Preview" instead of the subject of the listed emails. The problem was happening because during the refactor there was a mistake and we were trying to get a SendingQueueEntity via its ID using the ScheduledTaskEntity ID. This PR fixes this problem by getting a SendingQueueEntity that matches the given ScheduledTaskEntity ID.

[MAILPOET-4508]

[MAILPOET-4508]: https://mailpoet.atlassian.net/browse/MAILPOET-4508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ