### PR TITLE
Fix PHP Stan error [MAILPOET-4551]

### DIFF
--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -307,7 +307,7 @@ class SubscriberListingRepository extends ListingRepository {
     $group = $definition->getGroup();
 
     $allTagsList = [
-      'label' => WPFunctions::get()->__('All Tags', 'mailpoet'),
+      'label' => __('All Tags', 'mailpoet'),
       'value' => '',
     ];
 


### PR DESCRIPTION
We agreed that we can use WP translation functions directly.
This one was probably some leftover that remained in the file after merging branches.
The file was missing a use statement, so this was causing an error.

[MAILPOET-4551]

[MAILPOET-4551]: https://mailpoet.atlassian.net/browse/MAILPOET-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ