### PR TITLE
Fix sending system info to HelpScout via the Beacon API [MAILPOET-4525]

### DIFF
--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -37,12 +37,25 @@ class Beacon {
   }
 
   public function getData($maskApiKey = false) {
+    return array_merge($this->getUserData(), $this->getSiteData($maskApiKey));
+  }
+
+  public function getUserData() {
+    $currentUser = WPFunctions::get()->wpGetCurrentUser();
+    $sender = $this->settings->get('sender', ['address' => null]);
+
+    return [
+      'name' => $currentUser->display_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      'email' => $sender['address'],
+    ];
+  }
+
+  public function getSiteData($maskApiKey = false) {
     global $wpdb;
+
     $dbVersion = $wpdb->get_var('SELECT @@VERSION');
     $mta = $this->settings->get('mta');
     $currentTheme = WPFunctions::get()->wpGetTheme();
-    $currentUser = WPFunctions::get()->wpGetCurrentUser();
-    $sender = $this->settings->get('sender', ['address' => null]);
     $premiumKey = $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME) ?: $this->settings->get(Bridge::API_KEY_SETTING_NAME);
 
     if ($maskApiKey) {
@@ -59,8 +72,6 @@ class Beacon {
     }
 
     return [
-      'name' => $currentUser->display_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      'email' => $sender['address'],
       'PHP version' => PHP_VERSION,
       'MailPoet Free version' => MAILPOET_VERSION,
       'MailPoet Premium version' => (defined('MAILPOET_PREMIUM_VERSION')) ? MAILPOET_PREMIUM_VERSION : 'N/A',

--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -71,6 +71,7 @@ class Beacon {
       $cronPingUrl = __('Can‘t generate cron URL.', 'mailpoet') . ' (' . $e->getMessage() . ')';
     }
 
+    // the HelpScout Beacon API has a limit of 20 attribute-value pairs (https://developer.helpscout.com/beacon-2/web/javascript-api/#beacon-session-data)
     return [
       'PHP version' => PHP_VERSION,
       'MailPoet Free version' => MAILPOET_VERSION,
@@ -80,14 +81,10 @@ class Beacon {
       'Database version' => $dbVersion,
       'Web server' => (!empty($_SERVER["SERVER_SOFTWARE"])) ? sanitize_text_field(wp_unslash($_SERVER["SERVER_SOFTWARE"])) : 'N/A',
       'Server OS' => (function_exists('php_uname')) ? utf8_encode(php_uname()) : 'N/A',
-      'WP_MEMORY_LIMIT' => WP_MEMORY_LIMIT,
-      'WP_MAX_MEMORY_LIMIT' => WP_MAX_MEMORY_LIMIT,
-      'WP_DEBUG' => WP_DEBUG,
-      'PHP max_execution_time' => ini_get('max_execution_time'),
-      'PHP memory_limit' => ini_get('memory_limit'),
-      'PHP upload_max_filesize' => ini_get('upload_max_filesize'),
-      'PHP post_max_size' => ini_get('post_max_size'),
-      'WordPress language' => $this->wp->getLocale(),
+      'WP info' => 'WP_MEMORY_LIMIT: ' . WP_MEMORY_LIMIT . ' - WP_MAX_MEMORY_LIMIT: ' . WP_MAX_MEMORY_LIMIT . ' - WP_DEBUG: ' . WP_DEBUG .
+        ' - WordPress language: ' . $this->wp->getLocale(),
+      'PHP info' => 'PHP max_execution_time: ' . ini_get('max_execution_time') . ' - PHP memory_limit: ' . ini_get('memory_limit') .
+        ' - PHP upload_max_filesize: ' . ini_get('upload_max_filesize') . ' - PHP post_max_size: ' . ini_get('post_max_size'),
       'Multisite environment?' => (is_multisite() ? 'Yes' : 'No'),
       'Current Theme' => $currentTheme->get('Name') .
         ' (version ' . $currentTheme->get('Version') . ')',
@@ -97,12 +94,9 @@ class Beacon {
         $mta['frequency']['emails'],
         $mta['frequency']['interval']
       ),
-      "Send all site's emails with" => $this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method',
-      'Task Scheduler method' => $this->settings->get('cron_trigger.method'),
-      'Cron ping URL' => $cronPingUrl,
-      'Default FROM address' => $this->settings->get('sender.address'),
-      'Default Reply-To address' => $this->settings->get('reply_to.address'),
-      'Bounce Email Address' => $this->settings->get('bounce.address'),
+      'MailPoet sending info' => "Send all site's emails with: " . ($this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method') .
+        ' - Task Scheduler method: ' . $this->settings->get('cron_trigger.method') . ' - Cron ping URL: ' . $cronPingUrl . ' - Default FROM address: ' . $this->settings->get('sender.address') .
+        ' - Default Reply-To address: ' . $this->settings->get('reply_to.address') . ' - Bounce Email Address: ' . $this->settings->get('bounce.address'),
       'Total number of subscribers' => $this->subscribersFeature->getSubscribersCount(),
       'Plugin installed at' => $this->settings->get('installed_at'),
       'Installed via WooCommerce onboarding wizard' => $this->wooCommerceHelper->wasMailPoetInstalledViaWooCommerceOnboardingWizard(),

--- a/mailpoet/lib/Twig/Helpscout.php
+++ b/mailpoet/lib/Twig/Helpscout.php
@@ -10,14 +10,23 @@ class Helpscout extends \MailPoetVendor\Twig\Extension\AbstractExtension {
   public function getFunctions() {
     return [
       new TwigFunction(
-        'get_helpscout_data',
-        [$this, 'getHelpscoutData'],
+        'get_helpscout_user_data',
+        [$this, 'getHelpscoutUserData'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
+        'get_helpscout_site_data',
+        [$this, 'getHelpscoutSiteData'],
         ['is_safe' => ['all']]
       ),
     ];
   }
 
-  public function getHelpscoutData() {
-    return ContainerWrapper::getInstance()->get(Beacon::class)->getData();
+  public function getHelpscoutUserData() {
+    return ContainerWrapper::getInstance()->get(Beacon::class)->getUserData();
+  }
+
+  public function getHelpscoutSiteData() {
+    return ContainerWrapper::getInstance()->get(Beacon::class)->getSiteData();
   }
 }

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -58,35 +58,35 @@ class BeaconTest extends \MailPoetTest {
   }
 
   public function testItReturnsWpMemoryLimit() {
-    expect($this->beaconData['WP_MEMORY_LIMIT'])->equals(WP_MEMORY_LIMIT);
+    expect($this->beaconData['WP info'])->stringContainsString('WP_MEMORY_LIMIT: ' . WP_MEMORY_LIMIT);
   }
 
   public function testItReturnsWpMaxMemoryLimit() {
-    expect($this->beaconData['WP_MAX_MEMORY_LIMIT'])->equals(WP_MAX_MEMORY_LIMIT);
+    expect($this->beaconData['WP info'])->stringContainsString('WP_MAX_MEMORY_LIMIT: ' . WP_MAX_MEMORY_LIMIT);
   }
 
   public function testItReturnsWpDebugValue() {
-    expect($this->beaconData['WP_DEBUG'])->equals(WP_DEBUG);
-  }
-
-  public function testItReturnsPhpMaxExecutionTime() {
-    expect($this->beaconData['PHP max_execution_time'])->equals(ini_get('max_execution_time'));
-  }
-
-  public function testItReturnsPhpMemoryLimit() {
-    expect($this->beaconData['PHP memory_limit'])->equals(ini_get('memory_limit'));
-  }
-
-  public function testItReturnsPhpUploadMaxFilesize() {
-    expect($this->beaconData['PHP upload_max_filesize'])->equals(ini_get('upload_max_filesize'));
-  }
-
-  public function testItReturnsPhpPostMaxSize() {
-    expect($this->beaconData['PHP post_max_size'])->equals(ini_get('post_max_size'));
+    expect($this->beaconData['WP info'])->stringContainsString('WP_DEBUG: ' . WP_DEBUG);
   }
 
   public function testItReturnsWpLanguage() {
-    expect($this->beaconData['WordPress language'])->equals(get_locale());
+    expect($this->beaconData['WP info'])->stringContainsString('WordPress language: ' . get_locale());
+  }
+
+  public function testItReturnsPhpMaxExecutionTime() {
+    expect($this->beaconData['PHP info'])->stringContainsString('PHP max_execution_time: ' . ini_get('max_execution_time'));
+  }
+
+  public function testItReturnsPhpMemoryLimit() {
+    expect($this->beaconData['PHP info'])->stringContainsString('PHP memory_limit: ' . ini_get('memory_limit'));
+  }
+
+  public function testItReturnsPhpUploadMaxFilesize() {
+    expect($this->beaconData['PHP info'])->stringContainsString('PHP upload_max_filesize: ' . ini_get('upload_max_filesize'));
+  }
+
+  public function testItReturnsPhpPostMaxSize() {
+    expect($this->beaconData['PHP info'])->stringContainsString('PHP post_max_size: ' . ini_get('post_max_size'));
   }
 
   public function testItReturnsIfWpIsMultisite() {
@@ -116,19 +116,19 @@ class BeaconTest extends \MailPoetTest {
   }
 
   public function testItReturnsSomeSettings() {
-    expect($this->beaconData['Task Scheduler method'])->equals($this->settings->get('cron_trigger.method'));
-    expect($this->beaconData['Default FROM address'])->equals($this->settings->get('sender.address'));
-    expect($this->beaconData['Default Reply-To address'])->equals($this->settings->get('reply_to.address'));
-    expect($this->beaconData['Bounce Email Address'])->equals($this->settings->get('bounce.address'));
+    expect($this->beaconData['MailPoet sending info'])->stringContainsString('Task Scheduler method: ' . $this->settings->get('cron_trigger.method'));
+    expect($this->beaconData['MailPoet sending info'])->stringContainsString('Default FROM address: ' . $this->settings->get('sender.address'));
+    expect($this->beaconData['MailPoet sending info'])->stringContainsString('Default Reply-To address: ' . $this->settings->get('reply_to.address'));
+    expect($this->beaconData['MailPoet sending info'])->stringContainsString('Bounce Email Address: ' . $this->settings->get('bounce.address'));
     expect($this->beaconData['Plugin installed at'])->equals($this->settings->get('installed_at'));
   }
 
   public function testItReturnsTransactionalEmailSendingMethod() {
     $this->settings->set('send_transactional_emails', '');
     $beacon = $this->diContainer->get(Beacon::class);
-    expect($beacon->getData()["Send all site's emails with"])->equals('default WordPress sending method');
+    expect($beacon->getData()['MailPoet sending info'])->stringContainsString("Send all site's emails with: default WordPress sending method");
     $this->settings->set('send_transactional_emails', '1');
-    expect($beacon->getData()["Send all site's emails with"])->equals('current sending method');
+    expect($beacon->getData()['MailPoet sending info'])->stringContainsString("Send all site's emails with: current sending method");
   }
 
   public function testItReturnsTotalNumberOfSubscribers() {
@@ -147,7 +147,7 @@ class BeaconTest extends \MailPoetTest {
   }
 
   public function testItReturnsCronPingUrl() {
-    expect($this->beaconData['Cron ping URL'])->stringContainsString('&action=ping');
+    expect($this->beaconData['MailPoet sending info'])->stringContainsString('&action=ping');
     // cron ping URL should react to custom filters
     $filter = function($url) {
       return str_replace(home_url(), 'http://custom_url/', $url);
@@ -155,7 +155,7 @@ class BeaconTest extends \MailPoetTest {
     $wp = new WPFunctions;
     $wp->addFilter('mailpoet_cron_request_url', $filter);
     $beaconData = $this->beaconData = $this->diContainer->get(Beacon::class)->getData();
-    expect($beaconData['Cron ping URL'])->regExp('!^http:\/\/custom_url\/!');
+    expect($beaconData['MailPoet sending info'])->regExp('!http:\/\/custom_url\/!');
     $wp->removeFilter('mailpoet_cron_request_url', $filter);
   }
 

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -215,10 +215,15 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
         showContactFields: true
       });
 
-      // HelpScout Beacon: Custom information
+      // HelpScout Beacon: User identity information
       window.Beacon("identify",
-        <%= json_encode(get_helpscout_data()) %>
+        <%= json_encode(get_helpscout_user_data()) %>
       );
+
+      // HelpScout Beacon: Custom information
+      window.Beacon("session-data",
+        <%= json_encode(get_helpscout_site_data()) %>
+    );
 
       if (window.mailpoet_beacon_articles) {
         window.Beacon('suggest', window.mailpoet_beacon_articles)


### PR DESCRIPTION
**How to test this PR:**

- On a site with a valid premium key, create a new HelpScout ticket by clicking on the "Help" button.
- Check that the new ticket has all the system information that is displayed on the system info page (/wp-admin/admin.php?page=mailpoet-help#/systemInfo).

[MAILPOET-4525]

[MAILPOET-4525]: https://mailpoet.atlassian.net/browse/MAILPOET-4525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ