### PR TITLE
Remove all usages of MailPoet\Tasks\Sending::getScheduledQueues() [MAILPOET-4367]

### DIFF
--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -136,7 +136,7 @@ class WordPress {
       'status' => [ScheduledTaskEntity::STATUS_SCHEDULED],
     ]);
     // sending queue
-    $scheduledQueues = SchedulerWorker::getScheduledQueues();
+    $scheduledQueues = $this->scheduledTasksRepository->findScheduledSendingTasks(SchedulerWorker::TASK_BATCH_SIZE);
     $runningQueues = $this->scheduledTasksRepository->findRunningSendingTasks(SendingQueueWorker::TASK_BATCH_SIZE);
     $sendingLimitReached = MailerLog::isSendingLimitReached();
     $sendingIsPaused = MailerLog::isSendingPaused();

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -108,7 +108,7 @@ class Scheduler {
       $scheduledQueues[] = $scheduledQueue;
     }
 
-    $this->updateTasks($scheduledQueues);
+    $this->updateTasks($scheduledTasks);
     foreach ($scheduledQueues as $i => $queue) {
       $newsletter = Newsletter::findOneWithOptions($queue->newsletterId);
       if (!$newsletter || $newsletter->deletedAt !== null) {
@@ -392,10 +392,14 @@ class Scheduler {
     return $notificationHistory;
   }
 
-  private function updateTasks(array $scheduledQueues) {
-    $ids = array_map(function ($queue) {
-      return $queue->taskId;
-    }, $scheduledQueues);
+  /**
+   * @param ScheduledTaskEntity[] $scheduledTasks
+   */
+  private function updateTasks(array $scheduledTasks): void {
+    $ids = array_map(function (ScheduledTaskEntity $scheduledTask): ?int {
+      return $scheduledTask->getId();
+    }, $scheduledTasks);
+    $ids = array_filter($ids);
     $this->scheduledTasksRepository->touchAllByIds($ids);
   }
 

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -236,6 +236,27 @@ class ScheduledTasksRepository extends Repository {
       ->execute();
   }
 
+  /**
+   * @return ScheduledTaskEntity[]
+   */
+  public function findScheduledSendingTasks(int $limit): array {
+    $now = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
+    return $this->doctrineRepository->createQueryBuilder('st')
+      ->select('st')
+      ->join('st.sendingQueue', 'sq')
+      ->where('st.deletedAt IS NULL')
+      ->andWhere('st.status = :status')
+      ->andWhere('st.scheduledAt <= :now')
+      ->andWhere('st.type = :type')
+      ->orderBy('st.updatedAt', 'ASC')
+      ->setMaxResults($limit)
+      ->setParameter('status', ScheduledTaskEntity::STATUS_SCHEDULED)
+      ->setParameter('now', $now)
+      ->setParameter('type', SendingQueue::TASK_TYPE)
+      ->getQuery()
+      ->getResult();
+  }
+
   protected function findByTypeAndStatus($type, $status, $limit = null, $future = false) {
     $queryBuilder = $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -239,7 +239,7 @@ class ScheduledTasksRepository extends Repository {
   /**
    * @return ScheduledTaskEntity[]
    */
-  public function findScheduledSendingTasks(int $limit): array {
+  public function findScheduledSendingTasks(?int $limit = null): array {
     $now = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
     return $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -257,7 +257,7 @@ class ScheduledTasksRepository extends Repository {
       $queryBuilder->andWhere('st.scheduledAt <= :now');
     }
 
-    $now = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
+    $now = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
     $queryBuilder->setParameter('now', $now);
 
     if ($limit) {

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -8,8 +8,6 @@ use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Util\Helpers;
-use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Carbon\Carbon;
 
 /**
  * A facade class containing all necessary models to work with a sending queue
@@ -298,20 +296,5 @@ class Sending {
 
   private function isCommonProperty($prop) {
     return in_array($prop, $this->commonFields);
-  }
-
-  public static function getScheduledQueues($amount = self::RESULT_BATCH_SIZE) {
-    $wp = new WPFunctions();
-    $tasks = ScheduledTask::tableAlias('tasks')
-      ->select('tasks.*')
-      ->join(SendingQueue::$_table, 'tasks.id = queues.task_id', 'queues')
-      ->whereNull('tasks.deleted_at')
-      ->where('tasks.status', ScheduledTask::STATUS_SCHEDULED)
-      ->whereLte('tasks.scheduled_at', Carbon::createFromTimestamp($wp->currentTime('timestamp')))
-      ->where('tasks.type', 'sending')
-      ->orderByAsc('tasks.updated_at')
-      ->limit($amount)
-      ->findMany();
-    return static::createManyFromTasks($tasks);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -101,13 +101,14 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItCanGetScheduledQueues() {
-    expect(Scheduler::getScheduledQueues())->isEmpty();
+    $scheduler = $this->diContainer->get(Scheduler::class);
+    expect($scheduler->getScheduledSendingTasks())->isEmpty();
     $queue = SendingTask::create();
     $queue->newsletterId = 1;
     $queue->status = SendingQueue::STATUS_SCHEDULED;
     $queue->scheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $queue->save();
-    expect(Scheduler::getScheduledQueues())->notEmpty();
+    expect($scheduler->getScheduledSendingTasks())->notEmpty();
   }
 
   public function testItCanCreateNotificationHistory() {

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
@@ -198,7 +198,7 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
     $task = $this->scheduledTaskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDay());
     $this->sendingQueueFactory->create($task);
 
-    $tasks = $this->repository->findScheduledSendingTasks(5);
+    $tasks = $this->repository->findScheduledSendingTasks();
     $this->assertSame($expectedResult, $tasks);
   }
 

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -157,10 +157,10 @@ class SendingTest extends \MailPoetTest {
     $this->sending->status = ScheduledTask::STATUS_SCHEDULED;
     $this->sending->scheduled_at = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->subHours(1);
     $this->sending->save();
-    $tasks = SendingTask::getScheduledQueues();
+    $tasks = $this->scheduledTaskRepository->findScheduledSendingTasks(5);
     expect($tasks)->notEmpty();
     foreach ($tasks as $task) {
-      expect($task)->isInstanceOf('MailPoet\Tasks\Sending');
+      expect($task)->isInstanceOf(ScheduledTaskEntity::class);
     }
 
     // if task exists but sending queue is missing, results should not contain empty (false) values
@@ -175,13 +175,13 @@ class SendingTest extends \MailPoetTest {
     for ($i = 0; $i < $amount + 3; $i += 1) {
       $this->createNewSendingTask(['status' => ScheduledTask::STATUS_SCHEDULED]);
     }
-    expect(SendingTask::getScheduledQueues($amount))->count($amount);
+    expect($this->scheduledTaskRepository->findScheduledSendingTasks($amount))->count($amount);
   }
 
   public function testItDoesNotGetPaused() {
     $this->_after();
     $this->createNewSendingTask(['status' => ScheduledTask::STATUS_PAUSED]);
-    expect(SendingTask::getScheduledQueues())->count(0);
+    expect($this->scheduledTaskRepository->findScheduledSendingTasks(5))->count(0);
   }
 
   public function testItGetsRunningQueues() {
@@ -222,10 +222,10 @@ class SendingTest extends \MailPoetTest {
     $sending3->updatedAt = '2017-05-04 15:00:00';
     $sending3->save();
 
-    $queues = SendingTask::getScheduledQueues(3);
-    expect($queues[0]->task_id)->equals($sending1->id());
-    expect($queues[1]->task_id)->equals($sending3->id());
-    expect($queues[2]->task_id)->equals($sending2->id());
+    $tasks = $this->scheduledTaskRepository->findScheduledSendingTasks(3);
+    expect($tasks[0]->getId())->equals($sending1->id());
+    expect($tasks[1]->getId())->equals($sending3->id());
+    expect($tasks[2]->getId())->equals($sending2->id());
   }
 
   public function testItGetsBatchOfScheduledQueuesSortedByUpdatedTime() {

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -157,7 +157,7 @@ class SendingTest extends \MailPoetTest {
     $this->sending->status = ScheduledTask::STATUS_SCHEDULED;
     $this->sending->scheduled_at = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->subHours(1);
     $this->sending->save();
-    $tasks = $this->scheduledTaskRepository->findScheduledSendingTasks(5);
+    $tasks = $this->scheduledTaskRepository->findScheduledSendingTasks();
     expect($tasks)->notEmpty();
     foreach ($tasks as $task) {
       expect($task)->isInstanceOf(ScheduledTaskEntity::class);
@@ -181,7 +181,7 @@ class SendingTest extends \MailPoetTest {
   public function testItDoesNotGetPaused() {
     $this->_after();
     $this->createNewSendingTask(['status' => ScheduledTask::STATUS_PAUSED]);
-    expect($this->scheduledTaskRepository->findScheduledSendingTasks(5))->count(0);
+    expect($this->scheduledTaskRepository->findScheduledSendingTasks())->count(0);
   }
 
   public function testItGetsRunningQueues() {


### PR DESCRIPTION
## Description
This pull request starts with https://github.com/mailpoet/mailpoet/commit/cfc359b56fa6b22d5efab158793dc3811b984b57 because I wanted to avoid conflicts.

It should be merged after https://github.com/mailpoet/mailpoet/pull/4305 and rebased on the trunk before.

## QA notes
Make sure scheduled newsletter sending works as expected

## Linked tickets
[MAILPOET-4367]

[MAILPOET-4367]: https://mailpoet.atlassian.net/browse/MAILPOET-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ