### PR TITLE
Prevent the user from leaving the settings page without saving [MAILPOET-4499]

### DIFF
--- a/mailpoet/assets/js/src/common/notices/unsaved_changes_notice.jsx
+++ b/mailpoet/assets/js/src/common/notices/unsaved_changes_notice.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useSelect } from '@wordpress/data';
-import { MailPoet } from '../../mailpoet';
+import { MailPoet } from 'mailpoet';
 
 export function UnsavedChangesNotice({ storeName }) {
   const hasUnsavedChanges = useSelect(

--- a/mailpoet/assets/js/src/common/notices/unsaved_changes_notice.jsx
+++ b/mailpoet/assets/js/src/common/notices/unsaved_changes_notice.jsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
-import { MailPoet } from 'mailpoet';
 import { useSelect } from '@wordpress/data';
+import { MailPoet } from '../../mailpoet';
 
-export function UnsavedChangesNotice() {
+export function UnsavedChangesNotice({ storeName }) {
   const hasUnsavedChanges = useSelect(
-    (sel) => sel('mailpoet-form-editor').hasUnsavedChanges(),
+    (sel) => sel(storeName).hasUnsavedChanges(),
     [],
   );
 

--- a/mailpoet/assets/js/src/form_editor/components/editor.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/editor.jsx
@@ -21,7 +21,7 @@ import { Tutorial } from './tutorial';
 import { Sidebar } from './sidebar/sidebar';
 import { Inserter } from './inserter';
 import { Notices } from './notices.jsx';
-import { UnsavedChangesNotice } from './unsaved_changes_notice.jsx';
+import { UnsavedChangesNotice } from '../../common/notices/unsaved_changes_notice.jsx';
 import { FormStyles } from './form_styles.jsx';
 import { FormPreview } from './preview/preview';
 import { FormStylingBackground } from './form_styling_background.jsx';
@@ -133,7 +133,7 @@ export function Editor() {
                   )}
                   <div className="interface-interface-skeleton__content">
                     <Notices />
-                    <UnsavedChangesNotice />
+                    <UnsavedChangesNotice storeName="mailpoet-form-editor" />
                     <BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
                       <BlockTools>
                         <BlockEditorKeyboardShortcuts />

--- a/mailpoet/assets/js/src/form_editor/components/editor.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/editor.jsx
@@ -15,13 +15,13 @@ import {
 } from '@wordpress/block-editor';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 
+import { UnsavedChangesNotice } from 'common/notices/unsaved_changes_notice.jsx';
 import { fetchLinkSuggestions } from '../utils/link_suggestions';
 import { Header } from './header.jsx';
 import { Tutorial } from './tutorial';
 import { Sidebar } from './sidebar/sidebar';
 import { Inserter } from './inserter';
 import { Notices } from './notices.jsx';
-import { UnsavedChangesNotice } from '../../common/notices/unsaved_changes_notice.jsx';
 import { FormStyles } from './form_styles.jsx';
 import { FormPreview } from './preview/preview';
 import { FormStylingBackground } from './form_styling_background.jsx';

--- a/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
@@ -92,9 +92,11 @@ export function KeyActivation() {
     'authorized_emails_addresses_check',
   );
   const [apiKeyState] = useSetting('mta', 'mailpoet_api_key_state', 'data');
+  const setSaveDone = useAction('setSaveDone');
   const setAuthorizedAddress = async (address: string) => {
     await setSenderAddress(address);
     await setUnauthorizedAddresses(null);
+    setSaveDone();
   };
 
   const showFromAddressModal =

--- a/mailpoet/assets/js/src/settings/settings.tsx
+++ b/mailpoet/assets/js/src/settings/settings.tsx
@@ -5,6 +5,7 @@ import { t } from 'common/functions';
 import { RoutedTabs } from 'common/tabs/routed_tabs';
 import { Tab } from 'common/tabs/tab';
 import { TopBar } from 'common/top_bar/top_bar';
+import { UnsavedChangesNotice } from 'common/notices/unsaved_changes_notice';
 import {
   Advanced,
   Basics,
@@ -14,7 +15,6 @@ import {
   WooCommerce,
 } from './pages';
 import { useSelector } from './store/hooks';
-import { UnsavedChangesNotice } from '../common/notices/unsaved_changes_notice';
 
 const trackTabSwitched = (tabKey: string) => {
   MailPoet.trackEvent('User has clicked a tab in Settings', {

--- a/mailpoet/assets/js/src/settings/settings.tsx
+++ b/mailpoet/assets/js/src/settings/settings.tsx
@@ -14,6 +14,7 @@ import {
   WooCommerce,
 } from './pages';
 import { useSelector } from './store/hooks';
+import { UnsavedChangesNotice } from '../common/notices/unsaved_changes_notice';
 
 const trackTabSwitched = (tabKey: string) => {
   MailPoet.trackEvent('User has clicked a tab in Settings', {
@@ -29,6 +30,7 @@ export function Settings() {
       <TopBar />
       {isSaving && <Loading />}
       <Notices />
+      <UnsavedChangesNotice storeName="mailpoet-settings" />
       <RoutedTabs
         activeKey="basics"
         onSwitch={(tabKey: string) => trackTabSwitched(tabKey)}

--- a/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -87,6 +87,8 @@ export function* verifyPremiumKey(key: string) {
 
   MailPoet.trackEvent('User has validated a Premium key');
 
+  yield { type: 'SAVE_DONE' };
+
   return null;
 }
 

--- a/mailpoet/assets/js/src/settings/store/actions/settings.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/settings.ts
@@ -14,6 +14,10 @@ export function setSettings(value: any): Action {
   return { type: 'SET_SETTINGS', value };
 }
 
+export function setSaveDone(): Action {
+  return { type: 'SAVE_DONE' };
+}
+
 export function setErrorFlag(value: boolean): Action {
   return { type: 'SET_ERROR_FLAG', value };
 }

--- a/mailpoet/assets/js/src/settings/store/create_reducer.ts
+++ b/mailpoet/assets/js/src/settings/store/create_reducer.ts
@@ -1,4 +1,4 @@
-import { setWith, clone } from 'lodash';
+import { setWith, clone, isEqual } from 'lodash';
 import {
   State,
   Action,
@@ -24,7 +24,10 @@ export function createReducer(defaultValue: State) {
           clone,
         );
 
-        newState.save.hasUnsavedChanges = true;
+        newState.save.hasUnsavedChanges = !isEqual(
+          newState.data,
+          state.originalData,
+        );
 
         return newState;
       }

--- a/mailpoet/assets/js/src/settings/store/create_reducer.ts
+++ b/mailpoet/assets/js/src/settings/store/create_reducer.ts
@@ -24,7 +24,7 @@ export function createReducer(defaultValue: State) {
           clone,
         );
 
-        newState.hasUnsavedChanges = true;
+        newState.save.hasUnsavedChanges = true;
 
         return newState;
       }
@@ -32,16 +32,32 @@ export function createReducer(defaultValue: State) {
         return {
           ...state,
           data: normalizeSettings(action.value as Record<string, unknown>),
-          hasUnsavedChanges: false,
         };
       case 'SET_ERROR_FLAG':
         return { ...state, flags: { ...state.flags, error: !!action.value } };
       case 'SAVE_STARTED':
-        return { ...state, save: { inProgress: true, error: null } };
+        return {
+          ...state,
+          save: {
+            inProgress: true,
+            error: null,
+            hasUnsavedChanges: state.save.hasUnsavedChanges,
+          },
+        };
       case 'SAVE_DONE':
-        return { ...state, save: { inProgress: false, error: null } };
+        return {
+          ...state,
+          save: { inProgress: false, error: null, hasUnsavedChanges: false },
+        };
       case 'SAVE_FAILED':
-        return { ...state, save: { inProgress: false, error: action.error } };
+        return {
+          ...state,
+          save: {
+            inProgress: false,
+            error: action.error,
+            hasUnsavedChanges: state.save.hasUnsavedChanges,
+          },
+        };
       case 'SET_RE_ENGAGEMENT_NOTICE':
         return {
           ...state,

--- a/mailpoet/assets/js/src/settings/store/create_reducer.ts
+++ b/mailpoet/assets/js/src/settings/store/create_reducer.ts
@@ -31,11 +31,19 @@ export function createReducer(defaultValue: State) {
 
         return newState;
       }
-      case 'SET_SETTINGS':
-        return {
+      case 'SET_SETTINGS': {
+        const newState = {
           ...state,
           data: normalizeSettings(action.value as Record<string, unknown>),
         };
+
+        newState.save.hasUnsavedChanges = !isEqual(
+          newState.data,
+          state.originalData,
+        );
+
+        return newState;
+      }
       case 'SET_ERROR_FLAG':
         return { ...state, flags: { ...state.flags, error: !!action.value } };
       case 'SAVE_STARTED':

--- a/mailpoet/assets/js/src/settings/store/create_reducer.ts
+++ b/mailpoet/assets/js/src/settings/store/create_reducer.ts
@@ -16,17 +16,23 @@ export function createReducer(defaultValue: State) {
     action: Action,
   ): State => {
     switch (action.type) {
-      case 'SET_SETTING':
-        return setWith(
+      case 'SET_SETTING': {
+        const newState = setWith(
           clone(state),
           ['data', ...action.path],
           action.value,
           clone,
         );
+
+        newState.hasUnsavedChanges = true;
+
+        return newState;
+      }
       case 'SET_SETTINGS':
         return {
           ...state,
           data: normalizeSettings(action.value as Record<string, unknown>),
+          hasUnsavedChanges: false,
         };
       case 'SET_ERROR_FLAG':
         return { ...state, flags: { ...state.flags, error: !!action.value } };

--- a/mailpoet/assets/js/src/settings/store/make_default_state.ts
+++ b/mailpoet/assets/js/src/settings/store/make_default_state.ts
@@ -29,7 +29,7 @@ export function makeDefaultState(window: any): State {
   const paths = window.mailpoet_paths;
   const segments = window.mailpoet_segments;
   const hosts = window.mailpoet_hosts;
-  const save = { inProgress: false, error: null };
+  const save = { inProgress: false, error: null, hasUnsavedChanges: false };
   const data = normalizeSettings(
     window.mailpoet_settings as Record<string, unknown>,
   );
@@ -78,7 +78,6 @@ export function makeDefaultState(window: any): State {
     showNotice: false,
     action: null,
   };
-  const hasUnsavedChanges = false;
   return {
     data,
     flags,
@@ -90,6 +89,5 @@ export function makeDefaultState(window: any): State {
     hosts,
     testEmail,
     reEngagement,
-    hasUnsavedChanges,
   };
 }

--- a/mailpoet/assets/js/src/settings/store/make_default_state.ts
+++ b/mailpoet/assets/js/src/settings/store/make_default_state.ts
@@ -78,6 +78,7 @@ export function makeDefaultState(window: any): State {
     showNotice: false,
     action: null,
   };
+  const hasUnsavedChanges = false;
   return {
     data,
     flags,
@@ -89,5 +90,6 @@ export function makeDefaultState(window: any): State {
     hosts,
     testEmail,
     reEngagement,
+    hasUnsavedChanges,
   };
 }

--- a/mailpoet/assets/js/src/settings/store/make_default_state.ts
+++ b/mailpoet/assets/js/src/settings/store/make_default_state.ts
@@ -33,6 +33,7 @@ export function makeDefaultState(window: any): State {
   const data = normalizeSettings(
     window.mailpoet_settings as Record<string, unknown>,
   );
+  const originalData = data;
   const flags = {
     error: false,
     newUser: !!window.mailpoet_is_new_user,
@@ -80,6 +81,7 @@ export function makeDefaultState(window: any): State {
   };
   return {
     data,
+    originalData,
     flags,
     save,
     keyActivation,

--- a/mailpoet/assets/js/src/settings/store/selectors.ts
+++ b/mailpoet/assets/js/src/settings/store/selectors.ts
@@ -97,3 +97,7 @@ export function hasReEngagementNotice(state: State): boolean {
 export function getReEngagementAction(state: State) {
   return state.reEngagement.action;
 }
+
+export function hasUnsavedChanges(state: State) {
+  return state.hasUnsavedChanges || state.save.inProgress;
+}

--- a/mailpoet/assets/js/src/settings/store/selectors.ts
+++ b/mailpoet/assets/js/src/settings/store/selectors.ts
@@ -99,8 +99,5 @@ export function getReEngagementAction(state: State) {
 }
 
 export function hasUnsavedChanges(state: State) {
-  return (
-    (state.save.hasUnsavedChanges || state.save.inProgress) &&
-    !_.isEqual(state.data, state.originalData)
-  );
+  return state.save.hasUnsavedChanges || state.save.inProgress;
 }

--- a/mailpoet/assets/js/src/settings/store/selectors.ts
+++ b/mailpoet/assets/js/src/settings/store/selectors.ts
@@ -99,5 +99,8 @@ export function getReEngagementAction(state: State) {
 }
 
 export function hasUnsavedChanges(state: State) {
-  return state.save.hasUnsavedChanges || state.save.inProgress;
+  return (
+    (state.save.hasUnsavedChanges || state.save.inProgress) &&
+    !_.isEqual(state.data, state.originalData)
+  );
 }

--- a/mailpoet/assets/js/src/settings/store/selectors.ts
+++ b/mailpoet/assets/js/src/settings/store/selectors.ts
@@ -99,5 +99,5 @@ export function getReEngagementAction(state: State) {
 }
 
 export function hasUnsavedChanges(state: State) {
-  return state.hasUnsavedChanges || state.save.inProgress;
+  return state.save.hasUnsavedChanges || state.save.inProgress;
 }

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -247,6 +247,7 @@ export type State = {
   keyActivation: KeyActivationState;
   hosts: Hosts;
   reEngagement: ReEngagement;
+  hasUnsavedChanges: boolean;
 };
 
 export type Action =

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -239,6 +239,7 @@ export type State = {
   save: {
     inProgress: boolean;
     error: string[];
+    hasUnsavedChanges: boolean;
   };
   testEmail: {
     state: TestEmailState;
@@ -247,7 +248,6 @@ export type State = {
   keyActivation: KeyActivationState;
   hosts: Hosts;
   reEngagement: ReEngagement;
-  hasUnsavedChanges: boolean;
 };
 
 export type Action =

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -223,6 +223,7 @@ export enum TestEmailState {
 
 export type State = {
   data: Settings;
+  originalData: Settings;
   segments: Segment[];
   pages: Page[];
   paths: {

--- a/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
@@ -55,6 +55,7 @@ class BasicsPageCest {
     $i->click('[data-automation-id="subscribe-on_comment-checkbox"]');
     $i->selectOptionInReactSelect('Newsletter mailing list', '[data-automation-id="subscribe-on_comment-segments-selection"]');
     $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     //go to the post and perform commenting + opting
     $i->amOnPage('/');
     $i->waitForText($postTitle);
@@ -90,6 +91,7 @@ class BasicsPageCest {
     $i->click('[data-automation-id="subscribe-on_comment-checkbox"]');
     //save settings
     $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     //check to make sure comment subscription form is gone
     $i->amOnPage('/');
     $i->waitForText($postTitle);
@@ -116,6 +118,7 @@ class BasicsPageCest {
     $settings = new Settings();
     $settings->withSendingMethodMailPoet();
     $i->reloadPage();
+    $i->acceptPopup();
 
     $i->fillField($emailField, 'sender2@email.com');
     $i->dontSeeElement('[data-acceptance-id="freemail-sender-warning-new-installation"]');

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -27,6 +27,7 @@ class CreateNewWordPressUserCest {
     $i->waitForText('Settings');
     $i->selectOptionInReactSelect($secondListName, '[data-automation-id="subscribe-on_register-segments-selection"]');
     $i->click('[data-automation-id="settings-submit-button"]'); //save settings
+    $i->waitForElementNotVisible('#mailpoet_loading');
 
     // create a wp user via registration
     // Note: Xpath used to avoid flakyness and to pass multisite testing where we have different registration page designs


### PR DESCRIPTION
I'm creating this PR as a draft first to get early feedback on the implementation before I finish it. As I don't have a lot of experience with React there is a big change I'm missing a lot of things.

A few questions/comments that I have:

- I opted to reuse the component UnsavedChangesNotice from the form editor and pass the name of the store when creating the component. I'm not entirely sure if that is a good idea or not.
- I don't know if I could use the spread operator instead of clone to avoid having to create the newState variable in https://github.com/mailpoet/mailpoet/compare/add-confirmation-message-to-settings-page?expand=1#diff-6dfcee87da4b090835dfe995637b6974c1079a63dbaea7aa426b42fac230ee4fR20.
- I'm using `SET_SETTINGS` to set hasUnsavedChanges to `false` instead of `SAVE_DONE` as settings are saved when the user verifies a new premium key but in this flow `SAVE_DONE` is not called and `SET_SETTINGS` is. For some reason that I still have to figure out, `SET_SETTING` is also called (I don't know where yet) when the user verifies the key causing a bug as `hasUnsavedChanges` is set to `true` but there are no unsaved changes.
- I might need to change the name of the selector `hasUnsavedChanges()` to something more generic as in the settings page we are checking for unsaved changes but also if the page is being saved. Please let me know if you have any suggestions.

[MAILPOET-4499]

[MAILPOET-4499]: https://mailpoet.atlassian.net/browse/MAILPOET-4499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ