### PR TITLE
Improve the DMARC error message - MAILPOET-4311

### DIFF
--- a/mailpoet/assets/js/src/listing/notices.jsx
+++ b/mailpoet/assets/js/src/listing/notices.jsx
@@ -72,12 +72,33 @@ export function MailerError(props) {
       links[match],
       'text/xml',
     ).firstChild;
+
+    const listOfAttributeNames = link.getAttributeNames();
+    const allowedAttributesList = [
+      'target',
+      'rel',
+      'class',
+      'data-email',
+      'data-type',
+    ];
+
+    // include these custom attributes in the final link
+    const otherAttributes = listOfAttributeNames.reduce((acc, name) => {
+      if (allowedAttributesList.includes(name)) {
+        // react requires the class attribute to be named className.
+        return {
+          ...acc,
+          [name === 'class' ? 'className' : name]: link.getAttribute(name),
+        };
+      }
+      return { ...acc };
+    }, {});
+
     return (
       <a
         key={`a-${match}`}
         href={link.getAttribute('href')}
-        target={link.getAttribute('target')}
-        rel={link.getAttribute('rel')}
+        {...otherAttributes}
       >
         {link.textContent}
       </a>

--- a/mailpoet/assets/js/src/listing/notices.jsx
+++ b/mailpoet/assets/js/src/listing/notices.jsx
@@ -74,7 +74,7 @@ export function MailerError(props) {
     ).firstChild;
 
     const listOfAttributeNames = link.getAttributeNames();
-    const allowedAttributesList = [
+    const allowedAttributeNames = [
       'target',
       'rel',
       'class',
@@ -83,22 +83,22 @@ export function MailerError(props) {
     ];
 
     // include these custom attributes in the final link
-    const otherAttributes = listOfAttributeNames.reduce((acc, name) => {
-      if (allowedAttributesList.includes(name)) {
+    const allowedAttributes = listOfAttributeNames.reduce((acc, name) => {
+      if (allowedAttributeNames.includes(name)) {
         // react requires the class attribute to be named className.
         return {
           ...acc,
           [name === 'class' ? 'className' : name]: link.getAttribute(name),
         };
       }
-      return { ...acc };
+      return acc;
     }, {});
 
     return (
       <a
         key={`a-${match}`}
         href={link.getAttribute('href')}
-        {...otherAttributes}
+        {...allowedAttributes}
       >
         {link.textContent}
       </a>


### PR DESCRIPTION
<img width="1588" alt="Screenshot 2022-08-16 at 10 00 29 AM" src="https://user-images.githubusercontent.com/30554163/184841045-0e7b7f41-f440-4fff-89f6-0d2a5b5b5e0e.png">


When the DMARC error message is displayed, add the sentence "Click here to start the authentication". This will be a link that opens the verify domain dialogue

[MAILPOET-4311](https://mailpoet.atlassian.net/browse/MAILPOET-4311)

Testing:
* Clear your errors and make sure you don't have any sending error
* Create a new newsletter. You may use any of the demo contents
* On the newsletter sending page, use an email domain with restricted DMARC policy e.g @automattic.com (You might have to authenticate the email address)
* Fill in the other fields and send the email. (I would recommend the use of a sending list with few subscribers e.g 1 or 2 subscribers)
* Wait a few minutes for the error message 
* Click on the "Click here to start the authentication" link
* Notice the sender domain verification modal.