### PR TITLE
Add tracking for MailPoet logo in free plan emails - MAILPOET-4543

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -227,7 +227,7 @@ class Renderer {
           'blocks' => [
             [
               'type' => 'image',
-              'link' => 'http://www.mailpoet.com',
+              'link' => 'https://www.mailpoet.com/?ref=free-plan-user-email&utm_source=free_plan_user_email&utm_medium=email',
               'src' => Env::$assetsUrl . '/img/mailpoet_logo_newsletter.png',
               'fullWidth' => false,
               'alt' => 'Email Marketing Powered by MailPoet',


### PR DESCRIPTION
[MAILPOET-4543](https://mailpoet.atlassian.net/browse/MAILPOET-4543)

Testing
* Make sure you are on the free plan or use a Free MSS subscription API key
* Create a new newsletter, add demo contents
* Send newsletter
* Notice the MailPoet logo at the bottom of the newsletter
* Click on it. You should be redirected to mailpoet.com with some URL query params