### PR TITLE
Remove old model usage from MailPoet\WooCommerce\Subscription and WooCommerceBlocksIntegration [MAILPOET-4365]

### DIFF
--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -447,6 +447,12 @@ class SubscriberEntity {
     });
   }
 
+  public function getSubscribedSegments() {
+    $criteria = Criteria::create()
+      ->where(Criteria::expr()->eq('status', SubscriberEntity::STATUS_SUBSCRIBED));
+    return $this->getSubscriberSegments()->matching($criteria);
+  }
+
   /**
    * @return Collection<int, SubscriberCustomFieldEntity>
    */

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -435,8 +435,16 @@ class SubscriberEntity {
   /**
    * @return Collection<int, SubscriberSegmentEntity>
    */
-  public function getSubscriberSegments() {
-    return $this->subscriberSegments;
+  public function getSubscriberSegments(?string $status = null) {
+    if (!is_null($status)) {
+      $criteria = Criteria::create()
+        ->where(Criteria::expr()->eq('status', SubscriberEntity::STATUS_SUBSCRIBED));
+      $subscriberSegments = $this->subscriberSegments->matching($criteria);
+    } else {
+      $subscriberSegments = $this->subscriberSegments;
+    }
+
+    return $subscriberSegments;
   }
 
   public function getSegments() {
@@ -445,12 +453,6 @@ class SubscriberEntity {
     })->filter(function ($segment) {
       return $segment !== null;
     });
-  }
-
-  public function getSubscribedSegments() {
-    $criteria = Criteria::create()
-      ->where(Criteria::expr()->eq('status', SubscriberEntity::STATUS_SUBSCRIBED));
-    return $this->getSubscriberSegments()->matching($criteria);
   }
 
   /**

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use MailPoet\Config\Env;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\Subscriber;
 use MailPoet\Segments\WooCommerce as WooSegment;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -154,12 +153,6 @@ class WooCommerceBlocksIntegration {
       return null;
     }
 
-    // We temporarily need to fetch old model
-    $subscriberOldModel = Subscriber::findOne($subscriber->getId());
-    if (!$subscriberOldModel) {
-      return null;
-    }
-
-    $this->woocommerceSubscription->handleSubscriberOptin($subscriberOldModel, $checkoutOptinEnabled, $checkoutOptin);
+    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptinEnabled, $checkoutOptin);
   }
 }

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -187,17 +187,23 @@ class Subscription {
     $checkoutOptinEnabled = (bool)$this->settings->get(self::OPTIN_ENABLED_SETTING_NAME);
     $checkoutOptin = !empty($_POST[self::CHECKOUT_OPTIN_INPUT_NAME]);
 
-    return $this->handleSubscriberOptin($subscriber, $checkoutOptinEnabled, $checkoutOptin);
+    $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
+
+    if ($subscriberEntity instanceof SubscriberEntity) {
+      return $this->handleSubscriberOptin($subscriberEntity, $checkoutOptinEnabled, $checkoutOptin);
+    }
   }
 
   /**
    * Subscribe or unsubscribe a subscriber.
    *
-   * @param Subscriber $subscriber Subscriber object
+   * @param SubscriberEntity $subscriberEntity Subscriber object
    * @param bool $checkoutOptinEnabled
    * @param bool $checkoutOptin
    */
-  public function handleSubscriberOptin(Subscriber $subscriber, bool $checkoutOptinEnabled, bool $checkoutOptin): bool {
+  public function handleSubscriberOptin(SubscriberEntity $subscriberEntity, bool $checkoutOptinEnabled, bool $checkoutOptin): bool {
+    $subscriber = Subscriber::findOne($subscriberEntity->getId());
+
     $wcSegment = Segment::getWooCommerceSegment();
     $moreSegmentsToSubscribe = (array)$this->settings->get(self::OPTIN_SEGMENTS_SETTING_NAME, []);
     $signupConfirmation = $this->settings->get('signup_confirmation');

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -5,7 +5,6 @@ namespace MailPoet\WooCommerce;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\Segment;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -170,9 +169,9 @@ class Subscription {
     if (!$subscriber instanceof SubscriberEntity) {
       return false;
     }
-    $wcSegment = Segment::getWooCommerceSegment();
+    $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
     $subscriberSegment = SubscriberSegment::where('subscriber_id', $subscriber->getId())
-      ->where('segment_id', $wcSegment->id)
+      ->where('segment_id', $wcSegment->getId())
       ->findOne();
     return $subscriberSegment instanceof SubscriberSegment
       && $subscriberSegment->status === SubscriberEntity::STATUS_SUBSCRIBED;

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -5,7 +5,7 @@ namespace MailPoet\WooCommerce;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\SubscriberSegment;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\Unsubscribes;
@@ -169,12 +169,14 @@ class Subscription {
     if (!$subscriber instanceof SubscriberEntity) {
       return false;
     }
+
     $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
-    $subscriberSegment = SubscriberSegment::where('subscriber_id', $subscriber->getId())
-      ->where('segment_id', $wcSegment->getId())
-      ->findOne();
-    return $subscriberSegment instanceof SubscriberSegment
-      && $subscriberSegment->status === SubscriberEntity::STATUS_SUBSCRIBED;
+    $subscriberSegment = $this->subscriberSegmentRepository->findOneBy(
+      ['subscriber' => $subscriber->getId(), 'segment' => $wcSegment->getId()]
+    );
+
+    return $subscriberSegment instanceof SubscriberSegmentEntity
+      && $subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED;
   }
 
   public function subscribeOnOrderPay($orderId) {

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -276,7 +276,7 @@ class Subscription {
   }
 
   private function updateSubscriberStatus(SubscriberEntity $subscriber) {
-    $segmentsCount = $subscriber->getSubscribedSegments()->count();
+    $segmentsCount = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED)->count();
 
     if (!$segmentsCount) {
       $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -156,7 +156,7 @@ class Subscription {
       ->where('segment_id', $wcSegment->id)
       ->findOne();
     return $subscriberSegment instanceof SubscriberSegment
-      && $subscriberSegment->status === Subscriber::STATUS_SUBSCRIBED;
+      && $subscriberSegment->status === SubscriberEntity::STATUS_SUBSCRIBED;
   }
 
   public function subscribeOnOrderPay($orderId) {
@@ -232,7 +232,7 @@ class Subscription {
     $subscriber->source = Source::WOOCOMMERCE_CHECKOUT;
 
     if (
-      ($subscriber->status === Subscriber::STATUS_SUBSCRIBED)
+      ($subscriber->status === SubscriberEntity::STATUS_SUBSCRIBED)
       || ((bool)$signupConfirmation['enabled'] === false)
     ) {
       $this->subscribe($subscriber);
@@ -249,7 +249,7 @@ class Subscription {
   }
 
   private function subscribe(Subscriber $subscriber) {
-    $subscriber->status = Subscriber::STATUS_SUBSCRIBED;
+    $subscriber->status = SubscriberEntity::STATUS_SUBSCRIBED;
     if (empty($subscriber->confirmedIp) && empty($subscriber->confirmedAt)) {
       $subscriber->confirmedIp = Helpers::getIP();
       $subscriber->setExpr('confirmed_at', 'NOW()');
@@ -264,7 +264,7 @@ class Subscription {
     $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
 
     if ($subscriberEntity instanceof SubscriberEntity) {
-      $subscriberEntity->setStatus(Subscriber::STATUS_UNCONFIRMED);
+      $subscriberEntity->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
       $this->subscribersRepository->persist($subscriberEntity);
       $this->subscribersRepository->flush();
 
@@ -280,7 +280,7 @@ class Subscription {
     $ss = Subscriber::findOne($subscriber->id);
     $segmentsCount = $ss->segments()->count();
     if (!$segmentsCount) {
-      $subscriber->status = Subscriber::STATUS_UNSUBSCRIBED;
+      $subscriber->status = SubscriberEntity::STATUS_UNSUBSCRIBED;
       $subscriber->save();
       $this->unsubscribesTracker->track($subscriber->id, StatisticsUnsubscribeEntity::SOURCE_ORDER_CHECKOUT);
     }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -15,6 +15,7 @@ use MailPoet\API\JSON\v2\APITestNamespacedEndpointStubV2;
 use MailPoet\Config\AccessControl;
 use MailPoet\DI\ContainerConfigurator;
 use MailPoet\DI\ContainerFactory;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
@@ -335,5 +336,7 @@ class APITest extends \MailPoetTest {
 
   public function _after() {
     wp_delete_user($this->wpUserId);
+    // we need to trucate wp_mailpoet_subscriber_segment manually while https://mailpoet.atlassian.net/browse/MAILPOET-4580 is not fixed.
+    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Entities/SubscriberEntityTest.php
+++ b/mailpoet/tests/integration/Entities/SubscriberEntityTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace MailPoet\Entities;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use \MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use \MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class SubscriberEntityTest extends \MailPoetTest {
+
+  protected function _before() {
+    parent::_before();
+
+    // Calling cleanup() here as some tests from other classes don't remove all SubscriberSegmentEntities causing issues here.
+    $this->cleanup();
+  }
+
+  public function testGetSubscribedSegments() {
+    $segment1 = (new SegmentFactory())->create();
+    $segment2 = (new SegmentFactory())->create();
+
+    $subscriber = (new SubscriberFactory())->withSegments([$segment1, $segment2])->create();
+
+    $subscriberSegment1 = $subscriber->getSubscriberSegments()->first();
+    $this->assertInstanceOf(SubscriberSegmentEntity::class, $subscriberSegment1);
+    $subscriberSegment1->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->entityManager->persist($subscriberSegment1);
+    $this->entityManager->flush();
+
+    $subscriberSegment2 = $subscriber->getSubscriberSegments()->last();
+
+    $this->assertSame([1 => $subscriberSegment2], $subscriber->getSubscribedSegments()->toArray());
+  }
+
+  protected function _after() {
+    parent::_after();
+    $this->cleanup();
+  }
+
+  protected function cleanup() {
+    $this->truncateEntity(SegmentEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SubscriberSegmentEntity::class);
+  }
+}

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -9,11 +9,9 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\WP;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\WP\Functions as WPFunctions;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class SubscriptionTest extends \MailPoetTest {
@@ -48,7 +46,6 @@ class SubscriptionTest extends \MailPoetTest {
   public function _before() {
     $this->orderId = 123; // dummy
     $this->settings = SettingsController::getInstance();
-    $wp = WPFunctions::get();
     $wcHelper = $this->make(
       Helper::class,
       [
@@ -60,13 +57,9 @@ class SubscriptionTest extends \MailPoetTest {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->confirmationEmailMailer = $this->createMock(ConfirmationEmailMailer::class);
-    $this->subscription = new Subscription(
-      $this->settings,
-      $this->confirmationEmailMailer,
-      $wp,
-      $wcHelper,
-      $this->subscribersRepository,
-      $this->diContainer->get(Unsubscribes::class)
+    $this->subscription = $this->getServiceWithOverrides(
+      Subscription::class,
+      ['wcHelper' => $wcHelper, 'confirmationEmailMailer' => $this->confirmationEmailMailer]
     );
     $this->wcSegment = $this->segmentsRepository->getWooCommerceSegment();
     $this->wp = $this->diContainer->get(WP::class);


### PR DESCRIPTION
## Description
N/A

## QA notes
Make sure that users can still subscribe to lists when using the WooCommerce and WooCommerce Blocks checkouts.

## Linked tickets
[MAILPOET-4365]

[MAILPOET-4365]: https://mailpoet.atlassian.net/browse/MAILPOET-4365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ