### PR TITLE
Automation templates [MAILPOET-4538]

### DIFF
--- a/mailpoet/assets/js/src/automation/automation.tsx
+++ b/mailpoet/assets/js/src/automation/automation.tsx
@@ -81,11 +81,15 @@ function App(): JSX.Element {
       <Workflows />
       <div style={{ marginTop: 30, display: 'grid', gridGap: 8 }}>
         <CreateTestingWorkflowButton />
-        <CreateWorkflowFromTemplateButton template="delayed-email-after-signup">
+        <CreateWorkflowFromTemplateButton slug="simple-welcome-email">
           Create testing workflow from template (welcome email)
         </CreateWorkflowFromTemplateButton>
-        <CreateWorkflowFromTemplateButton template="welcome-email-sequence">
-          Create testing workflow from template (welcome sequence)
+        <CreateWorkflowFromTemplateButton slug="welcome-email-sequence">
+          Create testing workflow from template (welcome sequence, only premium)
+        </CreateWorkflowFromTemplateButton>
+        <CreateWorkflowFromTemplateButton slug="advanced-welcome-email-sequence">
+          Create testing workflow from template (advanced welcome sequence, only
+          premium)
         </CreateWorkflowFromTemplateButton>
         <RecreateSchemaButton />
         <DeleteSchemaButton />

--- a/mailpoet/assets/js/src/automation/testing.tsx
+++ b/mailpoet/assets/js/src/automation/testing.tsx
@@ -71,18 +71,21 @@ export function CreateTestingWorkflowButton(): JSX.Element {
 }
 
 type TemplateButtonProps = {
-  template: string;
+  slug: string;
   children?: ReactNode;
 };
 
 export function CreateWorkflowFromTemplateButton({
-  template,
+  slug,
   children,
 }: TemplateButtonProps): JSX.Element {
   const [createWorkflowFromTemplate, { loading, error }] = useMutation(
     'workflows/create-from-template',
     {
       method: 'POST',
+      body: JSON.stringify({
+        slug,
+      }),
     },
   );
 
@@ -92,12 +95,7 @@ export function CreateWorkflowFromTemplateButton({
         className="button button-primary"
         type="button"
         onClick={async () => {
-          await createWorkflowFromTemplate({
-            body: JSON.stringify({
-              name: `Test from template ${new Date().toISOString()}`,
-              template,
-            }),
-          });
+          await createWorkflowFromTemplate();
           window.location.reload();
         }}
         disabled={loading}

--- a/mailpoet/lib/Automation/Engine/Builder/CreateWorkflowFromTemplateController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/CreateWorkflowFromTemplateController.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine\Builder;
 
 use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage;
 use MailPoet\Automation\Integrations\MailPoet\Templates\WorkflowBuilder;
 use MailPoet\UnexpectedValueException;
 
@@ -11,33 +12,25 @@ class CreateWorkflowFromTemplateController {
   /** @var WorkflowStorage */
   private $storage;
 
-  /** @var WorkflowBuilder */
-  private $templates;
+  /** @var WorkflowTemplateStorage  */
+  private $templateStorage;
 
   public function __construct(
     WorkflowStorage $storage,
-    WorkflowBuilder $templates
+    WorkflowTemplateStorage $templateStorage
   ) {
     $this->storage = $storage;
-    $this->templates = $templates;
+    $this->templateStorage = $templateStorage;
   }
 
-  public function createWorkflow(array $data): Workflow {
-    $name = $data['name'];
-    $template = $data['template'];
+  public function createWorkflow(string $slug): Workflow {
 
-    switch ($template) {
-      case 'delayed-email-after-signup':
-        $workflow = $this->templates->delayedEmailAfterSignupWorkflow($name);
-        break;
-      case 'welcome-email-sequence':
-        $workflow = $this->templates->welcomeEmailSequence($name);
-        break;
-      default:
-        throw UnexpectedValueException::create()->withMessage('Template not found.');
+    $template = $this->templateStorage->getTemplateBySlug($slug);
+    if (! $template) {
+      throw UnexpectedValueException::create()->withMessage('Template not found.');
     }
 
-    $this->storage->createWorkflow($workflow);
-    return $workflow;
+    $this->storage->createWorkflow($template->getWorkflow());
+    return $template->getWorkflow();
   }
 }

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowTemplate.php
@@ -18,8 +18,8 @@ class WorkflowTemplate
     self::CATEGORY_WOOCOMMERCE,
   ];
 
-  /** @var int */
-  private $id;
+  /** @var string */
+  private $slug;
 
   /** @var int */
   private $category;
@@ -30,18 +30,18 @@ class WorkflowTemplate
   /** @var Workflow */
   private $workflow;
 
-  public function __construct(int $id, int $category, string $description, Workflow $workflow) {
+  public function __construct(string $slug, int $category, string $description, Workflow $workflow) {
     if (! in_array($category, self::ALL_CATEGORIES)) {
       throw new RuntimeException("$category is not a valid category.");
     }
-    $this->id = $id;
+    $this->slug = $slug;
     $this->category = $category;
     $this->description = $description;
     $this->workflow = $workflow;
   }
 
-  public function getId() : int {
-    return $this->id;
+  public function getSlug() : string {
+    return $this->slug;
   }
 
   public function getName() : string {
@@ -62,7 +62,7 @@ class WorkflowTemplate
 
   public function toArray() : array {
     return [
-      'id' => $this->getId(),
+      'slug' => $this->getSlug(),
       'name' => $this->getName(),
       'category' => $this->getCategory(),
       'description' => $this->getDescription(),

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowTemplate.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MailPoet\Automation\Engine\Data;
+
+use MailPoet\RuntimeException;
+
+class WorkflowTemplate
+{
+
+  public const CATEGORY_WELCOME = 1;
+  public const CATEGORY_ABANDONED_CART = 2;
+  public const CATEGORY_REENGAGEMENT = 3;
+  public const CATEGORY_WOOCOMMERCE = 4;
+  public const ALL_CATEGORIES = [
+    self::CATEGORY_WELCOME,
+    self::CATEGORY_ABANDONED_CART,
+    self::CATEGORY_REENGAGEMENT,
+    self::CATEGORY_WOOCOMMERCE,
+  ];
+
+  /** @var int */
+  private $id;
+
+  /** @var int */
+  private $category;
+
+  /** @var string */
+  private $description;
+
+  /** @var Workflow */
+  private $workflow;
+
+  public function __construct(int $id, int $category, string $description, Workflow $workflow) {
+    if (! in_array($category, self::ALL_CATEGORIES)) {
+      throw new RuntimeException("$category is not a valid category.");
+    }
+    $this->id = $id;
+    $this->category = $category;
+    $this->description = $description;
+    $this->workflow = $workflow;
+  }
+
+  public function getId() : int {
+    return $this->id;
+  }
+
+  public function getName() : string {
+    return $this->workflow->getName();
+  }
+
+  public function getCategory() : int {
+    return $this->category;
+  }
+
+  public function getDescription() : string {
+    return $this->description;
+  }
+
+  public function getWorkflow() : Workflow {
+    return $this->workflow;
+  }
+
+  public function toArray() : array {
+    return [
+      'id' => $this->getId(),
+      'name' => $this->getName(),
+      'category' => $this->getCategory(),
+      'description' => $this->getDescription(),
+      'workflow' => $this->getWorkflow()->toArray(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowTemplatesGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowTemplatesGetEndpoint.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MailPoet\Automation\Engine\Endpoints\Workflows;
+
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\API\Request;
+use MailPoet\Automation\Engine\API\Response;
+use MailPoet\Automation\Engine\Data\WorkflowTemplate;
+use MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage;
+use MailPoet\Validator\Builder;
+
+class WorkflowTemplatesGetEndpoint extends Endpoint
+{
+
+  private $storage;
+  public function __construct(WorkflowTemplateStorage $storage) {
+    $this->storage = $storage;
+  }
+
+  public function handle(Request $request): Response {
+    $templates = $this->storage->getTemplates((int) $request->getParam('category'));
+    return new Response(array_map(function (WorkflowTemplate $workflow) {
+      return $workflow->toArray();
+    }, $templates));
+  }
+
+  public static function getRequestSchema() : array {
+    return [
+      'category' => Builder::integer()->nullable(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
@@ -6,6 +6,8 @@ use MailPoet\Automation\Engine\API\Endpoint;
 use MailPoet\Automation\Engine\API\Request;
 use MailPoet\Automation\Engine\API\Response;
 use MailPoet\Automation\Engine\Builder\CreateWorkflowFromTemplateController;
+use MailPoet\RuntimeException;
+use MailPoet\UnexpectedValueException;
 use MailPoet\Validator\Builder;
 
 class WorkflowsCreateFromTemplateEndpoint extends Endpoint {
@@ -19,15 +21,13 @@ class WorkflowsCreateFromTemplateEndpoint extends Endpoint {
   }
 
   public function handle(Request $request): Response {
-    $data = $request->getParams();
-    $this->createWorkflowFromTemplateController->createWorkflow($data);
+    $this->createWorkflowFromTemplateController->createWorkflow((string)$request->getParam('slug'));
     return new Response();
   }
 
   public static function getRequestSchema(): array {
     return [
-      'name' => Builder::string()->required(),
-      'template' => Builder::string()->required(),
+      'slug' => Builder::string()->required(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -10,6 +10,7 @@ use MailPoet\Automation\Engine\Endpoints\System\DatabasePostEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsCreateFromTemplateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsPutEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowTemplatesGetEndpoint;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 use MailPoet\Automation\Integrations\Core\CoreIntegration;
 
@@ -74,6 +75,7 @@ class Engine {
       $api->registerPostRoute('workflows/create-from-template', WorkflowsCreateFromTemplateEndpoint::class);
       $api->registerPostRoute('system/database', DatabasePostEndpoint::class);
       $api->registerDeleteRoute('system/database', DatabaseDeleteEndpoint::class);
+      $api->registerGetRoute('workflow-templates', WorkflowTemplatesGetEndpoint::class);
     });
   }
 

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -24,6 +24,8 @@ class Hooks {
   public const WORKFLOW_BEFORE_SAVE = 'mailpoet/automation/workflow/before_save';
   public const WORKFLOW_STEP_BEFORE_SAVE = 'mailpoet/automation/workflow/step/before_save';
 
+  public const WORKFLOW_TEMPLATES = 'mailpoet/automation/workflow/templates';
+
   public function doWorkflowBeforeSave(Workflow $workflow): void {
     $this->wordPress->doAction(self::WORKFLOW_BEFORE_SAVE, $workflow);
   }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowTemplateStorage.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace MailPoet\Automation\Engine\Storage;
+
+use MailPoet\Automation\Engine\Data\WorkflowTemplate;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
+use MailPoet\Automation\Integrations\MailPoet\Templates\WorkflowBuilder;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger;
+use MailPoet\WP\Functions as WPFunctions;
+
+class WorkflowTemplateStorage
+{
+
+  /** @var WorkflowTemplate[]  */
+  private $templates = [];
+
+  /** @var WorkflowBuilder  */
+  private $builder;
+
+  /** @var WPFunctions  */
+  private $wp;
+
+  public function __construct(WorkflowBuilder $builder, WPFunctions $wp) {
+    $this->builder = $builder;
+    $this->wp = $wp;
+    $this->templates = $this->createTemplates();
+  }
+
+  public function getTemplateBySlug(string $slug) : ?WorkflowTemplate {
+    foreach ($this->templates as $template) {
+      if ($template->getSlug() === $slug) {
+        return $template;
+      }
+    }
+    return null;
+  }
+
+  /** @return WorkflowTemplate[] */
+  public function getTemplates(int $category = null) : array {
+    if (! $category) {
+      return $this->templates;
+    }
+    return array_values(
+      array_filter(
+        $this->templates,
+        function(WorkflowTemplate $template) use ($category) : bool {
+            return $template->getCategory() === $category;
+        }
+    )
+    );
+  }
+
+  private function createTemplates() : array {
+    $simpleWelcomeEmail = new WorkflowTemplate(
+      'simple-welcome-email',
+      WorkflowTemplate::CATEGORY_WELCOME,
+      "Automation template description is going to be here. Let's describe a lot of interesting ideas which incorporated into this beautiful and useful template",
+      $this->builder->createFromSequence(
+        __('Simple welcome email', 'mailpoet'),
+        [
+          SegmentSubscribedTrigger::class,
+          DelayAction::class,
+          SendEmailAction::class,
+        ]
+      )
+    );
+
+    $templates = $this->wp->applyFilters(Hooks::WORKFLOW_TEMPLATES,[
+      $simpleWelcomeEmail,
+    ]);
+    return is_array($templates)?$templates:[];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowTemplateStorage.php
@@ -60,9 +60,9 @@ class WorkflowTemplateStorage
       $this->builder->createFromSequence(
         __('Simple welcome email', 'mailpoet'),
         [
-          SegmentSubscribedTrigger::class,
-          DelayAction::class,
-          SendEmailAction::class,
+          'mailpoet:segment:subscribed',
+          'core:delay',
+          'mailpoet:send-email',
         ]
       )
     );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/WorkflowBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/WorkflowBuilder.php
@@ -4,6 +4,8 @@ namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Data\WorkflowTemplate;
+use MailPoet\Automation\Engine\Workflows\Trigger;
 use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SegmentSubscribedTrigger;
@@ -12,115 +14,28 @@ use MailPoet\Validator\Schema\ObjectSchema;
 
 class WorkflowBuilder {
 
-  /** @var DelayAction */
-  private $delayAction;
-
-  /** @var SegmentSubscribedTrigger */
-  private $segmentSubscribedTrigger;
-
-  /** @var SendEmailAction */
-  private $sendEmailAction;
-
-  public function __construct(
-    SegmentSubscribedTrigger $segmentSubscribedTrigger,
-    SendEmailAction $sendEmailAction,
-    DelayAction $delayAction
-  ) {
-    $this->delayAction = $delayAction;
-    $this->segmentSubscribedTrigger = $segmentSubscribedTrigger;
-    $this->sendEmailAction = $sendEmailAction;
-  }
-
-  public function delayedEmailAfterSignupWorkflow(string $name): Workflow {
-    $triggerStep = $this->segmentSubscribedTriggerStep();
-
-    $delayStep = $this->delayStep(null, "HOURS");
-    $triggerStep->setNextStepId($delayStep->getId());
-
-    $sendEmailStep = $this->sendEmailActionStep();
-    $delayStep->setNextStepId($sendEmailStep->getId());
-
-    $steps = [
-      $triggerStep,
-      $delayStep,
-      $sendEmailStep,
-    ];
-
-    return new Workflow($name, $steps);
-  }
-
-  public function welcomeEmailSequence(string $name): Workflow {
-    $triggerStep = $this->segmentSubscribedTriggerStep();
-
-    $firstDelayStep = $this->delayStep(null, 'HOURS');
-    $triggerStep->setNextStepId($firstDelayStep->getId());
-
-    $sendFirstEmailStep = $this->sendEmailActionStep();
-    $firstDelayStep->setNextStepId($sendFirstEmailStep->getId());
-
-    $secondDelayStep = $this->delayStep(null, 'HOURS');
-    $sendFirstEmailStep->setNextStepId($secondDelayStep->getId());
-
-    $sendSecondEmailStep = $this->sendEmailActionStep();
-    $secondDelayStep->setNextStepId($sendSecondEmailStep->getId());
-
-    $steps = [
-      $triggerStep,
-      $firstDelayStep,
-      $sendFirstEmailStep,
-      $secondDelayStep,
-      $sendSecondEmailStep,
-    ];
-
-    return new Workflow($name, $steps);
-  }
-
-  private function delayStep(?int $delay, string $delayType): Step {
-    return new Step(
-      $this->uniqueId(),
-      Step::TYPE_ACTION,
-      $this->delayAction->getKey(),
-      null,
-      [
-        'delay' => $delay,
-        'delay_type' => $delayType,
-      ] + $this->getDefaultArgs($this->delayAction->getArgsSchema())
-    );
-  }
-
-  private function segmentSubscribedTriggerStep(?int $segmentId = null): Step {
-    return new Step(
-      $this->uniqueId(),
-      Step::TYPE_TRIGGER,
-      $this->segmentSubscribedTrigger->getKey(),
-      null,
-      [
-        'segment_id' => $segmentId,
-      ] + $this->getDefaultArgs($this->segmentSubscribedTrigger->getArgsSchema())
-    );
-  }
-
-  private function sendEmailActionStep(): Step {
-    return new Step(
-      $this->uniqueId(),
-      Step::TYPE_ACTION,
-      $this->sendEmailAction->getKey(),
-      null,
-      $this->getDefaultArgs($this->sendEmailAction->getArgsSchema())
+  public function createFromSequence(string $name, array $sequence, array $sequenceArgs = []) : Workflow {
+    $steps = [];
+    $nextStep = null;
+    foreach (array_reverse($sequence) as $index => $stepClass) {
+      $step = new Step(
+        $this->uniqueId(),
+        in_array(Trigger::class, (array) class_implements($stepClass)) ? Step::TYPE_TRIGGER : Step::TYPE_ACTION,
+        $stepClass::getKey(),
+        $nextStep,
+        array_reverse($sequenceArgs)[$index] ?? []
+      );
+      $nextStep = $step->getId();
+      $steps[] = $step;
+    }
+    $steps = array_reverse($steps);
+    return new Workflow(
+      $name,
+      $steps
     );
   }
 
   private function uniqueId(): string {
     return Security::generateRandomString(16);
-  }
-
-  private function getDefaultArgs(ObjectSchema $argsSchema): array {
-    $args = [];
-    foreach ($argsSchema->toArray()['properties'] ?? [] as $name => $schema) {
-      if (array_key_exists('default', $schema)) {
-        $args[$name] = $schema['default'];
-      }
-    }
-    return $args;
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -126,6 +126,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowTemplatesGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsCreateFromTemplateEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\System\DatabasePostEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -121,6 +121,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunStorage::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -2,6 +2,11 @@ parameters:
 	ignoreErrors:
 
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
+
+		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/API.php

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -5,6 +5,10 @@ parameters:
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowTemplatesGetEndpoint.php
 
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -2,6 +2,15 @@ parameters:
 	ignoreErrors:
 
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowTemplatesGetEndpoint.php
+
+		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/API.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowTemplatesGetEndpoint.php
+
+
+		-
 			message: "#^Cannot cast string|void to string\\.$#"
 			count: 2
 			path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowTemplatesGetEndpointTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace MailPoet\REST\Automation\Workflows;
+
+use MailPoet\REST\Automation\AutomationTest;
+
+require_once __DIR__ . '/../AutomationTest.php';
+
+class WorkflowTemplatesGetEndpointTest extends AutomationTest
+{
+  private const ENDPOINT_PATH = '/mailpoet/v1/automation/workflow-templates';
+
+  public function testGetAllTemplates() {
+    $result = $this->get(self::ENDPOINT_PATH, []);
+    $this->assertCount(1, $result['data']);
+    $this->assertEquals('simple-welcome-email', $result['data'][0]['slug']);
+  }
+
+  public function testGetTemplatesByCategory() {
+    //@ToDo: Once we have templates in other categories, we should make this test more specific.
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'json' => [
+        'category' => 1,
+      ],
+    ]);
+    $this->assertCount(1, $result['data']);
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'json' => [
+        'category' => 2,
+      ],
+    ]);
+    $this->assertCount(0, $result['data']);
+  }
+}

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsCreateFromTemplateTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsCreateFromTemplateTest.php
@@ -16,8 +16,7 @@ class WorkflowsCreateFromTemplateTest extends AutomationTest {
     $countBefore = count($storage->getWorkflows());
     $this->post(self::ENDPOINT_PATH, [
       'json' => [
-        'name' => 'Testing workflow from template',
-        'template' => 'delayed-email-after-signup'
+        'slug' => 'simple-welcome-email'
       ],
     ]);
     $countAfter = count($storage->getWorkflows());
@@ -28,8 +27,7 @@ class WorkflowsCreateFromTemplateTest extends AutomationTest {
     $storage = ContainerWrapper::getInstance()->get(WorkflowStorage::class);
     $this->post(self::ENDPOINT_PATH, [
       'json' => [
-        'name' => 'Testing workflow from template',
-        'template' => 'delayed-email-after-signup'
+        'slug' => 'simple-welcome-email'
       ],
     ]);
     $allWorkflows = $storage->getWorkflows();


### PR DESCRIPTION
Fixes [MAILPOET-4538]

A `WorkflowTemplate entity has been added and a WorkflowTemplateStorage`, where the hardcoded templates can be found. With the help of a filter the Premium plugin can add its own templates.

The existing template logic has been rewired to use the storage now. Also, the `POST mailpoet/v1/workflows/create-from-template` endpoint has been altered and a new `GET mailpoet/v1/automation/workflow-templates` endpoint has been added.

[MAILPOET-4538]: https://mailpoet.atlassian.net/browse/MAILPOET-4538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ