### PR TITLE
Don't requiring a list to save email draft [MAILPOET-4549]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -611,14 +611,17 @@ class NewsletterSendComponent extends Component {
     return field;
   };
 
+  disableSegmentsSelectorWhenPaused = (isPaused) => (field) => {
+    if (field.name === 'segments' || field.name === 'options') {
+      return { ...field, disabled: isPaused };
+    }
+    return field;
+  };
+
   getPreparedFields = (isPaused) =>
-    this.state.fields.map((field) => {
-      const newField = field;
-      if (field.name === 'segments' || field.name === 'options') {
-        newField.disabled = isPaused;
-      }
-      return this.disableSegmentsValidation(newField);
-    });
+    this.state.fields
+      .map(this.disableSegmentsSelectorWhenPaused(isPaused))
+      .map(this.disableSegmentsValidation);
 
   render() {
     const isPaused =

--- a/mailpoet/tests/acceptance/Newsletters/SaveNewsletterAsDraftCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SaveNewsletterAsDraftCest.php
@@ -5,10 +5,40 @@ namespace MailPoet\Test\Acceptance;
 class SaveNewsletterAsDraftCest {
   public function saveStandardNewsletterAsDraft(\AcceptanceTester $i) {
     $i->wantTo('Create standard newsletter and save as a draft');
-
-    $inactiveNewsletterUI = '.mailpoet-listing-row-inactive';
     $newsletterTitle = 'Testing Newsletter ' . \MailPoet\Util\Security::generateRandomString();
+
     $segmentName = $i->createListWithSubscriber();
+    $inactiveNewsletterUI = '.mailpoet-listing-row-inactive';
+
+    $this->startCreatingNewsletter($i, $newsletterTitle);
+
+    // step 4 - Choose list and send
+    $sendFormElement = '[data-automation-id="newsletter_send_form"]';
+    $i->waitForElement($sendFormElement);
+    $i->selectOptionInSelect2($segmentName);
+    $i->click('Save as draft and close');
+    $i->waitForText($newsletterTitle);
+    $this->assertNewsletterNotSent($i);
+  }
+
+  public function saveStandardNewsletterWithoutListAsDraft(\AcceptanceTester $i) {
+    $i->wantTo('Create standard newsletter and save as a draft without selecting subscribers list');
+    $newsletterTitle = 'Testing Newsletter ' . \MailPoet\Util\Security::generateRandomString();
+
+    $this->startCreatingNewsletter($i, $newsletterTitle);
+
+    // step 4 - Save as draft without selecting a list
+    $sendFormElement = '[data-automation-id="newsletter_send_form"]';
+    $i->waitForElement($sendFormElement);
+    $i->click('Save as draft and close');
+    $i->waitForText($newsletterTitle);
+    $this->assertNewsletterNotSent($i);
+  }
+
+  /**
+   * Performs initial 3 steps for creating a newsletter
+   */
+  private function startCreatingNewsletter(\AcceptanceTester $i, string $title): void {
 
     $i->login();
     $i->amOnMailpoetPage('Emails');
@@ -24,15 +54,12 @@ class SaveNewsletterAsDraftCest {
     // step 3 - design newsletter (update subject)
     $titleElement = '[data-automation-id="newsletter_title"]';
     $i->waitForElement($titleElement);
-    $i->fillField($titleElement, $newsletterTitle);
+    $i->fillField($titleElement, $title);
     $i->click('Next');
+  }
 
-    // step 4 - Choose list and send
-    $sendFormElement = '[data-automation-id="newsletter_send_form"]';
-    $i->waitForElement($sendFormElement);
-    $i->selectOptionInSelect2($segmentName);
-    $i->click('Save as draft and close');
-    $i->waitForText($newsletterTitle);
+  private function assertNewsletterNotSent(\AcceptanceTester $i) {
+    $inactiveNewsletterUI = '.mailpoet-listing-row-inactive';
     $i->waitForText('Not sent yet');
     $i->seeElement($inactiveNewsletterUI);
   }


### PR DESCRIPTION
### Description
This PR allows saving the newsletter as a draft without requiring a list.

- Adds the change.
- Cleans up how the form fields are prepared for the form.

### Note for QA
Jira ticket [MAILPOET-4549](https://mailpoet.atlassian.net/browse/MAILPOET-4549)
1) Go to Emails page
2) Start creating a new newsletter
3) Go to the last step ( step 4 - Send )
4) Verify you can "Save as draft and close" without selecting a list.

### Note for Dev
I tried to see if there is any better way of updating the `data-parsley-required` parameter, I'll appreciate any better approach suggested by the reviewer.