### PR TITLE
Use submit button label of form for captcha submit button [MAILPOET-4496]

### DIFF
--- a/mailpoet/lib/Subscription/CaptchaRenderer.php
+++ b/mailpoet/lib/Subscription/CaptchaRenderer.php
@@ -48,38 +48,12 @@ class CaptchaRenderer {
   }
 
   public function getCaptchaPageContent($sessionId) {
+
     $this->captchaSession->init($sessionId);
-    $fields = [
-      [
-        'id' => 'captcha',
-        'type' => 'text',
-        'params' => [
-          'label' => __('Type in the characters you see in the picture above:', 'mailpoet'),
-          'value' => '',
-          'obfuscate' => false,
-        ],
-      ],
-    ];
-
-    $form = array_merge(
-      $fields,
-      [
-        [
-          'id' => 'submit',
-          'type' => 'submit',
-          'params' => [
-            'label' => __('Subscribe', 'mailpoet'),
-          ],
-        ],
-      ]
-    );
-
     $captchaSessionForm = $this->captchaSession->getFormData();
-    $formId = 0;
-
     $showSuccessMessage = !empty($_GET['mailpoet_success']);
     $showErrorMessage = !empty($_GET['mailpoet_error']);
-
+    $formId = 0;
     if (isset($captchaSessionForm['form_id'])) {
       $formId = (int)$captchaSessionForm['form_id'];
     } elseif ($showSuccessMessage) {
@@ -92,6 +66,33 @@ class CaptchaRenderer {
     if (!$formModel instanceof FormEntity) {
       return false;
     }
+
+    $fields = [
+      [
+        'id' => 'captcha',
+        'type' => 'text',
+        'params' => [
+          'label' => __('Type in the characters you see in the picture above:', 'mailpoet'),
+          'value' => '',
+          'obfuscate' => false,
+        ],
+      ],
+    ];
+
+    $submitBlocks = $formModel->getBlocksByTypes(['submit']);
+    $submitLabel = count($submitBlocks) && $submitBlocks[0]['params']['label'] ? $submitBlocks[0]['params']['label'] : __('Subscribe', 'mailpoet');
+    $form = array_merge(
+      $fields,
+      [
+        [
+          'id' => 'submit',
+          'type' => 'submit',
+          'params' => [
+            'label' => $submitLabel,
+          ],
+        ],
+      ]
+    );
 
     if ($showSuccessMessage) {
       // Display a success message in a no-JS flow

--- a/mailpoet/tests/integration/Subscription/CaptchaRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/CaptchaRendererTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace MailPoet\Test\Subscription;
+
+use MailPoet\Entities\FormEntity;
+use MailPoet\Form\FormsRepository;
+use MailPoet\Subscription\CaptchaRenderer;
+use MailPoet\Subscription\CaptchaSession;
+
+class CaptchaRendererTest extends \MailPoetTest
+{
+
+  public function testCaptchaSubmitTextIsConfigurable() {
+
+    $expectedLabel = 'EXPECTED_LABEL';
+    $formRepository = $this->diContainer->get(FormsRepository::class);
+    $form = new FormEntity('captcha-render-test-form');
+    $form->setBody([
+      [
+        'type' => 'text',
+        'id' => 'email',
+      ],
+      [
+        'type' => 'submit',
+        'params' => [
+          'label' => $expectedLabel,
+        ],
+      ],
+    ]);
+    $form->setSettings([
+      'success_message' => 'tada!',
+    ]);
+    $form->setId(1);
+    $formRepository->persist($form);
+    $formRepository->flush();
+    $captchaSession = $this->diContainer->get(CaptchaSession::class);
+    $captchaSession->init();
+    $captchaSession->setFormData(['form_id' => $form->getId()]);
+
+    $testee = $this->diContainer->get(CaptchaRenderer::class);
+    $result = $testee->getCaptchaPageContent($captchaSession->getId());
+    $this->assertStringContainsString('value="' . $expectedLabel . '"', $result);
+  }
+
+  public function testCaptchaSubmitTextHasDefault() {
+
+    $formRepository = $this->diContainer->get(FormsRepository::class);
+    $form = new FormEntity('captcha-render-test-form');
+    $form->setBody([
+      [
+        'type' => 'text',
+        'id' => 'email',
+      ],
+      [
+        'type' => 'submit',
+        'params' => [
+          'label' => '',
+        ],
+      ],
+    ]);
+    $form->setSettings([
+      'success_message' => 'tada!',
+    ]);
+    $form->setId(1);
+    $formRepository->persist($form);
+    $formRepository->flush();
+    $captchaSession = $this->diContainer->get(CaptchaSession::class);
+    $captchaSession->init();
+    $captchaSession->setFormData(['form_id' => $form->getId()]);
+
+    $testee = $this->diContainer->get(CaptchaRenderer::class);
+    $result = $testee->getCaptchaPageContent($captchaSession->getId());
+    $this->assertStringContainsString('value="Subscribe"', $result);
+  }
+
+  public function _before() {
+    $this->diContainer->get(FormsRepository::class)->truncate();
+    parent::_before();
+  }
+}


### PR DESCRIPTION
## Description

N/A

## QA notes
Simple steps to test:
1. Make sure you have some form already created (MailPoet > Forms)
2. In a private browsing window, go to the front-end of your test site and sign up to a form
3. After subscribing and seeing "Confirm you’re not a robot" page, make sure the Subscribe button is the same as in the form you were subscribing to
4. Feel free to change the text of the Subscribe button and test again
5. Check in different site language

## Linked tickets

Fixes [MAILPOET-4496]

[MAILPOET-4496]: https://mailpoet.atlassian.net/browse/MAILPOET-4496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ