### PR TITLE
Don't show spacer after the last item in <Steps> component [MAILPOET-4593]

### DIFF
--- a/mailpoet/assets/js/src/common/steps/steps.tsx
+++ b/mailpoet/assets/js/src/common/steps/steps.tsx
@@ -11,6 +11,7 @@ type Props = {
 function Steps({ count, current, titles }: Props) {
   return (
     <div className="mailpoet-steps">
+      <ContentWrapperFix />
       {range(1, count + 1).map((i) => (
         <div
           key={i}
@@ -30,7 +31,6 @@ function Steps({ count, current, titles }: Props) {
           )}
         </div>
       ))}
-      <ContentWrapperFix />
     </div>
   );
 }


### PR DESCRIPTION
The spacer is shown for all items except the last one. However, there are also inline styles (`<style>`) at the end of the component, which causes all items to show the spacer (because in DOM, `<style>` is the last item). 

The fix is to move inline styles to the beginning of the component. 

[MAILPOET-4593]

[MAILPOET-4593]: https://mailpoet.atlassian.net/browse/MAILPOET-4593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ