### PR TITLE
Check that changelog is not null before passing it to substr() [MAILPOET-4595]

### DIFF
--- a/mailpoet/tasks/release/JiraController.php
+++ b/mailpoet/tasks/release/JiraController.php
@@ -154,8 +154,8 @@ class JiraController {
     // Sort issues by importance of change (Added -> Updated -> Improved -> Changed -> Fixed -> Others)
     usort($issuesData['issues'], function($a, $b) use ($changelogId) {
       $order = array_flip(['added', 'updat', 'impro', 'chang', 'fixed']);
-      $aPrefix = strtolower(substr($a['fields'][$changelogId], 0, 5));
-      $bPrefix = strtolower(substr($b['fields'][$changelogId], 0, 5));
+      $aPrefix = !is_null($a['fields'][$changelogId]) ? strtolower(substr($a['fields'][$changelogId], 0, 5)) : '';
+      $bPrefix = !is_null($b['fields'][$changelogId]) ? strtolower(substr($b['fields'][$changelogId], 0, 5)) : '';
       $aRank = isset($order[$aPrefix]) ? $order[$aPrefix] : count($order);
       $bRank = isset($order[$bPrefix]) ? $order[$bPrefix] : count($order);
       return $aRank - $bRank;


### PR DESCRIPTION
Starting with PHP 8.1, substr() generates a warning if the first parameter is null. So, before calling it, we need to check if the changelog is null or not. See the Jira ticket for more details.

To test that the code still works even after the changes suggested here, you can add the following line to the foreach in \RoboFile::releaseCheckIssues() and run `./do release:check-issues`:

```
var_dump($issue['fields'][\MailPoetTasks\Release\JiraController::CHANGELOG_FIELD_ID]);
```

[MAILPOET-4595]

[MAILPOET-4595]: https://mailpoet.atlassian.net/browse/MAILPOET-4595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ