### PR TITLE
Remove old model usage from MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter - Part 1 [MAILPOET-4363]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -273,11 +273,17 @@ class SendingQueue {
     $statistics = [];
     $metas = [];
     foreach ($subscribers as $subscriber) {
+      $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
+
+      if (!$subscriberEntity instanceof SubscriberEntity) {
+        continue;
+      }
+
       // render shortcodes and replace subscriber data in tracked links
       $preparedNewsletters[] =
         $this->newsletterTask->prepareNewsletterForSending(
           $newsletter,
-          $subscriber,
+          $subscriberEntity,
           $queue
         );
       // format subscriber name/address according to mailer settings
@@ -288,12 +294,7 @@ class SendingQueue {
       // create personalized instant unsubsribe link
       $unsubscribeUrls[] = $this->links->getUnsubscribeUrl($queue, $subscriber->id);
 
-      $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
-      if ($subscriberEntity instanceof SubscriberEntity) {
-        $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriberEntity);
-      } else {
-        $metas[] = [];
-      }
+      $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriberEntity);
 
       // keep track of values for statistics purposes
       $statistics[] = [

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -177,7 +177,7 @@ class SendingQueue {
     // configure mailer
     $this->mailerTask->configureMailer($newsletter);
     // get newsletter segments
-    $newsletterSegmentsIds = $this->newsletterTask->getNewsletterSegments($newsletterEntity);
+    $newsletterSegmentsIds = $newsletterEntity->getSegmentIds();
     // Pause task in case some of related segments was deleted or trashed
     if ($newsletterSegmentsIds && !$this->checkDeletedSegments($newsletterSegmentsIds)) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -272,6 +272,9 @@ class SendingQueue {
     $unsubscribeUrls = [];
     $statistics = [];
     $metas = [];
+
+    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
+
     foreach ($subscribers as $subscriber) {
       $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
 
@@ -282,7 +285,7 @@ class SendingQueue {
       // render shortcodes and replace subscriber data in tracked links
       $preparedNewsletters[] =
         $this->newsletterTask->prepareNewsletterForSending(
-          $newsletter,
+          $newsletterEntity,
           $subscriberEntity,
           $queue
         );

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -219,7 +219,7 @@ class SendingQueue {
         );
         $queue->removeSubscribers($subscribersToRemove);
         if (!$queue->countToProcess) {
-          $this->newsletterTask->markNewsletterAsSent($newsletter, $queue);
+          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $queue);
           continue;
         }
         // if there aren't any subscribers to process in batch (e.g. all unsubscribed or were deleted) continue with next batch
@@ -250,9 +250,9 @@ class SendingQueue {
           'completed newsletter sending',
           ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
         );
-        $this->newsletterTask->markNewsletterAsSent($newsletter, $queue);
         $newsletter = $this->newslettersRepository->findOneById($newsletter->id);
         assert($newsletter instanceof NewsletterEntity);
+        $this->newsletterTask->markNewsletterAsSent($newsletter, $queue);
         $this->statsNotificationsScheduler->schedule($newsletter);
       }
       $this->enforceSendingAndExecutionLimits($timer);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -30,7 +30,10 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class SendingQueue {
+  /** @var MailerTask */
   public $mailerTask;
+
+  /** @var NewsletterTask  */
   public $newsletterTask;
 
   const TASK_TYPE = 'sending';
@@ -281,6 +284,10 @@ class SendingQueue {
       $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
 
       if (!$subscriberEntity instanceof SubscriberEntity) {
+        continue;
+      }
+
+      if (!$newsletterEntity instanceof NewsletterEntity) {
         continue;
       }
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -175,7 +175,7 @@ class SendingQueue {
     // configure mailer
     $this->mailerTask->configureMailer($newsletter);
     // get newsletter segments
-    $newsletterSegmentsIds = $this->newsletterTask->getNewsletterSegments($newsletter);
+    $newsletterSegmentsIds = $this->newsletterTask->getNewsletterSegments($newsletterEntity);
     // Pause task in case some of related segments was deleted or trashed
     if ($newsletterSegmentsIds && !$this->checkDeletedSegments($newsletterSegmentsIds)) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -15,6 +15,7 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
+use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\StatisticsNewsletters as StatisticsNewslettersModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
@@ -150,12 +151,13 @@ class SendingQueue {
       ['task_id' => $queue->taskId]
     );
 
-    $newsletter = $this->newsletterTask->getNewsletterFromQueue($queue);
-    if (!$newsletter) {
+    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($queue);
+    if (!$newsletterEntity) {
       return;
     }
-    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
-    if (!$newsletterEntity) {
+
+    $newsletter = Newsletter::findOne($newsletterEntity->getId());
+    if (!$newsletter) {
       return;
     }
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Router\Endpoints\Track;
@@ -43,8 +44,8 @@ class Links {
     $this->trackingConfig = $trackingConfig;
   }
 
-  public function process($renderedNewsletter, $newsletter, $queue) {
-    [$renderedNewsletter, $links] = $this->hashAndReplaceLinks($renderedNewsletter, $newsletter->id, $queue->id);
+  public function process($renderedNewsletter, NewsletterEntity $newsletter, $queue) {
+    [$renderedNewsletter, $links] = $this->hashAndReplaceLinks($renderedNewsletter, $newsletter->getId(), $queue->id);
     $this->saveLinks($links, $newsletter, $queue);
     return $renderedNewsletter;
   }
@@ -63,8 +64,8 @@ class Links {
     ];
   }
 
-  public function saveLinks($links, $newsletter, $queue) {
-    return $this->newsletterLinks->save($links, $newsletter->id, $queue->id);
+  public function saveLinks($links, NewsletterEntity $newsletter, $queue) {
+    return $this->newsletterLinks->save($links, $newsletter->getId(), $queue->id);
   }
 
   public function getUnsubscribeUrl($queue, $subscriberId) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -7,16 +7,18 @@ use MailPoet\Cron\Workers\SendingQueue\Tasks\Posts as PostsTask;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes as ShortcodesTask;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterSegmentEntity;
+use MailPoet\Entities\SegmentEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\Newsletter as NewsletterModel;
-use MailPoet\Models\NewsletterSegment as NewsletterSegmentModel;
 use MailPoet\Models\SendingQueue as SendingQueueModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\PostProcess\OpenTracking;
 use MailPoet\Newsletter\Renderer\Renderer;
+use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\GATracking;
@@ -63,6 +65,9 @@ class Newsletter {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var NewsletterSegmentRepository */
+  private $newsletterSegmentRepository;
+
   public function __construct(
     WPFunctions $wp = null,
     PostsTask $postsTask = null,
@@ -94,6 +99,7 @@ class Newsletter {
     $this->newsletterLinks = ContainerWrapper::getInstance()->get(NewsletterLinks::class);
     $this->sendingQueuesRepository = ContainerWrapper::getInstance()->get(SendingQueuesRepository::class);
     $this->subscribersRepository = ContainerWrapper::getInstance()->get(SubscribersRepository::class);
+    $this->newsletterSegmentRepository = ContainerWrapper::getInstance()->get(NewsletterSegmentRepository::class);
   }
 
   public function getNewsletterFromQueue($queue) {
@@ -283,11 +289,20 @@ class Newsletter {
     }
   }
 
-  public function getNewsletterSegments($newsletter) {
-    $segments = NewsletterSegmentModel::where('newsletter_id', $newsletter->id)
-      ->select('segment_id')
-      ->findArray();
-    return Helpers::flattenArray($segments);
+  public function getNewsletterSegments(NewsletterEntity $newsletter) {
+    $newsletterSegments = $this->newsletterSegmentRepository->findBy(['newsletter' => $newsletter]);
+    $segmentIds = array_map(
+      function(NewsletterSegmentEntity $newsletterSegment) {
+        $segment = $newsletterSegment->getSegment();
+
+        if ($segment instanceof SegmentEntity) {
+          return $segment->getId();
+        }
+      },
+      $newsletterSegments
+    );
+
+    return $segmentIds;
   }
 
   public function stopNewsletterPreProcessing($errorCode = null) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -7,8 +7,6 @@ use MailPoet\Cron\Workers\SendingQueue\Tasks\Posts as PostsTask;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes as ShortcodesTask;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterSegmentEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
@@ -17,7 +15,6 @@ use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\PostProcess\OpenTracking;
 use MailPoet\Newsletter\Renderer\Renderer;
-use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\GATracking;
 use MailPoet\Tasks\Sending;
@@ -57,9 +54,6 @@ class Newsletter {
   /** @var NewsletterLinks */
   private $newsletterLinks;
 
-  /** @var NewsletterSegmentRepository */
-  private $newsletterSegmentRepository;
-
   public function __construct(
     WPFunctions $wp = null,
     PostsTask $postsTask = null,
@@ -89,7 +83,6 @@ class Newsletter {
     $this->newslettersRepository = ContainerWrapper::getInstance()->get(NewslettersRepository::class);
     $this->linksTask = ContainerWrapper::getInstance()->get(LinksTask::class);
     $this->newsletterLinks = ContainerWrapper::getInstance()->get(NewsletterLinks::class);
-    $this->newsletterSegmentRepository = ContainerWrapper::getInstance()->get(NewsletterSegmentRepository::class);
   }
 
   public function getNewsletterFromQueue(Sending $sendingTask): ?NewsletterEntity {
@@ -263,22 +256,6 @@ class Newsletter {
       $this->newslettersRepository->persist($newsletter);
       $this->newslettersRepository->flush();
     }
-  }
-
-  public function getNewsletterSegments(NewsletterEntity $newsletter) {
-    $newsletterSegments = $this->newsletterSegmentRepository->findBy(['newsletter' => $newsletter]);
-    $segmentIds = array_map(
-      function(NewsletterSegmentEntity $newsletterSegment) {
-        $segment = $newsletterSegment->getSegment();
-
-        if ($segment instanceof SegmentEntity) {
-          return $segment->getId();
-        }
-      },
-      $newsletterSegments
-    );
-
-    return $segmentIds;
   }
 
   public function stopNewsletterPreProcessing($errorCode = null) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -150,7 +150,7 @@ class Newsletter {
       );
       $renderedNewsletter = $this->gaTracking->applyGATracking($renderedNewsletter, $newsletterEntity);
       // hash and save all links
-      $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletter, $sendingTask);
+      $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletterEntity, $sendingTask);
     } else {
       // render newsletter
       $renderedNewsletter = $this->renderer->render($newsletterEntity, $sendingTask);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -215,7 +215,7 @@ class Newsletter {
     return $newsletter;
   }
 
-  public function prepareNewsletterForSending($newsletter, SubscriberEntity $subscriber, $queue) {
+  public function prepareNewsletterForSending($newsletter, SubscriberEntity $subscriber, $queue): array {
     // shortcodes and links will be replaced in the subject, html and text body
     // to speed the processing, join content into a continuous string
     $renderedNewsletter = $queue->getNewsletterRenderedBody();

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -3,10 +3,13 @@
 namespace MailPoet\Tasks;
 
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueAlias;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -188,6 +191,13 @@ class Sending {
 
   public function queue() {
     return $this->queue;
+  }
+
+  public function getSendingQueueEntity(): SendingQueueEntity {
+    $sendingQueuesRepository = ContainerWrapper::getInstance()->get(SendingQueuesRepository::class);
+    $sendingQueueEntity = $sendingQueuesRepository->findOneById($this->queue->id);
+
+    return $sendingQueueEntity;
   }
 
   public function task() {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -155,7 +155,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->tasksLinks = $this->diContainer->get(TasksLinks::class);
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
-    $this->sendingQueueWorker = $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]));
+    $this->sendingQueueWorker = $this->getSendingQueueWorker();
   }
 
   private function getDirectUnsubscribeURL() {
@@ -222,7 +222,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItEnforcesExecutionLimitsAfterSendingWhenQueueStatusIsNotSetToComplete() {
     $sendingQueueWorker = $this->make(
-      $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class)),
+      $this->getSendingQueueWorker(),
       [
         'enforceSendingAndExecutionLimits' => Expected::exactly(1),
       ]);
@@ -267,7 +267,7 @@ class SendingQueueTest extends \MailPoetTest {
     $queue = $this->queue;
     $queue->status = SendingQueue::STATUS_COMPLETED;
     $sendingQueueWorker = $this->make(
-      $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class)),
+      $this->getSendingQueueWorker(),
       [
         'enforceSendingAndExecutionLimits' => Expected::never(),
       ]);
@@ -351,7 +351,6 @@ class SendingQueueTest extends \MailPoetTest {
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
     $directUnsubscribeURL = $this->getDirectUnsubscribeURL();
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -377,7 +376,6 @@ class SendingQueueTest extends \MailPoetTest {
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
     $trackedUnsubscribeURL = $this->getTrackedUnsubscribeURL();
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -401,7 +399,6 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItCanProcessSubscribersOneByOne() {
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -485,7 +482,6 @@ class SendingQueueTest extends \MailPoetTest {
     $timer = 1000000000000000000;
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->make(
         MailerTask::class,
         [
@@ -524,7 +520,6 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItCanProcessSubscribersInBulk() {
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -573,7 +568,6 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItProcessesStandardNewsletters() {
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -637,7 +631,7 @@ class SendingQueueTest extends \MailPoetTest {
       [new SubscriberError($wrongSubscriber->getEmail(), 'must be an email')]
     );
     $sendingQueueWorker = $this->make(
-      $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class))
+      $this->getSendingQueueWorker()
     );
     $sendingQueueWorker->__construct(
       $this->sendingErrorHandler,
@@ -714,7 +708,6 @@ class SendingQueueTest extends \MailPoetTest {
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class),
       $this->makeEmpty(MailerTask::class, [])
     );
     $sendingQueueWorker->process();
@@ -729,7 +722,6 @@ class SendingQueueTest extends \MailPoetTest {
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -781,7 +773,6 @@ class SendingQueueTest extends \MailPoetTest {
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      null,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -814,7 +805,6 @@ class SendingQueueTest extends \MailPoetTest {
       $unsubscribedSubscriber->getId(), // subscriber that should be skipped
     ]);
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      null,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -1039,7 +1029,7 @@ class SendingQueueTest extends \MailPoetTest {
       ->with('id')
       ->will($this->returnValue(100));
     $sendingQueueWorker = $this->make(
-      $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class))
+      $this->getSendingQueueWorker()
     );
     $sendingQueueWorker->__construct(
       $this->sendingErrorHandler,
@@ -1087,7 +1077,6 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItDoesNotUpdateNewsletterHashDuringSending() {
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -1112,7 +1101,7 @@ class SendingQueueTest extends \MailPoetTest {
     };
     $wp = new WPFunctions;
     $wp->addFilter('mailpoet_cron_worker_sending_queue_batch_size', $filter);
-    $sendingQueueWorker = $this->getSendingQueueWorker($this->makeEmpty(NewslettersRepository::class));
+    $sendingQueueWorker = $this->getSendingQueueWorker();
     expect($sendingQueueWorker->getBatchSize())->equals($customBatchSizeValue);
     $wp->removeFilter('mailpoet_cron_worker_sending_queue_batch_size', $filter);
   }
@@ -1125,7 +1114,6 @@ class SendingQueueTest extends \MailPoetTest {
     ]);
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(MailerTask::class, [$this->diContainer->get(MailerFactory::class)], [
         'send' => $this->mailerTaskDummyResponse,
       ])
@@ -1146,7 +1134,6 @@ class SendingQueueTest extends \MailPoetTest {
     ]);
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
-      $this->makeEmpty(NewslettersRepository::class, ['findOneById' => new NewsletterEntity()]),
       $this->construct(MailerTask::class, [$this->diContainer->get(MailerFactory::class)], [
         'send' => $this->mailerTaskDummyResponse,
       ])
@@ -1271,13 +1258,13 @@ class SendingQueueTest extends \MailPoetTest {
     return $queue;
   }
 
-  private function getSendingQueueWorker($newsletterRepositoryMock = null, $mailerMock = null): SendingQueueWorker {
+  private function getSendingQueueWorker($mailerMock = null): SendingQueueWorker {
     return new SendingQueueWorker(
       $this->sendingErrorHandler,
       $this->sendingThrottlingHandler,
       $this->statsNotificationsWorker,
       $this->loggerFactory,
-      $newsletterRepositoryMock ?: $this->newslettersRepository,
+      $this->newslettersRepository,
       $this->cronHelper,
       $this->subscribersFinder,
       $this->segmentsRepository,

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -43,7 +43,7 @@ class LinksTest extends \MailPoetTest {
     $this->links->saveLinks($links, $this->newsletter, $queue);
 
     $newsletterLink = $this->newsletterLinkRepository->findOneBy(['hash' => $links[0]['hash']]);
-    assert($newsletterLink instanceof NewsletterLinkEntity);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $newsletterLink);
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterLink->getNewsletter());
     expect($newsletterLink->getNewsletter()->getId())->equals($this->newsletter->getId());
     $this->assertInstanceOf(SendingQueueEntity::class, $newsletterLink->getQueue());
@@ -75,7 +75,7 @@ class LinksTest extends \MailPoetTest {
     $result = $this->links->process($renderedNewsletter, $this->newsletter, $this->queue);
 
     $newsletterLink = $this->newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter->getId()]);
-    assert($newsletterLink instanceof NewsletterLinkEntity);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $newsletterLink);
     expect($result['html'])->stringContainsString($newsletterLink->getHash());
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -38,10 +38,9 @@ class LinksTest extends \MailPoetTest {
         'hash' => 'some_hash',
       ],
     ];
-    $newsletter = (object)['id' => $this->newsletter->getId()];
     $queue = (object)['id' => $this->queue->getId()];
 
-    $this->links->saveLinks($links, $newsletter, $queue);
+    $this->links->saveLinks($links, $this->newsletter, $queue);
 
     $newsletterLink = $this->newsletterLinkRepository->findOneBy(['hash' => $links[0]['hash']]);
     assert($newsletterLink instanceof NewsletterLinkEntity);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -13,13 +13,14 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterPostEntity;
+use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\NewsletterSegment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -366,12 +367,17 @@ class NewsletterTest extends \MailPoetTest {
   }
 
   public function testItGetsSegments() {
+    $newsletterEntity = $this->newslettersRepository->findOneById($this->newsletter->id);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+
     for ($i = 1; $i <= 3; $i++) {
-      $newsletterSegment = NewsletterSegment::create();
-      $newsletterSegment->newsletterId = $this->newsletter->id;
-      $newsletterSegment->segmentId = $i;
-      $newsletterSegment->save();
+      $segment = $this->entityManager->getReference(SegmentEntity::class, $i);
+      $this->assertInstanceOf(SegmentEntity::class, $segment);
+      $newsletterSegment = new NewsletterSegmentEntity($newsletterEntity, $segment);
+      $this->entityManager->persist($newsletterSegment);
     }
+    $this->entityManager->flush();
+
     expect($this->newsletterTask->getNewsletterSegments($this->newsletter))->equals(
       [1,2,3]
     );

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -21,7 +21,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\Subscriber;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -29,6 +28,7 @@ use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\Tasks\Sending;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -36,7 +36,7 @@ class NewsletterTest extends \MailPoetTest {
   /** @var NewsletterTask */
   private $newsletterTask;
 
-  /** @var Subscriber */
+  /** @var SubscriberEntity */
   private $subscriber;
 
   /** @var Newsletter */
@@ -63,11 +63,7 @@ class NewsletterTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->newsletterTask = new NewsletterTask();
-    $this->subscriber = Subscriber::create();
-    $this->subscriber->email = 'test@example.com';
-    $this->subscriber->firstName = 'John';
-    $this->subscriber->lastName = 'Doe';
-    $this->subscriber->save();
+    $this->subscriber = (new SubscriberFactory())->create();
     $this->newsletter = Newsletter::create();
     $this->newsletter->type = NewsletterEntity::TYPE_STANDARD;
     $this->newsletter->status = NewsletterEntity::STATUS_ACTIVE;
@@ -344,7 +340,7 @@ class NewsletterTest extends \MailPoetTest {
       $this->subscriber,
       $this->queue
     );
-    expect($result['subject'])->stringContainsString($this->subscriber->firstName);
+    expect($result['subject'])->stringContainsString($this->subscriber->getFirstName());
     expect($result['body']['html'])
       ->stringContainsString(Router::NAME . '&endpoint=track&action=click&data=');
     expect($result['body']['text'])

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -361,24 +361,6 @@ class NewsletterTest extends \MailPoetTest {
       ->stringNotContainsString(Router::NAME . '&endpoint=track&action=click&data=');
   }
 
-  public function testItGetsSegments() {
-    $newsletterEntity = $this->newslettersRepository->findOneById($this->newsletter->id);
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
-    $segmentIds = [];
-
-    for ($i = 1; $i <= 3; $i++) {
-      $segment = (new SegmentFactory())->create();
-      $segmentIds[] = $segment->getId();
-      $newsletterSegment = new NewsletterSegmentEntity($newsletterEntity, $segment);
-      $this->entityManager->persist($newsletterSegment);
-    }
-    $this->entityManager->flush();
-
-    expect($this->newsletterTask->getNewsletterSegments($newsletterEntity))->equals(
-      $segmentIds
-    );
-  }
-
   public function testItLogsErrorWhenQueueWithCannotBeSaved() {
     $this->sendingTask->nonExistentColumn = true; // this will trigger save error
     try {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -310,6 +310,8 @@ class NewsletterTest extends \MailPoetTest {
   }
 
   public function testItUsesRenderedNewsletterBodyAndSubjectFromQueueObjectWhenPreparingNewsletterForSending() {
+    $newsletterEntity = $this->newslettersRepository->findOneById($this->newsletter->id);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $queue = $this->queue;
     $queue->newsletterRenderedBody = [
       'html' => 'queue HTML body',
@@ -324,7 +326,7 @@ class NewsletterTest extends \MailPoetTest {
     );
     $newsletterTask = new NewsletterTask(null, null, null, $emoji);
     $result = $newsletterTask->prepareNewsletterForSending(
-      $this->newsletter,
+      $newsletterEntity,
       $this->subscriber,
       $queue
     );
@@ -335,8 +337,10 @@ class NewsletterTest extends \MailPoetTest {
 
   public function testItRendersShortcodesAndReplacesSubscriberDataInLinks() {
     $newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->queue);
+    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $result = $this->newsletterTask->prepareNewsletterForSending(
-      $newsletter,
+      $newsletterEntity,
       $this->subscriber,
       $this->queue
     );
@@ -351,8 +355,10 @@ class NewsletterTest extends \MailPoetTest {
     $newsletterTask = $this->newsletterTask;
     $newsletterTask->trackingEnabled = false;
     $newsletter = $newsletterTask->preProcessNewsletter($this->newsletter, $this->queue);
+    $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $result = $newsletterTask->prepareNewsletterForSending(
-      $newsletter,
+      $newsletterEntity,
       $this->subscriber,
       $this->queue
     );

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -170,7 +170,7 @@ class NewsletterTest extends \MailPoetTest {
     $newsletterTask->trackingEnabled = true;
     $newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
     $link = $this->newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter->id]);
-    assert($link instanceof NewsletterLinkEntity);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $link);
     $updatedQueue = SendingTask::getByNewsletterId($this->newsletter->id);
     $renderedNewsletter = $updatedQueue->getNewsletterRenderedBody();
     expect($renderedNewsletter['html'])
@@ -254,7 +254,7 @@ class NewsletterTest extends \MailPoetTest {
     $this->newslettersRepository->flush();
     $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
-    assert($updatedNewsletter instanceof NewsletterEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
     expect($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     $sentAt = $updatedNewsletter->getSentAt();
     $this->assertInstanceOf(\DateTime::class, $sentAt);
@@ -267,7 +267,7 @@ class NewsletterTest extends \MailPoetTest {
     $this->newslettersRepository->flush();
     $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
-    assert($updatedNewsletter instanceof NewsletterEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
     expect($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     $sentAt = $updatedNewsletter->getSentAt();
     $this->assertInstanceOf(\DateTime::class, $sentAt);
@@ -280,7 +280,7 @@ class NewsletterTest extends \MailPoetTest {
     $this->newslettersRepository->flush();
     $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
-    assert($updatedNewsletter instanceof NewsletterEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
     expect($updatedNewsletter->getStatus())->notEquals(NewsletterEntity::STATUS_SENT);
   }
 
@@ -479,7 +479,7 @@ class NewsletterTest extends \MailPoetTest {
 
     // properly serialized object
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->sendingTask->id);
-    assert($sendingQueue instanceof SendingQueueEntity);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
     $sendingQueue->setNewsletterRenderedBody(['html' => 'test', 'text' => 'test']);
     $this->sendingQueuesRepository->persist($sendingQueue);
     $this->sendingQueuesRepository->flush();

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -15,7 +15,6 @@ use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
@@ -28,6 +27,7 @@ use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\Tasks\Sending;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -365,17 +365,18 @@ class NewsletterTest extends \MailPoetTest {
   public function testItGetsSegments() {
     $newsletterEntity = $this->newslettersRepository->findOneById($this->newsletter->id);
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+    $segmentIds = [];
 
     for ($i = 1; $i <= 3; $i++) {
-      $segment = $this->entityManager->getReference(SegmentEntity::class, $i);
-      $this->assertInstanceOf(SegmentEntity::class, $segment);
+      $segment = (new SegmentFactory())->create();
+      $segmentIds[] = $segment->getId();
       $newsletterSegment = new NewsletterSegmentEntity($newsletterEntity, $segment);
       $this->entityManager->persist($newsletterSegment);
     }
     $this->entityManager->flush();
 
-    expect($this->newsletterTask->getNewsletterSegments($this->newsletter))->equals(
-      [1,2,3]
+    expect($this->newsletterTask->getNewsletterSegments($newsletterEntity))->equals(
+      $segmentIds
     );
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -248,41 +248,41 @@ class NewsletterTest extends \MailPoetTest {
   public function testItUpdatesStatusAndSetsSentAtDateOnlyForStandardAndPostNotificationNewsletters() {
     $newsletter = $this->newslettersRepository->findOneById($this->newsletter->id);
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    $queue = new \stdClass();
-    $queue->processedAt = date('Y-m-d H:i:s');
+    $sendingQueue = $this->sendingTask->queue();
+    $sendingQueue->processedAt = date('Y-m-d H:i:s');
 
     // newsletter type is 'standard'
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
     $newsletter->setStatus('not_sent');
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    $this->newsletterTask->markNewsletterAsSent($newsletter, $queue);
+    $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
     assert($updatedNewsletter instanceof NewsletterEntity);
     expect($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     $sentAt = $updatedNewsletter->getSentAt();
     $this->assertInstanceOf(\DateTime::class, $sentAt);
-    expect($sentAt->format('Y-m-d H:i:s'))->equals($queue->processedAt);
+    expect($sentAt->format('Y-m-d H:i:s'))->equals($sendingQueue->processedAt);
 
     // newsletter type is 'notification history'
     $newsletter->setType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
     $newsletter->setStatus('not_sent');
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    $this->newsletterTask->markNewsletterAsSent($newsletter, $queue);
+    $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
     assert($updatedNewsletter instanceof NewsletterEntity);
     expect($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     $sentAt = $updatedNewsletter->getSentAt();
     $this->assertInstanceOf(\DateTime::class, $sentAt);
-    expect($sentAt->format('Y-m-d H:i:s'))->equals($queue->processedAt);
+    expect($sentAt->format('Y-m-d H:i:s'))->equals($sendingQueue->processedAt);
 
     // all other newsletter types
     $newsletter->setType(NewsletterEntity::TYPE_WELCOME);
     $newsletter->setStatus('not_sent');
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    $this->newsletterTask->markNewsletterAsSent($newsletter, $queue);
+    $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
     assert($updatedNewsletter instanceof NewsletterEntity);
     expect($updatedNewsletter->getStatus())->notEquals(NewsletterEntity::STATUS_SENT);


### PR DESCRIPTION
## Description
Creating this PR as a draft while #4330 is not merged.

I'm opting to split [MAILPOET-4363] into multiple PRs to reduce the size of the code changes. More PRs to come once this one is merged.

## QA notes
Please perform exploratory testing around sending newsletters

## Linked tickets
[MAILPOET-4363]

[MAILPOET-4363]: https://mailpoet.atlassian.net/browse/MAILPOET-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4363]: https://mailpoet.atlassian.net/browse/MAILPOET-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ