### PR TITLE
Improve error messages on the last step of sending [MAILPOET-4506]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_common.scss
+++ b/mailpoet/assets/css/src/components-plugin/_common.scss
@@ -44,7 +44,7 @@ p.sender_email_address_warning.sender_email_address_warning a {
 }
 
 p.sender_email_address_warning:first-child {
-  margin-top: 1em;
+  margin-top: 0; // unify spacing with parsley errors
 }
 
 .button.mailpoet-button-bigger {

--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -217,6 +217,11 @@ progress::-moz-progress-bar {
   .mailpoet-form-notice-message {
     font-style: italic;
   }
+
+  .parsley-errors-list {
+    left: 0;
+    margin-top: 6px;
+  }
 }
 
 // We need to hide the label because it doesn't fit to our form design, and it's added automatically by Gutenberg component

--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -35,6 +35,10 @@ textarea.regular-text {
   width: 25em !important;
 }
 
+.regular-text-full-width {
+  width: 100%;
+}
+
 @include respond-to(small-screen) {
   .select2-container {
     width: 100% !important;
@@ -220,7 +224,7 @@ progress::-moz-progress-bar {
 
   .parsley-errors-list {
     left: 0;
-    margin-top: 6px;
+    margin-top: 2px;
   }
 }
 

--- a/mailpoet/assets/css/src/components/_parsley.scss
+++ b/mailpoet/assets/css/src/components/_parsley.scss
@@ -17,7 +17,7 @@ textarea.parsley-error {
 .parsley-errors-list {
   color: #b94a48;
   font-size: .9em;
-  line-height: .9em;
+  line-height: 1em;
   list-style-type: none;
   margin: 8px 0 3px;
   opacity: 0;

--- a/mailpoet/assets/css/src/components/_parsley.scss
+++ b/mailpoet/assets/css/src/components/_parsley.scss
@@ -11,12 +11,12 @@ select.parsley-error,
 textarea.parsley-error {
   background-color: #f2dede;
   border-color: #eed3d7;
-  color: #b94a48;
+  color: #900;
 }
 
 .parsley-errors-list {
-  color: #b94a48;
-  font-size: .9em;
+  color: #900;
+  font-size: 13px;
   line-height: 1em;
   list-style-type: none;
   margin: 8px 0 3px;
@@ -38,7 +38,7 @@ textarea.parsley-error {
 
 .parsley-required,
 .parsley-custom-error-message {
-  color: #b94a48;
+  color: #900;
 }
 
 .mailpoet-form-errors {

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -41,18 +41,20 @@ function SenderEmailAddressWarning({
           <p className="sender_email_address_warning">
             {ReactStringReplace(
               MailPoet.I18n.t('youNeedToAuthorizeTheEmail'),
-              '[email]',
-              () => emailAddress,
-            )}{' '}
-            <a
-              className="mailpoet-link"
-              href="#"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => loadModal(e, 'sender_email')}
-            >
-              {MailPoet.I18n.t('authorizeMyEmail')}
-            </a>
+              /\[link\](.*?)\[\/link\]/g,
+              (match) => (
+                <a
+                  className="mailpoet-link"
+                  href="#"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => loadModal(e, 'sender_email')}
+                  key={emailAddress}
+                >
+                  {match}
+                </a>
+              ),
+            )}
           </p>
         </div>,
       );

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -113,7 +113,9 @@ class NewsletterSendComponent extends Component {
     this.loadItem(this.props.match.params.id).always(() => {
       this.setState({ loading: false });
     });
-    jQuery('#mailpoet_newsletter').parsley();
+    jQuery('#mailpoet_newsletter').parsley({
+      successClass: '', // Disable green inputs for the validation because it's not consistent for select2 and our custom validations
+    });
   }
 
   componentDidUpdate(prevProps) {

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -575,7 +575,6 @@ class NewsletterSendComponent extends Component {
       return {
         ...field,
         validation: {
-          ...field.validation,
           'data-parsley-required': false,
         },
       };

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -551,7 +551,10 @@ class NewsletterSendComponent extends Component {
         response.errors.map((error) => (
           <p key={error.message}>{error.message}</p>
         )),
-        { scroll: true },
+        {
+          scroll: true,
+          timeout: false,
+        },
       );
     }
   };

--- a/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
@@ -22,6 +22,8 @@ class SenderField extends Component {
     };
     this.onChange = this.onChange.bind(this);
     this.onBlur = this.onBlur.bind(this);
+    // to allow use the same error message from the last step of sending
+    window.mailpoet_sender_address_field_blur = this.onBlur;
 
     const fieldId = props.field.id || `field_${props.field.name}`;
     this.domElementSelector = `#${fieldId}`;

--- a/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
@@ -126,7 +126,7 @@ class SenderField extends Component {
           onBlurEvent={this.onBlur}
         />
 
-        <div className="regular-text" style={{ marginTop: '2rem' }}>
+        <div className="regular-text regular-text-full-width">
           <SenderEmailAddressWarning
             emailAddress={this.state.emailAddress}
             mssActive={window.mailpoet_mss_active}

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -181,6 +181,9 @@ let fields: Array<Field> = [
       'data-parsley-required-message': MailPoet.I18n.t(
         'noSegmentsSelectedError',
       ),
+      'data-parsley-segments-with-subscribers': MailPoet.I18n.t(
+        'noSegmentWithSubscribersSelectedError',
+      ),
     },
   },
   {

--- a/mailpoet/assets/js/src/parsley-validators.jsx
+++ b/mailpoet/assets/js/src/parsley-validators.jsx
@@ -34,4 +34,27 @@ jQuery(($) => {
       en: 'An email can only be scheduled up to 5 years in the future. Please choose a shorter period.',
     },
   });
+
+  Parsley.addValidator('segmentsWithSubscribers', {
+    requirementType: 'string',
+    validateMultiple: (values, noSegmentWithSubscribersError) => {
+      const segments = window.mailpoet_segments || [];
+
+      let isValid = true;
+      values.forEach((segmentId) => {
+        const segment = segments.find((s) => s.id === segmentId);
+        if (segment && segment.subscribers === 0) {
+          isValid = false;
+        }
+      });
+
+      if (!isValid) {
+        return $.Deferred().reject(noSegmentWithSubscribersError);
+      }
+      return true;
+    },
+    messages: {
+      en: 'Please select a list with subscribers',
+    },
+  });
 });

--- a/mailpoet/assets/js/src/parsley-validators.jsx
+++ b/mailpoet/assets/js/src/parsley-validators.jsx
@@ -54,7 +54,7 @@ jQuery(($) => {
       return true;
     },
     messages: {
-      en: 'Please select a list with subscribers',
+      en: 'Please select a list with subscribers.',
     },
   });
 });

--- a/mailpoet/assets/js/src/parsley-validators.jsx
+++ b/mailpoet/assets/js/src/parsley-validators.jsx
@@ -40,11 +40,11 @@ jQuery(($) => {
     validateMultiple: (values, noSegmentWithSubscribersError) => {
       const segments = window.mailpoet_segments || [];
 
-      let isValid = true;
+      let isValid = false;
       values.forEach((segmentId) => {
         const segment = segments.find((s) => s.id === segmentId);
-        if (segment && segment.subscribers === 0) {
-          isValid = false;
+        if (segment && segment.subscribers > 0) {
+          isValid = true;
         }
       });
 

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -277,6 +277,7 @@
     'segmentsTip': __('Subscribers in multiple lists will only receive one email.'),
     'selectSegmentPlaceholder': __('Select a list'),
     'noSegmentsSelectedError': __('Please select a list'),
+    'noSegmentWithSubscribersSelectedError': __('Please select a list with subscribers'),
     'sender': __('Sender'),
     'senderTip': __('Your name and email'),
     'senderNamePlaceholder': __('John Doe'),

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -296,7 +296,7 @@
     'websiteTimeIs': __("Your website’s time is"),
     'noScheduledDateError': __('Please enter the scheduled date.'),
     'schedule': __('Schedule'),
-    'youNeedToAuthorizeTheEmail': __('You need to authorize the email address [email] to be able to send with it.'),
+    'youNeedToAuthorizeTheEmail': __('Not an authorized sender email address. [link]Authorize it now.[/link]'),
     'authorizeMyEmail': __('Authorize my email address'),
 
     'next': __('Next'),
@@ -304,7 +304,6 @@
     'newsletterBeingSent': __('The newsletter is being sent...'),
     'newsletterHasBeenScheduled': __('The newsletter has been scheduled.'),
     'newsletterSendingHasBeenResumed': __('The newsletter sending has been resumed.'),
-    'newsletterInvalidFromAddress': _x('You need to authorize the email address <i>%1$s</i> to be able to send with it. [link]Authorize my email address[/link]', 'Users need to confirm that they own the email address they want to use to send their newsletter'),
     'welcomeEmailActivated': __('Your Welcome Email is now activated!'),
     'welcomeEmailActivationFailed': __('Your Welcome Email could not be activated, please check the settings.'),
     'reEngagementEmailActivated': __('Your ReEngagement Email is now activated!'),

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -277,7 +277,7 @@
     'segmentsTip': __('Subscribers in multiple lists will only receive one email.'),
     'selectSegmentPlaceholder': __('Select a list'),
     'noSegmentsSelectedError': __('Please select a list'),
-    'noSegmentWithSubscribersSelectedError': __('Please select a list with subscribers'),
+    'noSegmentWithSubscribersSelectedError': __('Please select a list with subscribers.'),
     'sender': __('Sender'),
     'senderTip': __('Your name and email'),
     'senderNamePlaceholder': __('John Doe'),

--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -97,7 +97,7 @@
     'readGuide': __('Read our guide'),
 
     'invalidEmail': __('Invalid email address'),
-    'youNeedToAuthorizeTheEmail': __('You need to authorize the email address [email] to be able to send with it.'),
+    'youNeedToAuthorizeTheEmail': __('Not an authorized sender email address. [link]Authorize it now.[/link]'),
     'authorizeMyEmail': __('Authorize my email address'),
     'authorizeSenderDomain': __('Email violates Sender Domain’s DMARC policy. Please set up [link]sender authentication[/link].'),
 


### PR DESCRIPTION
## Description
I decided to use a slightly different approach for validation segments compared to the ticket specification.
The error message is displayed under the select instead of a tooltip on the sending button.

## QA notes
1. Go to `MailPoet` > `Emails`
2. Click to create New simple Newsletter and go to the last step of the flow (4. Send step)
3. Select a list with zero subscribers
4. Try sending and observe the error message, compare it with the one from the Jira specs ticket
5. Check the styles from the specs and verify
6. Under the `Sender` section, change the existing email to some unauthorized email like example@moonbridge.rs and observe the results
7. Go to `MailPoet` > `Settings` > `Basics` tab and change the `Default Sender`'s `From` email to unauthorized and observe the results

## Linked tickets
[MAILPOET-4506]

[MAILPOET-4506]: https://mailpoet.atlassian.net/browse/MAILPOET-4506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ