### PR TITLE
Simplify subscribers last engagement migration by ignoring Woo data

### DIFF
--- a/mailpoet/lib/Cron/Workers/SubscribersLastEngagement.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersLastEngagement.php
@@ -6,8 +6,6 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Util\DBCollationChecker;
-use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class SubscribersLastEngagement extends SimpleWorker {
@@ -19,24 +17,11 @@ class SubscribersLastEngagement extends SimpleWorker {
   /** @var EntityManager */
   private $entityManager;
 
-  /** @var DBCollationChecker */
-  private $dbCollationChecker;
-
-  /** @var WooCommerceHelper */
-  private $wooCommereHelper;
-
-  /** @var null|string */
-  private $emailCollationCorrection;
-
   public function __construct(
-    EntityManager $entityManager,
-    DBCollationChecker $dbCollationChecker,
-    WooCommerceHelper $wooCommereHelper
+    EntityManager $entityManager
   ) {
     parent::__construct();
     $this->entityManager = $entityManager;
-    $this->dbCollationChecker = $dbCollationChecker;
-    $this->wooCommereHelper = $wooCommereHelper;
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer): bool {
@@ -56,22 +41,9 @@ class SubscribersLastEngagement extends SimpleWorker {
   }
 
   private function processBatch(int $minSubscriberId, int $maxSubscriberId): void {
-    global $wpdb;
     $statisticsClicksTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
     $statisticsOpensTable = $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $postsTable = $wpdb->posts;
-    $postsmetaTable = $wpdb->postmeta;
-
-    if (is_null($this->emailCollationCorrection)) {
-      $this->emailCollationCorrection = $this->dbCollationChecker->getCollateIfNeeded(
-        $subscribersTable,
-        'email',
-        $postsmetaTable,
-        'meta_value'
-      );
-    }
-    $emailCollate = $this->emailCollationCorrection;
 
     $query = "
       UPDATE $subscribersTable as mps
@@ -81,18 +53,6 @@ class SubscribersLastEngagement extends SimpleWorker {
       WHERE mps.last_engagement_at IS NULL AND mps.id >= $minSubscriberId AND  mps.id < $maxSubscriberId;
     ";
 
-    // Use more complex query that takes into the account also subscriber's latest WooCommerce order
-    if ($this->wooCommereHelper->isWooCommerceActive()) {
-      $query = "
-        UPDATE $subscribersTable as mps
-          LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsOpensTable as mpsoinner GROUP BY mpsoinner.subscriber_id) as mpso ON mpso.subscriber_id = mps.id
-          LEFT JOIN (SELECT max(created_at) as created_at, subscriber_id FROM $statisticsClicksTable as mpscinner GROUP BY mpscinner.subscriber_id) as mpsc ON mpsc.subscriber_id = mps.id
-          LEFT JOIN (SELECT MAX(post_id) AS post_id, meta_value as email FROM $postsmetaTable WHERE meta_key = '_billing_email' GROUP BY email) AS newestOrderIds ON newestOrderIds.email $emailCollate = mps.email
-          LEFT JOIN (SELECT ID, post_date FROM $postsTable WHERE post_type = 'shop_order') AS shopOrders ON newestOrderIds.post_id = shopOrders.ID
-        SET mps.last_engagement_at = NULLIF(GREATEST(COALESCE(mpso.created_at, '0'), COALESCE(mpsc.created_at, '0'), COALESCE(shopOrders.post_date, '0')), '0')
-        WHERE mps.last_engagement_at IS NULL AND mps.id >= $minSubscriberId AND  mps.id < $maxSubscriberId;
-      ";
-    }
     $this->entityManager->getConnection()->executeStatement($query);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
@@ -42,67 +42,26 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     expect($subscriber->getLastEngagementAt())->equals($clickTime);
   }
 
-  /**
-   * @group woo
-   */
-  public function testItCanSetLastEngagementFromWooOrder() {
-    $orderTime = new Carbon('2021-08-10 16:17:18');
-    $subscriber = $this->createSubscriber();
-    $this->createWooOrder($orderTime, $subscriber->getEmail());
-
-    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
-    $this->entityManager->refresh($subscriber);
-    expect($subscriber->getLastEngagementAt())->equals($orderTime);
-  }
-
-  /**
-   * @group woo
-   */
   public function testItPicksLatestTimeFromClick() {
     $openTime = new Carbon('2021-08-10 12:13:14');
     $clickTime = new Carbon('2021-08-10 13:14:15');
-    $wooOrderTime = new Carbon('2021-08-10 12:14:15');
     $subscriber = $this->createSubscriber();
     $newsletter = $this->createSentNewsletter();
     $this->createOpen($openTime, $newsletter, $subscriber);
     $this->createClick($clickTime, $newsletter, $subscriber);
-    $this->createWooOrder($wooOrderTime, $subscriber->getEmail());
 
     $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
     expect($subscriber->getLastEngagementAt())->equals($clickTime);
   }
 
-  /**
-   * @group woo
-   */
-  public function testItPicksLatestTimeFromOrder() {
-    $openTime = new Carbon('2021-08-10 12:13:14');
-    $clickTime = new Carbon('2021-08-10 13:14:15');
-    $wooOrderTime = new Carbon('2021-08-10 14:14:15');
-    $subscriber = $this->createSubscriber();
-    $newsletter = $this->createSentNewsletter();
-    $this->createOpen($openTime, $newsletter, $subscriber);
-    $this->createClick($clickTime, $newsletter, $subscriber);
-    $this->createWooOrder($wooOrderTime, $subscriber->getEmail());
-
-    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
-    $this->entityManager->refresh($subscriber);
-    expect($subscriber->getLastEngagementAt())->equals($wooOrderTime);
-  }
-
-  /**
-   * @group woo
-   */
   public function testItPicksLatestTimeFromOpen() {
     $openTime = new Carbon('2021-08-10 14:13:14');
     $clickTime = new Carbon('2021-08-10 13:14:15');
-    $wooOrderTime = new Carbon('2021-08-10 11:14:15');
     $subscriber = $this->createSubscriber();
     $newsletter = $this->createSentNewsletter();
     $this->createOpen($openTime, $newsletter, $subscriber);
     $this->createClick($clickTime, $newsletter, $subscriber);
-    $this->createWooOrder($wooOrderTime, $subscriber->getEmail());
 
     $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $this->entityManager->refresh($subscriber);
@@ -213,15 +172,7 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     return $newsletter;
   }
 
-  private function createWooOrder(Carbon $postDate, string $email): void {
-    $order = $this->tester->createWooCommerceOrder();
-    $order->set_billing_email($email);
-    $order->set_date_created($postDate->toDateTimeString());
-    $order->save();
-  }
-
   public function _after(): void {
-    $this->tester->deleteTestWooOrders();
     $this->truncateEntity(SubscriberEntity::class);
     $this->truncateEntity(ScheduledTaskEntity::class);
     $this->truncateEntity(SendingQueueEntity::class);


### PR DESCRIPTION
# Description
Instead of refactoring the complex SQL to work for both custom order tables and post tables, we decided to remove the Woo query and keep only the basic query that updates the last engagement only from MailPoet statistics. The query was a part of a migration that was needed for changes we released a year ago (introduced in 3.69.0). So the users who haven't updated and decide to do the update will have slightly less efficient queries for detecting engagement in the migration.
 
# QA notes
 This affects the migration that was added in version 3.69.0. In order to verify that the migration works, you can follow these steps:

1. Install plugin version prior 3.69.0 (e.g. [3.68.0](https://downloads.wordpress.org/plugin/mailpoet.3.68.0.zip)) on a clean site 
2. Create a couple of subscribers, send them a newsletter and make some clicks on links the received emails
3. Download the zip from this PR and upload/upgrade to your site
4. Check that `subscribers_last_engagement` task was scheduled and completed after the update
5. Check the last engagement date of the subscribers (it is visible on a subscriber's stats page) who clicked the links in emails. It should match the date and time of the most recent clicks

 
# Linked tickets
[MAILPOET-4578]

[MAILPOET-4578]: https://mailpoet.atlassian.net/browse/MAILPOET-4578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ