### PR TITLE
Add possibility of tagging imported subscribers [MAILPOET-4558]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_settings.scss
+++ b/mailpoet/assets/css/src/components-plugin/_settings.scss
@@ -100,6 +100,12 @@ ul.sending-method-benefits {
   .mailpoet-form-input:not(:first-child) {
     margin-top: $grid-gap-half;
   }
+
+  &.mailpoet-import-tags {
+    label.components-form-token-field__label {
+      display: none;
+    }
+  }
 }
 
 .mailpoet-settings-inputs-row {

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -136,4 +136,8 @@ interface Window {
   mailpoet_email_editor_tutorial_seen: number;
   mailpoet_email_editor_tutorial_url: string;
   mailpoet_deactivate_subscriber_after_inactive_days: string;
+  mailpoet_tags?: {
+    id: number;
+    name: string;
+  }[];
 }

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -63,6 +63,7 @@ export const MailPoet = {
   emailEditorTutorialUrl: window.mailpoet_email_editor_tutorial_url,
   deactivateSubscriberAfterInactiveDays:
     window.mailpoet_deactivate_subscriber_after_inactive_days,
+  tags: window.mailpoet_tags,
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation.jsx
@@ -9,6 +9,7 @@ import { NewSubscribersStatus } from './step_data_manipulation/new_subscribers_s
 import { ExistingSubscribersStatus } from './step_data_manipulation/existing_subscribers_status';
 import { UpdateExistingSubscribers } from './step_data_manipulation/update_existing_subscribers.jsx';
 import { doImport } from './step_data_manipulation/do_import.jsx';
+import { AssignTags } from './step_data_manipulation/assign_tags';
 
 function getPreviousStepLink(importData, subscribersLimitForValidation) {
   if (importData === undefined) {
@@ -36,6 +37,7 @@ function StepDataManipulationComponent({
     useState('subscribed');
   const [existingSubscribersStatus, setExistingSubscribersStatus] =
     useState('dontUpdate');
+  const [selectedTags, setSelectedTags] = useState([]);
   useEffect(() => {
     if (typeof stepMethodSelectionData === 'undefined') {
       history.replace('step_method_selection');
@@ -49,6 +51,7 @@ function StepDataManipulationComponent({
       newSubscribersStatus,
       existingSubscribersStatus,
       updateExistingSubscribers,
+      selectedTags,
       (importResults) => {
         setStepDataManipulationData(importResults);
         history.push('step_results');
@@ -80,6 +83,10 @@ function StepDataManipulationComponent({
         <UpdateExistingSubscribers
           setUpdateExistingSubscribers={setUpdateExistingSubscribers}
           updateExistingSubscribers={updateExistingSubscribers}
+        />
+        <AssignTags
+          selectedTags={selectedTags}
+          setSelectedTags={setSelectedTags}
         />
         <PreviousNextStepButtons
           canGoNext={selectedSegments.length > 0}

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/assign_tags.tsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/assign_tags.tsx
@@ -27,12 +27,13 @@ export function AssignTags({
           {MailPoet.I18n.t('assignTagsDescription')}
         </p>
       </div>
-      <div className="mailpoet-settings-inputs">
+      <div className="mailpoet-settings-inputs mailpoet-import-tags">
         <TokenField
           name="tags"
           onChange={handleChange}
           suggestedValues={tags}
           selectedValues={selectedTags}
+          placeholder={MailPoet.I18n.t('addNewTag')}
         />
       </div>
     </>

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/assign_tags.tsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/assign_tags.tsx
@@ -1,0 +1,40 @@
+import { MailPoet } from 'mailpoet';
+import { useCallback } from 'react';
+import { TokenField } from '../../../../common/form/tokenField/tokenField';
+
+interface Props {
+  selectedTags: string[];
+  setSelectedTags: (value) => void;
+}
+
+export function AssignTags({
+  selectedTags,
+  setSelectedTags,
+}: Props): JSX.Element {
+  const handleChange = useCallback(
+    ({ value }): void => {
+      setSelectedTags(value);
+    },
+    [setSelectedTags],
+  );
+
+  const tags = window.mailpoet_tags.map((tag) => tag.name);
+  return (
+    <>
+      <div className="mailpoet-settings-label">
+        {MailPoet.I18n.t('assignTagsLabel')}
+        <p className="description">
+          {MailPoet.I18n.t('assignTagsDescription')}
+        </p>
+      </div>
+      <div className="mailpoet-settings-inputs">
+        <TokenField
+          name="tags"
+          onChange={handleChange}
+          suggestedValues={tags}
+          selectedValues={selectedTags}
+        />
+      </div>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/assign_tags.tsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/assign_tags.tsx
@@ -18,7 +18,7 @@ export function AssignTags({
     [setSelectedTags],
   );
 
-  const tags = window.mailpoet_tags.map((tag) => tag.name);
+  const tags = MailPoet.tags.map((tag) => tag.name);
   return (
     <>
       <div className="mailpoet-settings-label">

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/do_import.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/do_import.jsx
@@ -9,6 +9,7 @@ export const doImport = (
   newSubscribersStatus,
   existingSubscribersStatus,
   updateExistingSubscribers,
+  tags,
   onImportComplete,
 ) => {
   const columns = {};
@@ -21,6 +22,7 @@ export const doImport = (
     updated: 0,
     errors: [],
     segments: [],
+    tags: [],
   };
 
   MailPoet.Modal.loading(true);
@@ -60,6 +62,7 @@ export const doImport = (
           newSubscribersStatus,
           existingSubscribersStatus,
           updateSubscribers: updateExistingSubscribers,
+          tags,
         }),
       })
         .done((response) => {

--- a/mailpoet/lib/API/JSON/v1/ImportExport.php
+++ b/mailpoet/lib/API/JSON/v1/ImportExport.php
@@ -20,6 +20,7 @@ use MailPoet\Subscribers\ImportExport\Import\Import;
 use MailPoet\Subscribers\ImportExport\Import\MailChimp;
 use MailPoet\Subscribers\ImportExport\ImportExportRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Tags\TagRepository;
 
 class ImportExport extends APIEndpoint {
 
@@ -47,6 +48,9 @@ class ImportExport extends APIEndpoint {
   /** @var SegmentsResponseBuilder */
   private $segmentsResponseBuilder;
 
+  /** @var TagRepository */
+  private $tagRepository;
+
   /** @var CronWorkerScheduler */
   private $cronWorkerScheduler;
 
@@ -63,7 +67,8 @@ class ImportExport extends APIEndpoint {
     SegmentSaveController $segmentSavecontroller,
     SegmentsResponseBuilder $segmentsResponseBuilder,
     CronWorkerScheduler $cronWorkerScheduler,
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    TagRepository $tagRepository
   ) {
     $this->wpSegment = $wpSegment;
     $this->customFieldsRepository = $customFieldsRepository;
@@ -74,6 +79,7 @@ class ImportExport extends APIEndpoint {
     $this->segmentSavecontroller = $segmentSavecontroller;
     $this->cronWorkerScheduler = $cronWorkerScheduler;
     $this->segmentsResponseBuilder = $segmentsResponseBuilder;
+    $this->tagRepository = $tagRepository;
   }
 
   public function getMailChimpLists($data) {
@@ -124,6 +130,7 @@ class ImportExport extends APIEndpoint {
         $this->importExportRepository,
         $this->newsletterOptionsRepository,
         $this->subscriberRepository,
+        $this->tagRepository,
         json_decode($data, true)
       );
       $process = $import->process();

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -616,9 +616,9 @@ class Import {
       'segment_id',
       'created_at',
     ];
-    foreach (array_chunk($subscribersIds, self::DB_QUERY_CHUNK_SIZE) as $subscriberIdsChunk) {
-      $data = [];
-      foreach ($segmentsIds as $segmentId) {
+    foreach ($segmentsIds as $segmentId) {
+      foreach (array_chunk($subscribersIds, self::DB_QUERY_CHUNK_SIZE) as $subscriberIdsChunk) {
+        $data = [];
         $data = array_merge($data, array_map(function ($subscriberId) use ($segmentId): array {
           return [
             $subscriberId,
@@ -626,12 +626,13 @@ class Import {
             $this->createdAt,
           ];
         }, $subscriberIdsChunk));
+
+        $this->importExportRepository->insertMultiple(
+          SubscriberSegmentEntity::class,
+          $columns,
+          $data
+        );
       }
-      $this->importExportRepository->insertMultiple(
-        SubscriberSegmentEntity::class,
-        $columns,
-        $data
-      );
     }
   }
 
@@ -654,9 +655,9 @@ class Import {
       'tag_id',
       'created_at',
     ];
-    foreach (array_chunk($subscribersIds, self::DB_QUERY_CHUNK_SIZE) as $subscriberIdsChunk) {
-      $data = [];
-      foreach ($tagIds as $tagId) {
+    foreach ($tagIds as $tagId) {
+      foreach (array_chunk($subscribersIds, self::DB_QUERY_CHUNK_SIZE) as $subscriberIdsChunk) {
+        $data = [];
         $data = array_merge($data, array_map(function ($subscriberId) use ($tagId): array {
           return [
             $subscriberId,
@@ -664,12 +665,13 @@ class Import {
             $this->createdAt,
           ];
         }, $subscriberIdsChunk));
+
+        $this->importExportRepository->insertMultiple(
+          SubscriberTagEntity::class,
+          $columns,
+          $data
+        );
       }
-      $this->importExportRepository->insertMultiple(
-        SubscriberTagEntity::class,
-        $columns,
-        $data
-      );
     }
   }
 }

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -5,7 +5,9 @@ namespace MailPoet\Subscribers\ImportExport;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\TagEntity;
 use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Tags\TagRepository;
 use MailPoet\Util\Helpers;
 
 class ImportExportFactory {
@@ -21,12 +23,16 @@ class ImportExportFactory {
   /** @var CustomFieldsRepository */
   private $customFieldsRepository;
 
+  /** @var TagRepository */
+  private $tagRepository;
+
   public function __construct(
     $action = null
   ) {
     $this->action = $action;
     $this->segmentsListRepository = ContainerWrapper::getInstance()->get(SegmentsSimpleListRepository::class);
     $this->customFieldsRepository = ContainerWrapper::getInstance()->get(CustomFieldsRepository::class);
+    $this->tagRepository = ContainerWrapper::getInstance()->get(TagRepository::class);
   }
 
   public function getSegments() {
@@ -172,6 +178,12 @@ class ImportExportFactory {
       );
       $data['maxPostSizeBytes'] = Helpers::getMaxPostSize('bytes');
       $data['maxPostSize'] = Helpers::getMaxPostSize();
+      $data['tags'] = array_map(function (TagEntity $tag): array {
+        return [
+          'id' => $tag->getId(),
+          'name' => $tag->getName(),
+        ];
+      }, $this->tagRepository->findAll());
     }
     $data['zipExtensionLoaded'] = extension_loaded('zip');
     return $data;

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -162,6 +163,16 @@ class SubscribersRepository extends Repository {
          DELETE scs FROM $subscriberCustomFieldTable scs
          JOIN $subscriberTable s ON s.`id` = scs.`subscriber_id`
          WHERE scs.`subscriber_id` IN (:ids)
+         AND s.`is_woocommerce_user` = false
+         AND s.`wp_user_id` IS NULL
+      ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);
+
+      // Delete subscriber tags
+      $subscriberTagTable = $entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
+      $entityManager->getConnection()->executeStatement("
+         DELETE st FROM $subscriberTagTable st
+         JOIN $subscriberTable s ON s.`id` = st.`subscriber_id`
+         WHERE st.`subscriber_id` IN (:ids)
          AND s.`is_woocommerce_user` = false
          AND s.`wp_user_id` IS NULL
       ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -56,7 +56,7 @@ parameters:
 			path: ../../lib/API/JSON/v1/ImportExport.php
 
 		-
-			message: "#^Parameter \\#6 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
+			message: "#^Parameter \\#7 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/v1/ImportExport.php
 

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -56,7 +56,7 @@ parameters:
 			path: ../../lib/API/JSON/v1/ImportExport.php
 
 		-
-			message: "#^Parameter \\#6 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
+			message: "#^Parameter \\#7 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/v1/ImportExport.php
 

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -66,7 +66,7 @@ parameters:
 			path: ../../lib/API/JSON/v1/ImportExport.php
 
 		-
-			message: "#^Parameter \\#6 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
+			message: "#^Parameter \\#7 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/v1/ImportExport.php
 

--- a/mailpoet/tests/acceptance/Subscribers/ManageImportExportCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageImportExportCest.php
@@ -53,6 +53,8 @@ class ManageImportExportCest {
     $i->click('[data-automation-id="show-more-details"]');
     $i->waitForText('1 emails are not valid:');
     $i->waitForText('1 role-based addresses are not permitted');
+    $i->wantTo('Select a tag for imported subscribers');
+    $i->fillField('.mailpoet-import-tags input[type="text"]', 'My tag,'); // the comma separates the tag
     $this->chooseListAndConfirm($i);
     $i->see('9 subscribers added to');
     // Test reimporting the same list
@@ -65,22 +67,31 @@ class ManageImportExportCest {
     $i->amOnMailPoetPage ('Subscribers');
     $i->searchFor('aaa@example.com');
     $i->waitForText('aaa@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('bbb@example.com');
     $i->waitForText('bbb@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('ccc@example.com');
     $i->waitForText('ccc@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('ddd@example.com');
     $i->waitForText('ddd@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('eee@example.com');
     $i->waitForText('eee@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('fff@example.com');
     $i->waitForText('fff@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('ggg@example.com');
     $i->waitForText('ggg@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('hhh@example.com');
     $i->waitForText('hhh@example.com');
+    $i->waitForText('My tag');
     $i->searchFor('iii@example.com');
     $i->waitForText('iii@example.com');
+    $i->waitForText('My tag');
     $i->seeNoJSErrors();
   }
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -16,6 +16,7 @@ use MailPoet\Subscribers\ImportExport\ImportExportRepository;
 use MailPoet\Subscribers\SubscriberCustomFieldRepository;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Tags\TagRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -59,6 +60,9 @@ class ImportTest extends \MailPoetTest {
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
+  /** @var TagRepository */
+  private $tagRepository;
+
   public function _before(): void {
     $this->wpSegment = $this->diContainer->get(WP::class);
     $this->customFieldsRepository = $this->diContainer->get(CustomFieldsRepository::class);
@@ -68,6 +72,7 @@ class ImportTest extends \MailPoetTest {
     $this->subscriberCustomFieldRepository = $this->diContainer->get(SubscriberCustomFieldRepository::class);
     $this->subscriberRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
+    $this->tagRepository = $this->diContainer->get(TagRepository::class);
     $customField = $this->customFieldsRepository->createOrUpdate([
       'name' => 'country',
       'type' => CustomFieldEntity::TYPE_TEXT,
@@ -780,6 +785,7 @@ class ImportTest extends \MailPoetTest {
       $this->importExportRepository,
       $this->newsletterOptionsRepository,
       $this->subscriberRepository,
+      $this->tagRepository,
       $data
     );
   }

--- a/mailpoet/views/subscribers/importExport/import.html
+++ b/mailpoet/views/subscribers/importExport/import.html
@@ -137,6 +137,7 @@
 'existingSubscribersStatus': __('Update existing subscribers’ status to'),
 'assignTagsLabel': __('Assign tags'),
 'assignTagsDescription': __('Pick a tag or create a new one to assign to these subscribers.'),
+'addNewTag': __('Add new tag'),
 
 }) %>
 <% endblock %>

--- a/mailpoet/views/subscribers/importExport/import.html
+++ b/mailpoet/views/subscribers/importExport/import.html
@@ -19,6 +19,7 @@
     importData = {},
     mailpoetColumnsSelect2 = <%= subscriberFieldsSelect2|raw %>,
     mailpoetColumns = <%= subscriberFields|raw %>,
+    mailpoet_tags = <%= json_encode(tags) %>,
     mailpoetSegments = <%= segments|raw %>;
     var mailpoet_beacon_articles = [
       '57ce07ffc6979108399a044b',
@@ -134,5 +135,8 @@
 'congratulationResult': __('Congratulations, you’ve imported your subscribers!'),
 'suppressionListReminder': __('Are you importing subscribers from another marketing service provider? You may need to separately import the list of bad or previously unsubscribed addresses to avoid contacting them. [link]See how to import a suppression list.[/link]'),
 'existingSubscribersStatus': __('Update existing subscribers’ status to'),
+'assignTagsLabel': __('Assign tags'),
+'assignTagsDescription': __('Pick a tag or create a new one to assign to these subscribers.'),
+
 }) %>
 <% endblock %>


### PR DESCRIPTION
## Description
This pull request extends the import form about a new input field. This input is optional and of [a type token field from Gutenberg](https://wp-gb.com/formtokenfield/). Selected tags are added to all imported subscribers.
 
## QA notes
**How to test:**

1. Prepare subscribers for import
2. Add a tag in the new text input field
   a. Select existing tag
   b. Type a not existing tag
3. Finish import
4. Check if all imported subscribers have selected tags
 
## Linked tickets
[MAILPOET-4558](https://mailpoet.atlassian.net/browse/MAILPOET-4558)