### PR TITLE
Make tags badges linkable to tags filtering [MAILPOET-4564]

### DIFF
--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -8,10 +8,18 @@ type Segment = {
   id?: string;
 };
 
+type SubscriberTag = {
+  id: string;
+  name: string;
+  subscriber_id: string;
+  tag_id: string;
+};
+
 type Props = {
   children?: ReactNode;
   dimension?: 'large';
   segments?: Segment[];
+  subscriberTags?: SubscriberTag[];
   strings?: string[];
   variant?: 'average' | 'good' | 'excellent' | 'list' | 'unknown' | 'wordpress';
   isInverted?: boolean;
@@ -21,6 +29,7 @@ function Tags({
   children,
   dimension,
   segments,
+  subscriberTags,
   strings,
   variant,
   isInverted,
@@ -50,6 +59,36 @@ function Tags({
                 data-tip=""
                 data-for={tooltipId}
                 href={`admin.php?page=mailpoet-subscribers#/filter[segment=${segment.id}]`}
+              >
+                {tag}
+              </a>
+            </div>
+          );
+        })}
+      {subscriberTags &&
+        subscriberTags.map((subscriberTag) => {
+          const randomId = Math.random().toString(36).substring(2, 15);
+          const tooltipId = `tag-tooltip-${randomId}`;
+          const tag = (
+            <Tag
+              key={subscriberTag.name}
+              dimension={dimension}
+              variant={variant || 'list'}
+              isInverted={isInverted}
+            >
+              {subscriberTag.name}
+            </Tag>
+          );
+
+          return (
+            <div key={randomId}>
+              <Tooltip id={tooltipId} place="top">
+                {MailPoet.I18n.t('viewFilteredSubscribersMessage')}
+              </Tooltip>
+              <a
+                data-tip=""
+                data-for={tooltipId}
+                href={`admin.php?page=mailpoet-subscribers#/filter[tag=${subscriberTag.tag_id}]`}
               >
                 {tag}
               </a>

--- a/mailpoet/assets/js/src/subscribers/list.jsx
+++ b/mailpoet/assets/js/src/subscribers/list.jsx
@@ -404,7 +404,6 @@ function SubscriberList({ match }) {
     }
 
     const subscribedSegments = [];
-    const subscriberTags = [];
 
     // Subscriptions
     if (subscriber.subscriptions.length > 0) {
@@ -414,13 +413,6 @@ function SubscriberList({ match }) {
         if (subscription.status === 'subscribed') {
           subscribedSegments.push(segment);
         }
-      });
-    }
-
-    // Tags
-    if (subscriber.tags.length > 0) {
-      subscriber.tags.forEach((tag) => {
-        subscriberTags.push(tag.name);
       });
     }
 
@@ -450,7 +442,11 @@ function SubscriberList({ match }) {
           <Tags segments={subscribedSegments} dimension="large" />
         </td>
         <td className="column" data-colname={MailPoet.I18n.t('tags')}>
-          <Tags strings={subscriberTags} variant="wordpress" isInverted />
+          <Tags
+            subscriberTags={subscriber.tags}
+            variant="wordpress"
+            isInverted
+          />
         </td>
         {mailpoetTrackingEnabled === true ? (
           <td


### PR DESCRIPTION
## Description
This pull request makes the tag badges on the subscribers list clickable. When a user clicks on the badge, the list should use a filter with this tag.
 
## QA notes
1. Go to Subscribers page
2. Make sure you edit a few subscribers and add a few tags to them
3. When on a Subscribers page, click on the tags separately and make sure you see subscribers with those tags
4. Check if anywhere else you see tag badges and if they are clickable
Note: The behavior should be equivalent to the list's badges.
 
## Linked tickets
[MAILPOET-4564]

[MAILPOET-4564]: https://mailpoet.atlassian.net/browse/MAILPOET-4564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ