### PR TITLE
Add logging of workflow steps [MAILPOET-4463]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -130,7 +130,7 @@ class StepHandler {
         throw $e;
       } finally {
         try {
-          $this->hooks->doWorkflowStepAfterRun($step, $log);
+          $this->hooks->doWorkflowStepAfterRun($log);
         } catch (Exception $e) {
           $log->addError($e);
         }

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -126,13 +126,13 @@ class StepHandler {
         $log->markCompletedSuccessfully();
       } catch (Throwable $e) {
         $log->markFailed();
-        $log->addError($e);
+        $log->setError($e);
         throw $e;
       } finally {
         try {
           $this->hooks->doWorkflowStepAfterRun($log);
         } catch (Throwable $e) {
-          $log->addError($e);
+          // Ignore integration errors
         }
         $this->workflowRunLogStorage->createWorkflowRunLog($log);
       }

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -123,8 +123,8 @@ class StepHandler {
       $log = new WorkflowRunLog($workflowRun->getId(), $step->getId(), $args);
       try {
         $this->stepRunners[$stepType]->run($step, $workflow, $workflowRun);
-        $log->markCompleted();
-      } catch (Exception $e) {
+        $log->markCompletedSuccessfully();
+      } catch (\Exception $e) {
         $log->markFailed();
         $log->addError($e);
         throw $e;

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -124,14 +124,14 @@ class StepHandler {
       try {
         $this->stepRunners[$stepType]->run($step, $workflow, $workflowRun);
         $log->markCompletedSuccessfully();
-      } catch (\Exception $e) {
+      } catch (Throwable $e) {
         $log->markFailed();
         $log->addError($e);
         throw $e;
       } finally {
         try {
           $this->hooks->doWorkflowStepAfterRun($log);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
           $log->addError($e);
         }
         $this->workflowRunLogStorage->createWorkflowRunLog($log);

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -120,7 +120,7 @@ class StepHandler {
 
     $stepType = $step->getType();
     if (isset($this->stepRunners[$stepType])) {
-      $log = new WorkflowRunLog($workflowRun->getId(), $step->getId(), $args);
+      $log = new WorkflowRunLog($workflowRun->getId(), $step->getId());
       try {
         $this->stepRunners[$stepType]->run($step, $workflow, $workflowRun);
         $log->markCompletedSuccessfully();

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -121,13 +121,14 @@ class WorkflowRunLog {
     ];
   }
 
-  public function markCompleted(): void {
+  public function markCompletedSuccessfully(): void {
     $this->status = self::STATUS_COMPLETED;
     $this->completedAt = new DateTimeImmutable();
   }
 
   public function markFailed(): void {
     $this->status = self::STATUS_FAILED;
+    $this->completedAt = new DateTimeImmutable();
   }
 
   public function addError(\Exception $exception, string $userFacingMessage = ''): void {

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -22,7 +22,7 @@ class WorkflowRunLog {
   private $workflowRunId;
 
   /** @var DateTimeImmutable */
-  private $createdAt;
+  private $startedAt;
 
   /** @var DateTimeImmutable|null */
   private $completedAt;
@@ -57,8 +57,7 @@ class WorkflowRunLog {
       $this->id = $id;
     }
 
-    $now = new DateTimeImmutable();
-    $this->createdAt = $now;
+    $this->startedAt = new DateTimeImmutable();
 
     $this->error = [];
     $this->data = [];
@@ -119,8 +118,8 @@ class WorkflowRunLog {
     $this->data[$key] = $value;
   }
 
-  public function getCreatedAt(): DateTimeImmutable {
-    return $this->createdAt;
+  public function getStartedAt(): DateTimeImmutable {
+    return $this->startedAt;
   }
 
   public function toArray(): array {
@@ -128,7 +127,7 @@ class WorkflowRunLog {
       'workflow_run_id' => $this->workflowRunId,
       'step_id' => $this->stepId,
       'status' => $this->status,
-      'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
+      'started_at' => $this->startedAt->format(DateTimeImmutable::W3C),
       'completed_at' => $this->completedAt ? $this->completedAt->format(DateTimeImmutable::W3C) : null,
       'args' => Json::encode($this->args),
       'error' => Json::encode($this->error),
@@ -164,7 +163,7 @@ class WorkflowRunLog {
     $workflowRunLog->error = Json::decode($data['error']);
     $workflowRunLog->data = Json::decode($data['data']);
     $workflowRunLog->args = Json::decode($data['args']);
-    $workflowRunLog->createdAt = new DateTimeImmutable($data['created_at']);
+    $workflowRunLog->startedAt = new DateTimeImmutable($data['started_at']);
 
     if ($data['completed_at']) {
       $workflowRunLog->completedAt = new DateTimeImmutable($data['completed_at']);

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+use DateTimeImmutable;
+use MailPoet\Automation\Engine\Utils\Json;
+
+class WorkflowRunLog {
+
+  const STATUS_RUNNING = 'running';
+  const STATUS_COMPLETED = 'completed';
+  const STATUS_FAILED = 'failed';
+
+  /** @var int */
+  private $id;
+
+  /** @var int */
+  private $workflowRunId;
+
+  /** @var DateTimeImmutable */
+  private $createdAt;
+
+  /** @var DateTimeImmutable */
+  private $updatedAt;
+
+  /** @var DateTimeImmutable|null */
+  private $completedAt;
+
+  /** @var string */
+  private $status;
+
+  /** @var array */
+  private $errors;
+
+  /** @var array */
+  private $data;
+
+  /** @var string */
+  private $stepId;
+
+  /** @var array */
+  private $args;
+
+  public function __construct(
+    int $workflowRunId,
+    string $stepId,
+    array $args,
+    int $id = null
+  ) {
+    $this->workflowRunId = $workflowRunId;
+    $this->stepId = $stepId;
+    $this->args = $args;
+    $this->status = self::STATUS_RUNNING;
+
+    if ($id) {
+      $this->id = $id;
+    }
+
+    $now = new DateTimeImmutable();
+    $this->createdAt = $now;
+    $this->updatedAt = $now;
+
+    $this->errors = [];
+    $this->data = [];
+  }
+
+  public function getId(): int {
+    return $this->id;
+  }
+
+  public function getWorkflowRunId(): int {
+    return $this->workflowRunId;
+  }
+
+  public function getStepId(): string {
+    return $this->stepId;
+  }
+
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  public function getArgs(): array {
+    return $this->args;
+  }
+
+  public function getErrors(): array {
+    return $this->errors;
+  }
+
+  public function getData(): array {
+    return $this->data;
+  }
+
+  /**
+   * @return DateTimeImmutable|null
+   */
+  public function getCompletedAt() {
+    return $this->completedAt;
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $value
+   * @return void
+   */
+  public function setData(string $key, $value): void {
+    $this->data[$key] = $value;
+  }
+
+  public function getCreatedAt(): DateTimeImmutable {
+    return $this->createdAt;
+  }
+
+  public function getUpdatedAt(): DateTimeImmutable {
+    return $this->updatedAt;
+  }
+
+  public function toArray(): array {
+    return [
+      'workflow_run_id' => $this->workflowRunId,
+      'step_id' => $this->stepId,
+      'status' => $this->status,
+      'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
+      'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
+      'completed_at' => $this->completedAt ? $this->completedAt->format(DateTimeImmutable::W3C) : null,
+      'args' => Json::encode($this->args),
+      'errors' => Json::encode($this->errors),
+      'data' => Json::encode($this->data),
+    ];
+  }
+
+  public function markCompleted(): void {
+    $this->status = self::STATUS_COMPLETED;
+    $this->completedAt = new DateTimeImmutable();
+  }
+
+  public function markFailed(): void {
+    $this->status = self::STATUS_FAILED;
+  }
+
+  public function addError(\Exception $exception, string $userFacingMessage = ''): void {
+    $error = [
+      'message' => $exception->getMessage(),
+      'exceptionClass' => get_class($exception),
+      'userFacingMessage' => $userFacingMessage,
+      'code' => $exception->getCode(),
+      'trace' => $exception->getTrace(),
+    ];
+
+    $this->errors[] = $error;
+  }
+
+  public static function fromArray(array $data): self {
+    $workflowRunLog = new WorkflowRunLog((int)$data['workflow_run_id'], $data['step_id'], []);
+    $workflowRunLog->id = (int)$data['id'];
+    $workflowRunLog->status = $data['status'];
+    $workflowRunLog->errors = Json::decode($data['errors']);
+    $workflowRunLog->data = Json::decode($data['data']);
+    $workflowRunLog->args = Json::decode($data['args']);
+    $workflowRunLog->createdAt = new DateTimeImmutable($data['created_at']);
+    $workflowRunLog->updatedAt = new DateTimeImmutable($data['updated_at']);
+
+    if ($data['completed_at']) {
+      $workflowRunLog->completedAt = new DateTimeImmutable($data['completed_at']);
+    }
+
+    return $workflowRunLog;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -3,6 +3,9 @@
 namespace MailPoet\Automation\Engine\Data;
 
 use DateTimeImmutable;
+use InvalidArgumentException;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Utils\Json;
 use Throwable;
 
@@ -102,6 +105,17 @@ class WorkflowRunLog {
    * @return void
    */
   public function setData(string $key, $value): void {
+    try {
+      $newData = $this->getData();
+      $newData[$key] = $value;
+      $encoded = Json::encode($newData);
+      $decoded = Json::decode($encoded);
+      if ($decoded !== $newData) {
+        throw new InvalidArgumentException('$value must be serializable');
+      }
+    } catch (InvalidStateException | InvalidArgumentException | UnexpectedValueException $e) {
+      throw new InvalidArgumentException("Invalid data provided for key $key.");
+    }
     $this->data[$key] = $value;
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -20,9 +20,6 @@ class WorkflowRunLog {
   /** @var DateTimeImmutable */
   private $createdAt;
 
-  /** @var DateTimeImmutable */
-  private $updatedAt;
-
   /** @var DateTimeImmutable|null */
   private $completedAt;
 
@@ -58,7 +55,6 @@ class WorkflowRunLog {
 
     $now = new DateTimeImmutable();
     $this->createdAt = $now;
-    $this->updatedAt = $now;
 
     $this->errors = [];
     $this->data = [];
@@ -112,17 +108,12 @@ class WorkflowRunLog {
     return $this->createdAt;
   }
 
-  public function getUpdatedAt(): DateTimeImmutable {
-    return $this->updatedAt;
-  }
-
   public function toArray(): array {
     return [
       'workflow_run_id' => $this->workflowRunId,
       'step_id' => $this->stepId,
       'status' => $this->status,
       'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
-      'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
       'completed_at' => $this->completedAt ? $this->completedAt->format(DateTimeImmutable::W3C) : null,
       'args' => Json::encode($this->args),
       'errors' => Json::encode($this->errors),
@@ -159,7 +150,6 @@ class WorkflowRunLog {
     $workflowRunLog->data = Json::decode($data['data']);
     $workflowRunLog->args = Json::decode($data['args']);
     $workflowRunLog->createdAt = new DateTimeImmutable($data['created_at']);
-    $workflowRunLog->updatedAt = new DateTimeImmutable($data['updated_at']);
 
     if ($data['completed_at']) {
       $workflowRunLog->completedAt = new DateTimeImmutable($data['completed_at']);

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -28,7 +28,7 @@ class WorkflowRunLog {
   private $status;
 
   /** @var array */
-  private $errors;
+  private $error;
 
   /** @var array */
   private $data;
@@ -57,7 +57,7 @@ class WorkflowRunLog {
     $now = new DateTimeImmutable();
     $this->createdAt = $now;
 
-    $this->errors = [];
+    $this->error = [];
     $this->data = [];
   }
 
@@ -81,8 +81,8 @@ class WorkflowRunLog {
     return $this->args;
   }
 
-  public function getErrors(): array {
-    return $this->errors;
+  public function getError(): array {
+    return $this->error;
   }
 
   public function getData(): array {
@@ -117,7 +117,7 @@ class WorkflowRunLog {
       'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
       'completed_at' => $this->completedAt ? $this->completedAt->format(DateTimeImmutable::W3C) : null,
       'args' => Json::encode($this->args),
-      'errors' => Json::encode($this->errors),
+      'error' => Json::encode($this->error),
       'data' => Json::encode($this->data),
     ];
   }
@@ -132,7 +132,7 @@ class WorkflowRunLog {
     $this->completedAt = new DateTimeImmutable();
   }
 
-  public function addError(Throwable $error): void {
+  public function setError(Throwable $error): void {
     $error = [
       'message' => $error->getMessage(),
       'errorClass' => get_class($error),
@@ -140,14 +140,14 @@ class WorkflowRunLog {
       'trace' => $error->getTrace(),
     ];
 
-    $this->errors[] = $error;
+    $this->error = $error;
   }
 
   public static function fromArray(array $data): self {
     $workflowRunLog = new WorkflowRunLog((int)$data['workflow_run_id'], $data['step_id'], []);
     $workflowRunLog->id = (int)$data['id'];
     $workflowRunLog->status = $data['status'];
-    $workflowRunLog->errors = Json::decode($data['errors']);
+    $workflowRunLog->error = Json::decode($data['error']);
     $workflowRunLog->data = Json::decode($data['data']);
     $workflowRunLog->args = Json::decode($data['args']);
     $workflowRunLog->createdAt = new DateTimeImmutable($data['created_at']);

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine\Data;
 
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Utils\Json;
+use Throwable;
 
 class WorkflowRunLog {
 
@@ -131,13 +132,13 @@ class WorkflowRunLog {
     $this->completedAt = new DateTimeImmutable();
   }
 
-  public function addError(\Exception $exception, string $userFacingMessage = ''): void {
+  public function addError(Throwable $error, string $userFacingMessage = ''): void {
     $error = [
-      'message' => $exception->getMessage(),
-      'exceptionClass' => get_class($exception),
+      'message' => $error->getMessage(),
+      'errorClass' => get_class($error),
       'userFacingMessage' => $userFacingMessage,
-      'code' => $exception->getCode(),
-      'trace' => $exception->getTrace(),
+      'code' => $error->getCode(),
+      'trace' => $error->getTrace(),
     ];
 
     $this->errors[] = $error;

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -39,18 +39,13 @@ class WorkflowRunLog {
   /** @var string */
   private $stepId;
 
-  /** @var array */
-  private $args;
-
   public function __construct(
     int $workflowRunId,
     string $stepId,
-    array $args,
     int $id = null
   ) {
     $this->workflowRunId = $workflowRunId;
     $this->stepId = $stepId;
-    $this->args = $args;
     $this->status = self::STATUS_RUNNING;
 
     if ($id) {
@@ -77,10 +72,6 @@ class WorkflowRunLog {
 
   public function getStatus(): string {
     return $this->status;
-  }
-
-  public function getArgs(): array {
-    return $this->args;
   }
 
   public function getError(): array {
@@ -126,7 +117,6 @@ class WorkflowRunLog {
       'status' => $this->status,
       'started_at' => $this->startedAt->format(DateTimeImmutable::W3C),
       'completed_at' => $this->completedAt ? $this->completedAt->format(DateTimeImmutable::W3C) : null,
-      'args' => Json::encode($this->args),
       'error' => Json::encode($this->error),
       'data' => Json::encode($this->data),
     ];
@@ -154,12 +144,11 @@ class WorkflowRunLog {
   }
 
   public static function fromArray(array $data): self {
-    $workflowRunLog = new WorkflowRunLog((int)$data['workflow_run_id'], $data['step_id'], []);
+    $workflowRunLog = new WorkflowRunLog((int)$data['workflow_run_id'], $data['step_id']);
     $workflowRunLog->id = (int)$data['id'];
     $workflowRunLog->status = $data['status'];
     $workflowRunLog->error = Json::decode($data['error']);
     $workflowRunLog->data = Json::decode($data['data']);
-    $workflowRunLog->args = Json::decode($data['args']);
     $workflowRunLog->startedAt = new DateTimeImmutable($data['started_at']);
 
     if ($data['completed_at']) {

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -91,10 +91,7 @@ class WorkflowRunLog {
     return $this->data;
   }
 
-  /**
-   * @return DateTimeImmutable|null
-   */
-  public function getCompletedAt() {
+  public function getCompletedAt(): ?DateTimeImmutable {
     return $this->completedAt;
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/WorkflowRunLog.php
@@ -132,11 +132,10 @@ class WorkflowRunLog {
     $this->completedAt = new DateTimeImmutable();
   }
 
-  public function addError(Throwable $error, string $userFacingMessage = ''): void {
+  public function addError(Throwable $error): void {
     $error = [
       'message' => $error->getMessage(),
       'errorClass' => get_class($error),
-      'userFacingMessage' => $userFacingMessage,
       'code' => $error->getCode(),
       'trace' => $error->getTrace(),
     ];

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -41,7 +41,7 @@ class Hooks {
     $this->wordPress->doAction(self::WORKFLOW_STEP_BEFORE_SAVE . '/key=' . $step->getKey(), $step);
   }
 
-  public function doWorkflowStepAfterRun(Step $step, WorkflowRunLog $workflowRunLog): void {
-    $this->wordPress->doAction(self::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, $step, $workflowRunLog);
+  public function doWorkflowStepAfterRun(WorkflowRunLog $workflowRunLog): void {
+    $this->wordPress->doAction(self::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, $workflowRunLog);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Data\WorkflowRunLog;
 
 class Hooks {
   /** @var WordPress */
@@ -24,6 +25,8 @@ class Hooks {
   public const WORKFLOW_BEFORE_SAVE = 'mailpoet/automation/workflow/before_save';
   public const WORKFLOW_STEP_BEFORE_SAVE = 'mailpoet/automation/workflow/step/before_save';
 
+  public const WORKFLOW_RUN_LOG_AFTER_STEP_RUN = 'mailpoet/automation/workflow/step/after_run';
+
   public const WORKFLOW_TEMPLATES = 'mailpoet/automation/workflow/templates';
 
   public function doWorkflowBeforeSave(Workflow $workflow): void {
@@ -36,5 +39,9 @@ class Hooks {
 
   public function doWorkflowStepByKeyBeforeSave(Step $step): void {
     $this->wordPress->doAction(self::WORKFLOW_STEP_BEFORE_SAVE . '/key=' . $step->getKey(), $step);
+  }
+
+  public function doWorkflowStepAfterRun(Step $step, WorkflowRunLog $workflowRunLog): void {
+    $this->wordPress->doAction(self::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, $step, $workflowRunLog);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -69,7 +69,6 @@ class Migrator {
         step_id varchar(255) NOT NULL,
         status varchar(255) NOT NULL,
         created_at timestamp NOT NULL,
-        updated_at timestamp NOT NULL,
         completed_at timestamp NULL DEFAULT NULL,
         args longtext,
         errors longtext,

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -61,12 +61,29 @@ class Migrator {
         PRIMARY KEY (id)
       );
     ");
+
+    $this->runQuery("
+      CREATE TABLE {$this->prefix}workflow_run_logs (
+        id int(11) unsigned NOT NULL AUTO_INCREMENT,
+        workflow_run_id int(11) unsigned NOT NULL,
+        step_id varchar(255) NOT NULL,
+        status varchar(255) NOT NULL,
+        created_at timestamp NOT NULL,
+        updated_at timestamp NOT NULL,
+        completed_at timestamp NULL DEFAULT NULL,
+        args longtext,
+        errors longtext,
+        data longtext,
+        PRIMARY KEY (id)
+      );
+    ");
   }
 
   public function deleteSchema(): void {
     $this->removeOldSchema();
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflows");
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_runs");
+    $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_run_logs");
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_versions");
 
     // clean Action Scheduler data

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -68,7 +68,7 @@ class Migrator {
         workflow_run_id int(11) unsigned NOT NULL,
         step_id varchar(255) NOT NULL,
         status varchar(255) NOT NULL,
-        created_at timestamp NOT NULL,
+        started_at timestamp NOT NULL,
         completed_at timestamp NULL DEFAULT NULL,
         args longtext,
         error longtext,

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -70,7 +70,6 @@ class Migrator {
         status varchar(255) NOT NULL,
         started_at timestamp NOT NULL,
         completed_at timestamp NULL DEFAULT NULL,
-        args longtext,
         error longtext,
         data longtext,
         PRIMARY KEY (id),

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -71,7 +71,7 @@ class Migrator {
         created_at timestamp NOT NULL,
         completed_at timestamp NULL DEFAULT NULL,
         args longtext,
-        errors longtext,
+        error longtext,
         data longtext,
         PRIMARY KEY (id)
       );

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -73,7 +73,8 @@ class Migrator {
         args longtext,
         error longtext,
         data longtext,
-        PRIMARY KEY (id)
+        PRIMARY KEY (id),
+        INDEX (workflow_run_id)
       );
     ");
   }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
@@ -52,7 +52,12 @@ class WorkflowRunLogStorage {
    */
   public function getLogsForWorkflowRun(int $workflowRunId): array {
     $table = esc_sql($this->table);
-    $query = $this->wpdb->prepare("SELECT * FROM $table WHERE workflow_run_id = %d", $workflowRunId);
+    $query = $this->wpdb->prepare("
+        SELECT *
+        FROM $table
+        WHERE workflow_run_id = %d
+        ORDER BY id ASC
+        ", $workflowRunId);
 
     if (!is_string($query)) {
       throw InvalidStateException::create();

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
@@ -28,21 +28,6 @@ class WorkflowRunLogStorage {
     return $this->wpdb->insert_id;
   }
 
-  public function updateWorkflowRunLog(WorkflowRunLog $workflowRunLog): int {
-    $data = $workflowRunLog->toArray();
-    unset($data['id']);
-    $data['updated_at'] = (new \DateTimeImmutable())->format(\DateTimeImmutable::W3C);
-    $where = ['id' => $workflowRunLog->getId()];
-
-    $result = $this->wpdb->update($this->table, $data, $where);
-
-    if ($result === false) {
-      throw Exceptions::databaseError($this->wpdb->last_error);
-    }
-
-    return $result;
-  }
-
   public function getWorkflowRunLog(int $id): ?WorkflowRunLog {
     $table = esc_sql($this->table);
     $query = $this->wpdb->prepare("SELECT * FROM $table WHERE id = %d", $id);

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Storage;
+
+use MailPoet\Automation\Engine\Data\WorkflowRunLog;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\InvalidStateException;
+use wpdb;
+
+class WorkflowRunLogStorage {
+  /** @var string */
+  private $table;
+
+  /** @var wpdb */
+  private $wpdb;
+
+  public function __construct() {
+    global $wpdb;
+    $this->table = $wpdb->prefix . 'mailpoet_workflow_run_logs';
+    $this->wpdb = $wpdb;
+  }
+
+  public function createWorkflowRunLog(WorkflowRunLog $workflowRunLog): int {
+    $result = $this->wpdb->insert($this->table, $workflowRunLog->toArray());
+    if ($result === false) {
+      throw Exceptions::databaseError($this->wpdb->last_error);
+    }
+    return $this->wpdb->insert_id;
+  }
+
+  public function updateWorkflowRunLog(WorkflowRunLog $workflowRunLog): int {
+    $data = $workflowRunLog->toArray();
+    unset($data['id']);
+    $data['updated_at'] = (new \DateTimeImmutable())->format(\DateTimeImmutable::W3C);
+    $where = ['id' => $workflowRunLog->getId()];
+
+    $result = $this->wpdb->update($this->table, $data, $where);
+
+    if ($result === false) {
+      throw Exceptions::databaseError($this->wpdb->last_error);
+    }
+
+    return $result;
+  }
+
+  public function getWorkflowRunLog(int $id): ?WorkflowRunLog {
+    $table = esc_sql($this->table);
+    $query = $this->wpdb->prepare("SELECT * FROM $table WHERE id = %d", $id);
+
+    if (!is_string($query)) {
+      throw InvalidStateException::create();
+    }
+
+    $result = $this->wpdb->get_row($query, ARRAY_A);
+
+    if ($result) {
+      $data = (array)$result;
+      return WorkflowRunLog::fromArray($data);
+    }
+    return null;
+  }
+
+  /**
+   * @param int $workflowRunId
+   * @return WorkflowRunLog[]
+   * @throws InvalidStateException
+   */
+  public function getLogsForWorkflowRun(int $workflowRunId): array {
+    $table = esc_sql($this->table);
+    $query = $this->wpdb->prepare("SELECT * FROM $table WHERE workflow_run_id = %d", $workflowRunId);
+
+    if (!is_string($query)) {
+      throw InvalidStateException::create();
+    }
+
+    $results = $this->wpdb->get_results($query, ARRAY_A);
+
+    if (!is_array($results)) {
+      throw InvalidStateException::create();
+    }
+
+    if ($results) {
+      return array_map(function($data) {
+        return WorkflowRunLog::fromArray($data);
+      }, $results);
+    }
+
+    return [];
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -124,6 +124,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunStorage::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunLogStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -1,0 +1,241 @@
+<?php declare(strict_types=1);
+
+namespace MailPoet\Test\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Control\StepHandler;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Data\WorkflowRun;
+use MailPoet\Automation\Engine\Data\WorkflowRunLog;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\WorkflowRunLogStorage;
+use MailPoet\Automation\Engine\Storage\WorkflowRunStorage;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\Workflows\Action;
+use MailPoet\Util\Security;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoet\WP\Functions as WPFunctions;
+
+class WorkflowRunLogTest extends \MailPoetTest {
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var StepHandler */
+  private $stepHandler;
+
+  /** @var WorkflowRunStorage */
+  private $workflowRunStorage;
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  /** @var Registry */
+  private $registry;
+
+  /** @var WorkflowRunLogStorage */
+  private $workflowRunLogStorage;
+
+  public function _before() {
+    parent::_before();
+
+    $this->workflowStorage = $this->diContainer->get(WorkflowStorage::class);
+    $this->workflowRunStorage = $this->diContainer->get(WorkflowRunStorage::class);
+    $this->workflowRunLogStorage = $this->diContainer->get(WorkflowRunLogStorage::class);
+    $this->stepHandler = $this->diContainer->get(StepHandler::class);
+    $this->registry = $this->diContainer->get(Registry::class);
+    $this->wp = new WPFunctions();
+  }
+
+  public function testItAllowsSettingData(): void {
+    $log = new WorkflowRunLog(1, 'step-id', []);
+    $this->assertSame([], $log->getData());
+    $log->setData('key', 'value');
+    $data = $log->getData();
+    $this->assertCount(1, $data);
+    $this->assertSame('value', $data['key']);
+  }
+
+  public function testItGetsExposedViaAction(): void {
+    $this->wp->addAction(Hooks::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, function(Step $step, WorkflowRunLog $log) {
+      $log->setData('test', 'value');
+    }, 10, 2);
+    $workflowRunLogs = $this->getLogsForAction();
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getData()['test'])->equals('value');
+  }
+
+  public function testBadActionIntegrationsCannotDerailStepFromRunning() {
+    $this->wp->addAction(Hooks::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, function(Step $step, WorkflowRunLog $log) {
+      throw new \Exception('bad integration');
+    }, 9, 2);
+    $workflowRunLogs = $this->getLogsForAction();
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getStatus())->equals(WorkflowRunLog::STATUS_COMPLETED);
+  }
+
+  public function testItStoresWorkflowRunAndStepIdsCorrectly() {
+    $testAction = $this->getRegisteredTestAction();
+    $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey());
+    $workflow = new Workflow('test_workflow', [$actionStep], new \WP_User());
+    $workflowId = $this->workflowStorage->createWorkflow($workflow);
+    // Reload to get additional data post-save
+    $workflow = $this->workflowStorage->getWorkflow($workflowId);
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $workflowRun = new WorkflowRun($workflowId, $workflow->getVersionId(), 'trigger-key', []);
+    $workflowRunId = $this->workflowRunStorage->createWorkflowRun($workflowRun);
+    $this->stepHandler->handle([
+      'workflow_run_id' => $workflowRunId,
+      'step_id' => 'action-step-id'
+    ]);
+
+    $log = $this->workflowRunLogStorage->getLogsForWorkflowRun($workflowRunId)[0];
+    expect($log->getWorkflowRunId())->equals($workflowRunId);
+    expect($log->getStepId())->equals('action-step-id');
+  }
+
+  public function testItLogsCompletedStatusCorrectly(): void {
+    $workflowRunLogs = $this->getLogsForAction(function() {
+      return true;
+    });
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getStatus())->equals('completed');
+  }
+
+  public function testItAddsCompletedAtTimestampAfterRunningSuccessfully(): void {
+    $this->wp->addAction(Hooks::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, function(Step $step, WorkflowRunLog $log) {
+      expect($log->getCompletedAt())->null();
+    }, 10, 2);
+    $workflowRunLogs = $this->getLogsForAction(function() {
+      return true;
+    });
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getCompletedAt())->isInstanceOf(\DateTimeImmutable::class);
+  }
+
+  public function testItLogsFailedStatusCorrectly(): void {
+    $workflowRunLogs = $this->getLogsForAction(function() {
+      throw new \Exception('error');
+    });
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getStatus())->equals('failed');
+  }
+
+  public function testItDoesNotHaveCompletedAtIfItFailsToRun(): void {
+    $workflowRunLogs = $this->getLogsForAction(function() {
+      throw new \Exception('error');
+    });
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getCompletedAt())->null();
+  }
+
+  public function testItIncludesErrorOnFailure(): void {
+    $workflowRunLogs = $this->getLogsForAction(function() {
+      throw new \Exception('error', 12345);
+    });
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getErrors())->count(1);
+    $error = $log->getErrors()[0];
+    expect($error['message'])->equals('error');
+    expect($error['code'])->equals(12345);
+    expect($error['exceptionClass'])->equals('Exception');
+    expect($error['trace'])->array();
+    expect(count($error['trace']))->greaterThan(0);
+  }
+
+  public function testItLogsStepArgs(): void {
+    $log = $this->getLogsForAction()[0];
+    expect($log->getArgs())->count(2);
+    expect(array_keys($log->getArgs()))->equals(['workflow_run_id', 'step_id']);
+  }
+
+  public function _after() {
+    global $wpdb;
+    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_run_logs';
+    $wpdb->query($sql);
+    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflows';
+    $wpdb->query($sql);
+    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_versions';
+    $wpdb->query($sql);
+    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_runs';
+    $wpdb->query($sql);
+  }
+
+  private function getLogsForAction($callback = null) {
+    $testAction = $this->getRegisteredTestAction($callback);
+    $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey());
+    $workflow = new Workflow('test_workflow', [$actionStep], new \WP_User());
+    $workflowId = $this->workflowStorage->createWorkflow($workflow);
+    // Reload to get additional data post-save
+    $workflow = $this->workflowStorage->getWorkflow($workflowId);
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $workflowRun = new WorkflowRun($workflowId, $workflow->getVersionId(), 'trigger-key', []);
+    $workflowRunId = $this->workflowRunStorage->createWorkflowRun($workflowRun);
+    try {
+      $this->stepHandler->handle([
+        'workflow_run_id' => $workflowRunId,
+        'step_id' => 'action-step-id'
+      ]);
+    } catch (\Exception $e) {
+      // allow exceptions so we can test failure states
+    }
+
+    return $this->workflowRunLogStorage->getLogsForWorkflowRun($workflowRunId);
+  }
+
+  private function getRegisteredTestAction($callback = null) {
+    if ($callback === null) {
+      $callback = function() { return true; };
+    }
+    $action = new TestAction();
+    $action->setCallback($callback);
+    $this->registry->addAction($action);
+
+    return $action;
+  }
+}
+
+class TestAction implements Action {
+
+  private $callback;
+  private $key;
+
+  public function __construct() {
+    $this->key = Security::generateRandomString(10);
+  }
+
+  public function setCallback($callback) {
+    $this->callback = $callback;
+  }
+
+  public function isValid(array $subjects, Step $step, Workflow $workflow): bool {
+    return true;
+  }
+
+  public function run(Workflow $workflow, WorkflowRun $workflowRun, Step $step): void {
+    if ($this->callback) {
+      ($this->callback)($workflow, $workflowRun, $step);
+    }
+  }
+
+  public function getKey(): string {
+    return $this->key;
+  }
+
+  public function getName(): string {
+    return 'Test Action';
+  }
+
+  public function getArgsSchema(): ObjectSchema {
+    return Builder::object();
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -58,6 +58,16 @@ class WorkflowRunLogTest extends \MailPoetTest {
     $this->assertSame('value', $data['key']);
   }
 
+  public function testItDoesNotAllowSettingDataThatCannotBeSaved(): void {
+    $log = new WorkflowRunLog(1, 'step-id', []);
+    $badData = [
+      function() { echo 'closures cannot be serialized'; }
+    ];
+    $this->expectException(\InvalidArgumentException::class);
+    $log->setData('badData', $badData);
+    expect($log->getData())->count(0);
+  }
+
   public function testItGetsExposedViaAction(): void {
     $this->wp->addAction(Hooks::WORKFLOW_RUN_LOG_AFTER_STEP_RUN, function(WorkflowRunLog $log) {
       $log->setData('test', 'value');

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -50,7 +50,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
   }
 
   public function testItAllowsSettingData(): void {
-    $log = new WorkflowRunLog(1, 'step-id', []);
+    $log = new WorkflowRunLog(1, 'step-id');
     $this->assertSame([], $log->getData());
     $log->setData('key', 'value');
     $data = $log->getData();
@@ -59,7 +59,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
   }
 
   public function testItDoesNotAllowSettingDataThatCannotBeSaved(): void {
-    $log = new WorkflowRunLog(1, 'step-id', []);
+    $log = new WorkflowRunLog(1, 'step-id');
     $badData = [
       function() { echo 'closures cannot be serialized'; }
     ];
@@ -155,12 +155,6 @@ class WorkflowRunLogTest extends \MailPoetTest {
     expect($error['errorClass'])->equals('Exception');
     expect($error['trace'])->array();
     expect(count($error['trace']))->greaterThan(0);
-  }
-
-  public function testItLogsStepArgs(): void {
-    $log = $this->getLogsForAction()[0];
-    expect($log->getArgs())->count(2);
-    expect(array_keys($log->getArgs()))->equals(['workflow_run_id', 'step_id']);
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -115,6 +115,15 @@ class WorkflowRunLogTest extends \MailPoetTest {
     expect($log->getCompletedAt())->isInstanceOf(\DateTimeImmutable::class);
   }
 
+  public function testItAddsCompletedAtTimestampAfterFailing(): void {
+    $workflowRunLogs = $this->getLogsForAction(function() {
+      throw new \Exception('error');
+    });
+    expect($workflowRunLogs)->count(1);
+    $log = $workflowRunLogs[0];
+    expect($log->getCompletedAt())->isInstanceOf(\DateTimeImmutable::class);
+  }
+
   public function testItLogsFailedStatusCorrectly(): void {
     $workflowRunLogs = $this->getLogsForAction(function() {
       throw new \Exception('error');
@@ -122,15 +131,6 @@ class WorkflowRunLogTest extends \MailPoetTest {
     expect($workflowRunLogs)->count(1);
     $log = $workflowRunLogs[0];
     expect($log->getStatus())->equals('failed');
-  }
-
-  public function testItDoesNotHaveCompletedAtIfItFailsToRun(): void {
-    $workflowRunLogs = $this->getLogsForAction(function() {
-      throw new \Exception('error');
-    });
-    expect($workflowRunLogs)->count(1);
-    $log = $workflowRunLogs[0];
-    expect($log->getCompletedAt())->null();
   }
 
   public function testItIncludesErrorOnFailure(): void {

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -143,7 +143,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
     $error = $log->getErrors()[0];
     expect($error['message'])->equals('error');
     expect($error['code'])->equals(12345);
-    expect($error['exceptionClass'])->equals('Exception');
+    expect($error['errorClass'])->equals('Exception');
     expect($error['trace'])->array();
     expect(count($error['trace']))->greaterThan(0);
   }

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -90,7 +90,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
 
   public function testItStoresWorkflowRunAndStepIdsCorrectly() {
     $testAction = $this->getRegisteredTestAction();
-    $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey());
+    $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey(), [], []);
     $workflow = new Workflow('test_workflow', [$actionStep], new \WP_User());
     $workflowId = $this->workflowStorage->createWorkflow($workflow);
     // Reload to get additional data post-save
@@ -174,7 +174,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
       $callback = function() { return true; };
     }
     $testAction = $this->getRegisteredTestAction($callback);
-    $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey());
+    $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey(), [], []);
     $workflow = new Workflow('test_workflow', [$actionStep], new \WP_User());
     $workflowId = $this->workflowStorage->createWorkflow($workflow);
     // Reload to get additional data post-save

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -139,8 +139,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
     });
     expect($workflowRunLogs)->count(1);
     $log = $workflowRunLogs[0];
-    expect($log->getErrors())->count(1);
-    $error = $log->getErrors()[0];
+    $error = $log->getError();
     expect($error['message'])->equals('error');
     expect($error['code'])->equals(12345);
     expect($error['errorClass'])->equals('Exception');

--- a/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
@@ -15,7 +15,7 @@ class WorkflowRunLogStorageTest extends \MailPoetTest {
   }
 
   public function testItSavesAndRetrievesAsExpected() {
-    $log = new WorkflowRunLog(1, 'step-id', []);
+    $log = new WorkflowRunLog(1, 'step-id');
     $log->setData('key', 'value');
     $log->setData('key2', ['arrayData']);
     $preSave = $log->toArray();
@@ -26,7 +26,7 @@ class WorkflowRunLogStorageTest extends \MailPoetTest {
   }
 
   public function testItCanStoreAnError() {
-    $log = new WorkflowRunLog(1, 'step-id', []);
+    $log = new WorkflowRunLog(1, 'step-id');
     $log->setError(new \Exception('test'));
     $id = $this->storage->createWorkflowRunLog($log);
     $log = $this->storage->getWorkflowRunLog($id);

--- a/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
@@ -25,24 +25,6 @@ class WorkflowRunLogStorageTest extends \MailPoetTest {
     expect($preSave)->equals($fromDatabase->toArray());
   }
 
-  public function testUpdatingLogUpdatesUpdatedAtTimestamp() {
-    $log = new WorkflowRunLog(1, 'step-id', []);
-    $reflectionClass = new \ReflectionClass(WorkflowRunLog::class);
-    $updatedAt = $reflectionClass->getProperty('updatedAt');
-    $updatedAt->setAccessible(true);
-    $updatedAt->setValue($log, new \DateTimeImmutable('2022-09-07'));
-    $id = $this->storage->createWorkflowRunLog($log);
-    $log = $this->storage->getWorkflowRunLog($id);
-    $this->assertInstanceOf(WorkflowRunLog::class, $log);
-    $originalUpdatedAt = $log->getUpdatedAt();
-    $log->setData('key', 'value');
-    $this->assertInstanceOf(WorkflowRunLog::class, $log);
-    $this->storage->updateWorkflowRunLog($log);
-    $fromDatabase = $this->storage->getWorkflowRunLog($id);
-    $this->assertInstanceOf(WorkflowRunLog::class, $fromDatabase);
-    expect($fromDatabase->getUpdatedAt())->greaterThan($originalUpdatedAt);
-  }
-
   public function testItStoresErrors() {
     $log = new WorkflowRunLog(1, 'step-id', []);
     $log->addError(new \Exception('test'));

--- a/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MailPoet\Test\Automation\Engine\Storage;
+
+use MailPoet\Automation\Engine\Data\WorkflowRunLog;
+use MailPoet\Automation\Engine\Storage\WorkflowRunLogStorage;
+
+class WorkflowRunLogStorageTest extends \MailPoetTest {
+
+  /** @var WorkflowRunLogStorage */
+  private $storage;
+
+  public function _before() {
+    $this->storage = $this->diContainer->get(WorkflowRunLogStorage::class);
+  }
+
+  public function testItSavesAndRetrievesAsExpected() {
+    $log = new WorkflowRunLog(1, 'step-id', []);
+    $log->setData('key', 'value');
+    $log->setData('key2', ['arrayData']);
+    $preSave = $log->toArray();
+    $id = $this->storage->createWorkflowRunLog($log);
+    $fromDatabase = $this->storage->getWorkflowRunLog($id);
+    $this->assertInstanceOf(WorkflowRunLog::class, $fromDatabase);
+    expect($preSave)->equals($fromDatabase->toArray());
+  }
+
+  public function testUpdatingLogUpdatesUpdatedAtTimestamp() {
+    $log = new WorkflowRunLog(1, 'step-id', []);
+    $reflectionClass = new \ReflectionClass(WorkflowRunLog::class);
+    $updatedAt = $reflectionClass->getProperty('updatedAt');
+    $updatedAt->setAccessible(true);
+    $updatedAt->setValue($log, new \DateTimeImmutable('2022-09-07'));
+    $id = $this->storage->createWorkflowRunLog($log);
+    $log = $this->storage->getWorkflowRunLog($id);
+    $this->assertInstanceOf(WorkflowRunLog::class, $log);
+    $originalUpdatedAt = $log->getUpdatedAt();
+    $log->setData('key', 'value');
+    $this->assertInstanceOf(WorkflowRunLog::class, $log);
+    $this->storage->updateWorkflowRunLog($log);
+    $fromDatabase = $this->storage->getWorkflowRunLog($id);
+    $this->assertInstanceOf(WorkflowRunLog::class, $fromDatabase);
+    expect($fromDatabase->getUpdatedAt())->greaterThan($originalUpdatedAt);
+  }
+
+  public function testItStoresErrors() {
+    $log = new WorkflowRunLog(1, 'step-id', []);
+    $log->addError(new \Exception('test'));
+    $id = $this->storage->createWorkflowRunLog($log);
+    $log = $this->storage->getWorkflowRunLog($id);
+    $this->assertInstanceOf(WorkflowRunLog::class, $log);
+    $errors = $log->getErrors();
+    expect($errors)->count(1);
+  }
+
+  public function _after() {
+    global $wpdb;
+    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_run_logs';
+    $wpdb->query($sql);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/WorkflowRunLogStorageTest.php
@@ -25,14 +25,22 @@ class WorkflowRunLogStorageTest extends \MailPoetTest {
     expect($preSave)->equals($fromDatabase->toArray());
   }
 
-  public function testItStoresErrors() {
+  public function testItCanStoreAnError() {
     $log = new WorkflowRunLog(1, 'step-id', []);
-    $log->addError(new \Exception('test'));
+    $log->setError(new \Exception('test'));
     $id = $this->storage->createWorkflowRunLog($log);
     $log = $this->storage->getWorkflowRunLog($id);
     $this->assertInstanceOf(WorkflowRunLog::class, $log);
-    $errors = $log->getErrors();
-    expect($errors)->count(1);
+    $errors = $log->getError();
+    expect($errors)->array();
+    expect(array_keys($errors))->equals([
+      'message',
+      'errorClass',
+      'code',
+      'trace'
+    ]);
+    expect($errors['trace'])->array();
+    expect(count($errors['trace']))->greaterThan(0);
   }
 
   public function _after() {


### PR DESCRIPTION
## Description

Adds a new type of automation record, workflow run logs, that store data about individual steps that have been run.

## Code review notes

Automation DB schema must be reset in order to get the new table.

This can be merged right after review, skipping QA step.

## QA notes

QA step can be skipped.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

Automation devs, reset your automation DB schema.

[MAILPOET-4463]: https://mailpoet.atlassian.net/browse/MAILPOET-4463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ