### PR TITLE
Fix logic to decide which PHPStan baseline file to use [MAILPOET-4626]

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -9,17 +9,6 @@ parameters:
 			count: 1
 			path: ../../lib/Automation/Engine/Endpoints/Workflows/WorkflowTemplatesGetEndpoint.php
 
-
-		-
-			message: "#^Cannot cast string|void to string\\.$#"
-			count: 2
-			path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
-
-		-
-			message: "#^Cannot cast string|void to string\\.$#"
-			count: 3
-			path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
-
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"
 			count: 1
@@ -389,11 +378,6 @@ parameters:
 			message: "#^Method MailPoet\\\\Listing\\\\ListingRepository\\:\\:getData\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Listing/ListingRepository.php
-
-		-
-			message: "#^Variable \\$mailer in empty\\(\\) is never defined\\.$#"
-			count: 1
-			path: ../../lib/Mailer/MailerLog.php
 
 		-
 			message: "#^Method MailPoet\\\\Models\\\\DynamicSegmentFilter\\:\\:__get\\(\\) should return string\\|null but returns mixed\\.$#"
@@ -872,16 +856,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot access offset 'status' on mixed\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot access offset 'subscribersCount' on mixed\\.$#"
 			count: 1
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
@@ -898,11 +872,6 @@ parameters:
 		-
 			message: "#^Cannot call method isStatic\\(\\) on mixed\\.$#"
 			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 3
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
 		-

--- a/mailpoet/tasks/phpstan/phpstan-baseline-fix-lib.php
+++ b/mailpoet/tasks/phpstan/phpstan-baseline-fix-lib.php
@@ -9,12 +9,12 @@ $config['parameters']['phpVersion'] = $phpVersion;
 # PHPStan will throw violations only in new and changed code.
 # read more here: https://phpstan.org/user-guide/baseline
 # we need to load different baseline file based on the php version
-if ($phpVersion == 80100) {
-  $config['includes'][] = 'phpstan-8.1-baseline.neon';
-} elseif ($phpVersion == 70100 || $phpVersion < 80000) {
+if ($phpVersion >= 70100 && $phpVersion < 80000) {
   $config['includes'][] = 'phpstan-7-baseline.neon';
-} else {
+} elseif ($phpVersion >= 80000 && $phpVersion < 80100) {
   $config['includes'][] = 'phpstan-8-baseline.neon';
+} else {
+  $config['includes'][] = 'phpstan-8.1-baseline.neon';
 }
 
 return $config;


### PR DESCRIPTION
This PR fixes a bug in the logic to decide which PHPStan baseline file to use that it was making the baseline file for PHP 8.1 not be used for PHP versions >= PHP 8.1.1. It also removes a few unmatched ignored errors from phpstan-8.1-baseline.neon that were uncovered when fixing the baseline load problem. See commit messages for more details on the changes.

I'm unsure if this PR needs to pass QA. I'm inclined to think it doesn't, but I will leave it for the reviewer to decide.

@triple0t I know you are on L2 support this week. So it is ok if you prefer to leave this review for next week. I chose you since you worked on this previously and I want to make sure I'm not missing something.

[MAILPOET-4626]

[MAILPOET-4626]: https://mailpoet.atlassian.net/browse/MAILPOET-4626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ