### PR TITLE
Add method to detect if WooCommerce Custom Order Tables is enabled [MAILPOET-4567]

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -20,6 +20,18 @@ class Helper {
     return true;
   }
 
+  public function isWooCommerceCustomOrdersTableEnabled(): bool {
+    if (
+      $this->isWooCommerceActive()
+      && method_exists('\Automattic\WooCommerce\Utilities\OrderUtil', 'custom_orders_table_usage_is_enabled')
+      && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled()
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   public function WC() {
     return WC();
   }

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -52,6 +52,14 @@ parameters:
       message: "#^Cannot cast string|void to string\\.$#"
       count: 5
       path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
+    -
+      message: '/^Call to static method custom_orders_table_usage_is_enabled\(\) on an unknown class Automattic\\WooCommerce\\Utilities\\OrderUtil\.$/'
+      count: 1
+      path: ../../lib/WooCommerce/Helper.php
+    -
+      message: '/^Call to function method_exists\(\) with/'
+      count: 1
+      path: ../../lib/WooCommerce/Helper.php
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED


### PR DESCRIPTION
I think it is not necessary to send this PR to QA but I will leave this decision to the reviewer.

To test the code, I called it from one of the integration tests and played with the environment of the test by enabling and disabling WooCommerce Custom Order Tables via the web interface.

[MAILPOET-4567]

[MAILPOET-4567]: https://mailpoet.atlassian.net/browse/MAILPOET-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ