### PR TITLE
Improvements to Send Email step UI [MAILPOET-4622]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_panel.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_panel.scss
@@ -1,3 +1,7 @@
+.mailpoet-automation-sidebar {
+  padding-bottom: 100px;
+}
+
 .components-panel__body-title.mailpoet-automation-panel-plain-body-title {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
+++ b/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
@@ -1,3 +1,9 @@
 .mailpoet-automation-email-content-separator {
   height: 16px;
 }
+
+.mailpoet-automation-email-buttons {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+}

--- a/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_thumbnail.scss
+++ b/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_thumbnail.scss
@@ -27,9 +27,3 @@
   margin: auto;
   max-width: 192px;
 }
-
-.mailpoet-automation-thumbnail-buttons {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: 1fr 1fr;
-}

--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/index.tsx
@@ -51,7 +51,7 @@ export function Sidebar(props: Props): JSX.Element {
       headerClassName="edit-site-sidebar__panel-tabs"
       title={__('Settings')}
       icon={cog}
-      className="edit-site-sidebar"
+      className="edit-site-sidebar mailpoet-automation-sidebar"
       panelClassName="edit-site-sidebar"
       smallScreenTitle={workflowName || __('(no title)')}
       scope={storeName}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
@@ -95,7 +95,7 @@ export function EmailPanel(): JSX.Element {
       />
 
       <div className="mailpoet-automation-email-content-separator" />
-      <PlainBodyTitle title="Email content" />
+      <PlainBodyTitle title="Email" />
       {selectedStep.args.email_id ? (
         <div className="mailpoet-automation-email-buttons">
           <Button

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react';
 import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { DesignEmailButton } from './design_email_button';
-import { Thumbnail } from './thumbnail';
+import { Button } from '../../../components/button';
 import { PlainBodyTitle } from '../../../../../editor/components/panel';
 import { storeName } from '../../../../../editor/store';
 import { StepName } from '../../../../../editor/components/panel/step-name';
@@ -97,7 +97,20 @@ export function EmailPanel(): JSX.Element {
       <div className="mailpoet-automation-email-content-separator" />
       <PlainBodyTitle title="Email content" />
       {selectedStep.args.email_id ? (
-        <Thumbnail emailId={selectedStep.args.email_id as number} />
+        <div className="mailpoet-automation-email-buttons">
+          <Button
+            variant="sidebar-primary"
+            centered
+            href={`?page=mailpoet-newsletter-editor&id=${
+              selectedStep.args.email_id as string
+            }`}
+          >
+            Edit content
+          </Button>
+          <Button variant="secondary" centered>
+            Preview
+          </Button>
+        </div>
       ) : (
         <DesignEmailButton />
       )}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from 'react';
 import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { DesignEmailButton } from './design_email_button';
+import { ShortcodeHelpText } from './shortcode_help_text';
 import { Button } from '../../../components/button';
 import { PlainBodyTitle } from '../../../../../editor/components/panel';
 import { storeName } from '../../../../../editor/store';
@@ -80,6 +81,7 @@ export function EmailPanel(): JSX.Element {
         onChange={(value) =>
           dispatch(storeName).updateStepArgs(selectedStep.id, 'subject', value)
         }
+        help={<ShortcodeHelpText />}
       />
       <SingleLineTextareaControl
         label="Preheader"
@@ -92,6 +94,7 @@ export function EmailPanel(): JSX.Element {
             value,
           )
         }
+        help={<ShortcodeHelpText />}
       />
 
       <div className="mailpoet-automation-email-content-separator" />

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/shortcode_help_text.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/shortcode_help_text.tsx
@@ -1,0 +1,15 @@
+export function ShortcodeHelpText(): JSX.Element {
+  return (
+    <div className="mailpoet-shortcode-selector">
+      You can use{' '}
+      <a
+        href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-beacon-article="59d662ef042863379ddc6faa"
+      >
+        MailPoet shortcodes
+      </a>
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/thumbnail.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/thumbnail.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps, ComponentType, useEffect, useState } from 'react';
 import { Spinner as WpSpinner } from '@wordpress/components';
-import { Button } from '../../../components/button';
 import { MailPoetAjax } from '../../../../../../ajax';
 
 // @types/wordpress__components don't define "className", which is supported
@@ -34,33 +33,18 @@ export function Thumbnail({ emailId }: Props): JSX.Element {
   }, [emailId]);
 
   return (
-    <>
-      <div className="mailpoet-automation-thumbnail-box">
-        {thumbnailUrl ? (
-          <div className="mailpoet-automation-thumbnail-wrapper">
-            <img
-              className="mailpoet-automation-thumbnail-image"
-              src={thumbnailUrl}
-              alt="Email thumbnail"
-            />
-          </div>
-        ) : (
-          <Spinner className="mailpoet-automation-thumbnail-spinner" />
-        )}
-      </div>
-
-      <div className="mailpoet-automation-thumbnail-buttons">
-        <Button
-          variant="sidebar-primary"
-          centered
-          href={`?page=mailpoet-newsletter-editor&id=${emailId}`}
-        >
-          Edit content
-        </Button>
-        <Button variant="secondary" centered>
-          Preview
-        </Button>
-      </div>
-    </>
+    <div className="mailpoet-automation-thumbnail-box">
+      {thumbnailUrl ? (
+        <div className="mailpoet-automation-thumbnail-wrapper">
+          <img
+            className="mailpoet-automation-thumbnail-image"
+            src={thumbnailUrl}
+            alt="Email thumbnail"
+          />
+        </div>
+      ) : (
+        <Spinner className="mailpoet-automation-thumbnail-spinner" />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Description

This PR makes some UI tweaks to the Send email Step sidebar when editing a workflow.

- Ensures the HelpScout icon doesn't cover any of the content in the lower right hand part of the automation sidebar (this should actually apply to any sidebar content, but right now Send email is probably the only one that generated enough content for this to be an issue for most browser sizes).
- Removes the email preview thumbnail
- Renames the header "Email content" to just "Email"
- Adds help text beneath Subject and Preheader fields informing users they can use MailPoet shortcodes inside those fields
    - If the user has HelpScout integration turned on, the link should open directly in the HelpScout widget thing.

## Code review notes

_N/A_

## QA notes

QA is not necessary since this only affects automations.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_