### PR TITLE
Feat/allow all emails from verified domains to be used for sending - MAILPOET-4601

### DIFF
--- a/mailpoet/assets/js/src/common/functions/extract_email_domain.ts
+++ b/mailpoet/assets/js/src/common/functions/extract_email_domain.ts
@@ -1,5 +1,6 @@
 export const extractEmailDomain = (email: string): string =>
   String(email || '')
+    .trim()
     .split('@')
     .pop()
     .toLowerCase();

--- a/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
@@ -92,14 +92,21 @@ class SenderField extends Component {
     if (!window.mailpoet_mss_active) return;
 
     const emailAddress = this.state.emailAddress;
+
+    const emailDomain = extractEmailDomain(emailAddress);
+
+    if (window.mailpoet_verified_sender_domains.includes(emailDomain)) {
+      // allow user send with any email address from verified domains
+      return;
+    }
+
     const emailAddressIsAuthorized =
       this.isEmailAddressAuthorized(emailAddress);
 
     this.showSenderFieldError(emailAddressIsAuthorized, emailAddress);
 
     // Skip domain DMARC validation if the email is a freemail
-    const isFreeDomain =
-      MailPoet.freeMailDomains.indexOf(extractEmailDomain(emailAddress)) > -1;
+    const isFreeDomain = MailPoet.freeMailDomains.indexOf(emailDomain) > -1;
     if (isFreeDomain) return;
 
     checkSenderEmailDomainDmarcPolicy(emailAddress)

--- a/mailpoet/lib/API/JSON/v1/Mailer.php
+++ b/mailpoet/lib/API/JSON/v1/Mailer.php
@@ -9,6 +9,7 @@ use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 
@@ -29,6 +30,9 @@ class Mailer extends APIEndpoint {
   /** @var MailerFactory */
   private $mailerFactory;
 
+  /** @var AuthorizedSenderDomainController */
+  private $senderDomainController;
+
   public $permissions = [
     'global' => AccessControl::PERMISSION_MANAGE_EMAILS,
   ];
@@ -38,13 +42,15 @@ class Mailer extends APIEndpoint {
     SettingsController $settings,
     Bridge $bridge,
     MailerFactory $mailerFactory,
-    MetaInfo $mailerMetaInfo
+    MetaInfo $mailerMetaInfo,
+    AuthorizedSenderDomainController $senderDomainController
   ) {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->settings = $settings;
     $this->bridge = $bridge;
     $this->mailerFactory = $mailerFactory;
     $this->mailerMetaInfo = $mailerMetaInfo;
+    $this->senderDomainController = $senderDomainController;
   }
 
   public function send($data = []) {
@@ -88,5 +94,10 @@ class Mailer extends APIEndpoint {
   public function getAuthorizedEmailAddresses() {
     $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses();
     return $this->successResponse($authorizedEmails);
+  }
+
+  public function getVerifiedSenderDomains() {
+    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomains();
+    return $this->successResponse($verifiedDomains);
   }
 }

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -16,6 +16,7 @@ use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\CongratulatoryMssEmailController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
 use MailPoet\WP\DateTime;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -245,8 +246,7 @@ class Services extends APIEndpoint {
 
     $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
 
-    $arrayOfItems = explode('@', trim($fromEmail));
-    $emailDomain = strtolower(array_pop($arrayOfItems));
+    $emailDomain = Helpers::extractEmailDomain($fromEmail);
 
     if (!$this->isItemInArray($emailDomain, $verifiedDomains)) {
       $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses();

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -51,7 +51,7 @@ class AuthorizedEmailsController {
 
   public function setFromEmailAddress(string $address) {
     $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses() ?: [];
-    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomains(true);
+    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
     $isAuthorized = $this->validateAuthorizedEmail($authorizedEmails, $address);
 
     $emailDomainIsVerified = $this->validateEmailDomainIsVerified($verifiedDomains, $address);
@@ -122,7 +122,7 @@ class AuthorizedEmailsController {
     }
     $authorizedEmails = array_map('strtolower', $authorizedEmails);
 
-    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomains(true);
+    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
 
     $result = [];
     $result = $this->validateAddressesInSettings($authorizedEmails, $verifiedDomains, $result);
@@ -213,7 +213,7 @@ class AuthorizedEmailsController {
     return in_array(strtolower($email), $lowercaseAuthorizedEmails, true);
   }
 
-  private function validateEmailDomainIsVerified($verifiedDomains = [], $email = ''): bool {
+  private function validateEmailDomainIsVerified(array $verifiedDomains = [], string $email = ''): bool {
     $lowercaseVerifiedDomains = array_map('strtolower', $verifiedDomains);
     $arrayOfItems = explode('@', $email);
     $emailDomain = array_pop($arrayOfItems);

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -9,6 +9,7 @@ use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
 
 class AuthorizedEmailsController {
   const AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING = 'authorized_emails_addresses_check';
@@ -215,8 +216,7 @@ class AuthorizedEmailsController {
 
   private function validateEmailDomainIsVerified(array $verifiedDomains = [], string $email = ''): bool {
     $lowercaseVerifiedDomains = array_map('strtolower', $verifiedDomains);
-    $arrayOfItems = explode('@', $email);
-    $emailDomain = array_pop($arrayOfItems);
-    return in_array(strtolower($emailDomain), $lowercaseVerifiedDomains, true);
+    $emailDomain = Helpers::extractEmailDomain($email);
+    return in_array($emailDomain, $lowercaseVerifiedDomains, true);
   }
 }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -46,21 +46,25 @@ class AuthorizedSenderDomainController {
    *
    * Note: This includes both verified and unverified domains
    */
-  public function getAllSenderDomains(bool $skipCache = false): array {
-    if ($skipCache) {
-      $this->currentRecords = null;
-    }
+  public function getAllSenderDomains(): array {
     return $this->returnAllDomains($this->getAllRecords());
+  }
+
+  public function getAllSenderDomainsIgnoringCache(): array {
+    $this->currentRecords = null;
+    return $this->getAllSenderDomains();
   }
 
   /**
    * Get all Verified Sender Domains
    */
-  public function getVerifiedSenderDomains(bool $skipCache = false): array {
-    if ($skipCache) {
-      $this->currentRecords = null;
-    }
+  public function getVerifiedSenderDomains(): array {
     return $this->returnVerifiedDomains($this->getAllRecords());
+  }
+
+  public function getVerifiedSenderDomainsIgnoringCache(): array {
+    $this->currentRecords = null;
+    return $this->getVerifiedSenderDomains();
   }
 
   /**

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -46,14 +46,20 @@ class AuthorizedSenderDomainController {
    *
    * Note: This includes both verified and unverified domains
    */
-  public function getAllSenderDomains(): array {
+  public function getAllSenderDomains(bool $skipCache = false): array {
+    if ($skipCache) {
+      $this->currentRecords = null;
+    }
     return $this->returnAllDomains($this->getAllRecords());
   }
 
   /**
    * Get all Verified Sender Domains
    */
-  public function getVerifiedSenderDomains(): array {
+  public function getVerifiedSenderDomains(bool $skipCache = false): array {
+    if ($skipCache) {
+      $this->currentRecords = null;
+    }
     return $this->returnVerifiedDomains($this->getAllRecords());
   }
 

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -107,4 +107,9 @@ class Helpers {
   public static function escapeSearch(string $search): string {
     return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], trim($search)); // escape for 'LIKE'
   }
+
+  public static function extractEmailDomain(string $email = ''): string {
+    $arrayOfItems = explode('@', trim($email));
+    return strtolower(array_pop($arrayOfItems));
+  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
@@ -9,6 +9,7 @@ use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 
@@ -22,9 +23,10 @@ class MailerTest extends \MailPoetTest {
     expect($mailerLog['status'])->equals(MailerLog::STATUS_PAUSED);
     $settings = SettingsController::getInstance();
     $authorizedEmailsController = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::never()]);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     // resumeSending() method should clear the mailer log's status
     $bridge = new Bridge($settings);
-    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $bridge, $this->diContainer->get(MailerFactory::class), new MetaInfo);
+    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $bridge, $this->diContainer->get(MailerFactory::class), new MetaInfo, $senderDomainController);
     $response = $mailerEndpoint->resumeSending();
     expect($response->status)->equals(APIResponse::STATUS_OK);
     $mailerLog = MailerLog::getMailerLog();
@@ -35,8 +37,9 @@ class MailerTest extends \MailPoetTest {
     $settings = SettingsController::getInstance();
     $settings->set(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, ['invalid_sender_address' => 'a@b.c']);
     $authorizedEmailsController = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::once()]);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $bridge = new Bridge($settings);
-    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $bridge, $this->diContainer->get(MailerFactory::class), new MetaInfo);
+    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $bridge, $this->diContainer->get(MailerFactory::class), new MetaInfo, $senderDomainController);
     $mailerEndpoint->resumeSending();
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -479,6 +479,7 @@ class ServicesTest extends \MailPoetTest {
 
   public function testCongratulatoryEmailRespondsWithErrorWhenNoEmailAuthorized() {
     $this->settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, ['method' => Mailer::METHOD_MAILPOET]);
+    $this->settings->set('sender.address', 'unauthorized@email.com');
     $bridge = $this->make(Bridge::class, [
       'getAuthorizedEmailAddresses' => [],
     ]);
@@ -497,7 +498,7 @@ class ServicesTest extends \MailPoetTest {
 
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
-      'getVerifiedSenderDomains' => Expected::once($verifiedDomains),
+      'getVerifiedSenderDomainsIgnoringCache' => $verifiedDomains,
     ]);
 
     $servicesEndpoint = $this->createServicesEndpointWithMocks([

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -12,6 +12,7 @@ use MailPoet\Cron\Workers\KeyCheck\PremiumKeyCheck;
 use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\CongratulatoryMssEmailController;
 use MailPoet\Settings\SettingsController;
@@ -549,7 +550,8 @@ class ServicesTest extends \MailPoetTest {
       $this->diContainer->get(PremiumKeyCheck::class),
       $this->diContainer->get(ServicesChecker::class),
       $mocks['congratulatoryEmailController'] ?? $this->diContainer->get(CongratulatoryMssEmailController::class),
-      $this->diContainer->get(WPFunctions::class)
+      $this->diContainer->get(WPFunctions::class),
+      $this->diContainer->get(AuthorizedSenderDomainController::class)
     );
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -129,10 +129,11 @@ class SettingsTest extends \MailPoetTest {
 
   public function testItSetsAuthorizedFromAddressAndResumesSending() {
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized@email.com'])]);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $this->endpoint = new Settings(
       $this->settings,
       $bridgeMock,
-      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class)),
+      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
       WPFunctions::get(),
@@ -159,10 +160,11 @@ class SettingsTest extends \MailPoetTest {
   public function testItSaveUnauthorizedAddressAndReturnsMeta() {
     $this->settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, ['method' => Mailer::METHOD_MAILPOET]);
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized@email.com'])]);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $this->endpoint = new Settings(
       $this->settings,
       $bridgeMock,
-      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class)),
+      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
       WPFunctions::get(),
@@ -191,10 +193,11 @@ class SettingsTest extends \MailPoetTest {
 
   public function testItRejectsUnauthorizedFromAddress() {
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized@email.com'])]);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $this->endpoint = new Settings(
       $this->settings,
       $bridgeMock,
-      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class)),
+      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
       WPFunctions::get(),

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -11,6 +11,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
@@ -267,7 +268,8 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       'createAuthorizedEmailAddress' => Expected::once($response)
     ]);
     $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+    $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
     $result = $controller->createAuthorizedEmailAddress('new-authorized@email.com');
     expect($result)->equals($response);
   }
@@ -282,7 +284,8 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       'createAuthorizedEmailAddress' => Expected::once(['error' => $errorMessage])
     ]);
     $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+    $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
     $controller->createAuthorizedEmailAddress('new-authorized@email.com');
   }
 
@@ -324,7 +327,9 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     }
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => $getEmailsExpectaton]);
     $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    return new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository);
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+
+    return new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -78,7 +78,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
 
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
-      'getVerifiedSenderDomains' => Expected::once($verifiedDomains),
+      'getVerifiedSenderDomainsIgnoringCache' => Expected::once($verifiedDomains),
     ]);
 
     $mocks = [
@@ -150,7 +150,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
 
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
-      'getVerifiedSenderDomains' => Expected::once($verifiedDomains),
+      'getVerifiedSenderDomainsIgnoringCache' => Expected::once($verifiedDomains),
     ]);
 
     $mocks = [
@@ -227,7 +227,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
 
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
-      'getVerifiedSenderDomains' => Expected::once($verifiedDomains),
+      'getVerifiedSenderDomainsIgnoringCache' => Expected::once($verifiedDomains),
     ]);
 
     $mocks = [

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -267,9 +267,10 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       'getAuthorizedEmailAddresses' => Expected::once($array),
       'createAuthorizedEmailAddress' => Expected::once($response)
     ]);
-    $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
-    $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
+    $mocks = [
+      'Bridge' => $bridgeMock
+    ];
+    $controller = $this->getControllerWithCustomMocks($mocks);
     $result = $controller->createAuthorizedEmailAddress('new-authorized@email.com');
     expect($result)->equals($response);
   }
@@ -283,9 +284,10 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       'getAuthorizedEmailAddresses' => Expected::once([]),
       'createAuthorizedEmailAddress' => Expected::once(['error' => $errorMessage])
     ]);
-    $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
-    $controller = new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
+    $mocks = [
+      'Bridge' => $bridgeMock
+    ];
+    $controller = $this->getControllerWithCustomMocks($mocks);
     $controller->createAuthorizedEmailAddress('new-authorized@email.com');
   }
 
@@ -326,8 +328,17 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       $getEmailsExpectaton = Expected::once($authorizedEmails);
     }
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => $getEmailsExpectaton]);
-    $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
-    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+
+    $mocks = [
+      'Bridge' => $bridgeMock
+    ];
+    return $this->getControllerWithCustomMocks($mocks);
+  }
+
+  private function getControllerWithCustomMocks($data = []) {
+    $bridgeMock = $data['Bridge'] ?? $this->diContainer->get(Bridge::class);
+    $newslettersRepository = $data['NewslettersRepository'] ?? $this->diContainer->get(NewslettersRepository::class);
+    $senderDomainController = $data['AuthorizedSenderDomainController'] ?? $this->diContainer->get(AuthorizedSenderDomainController::class);
 
     return new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
   }


### PR DESCRIPTION
## Description

In this PR, we made an update to our sending process.

Now, plugin users can send a Newsletter campaign from any email address of their verified domain.


## QA notes

Veljko to Alex notes:
2 domains are already authorized for testing on our test sites: `qawp.net` and `moonbridge.rs`
If you test positive scenario in this pr, you should use any email associated with above 2 domains, no errors/problems with sending etc.
If you test negative scenario in this pr, you should use any other email address not associated with above 2 domains. You should see warnings/errors in the settings page if you try to apply it for Default Sender's From field and/or on the last page when creating and sending newsletter (there's also From field there).


## Linked tickets

[MAILPOET-4601](https://mailpoet.atlassian.net/browse/MAILPOET-4601)


