### PR TITLE
Replace custom queries with native WooCommerce functions - part 1 [MAILPOET-4570]

### DIFF
--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -148,7 +148,7 @@ class WooCommerce {
       $status = SubscriberEntity::STATUS_SUBSCRIBED;
     }
 
-    $email = $this->insertSubscriberFromOrder($orderId, $status);
+    $email = $this->insertSubscriberFromOrder($wcOrder, $status);
 
     if (empty($email)) {
       return;
@@ -240,17 +240,10 @@ class WooCommerce {
     ", ['capabilities' => $wpdb->prefix . 'capabilities', 'source' => Source::WOOCOMMERCE_USER]);
   }
 
-  private function insertSubscriberFromOrder(int $orderId, string $status): ?string {
-    global $wpdb;
+  private function insertSubscriberFromOrder(\WC_Order $wcOrder, string $status): ?string {
     $validator = new ModelValidator();
 
-    $email = $this->connection->executeQuery("
-      SELECT wppm.meta_value AS email
-      FROM `{$wpdb->posts}` wpp
-      JOIN `{$wpdb->postmeta}` wppm ON wpp.ID = wppm.post_id AND wppm.meta_key = '_billing_email' AND wppm.meta_value != ''
-      WHERE wpp.post_type = 'shop_order'
-      AND wpp.ID = :orderId
-    ", ['orderId' => $orderId])->fetchOne();
+    $email = $wcOrder->get_billing_email();
 
     if (!$email || !$validator->validateEmail($email)) {
       return null;

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -261,11 +261,6 @@ parameters:
 			path: ../../lib/Cron/Workers/SubscribersLastEngagement.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: ../../lib/Cron/Workers/WooCommerceSync.php
-
-		-
 			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 1
 			path: ../../lib/DI/ContainerConfigurator.php

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -781,11 +781,6 @@ parameters:
 			path: ../../lib/Segments/WooCommerce.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\WooCommerce\\:\\:insertSubscriberFromOrder\\(\\) should return string\\|null but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/WooCommerce.php
-
-		-
 			message: "#^Parameter \\#1 \\$ch of function curl_errno expects resource, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Services/Bridge/API.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -261,11 +261,6 @@ parameters:
 			path: ../../lib/Cron/Workers/SubscribersLastEngagement.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: ../../lib/Cron/Workers/WooCommerceSync.php
-
-		-
 			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 1
 			path: ../../lib/DI/ContainerConfigurator.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -781,11 +781,6 @@ parameters:
 			path: ../../lib/Segments/WooCommerce.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\WooCommerce\\:\\:insertSubscriberFromOrder\\(\\) should return string\\|null but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/WooCommerce.php
-
-		-
 			message: "#^Parameter \\#1 \\$handle of function curl_errno expects CurlHandle, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Services/Bridge/API.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -260,11 +260,6 @@ parameters:
 			path: ../../lib/Cron/Workers/SubscribersLastEngagement.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: ../../lib/Cron/Workers/WooCommerceSync.php
-
-		-
 			message: "#^Cannot call method get\\(\\) on mixed\\.$#"
 			count: 1
 			path: ../../lib/DI/ContainerConfigurator.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -780,11 +780,6 @@ parameters:
 			path: ../../lib/Segments/WooCommerce.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\WooCommerce\\:\\:insertSubscriberFromOrder\\(\\) should return string\\|null but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/WooCommerce.php
-
-		-
 			message: "#^Parameter \\#1 \\$handle of function curl_errno expects CurlHandle, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Services/Bridge/API.php

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -9,7 +9,6 @@ use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\Connection;
 
 /**
  * @group woo
@@ -18,16 +17,14 @@ class WooCommerceSyncTest extends \MailPoetTest {
   public $worker;
   public $woocommerceHelper;
   public $woocommerceSegment;
-  public $connection;
   /** @var ScheduledTaskFactory */
   private $scheduledTaskFactory;
 
   public function _before() {
     $this->woocommerceSegment = $this->createMock(WooCommerceSegment::class);
     $this->woocommerceHelper = $this->createMock(WooCommerceHelper::class);
-    $this->connection = $this->diContainer->get(Connection::class);
     $this->scheduledTaskFactory = new ScheduledTaskFactory();
-    $this->worker = new WooCommerceSync($this->woocommerceSegment, $this->woocommerceHelper, $this->connection);
+    $this->worker = new WooCommerceSync($this->woocommerceSegment, $this->woocommerceHelper);
   }
 
   public function testItWillNotRunIfWooCommerceIsDisabled() {
@@ -46,7 +43,7 @@ class WooCommerceSyncTest extends \MailPoetTest {
     $this->tester->createWooCommerceOrder();
 
     $woocommerceHelper = $this->diContainer->get(WooCommerceHelper::class);
-    $worker = new WooCommerceSync($this->woocommerceSegment, $woocommerceHelper, $this->connection);
+    $worker = new WooCommerceSync($this->woocommerceSegment, $woocommerceHelper);
     $this->woocommerceSegment->expects($this->once())
       ->method('synchronizeCustomers')
       ->with(0, $this->greaterThan(0), WooCommercesync::BATCH_SIZE)


### PR DESCRIPTION
## Description

This PR replaces two custom queries with native WooCommerce functions in preparation for WooCommerce's move to dedicated tables for orders. The affected methods are \MailPoet\Segments\WooCommerce::insertSubscribers() and \MailPoet\Cron\Workers\WooCommerceSync::getHighestOrderId(). Some related integration tests were also updated to make sure we are running WooCommerce functions instead of mocking them.

In this PR I'm not addressing all the custom queries mentioned in [MAILPOET-4570]. I'm opting to split this ticket into multiple PRs so that it is easier to test and review. More PRs to come.

## Code review notes

_N/A_

## QA notes

- Regarding the change in \MailPoet\Segments\WooCommerce::insertSubscribers(), please test that when MailPoet is configured to create subscribers from WooCommerce orders, a subscriber is created when a guest customer places an order.
- I don't think there is anything to test regarding \MailPoet\Cron\Workers\WooCommerceSync::getHighestOrderId() as it is used only inside a worker.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4570]

## After-merge notes

_N/A_


[MAILPOET-4570]: https://mailpoet.atlassian.net/browse/MAILPOET-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4570]: https://mailpoet.atlassian.net/browse/MAILPOET-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ