### PR TITLE
Replace custom queries with native WooCommerce functions - part 2 [MAILPOET-4570]

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -201,15 +201,18 @@ class FirstPurchase {
     return $this->getGuestCustomerOrderCountByEmail($customerEmail);
   }
 
-  private function getGuestCustomerOrderCountByEmail($customerEmail) {
-    global $wpdb;
-    $count = $wpdb->get_var( $wpdb->prepare("SELECT COUNT(*)
-        FROM $wpdb->posts as posts
-        LEFT JOIN {$wpdb->postmeta} AS meta ON posts.ID = meta.post_id
-        WHERE   meta.meta_key = '_billing_email'
-        AND     posts.post_type = 'shop_order'
-        AND     meta_value = %s
-    ", $customerEmail));
-    return (int)$count;
+  private function getGuestCustomerOrderCountByEmail(string $customerEmail): int {
+    $ordersCount = $this->helper->wcGetOrders(
+      [
+        'status' => 'all',
+        'type' => 'shop_order',
+        'billing_email' => $customerEmail,
+        'limit' => 1,
+        'return' => 'ids',
+        'paginate' => true,
+      ]
+    )->total;
+
+    return $ordersCount;
   }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -80,13 +80,16 @@ class Helper {
     return wc_hex_is_light($color);
   }
 
-  public function getOrdersCountCreatedBefore($dateTime) {
-    global $wpdb;
-    $result = $wpdb->get_var($wpdb->prepare("
-        SELECT DISTINCT count(p.ID) FROM {$wpdb->prefix}posts as p
-        WHERE p.post_type = 'shop_order' AND p.post_date < %s
-    ", $dateTime));
-    return (int)$result;
+  public function getOrdersCountCreatedBefore(string $dateTime): int {
+    $ordersCount = $this->wcGetOrders([
+      'status' => 'all',
+      'type' => 'shop_order',
+      'date_created' => '<' . $dateTime,
+      'limit' => 1,
+      'paginate' => true,
+    ])->total;
+
+    return $ordersCount;
   }
 
   public function getRawPrice($price, array $args = []) {

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -50,9 +50,16 @@ class IntegrationTester extends \Codeception\Actor {
     }
   }
 
-  public function createWooCommerceOrder(): \WC_Order {
+  public function createWooCommerceOrder(array $data = []): \WC_Order {
     $helper = ContainerWrapper::getInstance()->get(Helper::class);
     $order = $helper->wcCreateOrder([]);
+
+    if (isset($data['date_created'])) {
+      $order->set_date_created($data['date_created']);
+    }
+
+    $order->save();
+
     $this->wooOrderIds[] = $order->get_id();
 
     return $order;

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -58,6 +58,10 @@ class IntegrationTester extends \Codeception\Actor {
       $order->set_date_created($data['date_created']);
     }
 
+    if (isset($data['billing_email'])) {
+      $order->set_billing_email($data['billing_email']);
+    }
+
     $order->save();
 
     $this->wooOrderIds[] = $order->get_id();

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -22,6 +22,7 @@ class HelperTest extends \MailPoetTest {
   }
 
   public function _after() {
+    $this->tester->deleteTestWooOrders();
     $this->wp->deleteOption('woocommerce_onboarding_profile');
   }
 
@@ -35,5 +36,13 @@ class HelperTest extends \MailPoetTest {
   public function testGetDataMailPoetInstalledViaWooCommerceOnboardingWizard() {
     $this->wp->updateOption('woocommerce_onboarding_profile', ['business_extensions' => ['jetpack', 'mailchimp', 'mailpoet', 'another_plugin']]);
     $this->assertTrue($this->helper->wasMailPoetInstalledViaWooCommerceOnboardingWizard());
+  }
+
+  public function testGetOrdersCountCreatedBefore() {
+    $this->tester->createWooCommerceOrder(['date_created' => '2022-07-01 00:00:00']);
+    $this->tester->createWooCommerceOrder(['date_created' => '2022-07-31 23:59:59']);
+    $this->tester->createWooCommerceOrder(['date_created' => '2022-08-01 00:00:00']);
+
+    $this->assertSame(2, $this->helper->getOrdersCountCreatedBefore('2022-08-01 00:00:00'));
   }
 }


### PR DESCRIPTION
## Description

This PR replaces two custom queries with native WooCommerce functions in preparation for WooCommerce's move to dedicated tables for orders. The affected methods are \MailPoet\WooCommerce\Helper::getOrdersCountCreatedBefore() and \MailPoet\AutomaticEmails\WooCommerce\Events\FirstPurchase::getGuestCustomerOrderCountByEmail(). The new queries are a little bit worst than the original queries, but I believe they should not cause, and significant impact on the performance of the plugin.

The other custom WooCommerce queries described in MAILPOET-4570](https://mailpoet.atlassian.net/browse/MAILPOET-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) were addressed in #4364.

## Code review notes

_N/A_

## QA notes

- For getGuestCustomerOrderCountByEmail() check that guest customers still receive the first purchase email when they place their first order and they don't receive it on subsequent orders.
- For getOrdersCountCreatedBefore() check that the notice asking an admin if they want to import WooCommerce customers as MailPoet subscribers is still working as expected (is displayed when MailPoet is installed and the site contains WooCommerce orders that were placed before).

## Linked PRs

#4364

## Linked tickets

[MAILPOET-4570]

## After-merge notes

_N/A_


[MAILPOET-4570]: https://mailpoet.atlassian.net/browse/MAILPOET-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ