### PR TITLE
Refactor MailPoet\Config\Populator class to doctrine [MAILPOET-4306]

### DIFF
--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -21,7 +21,6 @@ use MailPoet\Entities\StatisticsFormEntity;
 use MailPoet\Entities\UserFlagEntity;
 use MailPoet\Form\FormsRepository;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
@@ -891,7 +890,7 @@ class Populator {
       )
     );
     if ($premiumTableExists) {
-      $table = esc_sql(Newsletter::$_table);
+      $table = esc_sql($this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName());
       $query = "
         UPDATE
           `{$table}` as n

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -23,7 +23,6 @@ use MailPoet\Form\FormsRepository;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\Segment;
-use MailPoet\Models\SendingQueue;
 use MailPoet\Models\Subscriber;
 use MailPoet\Referrals\ReferralDetector;
 use MailPoet\Segments\WP;
@@ -618,7 +617,8 @@ class Populator {
     if (version_compare((string)$this->settings->get('db_version', '3.26.1'), '3.26.0', '>')) {
       return false;
     }
-    $tables = [ScheduledTask::$_table, SendingQueue::$_table];
+    $sendingQueueTable = $this->entityManager->getClassMetadata(SendingQueueEntity::class)->getTableName();
+    $tables = [ScheduledTask::$_table, $sendingQueueTable];
     foreach ($tables as $table) {
       $wpdb->query("UPDATE `" . esc_sql($table) . "` SET meta = NULL WHERE meta = 'null'");
     }

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -49,7 +49,21 @@ class SegmentsRepository extends Repository {
   }
 
   public function getWPUsersSegment(): ?SegmentEntity {
-    return $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
+    $segment = $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
+
+    if (!$segment) {
+      // create the wp users segment
+      $segment = new SegmentEntity(
+        __('WordPress Users', 'mailpoet'),
+        SegmentEntity::TYPE_WP_USERS,
+        __('This list contains all of your WordPress users.', 'mailpoet')
+      );
+
+      $this->entityManager->persist($segment);
+      $this->entityManager->flush();
+    }
+
+    return $segment;
   }
 
   public function getWooCommerceSegment(): SegmentEntity {

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -32,15 +32,7 @@ class SetupTest extends \MailPoetTest {
     $settings = SettingsController::getInstance();
     $referralDetector = new ReferralDetector($wpStub, $settings);
     $subscriptionCaptcha = $this->diContainer->get(Captcha::class);
-    $populator = new Populator(
-      $settings,
-      $wpStub,
-      $subscriptionCaptcha,
-      $referralDetector,
-      $this->diContainer->get(FormsRepository::class),
-      $this->entityManager,
-      $this->diContainer->get(WP::class)
-    );
+    $populator = $this->getServiceWithOverrides(Populator::class, ['wp' => $wpStub, 'referralDetector' => $referralDetector]);
     $migrator = $this->diContainer->get(Migrator::class);
     $router = new Setup($wpStub, new Activator($settings, $populator, $wpStub, $migrator));
     $response = $router->reset();


### PR DESCRIPTION
## Description

This PR refactors the MailPoet\Config\Populator class to use Doctrine instead of Paris.

## Code review notes

To test the changes while I was coding I created a very simple PopulatorTest function and used Xdebug to check that the code in the Populator class was still working as expected. Sharing it here in case it helps:

```
  public function testBasic() {
    $this->populator->up();
  }
```

I'm unsure about the change to \MailPoet\Segments\SegmentsRepository::getWPUsersSegment(). I don't like this pattern of creating a segment inside a method that seems to be a getter judging by its name, but at the same, this is the pattern that we are already using for \MailPoet\Segments\SegmentsRepository::getWooCommerceSegment() and the equivalent methods in the Segment model class. Any input is appreciated.

## QA notes

It is not very easy to test most of the changes in this PR. The Populator class is used to populate the database when MailPoet is installed or updated. Some of the changes will be executed whenever MP is installed and are easier to test. Other changes are executed only when updating from a specific version and are harder to test.

The only one that I believe is easy to test is to check that the default, WooCommerce and WordPress segments are created when MP is installed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4306]

## After-merge notes

_N/A_


[MAILPOET-4306]: https://mailpoet.atlassian.net/browse/MAILPOET-4306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ