### PR TITLE
Remove old model usage from WooCommercePastRevenues [MAILPOET-4377]

### DIFF
--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -7,11 +7,11 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsNewsletters;
 use MailPoet\Models\Subscriber;
@@ -299,7 +299,7 @@ class WooCommercePastRevenues implements Generator {
     $connection->executeStatement("ALTER TABLE `" . SubscriberSegment::$_table . "` DISABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName() . "` DISABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName() . "` DISABLE KEYS");
-    $connection->executeStatement("ALTER TABLE `" . ScheduledTaskSubscriber::$_table . "` DISABLE KEYS");
+    $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName() . "` DISABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . SendingQueue::$_table . "` DISABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName() . "` DISABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName() . "` DISABLE KEYS");
@@ -323,7 +323,7 @@ class WooCommercePastRevenues implements Generator {
     $connection->executeStatement("ALTER TABLE `" . SubscriberSegment::$_table . "` ENABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName() . "` ENABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName() . "` ENABLE KEYS");
-    $connection->executeStatement("ALTER TABLE `" . ScheduledTaskSubscriber::$_table . "` ENABLE KEYS");
+    $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName() . "` ENABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . SendingQueue::$_table . "` ENABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName() . "` ENABLE KEYS");
     $connection->executeStatement("ALTER TABLE `" . $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName() . "` ENABLE KEYS");
@@ -391,7 +391,7 @@ class WooCommercePastRevenues implements Generator {
       $batchData[] = "({$task->getId()}, $subscriberId, 1, '$sentAt')";
       if (count($batchData) % 1000 === 0) {
         $connection->executeStatement(
-          "INSERT INTO " . ScheduledTaskSubscriber::$_table . " (`task_id`, `subscriber_id`, `processed`, `created_at`) VALUES " . implode(', ', $batchData)
+          "INSERT INTO " . $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName() . " (`task_id`, `subscriber_id`, `processed`, `created_at`) VALUES " . implode(', ', $batchData)
         );
         $batchData = [];
       }
@@ -406,7 +406,7 @@ class WooCommercePastRevenues implements Generator {
 
     if ($batchData) {
       $connection->executeStatement(
-        "INSERT INTO " . ScheduledTaskSubscriber::$_table . " (`task_id`, `subscriber_id`, `processed`, `created_at`) VALUES " . implode(', ', $batchData)
+        "INSERT INTO " . $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName() . " (`task_id`, `subscriber_id`, `processed`, `created_at`) VALUES " . implode(', ', $batchData)
       );
     }
     if ($statsBatchData) {

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -10,9 +10,9 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\StatisticsNewsletters;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
@@ -402,7 +402,7 @@ class WooCommercePastRevenues implements Generator {
       $statsBatchData[] = "({$newsletter->getId()}, $subscriberId, {$queue->getId()}, '$sentAt')";
       if (count($statsBatchData) % 1000 === 0) {
         $connection->executeStatement(
-          "INSERT INTO " . StatisticsNewsletters::$_table . " (`newsletter_id`, `subscriber_id`, `queue_id`, `sent_at`) VALUES " . implode(', ', $statsBatchData)
+          "INSERT INTO " . $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName() . " (`newsletter_id`, `subscriber_id`, `queue_id`, `sent_at`) VALUES " . implode(', ', $statsBatchData)
         );
         $statsBatchData = [];
       }
@@ -415,7 +415,7 @@ class WooCommercePastRevenues implements Generator {
     }
     if ($statsBatchData) {
       $connection->executeStatement(
-        "INSERT INTO " . StatisticsNewsletters::$_table . " (`newsletter_id`, `subscriber_id`, `queue_id`, `sent_at`) VALUES " . implode(', ', $statsBatchData)
+        "INSERT INTO " . $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName() . " (`newsletter_id`, `subscriber_id`, `queue_id`, `sent_at`) VALUES " . implode(', ', $statsBatchData)
       );
     }
 

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -22,6 +22,7 @@ use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -334,12 +335,12 @@ class WooCommercePastRevenues implements Generator {
   }
 
   private function createSubscriber(string $email, string $lastName, string $createdAtDate, SegmentEntity $segment, $status = SubscriberEntity::STATUS_SUBSCRIBED): SubscriberEntity {
-    $subscriber = new SubscriberEntity();
-    $subscriber->setEmail($email);
-    $subscriber->setStatus($status);
-    $subscriber->setLastName($lastName);
-    $subscriber->setCreatedAt(new Carbon($createdAtDate));
-    $this->entityManager->persist($subscriber);
+    $subscriber = (new SubscriberFactory())
+      ->withEmail($email)
+      ->withStatus($status)
+      ->withLastName($lastName)
+      ->withCreatedAt(new Carbon($createdAtDate))
+      ->create();
 
     $subscriberSegment = new SubscriberSegmentEntity($segment, $subscriber, $status);
     $this->entityManager->persist($subscriberSegment);

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -435,8 +435,8 @@ class WooCommercePastRevenues implements Generator {
       $this->entityManager->refresh($newsletter);
     }
 
-    if ($newsletter->getStatus() === \MailPoet\Models\Newsletter::STATUS_DRAFT) {
-      $newsletter->setStatus(\MailPoet\Models\Newsletter::STATUS_SENT);
+    if ($newsletter->getStatus() === NewsletterEntity::STATUS_DRAFT) {
+      $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
       $newsletter->setSentAt(Carbon::createFromFormat('Y-m-d H:i:s', $sentAt));
       $this->entityManager->flush();
     }


### PR DESCRIPTION
## Description

This PR removes all old models from WooCommercePastRevenues and replaces them with Doctrine code.

## Code review notes

_N/A_

## QA notes

I'm not sure if there is much for QA to do in this PR. It changes code that is used for the CLI command `./do gen:data past_revenues`

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4377]

## After-merge notes

_N/A_


[MAILPOET-4377]: https://mailpoet.atlassian.net/browse/MAILPOET-4377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ