### PR TITLE
COT Run WooCommerce tests with different WC/COT configurations [MAILPOET-4572]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -713,6 +713,29 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
+          group: woo
+          enable_cot: 1
+          enable_cot_sync: 0
+          allow_fail: 1
+          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          name: integration_test_woo_cot_no_sync
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - integration_tests:
+          <<: *slack-fail-post-step
+          group: woo
+          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          name: integration_test_woo_cot_off
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - integration_tests:
+          <<: *slack-fail-post-step
           skip_group: woo
           skip_plugins: 1
           name: integration_test_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,7 +405,12 @@ jobs:
             # Convert test result filename values to be relative paths because the circleci CLI's split command requires exact matches
             sed -i.bak 's#/wp-core/wp-content/plugins/mailpoet/##g' $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json
             # `circleci tests split` returns different values based on the container it's run on
-            circleci tests glob "tests/acceptance/**/*Cest.php" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
+            # in case group is defined find only tests containing the group
+            if [[ -n '<< parameters.group >>' ]]; then
+              grep -rw 'tests/acceptance' -e '@group << parameters.group >>' | sed -e "s/:.*//" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
+            else
+              circleci tests glob "tests/acceptance/**/*Cest.php" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
+            fi
             cat tests/acceptance/_groups/circleci_split_group
       - run:
           name: Run acceptance tests
@@ -420,9 +425,6 @@ jobs:
               --xml
               -g circleci_split_group
             )
-            if [[ -n '<< parameters.group >>' ]]; then
-              args+=(--group << parameters.group >>)
-            fi
             if [[ << parameters.allow_fail >> == 1 ]]; then
               args+=(--no-exit)
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,6 +316,9 @@ jobs:
       multisite:
         type: integer
         default: 0
+      group:
+        type: string
+        default: ''
       mysql_command:
         type: string
         default: ''
@@ -340,6 +343,12 @@ jobs:
       woo_blocks_version:
         type: string
         default: ''
+      enable_cot:
+        type: integer
+        default: 0
+      enable_cot_sync:
+        type: integer
+        default: 0
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
@@ -400,7 +409,24 @@ jobs:
           command: |
             mkdir -m 777 -p tests/_output/exceptions
             cd tests/docker
-            docker-compose run -e SKIP_DEPS=1 -e CIRCLE_BRANCH=${CIRCLE_BRANCH} -e CIRCLE_JOB=${CIRCLE_JOB} -e MULTISITE=<< parameters.multisite >> codeception_acceptance -g circleci_split_group --steps --debug -vvv --html --xml
+            args=(
+              --steps
+              --debug
+              -vvv
+              --html
+              --xml
+              -g circleci_split_group
+            )
+            if [[ -n '<< parameters.group >>' ]]; then
+              args+=(--group << parameters.group >>)
+            fi
+            docker-compose run -e SKIP_DEPS=1 \
+            -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
+            -e CIRCLE_JOB=${CIRCLE_JOB} \
+            -e MULTISITE=<< parameters.multisite >> \
+            -e ENABLE_COT=<< parameters.enable_cot >> \
+            -e ENABLE_COT_SYNC=<< parameters.enable_cot_sync >> \
+            codeception_acceptance "${args[@]}"
       - run:
           name: Check exceptions
           command: |
@@ -600,6 +626,19 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_tests
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woo_cot_sync
+          group: woo
+          enable_cot: 1
+          enable_cot_sync: 1
+          allow_fail: 1
+          woo_core_version: woo-cot-beta # Temporarily force COT beta version
           requires:
             - unit_tests
             - static_analysis_php8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,14 @@ anchors:
         only:
           - trunk
           - release
+
+  only_trunk_and_cot: &only_trunk_and_cot
+    filters:
+      branches:
+        only:
+          - trunk
+          - /^cot-.*/
+
   multisite_acceptance_config: &multisite_acceptance_config
     multisite: 1
     requires:
@@ -651,6 +659,7 @@ workflows:
             - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
+          <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_sync
           group: woo
           enable_cot: 1
@@ -664,6 +673,7 @@ workflows:
             - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
+          <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_no_sync
           group: woo
           enable_cot: 1
@@ -677,6 +687,7 @@ workflows:
             - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
+          <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_off
           group: woo
           woo_core_version: woo-cot-beta # Temporarily force COT beta version
@@ -700,6 +711,7 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
+          <<: *only_trunk_and_cot
           group: woo
           enable_cot: 1
           enable_cot_sync: 1
@@ -713,6 +725,7 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
+          <<: *only_trunk_and_cot
           group: woo
           enable_cot: 1
           enable_cot_sync: 0
@@ -726,6 +739,7 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
+          <<: *only_trunk_and_cot
           group: woo
           woo_core_version: woo-cot-beta # Temporarily force COT beta version
           name: integration_test_woo_cot_off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,9 @@ jobs:
       enable_cot_sync:
         type: integer
         default: 0
+      allow_fail:
+        type: integer
+        default: 0
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
@@ -420,6 +423,9 @@ jobs:
             if [[ -n '<< parameters.group >>' ]]; then
               args+=(--group << parameters.group >>)
             fi
+            if [[ << parameters.allow_fail >> == 1 ]]; then
+              args+=(--no-exit)
+            fi
             docker-compose run -e SKIP_DEPS=1 \
             -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
             -e CIRCLE_JOB=${CIRCLE_JOB} \
@@ -427,13 +433,18 @@ jobs:
             -e ENABLE_COT=<< parameters.enable_cot >> \
             -e ENABLE_COT_SYNC=<< parameters.enable_cot_sync >> \
             codeception_acceptance "${args[@]}"
-      - run:
-          name: Check exceptions
-          command: |
-            if [ "$(ls tests/_output/exceptions/*.html)" ]; then
-              echo "There were some exceptions during the tests run"
-              exit 1
-            fi
+      - when:
+          condition:
+            not:
+              equal: [1, << parameters.allow_fail >>]
+          steps:
+            - run:
+                name: Check exceptions
+                command: |
+                  if [ "$(ls tests/_output/exceptions/*.html)" ]; then
+                    echo "There were some exceptions during the tests run"
+                    exit 1
+                  fi
       - store_artifacts:
           path: tests/_output
       - store_test_results:
@@ -500,6 +511,9 @@ jobs:
       woo_core_version:
         type: string
         default: ''
+      allow_fail:
+        type: integer
+        default: 0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -532,6 +546,9 @@ jobs:
             fi
             if [[ -n '<< parameters.skip_group >>' ]]; then
               args+=(--skip-group << parameters.skip_group >>)
+            fi
+            if [[ << parameters.allow_fail >> == 1 ]]; then
+              args+=(--no-exit)
             fi
             docker-compose run -e SKIP_DEPS=1 \
               -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
@@ -662,6 +679,7 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 1
+          allow_fail: 1
           woo_core_version: woo-cot-beta # Temporarily force COT beta version
           name: integration_test_woo_cot_sync
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ anchors:
         only:
           - trunk
           - release
-
   multisite_acceptance_config: &multisite_acceptance_config
     multisite: 1
     requires:
@@ -657,6 +656,29 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 1
           allow_fail: 1
+          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woo_cot_no_sync
+          group: woo
+          enable_cot: 1
+          enable_cot_sync: 0
+          allow_fail: 1
+          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woo_cot_off
+          group: woo
           woo_core_version: woo-cot-beta # Temporarily force COT beta version
           requires:
             - unit_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,9 +462,18 @@ jobs:
       skip_plugins:
         type: integer
         default: 0
+      enable_cot:
+        type: integer
+        default: 0
+      enable_cot_sync:
+        type: integer
+        default: 0
       multisite:
         type: integer
         default: 0
+      woo_core_version:
+        type: string
+        default: ''
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -472,6 +481,14 @@ jobs:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
           command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
+      - when:
+          condition: << parameters.woo_core_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Core
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps codeception_integration
       - run:
           name: 'PHP Integration tests'
           command: |
@@ -507,6 +524,8 @@ jobs:
               -e WP_TEST_MAILER_SMTP_LOGIN=${WP_TEST_MAILER_SMTP_LOGIN} \
               -e WP_TEST_MAILER_SMTP_PASSWORD=${WP_TEST_MAILER_SMTP_PASSWORD} \
               -e MULTISITE=<< parameters.multisite >> \
+              -e ENABLE_COT=<< parameters.enable_cot >> \
+              -e ENABLE_COT_SYNC=<< parameters.enable_cot_sync >> \
               codeception_integration "${args[@]}"
       - store_test_results:
           path: tests/_output
@@ -594,6 +613,18 @@ workflows:
           <<: *slack-fail-post-step
           group: woo
           name: integration_test_woocommerce
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - integration_tests:
+          <<: *slack-fail-post-step
+          group: woo
+          enable_cot: 1
+          enable_cot_sync: 1
+          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          name: integration_test_woo_cot_sync
           requires:
             - unit_tests
             - static_analysis_php8

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1077,6 +1077,12 @@ class RoboFile extends \Robo\Tasks {
     ->downloadPluginZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
+  public function downloadWooCommerceCotZip() {
+    $cotBuildUrl = 'https://github.com/woocommerce/woocommerce/files/9392652/woocommerce.zip';
+    file_put_contents(__DIR__ . '/tests/plugins/woocommerce.zip', file_get_contents($cotBuildUrl));
+    file_put_contents(__DIR__ . '/tests/plugins/woocommerce.zip-info', 'https://github.com/woocommerce/woocommerce/files/9392652/woocommerce.zip');
+  }
+
   public function generateData($generatorName = null, $threads = 1) {
     require_once __DIR__ . '/tests/DataGenerator/_bootstrap.php';
     $generator = new \MailPoet\Test\DataGenerator\DataGenerator(new \Codeception\Lib\Console\Output([]));

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -265,9 +265,21 @@ class RoboFile extends \Robo\Tasks {
     return $this->runTestsInContainer(array_merge($opts, ['multisite' => true]));
   }
 
+  /**
+   * Deletes docker stuff related to tests including docker images.
+   */
   public function deleteDocker() {
     return $this->taskExec(
       'docker-compose down -v --remove-orphans --rmi all'
+    )->dir(__DIR__ . '/tests/docker')->run();
+  }
+
+  /**
+   * Deletes docker containers and volumes used in tests
+   */
+  public function resetTestDocker() {
+    return $this->taskExec(
+      'docker-compose down -v --remove-orphans'
     )->dir(__DIR__ . '/tests/docker')->run();
   }
 

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -182,15 +182,15 @@ class RoboFile extends \Robo\Tasks {
     return $this->_exec($command);
   }
 
-  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false]) {
+  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false, 'enable-cot-sync' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 
-  public function testMultisiteIntegration($opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => true, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false]) {
+  public function testMultisiteIntegration($opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => true, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false, 'enable-cot-sync' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 
-  public function testWooIntegration(array $opts = ['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'enable-cot' => false]) {
+  public function testWooIntegration(array $opts = ['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'enable-cot' => false, 'enable-cot-sync' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration', 'group' => 'woo', 'skip-deps' => true, 'skip-plugins' => false]));
   }
 
@@ -257,11 +257,11 @@ class RoboFile extends \Robo\Tasks {
     return $this->testIntegration($opts);
   }
 
-  public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'timeout' => null, 'enable-cot' => false]) {
+  public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'group' => null, 'timeout' => null, 'enable-cot' => false, 'enable-cot-sync' => false]) {
     return $this->runTestsInContainer($opts);
   }
 
-  public function testAcceptanceMultisite($opts = ['file' => null, 'skip-deps' => false, 'timeout' => null]) {
+  public function testAcceptanceMultisite($opts = ['file' => null, 'skip-deps' => false, 'group' => null, 'timeout' => null, 'enable-cot' => false, 'enable-cot-sync' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['multisite' => true]));
   }
 
@@ -1276,6 +1276,7 @@ class RoboFile extends \Robo\Tasks {
       'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
       (isset($opts['skip-deps']) && $opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
       (isset($opts['enable-cot']) && $opts['enable-cot'] ? '-e ENABLE_COT=1 ' : '') .
+      (isset($opts['enable-cot-sync']) && $opts['enable-cot-sync'] ? '-e ENABLE_COT_SYNC=1 ' : '') .
       (isset($opts['skip-plugins']) && $opts['skip-plugins'] ? '-e SKIP_PLUGINS=1 ' : '') .
       (isset($opts['timeout']) && $opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
       (isset($opts['multisite']) && $opts['multisite'] ? '-e MULTISITE=1 ' : '-e MULTISITE=0 ') .

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -182,15 +182,15 @@ class RoboFile extends \Robo\Tasks {
     return $this->_exec($command);
   }
 
-  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false]) {
+  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 
-  public function testMultisiteIntegration($opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => true, 'skip-deps' => false, 'skip-plugins' => false]) {
+  public function testMultisiteIntegration($opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => true, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 
-  public function testWooIntegration(array $opts = ['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false]) {
+  public function testWooIntegration(array $opts = ['file' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'enable-cot' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration', 'group' => 'woo', 'skip-deps' => true, 'skip-plugins' => false]));
   }
 
@@ -257,7 +257,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->testIntegration($opts);
   }
 
-  public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'timeout' => null]) {
+  public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'timeout' => null, 'enable-cot' => false]) {
     return $this->runTestsInContainer($opts);
   }
 
@@ -1272,10 +1272,10 @@ class RoboFile extends \Robo\Tasks {
   private function runTestsInContainer(array $opts) {
     $testType = $opts['test_type'] ?? 'acceptance';
     $this->doctrineGenerateCache();
-
     return $this->taskExec(
       'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
       (isset($opts['skip-deps']) && $opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
+      (isset($opts['enable-cot']) && $opts['enable-cot'] ? '-e ENABLE_COT=1 ' : '') .
       (isset($opts['skip-plugins']) && $opts['skip-plugins'] ? '-e SKIP_PLUGINS=1 ' : '') .
       (isset($opts['timeout']) && $opts['timeout'] ? '-e WAIT_TIMEOUT=' . (int)$opts['timeout'] . ' ' : '') .
       (isset($opts['multisite']) && $opts['multisite'] ? '-e MULTISITE=1 ' : '-e MULTISITE=0 ') .

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1085,6 +1085,10 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function downloadWooCommerceZip($tag = null) {
+    if ($tag === 'woo-cot-beta') {
+      $this->downloadWooCommerceCotZip();
+      return;
+    }
     $this->createWpOrgDownloader('woocommerce')
     ->downloadPluginZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
   }

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -1,17 +1,36 @@
 <?php
 // phpcs:ignoreFile - This file contains stubs for 3rd party functions and classes that might break our PHPCS rules
 
-if (!function_exists('members_get_cap_group')) {
-  function members_get_cap_group($name) {
+namespace {
+  if (!function_exists('members_get_cap_group')) {
+    function members_get_cap_group($name) {
+    }
+  }
+
+  if (!class_exists(\WC_Subscription::class)) {
+    class WC_Subscription extends WC_Product {
+    }
+  }
+
+  if (!function_exists('wcs_create_subscription')) {
+    function wcs_create_subscription($args) {
+    }
   }
 }
 
-if (!class_exists(\WC_Subscription::class)) {
-  class WC_Subscription extends WC_Product {
-  }
-}
+// Temporary stubs for Woo Custom Tables.
+// We can remove them after the functionality is officially released and added into php-stubs/woocommerce-stubs
+namespace Automattic\WooCommerce\Internal\DataStores\Orders {
 
-if (!function_exists('wcs_create_subscription')) {
-  function wcs_create_subscription($args) {
+  if (!class_exists(\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)) {
+    class CustomOrdersTableController {
+      function show_feature() {}
+    }
+  }
+
+  if (!class_exists(\Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class)) {
+    class DataSynchronizer {
+      function create_database_tables() {}
+    }
   }
 }

--- a/mailpoet/tests/_support/woo_cot_helper_plugin.php
+++ b/mailpoet/tests/_support/woo_cot_helper_plugin.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+Plugin Name: MailPoet Woo COT Helper
+Description: Adds functionality for testing WooCommerce COT feature
+Author: MailPoet
+Version: 1.0
+*/
+
+use \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+
+/**
+ * Enable WooCommerce COT tables
+ * @see https://github.com/Automattic/woocommerce/wiki/COT-Upgrade-Recipe-Book#easy-way
+ */
+
+function mailpoet_enable_cot(): void {
+  if (!function_exists('wc_get_container')) {
+    return;
+  }
+  /** @var CustomOrdersTableController $orderController */
+  $orderController = wc_get_container()->get(CustomOrdersTableController::class);
+  if ($orderController instanceof CustomOrdersTableController) {
+    $orderController->show_feature();
+  }
+}
+add_action( 'init', 'mailpoet_enable_cot', 99 );
+
+
+/**
+ * Add wp create_cot WP CLI command for creating Custom Order Tables from command line
+ */
+function mailpoet_create_cot() {
+  if (!function_exists('wc_get_container')) {
+    WP_CLI::error('Can‘t create COT. WooCommerce is not active!');
+  }
+  try {
+    /** @var DataSynchronizer $dataSynchronizer */
+    $dataSynchronizer = wc_get_container()->get(DataSynchronizer::class);
+  } catch (\Exception $e) {
+    WP_CLI::error('DataSynchronizer for COT not found. Does installed WooCommerce version support COT? ' . $e->getMessage());
+    return;
+  }
+  $dataSynchronizer->create_database_tables();
+  WP_CLI::success('Database tables for COT feature created.');
+}
+
+if (class_exists(WP_CLI::class)) {
+  WP_CLI::add_command('create_cot', 'mailpoet_create_cot');
+}

--- a/mailpoet/tests/acceptance/Newsletters/CreateWooCommerceNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/CreateWooCommerceNewsletterCest.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Test\Acceptance;
 
+/**
+ * @group woo
+ */
 class CreateWooCommerceNewsletterCest {
   public function createFirstPurchaseEmail(\AcceptanceTester $i) {
     $i->wantTo('Create and configure a first purchase automatic email');

--- a/mailpoet/tests/acceptance/Newsletters/DeleteAutomaticWooCommerceEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteAutomaticWooCommerceEmailCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Newsletter;
 
+/**
+ * @group woo
+ */
 class DeleteAutomaticWooCommerceEmailCest {
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();

--- a/mailpoet/tests/acceptance/Newsletters/DuplicateAutomaticEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicateAutomaticEmailCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Newsletter;
 
+/**
+ * @group woo
+ */
 class DuplicateAutomaticEmailCest {
   public function duplicateAutomaticEmail(\AcceptanceTester $i) {
     $i->wantTo('Duplicate an automatic email');

--- a/mailpoet/tests/acceptance/Newsletters/EditAutomaticWooCommerceEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditAutomaticWooCommerceEmailCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Newsletter;
 
+/**
+ * @group woo
+ */
 class EditAutomaticWooCommerceEmailCest {
   public function dontSeeWooCommerceTabWhenWooCommerceIsNotActive(\AcceptanceTester $i) {
     $i->wantTo('Not see WooCommerce tab');

--- a/mailpoet/tests/acceptance/Newsletters/EditorProductsCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorProductsCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 use MailPoet\Util\Security;
 
+/**
+ * @group woo
+ */
 class EditorProductsCest {
   const EDITOR_PRODUCTS_SELECTOR = '.mailpoet_products_container > .mailpoet_block > .mailpoet_container';
   const EDITOR_PRODUCT_SELECTOR = '.mailpoet_products_container > .mailpoet_block > .mailpoet_container > .mailpoet_block';

--- a/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
@@ -8,6 +8,9 @@ use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 use MailPoet\Util\Security;
 
+/**
+ * @group woo
+ */
 class SendCategoryPurchaseEmailCest {
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();

--- a/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 
+/**
+ * @group woo
+ */
 class SendFirstPurchaseEmailCest {
   /** @var Settings */
   private $settingsFactory;

--- a/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 
+/**
+ * @group woo
+ */
 class SendProductPurchaseEmailCest {
   /** @var Settings */
   private $settingsFactory;

--- a/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 
+/**
+ * @group woo
+ */
 class WooCommerceDynamicSegmentsCest {
   const CATEGORY_SEGMENT = 'Purchase in category segment';
   const PRODUCT_SEGMENT = 'Purchased product segment';

--- a/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
@@ -6,6 +6,9 @@ use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\User;
 use MailPoet\Test\DataFactories\WooCommerceMembership;
 
+/**
+ * @group woo
+ */
 class WooCommerceMembershipsSegmentCest {
   public function _before(\AcceptanceTester $i, $scenario) {
     if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_MEMBERSHIPS_PLUGIN)) {

--- a/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\User;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 use MailPoet\Test\DataFactories\WooCommerceSubscription;
 
+/**
+ * @group woo
+ */
 class WooCommerceSubscriptionsSegmentCest {
   public function _before(\AcceptanceTester $i, $scenario) {
     if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN)) {

--- a/mailpoet/tests/acceptance/Settings/RevenueTrackingCookieCest.php
+++ b/mailpoet/tests/acceptance/Settings/RevenueTrackingCookieCest.php
@@ -6,6 +6,9 @@ use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group woo
+ */
 class RevenueTrackingCookieCest {
 
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Settings/WooCommerceEmailCustomizationCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceEmailCustomizationCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group woo
+ */
 class WooCommerceEmailCustomizationCest {
 
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group woo
+ */
 class WooCommerceSettingsTabCest {
 
   const CUSTOMIZE_SELECTOR = '[data-automation-id="mailpoet_woocommerce_customize"]';

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\WooCommerceCustomer;
 use MailPoet\Test\DataFactories\WooCommerceOrder;
 use PHPUnit\Framework\Exception;
 
+/**
+ * @group woo
+ */
 class WooCommerceSetupPageCest {
 
   /** @var WooCommerceCustomer */

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -85,6 +85,9 @@ class SubscriberCookieCest {
     $this->checkSubscriberCookie($i, $email);
   }
 
+  /**
+   * @group woo
+   */
   public function setSubscriberCookieOnWooCheckoutAndSubscriptionConfirmation(AcceptanceTester $i) {
     $i->wantTo('Set subscriber cookie on WooCommerce checkout and subscription confirmation');
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -14,6 +14,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
 /**
  * This class contains tests for subscriptions
  * of registered customers done via checkout page
+ * @group woo
  */
 class WooCheckoutBlocksCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
@@ -11,6 +11,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
 /**
  * This class contains tests for subscriptions
  * of registered customers done via checkout page
+ * @group woo
  */
 class WooCheckoutCustomerSubscriptionsCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
@@ -11,6 +11,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
 /**
  * This class contains tests for subscriptions
  * of guest customers done via checkout page
+ * @group woo
  */
 class WooCheckoutGuestSubscriptionsCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooMyAccountRegistrationCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooMyAccountRegistrationCest.php
@@ -8,6 +8,7 @@ use MailPoet\Test\DataFactories\Settings;
 /**
  * This class contains tests for subscriptions
  * of guest customers done via checkout page
+ * @group woo
  */
 class WooMyAccountRegistrationCest {
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -124,6 +124,10 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     unzip -q -o "$WOOCOMMERCE_BLOCKS_ZIP" -d /wp-core/wp-content/plugins/
   fi
 
+  # Install WooCommerce COT helper plugin
+  mkdir -p /wp-core/wp-content/plugins/woo_cot_helper_plugin
+  cp /wp-core/wp-content/plugins/mailpoet/tests/_support/woo_cot_helper_plugin.php /wp-core/wp-content/plugins/woo_cot_helper_plugin.php
+
   ACTIVATION_CONTEXT=$HTTP_HOST
   # For integration tests in multisite environment we need to activate the plugin for correct site that is loaded in tests
   # The acceptance tests activate/deactivate plugins using a helper.
@@ -143,6 +147,16 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
   wp plugin get woocommerce-subscriptions --url=$ACTIVATION_CONTEXT
   wp plugin get woocommerce-memberships --url=$ACTIVATION_CONTEXT
   wp plugin get woo-gutenberg-products-block --url=$ACTIVATION_CONTEXT
+
+   # Activate helper plugin for WooCommerce COT and create tables in DB
+   if [[ $ENABLE_COT == "1" ]]; then
+     wp plugin activate woo_cot_helper_plugin --url=$ACTIVATION_CONTEXT
+     wp create_cot
+     wp option update woocommerce_custom_orders_table_enabled yes
+     wp option update woocommerce_custom_orders_table_data_sync_enabled no
+     echo "WooCommerce COT ENABLED!";
+   fi
+
 fi
 
 # Set constants in wp-config.php

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -155,6 +155,11 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
      wp option update woocommerce_custom_orders_table_enabled yes
      wp option update woocommerce_custom_orders_table_data_sync_enabled no
      echo "WooCommerce COT ENABLED!";
+     # Enable Sync of COT and posts tables
+     if [[ $ENABLE_COT_SYNC == "1" ]]; then
+       wp option update woocommerce_custom_orders_table_data_sync_enabled yes
+       echo "WooCommerce COT Synchronization enabled!";
+     fi
    fi
 
 fi


### PR DESCRIPTION
## Description
This PR enables to running of integration and acceptance tests with different versions of the configuration of the COT feature.

### Downloading WooCommerce COT testing build

I added a Robo command for downloading the COT testing version of the WooCommerce plugin. This is a temporary command that currently downloads [COT Release testing build](https://github.com/woocommerce/woocommerce/releases/tag/feature-custom-order-table).
```
./do download:woo-commerce-cot-zip
```
**Note:** After downloading a new version of any plugin for tests, you need to destroy the test containers (`./do reset:test-docker`) so that the newly downloaded version is installed as we don't reinstall plugins every time for performance reasons.

### Running tests locally
I added two new flags for configuring the COT feature. Both can be used for integration and acceptance tests

- `--enable-cot`: When tests run with this flag, COT are created, and the shop is configured to use them. 
- `--enable-cot-sync`: When tests run with this flag, it enables sync ty from COT to the wp_posts. Note: without `--enable-cot` the flag is ignored.

e.g `./do test:integration --skip-deps --group woo --enable-cot --enable-cot-sync` runs Woo related integration tests with COT enabled and sync enabled.

I also added support for `--group` to the acceptance test and marked tests related to WooCommerce with this group.

### New jobs on Circle CI
I added three new acceptance test jobs and three new integration test jobs that use the WooCommerce COT release testing build and run in different configurations. These new jobs are set to run only on branches prefixed `cot-` and on `trunk`. Some of those jobs are also set to ignore failures (but you can still see what tests failed). This was done because we need to implement support for COT, and we don't want to have red builds. 
I created a follow-up ticket for enabling failure checks and allowing the jobs on all branches (MAILPOET-4648) after we fix all issues.

#### New jobs:
- acceptance_tests_woo_cot_sync // ingoring failures
- acceptance_tests_woo_cot_no_sync // ingoring failures
- acceptance_tests_woo_cot_off
- integration_test_woo_cot_sync // ingoring failures
- integration_test_woo_cot_no_sync // ingoring failures
- integration_test_woo_cot_off

I hope that from the names, it is clear what configurations are used.

## Code review notes
I ran into a problem when I was adding group woo on acceptance tests on Circle CI. Test splitting for parallel execution on Circle CI uses the group parameter. So I had to use a hack when running the `woo` group in acceptance tests. I search all test files that contain `/* @group woo` and pass those to the test split command. So when the group is used only for one test case on Circle CI, it will run all tests from a file. This is a bit suboptimal, but it seems to do the job.

## QA notes

All changes are related to tests and Circle CI. There is nothing to test in the plugin.

## Linked tickets

[MAILPOET-4572]

## After-merge notes

Ping developers on slack mailpoet-dev-code on slack and ask them to start adding acceptance tests related to WooCommerce to group  `woo`.


[MAILPOET-4572]: https://mailpoet.atlassian.net/browse/MAILPOET-4572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ