### PR TITLE
Fix memory issue in building newsletters lists for segments [MAILPOET-4646]

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -4,7 +4,6 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\API\JSON\ResponseBuilders\CustomFieldsResponseBuilder;
-use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
@@ -50,9 +49,6 @@ class Segments {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
-  /** @var NewslettersResponseBuilder */
-  private $newslettersResponseBuilder;
-
   /** @var TagRepository */
   private $tagRepository;
 
@@ -67,7 +63,6 @@ class Segments {
     SegmentDependencyValidator $segmentDependencyValidator,
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
-    NewslettersResponseBuilder $newslettersResponseBuilder,
     TagRepository $tagRepository
   ) {
     $this->pageRenderer = $pageRenderer;
@@ -81,7 +76,6 @@ class Segments {
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
     $this->tagRepository = $tagRepository;
-    $this->newslettersResponseBuilder = $newslettersResponseBuilder;
   }
 
   public function render() {
@@ -99,7 +93,7 @@ class Segments {
       ];
     }, array_keys($wpRoles), $wpRoles);
 
-    $data['newsletters_list'] = $this->newslettersResponseBuilder->buildForListing($this->newslettersRepository->getStandardNewsletterList());
+    $data['newsletters_list'] = $this->getNewslettersList();
 
     $data['static_segments_list'] = [];
     $criteria = new Criteria();
@@ -144,5 +138,17 @@ class Segments {
     $wooCurrencySymbol = $this->woocommerceHelper->isWooCommerceActive() ? $this->woocommerceHelper->getWoocommerceCurrencySymbol() : '';
     $data['woocommerce_currency_symbol'] = html_entity_decode($wooCurrencySymbol);
     $this->pageRenderer->displayPage('segments.html', $data);
+  }
+
+  private function getNewslettersList(): array {
+    $result = [];
+    foreach ($this->newslettersRepository->getStandardNewsletterList() as $newsletter) {
+      $result[] = [
+        'id' => (string)$newsletter->getId(),
+        'subject' => $newsletter->getSubject(),
+        'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format('Y-m-d H:i:s') : null,
+      ];
+    }
+    return $result;
   }
 }

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -428,7 +428,7 @@ class NewslettersRepository extends Repository {
    */
   public function getStandardNewsletterList(): array {
     return $this->entityManager->createQueryBuilder()
-      ->select('n')
+      ->select('PARTIAL n.{id,subject,sentAt}')
       ->addSelect('CASE WHEN n.sentAt IS NULL THEN 1 ELSE 0 END as HIDDEN sent_at_is_null')
       ->from(NewsletterEntity::class, 'n')
       ->where('n.type = :typeStandard')

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -1334,3 +1334,8 @@ parameters:
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
 			count: 5
 			path: ../../tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+
+		-
+			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:getStandardNewsletterList\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
+			count: 1
+			path: ../../lib/Newsletter/NewslettersRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -1339,3 +1339,8 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 5
 			path: ../../tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+
+		-
+			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:getStandardNewsletterList\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
+			count: 1
+			path: ../../lib/Newsletter/NewslettersRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -1338,3 +1338,8 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 5
 			path: ../../tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+
+		-
+			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:getStandardNewsletterList\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
+			count: 1
+			path: ../../lib/Newsletter/NewslettersRepository.php


### PR DESCRIPTION
## Description

Because some customers have a memory issue when we load all newsletters, I used partial loading newsletters to prevent this error caused by the JSON column type in the newsletter entity.

## Code review notes

_N/A_

## QA notes

Please check if newsletters in segments form are loaded correctly.
1. Make sure to send a few (2-3) simple newsletters to yourself, click any links inside ('view in your browser' is also good link to click)
2. Now that you have statistics data to those sent newsletters (opened, clicked link..), go to Lists page
3. Click to create a new Segment
4. Make a few segments with `opened` AND `clicked` types of segments, picking the sent newsletters from 1st step
5. When you have a few segments created containing above segment types, refresh the Segments page/tab few times and make sure you don't see any errors/warnings. You may click `Recalculate now` button also.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4646](https://mailpoet.atlassian.net/browse/MAILPOET-4646)

## After-merge notes

_N/A_
