### PR TITLE
Workflow validation part 1 [MAILPOET-4629]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Builder/UpdateStepsController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateStepsController.php
@@ -19,9 +19,9 @@ class UpdateStepsController {
 
   public function updateSteps(Workflow $workflow, array $data): Workflow {
     $steps = [];
-    foreach ($data as $stepData) {
+    foreach ($data as $index => $stepData) {
       $step = $this->processStep($stepData);
-      $steps[$step->getId()] = $step;
+      $steps[$index] = $step;
     }
     $workflow->setSteps($steps);
     return $workflow;

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateStepsController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateStepsController.php
@@ -20,17 +20,17 @@ class UpdateStepsController {
   public function updateSteps(Workflow $workflow, array $data): Workflow {
     $steps = [];
     foreach ($data as $index => $stepData) {
-      $step = $this->processStep($stepData);
+      $step = $this->processStep($stepData, $workflow->getStep($stepData['id']));
       $steps[$index] = $step;
     }
     $workflow->setSteps($steps);
     return $workflow;
   }
 
-  private function processStep(array $data): Step {
+  private function processStep(array $data, ?Step $existingStep): Step {
     $key = $data['key'];
     $step = $this->registry->getStep($key);
-    if (!$step) {
+    if (!$step && $existingStep && $data !== $existingStep->toArray()) {
       throw Exceptions::workflowStepNotFound($key);
     }
     return Step::fromArray($data);

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateWorkflowController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateWorkflowController.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\Validation\WorkflowValidator;
 
 class UpdateWorkflowController {
   /** @var Hooks */
@@ -16,24 +17,25 @@ class UpdateWorkflowController {
   /** @var WorkflowStorage */
   private $storage;
 
+  /** @var WorkflowValidator */
+  private $workflowValidator;
+
   /** @var UpdateStepsController */
   private $updateStepsController;
 
   public function __construct(
     Hooks $hooks,
     WorkflowStorage $storage,
+    WorkflowValidator $workflowValidator,
     UpdateStepsController $updateStepsController
   ) {
     $this->hooks = $hooks;
     $this->storage = $storage;
+    $this->workflowValidator = $workflowValidator;
     $this->updateStepsController = $updateStepsController;
   }
 
   public function updateWorkflow(int $id, array $data): Workflow {
-    // TODO: data & workflow validation (trigger existence, graph consistency, etc.)
-    // TODO: new revisions when content is changed
-    // TODO: validation when status being is changed
-
     $workflow = $this->storage->getWorkflow($id);
     if (!$workflow) {
       throw Exceptions::workflowNotFound($id);
@@ -58,6 +60,8 @@ class UpdateWorkflowController {
     }
 
     $this->hooks->doWorkflowBeforeSave($workflow);
+
+    $this->workflowValidator->validate($workflow);
     $this->storage->updateWorkflow($workflow);
 
     $workflow = $this->storage->getWorkflow($id);

--- a/mailpoet/lib/Automation/Engine/Control/RootStep.php
+++ b/mailpoet/lib/Automation/Engine/Control/RootStep.php
@@ -17,4 +17,8 @@ class RootStep implements Step {
   public function getArgsSchema(): ObjectSchema {
     return new ObjectSchema();
   }
+
+  public function getSubjectKeys(): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -181,7 +181,7 @@ class StepHandler {
   private function getSubjectEntries(WorkflowRun $workflowRun, array $requiredSubjectKeys): array {
     $subjectDataMap = [];
     foreach ($workflowRun->getSubjects() as $data) {
-      $subjectDataMap[$data->getKey()] = array_merge($subjectDataMap[$data->getKey()], [$data]);
+      $subjectDataMap[$data->getKey()] = array_merge($subjectDataMap[$data->getKey()] ?? [], [$data]);
     }
 
     $subjectEntries = [];

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Engine\Control;
 use Exception;
 use MailPoet\Automation\Engine\Control\Steps\ActionStepRunner;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Data\WorkflowRunLog;
@@ -133,7 +134,8 @@ class StepHandler {
       try {
         $requiredSubjects = $step instanceof Action ? $step->getSubjectKeys() : [];
         $subjectEntries = $this->getSubjectEntries($workflowRun, $requiredSubjects);
-        $this->stepRunners[$stepType]->run($workflow, $workflowRun, $step, $subjectEntries);
+        $args = new StepRunArgs($workflow, $workflowRun, $step, $subjectEntries);
+        $this->stepRunners[$stepType]->run($args);
         $log->markCompletedSuccessfully();
       } catch (Throwable $e) {
         $log->markFailed();

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -3,9 +3,11 @@
 namespace MailPoet\Automation\Engine\Control;
 
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 
 interface StepRunner {
-  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun): void;
+  /** @var SubjectEntry[] $subjectEntries */
+  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun, array $subjectEntries): void;
 }

--- a/mailpoet/lib/Automation/Engine/Control/StepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunner.php
@@ -2,12 +2,8 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
-use MailPoet\Automation\Engine\Data\Step;
-use MailPoet\Automation\Engine\Data\SubjectEntry;
-use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Data\WorkflowRun;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 
 interface StepRunner {
-  /** @var SubjectEntry[] $subjectEntries */
-  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun, array $subjectEntries): void;
+  public function run(StepRunArgs $args): void;
 }

--- a/mailpoet/lib/Automation/Engine/Control/Steps/ActionStepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/Steps/ActionStepRunner.php
@@ -3,10 +3,7 @@
 namespace MailPoet\Automation\Engine\Control\Steps;
 
 use MailPoet\Automation\Engine\Control\StepRunner;
-use MailPoet\Automation\Engine\Data\Step;
-use MailPoet\Automation\Engine\Data\SubjectEntry;
-use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Data\WorkflowRun;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Registry;
 
@@ -20,15 +17,14 @@ class ActionStepRunner implements StepRunner {
     $this->registry = $registry;
   }
 
-  /** @param SubjectEntry[] $subjectEntries */
-  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun, array $subjectEntries): void {
-    $action = $this->registry->getAction($step->getKey());
+  public function run(StepRunArgs $args): void {
+    $action = $this->registry->getAction($args->getStep()->getKey());
     if (!$action) {
       throw new InvalidStateException();
     }
-    if (!$action->isValid($workflowRun->getSubjects(), $step, $workflow)) {
+    if (!$action->isValid($args->getWorkflowRun()->getSubjects(), $args->getStep(), $args->getWorkflow())) {
       throw new InvalidStateException();
     }
-    $action->run($workflow, $workflowRun, $step);
+    $action->run($args);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/Steps/ActionStepRunner.php
+++ b/mailpoet/lib/Automation/Engine/Control/Steps/ActionStepRunner.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine\Control\Steps;
 
 use MailPoet\Automation\Engine\Control\StepRunner;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
@@ -19,7 +20,8 @@ class ActionStepRunner implements StepRunner {
     $this->registry = $registry;
   }
 
-  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun): void {
+  /** @param SubjectEntry[] $subjectEntries */
+  public function run(Step $step, Workflow $workflow, WorkflowRun $workflowRun, array $subjectEntries): void {
     $action = $this->registry->getAction($step->getKey());
     if (!$action) {
       throw new InvalidStateException();

--- a/mailpoet/lib/Automation/Engine/Control/SubjectLoader.php
+++ b/mailpoet/lib/Automation/Engine/Control/SubjectLoader.php
@@ -2,10 +2,12 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use MailPoet\Automation\Engine\Data\Subject as SubjectData;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Workflows\Payload;
 use MailPoet\Automation\Engine\Workflows\Subject;
-use Throwable;
 
 class SubjectLoader {
   /** @var Registry */
@@ -17,17 +19,28 @@ class SubjectLoader {
     $this->registry = $registry;
   }
 
-  public function loadSubject(string $key, array $args): Subject {
+  /**
+   * @param SubjectData[] $subjectData
+   * @return SubjectEntry<Subject<Payload>>[]
+   */
+  public function getSubjectsEntries(array $subjectData): array {
+    $subjectEntries = [];
+    foreach ($subjectData as $data) {
+      $subjectEntries[] = $this->getSubjectEntry($data);
+    }
+    return $subjectEntries;
+  }
+
+  /**
+   * @param SubjectData $subjectData
+   * @return SubjectEntry<Subject<Payload>>
+   */
+  public function getSubjectEntry(SubjectData $subjectData): SubjectEntry {
+    $key = $subjectData->getKey();
     $subject = $this->registry->getSubject($key);
     if (!$subject) {
       throw Exceptions::subjectNotFound($key);
     }
-
-    try {
-      $subject->load($args);
-    } catch (Throwable $e) {
-      throw Exceptions::subjectLoadFailed($key, $args);
-    }
-    return $subject;
+    return new SubjectEntry($subject, $subjectData);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Exceptions;
@@ -60,11 +61,11 @@ class TriggerHandler {
         $entry->getPayload();
       }
 
-      if (!$trigger->isTriggeredBy($step->getArgs(), $subjectEntries)) {
+      $workflowRun = new WorkflowRun($workflow->getId(), $workflow->getVersionId(), $trigger->getKey(), $subjects);
+      if (!$trigger->isTriggeredBy(new StepRunArgs($workflow, $workflowRun, $step, $subjectEntries))) {
         return;
       }
 
-      $workflowRun = new WorkflowRun($workflow->getId(), $workflow->getVersionId(), $trigger->getKey(), $subjects);
       $workflowRunId = $this->workflowRunStorage->createWorkflowRun($workflowRun);
       $nextStep = $step->getNextSteps()[0] ?? null;
       $this->actionScheduler->enqueue(Hooks::WORKFLOW_STEP, [

--- a/mailpoet/lib/Automation/Engine/Data/Step.php
+++ b/mailpoet/lib/Automation/Engine/Data/Step.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Data;
 
 class Step {
+  public const TYPE_ROOT = 'root';
   public const TYPE_TRIGGER = 'trigger';
   public const TYPE_ACTION = 'action';
 

--- a/mailpoet/lib/Automation/Engine/Data/StepRunArgs.php
+++ b/mailpoet/lib/Automation/Engine/Data/StepRunArgs.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Workflows\Payload;
+use MailPoet\Automation\Engine\Workflows\Subject;
+
+class StepRunArgs {
+  /** @var Workflow */
+  private $workflow;
+
+  /** @var WorkflowRun */
+  private $workflowRun;
+
+  /** @var Step */
+  private $step;
+
+  /** @var array<string, SubjectEntry<Subject<Payload>>[]> */
+  private $subjectEntries = [];
+
+  /** @param SubjectEntry<Subject<Payload>>[] $subjectsEntries */
+  public function __construct(
+    Workflow $workflow,
+    WorkflowRun $workflowRun,
+    Step $step,
+    array $subjectsEntries
+  ) {
+    $this->workflow = $workflow;
+    $this->step = $step;
+    $this->workflowRun = $workflowRun;
+
+    foreach ($subjectsEntries as $entry) {
+      $subject = $entry->getSubject();
+      $key = $subject->getKey();
+      $this->subjectEntries[$key] = array_merge($this->subjectEntries[$key] ?? [], [$entry]);
+    }
+  }
+
+  public function getWorkflow(): Workflow {
+    return $this->workflow;
+  }
+
+  public function getWorkflowRun(): WorkflowRun {
+    return $this->workflowRun;
+  }
+
+  public function getStep(): Step {
+    return $this->step;
+  }
+
+  /** @return SubjectEntry<Subject<Payload>> */
+  public function getSingleSubjectEntry(string $key): SubjectEntry {
+    $subjects = $this->subjectEntries[$key] ?? [];
+    if (count($subjects) === 0) {
+      throw Exceptions::subjectDataNotFound($key, $this->workflowRun->getId());
+    }
+    if (count($subjects) > 1) {
+      throw Exceptions::multipleSubjectsFound($key, $this->workflowRun->getId());
+    }
+    return $subjects[0];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Data/Subject.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+class Subject {
+  /** @var string */
+  private $key;
+
+  /** @var array */
+  private $args;
+
+  public function __construct(
+    string $key,
+    array $args
+  ) {
+    $this->key = $key;
+    $this->args = $args;
+  }
+
+  public function getKey(): string {
+    return $this->key;
+  }
+
+  public function getArgs(): array {
+    return $this->args;
+  }
+
+  public function toArray(): array {
+    return [
+      'key' => $this->getKey(),
+      'args' => $this->getArgs(),
+    ];
+  }
+
+  public static function fromArray(array $data): self {
+    return new self($data['key'], $data['args']);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/SubjectEntry.php
+++ b/mailpoet/lib/Automation/Engine/Data/SubjectEntry.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Data\Subject as SubjectData;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Workflows\Payload;
+use MailPoet\Automation\Engine\Workflows\Subject;
+use Throwable;
+
+/**
+ * @template-covariant S of Subject<Payload>
+ */
+class SubjectEntry {
+  /** @var S */
+  private $subject;
+
+  /** @var SubjectData */
+  private $subjectData;
+
+  /** @var Payload|null */
+  private $payloadCache;
+
+  /** @param S $subject */
+  public function __construct(
+    Subject $subject,
+    SubjectData $subjectData
+  ) {
+    $this->subject = $subject;
+    $this->subjectData = $subjectData;
+  }
+
+  /** @return S */
+  public function getSubject(): Subject {
+    return $this->subject;
+  }
+
+  /** @return Payload */
+  public function getPayload() {
+    if ($this->payloadCache === null) {
+      try {
+        $this->payloadCache = $this->subject->getPayload($this->subjectData);
+      } catch (Throwable $e) {
+        throw Exceptions::subjectLoadFailed($this->subject->getKey(), $this->subjectData->getArgs());
+      }
+    }
+    return $this->payloadCache;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Data/Workflow.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Data;
 
 use DateTimeImmutable;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Utils\Json;
 
 class Workflow {
@@ -17,10 +18,10 @@ class Workflow {
     self::STATUS_TRASH,
   ];
 
-  /** @var int */
+  /** @var int|null */
   private $id;
 
-  /** @var int */
+  /** @var int|null */
   private $versionId;
 
   /** @var string */
@@ -55,13 +56,8 @@ class Workflow {
     $this->name = $name;
     $this->steps = $steps;
     $this->author = $author;
-
-    if ($id) {
-      $this->id = $id;
-    }
-    if ($versionId) {
-      $this->versionId = $versionId;
-    }
+    $this->id = $id;
+    $this->versionId = $versionId;
 
     $now = new DateTimeImmutable();
     $this->createdAt = $now;
@@ -69,10 +65,16 @@ class Workflow {
   }
 
   public function getId(): int {
+    if (!$this->id) {
+      throw InvalidStateException::create()->withMessage('No workflow ID was set');
+    }
     return $this->id;
   }
 
   public function getVersionId(): int {
+    if (!$this->versionId) {
+      throw InvalidStateException::create()->withMessage('No workflow version ID was set');
+    }
     return $this->versionId;
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Data/Workflow.php
@@ -44,7 +44,7 @@ class Workflow {
   /** @var array<string, Step> */
   private $steps;
 
-  /** @param Step[] $steps */
+  /** @param array<string, Step> $steps */
   public function __construct(
     string $name,
     array $steps,
@@ -53,11 +53,8 @@ class Workflow {
     int $versionId = null
   ) {
     $this->name = $name;
-    $this->steps = [];
+    $this->steps = $steps;
     $this->author = $author;
-    foreach ($steps as $step) {
-      $this->steps[$step->getId()] = $step;
-    }
 
     if ($id) {
       $this->id = $id;

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsPutEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsPutEndpoint.php
@@ -10,7 +10,7 @@ use MailPoet\Automation\Engine\Builder\UpdateWorkflowController;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Validators\WorkflowSchema;
+use MailPoet\Automation\Engine\Validation\WorkflowSchema;
 use MailPoet\Validator\Builder;
 
 class WorkflowsPutEndpoint extends Endpoint {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -140,11 +140,13 @@ class Exceptions {
       );
   }
 
-  public static function multipleSubjectsFound(string $key): InvalidStateException {
+  public static function multipleSubjectsFound(string $key, int $workflowRunId): InvalidStateException {
     return InvalidStateException::create()
       ->withErrorCode(self::MULTIPLE_SUBJECTS_FOUND)
-      // translators: %s is the name of the key.
-      ->withMessage(sprintf(__("Multiple subjects with key '%s' found, only one expected.", 'mailpoet'), $key));
+      // translators: %1$s is the key of the subject, %2$d is workflow run ID.
+      ->withMessage(
+        sprintf(__("Multiple subjects with key '%1\$s' found for workflow run with ID '%2\$d', only one expected.", 'mailpoet'), $key, $workflowRunId)
+      );
   }
 
   public static function workflowStructureModificationNotSupported(): UnexpectedValueException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -24,6 +24,8 @@ class Exceptions {
   private const SUBJECT_LOAD_FAILED = 'mailpoet_automation_workflow_subject_load_failed';
   private const SUBJECT_DATA_NOT_FOUND = 'mailpoet_automation_subject_data_not_found';
   private const MULTIPLE_SUBJECTS_FOUND = 'mailpoet_automation_multiple_subjects_found';
+  private const PAYLOAD_NOT_FOUND = 'mailpoet_automation_payload_not_found';
+  private const MULTIPLE_PAYLOADS_FOUND = 'mailpoet_automation_multiple_payloads_found';
   private const WORKFLOW_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_workflow_structure_modification_not_supported';
   private const WORKFLOW_STRUCTURE_NOT_VALID = 'mailpoet_automation_workflow_structure_not_valid';
   private const WORKFLOW_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_workflow_step_modified_when_unknon';
@@ -146,6 +148,24 @@ class Exceptions {
       // translators: %1$s is the key of the subject, %2$d is workflow run ID.
       ->withMessage(
         sprintf(__("Multiple subjects with key '%1\$s' found for workflow run with ID '%2\$d', only one expected.", 'mailpoet'), $key, $workflowRunId)
+      );
+  }
+
+  public static function payloadNotFound(string $class, int $workflowRunId): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::PAYLOAD_NOT_FOUND)
+      // translators: %1$s is the class of the payload, %2$d is workflow run ID.
+      ->withMessage(
+        sprintf(__("Payload of class '%1\$s' not found for workflow run with ID '%2\$d'.", 'mailpoet'), $class, $workflowRunId)
+      );
+  }
+
+  public static function multiplePayloadsFound(string $class, int $workflowRunId): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::MULTIPLE_PAYLOADS_FOUND)
+      // translators: %1$s is the class of the payloads, %2$d is workflow run ID.
+      ->withMessage(
+        sprintf(__("Multiple payloads of class '%1\$s' found for workflow run with ID '%2\$d'.", 'mailpoet'), $class, $workflowRunId)
       );
   }
 

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -108,7 +108,7 @@ class Exceptions {
   public static function workflowRunNotRunning(int $id, string $status): InvalidStateException {
     return InvalidStateException::create()
       ->withErrorCode(self::WORKFLOW_RUN_NOT_RUNNING)
-      // translators: %1$d is the ID of the workflow run, %2$s it's current status.
+      // translators: %1$d is the ID of the workflow run, %2$s its current status.
       ->withMessage(sprintf(__('Workflow run with ID "%1$d" is not running. Status: %2$s', 'mailpoet'), $id, $status));
   }
 
@@ -119,11 +119,11 @@ class Exceptions {
       ->withMessage(sprintf(__("Subject with key '%s' not found.", 'mailpoet'), $key));
   }
 
-  public static function subjectClassNotFound(string $key): NotFoundException {
+  public static function subjectClassNotFound(string $class): NotFoundException {
     return NotFoundException::create()
       ->withErrorCode(self::SUBJECT_NOT_FOUND)
-      // translators: %s is the key of the subject class not found.
-      ->withMessage(sprintf(__("Subject of class '%s' not found.", 'mailpoet'), $key));
+      // translators: %s is the class name of the subject not found.
+      ->withMessage(sprintf(__("Subject of class '%s' not found.", 'mailpoet'), $class));
   }
 
   public static function subjectLoadFailed(string $key, array $args): InvalidStateException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -23,6 +23,7 @@ class Exceptions {
   private const SUBJECT_LOAD_FAILED = 'mailpoet_automation_workflow_subject_load_failed';
   private const MULTIPLE_SUBJECTS_FOUND = 'mailpoet_automation_multiple_subjects_found';
   private const WORKFLOW_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_workflow_structure_modification_not_supported';
+  private const WORKFLOW_STRUCTURE_NOT_VALID = 'mailpoet_automation_workflow_structure_not_valid';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -138,5 +139,12 @@ class Exceptions {
     return UnexpectedValueException::create()
       ->withErrorCode(self::WORKFLOW_STRUCTURE_MODIFICATION_NOT_SUPPORTED)
       ->withMessage(__("Workflow structure modification not supported.", 'mailpoet'));
+  }
+
+  public static function workflowStructureNotValid(string $detail): UnexpectedValueException {
+    return UnexpectedValueException::create()
+      ->withErrorCode(self::WORKFLOW_STRUCTURE_NOT_VALID)
+      // translators: %s is a detailed information
+      ->withMessage(sprintf(__("Invalid workflow structure: %s", 'mailpoet'), $detail));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -22,6 +22,7 @@ class Exceptions {
   private const WORKFLOW_RUN_NOT_RUNNING = 'mailpoet_automation_workflow_run_not_running';
   private const SUBJECT_NOT_FOUND = 'mailpoet_automation_subject_not_found';
   private const SUBJECT_LOAD_FAILED = 'mailpoet_automation_workflow_subject_load_failed';
+  private const SUBJECT_DATA_NOT_FOUND = 'mailpoet_automation_subject_data_not_found';
   private const MULTIPLE_SUBJECTS_FOUND = 'mailpoet_automation_multiple_subjects_found';
   private const WORKFLOW_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_workflow_structure_modification_not_supported';
   private const WORKFLOW_STRUCTURE_NOT_VALID = 'mailpoet_automation_workflow_structure_not_valid';
@@ -128,6 +129,15 @@ class Exceptions {
       ->withErrorCode(self::SUBJECT_LOAD_FAILED)
       // translators: %1$s is the name of the key, %2$s the arguments.
       ->withMessage(sprintf(__('Subject with key "%1$s" and args "%2$s" failed to load.', 'mailpoet'), $key, Json::encode($args)));
+  }
+
+  public static function subjectDataNotFound(string $key, int $workflowRunId): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::SUBJECT_DATA_NOT_FOUND)
+      // translators: %1$s is the key of the subject, %2$d is workflow run ID.
+      ->withMessage(
+        sprintf(__("Subject data for subject with key '%1\$s' not found for workflow run with ID '%2\$d'.", 'mailpoet'), $key, $workflowRunId)
+      );
   }
 
   public static function multipleSubjectsFound(string $key): InvalidStateException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine;
 
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
@@ -24,6 +25,7 @@ class Exceptions {
   private const MULTIPLE_SUBJECTS_FOUND = 'mailpoet_automation_multiple_subjects_found';
   private const WORKFLOW_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_workflow_structure_modification_not_supported';
   private const WORKFLOW_STRUCTURE_NOT_VALID = 'mailpoet_automation_workflow_structure_not_valid';
+  private const WORKFLOW_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_workflow_step_modified_when_unknon';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -146,5 +148,19 @@ class Exceptions {
       ->withErrorCode(self::WORKFLOW_STRUCTURE_NOT_VALID)
       // translators: %s is a detailed information
       ->withMessage(sprintf(__("Invalid workflow structure: %s", 'mailpoet'), $detail));
+  }
+
+  public static function workflowStepModifiedWhenUnknown(Step $step): UnexpectedValueException {
+    return UnexpectedValueException::create()
+      ->withErrorCode(self::WORKFLOW_STEP_MODIFIED_WHEN_UNKNOWN)
+      // translators: %1$s is the key of the step, %2$s is the type of the step, %3\$s is its ID.
+      ->withMessage(
+        sprintf(
+          __("Modification of step '%1\$s' of type '%2\$s' with ID '%3\$s' is not supported when the related plugin is not active.", 'mailpoet'),
+          $step->getKey(),
+          $step->getType(),
+          $step->getId()
+        )
+      );
   }
 }

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\Control\RootStep;
 use MailPoet\Automation\Engine\Workflows\Action;
+use MailPoet\Automation\Engine\Workflows\Payload;
 use MailPoet\Automation\Engine\Workflows\Step;
 use MailPoet\Automation\Engine\Workflows\Subject;
 use MailPoet\Automation\Engine\Workflows\Trigger;
@@ -12,7 +13,7 @@ class Registry {
   /** @var array<string, Step> */
   private $steps = [];
 
-  /** @var array<string, Subject> */
+  /** @var array<string, Subject<Payload>> */
   private $subjects = [];
 
   /** @var array<string, Trigger> */
@@ -32,6 +33,7 @@ class Registry {
     $this->steps[$rootStep->getKey()] = $rootStep;
   }
 
+  /** @param Subject<Payload> $subject */
   public function addSubject(Subject $subject): void {
     $key = $subject->getKey();
     if (isset($this->subjects[$key])) {
@@ -40,11 +42,12 @@ class Registry {
     $this->subjects[$key] = $subject;
   }
 
+  /** @return Subject<Payload>|null */
   public function getSubject(string $key): ?Subject {
     return $this->subjects[$key] ?? null;
   }
 
-  /** @return array<string, Subject> */
+  /** @return array<string, Subject<Payload>> */
   public function getSubjects(): array {
     return $this->subjects;
   }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -2,10 +2,8 @@
 
 namespace MailPoet\Automation\Engine\Storage;
 
-use MailPoet\Automation\Engine\Control\SubjectLoader;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Exceptions;
-use MailPoet\Automation\Engine\Utils\Json;
 use wpdb;
 
 class WorkflowRunStorage {
@@ -15,16 +13,10 @@ class WorkflowRunStorage {
   /** @var wpdb */
   private $wpdb;
 
-  /** @var SubjectLoader */
-  private $subjectLoader;
-
-  public function __construct(
-    SubjectLoader $subjectLoader
-  ) {
+  public function __construct() {
     global $wpdb;
     $this->table = $wpdb->prefix . 'mailpoet_workflow_runs';
     $this->wpdb = $wpdb;
-    $this->subjectLoader = $subjectLoader;
   }
 
   public function createWorkflowRun(WorkflowRun $workflowRun): int {
@@ -39,15 +31,7 @@ class WorkflowRunStorage {
     $table = esc_sql($this->table);
     $query = (string)$this->wpdb->prepare("SELECT * FROM $table WHERE id = %d", $id);
     $result = $this->wpdb->get_row($query, ARRAY_A);
-
-    if ($result) {
-      $data = (array)$result;
-      $data['subjects'] = array_map(function (array $subject) {
-        return $this->subjectLoader->loadSubject($subject['key'], $subject['args']);
-      }, Json::decode($data['subjects']));
-      return WorkflowRun::fromArray($data);
-    }
-    return null;
+    return $result ? WorkflowRun::fromArray((array)$result) : null;
   }
 
   public function updateStatus(int $id, string $status): void {

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowGraph/WorkflowNode.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowGraph/WorkflowNode.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowGraph;
+
+use MailPoet\Automation\Engine\Data\Step;
+
+class WorkflowNode {
+  /** @var Step */
+  private $step;
+
+  /** @var array */
+  private $parents;
+
+  /* @param Step[] $parents */
+  public function __construct(
+    Step $step,
+    array $parents
+  ) {
+    $this->step = $step;
+    $this->parents = $parents;
+  }
+
+  public function getStep(): Step {
+    return $this->step;
+  }
+
+  /** @return Step[] */
+  public function getParents(): array {
+    return $this->parents;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowGraph/WorkflowNodeVisitor.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowGraph/WorkflowNodeVisitor.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowGraph;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+
+interface WorkflowNodeVisitor {
+  public function initialize(Workflow $workflow): void;
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void;
+
+  public function complete(Workflow $workflow): void;
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowGraph/WorkflowWalker.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowGraph/WorkflowWalker.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowGraph;
+
+use Generator;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+
+class WorkflowWalker {
+  /** @param WorkflowNodeVisitor[] $visitors */
+  public function walk(Workflow $workflow, array $visitors = []): void {
+    $steps = $workflow->getSteps();
+    $root = $steps['root'] ?? null;
+    if (!$root) {
+      throw Exceptions::workflowStructureNotValid(__("Workflow must contain a 'root' step", 'mailpoet'));
+    }
+
+    foreach ($visitors as $visitor) {
+      $visitor->initialize($workflow);
+    }
+
+    foreach ($this->walkStepsDepthFirstPreOrder($steps, $root) as $record) {
+      [$step, $parents] = $record;
+      foreach ($visitors as $visitor) {
+        $visitor->visitNode($workflow, new WorkflowNode($step, array_values($parents)));
+      }
+    }
+
+    foreach ($visitors as $visitor) {
+      $visitor->complete($workflow);
+    }
+  }
+
+  /**
+   * @param array<string, Step> $steps
+   * @return Generator<array{0: Step, 1: array<string, Step>}>
+   */
+  private function walkStepsDepthFirstPreOrder(array $steps, Step $root): Generator {
+    /** @var array{0: Step, 1: array<string, Step>}[] $stack */
+    $stack = [
+      [$root, []],
+    ];
+
+    do {
+      $record = array_pop($stack);
+      if (!$record) {
+        throw new InvalidStateException();
+      }
+      yield $record;
+      [$step, $parents] = $record;
+
+      foreach (array_reverse($step->getNextSteps()) as $nextStepData) {
+        $nextStepId = $nextStepData->getId();
+        $nextStep = $steps[$nextStepId] ?? null;
+        if (!$nextStep) {
+          throw $this->createStepNotFoundException($nextStepId, $step->getId());
+        }
+
+        $nextStepParents = array_merge($parents, [$step->getId() => $step]);
+        if (isset($nextStepParents[$nextStepId])) {
+          continue; // cycle detected, do not enter the path again
+        }
+        array_push($stack, [$nextStep, $nextStepParents]);
+      }
+    } while (count($stack) > 0);
+  }
+
+  private function createStepNotFoundException(string $stepId, string $parentStepId): UnexpectedValueException {
+    return Exceptions::workflowStructureNotValid(
+      // translators: %1$s is ID of the step not found, %2$s is ID of the step that references it
+      sprintf(
+        __("Step with ID '%1\$s' not found (referenced from '%2\$s')", 'mailpoet'),
+        $stepId,
+        $parentStepId
+      )
+    );
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRule.php
@@ -11,7 +11,10 @@ class ConsistentStepMapRule implements WorkflowNodeVisitor {
   public function initialize(Workflow $workflow): void {
     foreach ($workflow->getSteps() as $id => $step) {
       if ($id !== $step->getId()) {
-        throw Exceptions::workflowStructureNotValid(__('TODO', 'mailpoet'));
+        // translators: %1$s is the ID of the step, %2$s is its index in the steps object.
+        throw Exceptions::workflowStructureNotValid(
+          sprintf(__("Step with ID '%1\$s' stored under a mismatched index '%2\$s'.", 'mailpoet'), $step->getId(), $id)
+        );
       }
     }
   }

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRule.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class ConsistentStepMapRule implements WorkflowNodeVisitor {
+  public function initialize(Workflow $workflow): void {
+    foreach ($workflow->getSteps() as $id => $step) {
+      if ($id !== $step->getId()) {
+        throw Exceptions::workflowStructureNotValid(__('TODO', 'mailpoet'));
+      }
+    }
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+  }
+
+  public function complete(Workflow $workflow): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoCycleRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoCycleRule.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class NoCycleRule implements WorkflowNodeVisitor {
+  public function initialize(Workflow $workflow): void {
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+    $step = $node->getStep();
+    $parents = $node->getParents();
+    $parentIdsMap = array_combine(
+      array_map(function (Step $parent) {
+        return $parent->getId();
+      }, $node->getParents()),
+      $parents
+    ) ?: [];
+
+    foreach ($step->getNextSteps() as $nextStep) {
+      $nextStepId = $nextStep->getId();
+      if ($nextStepId === $step->getId() || isset($parentIdsMap[$nextStepId])) {
+        throw Exceptions::workflowStructureNotValid(__('Cycle found in workflow graph', 'mailpoet'));
+      }
+    }
+  }
+
+  public function complete(Workflow $workflow): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoDuplicateEdgesRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoDuplicateEdgesRule.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class NoDuplicateEdgesRule implements WorkflowNodeVisitor {
+  public function initialize(Workflow $workflow): void {
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+    $visitedNextStepIdsMap = [];
+    foreach ($node->getStep()->getNextSteps() as $nextStep) {
+      if (isset($visitedNextStepIdsMap[$nextStep->getId()])) {
+        throw Exceptions::workflowStructureNotValid(__('Duplicate next step definition found', 'mailpoet'));
+      }
+      $visitedNextStepIdsMap[$nextStep->getId()] = true;
+    }
+  }
+
+  public function complete(Workflow $workflow): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoJoinRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoJoinRule.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class NoJoinRule implements WorkflowNodeVisitor {
+  /** @var array<string, Step> */
+  private $visitedSteps = [];
+
+  public function initialize(Workflow $workflow): void {
+    $this->visitedSteps = [];
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+    $step = $node->getStep();
+    $this->visitedSteps[$step->getId()] = $step;
+    foreach ($step->getNextSteps() as $nextStep) {
+      $nextStepId = $nextStep->getId();
+      if (isset($this->visitedSteps[$nextStepId])) {
+        throw Exceptions::workflowStructureNotValid(__('Path join found in workflow graph', 'mailpoet'));
+      }
+    }
+  }
+
+  public function complete(Workflow $workflow): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoSplitRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoSplitRule.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class NoSplitRule implements WorkflowNodeVisitor {
+  public function initialize(Workflow $workflow): void {
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+    $step = $node->getStep();
+    if (count($step->getNextSteps()) > 1) {
+      throw Exceptions::workflowStructureNotValid(__('Path split found in workflow graph', 'mailpoet'));
+    }
+  }
+
+  public function complete(Workflow $workflow): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoUnreachableStepsRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/NoUnreachableStepsRule.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class NoUnreachableStepsRule implements WorkflowNodeVisitor {
+  /** @var WorkflowNode[] */
+  private $visitedNodes = [];
+
+  public function initialize(Workflow $workflow): void {
+    $this->visitedNodes = [];
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+    $this->visitedNodes[] = $node;
+  }
+
+  public function complete(Workflow $workflow): void {
+    if (count($this->visitedNodes) !== count($workflow->getSteps())) {
+      throw Exceptions::workflowStructureNotValid(__('Unreachable steps found in workflow graph', 'mailpoet'));
+    }
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/TriggersUnderRootRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowRules/TriggersUnderRootRule.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNode;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowNodeVisitor;
+
+class TriggersUnderRootRule implements WorkflowNodeVisitor {
+  /** @var array<string, Step> $triggersMap */
+  private $triggersMap = [];
+
+  public function initialize(Workflow $workflow): void {
+    $this->triggersMap = [];
+    foreach ($workflow->getSteps() as $step) {
+      if ($step->getType() === 'trigger') {
+        $this->triggersMap[$step->getId()] = $step;
+      }
+    }
+  }
+
+  public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+    $step = $node->getStep();
+    if ($step->getType() === Step::TYPE_ROOT) {
+      return;
+    }
+
+    foreach ($step->getNextSteps() as $nextStep) {
+      $nextStepId = $nextStep->getId();
+      if (isset($this->triggersMap[$nextStepId])) {
+        throw Exceptions::workflowStructureNotValid(__('Trigger must be a direct descendant of workflow root', 'mailpoet'));
+      }
+    }
+  }
+
+  public function complete(Workflow $workflow): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowSchema.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowSchema.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Engine\Validators;
+namespace MailPoet\Automation\Engine\Validation;
 
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ArraySchema;

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowSchema.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowSchema.php
@@ -18,7 +18,7 @@ class WorkflowSchema {
 
   public static function getStepsSchema(): ObjectSchema {
     return Builder::object()
-      ->properties(['root' => self::getRootStepSchema()])
+      ->properties(['root' => self::getRootStepSchema()->required()])
       ->additionalProperties(self::getStepSchema());
   }
 

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowStepsValidator.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowStepsValidator.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Validator\Validator;
+
+class WorkflowStepsValidator {
+  /** @var Registry */
+  private $registry;
+
+  /** @var Validator */
+  private $validator;
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  /** @var Workflow|null|false */
+  private $cachedExistingWorkflow = false;
+
+  public function __construct(
+    Registry $registry,
+    Validator $validator,
+    WorkflowStorage $workflowStorage
+  ) {
+    $this->validator = $validator;
+    $this->registry = $registry;
+    $this->workflowStorage = $workflowStorage;
+  }
+
+  public function validateSteps(Workflow $workflow): void {
+    foreach ($workflow->getSteps() as $step) {
+      $this->validateStep($workflow, $step);
+    }
+  }
+
+  private function validateStep(Workflow $workflow, Step $step): void {
+    $registryStep = $this->registry->getStep($step->getKey());
+    if ($registryStep) {
+      $this->validator->validate($registryStep->getArgsSchema(), $step->getArgs());
+    } else {
+      // step not registered (e.g. plugin was deactivated) - allow saving it only if it hasn't changed
+      $currentWorkflow = $this->getCurrentWorkflow($workflow->getId());
+      $currentStep = $currentWorkflow ? ($currentWorkflow->getSteps()[$step->getId()] ?? null) : null;
+      if (!$currentStep || $step->toArray() !== $currentStep->toArray()) {
+        throw Exceptions::workflowStepModifiedWhenUnknown($step);
+      }
+    }
+  }
+
+  private function getCurrentWorkflow(int $id): ?Workflow {
+    if ($this->cachedExistingWorkflow === false) {
+      $this->cachedExistingWorkflow = $this->workflowStorage->getWorkflow($id);
+    }
+    return $this->cachedExistingWorkflow;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowValidator.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowValidator.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\ConsistentStepMapRule;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\NoCycleRule;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\NoDuplicateEdgesRule;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\NoJoinRule;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\NoSplitRule;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\NoUnreachableStepsRule;
+use MailPoet\Automation\Engine\Validation\WorkflowRules\TriggersUnderRootRule;
+
+class WorkflowValidator {
+  /** @var WorkflowWalker */
+  private $workflowWalker;
+
+  public function __construct(
+    WorkflowWalker $workflowWalker
+  ) {
+    $this->workflowWalker = $workflowWalker;
+  }
+
+  public function validate(Workflow $workflow): void {
+    $this->workflowWalker->walk($workflow, [
+      new NoUnreachableStepsRule(),
+      new ConsistentStepMapRule(),
+      new NoDuplicateEdgesRule(),
+      new TriggersUnderRootRule(),
+      new NoCycleRule(),
+      new NoJoinRule(),
+      new NoSplitRule(),
+    ]);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/WorkflowValidator.php
+++ b/mailpoet/lib/Automation/Engine/Validation/WorkflowValidator.php
@@ -13,16 +13,22 @@ use MailPoet\Automation\Engine\Validation\WorkflowRules\NoUnreachableStepsRule;
 use MailPoet\Automation\Engine\Validation\WorkflowRules\TriggersUnderRootRule;
 
 class WorkflowValidator {
+  /** @var WorkflowStepsValidator */
+  private $stepsValidator;
+
   /** @var WorkflowWalker */
   private $workflowWalker;
 
   public function __construct(
+    WorkflowStepsValidator $stepsValidator,
     WorkflowWalker $workflowWalker
   ) {
     $this->workflowWalker = $workflowWalker;
+    $this->stepsValidator = $stepsValidator;
   }
 
   public function validate(Workflow $workflow): void {
+    // validate graph
     $this->workflowWalker->walk($workflow, [
       new NoUnreachableStepsRule(),
       new ConsistentStepMapRule(),
@@ -32,5 +38,8 @@ class WorkflowValidator {
       new NoJoinRule(),
       new NoSplitRule(),
     ]);
+
+    // validate steps
+    $this->stepsValidator->validateSteps($workflow);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Action.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Action.php
@@ -3,11 +3,13 @@
 namespace MailPoet\Automation\Engine\Workflows;
 
 use MailPoet\Automation\Engine\Data\Step as StepData;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 
 interface Action extends Step {
   public function isValid(array $subjects, StepData $step, Workflow $workflow): bool;
 
-  public function run(Workflow $workflow, WorkflowRun $workflowRun, StepData $step): void;
+  /** @var SubjectEntry[] $subjectEntries */
+  public function run(Workflow $workflow, WorkflowRun $workflowRun, StepData $step, array $subjectEntries): void;
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Action.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Action.php
@@ -3,13 +3,11 @@
 namespace MailPoet\Automation\Engine\Workflows;
 
 use MailPoet\Automation\Engine\Data\Step as StepData;
-use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Data\WorkflowRun;
 
 interface Action extends Step {
   public function isValid(array $subjects, StepData $step, Workflow $workflow): bool;
 
-  /** @var SubjectEntry[] $subjectEntries */
-  public function run(Workflow $workflow, WorkflowRun $workflowRun, StepData $step, array $subjectEntries): void;
+  public function run(StepRunArgs $args): void;
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Payload.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Payload.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Workflows;
+
+interface Payload {
+}

--- a/mailpoet/lib/Automation/Engine/Workflows/Step.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Step.php
@@ -10,4 +10,7 @@ interface Step {
   public function getName(): string;
 
   public function getArgsSchema(): ObjectSchema;
+
+  /** @return string[] */
+  public function getSubjectKeys(): array;
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Subject.php
@@ -2,13 +2,19 @@
 
 namespace MailPoet\Automation\Engine\Workflows;
 
+use MailPoet\Automation\Engine\Data\Subject as SubjectData;
+use MailPoet\Validator\Schema\ObjectSchema;
+
+/**
+ * @template-covariant T of Payload
+ */
 interface Subject {
   public function getKey(): string;
 
-  /** array<SubjectField> */
-  public function getFields(): array;
+  public function getName(): string;
 
-  public function load(array $args): void;
+  public function getArgsSchema(): ObjectSchema;
 
-  public function pack(): array;
+  /** @return T */
+  public function getPayload(SubjectData $subjectData): Payload;
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Trigger.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Trigger.php
@@ -2,12 +2,16 @@
 
 namespace MailPoet\Automation\Engine\Workflows;
 
+use MailPoet\Automation\Engine\Data\SubjectEntry;
+
 interface Trigger extends Step {
   public function registerHooks(): void;
 
   /**
    * Validate if the specific context of a run meets the
    * settings of a given trigger.
+   *
+   * @param SubjectEntry[] $subjectEntries
    */
-  public function isTriggeredBy(array $args, Subject ...$subjects): bool;
+  public function isTriggeredBy(array $args, array $subjectEntries): bool;
 }

--- a/mailpoet/lib/Automation/Engine/Workflows/Trigger.php
+++ b/mailpoet/lib/Automation/Engine/Workflows/Trigger.php
@@ -2,16 +2,10 @@
 
 namespace MailPoet\Automation\Engine\Workflows;
 
-use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 
 interface Trigger extends Step {
   public function registerHooks(): void;
 
-  /**
-   * Validate if the specific context of a run meets the
-   * settings of a given trigger.
-   *
-   * @param SubjectEntry[] $subjectEntries
-   */
-  public function isTriggeredBy(array $args, array $subjectEntries): bool;
+  public function isTriggeredBy(StepRunArgs $args): bool;
 }

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
@@ -4,8 +4,8 @@ namespace MailPoet\Automation\Integrations\Core\Actions;
 
 use MailPoet\Automation\Engine\Control\ActionScheduler;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Workflows\Action;
 use MailPoet\Validator\Builder;
@@ -40,11 +40,12 @@ class DelayAction implements Action {
     return [];
   }
 
-  public function run(Workflow $workflow, WorkflowRun $workflowRun, Step $step): void {
+  public function run(StepRunArgs $args): void {
+    $step = $args->getStep();
     $nextStep = $step->getNextSteps()[0] ?? null;
     $this->actionScheduler->schedule(time() + $this->calculateSeconds($step), Hooks::WORKFLOW_STEP, [
       [
-        'workflow_run_id' => $workflowRun->getId(),
+        'workflow_run_id' => $args->getWorkflowRun()->getId(),
         'step_id' => $nextStep ? $nextStep->getId() : null,
       ],
     ]);

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
@@ -36,6 +36,10 @@ class DelayAction implements Action {
     ]);
   }
 
+  public function getSubjectKeys(): array {
+    return [];
+  }
+
   public function run(Workflow $workflow, WorkflowRun $workflowRun, Step $step): void {
     $nextStep = $step->getNextSteps()[0] ?? null;
     $this->actionScheduler->schedule(time() + $this->calculateSeconds($step), Hooks::WORKFLOW_STEP, [

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -100,18 +100,8 @@ class SendEmailAction implements Action {
 
   public function run(StepRunArgs $args): void {
     $newsletter = $this->getEmailForStep($args->getStep());
-
-    $segmentPayload = $args->getSingleSubjectEntry('mailpoet:segment')->getPayload();
-    if (!$segmentPayload instanceof SegmentPayload) {
-      throw new InvalidStateException();
-    }
-    $segmentId = $segmentPayload->getId();
-
-    $subscriberPayload = $args->getSingleSubjectEntry('mailpoet:subscriber')->getPayload();
-    if (!$subscriberPayload instanceof SubscriberPayload) {
-      throw new InvalidStateException();
-    }
-    $subscriberId = $subscriberPayload->getId();
+    $segmentId = $args->getSinglePayloadByClass(SegmentPayload::class)->getId();
+    $subscriberId = $args->getSinglePayloadByClass(SubscriberPayload::class)->getId();
 
     $subscriberSegment = $this->subscriberSegmentRepository->findOneBy([
       'subscriber' => $subscriberId,

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -72,6 +72,13 @@ class SendEmailAction implements Action {
     ]);
   }
 
+  public function getSubjectKeys(): array {
+    return [
+      'mailpoet:segment',
+      'mailpoet:subscriber',
+    ];
+  }
+
   public function isValid(array $subjects, Step $step, Workflow $workflow): bool {
     try {
       $this->getEmailForStep($step);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SegmentPayload.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SegmentPayload.php
@@ -27,4 +27,8 @@ class SegmentPayload implements Payload {
   public function getName(): string {
     return $this->segment->getName();
   }
+
+  public function getType(): string {
+    return $this->segment->getType();
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SegmentPayload.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SegmentPayload.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Payloads;
+
+use MailPoet\Automation\Engine\Workflows\Payload;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\InvalidStateException;
+
+class SegmentPayload implements Payload {
+  /** @var SegmentEntity */
+  private $segment;
+
+  public function __construct(
+    SegmentEntity $segment
+  ) {
+    $this->segment = $segment;
+  }
+
+  public function getId(): int {
+    $id = $this->segment->getId();
+    if (!$id) {
+      throw new InvalidStateException();
+    }
+    return $id;
+  }
+
+  public function getName(): string {
+    return $this->segment->getName();
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SubscriberPayload.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SubscriberPayload.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Payloads;
+
+use MailPoet\Automation\Engine\Workflows\Payload;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\InvalidStateException;
+
+class SubscriberPayload implements Payload {
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  public function __construct(
+    SubscriberEntity $subscriber
+  ) {
+    $this->subscriber = $subscriber;
+  }
+
+  public function getId(): int {
+    $id = $this->subscriber->getId();
+    if (!$id) {
+      throw new InvalidStateException();
+    }
+    return $id;
+  }
+
+  public function getEmail(): string {
+    return $this->subscriber->getEmail();
+  }
+
+  public function getStatus(): string {
+    return $this->subscriber->getStatus();
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SubscriberPayload.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SubscriberPayload.php
@@ -31,4 +31,12 @@ class SubscriberPayload implements Payload {
   public function getStatus(): string {
     return $this->subscriber->getStatus();
   }
+
+  public function isWpUser(): bool {
+    return $this->subscriber->isWPUser();
+  }
+
+  public function getWpUserId(): ?int {
+    return $this->subscriber->getWpUserId();
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
@@ -3,77 +3,73 @@
 namespace MailPoet\Automation\Integrations\MailPoet\Subjects;
 
 use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Engine\Data\Subject as SubjectData;
+use MailPoet\Automation\Engine\Workflows\Payload;
 use MailPoet\Automation\Engine\Workflows\Subject;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\InvalidStateException;
+use MailPoet\Automation\Integrations\MailPoet\Payloads\SegmentPayload;
 use MailPoet\NotFoundException;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema\ObjectSchema;
 
+/**
+ * @implements Subject<SegmentPayload>
+ */
 class SegmentSubject implements Subject {
   const KEY = 'mailpoet:segment';
 
-  /** @var Field[] */
-  private $fields;
-
   /** @var SegmentsRepository */
   private $segmentsRepository;
-
-  /** @var SegmentEntity|null */
-  private $segment;
 
   public function __construct(
     SegmentsRepository $segmentsRepository
   ) {
     $this->segmentsRepository = $segmentsRepository;
-
-    $this->fields = [
-      'name' =>
-      new Field(
-        'mailpoet:segment:name',
-        Field::TYPE_STRING,
-        __('Segment name', 'mailpoet'),
-        function () {
-          return $this->getSegment()->getName();
-        }
-      ),
-      'id' =>
-      new Field(
-        'mailpoet:segment:id',
-        Field::TYPE_INTEGER,
-        __('Segment ID', 'mailpoet'),
-        function () {
-          return $this->getSegment()->getId();
-        }
-      ),
-    ];
   }
 
   public function getKey(): string {
     return self::KEY;
   }
 
-  public function getFields(): array {
-    return $this->fields;
+  public function getName(): string {
+    return __('MailPoet segment', 'mailpoet');
   }
 
-  public function load(array $args): void {
-    $id = $args['segment_id'];
-    $this->segment = $this->segmentsRepository->findOneById($args['segment_id']);
-    if (!$this->segment) {
+  public function getArgsSchema(): ObjectSchema {
+    return Builder::object([
+      'segment_id' => Builder::integer()->required(),
+    ]);
+  }
+
+  public function getPayload(SubjectData $subjectData): Payload {
+    $id = $subjectData->getArgs()['segment_id'];
+    $segment = $this->segmentsRepository->findOneById($id);
+    if (!$segment) {
       // translators: %d is the ID.
       throw NotFoundException::create()->withMessage(sprintf(__("Segment with ID '%d' not found.", 'mailpoet'), $id));
     }
+    return new SegmentPayload($segment);
   }
 
-  public function pack(): array {
-    $segment = $this->getSegment();
-    return ['segment_id' => $segment->getId()];
-  }
-
-  public function getSegment(): SegmentEntity {
-    if (!$this->segment) {
-      throw InvalidStateException::create()->withMessage(__('Segment was not loaded.', 'mailpoet'));
-    }
-    return $this->segment;
+  /** @return Field[] */
+  public function getFields(): array {
+    return [
+      new Field(
+        'mailpoet:segment:id',
+        Field::TYPE_INTEGER,
+        __('Segment ID', 'mailpoet'),
+        function (SegmentPayload $payload) {
+          return $payload->getId();
+        }
+      ),
+      new Field(
+        'mailpoet:segment:name',
+        Field::TYPE_STRING,
+        __('Segment name', 'mailpoet'),
+        function (SegmentPayload $payload) {
+          return $payload->getName();
+        }
+      ),
+    ];
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/WorkflowBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/WorkflowBuilder.php
@@ -38,9 +38,9 @@ class WorkflowBuilder {
         $nextSteps
       );
       $nextSteps = [new NextStep($step->getId())];
-      $steps[] = $step;
+      $steps[$step->getId()] = $step;
     }
-    $steps[] = new Step('root', 'root', 'core:root', [], $nextSteps);
+    $steps['root'] = new Step('root', 'root', 'core:root', [], $nextSteps);
     $steps = array_reverse($steps);
     return new Workflow(
       $name,

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
@@ -39,6 +39,13 @@ class SomeoneSubscribesTrigger implements Trigger {
     ]);
   }
 
+  public function getSubjectKeys(): array {
+    return [
+      SubscriberSubject::KEY,
+      SegmentSubject::KEY,
+    ];
+  }
+
   public function registerHooks(): void {
     $this->wp->addAction('mailpoet_segment_subscribed', [$this, 'handleSubscription'], 10, 2);
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
@@ -2,10 +2,11 @@
 
 namespace MailPoet\Automation\Integrations\MailPoet\Triggers;
 
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Hooks;
-use MailPoet\Automation\Engine\Workflows\Subject;
 use MailPoet\Automation\Engine\Workflows\Trigger;
+use MailPoet\Automation\Integrations\MailPoet\Payloads\SegmentPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -64,26 +65,12 @@ class SomeoneSubscribesTrigger implements Trigger {
     ]);
   }
 
-  public function isTriggeredBy(array $args, Subject ...$subjects): bool {
+  public function isTriggeredBy(StepRunArgs $args): bool {
+    $segmentId = $args->getSinglePayloadByClass(SegmentPayload::class)->getId();
 
-    $segment = null;
-    foreach ($subjects as $subject) {
-      if (!$subject instanceof SegmentSubject) {
-        continue;
-      }
-      /**
-       * @var SegmentSubject $subject
-       */
-      $segment = $subject->getSegment();
-    }
-
-    // Return true, when no segment list is defined (=any list) or the segment matches the definition.
-    return (
-      !$segment
-      || !isset($args['segment_ids'])
-      || !is_array($args['segment_ids'])
-      || !count($args['segment_ids'])
-      || in_array($segment->getId(), $args['segment_ids'], true)
-    );
+    // Triggers when no segment IDs defined (= any segment) or the current segment paylo.
+    $triggerArgs = $args->getStep()->getArgs();
+    $segmentIds = $triggerArgs['segment_ids'] ?? [];
+    return !is_array($segmentIds) || !$segmentIds || in_array($segmentId, $segmentIds, true);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Integrations\MailPoet\Triggers;
 
+use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Workflows\Subject;
 use MailPoet\Automation\Engine\Workflows\Trigger;
@@ -51,18 +52,8 @@ class SomeoneSubscribesTrigger implements Trigger {
     }
 
     $this->wp->doAction(Hooks::TRIGGER, $this, [
-      [
-        'key' => SegmentSubject::KEY,
-        'args' => [
-          'segment_id' => $segment->getId(),
-        ],
-      ],
-      [
-        'key' => SubscriberSubject::KEY,
-        'args' => [
-          'subscriber_id' => $subscriber->getId(),
-        ],
-      ],
+      new Subject(SegmentSubject::KEY, ['segment_id' => $segment->getId()]),
+      new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]),
     ]);
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -129,6 +129,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Validation\WorkflowValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsGetEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -128,6 +128,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunLogStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsGetEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -129,6 +129,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Validation\WorkflowStepsValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\WorkflowValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Automation\Engine\Data;
 
 use MailPoet\Automation\Engine\Control\StepHandler;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
@@ -294,9 +295,9 @@ class TestAction implements Action {
     return true;
   }
 
-  public function run(Workflow $workflow, WorkflowRun $workflowRun, Step $step): void {
+  public function run(StepRunArgs $args): void {
     if ($this->callback) {
-      ($this->callback)($workflow, $workflowRun, $step);
+      ($this->callback)($args);
     }
   }
 

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -154,7 +154,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
   public function testItStoresWorkflowRunAndStepIdsCorrectly() {
     $testAction = $this->getRegisteredTestAction();
     $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey(), [], []);
-    $workflow = new Workflow('test_workflow', [$actionStep], new \WP_User());
+    $workflow = new Workflow('test_workflow', [$actionStep->getId() => $actionStep], new \WP_User());
     $workflowId = $this->workflowStorage->createWorkflow($workflow);
     // Reload to get additional data post-save
     $workflow = $this->workflowStorage->getWorkflow($workflowId);
@@ -240,7 +240,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
     }
     $testAction = $this->getRegisteredTestAction($callback);
     $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey(), [], []);
-    $workflow = new Workflow('test_workflow', [$actionStep], new \WP_User());
+    $workflow = new Workflow('test_workflow', [$actionStep->getId() => $actionStep], new \WP_User());
     $workflowId = $this->workflowStorage->createWorkflow($workflow);
     // Reload to get additional data post-save
     $workflow = $this->workflowStorage->getWorkflow($workflowId);

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -285,6 +285,11 @@ class TestAction implements Action {
     $this->callback = $callback;
   }
 
+
+  public function getSubjectKeys(): array {
+    return [];
+  }
+
   public function isValid(array $subjects, Step $step, Workflow $workflow): bool {
     return true;
   }

--- a/mailpoet/tests/integration/Automation/Integrations/Core/Actions/DelayActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/Core/Actions/DelayActionTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Automation\Integrations\Core\Actions;
 
 use MailPoet\Automation\Engine\Control\ActionScheduler;
 use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
@@ -40,11 +41,7 @@ class DelayActionTest extends \MailPoetTest {
       ]]
     );
     $testee = new DelayAction($actionScheduler);
-    $testee->run(
-      $workflow,
-      $workflowRun,
-      $step
-    );
+    $testee->run(new StepRunArgs($workflow, $workflowRun, $step, []));
   }
 
   public function dataForTestItCalculatesDelayTypesCorrectly() : array {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -107,7 +107,7 @@ class SendEmailActionTest extends \MailPoetTest {
     $email = (new Newsletter())->withAutomationType()->create();
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-    $workflow = new Workflow('some-workflow', [$step], new \WP_User());
+    $workflow = new Workflow('some-workflow', [$step->getId() => $step], new \WP_User());
     $run = new WorkflowRun(1, 1, 'trigger-key', $subjects);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
@@ -129,7 +129,7 @@ class SendEmailActionTest extends \MailPoetTest {
     $email = (new Newsletter())->withAutomationType()->create();
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-    $workflow = new Workflow('some-workflow', [$step], new \WP_User());
+    $workflow = new Workflow('some-workflow', [$step->getId() => $step], new \WP_User());
     $run = new WorkflowRun(1, 1, 'trigger-key', $subjects);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
@@ -161,7 +161,7 @@ class SendEmailActionTest extends \MailPoetTest {
     $email = (new Newsletter())->withAutomationType()->create();
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-    $workflow = new Workflow('some-workflow', [$step], new \WP_User());
+    $workflow = new Workflow('some-workflow', [$step->getId() => $step], new \WP_User());
     $run = new WorkflowRun(1, 1, 'trigger-key', $subjects);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
@@ -190,7 +190,7 @@ class SendEmailActionTest extends \MailPoetTest {
     $email = (new Newsletter())->withAutomationType()->create();
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-    $workflow = new Workflow('some-workflow', [$step], new \WP_User());
+    $workflow = new Workflow('some-workflow', [$step->getId() => $step], new \WP_User());
     $run = new WorkflowRun(1, 1, 'trigger-key', $subjects);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
@@ -228,7 +228,7 @@ class SendEmailActionTest extends \MailPoetTest {
       $email = (new Newsletter())->withAutomationType()->create();
 
       $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-      $workflow = new Workflow('some-workflow', [$step], new \WP_User());
+      $workflow = new Workflow('some-workflow', [$step->getId() => $step], new \WP_User());
       $run = new WorkflowRun(1, 1, 'trigger-key', $subjects);
 
       $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
@@ -257,7 +257,7 @@ class SendEmailActionTest extends \MailPoetTest {
     $email = (new Newsletter())->withAutomationType()->create();
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-    $workflow = new Workflow('some-workflow', [$step], new \WP_User());
+    $workflow = new Workflow('some-workflow', [$step->getId() => $step], new \WP_User());
     $run = new WorkflowRun(1, 1, 'trigger-key', $subjects);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
@@ -1,15 +1,19 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Integrations\MailPoet\Triggers;
 
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
 
-class SomeoneSubscribesTriggerTest extends \MailPoetTest
-{
-
+class SomeoneSubscribesTriggerTest extends \MailPoetTest {
   /** @var SegmentsRepository */
   private $segmentRepository;
 
@@ -19,35 +23,37 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest
   public function _before() {
     $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->segments = [
-        'segment_1' => $this->segmentRepository->createOrUpdate('Segment 1'),
-        'segment_2' => $this->segmentRepository->createOrUpdate('Segment 2'),
+      'segment_1' => $this->segmentRepository->createOrUpdate('Segment 1'),
+      'segment_2' => $this->segmentRepository->createOrUpdate('Segment 2'),
     ];
   }
 
   /**
    * @dataProvider dataForTestTriggeredByWorkflowRun
    */
-  public function testTriggeredByWorkflowRun(array $segmentSetting, string $currentSegmentId, bool $expectation) {
-    /** @var SomeoneSubscribesTrigger $testee */
+  public function testTriggeredByWorkflowRun(array $segmentIndexes, string $currentSegmentIndex, bool $expectation): void {
+    $segmentIds = $this->getSegmentIds($segmentIndexes);
+    $currentSegmentId = $this->getSegmentId($currentSegmentIndex);
+
     $testee = $this->diContainer->get(SomeoneSubscribesTrigger::class);
-    $args = [
-      'segment_ids' => array_map(
-        function($key) {
-          return isset($this->segments[$key]) ? $this->segments[$key]->getId() : $key;
-        },
-        $segmentSetting
-      )
-    ];
-    /** @var SegmentSubject $segmentSubject */
-    $segmentSubject = $this->diContainer->get(SegmentSubject::class);
-    $segmentSubject->load(['segment_id' => $this->segments[$currentSegmentId]->getId()]);
-    $this->assertSame($expectation, $testee->isTriggeredBy($args, $segmentSubject));
+    $stepRunArgs = new StepRunArgs(
+      $this->make(Workflow::class),
+      $this->make(WorkflowRun::class),
+      new Step('test-id', 'trigger', 'test:trigger', ['segment_ids' => $segmentIds], []),
+      [
+        new SubjectEntry(
+          $this->diContainer->get(SegmentSubject::class),
+          new Subject('mailpoet:segment', ['segment_id' => $currentSegmentId])
+        ),
+      ]
+    );
+    $this->assertSame($expectation, $testee->isTriggeredBy($stepRunArgs));
   }
 
-  public function dataForTestTriggeredByWorkflowRun() : array {
+  public function dataForTestTriggeredByWorkflowRun(): array {
     return [
       'any_list' => [
-        [], //Any list setting
+        [], // any list
         'segment_1',
         true,
       ],
@@ -63,13 +69,19 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest
       ],
     ];
   }
+
   public function _after() {
-    $segmentIds = array_values(array_map(
-      function(SegmentEntity $seg) : int { return (int)$seg->getId(); },
-      $this->segments
-    ));
-    $this->segmentRepository->bulkDelete(
-      $segmentIds
-    );
+    $segmentIds = $this->getSegmentIds(array_keys($this->segments));
+    $this->segmentRepository->bulkDelete($segmentIds);
+  }
+
+  private function getSegmentId(string $index): int {
+    return (int)$this->segments[$index]->getId();
+  }
+
+  private function getSegmentIds(array $indexes): array {
+    return array_map(function (string $index): int {
+      return $this->getSegmentId($index);
+    }, $indexes);
   }
 }

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowGraph/WorkflowWalkerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowGraph/WorkflowWalkerTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowGraph;
+
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoetUnitTest;
+
+class WorkflowWalkerTest extends MailPoetUnitTest {
+  public function testRootStepMissing(): void {
+    $workflow = $this->createWorkflow([]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage("Invalid workflow structure: Workflow must contain a 'root' step");
+    $this->walkWorkflow($workflow);
+  }
+
+  public function testNonRootStepMissing(): void {
+    $workflow = $this->createWorkflow(['root' => ['a']]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage("Invalid workflow structure: Step with ID 'a' not found (referenced from 'root')");
+    $this->walkWorkflow($workflow);
+  }
+
+  public function testSimpleWorkflow(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    $path = $this->walkWorkflow($workflow);
+    $this->assertSame([
+      ['root', []],
+      ['a', ['root']],
+      ['b', ['root', 'a']],
+      ['c', ['root', 'a', 'b']],
+    ], $path);
+  }
+
+  public function testMultiBranchWorkflow(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a1', 'a2'],
+      'a1' => ['b1', 'b2'],
+      'a2' => ['c'],
+      'b1' => ['d'],
+      'b2' => [],
+      'c' => [],
+      'd' => [],
+    ]);
+
+    $path = $this->walkWorkflow($workflow);
+    $this->assertSame([
+      ['root', []],
+      ['a1', ['root']],
+      ['b1', ['root', 'a1']],
+      ['d', ['root', 'a1', 'b1']],
+      ['b2', ['root', 'a1']],
+      ['a2', ['root']],
+      ['c', ['root', 'a2']],
+    ], $path);
+  }
+
+
+  public function testCyclicWorkflow(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a', 'root'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => ['a', 'd'],
+      'd' => ['d'],
+    ]);
+
+    $path = $this->walkWorkflow($workflow);
+    $this->assertSame([
+      ['root', []],
+      ['a', ['root']],
+      ['b', ['root', 'a']],
+      ['c', ['root', 'a', 'b']],
+      ['d', ['root', 'a', 'b', 'c']],
+    ], $path);
+  }
+
+  private function createStep(string $id, array $nextStepIds): Step {
+    return new Step(
+      $id,
+      'test-type',
+      'test-key',
+      [],
+      array_map(function (string $id) {
+        return new NextStep($id);
+      }, $nextStepIds));
+  }
+
+  private function createWorkflow(array $steps): Workflow {
+    $stepMap = [];
+    foreach ($steps as $id => $nextStepIds) {
+      $stepMap[$id] = $this->createStep($id, $nextStepIds);
+    }
+    return $this->make(Workflow::class, ['getSteps' => $stepMap]);
+  }
+
+  private function walkWorkflow(Workflow $workflow): array {
+    $visitor = new class implements WorkflowNodeVisitor {
+      public $nodes = [];
+
+      public function initialize(Workflow $workflow): void {
+        $this->nodes = [];
+      }
+
+      public function visitNode(Workflow $workflow, WorkflowNode $node): void {
+        $this->nodes[] = $node;
+      }
+
+      public function complete(Workflow $workflow): void {}
+    };
+
+    $walker = new WorkflowWalker();
+    $walker->walk($workflow, [$visitor]);
+    return array_map(function (WorkflowNode $node) {
+      return [$node->getStep()->getId(), array_map(function (Step $parent) {
+        return $parent->getId();
+      }, $node->getParents())];
+    }, $visitor->nodes);
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRuleTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class ConsistentStepMapRuleTest extends WorkflowRuleTest {
+  public function testItDetectsWrongKeyValuePair(): void {
+    $workflow = $this->make(Workflow::class, ['getSteps' => [
+      'root' => $this->createStep('a'),
+    ]]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: TODO');
+    (new WorkflowWalker())->walk($workflow, [new ConsistentStepMapRule()]);
+  }
+
+  public function testItPassesWithCorrectKeyValuePair(): void {
+    $workflow = $this->make(Workflow::class, ['getSteps' => [
+      'root' => $this->createStep('root'),
+    ]]);
+
+    (new WorkflowWalker())->walk($workflow, [new ConsistentStepMapRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/ConsistentStepMapRuleTest.php
@@ -15,7 +15,7 @@ class ConsistentStepMapRuleTest extends WorkflowRuleTest {
     ]]);
 
     $this->expectException(UnexpectedValueException::class);
-    $this->expectExceptionMessage('Invalid workflow structure: TODO');
+    $this->expectExceptionMessage("Invalid workflow structure: Step with ID 'a' stored under a mismatched index 'root'.");
     (new WorkflowWalker())->walk($workflow, [new ConsistentStepMapRule()]);
   }
 

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoCycleRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoCycleRuleTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class NoCycleRuleTest extends WorkflowRuleTest {
+  public function testItDetectsLongCycle(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => ['a'],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Cycle found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoCycleRule()]);
+  }
+
+  public function testItDetectsSelfCycle(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['root'],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Cycle found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoCycleRule()]);
+  }
+
+  public function testItPassesWithSimplePath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoCycleRule()]);
+    // no exception thrown
+  }
+
+  public function testItPassesWithPathSplitAndJoin(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a1', 'a2'],
+      'a1' => ['b'],
+      'a2' => ['b'],
+      'b' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoCycleRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoDuplicateEdgesTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoDuplicateEdgesTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class NoDuplicateEdgesTest extends WorkflowRuleTest {
+  public function testItDetectsDuplicateEdges(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a', 'a'],
+      'a' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Duplicate next step definition found');
+    (new WorkflowWalker())->walk($workflow, [new NoDuplicateEdgesRule()]);
+  }
+
+  public function testItPassesWithSingleEdges(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoDuplicateEdgesRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoJoinRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoJoinRuleTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class NoJoinRuleTest extends WorkflowRuleTest {
+  public function testItDetectsJoinedPath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a1', 'a2'],
+      'a1' => ['b'],
+      'a2' => ['b'],
+      'b' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Path join found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoJoinRule()]);
+  }
+
+  public function testItDetectsLongJoinedPath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a1', 'a2'],
+      'a1' => ['b1'],
+      'a2' => ['b2'],
+      'b1' => ['c1'],
+      'b2' => ['c2'],
+      'c1' => ['d'],
+      'c2' => ['d'],
+      'd' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Path join found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoJoinRule()]);
+  }
+
+  public function testItDetectsJoinedPathToSelf(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['root', 'root'],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Path join found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoJoinRule()]);
+  }
+
+  public function testItPassesWithSimplePath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoJoinRule()]);
+    // no exception thrown
+  }
+
+  public function testItPassesWithPathSplit(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a1', 'a1'],
+      'a1' => [],
+      'a2' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoJoinRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoSplitRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoSplitRuleTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class NoSplitRuleTest extends WorkflowRuleTest {
+  public function testItDetectsSplitPath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a1', 'a2'],
+      'a1' => [],
+      'a2' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Path split found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoSplitRule()]);
+  }
+
+  public function testItDetectsSplitPathWithSelfLoop(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['root', 'a'],
+      'a' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Path split found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoSplitRule()]);
+  }
+
+  public function testItPassesWithSimplePath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoSplitRule()]);
+    // no exception thrown
+  }
+
+  public function testItPassesWithJoinedPath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['a'],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoSplitRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoUnreachableStepsRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/NoUnreachableStepsRuleTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class NoUnreachableStepsRuleTest extends WorkflowRuleTest {
+  public function testItDetectsUnreachableSteps(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => [],
+      'b' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Unreachable steps found in workflow graph');
+    (new WorkflowWalker())->walk($workflow, [new NoUnreachableStepsRule()]);
+  }
+
+  public function testItDetectsUnreachableSubgraphs(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => [],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Unreachable steps found in workflow graph');
+    $walker = new WorkflowWalker();
+    (new WorkflowWalker())->walk($workflow, [new NoUnreachableStepsRule()]);
+  }
+
+  public function testItPassesWithSimplePath(): void {
+    $workflow = $this->createWorkflow([
+      'root' => ['a'],
+      'a' => ['b'],
+      'b' => ['c'],
+      'c' => [],
+    ]);
+
+    (new WorkflowWalker())->walk($workflow, [new NoUnreachableStepsRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/TriggersUnderRootRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/TriggersUnderRootRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+require_once __DIR__ . '/WorkflowRuleTest.php';
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Validation\WorkflowGraph\WorkflowWalker;
+
+class TriggersUnderRootRuleTest extends WorkflowRuleTest {
+  public function testItDetectsTriggersNotUnderRoot(): void {
+    $workflow = $this->make(Workflow::class, ['getSteps' => [
+      'root' => $this->createStep('root', Step::TYPE_ROOT, ['t', 'a']),
+      'a' => $this->createStep('a', Step::TYPE_ACTION, ['t']),
+      't' => $this->createStep('t', Step::TYPE_TRIGGER, []),
+    ]]);
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid workflow structure: Trigger must be a direct descendant of workflow root');
+    (new WorkflowWalker())->walk($workflow, [new TriggersUnderRootRule()]);
+  }
+
+  public function testItPassesWithTriggersUnderRoot(): void {
+    $workflow = $this->make(Workflow::class, ['getSteps' => [
+      'root' => $this->createStep('root', Step::TYPE_ROOT, ['t']),
+      't' => $this->createStep('t', Step::TYPE_TRIGGER, []),
+    ]]);
+
+    (new WorkflowWalker())->walk($workflow, [new TriggersUnderRootRule()]);
+    // no exception thrown
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/WorkflowRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/WorkflowRules/WorkflowRuleTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\WorkflowRules;
+
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoetUnitTest;
+
+abstract class WorkflowRuleTest extends MailPoetUnitTest {
+  public function createWorkflow(array $steps): Workflow {
+    $stepMap = [];
+    foreach ($steps as $id => $nextStepIds) {
+      $stepMap[$id] = $this->createStep($id, 'test-type', $nextStepIds);
+    }
+    return $this->make(Workflow::class, ['getSteps' => $stepMap]);
+  }
+
+  public function createStep(string $id, string $type = 'test-type', array $nextStepIds = []): Step {
+    $nextSteps = array_map(function (string $id) {
+      return new NextStep($id);
+    }, $nextStepIds);
+    return new Step($id, $type, 'test-key', [], $nextSteps);
+  }
+}


### PR DESCRIPTION
## Description

This ticket implements the first part of workflow validation. On the way, it was necessary to improve and refactor the logic around subjects so we're able to validate steps and provide information about their compatibility with other steps.

The contents of this PR:
1. Universal workflow graph walker to traverse workflow graph and allow implementing validation on top of that (+ tests).
2. Implementation of various "rules" that validate the graph while it's being traversed (+ tests).
3. Running the validation on workflow creation and update.
4. Refactor subjects to separate data from services and define their step requirements. This introduces `Payload` (the data a subject is carrying) and `SubjectEntry` (subject, the service + payload). It also improves some architecture around it and removes logic that felt a bit misplaced from `WorkflowRun` and `WorkflowStorage`.
5. Introducing `StepRunArgs` for convenience and resolving subject data.

To be continued in the next ticket:
1. Validation of workflow steps before workflow activation.
2. Validation of step compatibility (if they can be in a specific order).
3. UI.

## Code review notes

The commit messages should tell the story. A lot of the bigger changes are moving stuff around. It's not too complex, I think.

This can be merged right after review, skipping QA step.

## QA notes

QA step can be skipped.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/624

## Linked tickets

[MAILPOET-4629]

## After-merge notes

_N/A_


[MAILPOET-4523]: https://mailpoet.atlassian.net/browse/MAILPOET-4523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-4629]: https://mailpoet.atlassian.net/browse/MAILPOET-4629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ