### PR TITLE
Remove old model usages from MailPoet\Test\API\JSON\v1 [MAILPOET-4378]

### DIFF
--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -141,6 +141,15 @@ class Subscriber {
   }
 
   /**
+   * @param DateTimeInterface $deletedAt
+   * @return $this
+   */
+  public function withDeletedAt(DateTimeInterface $deletedAt) {
+    $this->data['deletedAt'] = $deletedAt;
+    return $this;
+  }
+
+  /**
    * @return $this
    */
   public function withSubscribedIp(string $subscribedIp) {
@@ -197,6 +206,11 @@ class Subscriber {
     if (isset($this->data['linkToken'])) {
       $subscriber->setLinkToken($this->data['linkToken']);
     }
+
+    if (isset($this->data['deletedAt'])) {
+      $subscriber->setDeletedAt($this->data['deletedAt']);
+    }
+
     $entityManager->persist($subscriber);
 
     foreach ($this->segments as $segment) {

--- a/mailpoet/tests/integration/API/JSON/v1/CustomFieldsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/CustomFieldsTest.php
@@ -8,7 +8,6 @@ use MailPoet\API\JSON\v1\CustomFields;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\CustomFieldEntity;
-use MailPoet\Models\CustomField;
 
 class CustomFieldsTest extends \MailPoetTest {
 
@@ -83,16 +82,16 @@ class CustomFieldsTest extends \MailPoetTest {
   }
 
   public function testItCanDeleteACustomField() {
-    $customField = CustomField::where('type', 'date')->findOne();
-    assert($customField instanceof CustomField);
-    $customFieldId = $customField->id();
+    $customField = $this->repository->findOneBy(['type' => 'date']);
+    assert($customField instanceof CustomFieldEntity);
+    $customFieldId = $customField->getId();
 
     $router = new CustomFields($this->repository, new CustomFieldsResponseBuilder());
     $response = $router->delete(['id' => $customFieldId]);
     expect($response->status)->equals(APIResponse::STATUS_OK);
 
-    $customField = CustomField::where('type', 'date')->findOne();
-    expect($customField)->false();
+    $customField = $this->repository->findOneBy(['type' => 'date']);
+    expect($customField)->null();
 
     $response = $router->delete(['id' => $customFieldId]);
     expect($response->status)->equals(APIResponse::STATUS_NOT_FOUND);

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -24,7 +24,6 @@ use MailPoet\Entities\SubscriberIPEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Listing\Handler;
-use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -995,7 +994,7 @@ class SubscribersTest extends \MailPoetTest {
   public function testItKeepsSpecialSegmentsUnchangedAfterSaving() {
     $wcSegment = (new SegmentFactory())
       ->withName('WooCommerce Users')
-      ->withType(Segment::TYPE_WC_USERS)
+      ->withType(SegmentEntity::TYPE_WC_USERS)
       ->create();
     $subscriber = (new SubscriberFactory())
       ->withEmail('woo@commerce.com')

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -24,7 +24,6 @@ use MailPoet\Entities\SubscriberIPEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Listing\Handler;
-use MailPoet\Models\CustomField;
 use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\Subscriber;
@@ -40,6 +39,7 @@ use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\SubscriberSubscribeController;
 use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\CaptchaSession;
+use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
 use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
@@ -779,16 +779,13 @@ class SubscribersTest extends \MailPoetTest {
   }
 
   public function testItCannotSubscribeWithoutMandatoryCustomField() {
-    $customField = CustomField::createOrUpdate([
-      'name' => 'custom field',
-      'type' => 'text',
-      'params' => ['required' => '1'],
-    ]);
+    $customField = (new CustomFieldFactory())->create();
+
     $form = new FormEntity('form');
     $form->setBody([[
       'type' => 'text',
       'name' => 'mandatory',
-      'id' => $customField->id(),
+      'id' => $customField->getId(),
       'unique' => '1',
       'static' => '0',
       'params' => ['required' => '1'],

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -24,7 +24,7 @@ use MailPoet\Entities\SubscriberIPEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Listing\Handler;
-use MailPoet\Models\SendingQueue;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
@@ -79,6 +79,9 @@ class SubscribersTest extends \MailPoetTest {
 
   /** @var SubscribersRepository */
   private $subscribersRepository;
+
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
 
   public function _before() {
     parent::_before();
@@ -157,6 +160,7 @@ class SubscribersTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
   }
 
   public function testItCanGetASubscriber() {
@@ -922,7 +926,7 @@ class SubscribersTest extends \MailPoetTest {
     ];
 
     $this->endpoint->save($subscriberData);
-    expect(SendingQueue::findMany())->count(1);
+    expect($this->sendingQueuesRepository->findAll())->count(1);
   }
 
   public function testItSchedulesWelcomeEmailNotificationWhenExistedSubscriberIsUpdated() {
@@ -938,11 +942,11 @@ class SubscribersTest extends \MailPoetTest {
 
     // welcome notification is created only for segment #1
     $this->endpoint->save($subscriberData);
-    expect(SendingQueue::findMany())->isEmpty();
+    expect($this->sendingQueuesRepository->findAll())->isEmpty();
 
     $subscriberData['segments'] = [$this->segment1->getId()];
     $this->endpoint->save($subscriberData);
-    expect(SendingQueue::findMany())->count(1);
+    expect($this->sendingQueuesRepository->findAll())->count(1);
   }
 
   public function testItDoesNotSchedulesWelcomeEmailNotificationWhenNoNewSegmentIsAdded() {
@@ -967,7 +971,7 @@ class SubscribersTest extends \MailPoetTest {
     ];
 
     $this->endpoint->save($subscriberData);
-    expect(SendingQueue::findMany())->count(0);
+    expect($this->sendingQueuesRepository->findAll())->count(0);
   }
 
   public function testItSendsConfirmationEmail() {


### PR DESCRIPTION
## Description

This PR removes Paris code from all the JSON v1 test classes and replaces it with Doctrine code.

## Code review notes

_N/A_

## QA notes

This PR only changes integration tests code and should not affect the plugin in any way, so I don't think QA is needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4378]

## After-merge notes

_N/A_


[MAILPOET-4378]: https://mailpoet.atlassian.net/browse/MAILPOET-4378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ