### PR TITLE
Workflow listing actions — part 1 [MAILPOET-4540]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-listing/_listing.scss
+++ b/mailpoet/assets/css/src/components-automation-listing/_listing.scss
@@ -8,8 +8,6 @@
   .mailpoet-automation-listing {
     /* Prevent border radius beneath tabs */
     border-radius: 0 0 1px 1px;
-    /* Prevent overlapping box shadow since listing is rendered inside tabs */
-    clip-path: inset(-1px 0 0 0);
   }
 }
 

--- a/mailpoet/assets/js/src/automation/listing/components/cells/more.tsx
+++ b/mailpoet/assets/js/src/automation/listing/components/cells/more.tsx
@@ -13,12 +13,6 @@ export function More({ workflow }: Props): JSX.Element {
       renderContent={() => (
         <div>
           <MenuItem onInvoke={() => {}}>
-            <p>{__('Rename automation', 'mailpoet')}</p>
-          </MenuItem>
-          <MenuItem onInvoke={() => {}}>
-            <p>{__('Statistics', 'mailpoet')}</p>
-          </MenuItem>
-          <MenuItem onInvoke={() => {}}>
             <p>{__('Duplicate', 'mailpoet')}</p>
           </MenuItem>
           <MenuItem onInvoke={() => {}}>

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -75,12 +75,17 @@ export function AutomationListing({ workflows, loading }: Props): JSX.Element {
   );
 
   const groupedWorkflows = useMemo<Record<string, Workflow[]>>(() => {
-    const grouped = {};
+    const grouped = {
+      all: [],
+    };
     workflows.forEach((workflow) => {
       if (!grouped[workflow.status]) {
         grouped[workflow.status] = [];
       }
       grouped[workflow.status].push(workflow);
+      if (workflow.status !== WorkflowStatus.TRASH) {
+        grouped.all.push(workflow);
+      }
     });
     return grouped;
   }, [workflows]);
@@ -88,10 +93,7 @@ export function AutomationListing({ workflows, loading }: Props): JSX.Element {
   const tabs = useMemo(
     () =>
       filterTabs.map((filterTab) => {
-        const count =
-          filterTab.name === 'all'
-            ? workflows.length
-            : (groupedWorkflows[filterTab.name] || []).length;
+        const count = (groupedWorkflows[filterTab.name] || []).length;
         return {
           name: filterTab.name,
           title:
@@ -106,13 +108,12 @@ export function AutomationListing({ workflows, loading }: Props): JSX.Element {
           className: filterTab.className,
         };
       }),
-    [workflows, groupedWorkflows],
+    [groupedWorkflows],
   );
 
   const tabRenderer = useCallback(
     (tab) => {
-      const filteredWorkflows: Workflow[] =
-        tab.name === 'all' ? workflows : groupedWorkflows[tab.name] ?? [];
+      const filteredWorkflows: Workflow[] = groupedWorkflows[tab.name] ?? [];
       const rowsPerPage = parseInt(pageSearch.get('per_page') || '25', 10);
       const currentPage = parseInt(pageSearch.get('paged') || '1', 10);
       const start = (currentPage - 1) * rowsPerPage;

--- a/mailpoet/lib/Automation/Engine/Builder/DeleteWorkflowController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DeleteWorkflowController.php
@@ -21,6 +21,11 @@ class DeleteWorkflowController {
     if (!$workflow) {
       throw Exceptions::workflowNotFound($id);
     }
+
+    if ($workflow->getStatus() !== Workflow::STATUS_TRASH) {
+      throw Exceptions::workflowNotTrashed($id);
+    }
+
     $this->workflowStorage->deleteWorkflow($workflow);
     return $workflow;
   }

--- a/mailpoet/lib/Automation/Engine/Builder/DeleteWorkflowController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DeleteWorkflowController.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Builder;
+
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+
+class DeleteWorkflowController {
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  public function __construct(
+    WorkflowStorage $workflowStorage
+  ) {
+    $this->workflowStorage = $workflowStorage;
+  }
+
+  public function deleteWorkflow(int $id): Workflow {
+    $workflow = $this->workflowStorage->getWorkflow($id);
+    if (!$workflow) {
+      throw Exceptions::workflowNotFound($id);
+    }
+    $this->workflowStorage->deleteWorkflow($workflow);
+    return $workflow;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Builder/DuplicateWorkflowController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DuplicateWorkflowController.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Builder;
+
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Util\Security;
+
+class DuplicateWorkflowController {
+  /** @var WordPress */
+  private $wordPress;
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  public function __construct(
+    WordPress $wordPress,
+    WorkflowStorage $workflowStorage
+  ) {
+    $this->wordPress = $wordPress;
+    $this->workflowStorage = $workflowStorage;
+  }
+
+  public function duplicateWorkflow(int $id): Workflow {
+    $workflow = $this->workflowStorage->getWorkflow($id);
+    if (!$workflow) {
+      throw Exceptions::workflowNotFound($id);
+    }
+
+    $duplicate = new Workflow(
+      $this->getName($workflow->getName()),
+      $this->getSteps($workflow->getSteps()),
+      $this->wordPress->wpGetCurrentUser()
+    );
+    $duplicate->setStatus(Workflow::STATUS_DRAFT);
+
+    $workflowId = $this->workflowStorage->createWorkflow($duplicate);
+    $savedWorkflow = $this->workflowStorage->getWorkflow($workflowId);
+    if (!$savedWorkflow) {
+      throw new InvalidStateException('Workflow not found.');
+    }
+    return $savedWorkflow;
+  }
+
+  private function getName(string $name): string {
+    // translators: %s is the original workflow name.
+    $newName = sprintf(__('Copy of %s', 'mailpoet'), $name);
+    $maxLength = $this->workflowStorage->getNameColumnLength();
+    if (strlen($newName) > $maxLength) {
+      $append = '…';
+      return substr($newName, 0, $maxLength - strlen($append)) . $append;
+    }
+    return $newName;
+  }
+
+  /**
+   * @param Step[] $steps
+   * @return Step[]
+  */
+  private function getSteps(array $steps): array {
+    $newIds = [];
+    foreach ($steps as $step) {
+      $id = $step->getId();
+      $newIds[$id] = $id === 'root' ? 'root' : $this->getId();
+    }
+
+    $newSteps = [];
+    foreach ($steps as $step) {
+      $newId = $newIds[$step->getId()];
+      $newSteps[$newId] = new Step(
+        $newId,
+        $step->getType(),
+        $step->getKey(),
+        $step->getArgs(),
+        array_map(function (NextStep $nextStep) use ($newIds): NextStep {
+          return new NextStep($newIds[$nextStep->getId()]);
+        }, $step->getNextSteps())
+      );
+    }
+    return $newSteps;
+  }
+
+  private function getId(): string {
+    return Security::generateRandomString(16);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Data/Workflow.php
@@ -191,8 +191,8 @@ class Workflow {
       }, Json::decode($data['steps'])),
       new \WP_User((int)$data['author'])
     );
-    $workflow->id = (int)($data['id'] ?? 0);
-    $workflow->versionId = (int)($data['version_id'] ?? 0);
+    $workflow->id = (int)$data['id'];
+    $workflow->versionId = (int)$data['version_id'];
     $workflow->status = $data['status'];
     $workflow->createdAt = new DateTimeImmutable($data['created_at']);
     $workflow->updatedAt = new DateTimeImmutable($data['updated_at']);

--- a/mailpoet/lib/Automation/Engine/Data/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Data/Workflow.php
@@ -191,8 +191,8 @@ class Workflow {
       }, Json::decode($data['steps'])),
       new \WP_User((int)$data['author'])
     );
-    $workflow->id = (int)$data['id'];
-    $workflow->versionId = (int)$data['version_id'];
+    $workflow->id = (int)($data['id'] ?? 0);
+    $workflow->versionId = (int)($data['version_id'] ?? 0);
     $workflow->status = $data['status'];
     $workflow->createdAt = new DateTimeImmutable($data['created_at']);
     $workflow->updatedAt = new DateTimeImmutable($data['updated_at']);

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsCreateFromTemplateEndpoint.php
@@ -6,51 +6,27 @@ use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
 use MailPoet\Automation\Engine\Builder\CreateWorkflowFromTemplateController;
-use MailPoet\Automation\Engine\Data\NextStep;
-use MailPoet\Automation\Engine\Data\Step;
-use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Mappers\WorkflowMapper;
 use MailPoet\Validator\Builder;
-use MailPoetVendor\Monolog\DateTimeImmutable;
 
 class WorkflowsCreateFromTemplateEndpoint extends Endpoint {
   /** @var CreateWorkflowFromTemplateController */
   private $createWorkflowFromTemplateController;
 
+  /** @var WorkflowMapper */
+  private $workflowMapper;
+
   public function __construct(
-    CreateWorkflowFromTemplateController $createWorkflowFromTemplateController
+    CreateWorkflowFromTemplateController $createWorkflowFromTemplateController,
+    WorkflowMapper $workflowMapper
   ) {
     $this->createWorkflowFromTemplateController = $createWorkflowFromTemplateController;
+    $this->workflowMapper = $workflowMapper;
   }
 
   public function handle(Request $request): Response {
     $workflow = $this->createWorkflowFromTemplateController->createWorkflow((string)$request->getParam('slug'));
-    return new Response($this->buildWorkflow($workflow));
-  }
-
-  private function buildWorkflow(Workflow $workflow): array {
-    return [
-      'id' => $workflow->getId(),
-      'name' => $workflow->getName(),
-      'status' => $workflow->getStatus(),
-      'created_at' => $workflow->getCreatedAt()->format(DateTimeImmutable::W3C),
-      'updated_at' => $workflow->getUpdatedAt()->format(DateTimeImmutable::W3C),
-      'activated_at' => $workflow->getActivatedAt() ? $workflow->getActivatedAt()->format(DateTimeImmutable::W3C) : null,
-      'author' => [
-        'id' => $workflow->getAuthor()->ID,
-        'name' => $workflow->getAuthor()->display_name,
-      ],
-      'steps' => array_map(function (Step $step) {
-        return [
-          'id' => $step->getId(),
-          'type' => $step->getType(),
-          'key' => $step->getKey(),
-          'args' => $step->getArgs(),
-          'next_steps' => array_map(function (NextStep $nextStep) {
-            return $nextStep->toArray();
-          }, $step->getNextSteps()),
-        ];
-      }, $workflow->getSteps()),
-    ];
+    return new Response($this->workflowMapper->buildWorkflow($workflow));
   }
 
   public static function getRequestSchema(): array {

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDeleteEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDeleteEndpoint.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Workflows;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Validator\Builder;
+
+class WorkflowsDeleteEndpoint extends Endpoint {
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  public function __construct(
+    WorkflowStorage $workflowStorage
+  ) {
+    $this->workflowStorage = $workflowStorage;
+  }
+
+  public function handle(Request $request): Response {
+    $workflowId = $request->getParam('id');
+    if (!is_int($workflowId)) {
+      throw InvalidStateException::create();
+    }
+    $existingWorkflow = $this->workflowStorage->getWorkflow($workflowId);
+    if (!$existingWorkflow instanceof Workflow) {
+      throw InvalidStateException::create();
+    }
+    $this->workflowStorage->deleteWorkflow($existingWorkflow);
+
+    return new Response(null);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDeleteEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDeleteEndpoint.php
@@ -5,32 +5,22 @@ namespace MailPoet\Automation\Engine\Endpoints\Workflows;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
-use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
-use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Engine\Builder\DeleteWorkflowController;
 use MailPoet\Validator\Builder;
 
 class WorkflowsDeleteEndpoint extends Endpoint {
-  /** @var WorkflowStorage */
-  private $workflowStorage;
+  /** @var DeleteWorkflowController */
+  private $deleteController;
 
   public function __construct(
-    WorkflowStorage $workflowStorage
+    DeleteWorkflowController $deleteController
   ) {
-    $this->workflowStorage = $workflowStorage;
+    $this->deleteController = $deleteController;
   }
 
   public function handle(Request $request): Response {
-    $workflowId = $request->getParam('id');
-    if (!is_int($workflowId)) {
-      throw InvalidStateException::create();
-    }
-    $existingWorkflow = $this->workflowStorage->getWorkflow($workflowId);
-    if (!$existingWorkflow instanceof Workflow) {
-      throw InvalidStateException::create();
-    }
-    $this->workflowStorage->deleteWorkflow($existingWorkflow);
-
+    $workflowId = intval($request->getParam('id'));
+    $this->deleteController->deleteWorkflow($workflowId);
     return new Response(null);
   }
 

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDuplicateEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDuplicateEndpoint.php
@@ -5,41 +5,28 @@ namespace MailPoet\Automation\Engine\Endpoints\Workflows;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
-use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Builder\DuplicateWorkflowController;
 use MailPoet\Automation\Engine\Mappers\WorkflowMapper;
-use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 use MailPoet\Validator\Builder;
 
 class WorkflowsDuplicateEndpoint extends Endpoint {
   /** @var WorkflowMapper */
   private $workflowMapper;
 
-  /** @var WorkflowStorage */
-  private $workflowStorage;
+  /** @var DuplicateWorkflowController */
+  private $duplicateController;
 
   public function __construct(
-    WorkflowMapper $workflowMapper,
-    WorkflowStorage $workflowStorage
+    DuplicateWorkflowController $duplicateController,
+    WorkflowMapper $workflowMapper
   ) {
     $this->workflowMapper = $workflowMapper;
-    $this->workflowStorage = $workflowStorage;
+    $this->duplicateController = $duplicateController;
   }
 
   public function handle(Request $request): Response {
-    $workflowId = $request->getParam('id');
-    if (!is_int($workflowId)) {
-      throw InvalidStateException::create();
-    }
-    $existingWorkflow = $this->workflowStorage->getWorkflow($workflowId);
-    if (!$existingWorkflow instanceof Workflow) {
-      throw InvalidStateException::create();
-    }
-    $duplicateId = $this->workflowStorage->duplicateWorkflow($existingWorkflow);
-    $duplicate = $this->workflowStorage->getWorkflow($duplicateId);
-    if (!$duplicate instanceof Workflow) {
-      throw InvalidStateException::create();
-    }
+    $workflowId = intval($request->getParam('id'));
+    $duplicate = $this->duplicateController->duplicateWorkflow($workflowId);
     return new Response($this->workflowMapper->buildWorkflow($duplicate));
   }
 

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDuplicateEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsDuplicateEndpoint.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Workflows;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Mappers\WorkflowMapper;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Validator\Builder;
+
+class WorkflowsDuplicateEndpoint extends Endpoint {
+  /** @var WorkflowMapper */
+  private $workflowMapper;
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  public function __construct(
+    WorkflowMapper $workflowMapper,
+    WorkflowStorage $workflowStorage
+  ) {
+    $this->workflowMapper = $workflowMapper;
+    $this->workflowStorage = $workflowStorage;
+  }
+
+  public function handle(Request $request): Response {
+    $workflowId = $request->getParam('id');
+    if (!is_int($workflowId)) {
+      throw InvalidStateException::create();
+    }
+    $existingWorkflow = $this->workflowStorage->getWorkflow($workflowId);
+    if (!$existingWorkflow instanceof Workflow) {
+      throw InvalidStateException::create();
+    }
+    $duplicateId = $this->workflowStorage->duplicateWorkflow($existingWorkflow);
+    $duplicate = $this->workflowStorage->getWorkflow($duplicateId);
+    if (!$duplicate instanceof Workflow) {
+      throw InvalidStateException::create();
+    }
+    return new Response($this->workflowMapper->buildWorkflow($duplicate));
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsGetEndpoint.php
@@ -2,59 +2,37 @@
 
 namespace MailPoet\Automation\Engine\Endpoints\Workflows;
 
-use DateTimeImmutable;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
-use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Data\WorkflowStatistics;
-use MailPoet\Automation\Engine\Storage\WorkflowStatisticsStorage;
+use MailPoet\Automation\Engine\Mappers\WorkflowMapper;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 use MailPoet\Validator\Builder;
 
 class WorkflowsGetEndpoint extends Endpoint {
+  /** @var WorkflowMapper */
+  private $workflowMapper;
+
   /** @var WorkflowStorage */
   private $workflowStorage;
 
-  /** @var WorkflowStatisticsStorage  */
-  private $statisticsStorage;
-
   public function __construct(
-    WorkflowStorage $workflowStorage,
-    WorkflowStatisticsStorage $statisticsStorage
+    WorkflowMapper $workflowMapper,
+    WorkflowStorage $workflowStorage
   ) {
+    $this->workflowMapper = $workflowMapper;
     $this->workflowStorage = $workflowStorage;
-    $this->statisticsStorage = $statisticsStorage;
   }
 
   public function handle(Request $request): Response {
     $status = $request->getParam('status') ? (array)$request->getParam('status') : null;
     $workflows = $this->workflowStorage->getWorkflows($status);
-    $statistics = $this->statisticsStorage->getWorkflowStatisticsForWorkflows(...$workflows);
-    return new Response(array_map(function (Workflow $workflow) use ($statistics) {
-      return $this->buildWorkflow($workflow, $statistics[$workflow->getId()]);
-    }, $workflows));
+    return new Response($this->workflowMapper->buildWorkflowList($workflows));
   }
 
   public static function getRequestSchema(): array {
     return [
       'status' => Builder::array(Builder::string()),
-    ];
-  }
-
-  private function buildWorkflow(Workflow $workflow, WorkflowStatistics $statistics): array {
-    return [
-      'id' => $workflow->getId(),
-      'name' => $workflow->getName(),
-      'status' => $workflow->getStatus(),
-      'created_at' => $workflow->getCreatedAt()->format(DateTimeImmutable::W3C),
-      'updated_at' => $workflow->getUpdatedAt()->format(DateTimeImmutable::W3C),
-      'stats' => $statistics->toArray(),
-      'activated_at' => $workflow->getActivatedAt() ? $workflow->getActivatedAt()->format(DateTimeImmutable::W3C) : null,
-      'author' => [
-        'id' => $workflow->getAuthor()->ID,
-        'name' => $workflow->getAuthor()->display_name,
-      ],
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsPutEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Workflows/WorkflowsPutEndpoint.php
@@ -2,15 +2,11 @@
 
 namespace MailPoet\Automation\Engine\Endpoints\Workflows;
 
-use DateTimeImmutable;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
 use MailPoet\Automation\Engine\Builder\UpdateWorkflowController;
-use MailPoet\Automation\Engine\Data\NextStep;
-use MailPoet\Automation\Engine\Data\Step;
-use MailPoet\Automation\Engine\Data\Workflow;
-use MailPoet\Automation\Engine\Storage\WorkflowStatisticsStorage;
+use MailPoet\Automation\Engine\Mappers\WorkflowMapper;
 use MailPoet\Automation\Engine\Validation\WorkflowSchema;
 use MailPoet\Validator\Builder;
 
@@ -18,21 +14,21 @@ class WorkflowsPutEndpoint extends Endpoint {
   /** @var UpdateWorkflowController */
   private $updateController;
 
-  /** @var WorkflowStatisticsStorage  */
-  private $statisticsStorage;
+  /** @var WorkflowMapper */
+  private $workflowMapper;
 
   public function __construct(
     UpdateWorkflowController $updateController,
-    WorkflowStatisticsStorage $statisticsStorage
+    WorkflowMapper $workflowMapper
   ) {
     $this->updateController = $updateController;
-    $this->statisticsStorage = $statisticsStorage;
+    $this->workflowMapper = $workflowMapper;
   }
 
   public function handle(Request $request): Response {
     $data = $request->getParams();
     $workflow = $this->updateController->updateWorkflow(intval($request->getParam('id')), $data);
-    return new Response($this->buildWorkflow($workflow));
+    return new Response($this->workflowMapper->buildWorkflow($workflow));
   }
 
   public static function getRequestSchema(): array {
@@ -41,33 +37,6 @@ class WorkflowsPutEndpoint extends Endpoint {
       'name' => Builder::string()->minLength(1),
       'status' => Builder::string(),
       'steps' => WorkflowSchema::getStepsSchema(),
-    ];
-  }
-
-  protected function buildWorkflow(Workflow $workflow): array {
-    return [
-      'id' => $workflow->getId(),
-      'name' => $workflow->getName(),
-      'status' => $workflow->getStatus(),
-      'created_at' => $workflow->getCreatedAt()->format(DateTimeImmutable::W3C),
-      'updated_at' => $workflow->getUpdatedAt()->format(DateTimeImmutable::W3C),
-      'activated_at' => $workflow->getActivatedAt() ? $workflow->getActivatedAt()->format(DateTimeImmutable::W3C) : null,
-      'author' => [
-        'id' => $workflow->getAuthor()->ID,
-        'name' => $workflow->getAuthor()->display_name,
-      ],
-      'stats' => $this->statisticsStorage->getWorkflowStats($workflow->getId())->toArray(),
-      'steps' => array_map(function (Step $step) {
-        return [
-          'id' => $step->getId(),
-          'type' => $step->getType(),
-          'key' => $step->getKey(),
-          'args' => $step->getArgs(),
-          'next_steps' => array_map(function (NextStep $nextStep) {
-            return $nextStep->toArray();
-          }, $step->getNextSteps()),
-        ];
-      }, $workflow->getSteps()),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Endpoints\System\DatabaseDeleteEndpoint;
 use MailPoet\Automation\Engine\Endpoints\System\DatabasePostEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsCreateFromTemplateEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsDuplicateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsPutEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowTemplatesGetEndpoint;
@@ -73,6 +74,7 @@ class Engine {
       $api->registerGetRoute('workflows', WorkflowsGetEndpoint::class);
       $api->registerPutRoute('workflows/(?P<id>\d+)', WorkflowsPutEndpoint::class);
       $api->registerPostRoute('workflows/create-from-template', WorkflowsCreateFromTemplateEndpoint::class);
+      $api->registerPostRoute('workflows/(?P<id>\d+)/duplicate', WorkflowsDuplicateEndpoint::class);
       $api->registerPostRoute('system/database', DatabasePostEndpoint::class);
       $api->registerDeleteRoute('system/database', DatabaseDeleteEndpoint::class);
       $api->registerGetRoute('workflow-templates', WorkflowTemplatesGetEndpoint::class);

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Endpoints\System\DatabaseDeleteEndpoint;
 use MailPoet\Automation\Engine\Endpoints\System\DatabasePostEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsCreateFromTemplateEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsDeleteEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsDuplicateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsPutEndpoint;
@@ -73,8 +74,9 @@ class Engine {
     $this->wordPress->addAction(Hooks::API_INITIALIZE, function (API $api) {
       $api->registerGetRoute('workflows', WorkflowsGetEndpoint::class);
       $api->registerPutRoute('workflows/(?P<id>\d+)', WorkflowsPutEndpoint::class);
-      $api->registerPostRoute('workflows/create-from-template', WorkflowsCreateFromTemplateEndpoint::class);
+      $api->registerDeleteRoute('workflows/(?P<id>\d+)', WorkflowsDeleteEndpoint::class);
       $api->registerPostRoute('workflows/(?P<id>\d+)/duplicate', WorkflowsDuplicateEndpoint::class);
+      $api->registerPostRoute('workflows/create-from-template', WorkflowsCreateFromTemplateEndpoint::class);
       $api->registerPostRoute('system/database', DatabasePostEndpoint::class);
       $api->registerDeleteRoute('system/database', DatabaseDeleteEndpoint::class);
       $api->registerGetRoute('workflow-templates', WorkflowTemplatesGetEndpoint::class);

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -29,6 +29,7 @@ class Exceptions {
   private const WORKFLOW_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_workflow_step_modified_when_unknown';
   private const WORKFLOW_NOT_VALID = 'mailpoet_automation_workflow_not_valid';
   private const MISSING_REQUIRED_SUBJECTS = 'mailpoet_automation_missing_required_subjects';
+  private const WORKFLOW_NOT_TRASHED = 'mailpoet_automation_workflow_not_trashed';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -203,5 +204,12 @@ class Exceptions {
           implode(', ', $missingSubjectKeys)
         )
       );
+  }
+
+  public static function workflowNotTrashed(int $id): UnexpectedValueException {
+    return UnexpectedValueException::create()
+      ->withErrorCode(self::WORKFLOW_NOT_TRASHED)
+      // translators: %d is the ID of the workflow.
+      ->withMessage(sprintf(__("Can't delete workflow with ID '%d' because it was not trashed.", 'mailpoet'), $id));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Mappers/WorkflowMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/WorkflowMapper.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Mappers;
+
+use DateTimeImmutable;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Storage\WorkflowStatisticsStorage;
+
+class WorkflowMapper {
+  /** @var WorkflowStatisticsStorage */
+  private $statisticsStorage;
+
+  public function __construct(
+    WorkflowStatisticsStorage $statisticsStorage
+  ) {
+    $this->statisticsStorage = $statisticsStorage;
+  }
+
+  public function buildWorkflow(Workflow $workflow): array {
+    return [
+      'id' => $workflow->getId(),
+      'name' => $workflow->getName(),
+      'status' => $workflow->getStatus(),
+      'created_at' => $workflow->getCreatedAt()->format(DateTimeImmutable::W3C),
+      'updated_at' => $workflow->getUpdatedAt()->format(DateTimeImmutable::W3C),
+      'activated_at' => $workflow->getActivatedAt() ? $workflow->getActivatedAt()->format(DateTimeImmutable::W3C) : null,
+      'author' => [
+        'id' => $workflow->getAuthor()->ID,
+        'name' => $workflow->getAuthor()->display_name,
+      ],
+      'stats' => $this->statisticsStorage->getWorkflowStats($workflow->getId())->toArray(),
+      'steps' => array_map(function (Step $step) {
+        return [
+          'id' => $step->getId(),
+          'type' => $step->getType(),
+          'key' => $step->getKey(),
+          'args' => $step->getArgs(),
+          'next_steps' => array_map(function (NextStep $nextStep) {
+            return $nextStep->toArray();
+          }, $step->getNextSteps()),
+        ];
+      }, $workflow->getSteps()),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Mappers/WorkflowMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/WorkflowMapper.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Data\WorkflowStatistics;
 use MailPoet\Automation\Engine\Storage\WorkflowStatisticsStorage;
 
 class WorkflowMapper {
@@ -42,6 +43,30 @@ class WorkflowMapper {
           }, $step->getNextSteps()),
         ];
       }, $workflow->getSteps()),
+    ];
+  }
+
+  /** @param Workflow[] $workflows */
+  public function buildWorkflowList(array $workflows): array {
+    $statistics = $this->statisticsStorage->getWorkflowStatisticsForWorkflows(...$workflows);
+    return array_map(function (Workflow $workflow) use ($statistics) {
+      return $this->buildWorkflowListItem($workflow, $statistics[$workflow->getId()]);
+    }, $workflows);
+  }
+
+  private function buildWorkflowListItem(Workflow $workflow, WorkflowStatistics $statistics): array {
+    return [
+      'id' => $workflow->getId(),
+      'name' => $workflow->getName(),
+      'status' => $workflow->getStatus(),
+      'created_at' => $workflow->getCreatedAt()->format(DateTimeImmutable::W3C),
+      'updated_at' => $workflow->getUpdatedAt()->format(DateTimeImmutable::W3C),
+      'stats' => $statistics->toArray(),
+      'activated_at' => $workflow->getActivatedAt() ? $workflow->getActivatedAt()->format(DateTimeImmutable::W3C) : null,
+      'author' => [
+        'id' => $workflow->getAuthor()->ID,
+        'name' => $workflow->getAuthor()->display_name,
+      ],
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -59,6 +59,7 @@ class Migrator {
         updated_at timestamp NOT NULL,
         subjects longtext,
         PRIMARY KEY (id),
+        INDEX (workflow_id),
         INDEX (status)
       );
     ");

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -43,7 +43,18 @@ class WorkflowStorage {
     $data['created_at'] = $now;
     $data['updated_at'] = $now;
     $data['status'] = Workflow::STATUS_DRAFT;
-    $data['name'] = 'Copy of ' . $workflow->getName();
+    $prefix = 'Copy of ';
+    $newName = $prefix . $workflow->getName();
+    $nameColumnLengthInfo = $this->wpdb->get_col_length($this->workflowTable, 'name');
+    $maxLength = is_array($nameColumnLengthInfo)
+      ? $nameColumnLengthInfo['length'] ?? 255
+      : 255;
+    if (strlen($newName) > $maxLength) {
+      $truncateWith = '…';
+      $truncationLength = strlen($truncateWith);
+      $newName = substr($newName, 0, $maxLength - $truncationLength) . $truncateWith;
+    }
+    $data['name'] = $newName;
     $duplicate = Workflow::fromArray($data);
     return $this->createWorkflow($duplicate);
   }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -26,7 +26,9 @@ class WorkflowStorage {
   }
 
   public function createWorkflow(Workflow $workflow): int {
-    $result = $this->wpdb->insert($this->workflowTable, $this->getWorkflowHeaderData($workflow));
+    $workflowHeaderData = $this->getWorkflowHeaderData($workflow);
+    unset($workflowHeaderData['id']);
+    $result = $this->wpdb->insert($this->workflowTable, $workflowHeaderData);
     if (!$result) {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Automation\Engine;
 
+use WP_User;
+
 class WordPress {
   public function addAction(string $hookName, callable $callback, int $priority = 10, int $acceptedArgs = 1): bool {
     return add_action($hookName, $callback, $priority, $acceptedArgs);
@@ -10,6 +12,10 @@ class WordPress {
   /** @param mixed ...$arg */
   public function doAction(string $hookName, ...$arg): void {
     do_action($hookName, ...$arg);
+  }
+
+  public function wpGetCurrentUser(): WP_User {
+    return wp_get_current_user();
   }
 
   /** @param mixed ...$args */

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -143,6 +143,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsCreateFromTemplateEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsDuplicateEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsDeleteEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\System\DatabasePostEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\System\DatabaseDeleteEndpoint::class)->setPublic(true);
     // Automation - core integration

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -112,6 +112,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Automation
     $container->autowire(\MailPoet\Automation\Engine\API\API::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowFromTemplateController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Builder\DuplicateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateStepsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -112,6 +112,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Automation
     $container->autowire(\MailPoet\Automation\Engine\API\API::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\CreateWorkflowFromTemplateController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Builder\DeleteWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\DuplicateWorkflowController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateStepsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateWorkflowController::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -122,6 +122,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Control\TriggerHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Hooks::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Mappers\WorkflowMapper::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Migrations\Migrator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\WorkflowRunStorage::class)->setPublic(true);
@@ -141,6 +142,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowTemplatesGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsCreateFromTemplateEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Workflows\WorkflowsDuplicateEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\System\DatabasePostEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\System\DatabaseDeleteEndpoint::class)->setPublic(true);
     // Automation - core integration

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDeleteEndpointTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\REST\Automation\Workflows;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\REST\Automation\AutomationTest;
+
+require_once __DIR__ . '/../AutomationTest.php';
+
+class WorkflowsDeleteEndpointTest extends AutomationTest {
+  private const ENDPOINT_PATH = '/mailpoet/v1/automation/workflows/%d';
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  /** @var Workflow */
+  private $workflow;
+
+  public function _before() {
+    parent::_before();
+    $this->workflowStorage = $this->diContainer->get(WorkflowStorage::class);
+    $id = $this->workflowStorage->createWorkflow(
+      new Workflow(
+        'Testing workflow',
+        ['root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [])],
+        wp_get_current_user()
+      )
+    );
+    $workflow = $this->workflowStorage->getWorkflow($id);
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $this->workflow = $workflow;
+  }
+
+  public function testGuestNotAllowed(): void {
+    wp_set_current_user(0);
+    $data = $this->delete(sprintf(self::ENDPOINT_PATH, $this->workflow->getId()));
+
+    $this->assertSame([
+      'code' => 'rest_forbidden',
+      'message' => 'Sorry, you are not allowed to do that.',
+      'data' => ['status' => 401],
+    ], $data);
+
+    $workflow = $this->workflowStorage->getWorkflow($this->workflow->getId());
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $this->assertSame('Testing workflow', $workflow->getName());
+  }
+
+  public function testItDeletesAWorkflow(): void {
+    $data = $this->delete(sprintf(self::ENDPOINT_PATH, $this->workflow->getId()));
+    $this->assertSame(['data' => null], $data);
+
+    $workflow = $this->workflowStorage->getWorkflow($this->workflow->getId());
+    $this->assertNull($workflow);
+  }
+
+  public function _after() {
+    $this->workflowStorage->truncate();
+    parent::_after();
+  }
+}

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDeleteEndpointTest.php
@@ -48,7 +48,24 @@ class WorkflowsDeleteEndpointTest extends AutomationTest {
     $this->assertSame('Testing workflow', $workflow->getName());
   }
 
+  public function testCantDeleteWorkflowWhenNotTrashed(): void {
+    $data = $this->delete(sprintf(self::ENDPOINT_PATH, $this->workflow->getId()));
+
+    $this->assertSame([
+      'code' => 'mailpoet_automation_workflow_not_trashed',
+      'message' => "Can't delete workflow with ID '{$this->workflow->getId()}' because it was not trashed.",
+      'data' => ['status' => 400, 'errors' => []],
+    ], $data);
+
+    $workflow = $this->workflowStorage->getWorkflow($this->workflow->getId());
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $this->assertSame('Testing workflow', $workflow->getName());
+  }
+
   public function testItDeletesAWorkflow(): void {
+    $this->workflow->setStatus(Workflow::STATUS_TRASH);
+    $this->workflowStorage->updateWorkflow($this->workflow);
+
     $data = $this->delete(sprintf(self::ENDPOINT_PATH, $this->workflow->getId()));
     $this->assertSame(['data' => null], $data);
 

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDuplicateEndpointTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\REST\Automation\Workflows;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\REST\Automation\AutomationTest;
+use MailPoetVendor\Monolog\DateTimeImmutable;
+
+require_once __DIR__ . '/../AutomationTest.php';
+
+class WorkflowsDuplicateEndpointTest extends AutomationTest {
+  private const ENDPOINT_PATH = '/mailpoet/v1/automation/workflows/%d/duplicate';
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  /** @var Workflow */
+  private $workflow;
+
+  public function _before() {
+    parent::_before();
+    $this->workflowStorage = $this->diContainer->get(WorkflowStorage::class);
+    $id = $this->workflowStorage->createWorkflow(
+      new Workflow(
+        'Testing workflow',
+        ['root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [])],
+        wp_get_current_user()
+      )
+    );
+    $workflow = $this->workflowStorage->getWorkflow($id);
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $this->workflow = $workflow;
+  }
+
+  public function testGuestNotAllowed(): void {
+    wp_set_current_user(0);
+    $data = $this->post(sprintf(self::ENDPOINT_PATH, $this->workflow->getId()));
+
+    $this->assertSame([
+      'code' => 'rest_forbidden',
+      'message' => 'Sorry, you are not allowed to do that.',
+      'data' => ['status' => 401],
+    ], $data);
+
+    $workflow = $this->workflowStorage->getWorkflow($this->workflow->getId());
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $this->assertSame('Testing workflow', $workflow->getName());
+  }
+
+  public function testItDuplicatesAWorkflow(): void {
+    $data = $this->post(sprintf(self::ENDPOINT_PATH, $this->workflow->getId()));
+
+    $id = $this->workflow->getId() + 1;
+    $user = wp_get_current_user();
+    $createdAt = DateTimeImmutable::createFromFormat(DateTimeImmutable::W3C, $data['data']['created_at'] ?? null);
+    $updatedAt = DateTimeImmutable::createFromFormat(DateTimeImmutable::W3C, $data['data']['updated_at'] ?? null);
+
+    $this->assertInstanceOf(DateTimeImmutable::class, $createdAt);
+    $this->assertInstanceOf(DateTimeImmutable::class, $updatedAt);
+    $this->assertEquals($createdAt, $updatedAt);
+
+    $expected = [
+      'id' => $id,
+      'name' => 'Copy of Testing workflow',
+      'status' => 'draft',
+      'created_at' => $createdAt->format(DateTimeImmutable::W3C),
+      'updated_at' => $updatedAt->format(DateTimeImmutable::W3C),
+      'activated_at' => null,
+      'author' => [
+        'id' => $user->ID,
+        'name' => $user->display_name
+      ],
+      'stats' => [
+        'workflow_id' => $id,
+        'totals' => [
+          'entered' => 0,
+          'in_progress' => 0,
+          'exited' => 0,
+        ],
+      ],
+      'steps' => [
+        'root' => [
+          'id' => 'root',
+          'type' => 'root',
+          'key' => 'core:root',
+          'args' => [],
+          'next_steps' => [],
+        ],
+      ],
+    ];
+    $this->assertSame(['data' => $expected], $data);
+
+    $expectedWorkflow = Workflow::fromArray(
+      array_merge($expected, ['steps' => json_encode($expected['steps']), 'version_id' => 1])
+    );
+    $workflow = $this->workflowStorage->getWorkflow($id);
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $this->assertTrue($workflow->equals($expectedWorkflow));
+  }
+
+  public function _after() {
+    $this->workflowStorage->truncate();
+    parent::_after();
+  }
+}

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDuplicateEndpointTest.php
@@ -47,6 +47,7 @@ class WorkflowsDuplicateEndpointTest extends AutomationTest {
     $workflow = $this->workflowStorage->getWorkflow($this->workflow->getId());
     $this->assertInstanceOf(Workflow::class, $workflow);
     $this->assertSame('Testing workflow', $workflow->getName());
+    $this->assertNull($this->workflowStorage->getWorkflow($this->workflow->getId() + 1));
   }
 
   public function testItDuplicatesAWorkflow(): void {

--- a/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Workflows/WorkflowsDuplicateEndpointTest.php
@@ -71,7 +71,7 @@ class WorkflowsDuplicateEndpointTest extends AutomationTest {
       'activated_at' => null,
       'author' => [
         'id' => $user->ID,
-        'name' => $user->display_name
+        'name' => $user->display_name,
       ],
       'stats' => [
         'workflow_id' => $id,


### PR DESCRIPTION
## Description

Implements actions in the automation listing table.

## Code review notes

This is the backend part, extracted from the original large PR.
A frontend PR where all the changes will be visible and testable will follow (some related comments are visible here).

From the original PR by @johnolek I made a few changes:

1. Did a rebase.
2. Extracted workflow response building to a mapper (the previous response object was not DI-injectable).
3. Extracted delete and duplicate logic to controllers. Now I'm thinking if most of the delete logic should also go out of the storage to a controller 🤔
4. Added regenerating step IDs on duplication. Just to be sure...
5. Added tests for both new endpoints.

## QA notes

Automation only, QA step can be skipped.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/634

## Linked tickets

[MAILPOET-4540]

## After-merge notes

_N/A_


[MAILPOET-4540]: https://mailpoet.atlassian.net/browse/MAILPOET-4540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ