### PR TITLE
Fix wizard [MAILPOET-4665]

### DIFF
--- a/mailpoet/assets/js/src/wizard/steps_numbers.jsx
+++ b/mailpoet/assets/js/src/wizard/steps_numbers.jsx
@@ -3,7 +3,7 @@ export const getStepsCount = () => {
   if (!window.has_mss_key_specified) {
     stepsCount += 1;
   }
-  if (window.is_woocommerce_active) {
+  if (window.mailpoet_woocommerce_active) {
     stepsCount += 1;
   }
   return stepsCount;
@@ -25,7 +25,7 @@ export const mapStepNumberToStepName = (stepNumber) => {
   if (stepNumber === 2) {
     return 'WelcomeWizardUsageTrackingStep';
   }
-  if (window.is_woocommerce_active && stepNumber === getStepsCount()) {
+  if (window.mailpoet_woocommerce_active && stepNumber === getStepsCount()) {
     return 'WizardWooCommerceStep';
   }
   return 'WelcomeWizardPitchMSSStep';

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
@@ -134,7 +134,7 @@ function WelcomeWizardStepsController(props) {
           >
             <WelcomeWizardPitchMSSStep
               next={() => redirect(step)}
-              subscribersCount={window.subscribers_count}
+              subscribersCount={window.mailpoet_subscribers_count}
               mailpoetAccountUrl={window.mailpoet_account_url}
               purchaseUrl={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
                 MailPoet.subscribersCount,

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
@@ -87,7 +87,7 @@ function WelcomeWizardStepsController(props) {
       updateSettings(
         createSenderSettings({ address: window.admin_email, name: '' }),
       ).then(() => {
-        if (window.is_woocommerce_active) {
+        if (window.mailpoet_woocommerce_active) {
           redirect(stepsCount - 1);
         } else {
           finishWizard();

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -77,6 +77,10 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   var mailpoet_installed_days_ago = <%= installed_days_ago %>;
   var mailpoet_deactivate_subscriber_after_inactive_days = <%= json_encode(deactivate_subscriber_after_inactive_days) %>;
 
+  var mailpoet_site_name = '<%= site_name %>';
+  var mailpoet_site_url = "<%= site_url %>";
+  var mailpoet_site_address = '<%= site_address %>';
+
   // Premium status
   var mailpoet_current_wp_user_email = '<%= current_wp_user_email|escape('js') %>';
   var mailpoet_premium_link = <%= json_encode(link_premium) %>;


### PR DESCRIPTION
## Description

1. The welcome wizard offers Business plan instead of Starter plan.
2. I also suspect it doesn't add the WooCommerce steps when WC is installed.
3. Additionally, I think the WooCommerce block in the site editor has site name and address undefined.
4. And finally, I think the NPS poll may have been tracking `userId`s without the appended site URL.

https://a8c.slack.com/archives/C01GH764202/p1663771925199369

## QA notes

1. Check that welcome wizard offers Starter plan to new users (and not Business plan).
2. Check that welcome wizard includes the WooCommerce step when WC is installed.
3. Check that the WooCommerce block in the newsletter editor has the correct site name and site address.
4. Check that NPS poll tracks `userId` as user ID + site URL.

## Linked tickets

[MAILPOET-4665]


[MAILPOET-4665]: https://mailpoet.atlassian.net/browse/MAILPOET-4665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ