### PR TITLE
UserRegistrationTriggerTest: Delete user properly in multisite environment [MAILPOET-4666]

### DIFF
--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
@@ -96,7 +96,7 @@ class UserRegistrationTriggerTest extends \MailPoetTest
     if (! $this->userId) {
       return;
     }
-    wp_delete_user($this->userId);
+    is_multisite() ? wpmu_delete_user($this->userId) : wp_delete_user($this->userId);
     $this->userId = null;
     $this->wpSegment->synchronizeUsers();
   }


### PR DESCRIPTION
## Description
The `UserRegistrationTriggerTest` fails on the multisite integration test, because the test creates a user and does not properly delete the user again after a test has been run. The next time, we try to create the user, it exists already and thus the next test fails.

## Code review notes
I pushed another commit which forced the multisite integration tests to run. The result can be seen here: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/11402/workflows/0c101760-e3f0-4931-a23c-ea2c15b878d3/jobs/195838

I did reset the branch afterwards (and added the issue number in the commit description, thus creating a new history at that point). The diff of that run can be viewed here: https://github.com/mailpoet/mailpoet/compare/2c159b16948de91dbc33f1320aa85a961b95a41c..8212cdb01e1cf4ff4f237d420edae931e8a9b12d
## QA notes
This change only affects the tests.

## Linked tickets
[MAILPOET-4666]

## After-merge notes
Check that trunk does not fail.

[MAILPOET-4666]: https://mailpoet.atlassian.net/browse/MAILPOET-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ