### PR TITLE
Improve linux cron error message [MAILPOET-2525]

### DIFF
--- a/mailpoet/mailpoet-cron.php
+++ b/mailpoet/mailpoet-cron.php
@@ -48,7 +48,9 @@ $container = \MailPoet\DI\ContainerWrapper::getInstance(WP_DEBUG);
 // Check if Linux Cron method is set in plugin settings
 $settings = $container->get(\MailPoet\Settings\SettingsController::class);
 if ($settings->get('cron_trigger.method') !== \MailPoet\Cron\CronTrigger::METHOD_LINUX_CRON) {
-  echo 'MailPoet is not configured to run with Linux Cron.';
+  echo 'You attempt to run MailPoets "Server side cron (Linux cron)."' . PHP_EOL .
+    'But in your settings, you have defined a different method for the Newsletter task scheduler.' . PHP_EOL .
+    'If you want to use the "Server side cron", please go to MailPoet > Settings > Advanced and choose the correct Newsletter task scheduler.' . PHP_EOL;
   exit(1);
 }
 


### PR DESCRIPTION
## Description
Improves error message of linux cron.

## QA notes
To see the improved error:
Go to the settings and copy paste the PHP command, you find in the linux cron option
![image](https://user-images.githubusercontent.com/6458412/191896516-e8554c72-82f9-420e-a22e-24abe3d98e20.png)

Choose another cron option

Log into your server via SSH and run the PHP command you found. You should see something like this:
![image](https://user-images.githubusercontent.com/6458412/191896654-3f76a37f-4fdd-40bb-bef0-4a7a49ceebce.png)

## Linked tickets
[MAILPOET-2525]

[MAILPOET-2525]: https://mailpoet.atlassian.net/browse/MAILPOET-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ