### PR TITLE
Update Black Friday notice [MAILPOET-4670]

### DIFF
--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -22,8 +22,8 @@ class BlackFridayNotice {
 
   public function init($shouldDisplay) {
     $shouldDisplay = $shouldDisplay
-      && (time() <= strtotime('2021-11-30 12:00:00'))
-      && (time() >= strtotime('2021-11-24 12:00:00'))
+      && (time() <= strtotime('2022-10-07 12:00:00'))
+      && (time() >= strtotime('2022-10-03 12:00:00'))
       && !get_transient(self::OPTION_NAME);
     if ($shouldDisplay) {
       $this->display();
@@ -32,8 +32,8 @@ class BlackFridayNotice {
 
   private function display() {
     $subscribers = $this->subscribersRepository->countBy(['deletedAt' => null]);
-    $header = '<h3 class="mailpoet-h3">' . __('Save big on MailPoet – 40% off this Black Friday', 'mailpoet') . '</h3>';
-    $body = '<h5 class="mailpoet-h5">' . __('Our biggest ever sale is here! Save 40% on all annual plans and licenses until 8 am UTC, November 30. Terms and conditions apply.', 'mailpoet') . '</h5>';
+    $header = '<h3 class="mailpoet-h3">' . __('Get ready for Black Friday with 40% off MailPoet plans', 'mailpoet') . '</h3>';
+    $body = '<h5 class="mailpoet-h5">' . __('Save 40% on all annual plans and licenses until 2 pm UTC, 7 October. Terms & conditions apply.', 'mailpoet') . '</h5>';
     $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers' class='mailpoet-button button-primary' target='_blank'>"
       . __('Shop now', 'mailpoet')
       . '</a></p>';

--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -22,8 +22,8 @@ class BlackFridayNotice {
 
   public function init($shouldDisplay) {
     $shouldDisplay = $shouldDisplay
-      && (time() <= strtotime('2022-10-07 12:00:00'))
-      && (time() >= strtotime('2022-10-03 12:00:00'))
+      && (time() >= strtotime('2022-10-03 14:00:00 UTC'))
+      && (time() <= strtotime('2022-10-07 14:00:00 UTC'))
       && !get_transient(self::OPTION_NAME);
     if ($shouldDisplay) {
       $this->display();
@@ -33,9 +33,9 @@ class BlackFridayNotice {
   private function display() {
     $subscribers = $this->subscribersRepository->countBy(['deletedAt' => null]);
     $header = '<h3 class="mailpoet-h3">' . __('Get ready for Black Friday with 40% off MailPoet plans', 'mailpoet') . '</h3>';
-    $body = '<h5 class="mailpoet-h5">' . __('Save 40% on all annual plans and licenses until 2 pm UTC, 7 October. Terms & conditions apply.', 'mailpoet') . '</h5>';
-    $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers' class='mailpoet-button button-primary' target='_blank'>"
-      . __('Shop now', 'mailpoet')
+    $body = '<h5 class="mailpoet-h5">' . __('Save 40% on all annual plans until 2 pm UTC, October 7. Terms & conditions apply.', 'mailpoet') . '</h5>';
+    $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers&billing=yearly&ref=sale-october-2022-plugin&utm_source=MP&utm_medium=plugin&utm_campaign=mp_prebfcm' class='mailpoet-button button-primary' target='_blank'>"
+      . __('Shop Now', 'mailpoet')
       . '</a></p>';
 
     $extraClasses = 'mailpoet-dismissible-notice is-dismissible';


### PR DESCRIPTION
## Description
This PR updates the Black Friday notice for the current year.

## Code review notes
The specification mentions: `Make sure the banner will be shown even for users who dismissed the last year’s Black Friday banner.`
The information about the dismissal of the banner was saved with 30 days expiration, the banner was displayed a year ago, so for this year, we should be fine.

## QA notes
For displaying the banner you need to change the system date, or maybe it would be easier [to edit the dates in the code](https://github.com/mailpoet/mailpoet/commit/e4f2761fbc7841dce2e67b8b575f60e429a73246#diff-53170429e3e13f729d6b3cc61518ccf33dd42d3fa49bf4333c0b653d0dec2c5bR25-R26).

## Linked tickets
[MAILPOET-4670]


[MAILPOET-4670]: https://mailpoet.atlassian.net/browse/MAILPOET-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ