### PR TITLE
Remove old model usage from MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter - Part 2 [MAILPOET-4680]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -155,7 +155,7 @@ class Newsletter {
     // check if this is a post notification and if it contains at least 1 ALC post
     if (
       $newsletter->type === NewsletterEntity::TYPE_NOTIFICATION_HISTORY &&
-      $this->postsTask->getAlcPostsCount($renderedNewsletter, $newsletter) === 0
+      $this->postsTask->getAlcPostsCount($renderedNewsletter, $newsletterEntity) === 0
     ) {
       // delete notification history record since it will never be sent
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -134,7 +134,7 @@ class Newsletter {
       // render newsletter
       $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask);
       $renderedNewsletter = $this->wp->applyFilters(
-        'mailpoet_sending_newsletter_render_after',
+        'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
         $newsletter
       );
@@ -145,12 +145,23 @@ class Newsletter {
       // render newsletter
       $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask);
       $renderedNewsletter = $this->wp->applyFilters(
-        'mailpoet_sending_newsletter_render_after',
+        'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
         $newsletter
       );
       $renderedNewsletter = $this->gaTracking->applyGATracking($renderedNewsletter, $newsletter);
     }
+
+    // This deprecated notice can be removed after 2023-03-23
+    if ($this->wp->hasFilter('mailpoet_sending_newsletter_render_after')) {
+      $this->wp->deprecatedHook(
+        'mailpoet_sending_newsletter_render_after',
+        '3.98.1',
+        'mailpoet_sending_newsletter_render_after_pre_process',
+        __('Please note that mailpoet_sending_newsletter_render_after no longer runs and that the list of parameters of the new filter is different.', 'mailpoet')
+      );
+    }
+
     // check if this is a post notification and if it contains at least 1 ALC post
     if (
       $newsletter->getType() === NewsletterEntity::TYPE_NOTIFICATION_HISTORY &&

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Posts.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Posts.php
@@ -56,8 +56,8 @@ class Posts {
     return true;
   }
 
-  public function getAlcPostsCount($renderedNewsletter, \MailPoet\Models\Newsletter $newsletter) {
-    $templatePostsCount = substr_count($newsletter->getBodyString(), 'data-post-id');
+  public function getAlcPostsCount($renderedNewsletter, NewsletterEntity $newsletter) {
+    $templatePostsCount = substr_count($newsletter->getContent(), 'data-post-id');
     $newsletterPostsCount = substr_count($renderedNewsletter['html'], 'data-post-id');
     return $newsletterPostsCount - $templatePostsCount;
   }

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -403,7 +403,7 @@ class NewsletterSaveController {
       $queueModel->newsletterRenderedBody = null;
 
       $newsletterQueueTask = new NewsletterQueueTask();
-      $newsletterQueueTask->preProcessNewsletter($newsletterModel, $queueModel);
+      $newsletterQueueTask->preProcessNewsletter($newsletter, $queueModel);
 
       // 'preProcessNewsletter' modifies queue by old model - let's reload it
       $this->entityManager->refresh($queue);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -18,7 +18,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -179,10 +178,10 @@ class NewsletterTest extends \MailPoetTest {
     expect($renderedNewsletter['html'])
       ->stringContainsString('[mailpoet_open_data]');
 
-    $hookName = 'mailpoet_sending_newsletter_render_after';
+    $hookName = 'mailpoet_sending_newsletter_render_after_pre_process';
     expect(WPHooksHelper::isFilterApplied($hookName))->true();
     expect(WPHooksHelper::getFilterApplied($hookName)[0])->array();
-    expect(WPHooksHelper::getFilterApplied($hookName)[1] instanceof Newsletter)->true();
+    expect(WPHooksHelper::getFilterApplied($hookName)[1] instanceof NewsletterEntity)->true();
   }
 
   public function testItDoesNotHashLinksAndInsertTrackingCodeWhenTrackingIsDisabled() {
@@ -201,10 +200,10 @@ class NewsletterTest extends \MailPoetTest {
     expect($renderedNewsletter['html'])
       ->stringNotContainsString('[mailpoet_open_data]');
 
-    $hookName = 'mailpoet_sending_newsletter_render_after';
+    $hookName = 'mailpoet_sending_newsletter_render_after_pre_process';
     expect(WPHooksHelper::isFilterApplied($hookName))->true();
     expect(WPHooksHelper::getFilterApplied($hookName)[0])->array();
-    expect(WPHooksHelper::getFilterApplied($hookName)[1] instanceof Newsletter)->true();
+    expect(WPHooksHelper::getFilterApplied($hookName)[1] instanceof NewsletterEntity)->true();
   }
 
   public function testItReturnsFalseAndDeletesNewsletterWhenPostNotificationContainsNoPosts() {


### PR DESCRIPTION
## Description

This PR is a continuation of #4336 and it removes the remaining models from `MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter` and its test class.

## Code review notes

Please note that I opted to leave a call to the `SendingQueue` model in Newsletter.php: https://github.com/mailpoet/mailpoet/blob/ccbeb74a77da9cebe0ff82dc7c8cce5f7bc6cf94/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php#L203

I decided to do this as this call is tied to how the `Sending` class works and this class still uses the old `SendingQueue` model. Replacing the model in Newsletter.php with the corresponding entity without doing the same in `Sending` could cause inconsistencies as the same code path also uses the model within `Sending`. My suggestion is that we remove this remaining model from Newsletter.php in the ticket where we will address `Sending`.

Please let me know if you agree, and I will add a note to the corresponding ticket. 

## QA notes

This PR refactors code in a key part of MailPoet: the part responsible for sending e-mails. Please test sending different emails and make sure that they are delivered and that the subject and the body of the mails match what is expected.

## Linked PRs

#4336

## Linked tickets

[MAILPOET-4680]

## After-merge notes

This PR deprecates a filter and creates a new one. We should probably notify the users and update the documentation. See commit ccbeb74a77da9cebe0ff82dc7c8cce5f7bc6cf94 for more details.


[MAILPOET-4680]: https://mailpoet.atlassian.net/browse/MAILPOET-4680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ