### PR TITLE
Update insertSubscribersFromOrders() query to work with WooCommerce Custom Orders Tables [MAILPOET-4577]

### DIFF
--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -276,14 +276,22 @@ class WooCommerce {
       'highestOrderId' => \PDO::PARAM_INT,
     ];
 
-    $result = $this->connection->executeQuery("
-      SELECT wpp.id AS order_id, wppm.meta_value AS email
-      FROM `{$wpdb->posts}` wpp
-      JOIN `{$wpdb->postmeta}` wppm ON wpp.ID = wppm.post_id AND wppm.meta_key = '_billing_email' AND wppm.meta_value != ''
-      WHERE wpp.post_type = 'shop_order'
-      AND (wpp.ID > :lowestOrderId AND wpp.ID <= :highestOrderId)
-      ORDER BY wpp.id
-    ", $parameters, $parametersType)->fetchAllAssociative();
+    if ($this->woocommerceHelper->isWooCommerceCustomOrdersTableEnabled()) {
+      $ordersTable = $this->woocommerceHelper->getOrdersTableName();
+      $query = "SELECT id AS order_id, billing_email AS email
+        FROM `{$ordersTable}`
+        WHERE type = 'shop_order' AND billing_email != '' AND (id > :lowestOrderId AND id <= :highestOrderId)
+        ORDER BY id";
+    } else {
+      $query = "SELECT wpp.id AS order_id, wppm.meta_value AS email
+        FROM `{$wpdb->posts}` wpp
+        JOIN `{$wpdb->postmeta}` wppm ON wpp.ID = wppm.post_id AND wppm.meta_key = '_billing_email' AND wppm.meta_value != ''
+        WHERE wpp.post_type = 'shop_order'
+        AND (wpp.ID > :lowestOrderId AND wpp.ID <= :highestOrderId)
+        ORDER BY wpp.id";
+    }
+
+    $result = $this->connection->executeQuery($query, $parameters, $parametersType)->fetchAllAssociative();
 
     $processedOrders = [];
     foreach ($result as $item) {

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -3,6 +3,7 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\RuntimeException;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Helper {
@@ -117,7 +118,7 @@ class Helper {
 
   public function getOrdersTableName() {
     if (!method_exists('\Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore', 'get_orders_table_name')) {
-      throw new \Exception('Cannot get orders table name when running a WooCommerce version that doesn\'t support custom order tables.');
+      throw new RuntimeException('Cannot get orders table name when running a WooCommerce version that doesn\'t support custom order tables.');
     }
 
     return \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::get_orders_table_name();

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -114,4 +114,12 @@ class Helper {
 
     return $installedViaWooCommerce;
   }
+
+  public function getOrdersTableName() {
+    if (!method_exists('\Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore', 'get_orders_table_name')) {
+      throw new \Exception('Cannot get orders table name when running a WooCommerce version that doesn\'t support custom order tables.');
+    }
+
+    return \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::get_orders_table_name();
+  }
 }

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -57,8 +57,12 @@ parameters:
       count: 1
       path: ../../lib/WooCommerce/Helper.php
     -
-      message: '/^Call to function method_exists\(\) with/'
+      message: '/^Call to static method get_orders_table_name\(\) on an unknown class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore\.$/'
       count: 1
+      path: ../../lib/WooCommerce/Helper.php
+    -
+      message: '/^Call to function method_exists\(\) with/'
+      count: 2
       path: ../../lib/WooCommerce/Helper.php
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:


### PR DESCRIPTION
## Description

This PR updates the method `\MailPoet\Segments\WooCommerce::insertSubscribersFromOrders()` to use a different query if WooCommerce Custom Orders Tables is enabled. 

## Code review notes

_N/A_

## QA notes

Install MailPoet in a WooCommerce shop that already has a few orders placed by guest customers. Configure MailPoet to synchronize WooCommerce customers as MailPoet subscribers and check that subscribers are created for the WooCommerce guest customers. The functionality should continue working as expected with WooCommerce Custom Orders Table disabled (which is the default behavior). It still doesn't work with Woo COT enabled but that will be fixed in a subsequent PR when https://mailpoet.atlassian.net/browse/MAILPOET-4569 is implemented.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4577]

## After-merge notes

_N/A_


[MAILPOET-4577]: https://mailpoet.atlassian.net/browse/MAILPOET-4577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ