### PR TITLE
Newsletter template UI updates for automation [MAILPOET-4520]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -96,10 +96,6 @@ h1.title.mailpoet-newsletter-listing-heading {
   .mailpoet-top-bar {
     left: 0;
 
-    .mailpoet-top-bar-logo {
-      z-index: 1;
-    }
-
     .mailpoet-top-bar-beamer {
       top: 4px;
     }

--- a/mailpoet/assets/css/src/components/_top_bar.scss
+++ b/mailpoet/assets/css/src/components/_top_bar.scss
@@ -32,6 +32,7 @@ $beamer-dot-size: 8px;
     cursor: pointer;
     position: relative;
     top: 2px;
+    z-index: 1;
 
     svg {
       max-height: 100%;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/design_email_button.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/design_email_button.tsx
@@ -49,7 +49,7 @@ export function DesignEmailButton(): JSX.Element {
   // and the workflow is saved, we can safely redirect to the email design flow.
   useEffect(() => {
     if (emailId && workflowSaved) {
-      window.location.href = `admin.php?page=mailpoet-newsletter-editor&id=${emailId}`;
+      window.location.href = `admin.php?page=mailpoet-newsletters#/template/${emailId}`;
     }
   }, [emailId, workflowSaved]);
 

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/email_panel.tsx
@@ -1,12 +1,11 @@
 import { ComponentProps } from 'react';
 import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
-import { DesignEmailButton } from './design_email_button';
 import { ShortcodeHelpText } from './shortcode_help_text';
-import { Button } from '../../../components/button';
 import { PlainBodyTitle } from '../../../../../editor/components/panel';
 import { storeName } from '../../../../../editor/store';
 import { StepName } from '../../../../../editor/components/panel/step-name';
+import { EditNewsletter } from './edit_newsletter';
 
 function SingleLineTextareaControl(
   props: ComponentProps<typeof TextareaControl>,
@@ -99,24 +98,7 @@ export function EmailPanel(): JSX.Element {
 
       <div className="mailpoet-automation-email-content-separator" />
       <PlainBodyTitle title="Email" />
-      {selectedStep.args.email_id ? (
-        <div className="mailpoet-automation-email-buttons">
-          <Button
-            variant="sidebar-primary"
-            centered
-            href={`?page=mailpoet-newsletter-editor&id=${
-              selectedStep.args.email_id as string
-            }`}
-          >
-            Edit content
-          </Button>
-          <Button variant="secondary" centered>
-            Preview
-          </Button>
-        </div>
-      ) : (
-        <DesignEmailButton />
-      )}
+      <EditNewsletter />
     </PanelBody>
   );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/shortcode_help_text.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/shortcode_help_text.tsx
@@ -1,6 +1,6 @@
 export function ShortcodeHelpText(): JSX.Element {
   return (
-    <div className="mailpoet-shortcode-selector">
+    <span className="mailpoet-shortcode-selector">
       You can use{' '}
       <a
         href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes"
@@ -10,6 +10,6 @@ export function ShortcodeHelpText(): JSX.Element {
       >
         MailPoet shortcodes
       </a>
-    </div>
+    </span>
   );
 }

--- a/mailpoet/assets/js/src/common/top_bar/mailpoet_logo_responsive.tsx
+++ b/mailpoet/assets/js/src/common/top_bar/mailpoet_logo_responsive.tsx
@@ -3,9 +3,15 @@ import { t } from 'common/functions/t';
 import { MailPoetLogo } from './mailpoet_logo';
 import { MailPoetLogoMobile } from './mailpoet_logo_mobile';
 
-export function MailPoetLogoResponsive() {
+type Props = {
+  onClick?: () => void;
+};
+export function MailPoetLogoResponsive({ onClick }: Props) {
   const history = useHistory();
-  const onLogoClick = () => history.push('/');
+  let onLogoClick = onClick;
+  if (!onClick) {
+    onLogoClick = () => history.push('/');
+  }
   return (
     <a
       role="button"

--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -14,12 +14,16 @@ const renderHeading = (newsletterType, newsletterOptions) => {
     const step = newsletterType === 'automation' ? 2 : 3;
 
     let buttons = null;
+    let onLogoClick = () => {
+      window.location = `admin.php?page=mailpoet-newsletters`;
+    };
     if (newsletterType === 'automation') {
       const workflowId = newsletterOptions.workflowId;
       const goToUrl = `admin.php?page=mailpoet-automation-editor&id=${workflowId}`;
       const onClickCancel = () => {
         window.location = goToUrl;
       };
+      onLogoClick = onClickCancel;
       // These actions are set up from Marionette, we just trigger them here.
       const onClickPreview = () =>
         document.querySelector('.mailpoet_show_preview').click();
@@ -55,7 +59,7 @@ const renderHeading = (newsletterType, newsletterOptions) => {
         emailType={newsletterType}
         step={step}
         buttons={buttons}
-        showMailPoetLogo
+        onLogoClick={onLogoClick}
       />
     );
 

--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -20,10 +20,9 @@ const renderHeading = (newsletterType, newsletterOptions) => {
     if (newsletterType === 'automation') {
       const workflowId = newsletterOptions.workflowId;
       const goToUrl = `admin.php?page=mailpoet-automation-editor&id=${workflowId}`;
-      const onClickCancel = () => {
+      onLogoClick = () => {
         window.location = goToUrl;
       };
-      onLogoClick = onClickCancel;
       // These actions are set up from Marionette, we just trigger them here.
       const onClickPreview = () =>
         document.querySelector('.mailpoet_show_preview').click();
@@ -31,12 +30,6 @@ const renderHeading = (newsletterType, newsletterOptions) => {
         document.querySelector('.mailpoet_save_go_to_workflow').click();
       buttons = (
         <>
-          <input
-            type="button"
-            className="button link-button"
-            onClick={onClickCancel}
-            value="Cancel"
-          />{' '}
           <input
             type="button"
             name="preview"

--- a/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
@@ -59,10 +59,7 @@ const getEmailSendTitle = (emailType: string): string => {
   return typeMap[emailType] || MailPoet.I18n.t('stepNameSend');
 };
 
-const tutorialIcon = (emailType: string): JSX.Element | null => {
-  if (emailType === 'automation') {
-    return null;
-  }
+function TutorialIcon(): JSX.Element {
   return (
     <div>
       <a
@@ -87,7 +84,7 @@ const tutorialIcon = (emailType: string): JSX.Element | null => {
       <span id="beamer-empty-element" />
     </div>
   );
-};
+}
 
 const stepsListingHeading = (
   step: number,
@@ -125,7 +122,7 @@ const stepsListingHeading = (
         {' '}
       </h1>
       <div className="mailpoet-flex-grow" />
-      {tutorialIcon(emailType)}
+      {emailType !== 'automation' && <TutorialIcon />}
     </div>
   );
 };

--- a/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
@@ -59,6 +59,36 @@ const getEmailSendTitle = (emailType: string): string => {
   return typeMap[emailType] || MailPoet.I18n.t('stepNameSend');
 };
 
+const tutorialIcon = (emailType: string): JSX.Element | null => {
+  if (emailType === 'automation') {
+    return null;
+  }
+  return (
+    <div>
+      <a
+        role="button"
+        onClick={displayTutorial}
+        className="mailpoet-top-bar-beamer"
+        title={MailPoet.I18n.t('topBarTutorial')}
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (
+            ['keydown', 'keypress'].includes(event.type) &&
+            ['Enter', ' '].includes(event.key)
+          ) {
+            event.preventDefault();
+            displayTutorial();
+          }
+        }}
+      >
+        <Icon icon={video} />
+        <span>{MailPoet.I18n.t('topBarTutorial')}</span>
+      </a>
+      <span id="beamer-empty-element" />
+    </div>
+  );
+};
+
 const stepsListingHeading = (
   step: number,
   emailType: string,
@@ -80,6 +110,7 @@ const stepsListingHeading = (
       MailPoet.I18n.t('stepNameDesign'),
     ];
   }
+
   return (
     <div className="mailpoet-top-bar" data-automation-id={automationId}>
       {showMailPoetLogo && <MailPoetLogoResponsive />}
@@ -94,28 +125,7 @@ const stepsListingHeading = (
         {' '}
       </h1>
       <div className="mailpoet-flex-grow" />
-      <div>
-        <a
-          role="button"
-          onClick={displayTutorial}
-          className="mailpoet-top-bar-beamer"
-          title={MailPoet.I18n.t('topBarTutorial')}
-          tabIndex={0}
-          onKeyDown={(event) => {
-            if (
-              ['keydown', 'keypress'].includes(event.type) &&
-              ['Enter', ' '].includes(event.key)
-            ) {
-              event.preventDefault();
-              displayTutorial();
-            }
-          }}
-        >
-          <Icon icon={video} />
-          <span>{MailPoet.I18n.t('topBarTutorial')}</span>
-        </a>
-        <span id="beamer-empty-element" />
-      </div>
+      {tutorialIcon(emailType)}
     </div>
   );
 };

--- a/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
@@ -93,8 +93,8 @@ const stepsListingHeading = (
   step: number,
   emailType: string,
   automationId: string,
-  showMailPoetLogo: boolean,
   buttons: ReactNode,
+  onLogoClick?: () => void,
 ): JSX.Element => {
   const emailTypeTitle = getEmailTypeTitle(emailType);
   let stepTitles = [
@@ -113,7 +113,7 @@ const stepsListingHeading = (
 
   return (
     <div className="mailpoet-top-bar" data-automation-id={automationId}>
-      {showMailPoetLogo && <MailPoetLogoResponsive />}
+      <MailPoetLogoResponsive onClick={onLogoClick} />
       <HideScreenOptions />
       <Steps count={stepTitles.length} current={step} titles={stepTitles} />
       {buttons && (
@@ -135,7 +135,7 @@ export interface Props {
   emailType?: string;
   automationId?: string;
   location: Location;
-  showMailPoetLogo?: boolean;
+  onLogoClick?: () => void;
   buttons?: ReactNode;
 }
 
@@ -144,17 +144,18 @@ function ListingHeadingSteps({
   emailType,
   location,
   automationId,
-  showMailPoetLogo,
   buttons,
+  onLogoClick,
 }: Props): JSX.Element {
   const stepNumber = step || mapPathToSteps(location, emailType);
+
   if (stepNumber !== null) {
     return stepsListingHeading(
       stepNumber,
       emailType,
       automationId,
-      showMailPoetLogo,
       buttons,
+      onLogoClick,
     );
   }
   return null;

--- a/mailpoet/assets/js/src/newsletters/templates.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates.jsx
@@ -341,6 +341,7 @@ class NewsletterTemplates extends Component {
           emailType={this.state.emailType}
           automationId="email_template_selection_heading"
           buttons={buttons}
+          showMailPoetLogo={this.state.emailType === 'automation'}
         />
 
         <div className="mailpoet-templates">

--- a/mailpoet/assets/js/src/newsletters/templates.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates.jsx
@@ -315,12 +315,13 @@ class NewsletterTemplates extends Component {
     }
 
     let buttons = null;
+    let onClick;
     if (this.state.emailType === 'automation') {
       const workflowId = this.state.emailOptions?.workflowId;
       const goToUrl = workflowId
         ? `admin.php?page=mailpoet-automation-editor&id=${workflowId}`
-        : '/';
-      const onClick = () => {
+        : 'admin.php?page=mailpoet-automation';
+      onClick = () => {
         window.location = goToUrl;
       };
       buttons = (
@@ -341,7 +342,7 @@ class NewsletterTemplates extends Component {
           emailType={this.state.emailType}
           automationId="email_template_selection_heading"
           buttons={buttons}
-          showMailPoetLogo={this.state.emailType === 'automation'}
+          onLogoClick={onClick}
         />
 
         <div className="mailpoet-templates">

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -7,6 +7,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 use MailPoet\Segments\SegmentsRepository;
@@ -45,6 +46,8 @@ class AutomationEditor {
 
   public function render() {
     $id = isset($_GET['id']) ? (int)$_GET['id'] : null;
+
+    $this->wp->doAction(Hooks::EDITOR_BEFORE_LOAD, (int)$id);
 
     $workflow = $id ? $this->workflowStorage->getWorkflow($id) : null;
     if (!$workflow) {

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -22,6 +22,8 @@ class Hooks {
   public const TRIGGER = 'mailpoet/automation/trigger';
   public const WORKFLOW_STEP = 'mailpoet/automation/workflow/step';
 
+  public const EDITOR_BEFORE_LOAD = 'mailpoet/automation/editor/before_load';
+
   public const WORKFLOW_BEFORE_SAVE = 'mailpoet/automation/workflow/before_save';
   public const WORKFLOW_STEP_BEFORE_SAVE = 'mailpoet/automation/workflow/step/before_save';
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -137,7 +137,7 @@ class SendEmailAction implements Action {
 
   public function saveEmailSettings(Step $step): void {
     $args = $step->getArgs();
-    if (!isset($args['email_id'])) {
+    if (!isset($args['email_id']) || !$args['email_id']) {
       return;
     }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -60,11 +60,13 @@ class AutomationEditorLoadingHooks {
       }
 
       $this->newslettersRepository->bulkDelete([$emailId]);
+      $args = $step->getArgs();
+      unset($args['email_id']);
       $updatedStep = new Step(
         $step->getId(),
         $step->getType(),
         $step->getKey(),
-        array_merge($step->getArgs(), ['email_id' => 0]),
+        $args,
         $step->getNextSteps()
       );
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -58,6 +58,8 @@ class AutomationEditorLoadingHooks {
       if ($newsletterEntity && $newsletterEntity->getBody() !== null) {
         continue;
       }
+
+      $this->newslettersRepository->bulkDelete([$emailId]);
       $updatedStep = new Step(
         $step->getId(),
         $step->getType(),

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Hooks;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\WP\Functions as WP;
+
+class AutomationEditorLoadingHooks {
+
+  /** @var WP */
+  private $wp;
+
+  /** @var WorkflowStorage  */
+  private $workflowStorage;
+
+  /** @var NewslettersRepository  */
+  private $newslettersRepository;
+
+  public function __construct(
+    WP $wp,
+    WorkflowStorage $workflowStorage,
+    NewslettersRepository $newslettersRepository
+  ) {
+    $this->wp = $wp;
+    $this->workflowStorage = $workflowStorage;
+    $this->newslettersRepository = $newslettersRepository;
+  }
+
+  public function init(): void {
+    $this->wp->addAction(Hooks::EDITOR_BEFORE_LOAD, [$this, 'beforeEditorLoad']);
+  }
+
+  public function beforeEditorLoad(int $workflowId): void {
+    $workflow = $this->workflowStorage->getWorkflow($workflowId);
+    if (!$workflow) {
+      return;
+    }
+    $this->disconnectEmptyEmailsFromSendEmailStep($workflow);
+  }
+
+  private function disconnectEmptyEmailsFromSendEmailStep(Workflow $workflow): void {
+    $sendEmailSteps = array_filter(
+      $workflow->getSteps(),
+      function(Step $step): bool {
+        return $step->getKey() === 'mailpoet:send-email';
+      }
+    );
+    foreach ($sendEmailSteps as $step) {
+      $emailId = $step->getArgs()['email_id'] ?? 0;
+      if (!$emailId) {
+        continue;
+      }
+      $newsletterEntity = $this->newslettersRepository->findOneById($emailId);
+      if ($newsletterEntity && $newsletterEntity->getBody() !== null) {
+        continue;
+      }
+      $updatedStep = new Step(
+        $step->getId(),
+        $step->getType(),
+        $step->getKey(),
+        array_merge($step->getArgs(), ['email_id' => 0]),
+        $step->getNextSteps()
+      );
+
+      $steps = array_merge(
+        $workflow->getSteps(),
+        [$updatedStep->getId() => $updatedStep]
+      );
+      $workflow->setSteps($steps);
+
+      //To be valid, an email would need to be associated to an active workflow.
+      if ($workflow->getStatus() === Workflow::STATUS_ACTIVE) {
+        $workflow->setStatus(Workflow::STATUS_DRAFT);
+      }
+      $this->workflowStorage->updateWorkflow($workflow);
+    }
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Integrations\MailPoet;
 use MailPoet\Automation\Engine\Integration;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
+use MailPoet\Automation\Integrations\MailPoet\Hooks\AutomationEditorLoadingHooks;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
@@ -26,18 +27,22 @@ class MailPoetIntegration implements Integration {
   /** @var SendEmailAction */
   private $sendEmailAction;
 
+  private $automationEditorLoadingHooks;
+
   public function __construct(
     SegmentSubject $segmentSubject,
     SubscriberSubject $subscriberSubject,
     SomeoneSubscribesTrigger $someoneSubscribesTrigger,
     UserRegistrationTrigger $userRegistrationTrigger,
-    SendEmailAction $sendEmailAction
+    SendEmailAction $sendEmailAction,
+    AutomationEditorLoadingHooks $automationEditorLoadingHooks
   ) {
     $this->segmentSubject = $segmentSubject;
     $this->subscriberSubject = $subscriberSubject;
     $this->someoneSubscribesTrigger = $someoneSubscribesTrigger;
     $this->userRegistrationTrigger = $userRegistrationTrigger;
     $this->sendEmailAction = $sendEmailAction;
+    $this->automationEditorLoadingHooks = $automationEditorLoadingHooks;
   }
 
   public function register(Registry $registry): void {
@@ -52,5 +57,7 @@ class MailPoetIntegration implements Integration {
       [$this->sendEmailAction, 'saveEmailSettings'],
       $this->sendEmailAction->getKey()
     );
+
+    $this->automationEditorLoadingHooks->init();
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -150,6 +150,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\UserRegistrationTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\WorkflowBuilder::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Hooks\AutomationEditorLoadingHooks::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Activator::class)->setPublic(true);


### PR DESCRIPTION
## Description
Updates the newsletter templates page:
* Adds MailPoet logo, which redirects to the automation editor.
* Adds Cancel button, which disconnects the current email_id in the step, so that the next time we go to the send email settings, we see "Design email" button again, instead of the "Edit email" button.
* Removes the Cancel button on the newsletter editor (discussed in [Slack](https://a8c.slack.com/archives/C0313447YBC/p1664192125708849?thread_ts=1664189210.533199&cid=C0313447YBC)) (dc94b3bdec558708fd8608a2f17e7956864668fc)
* Removes Tutorial button in editor (cbed281c427588281ed6b0ac4c90a61d5f5d9c31)
* There was a small JS error in the send email settings, where we tried to create a DOM structure like `<p><div>text</div></p>`. I fixed this in 5d090727a437a5db37b949752164d5b58159bb58

## Code review notes
In order to disconnect the email_id in the send_email settings, I created an additional $_GET parameter which will be read before the AutomationEditor renders. The basic idea is: Removing this ID is the responsibility of the Step. The Step interface therefore got a `performActions(StepData $step, array $action)`. The `?steps[<stepId>][<action>]=<value>` parameter enables us now, to target the data of specific steps and let the `Step` take care of what to do in case of an `action`.

I preferred that approach over a simple `$_GET['delete_mail']`. It seemed a bit more flexible, so that 3rd party steps might be able to perform similar actions on the editor page as well.

## QA notes
These are the things, which needs testing from my perspective:
* Did the Cancel button disappear in the editor?
* Does the cancel button actually cancel the current action, return to the automation editor and I can return to the template screen through the "Design email" button in the "send email"-step?
* Do I get redirected to the automation Editor when clicking the MailPoet logo in the top bar on the templates and the newsletter editor?
* When I create a normal newsletter: Does the logo redirect to the newsletter listing page?

## Linked PRs
https://github.com/mailpoet/mailpoet-premium/pull/627

## Linked tickets
[MAILPOET-4520]


[MAILPOET-4520]: https://mailpoet.atlassian.net/browse/MAILPOET-4520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ