### PR TITLE
Remove messages showing each truncated table [MAILPOET-4682]

### DIFF
--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -42,7 +42,6 @@ $entityManager = ContainerWrapper::getInstance(WP_DEBUG)->get(EntityManager::cla
 $entitiesMeta = $entityManager->getMetadataFactory()->getAllMetadata();
 foreach ($entitiesMeta as $entityMeta) {
   $tableName = $entityMeta->getTableName();
-  $console->writeln("Truncating up {$tableName}...");
   $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
   $connection->executeStatement("TRUNCATE $tableName");
   $connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');


### PR DESCRIPTION
This PR removes the messages that were displayed during the initial stages of the integration tests execution showing the tables that were truncated (one line per table).

We decided to do this to make the output of the tests execution cleaner and to make it easier to find the actual results of the tests without having to scroll down quite a bit.

We still show a message marking the stage where the tables are truncated: `Cleaning up database...`.

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

Since this PR only changes a detail in the execution of the integration tests, I think we can skip QA.

## Linked PRs

[MAILPOET-4682]

## Linked tickets

_N/A_

## After-merge notes

_N/A_


[MAILPOET-4682]: https://mailpoet.atlassian.net/browse/MAILPOET-4682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ