### PR TITLE
Removing fixing styles from the compile command [MAILPOET-4550]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -90,9 +90,11 @@ class RoboFile extends \Robo\Tasks {
     // Clean up folder from previous files
     array_map('unlink', glob("assets/dist/css/*.*"));
 
-    $this->_exec('pnpm run stylelint -- "assets/css/src/**/*.scss"');
-    $this->_exec('pnpm run scss');
-    $compilationResult = $this->_exec('pnpm run autoprefixer');
+    $compilationResult = $this->taskExecStack()
+      ->exec('pnpm run stylelint-check -- "assets/css/src/**/*.scss"')
+      ->exec('pnpm run scss')
+      ->exec('pnpm run autoprefixer')
+      ->run();
 
     // Create manifest file
     $manifest = [];


### PR DESCRIPTION
## Description

This pull request replaces style fixing with style checking only. The main reason is possible disabling pre-commit hooks that allow committing CSS with an invalid code style.

## Code review notes

_N/A_

## QA notes

I tried to push a test commit with the wrong code style, and the expected behavior is visible on CircleCI.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/629

## Linked tickets

[MAILPOET-4550]

## After-merge notes

_N/A_


[MAILPOET-4550]: https://mailpoet.atlassian.net/browse/MAILPOET-4550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ