### PR TITLE
Fix sending post notification [MAILPOET-4685]

### DIFF
--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -20,6 +20,7 @@ use MailPoet\Newsletter\Scheduler\Scheduler as NewsletterScheduler;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -54,6 +55,9 @@ class Scheduler {
   /** @var NewsletterSegmentRepository */
   private $newsletterSegmentRepository;
 
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
   /** @var WPFunctions */
   private $wp;
 
@@ -72,6 +76,7 @@ class Scheduler {
     NewslettersRepository $newslettersRepository,
     SegmentsRepository $segmentsRepository,
     NewsletterSegmentRepository $newsletterSegmentRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
     WPFunctions $wp,
     Security $security,
     NewsletterScheduler $scheduler
@@ -84,6 +89,7 @@ class Scheduler {
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newsletterSegmentRepository = $newsletterSegmentRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->wp = $wp;
     $this->security = $security;
     $this->scheduler = $scheduler;
@@ -211,6 +217,7 @@ class Scheduler {
 
     // Because there is mixed usage of the old and new model, we want to be sure about the correct state
     $this->newslettersRepository->refresh($notificationHistory);
+    $this->sendingQueuesRepository->refresh($queue->getSendingQueueEntity());
 
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
       'post notification set status to sending',

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -250,9 +250,9 @@ class Newsletter {
       $newsletter->getType() === NewsletterEntity::TYPE_STANDARD ||
        $newsletter->getType() === NewsletterEntity::TYPE_NOTIFICATION_HISTORY
     ) {
-      $sendingQueue = $sendingTask->queue();
+      $scheduledTask = $sendingTask->task();
       $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
-      $newsletter->setSentAt(new Carbon($sendingQueue->processedAt));
+      $newsletter->setSentAt(new Carbon($scheduledTask->processedAt));
       $this->newslettersRepository->persist($newsletter);
       $this->newslettersRepository->flush();
     }

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -413,6 +413,7 @@ class NewslettersRepository extends Repository {
       ->where('n.parent = :parent')
       ->andWhere('n.type = :type')
       ->andWhere('n.status = :status')
+      ->andWhere('n.deletedAt IS NULL')
       ->andWhere('t.status != :taskStatus')
       ->setParameter('parent', $newsletter)
       ->setParameter('type', NewsletterEntity::TYPE_NOTIFICATION_HISTORY)

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -404,8 +404,8 @@ class NewslettersRepository extends Repository {
   /**
    * @return NewsletterEntity[]
    */
-  public function findSendigNotificationHistoryWithPausedTask(NewsletterEntity $newsletter): array {
-    $result = $this->entityManager->createQueryBuilder()
+  public function findSendingNotificationHistoryWithoutPausedTask(NewsletterEntity $newsletter): array {
+    return $this->entityManager->createQueryBuilder()
       ->select('n')
       ->from(NewsletterEntity::class, 'n')
       ->join('n.queues', 'q')
@@ -418,8 +418,7 @@ class NewslettersRepository extends Repository {
       ->setParameter('type', NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
       ->setParameter('status', NewsletterEntity::STATUS_SENDING)
       ->setParameter('taskStatus', ScheduledTaskEntity::STATUS_PAUSED)
-      ->getQuery()->execute();
-    return $result;
+      ->getQuery()->getResult();
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
@@ -110,7 +110,7 @@ class PostNotificationScheduler {
   }
 
   public function createPostNotificationSendingTask(NewsletterEntity $newsletter): ?ScheduledTaskEntity {
-    $notificationHistory = $this->newslettersRepository->findSendigNotificationHistoryWithPausedTask($newsletter);
+    $notificationHistory = $this->newslettersRepository->findSendingNotificationHistoryWithoutPausedTask($newsletter);
     if (count($notificationHistory) > 0) {
       return null;
     }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -486,11 +486,6 @@ parameters:
 			path: ../../lib/Newsletter/NewslettersRepository.php
 
 		-
-			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:findSendigNotificationHistoryWithPausedTask\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Newsletter/NewslettersRepository.php
-
-		-
 			message: "#^Method MailPoet\\\\Newsletter\\\\Renderer\\\\Renderer\\:\\:postProcessTemplate\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Newsletter/Renderer/Renderer.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -486,11 +486,6 @@ parameters:
 			path: ../../lib/Newsletter/NewslettersRepository.php
 
 		-
-			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:findSendigNotificationHistoryWithPausedTask\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Newsletter/NewslettersRepository.php
-
-		-
 			message: "#^Method MailPoet\\\\Newsletter\\\\Renderer\\\\Renderer\\:\\:postProcessTemplate\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Newsletter/Renderer/Renderer.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -485,11 +485,6 @@ parameters:
 			path: ../../lib/Newsletter/NewslettersRepository.php
 
 		-
-			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:findSendigNotificationHistoryWithPausedTask\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Newsletter/NewslettersRepository.php
-
-		-
 			message: "#^Method MailPoet\\\\Newsletter\\\\Renderer\\\\Renderer\\:\\:postProcessTemplate\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Newsletter/Renderer/Renderer.php

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -31,6 +31,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -72,6 +73,9 @@ class SchedulerTest extends \MailPoetTest {
   /** @var NewsletterSegmentRepository */
   private $newsletterSegmentRepository;
 
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
   /** @var Security */
   private $security;
 
@@ -87,6 +91,7 @@ class SchedulerTest extends \MailPoetTest {
     $this->newsletterScheduler = $this->diContainer->get(NewsletterScheduler::class);
     $this->newsletterOptionFactory = new NewsletterOptionFactory();
     $this->newsletterSegmentRepository = $this->diContainer->get(NewsletterSegmentRepository::class);
+    $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->security = $this->diContainer->get(Security::class);
   }
 
@@ -534,6 +539,7 @@ class SchedulerTest extends \MailPoetTest {
         $this->newslettersRepository,
         $this->segmentsRepository,
         $this->newsletterSegmentRepository,
+        $this->sendingQueuesRepository,
         WPFunctions::get(),
         $this->security,
         $this->newsletterScheduler,


### PR DESCRIPTION
## Description

This PR fixes issues with sending post notifications. There is a list of a few of them:
- Daily post notification sends out posts of the last many days instead of just the last day
- The same post notification is being sent over and over again
- The same post notification for a specific term is sent many times
- An old post notification was resent

## Code review notes

_N/A_

## QA notes

Please, focus on post notification and a variety of configurations. Try the behavior before the update and after it.

**Steps to reproduce:**
1. Set up a post notification with `1` post set to send `immediately`.
2. Create a post — the post notification should be received.
3. In `wp_mailpoet_newsletter_posts` delete the record with the post notification ID — this simulates the invalid data some users have.
4. Edit or create a page.
5. You’ll receive a post notification for that post from point 1 (= issue).

**Then (the issues):**
1. The notification history record may remain sending and in that case you won’t receive any further emails for that post notification, not even for legit new posts.
2. Or the post notification history record may become sent and now every new post or page edit will trigger the post notification again.

I don’t know why sometimes error 1. occurs (my local site or [here](https://secure.helpscout.net/conversation/2022809488/518554?folderId=59660) and [here](https://secure.helpscout.net/conversation/2023365837/518768?folderId=59658)) and sometimes error 2. (e.g. [here](https://secure.helpscout.net/conversation/2021549999/518142?folderId=1110911)).

This PR should fix both issues.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4685](https://mailpoet.atlassian.net/browse/MAILPOET-4685)

## After-merge notes

_N/A_
