### PR TITLE
Confusing errors when activating creator and starter plan [MAILPOET-4464]

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/key_activation/messages/mss_messages.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/messages/mss_messages.tsx
@@ -53,6 +53,8 @@ export function MssMessages(props: Props) {
       );
     case MssStatus.INVALID:
       return <NotValidMessage message={props.keyMessage} />;
+
+    case MssStatus.VALID_UNDERPRIVILEGED:
     default:
       return null;
   }

--- a/mailpoet/assets/js/src/settings/pages/key_activation/messages/mss_messages.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/messages/mss_messages.tsx
@@ -2,7 +2,7 @@ import { MailPoet } from 'mailpoet';
 import { useSelector } from 'settings/store/hooks';
 import { MssStatus } from 'settings/store/types';
 
-function ActiveMessage() {
+function MssActiveMessage() {
   return (
     <div className="mailpoet_success_item mailpoet_success mailpoet_mss_key_valid">
       {MailPoet.I18n.t('premiumTabMssActiveMessage')}
@@ -46,7 +46,7 @@ export function MssMessages(props: Props) {
   const { mssStatus } = useSelector('getKeyActivationState')();
   switch (mssStatus) {
     case MssStatus.VALID_MSS_ACTIVE:
-      return <ActiveMessage />;
+      return <MssActiveMessage />;
     case MssStatus.VALID_MSS_NOT_ACTIVE:
       return (
         <MssNotActiveMessage activationCallback={props.activationCallback} />

--- a/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -10,6 +10,7 @@ import {
 } from 'settings/store/types';
 import { updateKeyActivationState } from './key_activation';
 import { setSettings, setSetting } from './settings';
+import { getMssStatus } from '../make_default_state';
 
 export function* verifyMssKey(key: string) {
   const { success, error, res } = yield {
@@ -43,7 +44,10 @@ export function* verifyMssKey(key: string) {
     fields.mssStatus = MssStatus.VALID_MSS_NOT_ACTIVE;
   } else {
     yield setSettings(call.res.data);
-    fields.mssStatus = MssStatus.VALID_MSS_ACTIVE;
+    fields.mssStatus = getMssStatus(
+      call.res.data.mta.mailpoet_api_key_state.code === 200,
+      call.res.data,
+    );
   }
   return updateKeyActivationState(fields);
 }

--- a/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -45,7 +45,9 @@ export function* verifyMssKey(key: string) {
   } else {
     yield setSettings(call.res.data);
     fields.mssStatus = getMssStatus(
-      call.res.data.mta.mailpoet_api_key_state.code === 200,
+      ['200', 200].includes(
+        call.res.data.mta.mailpoet_api_key_state.code as number | string,
+      ),
       call.res.data,
     );
   }

--- a/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -45,9 +45,7 @@ export function* verifyMssKey(key: string) {
   } else {
     yield setSettings(call.res.data);
     fields.mssStatus = getMssStatus(
-      ['200', 200].includes(
-        call.res.data.mta.mailpoet_api_key_state.code as number | string,
-      ),
+      Number(call.res.data.mta.mailpoet_api_key_state.code) === 200,
       call.res.data,
     );
   }

--- a/mailpoet/assets/js/src/settings/store/make_default_state.ts
+++ b/mailpoet/assets/js/src/settings/store/make_default_state.ts
@@ -15,8 +15,12 @@ function getPremiumStatus(keyValid, premiumInstalled): PremiumStatus {
     : PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_INSTALLED;
 }
 
-function getMssStatus(keyValid, data): MssStatus {
-  if (!keyValid) return MssStatus.INVALID;
+export function getMssStatus(keyValid, data): MssStatus {
+  if (!keyValid)
+    return data.mta.mailpoet_api_key_state.state === 'valid_underprivileged'
+      ? MssStatus.VALID_UNDERPRIVILEGED
+      : MssStatus.INVALID;
+
   const mssActive = data.mta.method === 'MailPoet';
   return mssActive
     ? MssStatus.VALID_MSS_ACTIVE

--- a/mailpoet/assets/js/src/settings/store/normalize_settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize_settings.ts
@@ -149,7 +149,14 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
       authentication: asEnum(['1', '-1'], '1'),
       mailpoet_api_key_state: asObject({
         state: asEnum(
-          ['valid', 'invalid', 'expiring', 'already_used', 'check_error'],
+          [
+            'valid',
+            'invalid',
+            'expiring',
+            'already_used',
+            'check_error',
+            'valid_underprivileged',
+          ],
           'check_error',
         ),
         data: asIs,

--- a/mailpoet/assets/js/src/settings/store/normalize_settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize_settings.ts
@@ -160,6 +160,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
           'check_error',
         ),
         data: asIs,
+        code: asIs,
       }),
     }),
     mailpoet_smtp_provider: smtpServer,

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -85,8 +85,15 @@ export type Settings = {
     encryption: string;
     authentication: '1' | '-1';
     mailpoet_api_key_state: {
-      state: 'valid' | 'invalid' | 'expiring' | 'already_used' | 'check_error';
+      state:
+        | 'valid'
+        | 'invalid'
+        | 'expiring'
+        | 'already_used'
+        | 'check_error'
+        | 'valid_underprivileged';
       data: Record<string, unknown>;
+      code: number;
     };
   };
   mailpoet_smtp_provider: 'server' | 'manual' | 'AmazonSES' | 'SendGrid';
@@ -180,6 +187,7 @@ export enum MssStatus {
   INVALID,
   VALID_MSS_NOT_ACTIVE,
   VALID_MSS_ACTIVE,
+  VALID_UNDERPRIVILEGED,
 }
 
 export enum PremiumInstallationStatus {

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -111,6 +111,8 @@ class Services extends APIEndpoint {
     $successMessage = null;
     if ($state == Bridge::KEY_VALID) {
       $successMessage = __('Your MailPoet Sending Service key has been successfully validated', 'mailpoet');
+    } else if ($state == Bridge::KEY_VALID_UNDERPRIVILEGED) {
+      $successMessage = __('Your Premium key has been successfully validated, but is not valid for MailPoet Sending Service', 'mailpoet');
     } elseif ($state == Bridge::KEY_EXPIRING) {
       $successMessage = sprintf(
         // translators: %s is the expiration date.
@@ -175,6 +177,8 @@ class Services extends APIEndpoint {
     $successMessage = null;
     if ($state == Bridge::KEY_VALID) {
       $successMessage = __('Your Premium key has been successfully validated', 'mailpoet');
+    } else if ($state == Bridge::KEY_VALID_UNDERPRIVILEGED) {
+      $successMessage = __('Your Premium key has been successfully validated, but is not valid for MailPoet Sending Service', 'mailpoet');
     } elseif ($state == Bridge::KEY_EXPIRING) {
       $successMessage = sprintf(
         // translators: %s is the expiration date.

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -23,6 +23,7 @@ class Bridge {
   const KEY_INVALID = 'invalid';
   const KEY_EXPIRING = 'expiring';
   const KEY_ALREADY_USED = 'already_used';
+  const KEY_VALID_UNDERPRIVILEGED = 'valid_underprivileged';
 
   const KEY_CHECK_ERROR = 'check_error';
 
@@ -235,7 +236,7 @@ class Bridge {
       200 => self::KEY_VALID,
       401 => self::KEY_INVALID,
       402 => self::KEY_ALREADY_USED,
-      403 => self::KEY_INVALID,
+      403 => self::KEY_VALID_UNDERPRIVILEGED,
     ];
 
     if (!empty($result['code']) && isset($stateMap[$result['code']])) {

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -111,13 +111,13 @@ class Settings {
 
   public function withValidPremiumKey($key) {
     $this->settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, $key);
-    $this->settings->set(Bridge::PREMIUM_KEY_STATE_SETTING_NAME, ['state' => Bridge::PREMIUM_KEY_VALID]);
+    $this->settings->set(Bridge::PREMIUM_KEY_STATE_SETTING_NAME, ['state' => Bridge::PREMIUM_KEY_VALID, 'code' => 200]);
     return $this;
   }
 
   public function withValidMssKey($key) {
     $this->settings->set(Bridge::API_KEY_SETTING_NAME, $key);
-    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_VALID]);
+    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_VALID, 'code' => 200]);
     return $this;
   }
 

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -18,7 +18,7 @@ class BridgeTest extends \MailPoetTest {
   public $usedPremiumKey;
   public $expiringPremiumKey;
   public $uncheckableKey;
-  public $forbiddenEndpointKey;
+  public $underPrivilegedKey;
   public $usedKey;
   public $expiringKey;
   public $invalidKey;
@@ -36,7 +36,7 @@ class BridgeTest extends \MailPoetTest {
     $this->invalidKey = '401' . $this->validKey;
     $this->expiringKey = 'expiring' . $this->validKey;
     $this->usedKey = '402' . $this->validKey;
-    $this->forbiddenEndpointKey = '403' . $this->validKey;
+    $this->underPrivilegedKey = '403' . $this->validKey;
     $this->uncheckableKey = '503' . $this->validKey;
 
     $this->expiringPremiumKey = 'expiring' . $this->validKey;
@@ -95,9 +95,9 @@ class BridgeTest extends \MailPoetTest {
   }
 
   public function testItChecksForbiddenEndpointMSSKey() {
-    $result = $this->bridge->checkMSSKey($this->forbiddenEndpointKey);
+    $result = $this->bridge->checkMSSKey($this->underPrivilegedKey);
     expect($result)->notEmpty();
-    expect($result['state'])->equals(Bridge::KEY_INVALID);
+    expect($result['state'])->equals(Bridge::KEY_VALID_UNDERPRIVILEGED);
   }
 
   public function testItReturnsErrorStateOnEmptyAPIResponseCodeDuringMSSCheck() {
@@ -153,9 +153,9 @@ class BridgeTest extends \MailPoetTest {
   }
 
   public function testItChecksForbiddenEndpointPremiumKey() {
-    $result = $this->bridge->checkPremiumKey($this->forbiddenEndpointKey);
+    $result = $this->bridge->checkPremiumKey($this->underPrivilegedKey);
     expect($result)->notEmpty();
-    expect($result['state'])->equals(Bridge::KEY_INVALID);
+    expect($result['state'])->equals(Bridge::KEY_VALID_UNDERPRIVILEGED);
   }
 
   public function testItChecksExpiringPremiumKey() {

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -113,6 +113,9 @@ class BridgeTest extends \MailPoetTest {
       Bridge::KEY_VALID => $this->validKey,
       Bridge::KEY_INVALID => $this->invalidKey,
       Bridge::KEY_EXPIRING => $this->expiringKey,
+      Bridge::KEY_ALREADY_USED => $this->usedKey,
+      Bridge::CHECK_ERROR_UNAVAILABLE => $this->uncheckableKey,
+      Bridge::KEY_VALID_UNDERPRIVILEGED => $this->underPrivilegedKey,
     ];
     foreach ($states as $state => $key) {
       $state = ['state' => $state];


### PR DESCRIPTION
## Description

This PR basically makes sure that if the key is valid, but lacks MSS support (which currently happens for Creator plan), the messages about MSS not being activated is not shown, instead only the activated services are printed out on the screen.
<img width="1067" alt="Screen Shot 2022-10-10 at 16 32 48" src="https://user-images.githubusercontent.com/789421/194891604-f3b612a5-f853-433e-8d55-517bbf4dffc8.png">
Current state on trunk where if the key lacks MSS support

<img width="1174" alt="Screen Shot 2022-10-10 at 16 40 51" src="https://user-images.githubusercontent.com/789421/194892131-cf3f4c50-5daa-444c-a595-1c4abcffec6e.png">
MSS error message not shown anymore if the key is valid for Premium plugin

## QA notes

Use keys with/without MSS support and verify the correct messages are shown and if the Creator key is valid, no error for MSS is shown.

Please note that the implementation covers the new signups/new verifications only, so if the user is old and their Creator plan key has already been added, they will still see the message about MSS not being active for them until they press on verify again.
 
## Linked tickets

[MAILPOET-4464]

[MAILPOET-4464]: https://mailpoet.atlassian.net/browse/MAILPOET-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ