### PR TITLE
Remove old model usage from AutomaticEmailScheduler [MAILPOET-4372]

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
@@ -165,11 +165,11 @@ class AbandonedCart {
     }
 
     $meta = [self::TASK_META_NAME => $cartProductIds];
-    $this->scheduler->scheduleOrRescheduleAutomaticEmail(WooCommerceEmail::SLUG, self::SLUG, (int)$subscriber->getId(), $meta);
+    $this->scheduler->scheduleOrRescheduleAutomaticEmail(WooCommerceEmail::SLUG, self::SLUG, $subscriber, $meta);
   }
 
-  private function rescheduleAbandonedCartEmail(SubscriberEntity $subscriberEntity) {
-    $this->scheduler->rescheduleAutomaticEmail(WooCommerceEmail::SLUG, self::SLUG, (int)$subscriberEntity->getId());
+  private function rescheduleAbandonedCartEmail(SubscriberEntity $subscriber) {
+    $this->scheduler->rescheduleAutomaticEmail(WooCommerceEmail::SLUG, self::SLUG, $subscriber);
   }
 
   private function cancelAbandonedCartEmail() {
@@ -177,7 +177,7 @@ class AbandonedCart {
     if (!$subscriber) {
       return;
     }
-    $this->scheduler->cancelAutomaticEmail(WooCommerceEmail::SLUG, self::SLUG, (int)$subscriber->getId());
+    $this->scheduler->cancelAutomaticEmail(WooCommerceEmail::SLUG, self::SLUG, $subscriber);
   }
 
   private function getSubscriber(): ?SubscriberEntity {

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -188,7 +188,7 @@ class FirstPurchase {
         'subscriber_id' => $subscriber->getId(),
       ]
     );
-    $this->scheduler->scheduleAutomaticEmail(WooCommerce::SLUG, self::SLUG, $checkEmailWasNotScheduled, $subscriber->getId(), $meta);
+    $this->scheduler->scheduleAutomaticEmail(WooCommerce::SLUG, self::SLUG, $checkEmailWasNotScheduled, $subscriber, $meta);
   }
 
   public function getCustomerOrderCount($customerEmail) {

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -160,7 +160,7 @@ class PurchasedInCategory {
       WooCommerce::SLUG,
       self::SLUG,
       $schedulingCondition,
-      $subscriber->getId(),
+      $subscriber,
       ['orderedProductCategories' => $orderedProductCategories],
       [$this, 'metaModifier']
     );

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -162,7 +162,7 @@ class PurchasedProduct {
       WooCommerce::SLUG,
       self::SLUG,
       $schedulingCondition,
-      $subscriber->getId(),
+      $subscriber,
       ['orderedProducts' => $orderedProducts],
       [$this, 'metaModifier']
     );

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -62,7 +62,7 @@ class AutomaticEmailScheduler {
       if (is_callable($metaModifier)) {
         $meta = $metaModifier($newsletter, $meta);
       }
-      $this->createAutomaticEmailSendingTask($newsletter, $subscriberId, $meta);
+      $this->createAutomaticEmailScheduledTask($newsletter, $subscriberId, $meta);
     }
   }
 
@@ -82,7 +82,7 @@ class AutomaticEmailScheduler {
       if ($task) {
         $this->rescheduleAutomaticEmailSendingTask($newsletter, $task, $meta);
       } else {
-        $this->createAutomaticEmailSendingTask($newsletter, $subscriberId, $meta);
+        $this->createAutomaticEmailScheduledTask($newsletter, $subscriberId, $meta);
       }
     }
   }
@@ -128,7 +128,7 @@ class AutomaticEmailScheduler {
     }
   }
 
-  public function createAutomaticEmailSendingTask(NewsletterEntity $newsletter, $subscriberId, $meta = false) {
+  public function createAutomaticEmailScheduledTask(NewsletterEntity $newsletter, $subscriberId, $meta = false): ScheduledTaskEntity {
     $subscriber = $subscriberId ? $this->subscribersRepository->findOneById($subscriberId) : null;
     $scheduledTask = new ScheduledTaskEntity();
     $scheduledTask->setType(SendingQueue::TASK_TYPE);
@@ -161,6 +161,8 @@ class AutomaticEmailScheduler {
       $this->scheduledTaskSubscribersRepository->flush();
       $scheduledTask->getSubscribers()->add($scheduledTaskSubscriber);
     }
+
+    return $scheduledTask;
   }
 
   private function rescheduleAutomaticEmailSendingTask(NewsletterEntity $newsletter, ScheduledTaskEntity $scheduledTask, $meta = false) {

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -77,6 +77,15 @@ class ScheduledTaskSubscribersRepository extends Repository {
     return $subscribersIds;
   }
 
+  public function deleteByTask(ScheduledTaskEntity $scheduledTask): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskSubscriberEntity::class, 'sts')
+      ->where('sts.task = :task')
+      ->setParameter('task', $scheduledTask)
+      ->getQuery()
+      ->execute();
+  }
+
   private function getBaseSubscribersIdsBatchForTaskQuery(int $taskId, int $lastProcessedSubscriberId): QueryBuilder {
     return $this->entityManager
       ->createQueryBuilder()

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -96,6 +96,23 @@ class ScheduledTasksRepository extends Repository {
       ->getResult();
   }
 
+  public function findOneScheduledByNewsletterAndSubscriberId(NewsletterEntity $newsletter, int $subscriberId): ?ScheduledTaskEntity {
+    $scheduledTask = $this->doctrineRepository->createQueryBuilder('st')
+      ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
+      ->join(ScheduledTaskSubscriberEntity::class, 'sts', Join::WITH, 'st = sts.task')
+      ->andWhere('st.status = :status')
+      ->andWhere('sq.newsletter = :newsletter')
+      ->andWhere('sts.subscriber = :subscriber')
+      ->setMaxResults(1)
+      ->setParameter('status', ScheduledTaskEntity::STATUS_SCHEDULED)
+      ->setParameter('newsletter', $newsletter)
+      ->setParameter('subscriber', $subscriberId)
+      ->getQuery()
+      ->getOneOrNullResult();
+    // for phpstan because it detects mixed instead of entity
+    return ($scheduledTask instanceof ScheduledTaskEntity) ? $scheduledTask : null;
+  }
+
   public function findScheduledOrRunningTask(?string $type): ?ScheduledTaskEntity {
     $queryBuilder = $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -49,6 +49,22 @@ class ScheduledTasksRepository extends Repository {
 
   /**
    * @param NewsletterEntity $newsletter
+   */
+  public function findOneByNewsletter(NewsletterEntity $newsletter): ?ScheduledTaskEntity {
+    $scheduledTask = $this->doctrineRepository->createQueryBuilder('st')
+      ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
+      ->andWhere('sq.newsletter = :newsletter')
+      ->orderBy('sq.updatedAt', 'desc')
+      ->setMaxResults(1)
+      ->setParameter('newsletter', $newsletter)
+      ->getQuery()
+      ->getOneOrNullResult();
+    // for phpstan because it detects mixed instead of entity
+    return ($scheduledTask instanceof ScheduledTaskEntity) ? $scheduledTask : null;
+  }
+
+  /**
+   * @param NewsletterEntity $newsletter
    * @return ScheduledTaskEntity[]
    */
   public function findByScheduledAndRunningForNewsletter(NewsletterEntity $newsletter): array {

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Carbon\CarbonImmutable;
@@ -96,7 +97,7 @@ class ScheduledTasksRepository extends Repository {
       ->getResult();
   }
 
-  public function findOneScheduledByNewsletterAndSubscriberId(NewsletterEntity $newsletter, int $subscriberId): ?ScheduledTaskEntity {
+  public function findOneScheduledByNewsletterAndSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber): ?ScheduledTaskEntity {
     $scheduledTask = $this->doctrineRepository->createQueryBuilder('st')
       ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
       ->join(ScheduledTaskSubscriberEntity::class, 'sts', Join::WITH, 'st = sts.task')
@@ -106,7 +107,7 @@ class ScheduledTasksRepository extends Repository {
       ->setMaxResults(1)
       ->setParameter('status', ScheduledTaskEntity::STATUS_SCHEDULED)
       ->setParameter('newsletter', $newsletter)
-      ->setParameter('subscriber', $subscriberId)
+      ->setParameter('subscriber', $subscriber)
       ->getQuery()
       ->getOneOrNullResult();
     // for phpstan because it detects mixed instead of entity

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -141,4 +141,13 @@ class SendingQueuesRepository extends Repository {
       $this->flush();
     }
   }
+
+  public function deleteByTask(ScheduledTaskEntity $scheduledTask): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(SendingQueueEntity::class, 'sq')
+      ->where('sq.task = :task')
+      ->setParameter('task', $scheduledTask)
+      ->getQuery()
+      ->execute();
+  }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -100,7 +100,7 @@ class AbandonedCartTest extends \MailPoetTest {
     $this->wp = $wp;
     WPFunctions::set($this->wp);
 
-    $this->automaticEmailScheduler = new AutomaticEmailScheduler(new Scheduler($this->wp, $this->diContainer->get(NewslettersRepository::class)));
+    $this->automaticEmailScheduler = $this->getServiceWithOverrides(AutomaticEmailScheduler::class, ['wp' => $this->wp]);
 
     $this->wooCommerceCartMock = $this->mockWooCommerceClass(WC_Cart::class, ['is_empty', 'get_cart']);
     $this->cartBackup = $this->wooCommerce->cart;
@@ -275,7 +275,7 @@ class AbandonedCartTest extends \MailPoetTest {
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduled);
     $this->assertEquals($scheduled->getScheduledAt(), $expectedTime);
   }
-  
+
   public function testItPostponesEmailWhenSubscriberIsActiveOnSite() {
     $newsletter = $this->createNewsletter();
     $subscriber = $this->createSubscriberAsCurrentUser();

--- a/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
@@ -10,11 +10,13 @@ use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler;
 use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\NewsletterOption;
+use MailPoet\Test\DataFactories\Subscriber;
 use MailPoet\WP\Functions as WPFunctions;
 
 class AbandonedCartContentTest extends \MailPoetTest {
@@ -136,7 +138,7 @@ class AbandonedCartContentTest extends \MailPoetTest {
     $this->setGroupAndEventOptions($newsletter);
     $this->accBlock['displayType'] = 'titleOnly';
     $this->accBlock['pricePosition'] = 'hidden';
-    $sendingTask = $this->createSendingTask($newsletter, 1, [AbandonedCart::TASK_META_NAME => []]);
+    $sendingTask = $this->createSendingTask($newsletter, [AbandonedCart::TASK_META_NAME => []]);
     $result = $this->block->render($newsletter, $this->accBlock, false, $sendingTask);
     $encodedResult = json_encode($result);
     expect($encodedResult)->equals('[]');
@@ -183,10 +185,10 @@ class AbandonedCartContentTest extends \MailPoetTest {
     ]);
   }
 
-  private function createSendingTask($newsletter, $subscriberId = null, $meta = null) {
-    $subscriberId = $subscriberId ?: 1; // dummy default value
+  private function createSendingTask(NewsletterEntity $newsletter, ?array $meta = null) {
+    $subscriber = (new Subscriber())->create(); // dummy default value
     $meta = $meta ?: [AbandonedCart::TASK_META_NAME => array_slice($this->productIds, 0, 3)];
-    $scheduledTask = $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriberId, $meta);
+    $scheduledTask = $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber, $meta);
     // this can be removed when SendingTask usage is removed from AbandonedCartContent
     $parisTask = ScheduledTask::findOne($scheduledTask->getId());
     $this->assertInstanceOf(ScheduledTask::class, $parisTask);

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -67,7 +67,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
     $subscriber = (new SubscriberFactory())->create();
 
-    $this->automaticEmailScheduler->createAutomaticEmailSendingTask($newsletter, $subscriber->getId());
+    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber->getId());
     // new scheduled task should be created
     $task = $this->scheduledTasksRepository->findOneByNewsletter($newsletter);
     $currentTime = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
@@ -92,7 +92,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $subscriber = (new SubscriberFactory())->create();
     $meta = ['some' => 'value'];
 
-    $this->automaticEmailScheduler->createAutomaticEmailSendingTask($newsletter, $subscriber->getId(), $meta);
+    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber->getId(), $meta);
     // new queue record should be created with meta data
     $queue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $newsletter]);
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
@@ -103,7 +103,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $newsletter = $this->newslettersRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
 
-    $this->automaticEmailScheduler->createAutomaticEmailSendingTask($newsletter, null);
+    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, null);
     // new scheduled task should be created
     $task = $this->scheduledTasksRepository->findOneByNewsletter($newsletter);
     $currentTime = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -178,7 +178,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $wpMock->expects($this->any())
       ->method('currentTime')
       ->willReturn($currentTime->getTimestamp());
-    $automaticEmailScheduler = new AutomaticEmailScheduler(new Scheduler($wpMock, $this->diContainer->get(NewslettersRepository::class)));
+    $automaticEmailScheduler = $this->getServiceWithOverrides(AutomaticEmailScheduler::class, ['wp' => $wpMock]);
     // email should only be scheduled if it matches condition ("send to segment")
     $automaticEmailScheduler->scheduleAutomaticEmail('some_group', 'some_event', $condition);
     $result = $this->sendingQueuesRepository->findAll();

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -67,7 +67,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
     $subscriber = (new SubscriberFactory())->create();
 
-    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber->getId());
+    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber);
     // new scheduled task should be created
     $task = $this->scheduledTasksRepository->findOneByNewsletter($newsletter);
     $currentTime = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
@@ -92,7 +92,7 @@ class AutomaticEmailTest extends \MailPoetTest {
     $subscriber = (new SubscriberFactory())->create();
     $meta = ['some' => 'value'];
 
-    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber->getId(), $meta);
+    $this->automaticEmailScheduler->createAutomaticEmailScheduledTask($newsletter, $subscriber, $meta);
     // new queue record should be created with meta data
     $queue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $newsletter]);
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);


### PR DESCRIPTION
## Description

This PR aims to remove old model usages from the AutomaticEmailScheduled and its test. The class Sending is considered a part of the old model.

## Code review notes

As a side effect, there are minor improvements in parameter types and replacing the subscriber's id with the entity.

## QA notes

Please focus on automated emails such as First Purchase, Welcome Email, Purchased In This Category, and Purchased This Product.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4372]

## After-merge notes

_N/A_


[MAILPOET-4372]: https://mailpoet.atlassian.net/browse/MAILPOET-4372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ