### PR TITLE
Make triggers valid [MAILPOET-4689]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
@@ -36,7 +36,7 @@ class SomeoneSubscribesTrigger implements Trigger {
 
   public function getArgsSchema(): ObjectSchema {
     return Builder::object([
-      'segment_ids' => Builder::array(Builder::number())->required(),
+      'segment_ids' => Builder::array(Builder::number()),
     ]);
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
@@ -38,7 +38,7 @@ class UserRegistrationTrigger implements Trigger {
 
   public function getArgsSchema(): ObjectSchema {
     return Builder::object([
-      'roles' => Builder::array(Builder::string())->required(),
+      'roles' => Builder::array(Builder::string()),
     ]);
   }
 


### PR DESCRIPTION
## Description
To replicate:

On `trunk`
* Click "Create testing workflow"
* Open the new workflow in the editor
* Configure Delay & Send email (or remove them): Important: Do not open the trigger to configure it
* Try to activate the workflow
* Observe error

There shouldn't be an error, because "Any list" should be the default, thus we do not need to configure the trigger to make it valid.

The same is true for the WordPress user trigger.

## Code review notes
From the code base: We already handle the `roles`([#](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php#L81)) and `segment_ids` ([#](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php#L73)) properties in an optional way. Therefore I decided, to make the property itself optional.

## Linked tickets

[MAILPOET-4689]

[MAILPOET-4689]: https://mailpoet.atlassian.net/browse/MAILPOET-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ