### PR TITLE
Action scheduler cron fixes and improvements [MAILPOET-4684]

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -9,7 +9,7 @@
     "php": ">=7.2",
     "mtdowling/cron-expression": "^1.1",
     "soundasleep/html2text": "dev-master",
-    "woocommerce/action-scheduler": "^3.4"
+    "woocommerce/action-scheduler": "^3.5"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6829fbf64ed0f49aa5a3e5ab7884034",
+    "content-hash": "b59c2173fe3197f3e5227f4038218033",
     "packages": [
         {
             "name": "mtdowling/cron-expression",
@@ -111,16 +111,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.4.2",
+            "version": "3.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "7d8e830b6387410ccf11708194d3836f01cb2942"
+                "reference": "519cfa20db89eb85511cad08301d3fa33522ed8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/7d8e830b6387410ccf11708194d3836f01cb2942",
-                "reference": "7d8e830b6387410ccf11708194d3836f01cb2942",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/519cfa20db89eb85511cad08301d3fa33522ed8b",
+                "reference": "519cfa20db89eb85511cad08301d3fa33522ed8b",
                 "shasum": ""
             },
             "require-dev": {
@@ -145,9 +145,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.4.2"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.5.2"
             },
-            "time": "2022-06-08T15:46:07+00:00"
+            "time": "2022-09-16T15:31:00+00:00"
         }
     ],
     "packages-dev": [

--- a/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
+++ b/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
@@ -14,6 +14,11 @@ class ActionScheduler {
     return $id !== null ? intval($id) : null;
   }
 
+  public function unscheduleAllCronActions(): void {
+    // Passing only group to unschedule all by group
+    as_unschedule_all_actions('', [], self::GROUP_ID);
+  }
+
   public function hasScheduledAction(string $hook, array $args = []): bool {
     return as_has_scheduled_action($hook, $args, self::GROUP_ID);
   }

--- a/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
+++ b/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
@@ -5,8 +5,8 @@ namespace MailPoet\Cron\ActionScheduler;
 class ActionScheduler {
   public const GROUP_ID = 'mailpoet-cron';
 
-  public function scheduleRecurringAction(int $timestamp, int $interval_in_seconds, string $hook, array $args = []): int {
-    return as_schedule_recurring_action($timestamp, $interval_in_seconds, $hook, $args, self::GROUP_ID);
+  public function scheduleRecurringAction(int $timestamp, int $interval_in_seconds, string $hook, array $args = [], bool $unique = true): int {
+    return as_schedule_recurring_action($timestamp, $interval_in_seconds, $hook, $args, self::GROUP_ID, $unique);
   }
 
   public function unscheduleAction(string $hook, array $args = []): ?int {

--- a/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
+++ b/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
@@ -2,11 +2,26 @@
 
 namespace MailPoet\Cron\ActionScheduler;
 
+use MailPoet\WP\Functions as WPFunctions;
+
 class ActionScheduler {
   public const GROUP_ID = 'mailpoet-cron';
 
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
   public function scheduleRecurringAction(int $timestamp, int $interval_in_seconds, string $hook, array $args = [], bool $unique = true): int {
     return as_schedule_recurring_action($timestamp, $interval_in_seconds, $hook, $args, self::GROUP_ID, $unique);
+  }
+
+  public function scheduleImmediateSingleAction(string $hook, array $args = [], bool $unique = true): int {
+    return as_schedule_single_action($this->wp->currentTime('timestamp', true), $hook, $args, self::GROUP_ID, $unique);
   }
 
   public function unscheduleAction(string $hook, array $args = []): ?int {

--- a/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonRun.php
+++ b/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonRun.php
@@ -79,12 +79,11 @@ class DaemonRun {
    */
   public function afterProcess(): void {
     if ($this->wordpressTrigger->checkExecutionRequirements()) {
+      $this->actionScheduler->scheduleImmediateSingleAction(self::NAME);
       // The automatic rescheduling schedules the next recurring action to run after 1 second.
       // So we need to wait before we trigger new remote executor to avoid skipping the action
       sleep(2);
       $this->remoteExecutorHandler->triggerExecutor();
-    } else {
-      $this->actionScheduler->unscheduleAction(self::NAME);
     }
   }
 

--- a/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonRun.php
+++ b/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonRun.php
@@ -106,8 +106,8 @@ class DaemonRun {
       return;
     }
     $this->actionScheduler->scheduleImmediateSingleAction(self::NAME);
-    // The automatic rescheduling schedules the next recurring action to run after 1 second.
-    // So we need to wait before we trigger new remote executor to avoid skipping the action
+    // Chaining async requests can crash MySQL. A brief sleep call in PHP prevents that.
+    // @see https://github.com/woocommerce/action-scheduler/blob/6633378283d33746eec7314586783f58deee5375/classes/ActionScheduler_AsyncRequest_QueueRunner.php#L91-L96
     sleep(2);
     $this->remoteExecutorHandler->triggerExecutor();
   }

--- a/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonTrigger.php
+++ b/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonTrigger.php
@@ -55,8 +55,8 @@ class DaemonTrigger {
     if ($this->actionScheduler->hasScheduledAction(DaemonRun::NAME)) {
       return;
     }
-    // Start recurring action with minimal interval to ensure continuous execution of the daemon
-    $this->actionScheduler->scheduleRecurringAction($this->wp->currentTime('timestamp', true) - 1, 1, DaemonRun::NAME);
+    // Schedule immediate action for execution of the daemon
+    $this->actionScheduler->scheduleImmediateSingleAction(DaemonRun::NAME);
     $this->remoteExecutorHandler->triggerExecutor();
   }
 }

--- a/mailpoet/lib/Cron/CronWorkerRunner.php
+++ b/mailpoet/lib/Cron/CronWorkerRunner.php
@@ -73,6 +73,8 @@ class CronWorkerRunner {
       foreach ($dueTasks as $task) {
         $this->prepareTask($worker, $task);
       }
+      // Re-fetch running tasks so that we can process tasks that were just prepared
+      $runningTasks = $this->getRunningTasks($worker);
       foreach ($runningTasks as $task) {
         $this->processTask($worker, $task);
       }

--- a/mailpoet/lib/Cron/DaemonActionSchedulerRunner.php
+++ b/mailpoet/lib/Cron/DaemonActionSchedulerRunner.php
@@ -49,8 +49,7 @@ class DaemonActionSchedulerRunner {
   }
 
   public function deactivate(): void {
-    $this->actionScheduler->unscheduleAction(DaemonTrigger::NAME);
-    $this->actionScheduler->unscheduleAction(DaemonRun::NAME);
+    $this->actionScheduler->unscheduleAllCronActions();
   }
 
   /**

--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -140,6 +140,7 @@ class WordPress {
     $runningQueues = $this->scheduledTasksRepository->findRunningSendingTasks(SendingQueueWorker::TASK_BATCH_SIZE);
     $sendingLimitReached = MailerLog::isSendingLimitReached();
     $sendingIsPaused = MailerLog::isSendingPaused();
+    $sendingWaitingForRetry = MailerLog::isSendingWaitingForRetry();
     // sending service
     $mpSendingEnabled = Bridge::isMPSendingServiceEnabled();
     // bounce sync
@@ -292,7 +293,7 @@ class WordPress {
     ]);
 
     // check requirements for each worker
-    $sendingQueueActive = (($scheduledQueues || $runningQueues) && !$sendingLimitReached && !$sendingIsPaused);
+    $sendingQueueActive = (($scheduledQueues || $runningQueues) && !$sendingLimitReached && !$sendingIsPaused && !$sendingWaitingForRetry);
     $bounceSyncActive = ($mpSendingEnabled && ($bounceDueTasks || !$bounceFutureTasks));
     $sendingServiceKeyCheckActive = ($mpSendingEnabled && ($msskeycheckDueTasks || !$msskeycheckFutureTasks));
     $premiumKeyCheckActive = ($premiumKeySpecified && ($premiumKeycheckDueTasks || !$premiumKeycheckFutureTasks));

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -31,6 +31,7 @@ class LoggerFactory {
   const TOPIC_MSS = 'mss';
   const TOPIC_BRIDGE = 'bridge-api';
   const TOPIC_SENDING = 'sending';
+  const TOPIC_CRON = 'cron';
 
   /** @var LoggerFactory */
   private static $instance;

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -64,7 +64,10 @@ parameters:
       message: '/^Call to function method_exists\(\) with/'
       count: 2
       path: ../../lib/WooCommerce/Helper.php
-
+    - # WooCommerce stubs contains stubs for older ActionScheduler version
+      message: '/^Function as_schedule_recurring_action invoked with 6 parameters, 3-5 required.$/'
+      count: 1
+      path: ../../lib/Cron/ActionScheduler/ActionScheduler.php
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -68,6 +68,10 @@ parameters:
       message: '/^Function as_schedule_recurring_action invoked with 6 parameters, 3-5 required.$/'
       count: 1
       path: ../../lib/Cron/ActionScheduler/ActionScheduler.php
+    - # WooCommerce stubs contains stubs for older ActionScheduler version
+      message: '/^Function as_schedule_single_action invoked with 5 parameters, 2-4 required.$/'
+      count: 1
+      path: ../../lib/Cron/ActionScheduler/ActionScheduler.php
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -9,6 +9,7 @@ use MailPoet\API\JSON\v1\Setup;
 use MailPoet\Config\Activator;
 use MailPoet\Config\Migrator;
 use MailPoet\Config\Populator;
+use MailPoet\Cron\ActionScheduler\ActionScheduler;
 use MailPoet\Form\FormsRepository;
 use MailPoet\Referrals\ReferralDetector;
 use MailPoet\Segments\WP;
@@ -34,7 +35,8 @@ class SetupTest extends \MailPoetTest {
     $subscriptionCaptcha = $this->diContainer->get(Captcha::class);
     $populator = $this->getServiceWithOverrides(Populator::class, ['wp' => $wpStub, 'referralDetector' => $referralDetector]);
     $migrator = $this->diContainer->get(Migrator::class);
-    $router = new Setup($wpStub, new Activator($settings, $populator, $wpStub, $migrator));
+    $cronActionScheduler = $this->diContainer->get(ActionScheduler::class);
+    $router = new Setup($wpStub, new Activator($settings, $populator, $wpStub, $migrator, $cronActionScheduler));
     $response = $router->reset();
     expect($response->status)->equals(APIResponse::STATUS_OK);
 

--- a/mailpoet/tests/integration/Cron/ActionScheduler/ActionSchedulerTestHelper.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/ActionSchedulerTestHelper.php
@@ -18,4 +18,11 @@ class ActionSchedulerTestHelper  {
     ]);
     return $actions;
   }
+
+  public function getMailPoetCronActions(): array {
+    $actions = as_get_scheduled_actions([
+      'group' => ActionScheduler::GROUP_ID,
+    ]);
+    return $actions;
+  }
 }

--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
@@ -128,6 +128,6 @@ class DaemonRunTest extends \MailPoetTest {
     $claimsTable = $wpdb->prefix . 'actionscheduler_claims';
     $wpdb->query('TRUNCATE ' . $claimsTable);
     $this->truncateEntity(ScheduledTaskEntity::class);
-    //$this->truncateEntity(LogEntity::class);
+    $this->truncateEntity(LogEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
@@ -41,7 +41,7 @@ class DaemonRunTest extends \MailPoetTest {
     $this->daemonRun->init();
     expect($this->daemonRun->getDaemonExecutionLimit())->equals(20); // Verify initial execution limit
 
-    $this->actionScheduler->scheduleRecurringAction(time() - 1, 100, DaemonRun::NAME);
+    $this->actionScheduler->scheduleImmediateSingleAction(DaemonRun::NAME);
     $actions = $this->actionSchedulerHelper->getMailPoetScheduledActions();
     expect($actions)->count(1);
     $doneActions = $this->actionSchedulerHelper->getMailPoetCompleteActions();

--- a/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
@@ -47,10 +47,10 @@ class CronWorkerRunnerTest extends \MailPoetTest {
     $this->cronWorkerRunner->run($worker);
   }
 
-  public function testItPreparesTask() {
+  public function testItPreparesTaskAndProcessesItImmediately() {
     $worker = $this->make(SimpleWorkerMockImplementation::class, [
       'prepareTaskStrategy' => Expected::once(true),
-      'processTaskStrategy' => Expected::never(),
+      'processTaskStrategy' => Expected::once(true),
     ]);
 
     $task = $this->createScheduledTask();
@@ -58,7 +58,7 @@ class CronWorkerRunnerTest extends \MailPoetTest {
     expect($result)->true();
     $scheduledTask = $this->scheduledTasksRepository->findOneById($task->getId());
     assert($scheduledTask instanceof ScheduledTaskEntity);
-    expect($scheduledTask->getStatus())->null();
+    expect($scheduledTask->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
   }
 
   public function testItProcessesTask() {

--- a/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
@@ -50,7 +50,7 @@ class DaemonActionSchedulerRunnerTest extends \MailPoetTest {
 
   public function testItDeactivatesAllTasksOnTrigger(): void {
     $this->actionScheduler->scheduleRecurringAction(time() - 1, 100, DaemonTrigger::NAME);
-    $this->actionScheduler->scheduleRecurringAction(time() - 1, 100, DaemonRun::NAME);
+    $this->actionScheduler->scheduleImmediateSingleAction(DaemonRun::NAME);
     $actions = $this->actionSchedulerHelper->getMailPoetScheduledActions();
     expect($actions)->count(2);
     $this->actionSchedulerRunner->init(false);

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
@@ -83,15 +83,7 @@ class WooCommerceOrdersTest extends \MailPoetTest {
     assert($task instanceof ScheduledTaskEntity);
     expect($task->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
 
-    // 2. prepare
-    expect($this->worker->checkProcessingRequirements())->true();
-    $this->cronWorkerRunner->run($this->worker);
-    $this->entityManager->clear();
-    $task = $this->scheduledTaskRepository->findOneBy(['type' => WooCommercePastOrders::TASK_TYPE]);
-    assert($task instanceof ScheduledTaskEntity);
-    expect($task->getStatus())->null(); // null means 'running'
-
-    // 3. run
+    // 2. prepare and run
     expect($this->worker->checkProcessingRequirements())->true();
     $this->cronWorkerRunner->run($this->worker);
     $this->entityManager->clear();
@@ -99,7 +91,7 @@ class WooCommerceOrdersTest extends \MailPoetTest {
     assert($task instanceof ScheduledTaskEntity);
     expect($task->getStatus())->equals(ScheduledTaskEntity::STATUS_COMPLETED);
 
-    // 4. complete (do not schedule again)
+    // 3. complete (do not schedule again)
     expect($this->worker->checkProcessingRequirements())->false();
     $this->cronWorkerRunner->run($this->worker);
     $this->entityManager->clear();
@@ -120,8 +112,7 @@ class WooCommerceOrdersTest extends \MailPoetTest {
     $this->woocommercePurchases->expects($this->exactly(3))->method('trackPurchase');
 
     $this->cronWorkerRunner->run($this->worker); // schedule
-    $this->cronWorkerRunner->run($this->worker); // prepare
-    $this->cronWorkerRunner->run($this->worker); // run
+    $this->cronWorkerRunner->run($this->worker); // prepare and run
 
     $this->entityManager->clear();
     $tasks = $this->scheduledTaskRepository->findBy(['type' => WooCommercePastOrders::TASK_TYPE]);
@@ -137,8 +128,7 @@ class WooCommerceOrdersTest extends \MailPoetTest {
     $this->woocommercePurchases->expects($this->exactly(5))->method('trackPurchase');
 
     $this->cronWorkerRunner->run($this->worker); // schedule
-    $this->cronWorkerRunner->run($this->worker); // prepare
-    $this->cronWorkerRunner->run($this->worker); // run for 1, 2, 3
+    $this->cronWorkerRunner->run($this->worker); // prepare and run for 1, 2, 3
 
     $task = $this->scheduledTaskRepository->findOneBy(['type' => WooCommercePastOrders::TASK_TYPE]);
     assert($task instanceof ScheduledTaskEntity);


### PR DESCRIPTION
## Description

This PR addresses a couple of issues we identified on a customer page:
1) There were duplicate `mailpoet/cron/daemon-trigger` action. Probably created because of some race condition
2) In some cases, the `mailpoet/cron/daemon-run` action was running 20 times per minute.

To prevent these issue the PR introduces these changes:
1) Update of the Action Scheduler package from 3.4 to 3.5. Version 3.5 supports unique actions, and this should prevent creating duplicate actions.
2) Unscheduling all mailpoet cron actions during activation or update. This should clean up potential duplicate actions users have.
3) Cron will now pause its execution if the sending job is waiting for retry. The wait interval is 120, and the cron was running in a loop, not doing anything. This also affects the website visitors' type of cron.
4) Switched `mailpoet/cron/daemon-run` from a recurring action to a simple action. We now have complete control over the continuous scheduling of daemon's runs. This might also be less confusing for users as they should not see recurring actions scheduled to run once per second in the action scheduler logs.
5) Added protection against endless loops of the`mailpoet/cron/daemon-run` action. In case we detect that the deamon worked less than 2 seconds and there is still some execution time left, and the daemon still has more jobs to we won't trigger another `mailpoet/cron/daemon-run` action to run immediately, but we wait for the `mailpoet/cron/daemon-trigger` action to trigger it. So in case the daemon is stuck because of some issue we will run the cron only every 2 minutes instead of keeping it running continuously.
6) In order to make 5) work efficiently, I also made a change in the cron worker runner, and it will now immediately start processing tasks that were switched to running. Before the change, the worker just switched them to running, and they had to wait to be processed for the next iteration of the cron process.

## Code review notes

I tried to explain changes in commit messages. It is better to review commit by commit.

## QA notes

Please test sending to a bigger amount of subscribers (10K+). I've prepared a testing build that is faking sending emails. The process is running, but no emails go out. It can be used with MSS, SMTP, and sending with its own host methods. 
Download: [mailpoet-dummy-sending.zip](https://github.com/mailpoet/mailpoet/files/9683410/mailpoet-dummy-sending.zip)
You can observe action scheduler actions in WP Admin > Tools > Scheduled Actions. There should be only one `mailpoet/cron/daemon-trigger` in pending, and during sending you may observe that there will be logged `mailpoet/cron/daemon-run` actions approx every 20 seconds.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4684]

## After-merge notes

_N/A_


[MAILPOET-4684]: https://mailpoet.atlassian.net/browse/MAILPOET-4684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ