### PR TITLE
Escape string for usage in JavaScript [MAILPOET-4694]

### DIFF
--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -105,7 +105,7 @@ setTimeout(initMailpoetTranslation, 250);
 EOL;
     $this->wp->wpAddInlineScript(
       'mailpoet_public',
-      sprintf($inlineScript, $ajaxFailedErrorMessage),
+      sprintf($inlineScript, esc_js($ajaxFailedErrorMessage)),
       'after'
     );
   }


### PR DESCRIPTION
## Description
https://github.com/mailpoet/mailpoet/issues/4370

I couldn't really reproduce it with the Italian translation from transifex because somehow my instance had the translation `Si è verificato un errore nell’elaborazione della richiesta, riprova più tardi.` which did not contain a `'`.

Nevertheless, the report is valid and we need to escape this string.

## Code review notes
If you quickly want to validate its working, what I did was simply providing a string with a `'` character to reproduce the issue on `trunk` and verify that 155a305 fixes the issue.

## QA notes
* Make sure you have the Italian translation
* You could switch to Italian.
* In the widget you should see an error

If the error like described in #4370 does not immediately appear (like for me), you should alter the Italian translation files and change `Si è verificato un errore nell’elaborazione della richiesta, riprova più tardi` to `Si è verificato un errore nell'elaborazione della richiesta, riprova più tardi`

## Linked tickets
[MAILPOET-4694]

[MAILPOET-4694]: https://mailpoet.atlassian.net/browse/MAILPOET-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ