### PR TITLE
Skip WooCommerce Subscriptions tests when Woo Custom Orders Tables is enabled [MAILPOET-4695]

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -64,10 +64,6 @@ parameters:
       message: '/^Call to function method_exists\(\) with/'
       count: 2
       path: ../../lib/WooCommerce/Helper.php
-    -
-      message: '/^Call to an undefined method Codeception\\TestInterface::getName()./'
-      count: 1
-      path: ../../tests/_support/CheckSkippedTestsExtension.php
 
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -64,6 +64,11 @@ parameters:
       message: '/^Call to function method_exists\(\) with/'
       count: 2
       path: ../../lib/WooCommerce/Helper.php
+    -
+      message: '/^Call to an undefined method Codeception\\TestInterface::getName()./'
+      count: 1
+      path: ../../tests/_support/CheckSkippedTestsExtension.php
+
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -705,4 +705,8 @@ class AcceptanceTester extends \Codeception\Actor {
     ]);
     $i->cli(['action-scheduler', 'run', '--force']);
   }
+
+  public function isWooCustomOrdersTableEnabled(): bool {
+    return (bool)getenv('ENABLE_COT');
+  }
 }

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -12,7 +12,7 @@ class CheckSkippedTestsExtension extends Extension {
 
   public function checkSkippedTests(FailEvent $event) {
     $branch = getenv('CIRCLE_BRANCH');
-    $testName = $event->getTest()->getName();
+    $testName = $event->getTest()->getMetadata()->getName();
 
     // list of tests that are allowed to be skipped on trunk and release branches
     $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -15,7 +15,7 @@ class CheckSkippedTestsExtension extends Extension {
     $testName = $event->getTest()->getName();
 
     // list of tests that are allowed to be skipped on trunk and release branches
-    $allowedToSkipList = [];
+    $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
       throw new \PHPUnit\Framework\ExpectationFailedException("Failed, Cannot skip tests on branch $branch.");

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -1,19 +1,23 @@
 <?php
 
-use Codeception\Event\SuiteEvent;
+use Codeception\Event\FailEvent;
 use Codeception\Events;
 use Codeception\Extension;
 
 // phpcs:ignore PSR1.Classes.ClassDeclaration
 class CheckSkippedTestsExtension extends Extension {
   public static $events = [
-    Events::SUITE_AFTER => 'checkErrorsAfterTests',
+    Events::TEST_SKIPPED => 'checkSkippedTests',
   ];
 
-  public function checkErrorsAfterTests(SuiteEvent $e) {
+  public function checkSkippedTests(FailEvent $event) {
     $branch = getenv('CIRCLE_BRANCH');
-    $skipped = $e->getResult()->skipped();
-    if (in_array($branch, ['trunk', 'release']) && (count($skipped) !== 0)) {
+    $testName = $event->getTest()->getName();
+
+    // list of tests that are allowed to be skipped on trunk and release branches
+    $allowedToSkipList = [];
+
+    if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
       throw new \PHPUnit\Framework\ExpectationFailedException("Failed, Cannot skip tests on branch $branch.");
     }
   }

--- a/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -15,6 +15,9 @@ class WooCommerceSubscriptionsSegmentCest {
     if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN)) {
       $scenario->skip('Can‘t test without woocommerce-subscriptions');
     }
+    if ($i->isWooCustomOrdersTableEnabled()) {
+      $scenario->skip('Can‘t test when WooCommerce Custom Orders Table is enabled.');
+    }
     (new Settings())->withWooCommerceListImportPageDisplayed(true);
     (new Settings())->withCookieRevenueTrackingDisabled();
     $i->activateWooCommerce();


### PR DESCRIPTION
## Description

This PR changes a WooCommerce Subscriptions test to skip it when Woo Custom Orders Tables is enabled. To do that it was necessary to change how we forbid skipping tests when they are executed in the `trunk` and `release` branches (see commit message for more details).

I also created a branch that we can delete called `cot-skip-woocommerce-subscription-test-delme` to show that skipping the tests, with the exception of the ones in the accept list, is still not possible when using the two branches mentioned above: https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=cot-skip-woocommerce-subscription-test-delme

We can delete this branch, after merging this PR.

## Code review notes

_N/A_

## QA notes

I don´t think QA is needed for this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4695]

## After-merge notes

_N/A_


[MAILPOET-4695]: https://mailpoet.atlassian.net/browse/MAILPOET-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ