### PR TITLE
Fix entity manager closed in cron [MAILPOET-4699]

### DIFF
--- a/mailpoet/lib/Config/Migrator.php
+++ b/mailpoet/lib/Config/Migrator.php
@@ -218,7 +218,7 @@ class Migrator {
     $attributes = [
       'id int(11) unsigned NOT NULL AUTO_INCREMENT,',
       'task_id int(11) unsigned NOT NULL,',
-      'newsletter_id int(11) unsigned NOT NULL,',
+      'newsletter_id int(11) unsigned NULL,',
       'newsletter_rendered_body longtext,',
       'newsletter_rendered_subject varchar(250) NULL DEFAULT NULL,',
       'subscribers longtext,',

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -156,17 +156,14 @@ class SendingQueue {
 
     $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($queue);
     if (!$newsletterEntity) {
+      $this->deleteTask($queue);
       return;
     }
 
     // pre-process newsletter (render, replace shortcodes/links, etc.)
     $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $queue);
     if (!$newsletterEntity) {
-      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
-        'delete task in sending queue',
-        ['task_id' => $queue->taskId]
-      );
-      $queue->delete();
+      $this->deleteTask($queue);
       return;
     }
 
@@ -493,5 +490,13 @@ class SendingQueue {
 
   private function getExecutionLimit(): int {
     return $this->cronHelper->getDaemonExecutionLimit() * 3;
+  }
+
+  private function deleteTask(SendingTask $queue) {
+    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
+      'delete task in sending queue',
+      ['task_id' => $queue->taskId]
+    );
+    $queue->delete();
   }
 }

--- a/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
@@ -9,6 +9,7 @@ use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Cron\Workers\SimpleWorkerMockImplementation;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\WP\Functions as WPFunctions;
@@ -33,7 +34,8 @@ class CronWorkerRunnerTest extends \MailPoetTest {
       $this->cronHelper,
       $this->diContainer->get(CronWorkerScheduler::class),
       $this->diContainer->get(WPFunctions::class),
-      $this->scheduledTasksRepository
+      $this->scheduledTasksRepository,
+      $this->diContainer->get(LoggerFactory::class)
     );
   }
 

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -11,6 +11,7 @@ use MailPoet\Cron\DaemonHttpRunner;
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Cron\Workers\WorkersFactory;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\WP\Functions as WPFunctions;
@@ -79,7 +80,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       ->method('run')
       ->willThrowException(new \Exception());
 
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock());
+    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
     $daemonHttpRunner = $this->make(DaemonHttpRunner::class, [
       'pauseExecution' => null,
       'callSelf' => null,
@@ -205,7 +206,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $cronWorkerRunner = $this->make(CronWorkerRunner::class, [
       'run' => null,
     ]);
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunner, $this->createWorkersFactoryMock());
+    $daemon = new Daemon($this->cronHelper, $cronWorkerRunner, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
     $daemonHttpRunner->__construct($daemon, $this->cronHelper, SettingsController::getInstance(), $this->diContainer->get(WordPress::class));
     $daemonHttpRunner->run($data);
     $updatedDaemon = $this->settings->get(CronHelper::DAEMON_SETTING);
@@ -225,7 +226,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       ->method('run')
       ->willThrowException(new \Exception());
 
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock());
+    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
     $daemonHttpRunner = $this->make(DaemonHttpRunner::class, [
       'pauseExecution' => null,
       'callSelf' => null,
@@ -261,7 +262,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $cronWorkerRunnerMock = $this->make(CronWorkerRunner::class, [
       'run' => null,
     ]);
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock());
+    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
     $daemonHttpRunner->__construct($daemon, $this->cronHelper, SettingsController::getInstance(), $this->diContainer->get(WordPress::class));
     $daemonHttpRunner->run($data);
     expect(ignore_user_abort())->equals(true);

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -8,6 +8,7 @@ use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Cron\Daemon;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Cron\Workers\WorkersFactory;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
 
@@ -31,7 +32,7 @@ class DaemonTest extends \MailPoetTest {
       'token' => 123,
     ];
     $this->settings->set(CronHelper::DAEMON_SETTING, $data);
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunner, $this->createWorkersFactoryMock());
+    $daemon = new Daemon($this->cronHelper, $cronWorkerRunner, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
     $daemon->run($data);
   }
 


### PR DESCRIPTION
## Description
Sometimes, it can happen (we do not know yet why) that the `newsletter_id` in the `sending_queues` table is zero. When fetched the `$newsletter` of the `SendingQueueEntity` is `null`. Somehow Doctrine started (we suspect a recent refactor) to recognize this as an alteration, which needed to be stored. So, it attempted to set `newsletter_id` to `null`. But the column is not nullable. This provoked an error and closed the EntityManager during the cron run.

Additionally, such a task with a `0`-newsletter remains running forever, now blocking effectively the cron system from working properly.

This PR attempts to fix the problem by
1. making the column nullable (28e9ac58654cc323ece903e4b87783e1beca57c1 and 28e9ac58654cc323ece903e4b87783e1beca57c1)
2. deleting a task when no newsletter is found, so to not run the task endlessly (335977a58d79aaa314c610b8089691672166c187)

While debugging the issue it was helpful to extend our logging to more precisely logging errors. We just logged the latest error in our cron system, but here, we had overlapping errors.

One job created an SQL error while the next one created an EntityManagerClosed error. With a97836c049bdfe5d4684c0276e585345e9af6d02 I improve the logging so that all errors will be catched and stored in the database.

## QA notes

Validate error
1. Use mailpoet v3.100, I would make it with a blank new installation
2. Execute the following two SQL commands: 
```
INSERT INTO `wp_mailpoet_sending_queues` (`id`, `task_id`, `newsletter_id`, `newsletter_rendered_body`, `newsletter_rendered_subject`, `subscribers`, `count_total`, `count_processed`, `count_to_process`, `meta`, `created_at`, `updated_at`, `deleted_at`) VALUES ('10000000', '10000000', '0', NULL, NULL, NULL, '0', '0', '0', NULL, NULL, CURRENT_TIMESTAMP, NULL);
```
```
INSERT INTO `wp_mailpoet_scheduled_tasks` (`id`, `type`, `status`, `priority`, `scheduled_at`, `processed_at`, `created_at`, `updated_at`, `deleted_at`, `in_progress`, `reschedule_count`, `meta`) VALUES ('10000000', 'sending', NULL, '5', '2022-10-04 10:47:00', NULL, '2022-10-04 10:47:00', '2022-10-04 10:47:00', NULL, NULL, '0', NULL); 
```
3. Run the cron
4. See the error message in the Help section. There can be multiple. At least one should say "EntityManager closed" or contain "Integrity constraint violation: 1048 Column 'newsletter_id' cannot be null"
5. Install the ZIP file which was provided in this run
6. To emulate, this ZIP file is version 3.100.1, you need to open the file `/mailpoet.php` and change the version in L23 from `3.100.0` to `3.100.1`
7. Go to wp-admin
8. Run the cron
9. Check that the entries you created in `wp_mailpoet_scheduled_tasks` and `wp_mailpoet_sending_queues` have been removed
10. The errors might still exist in the Help section, but you can see, how the "Last seen" date differs from the "Last run" date.
11. If the errors are visible: Create a newsletter and send it. I think afterwards the Last errors section should be empty.

## Merge notes
It seems the Doctrine refactor is continuing and we can't really merge this PR into trunk. In the end, we need to make an emergency release and cherry-pick anyway, if I see that correctly. And then we need to see, how to solve those merge conflicts. Not completely sure about the best process at the moment, as I just saw the merge conflict.


## Linked tickets

[MAILPOET-4699]


[MAILPOET-4699]: https://mailpoet.atlassian.net/browse/MAILPOET-4699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ