### PR TITLE
Skip WooCommerce Subscriptions integration tests when Woo COT is enabled [MAILPOET-4695]

### DIFF
--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\WooCommerce\Helper;
 use MailPoetVendor\Doctrine\DBAL\ForwardCompatibility\DriverStatement;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -34,6 +35,12 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   private $products = [];
 
   public function _before(): void {
+    $wooCommerceHelper = $this->diContainer->get(Helper::class);
+
+    if ($wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled()) {
+      $this->markTestSkipped('WooCommerce Subscriptions does not work with WooCommerce Custom Orders Table.');
+    }
+
     $this->cleanup();
     $productId = $this->createProduct('Premium Newsletter');
     foreach (self::SUBSCRIBER_EMAILS as $email) {


### PR DESCRIPTION
WooCommerce Subscriptions doesn't support WooCommerce Custom Orders Tables, so we should skip the WooCommerce Subscriptions related tests when Woo COT is enabled.

This PR is very similar to #4410 but it addresses integration tests instead of acceptance tests. When working on #4410, I missed that there are integration tests for MailPoet code that relies on WooCommerce Subscriptions.

The tests that were failing and that should be skipped in this PR are the three tests that failed in the build below:

https://app.circleci.com/pipelines/github/mailpoet/mailpoet/11567/workflows/4f6f8af3-5e70-4905-be19-d2d49ec519f0/jobs/198439

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

I don't think QA is needed for this PR.

## Linked PRs

[MAILPOET-4695]

## Linked tickets

_N/A_

## After-merge notes

_N/A_


[MAILPOET-4695]: https://mailpoet.atlassian.net/browse/MAILPOET-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ