### PR TITLE
Skip customer sync setting for new stores [MAILPOET-4652]

### DIFF
--- a/mailpoet/assets/js/src/settings/store/normalize_settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize_settings.ts
@@ -185,7 +185,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
       }),
     }),
     mailpoet_subscribe_old_woocommerce_customers: asObject({
-      enabled: enabledRadio,
+      enabled: disabledCheckbox,
     }),
     premium: asObject({
       premium_key: text,

--- a/mailpoet/assets/js/src/wizard/steps/woo_commerce_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/woo_commerce_step.jsx
@@ -8,7 +8,9 @@ import { YesNo } from '../../common/form/yesno/yesno';
 
 function WizardWooCommerceStep(props) {
   const [allowed, setAllowed] = useState(null);
-  const [importType, setImportType] = useState(null);
+  const [importType, setImportType] = useState(
+    props.showCustomersImportSetting === false ? 'unsubscribed' : null,
+  );
   const [submitted, setSubmitted] = useState(false);
 
   const submit = (event) => {
@@ -39,43 +41,44 @@ function WizardWooCommerceStep(props) {
       <p>{MailPoet.I18n.t('wooCommerceSetupInfo')}</p>
       <div className="mailpoet-gap" />
       <form onSubmit={submit}>
-        <div className="mailpoet-wizard-woocommerce-option">
-          <div className="mailpoet-wizard-woocommerce-toggle">
-            <YesNo
-              showError={submitted && importType === null}
-              checked={importTypeChecked}
-              onCheck={(value) =>
-                setImportType(value ? 'subscribed' : 'unsubscribed')
-              }
-              name="mailpoet_woocommerce_import_type"
-              automationId="woocommerce_import_type"
-            />
-          </div>
-          <div>
-            <p>
-              {ReactStringReplace(
-                MailPoet.I18n.t('wooCommerceSetupImportInfo'),
-                /\[link\](.*?)\[\/link\]/,
-                (match) => (
-                  <a
-                    key={match}
-                    href="https://kb.mailpoet.com/article/284-import-old-customers-to-the-woocommerce-customers-list"
-                    data-beacon-article="5d722c7104286364bc8ecf19"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {match}
-                  </a>
-                ),
-              )}
-            </p>
-            <div className="mailpoet-wizard-note">
-              <span>GDPR</span>
-              {MailPoet.I18n.t('wooCommerceSetupImportGDPRInfo')}
+        {props.showCustomersImportSetting ? (
+          <div className="mailpoet-wizard-woocommerce-option">
+            <div className="mailpoet-wizard-woocommerce-toggle">
+              <YesNo
+                showError={submitted && importType === null}
+                checked={importTypeChecked}
+                onCheck={(value) =>
+                  setImportType(value ? 'subscribed' : 'unsubscribed')
+                }
+                name="mailpoet_woocommerce_import_type"
+                automationId="woocommerce_import_type"
+              />
+            </div>
+            <div>
+              <p>
+                {ReactStringReplace(
+                  MailPoet.I18n.t('wooCommerceSetupImportInfo'),
+                  /\[link\](.*?)\[\/link\]/,
+                  (match) => (
+                    <a
+                      key={match}
+                      href="https://kb.mailpoet.com/article/284-import-old-customers-to-the-woocommerce-customers-list"
+                      data-beacon-article="5d722c7104286364bc8ecf19"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      {match}
+                    </a>
+                  ),
+                )}
+              </p>
+              <div className="mailpoet-wizard-note">
+                <span>GDPR</span>
+                {MailPoet.I18n.t('wooCommerceSetupImportGDPRInfo')}
+              </div>
             </div>
           </div>
-        </div>
-
+        ) : null}
         <div className="mailpoet-wizard-woocommerce-option">
           <div className="mailpoet-wizard-woocommerce-toggle">
             <YesNo
@@ -129,6 +132,7 @@ function WizardWooCommerceStep(props) {
 WizardWooCommerceStep.propTypes = {
   submitForm: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
+  showCustomersImportSetting: PropTypes.bool.isRequired,
   isWizardStep: PropTypes.bool,
 };
 

--- a/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
@@ -57,6 +57,7 @@ function WooCommerceController({ isWizardStep = false }) {
         loading={loading}
         submitForm={submit}
         isWizardStep={isWizardStep}
+        showCustomersImportSetting={window.mailpoet_show_customers_import}
       />
     </WelcomeWizardStepLayout>
   );

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -5,6 +5,7 @@ namespace MailPoet\AdminPages\Pages;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\Menu;
 use MailPoet\Settings\SettingsController;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
 class WelcomeWizard {
@@ -17,13 +18,18 @@ class WelcomeWizard {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var WooCommerceHelper */
+  private $wooCommerceHelper;
+
   public function __construct(
     PageRenderer $pageRenderer,
     SettingsController $settings,
+    WooCommerceHelper $wooCommerceHelper,
     WPFunctions $wp
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->settings = $settings;
+    $this->wooCommerceHelper = $wooCommerceHelper;
     $this->wp = $wp;
   }
 
@@ -34,6 +40,7 @@ class WelcomeWizard {
       'sender' => $this->settings->get('sender'),
       'admin_email' => $this->wp->getOption('admin_email'),
       'current_wp_user' => $this->wp->wpGetCurrentUser()->to_array(),
+      'show_customers_import' => $this->wooCommerceHelper->getCustomersCount() > 0,
     ];
     $this->pageRenderer->displayPage('welcome_wizard.html', $data);
   }

--- a/mailpoet/lib/AdminPages/Pages/WooCommerceSetup.php
+++ b/mailpoet/lib/AdminPages/Pages/WooCommerceSetup.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\Menu;
+use MailPoet\WooCommerce\Helper;
 use MailPoet\WP\Functions as WPFunctions;
 
 class WooCommerceSetup {
@@ -13,11 +14,16 @@ class WooCommerceSetup {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var Helper */
+  private $wooCommerceHelper;
+
   public function __construct(
     PageRenderer $pageRenderer,
+    Helper $wooCommerceHelper,
     WPFunctions $wp
   ) {
     $this->pageRenderer = $pageRenderer;
+    $this->wooCommerceHelper = $wooCommerceHelper;
     $this->wp = $wp;
   }
 
@@ -25,6 +31,7 @@ class WooCommerceSetup {
     if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
     $data = [
       'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
+      'show_customers_import' => $this->wooCommerceHelper->getCustomersCount() > 0,
     ];
     $this->pageRenderer->displayPage('woocommerce_setup.html', $data);
   }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\WooCommerce;
 
+use Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Query;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\RuntimeException;
 use MailPoet\WP\Functions as WPFunctions;
@@ -100,6 +101,18 @@ class Helper {
 
   public function getAllowedCountries(): array {
     return (new \WC_Countries)->get_allowed_countries() ?? [];
+  }
+
+  public function getCustomersCount(): int {
+    if (!class_exists(Query::class)) {
+      return 0;
+    }
+    $query = new Query([
+      'fields' => ['customers_count'],
+    ]);
+    // Query::get_data declares it returns array but the underlying DataStore returns stdClass
+    $result = (array)$query->get_data();
+    return isset($result['customers_count']) ? intval($result['customers_count']) : 0;
   }
 
   public function wasMailPoetInstalledViaWooCommerceOnboardingWizard(): bool {

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
@@ -35,6 +35,10 @@ class WooCommerceSetupPageCest {
     $order = $this->orderFactory->create();
     $guestUserData = $order['billing'];
     $registeredCustomer = $this->customerFactory->withEmail('customer1@email.com')->create();
+    // run action scheduler to sync customer and order data to lookup tables
+    $i->wait(2);
+    $i->cli(['action-scheduler', 'run', '--force']);
+
     $i->login();
     $i->amOnPage('wp-admin/admin.php?page=mailpoet-woocommerce-setup');
     $importTypeToggle = '[data-automation-id="woocommerce_import_type"]';
@@ -72,9 +76,29 @@ class WooCommerceSetupPageCest {
     $i->see($guestUserData['email']);
   }
 
+
+  public function noCustomersBehaviourTest(\AcceptanceTester $i) {
+    $i->wantTo('Make sure we don‘t show import setting when there are no customers');
+    $i->login();
+    $i->amOnPage('wp-admin/admin.php?page=mailpoet-woocommerce-setup');
+    $i->see('Get ready to use MailPoet for WooCommerce');
+    $importTypeToggle = '[data-automation-id="woocommerce_import_type"]';
+    $trackingToggle = '[data-automation-id="woocommerce_tracking"]';
+    $submitButton = '[data-automation-id="submit_woocommerce_setup"]';
+    $errorClass = '.mailpoet-form-yesno-error';
+    $i->dontSeeElement($importTypeToggle);
+    $i->seeElement($trackingToggle);
+  }
+
   public function setupPageFormBehaviourTest(\AcceptanceTester $i) {
+    $order = $this->orderFactory->create();
+
     $i->wantTo('Make sure the form shows errors when it is submitted without making choices');
     $i->login();
+    // run action scheduler to sync customer and order data to lookup tables
+    $i->wait(2);
+    $i->cli(['action-scheduler', 'run', '--force']);
+
     $i->amOnPage('wp-admin/admin.php?page=mailpoet-woocommerce-setup');
     $i->see('Get ready to use MailPoet for WooCommerce');
     $importTypeToggle = '[data-automation-id="woocommerce_import_type"]';

--- a/mailpoet/views/welcome_wizard.html
+++ b/mailpoet/views/welcome_wizard.html
@@ -11,6 +11,7 @@
   var sender_data = <%= json_encode(sender) %>;
   var admin_email = <%= json_encode(admin_email) %>;
   var hide_mailpoet_beacon = true;
+  var mailpoet_show_customers_import = <%= json_encode(show_customers_import) %>;
   var mailpoet_account_url = '<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&email=" ~ current_wp_user.user_email|escape('js')) %>';
 </script>
 

--- a/mailpoet/views/woocommerce_setup.html
+++ b/mailpoet/views/woocommerce_setup.html
@@ -4,6 +4,7 @@
 <script>
   var mailpoet_logo_url = '<%= cdn_url('welcome-wizard/mailpoet-logo.20200623.png') %>';
   var wizard_woocommerce_illustration_url = '<%= cdn_url('welcome-wizard/woocommerce.20200623.png') %>';
+  var mailpoet_show_customers_import = <%= json_encode(show_customers_import) %>;
   var finish_wizard_url = '<%= finish_wizard_url %>';
 </script>
 

--- a/mailpoet/views/woocommerce_setup_translations.html
+++ b/mailpoet/views/woocommerce_setup_translations.html
@@ -4,7 +4,7 @@
   'wooCommerceSetupGDPRTag': _x('GDPR', 'WooCommerce setup GDPR tag'),
   'wooCommerceSetupImportInfo': __('MailPoet will import all your WooCommerce customers. Do you want to import your WooCommerce customers as subscribed? [link]Learn more[/link].'),
   'wooCommerceSetupImportGDPRInfo': _x('To be compliant, your customers must have accepted to receive your emails.', 'GDPR compliance information'),
-  'wooCommerceSetupTrackingInfo': __('Do you want to enable cookie tracking on your website? MailPoet will use cookies to provide you with more precise statistics. [link]Learn more[/link].'),
+  'wooCommerceSetupTrackingInfo': __('Collect more precise email and site engagement, and e-commerce metrics by enabling cookie tracking. [link]Learn more[/link].'),
   'wooCommerceSetupTrackingGDPRInfo': _x('To be compliant, you should display a cookie tracking banner on your website.', 'GDPR compliance information'),
   'wooCommerceSetupFinishButtonTextWizard': _x('Start using MailPoet', 'Submit button caption in the WooCommerce step in the wizard'),
   'wooCommerceSetupFinishButtonTextStandalone': _x('Start using WooCommerce features', 'Submit button caption on the standalone WooCommerce setup page'),


### PR DESCRIPTION
## Description
This PR changes how we display the WooCommerce setup screen. 

The screen for shops with no customers:
![Screenshot 2022-10-07 at 10 39 04](https://user-images.githubusercontent.com/1082140/194511263-05ad18c4-831c-4235-bd1d-0d4a117b1812.png)

The screen for shops with some customers (guest or registered).
![Screenshot 2022-10-07 at 10 38 27](https://user-images.githubusercontent.com/1082140/194511388-a62c4cb8-74e5-4cca-a201-2d9cf40cb50a.png)

Note: During implementation, I found out that we need to save a value for the first checkbox event when it is not displayed. This is because it is then used in `Settings > WooCommerce > Subscribe old WooCommerce customers`, and the setting is used in Customer sync for [updating the status of subscribers who don't have confirmation records](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Segments/WooCommerce.php#L527-L551). I discussed it with @pavel-mailpoet in the Jira ticket, and we chose to use `false` since it is safer for list hygiene.

## Code review notes
I discussed the approach for fetching the subscribers count with the proton team.


## QA notes
The page can be displayed any time by going to URL: `wp-admin/admin.php?page=mailpoet-woocommerce-setup#/woocommerce`

1) Check the screen on with a fresh WooCommerce installation without any customers. You should see only one setting.
2) Create an order or register a customer and check the screen again and you should see both settings.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4652]

## After-merge notes

_N/A_


[MAILPOET-4652]: https://mailpoet.atlassian.net/browse/MAILPOET-4652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ