### PR TITLE
Localize plugin description [MAILPOET-4709]

### DIFF
--- a/mailpoet/tasks/makepot/pot-ext-meta.php
+++ b/mailpoet/tasks/makepot/pot-ext-meta.php
@@ -17,7 +17,7 @@ class PotExtMeta {
 		//'Theme Name',
 		//'Plugin URI',
 		//'Theme URI',
-		//'Description',
+		'Description',
 		//'Author',
 		//'Author URI',
 		//'Tags',


### PR DESCRIPTION
This PR is a duplicate of https://github.com/mailpoet/mailpoet/pull/4416 by @d-alleyne. I needed to recreate it because we still have the issue with failing builds for external PRs.

**Original description:**
Currently, the plugin's description displays in English in all languages that the project supports.
This change ensures users see the description in their language once it is supported.

## Description

_N/A_

## Code review notes

_N/A_

## QA notes
You can check the `lang/mailpoet.pot` file located [in the build from this branch](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/11584/workflows/a99de7bb-0670-4adc-8cbb-6c97235d56d5/jobs/198758).
The file should contain `Description of the plugin/theme` section containing the plugin description

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/4416

## Linked tickets

[MAILPOET-4709]

Related to 462-gh-Automattic/i18n-issues

## After-merge notes

_N/A_


[MAILPOET-4709]: https://mailpoet.atlassian.net/browse/MAILPOET-4709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ