### PR TITLE
Update \MailPoet\Segments\WooCommerce::updateNames() query to work with Woo HPOS [MAILPOET-4711]

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -126,4 +126,12 @@ class Helper {
 
     return \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::get_orders_table_name();
   }
+
+  public function getAddressesTableName() {
+    if (!method_exists('\Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore', 'get_addresses_table_name')) {
+      throw new RuntimeException('Cannot get addresses table name when running a WooCommerce version that doesn\'t support custom order tables.');
+    }
+
+    return \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::get_addresses_table_name();
+  }
 }

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -61,8 +61,12 @@ parameters:
       count: 1
       path: ../../lib/WooCommerce/Helper.php
     -
+      message: '/^Call to static method get_addresses_table_name\(\) on an unknown class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore\.$/'
+      count: 1
+      path: ../../lib/WooCommerce/Helper.php
+    -
       message: '/^Call to function method_exists\(\) with/'
-      count: 2
+      count: 3
       path: ../../lib/WooCommerce/Helper.php
 
   reportUnmatchedIgnoredErrors: true


### PR DESCRIPTION
## Description

This PR changes `\MailPoet\Segments\WooCommerce::updateNames()` to work with WooCommerce High Performance Orders Storage. To achieve that an `if` was added to use two different queries depending on whether Woo HPOS is enabled or not. It was also necessary to add a new Woo helper method to get the name of the new table that stores information about addresses.

## Code review notes

_N/A_

## QA notes

Test that MailPoet can correctly synchronize WooCommerce customers and create corresponding MailPoet subscribers. More specifically, check that the synchronization of the first and last names works as expected. To do that, install WooCommerce and create a few customers (/wp-admin/user-new.php). Then install MailPoet, activate the WooCommerce integration, and check that the corresponding subscribers were created. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4711]

## After-merge notes

_N/A_


[MAILPOET-4711]: https://mailpoet.atlassian.net/browse/MAILPOET-4711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ