### PR TITLE
Prevent displaying google analytics to free users [PREMIUM-200]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -232,3 +232,7 @@ progress::-moz-progress-bar {
 .mailpoet-form-field-tags label.components-form-token-field__label {
   display: none;
 }
+
+.mailpoet-form-field-disabled {
+  cursor: not-allowed;
+}

--- a/mailpoet/assets/js/src/form/fields/field.jsx
+++ b/mailpoet/assets/js/src/form/fields/field.jsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import { FormFieldText } from 'form/fields/text.jsx';
 import jQuery from 'jquery';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { FormFieldTextarea } from 'form/fields/textarea.jsx';
 import { FormFieldSelect } from 'form/fields/select.jsx';
@@ -152,14 +153,25 @@ class FormField extends Component {
         break;
     }
 
+    const isDisabled =
+      typeof this.props.field.disabled === 'function'
+        ? this.props.field.disabled(this.props.field)
+        : this.props.field.disabled;
+
     const eventListeners = {
       ...(this.props.field.onWrapperClick
         ? { onClick: this.props.field.onWrapperClick }
         : {}),
     };
-    
+
     return (
-      <div className="mailpoet-form-field" key={`field-${data.index || 0}`} {...eventListeners}>
+      <div
+        className={classNames('mailpoet-form-field', {
+          'mailpoet-form-field-disabled': isDisabled,
+        })}
+        key={`field-${data.index || 0}`}
+        {...eventListeners}
+      >
         {field}
         {description}
       </div>
@@ -220,6 +232,7 @@ FormField.propTypes = {
     fields: PropTypes.arrayOf(PropTypes.object),
     description: PropTypes.string,
     onWrapperClick: PropTypes.func,
+    disabled: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   }).isRequired,
   item: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/mailpoet/assets/js/src/form/fields/field.jsx
+++ b/mailpoet/assets/js/src/form/fields/field.jsx
@@ -151,8 +151,15 @@ class FormField extends Component {
         field = 'invalid';
         break;
     }
+
+    const eventListeners = {
+      ...(this.props.field.onWrapperClick
+        ? { onClick: this.props.field.onWrapperClick }
+        : {}),
+    };
+    
     return (
-      <div className="mailpoet-form-field" key={`field-${data.index || 0}`}>
+      <div className="mailpoet-form-field" key={`field-${data.index || 0}`} {...eventListeners}>
         {field}
         {description}
       </div>
@@ -212,6 +219,7 @@ FormField.propTypes = {
     label: PropTypes.string,
     fields: PropTypes.arrayOf(PropTypes.object),
     description: PropTypes.string,
+    onWrapperClick: PropTypes.func,
   }).isRequired,
   item: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/mailpoet/assets/js/src/form/types/field.ts
+++ b/mailpoet/assets/js/src/form/types/field.ts
@@ -26,4 +26,5 @@ export type Field = {
   getLabel?: (segment: Segment) => string;
   getCount?: (segment: Segment) => string;
   transformChangedValue?: (arg: unknown) => Segment;
+  onWrapperClick?: () => void;
 };

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -217,7 +217,7 @@ class NewsletterSendComponent extends Component {
             },
           );
         }
-        if (!item.ga_campaign) {
+        if (!item.ga_campaign && !this.isGaFieldDisabled()) {
           item.ga_campaign = generateGaTrackingCampaignName(
             item.id,
             item.subject,

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -182,6 +182,8 @@ class NewsletterSendComponent extends Component {
     return addresses.indexOf(fromAddress) !== -1;
   };
 
+  isGaFieldDisabled = () => !window.mailpoet_premium_active;
+
   loadItem = (id) => {
     this.setState({ loading: true });
 
@@ -645,9 +647,17 @@ class NewsletterSendComponent extends Component {
     return field;
   };
 
-  getPreparedFields = (isPaused) =>
+  disableGAIfPremiumInactive = (disabled) => (field) => {
+    if (field.name === 'ga_campaign') {
+      return { ...field, disabled };
+    }
+    return field;
+  };
+
+  getPreparedFields = (isPaused, gaFieldDisabled) =>
     this.state.fields
       .map(this.disableSegmentsSelectorWhenPaused(isPaused))
+      .map(this.disableGAIfPremiumInactive(gaFieldDisabled))
       .map(this.disableSegmentsValidation);
 
   render() {
@@ -657,7 +667,7 @@ class NewsletterSendComponent extends Component {
       this.state.item.queue.status === 'paused';
 
     const sendButtonOptions = this.getSendButtonOptions();
-    const fields = this.getPreparedFields(isPaused);
+    const fields = this.getPreparedFields(isPaused, this.isGaFieldDisabled);
 
     const sendingDisabled = !!(
       window.mailpoet_subscribers_limit_reached ||

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -410,6 +410,7 @@
 
     'gaCampaignLine': __('Google Analytics Campaign'),
     'gaCampaignTip': __('For example, “Spring email”. [link]Read the guide.[/link]'),
+    'gaOnlyAvailableForPremium': __('Google Analytics tracking is not available in the free version of the MailPoet plugin.'),
 
     'automaticEmail': __('Automatic Email'),
     'tip': __('Tip:'),


### PR DESCRIPTION
## Description

This PR makes sure we are not showing an enabled GA field to users without active premium plugins.

- Disables the field
- Opens up the modal to activate plugin plugin
- Removes the default value if the field is disabled
- Shows a `no-allowed`  cursor on hover of the disabled field, please note that this is added for all disabled fields.

## QA notes
Please follow the steps from the Jira ticket.

Note if you encounter problem:
Make sure you have uploaded the latest premium trunk if you hit the following error message when trying to activate the premium plugin using the upsell modal.
```
{error: "bad_request", message: "Interface 'MailPoet\Automation\Engine\Workflows\Action' not found"}
error: "bad_request"
message: "Interface 'MailPoet\\Automation\\Engine\\Workflows\\Action' not found" 
```

## Linked tickets

[PREMIUM-200]


[PREMIUM-200]: https://mailpoet.atlassian.net/browse/PREMIUM-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ