### PR TITLE
Users should be able to save an email as a draft even if the required fields are empty [MAILPOET-4591]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -114,7 +114,6 @@ class NewsletterSendComponent extends Component {
       item: {},
       loading: true,
       thumbnailPromise: null,
-      isSavingDraft: false,
       showPremiumModal: false,
     };
   }
@@ -622,28 +621,6 @@ class NewsletterSendComponent extends Component {
   handleSaveDraft = () => {
     // Disabling all validations when saving a draft
     jQuery('#mailpoet_newsletter').parsley().destroy();
-
-    this.setState({
-      isSavingDraft: true,
-    });
-  };
-
-  disableSegmentsValidation = (field) => {
-    if (
-      this.state.isSavingDraft &&
-      field.name === 'segments' &&
-      field.validation &&
-      field.validation['data-parsley-required']
-    ) {
-      return {
-        ...field,
-        validation: {
-          'data-parsley-required': false,
-        },
-      };
-    }
-
-    return field;
   };
 
   disableSegmentsSelectorWhenPaused = (isPaused) => (field) => {
@@ -673,7 +650,6 @@ class NewsletterSendComponent extends Component {
     this.state.fields
       .map(this.disableSegmentsSelectorWhenPaused(isPaused))
       .map(this.disableGAIfPremiumInactive(gaFieldDisabled))
-      .map(this.disableSegmentsValidation);
 
   closePremiumModal = () => this.setState({ showPremiumModal: false });
 

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -619,10 +619,14 @@ class NewsletterSendComponent extends Component {
     return true;
   };
 
-  handleSaveDraft = () =>
+  handleSaveDraft = () => {
+    // Disabling all validations when saving a draft
+    jQuery('#mailpoet_newsletter').parsley().destroy();
+
     this.setState({
       isSavingDraft: true,
     });
+  };
 
   disableSegmentsValidation = (field) => {
     if (

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -649,7 +649,7 @@ class NewsletterSendComponent extends Component {
   getPreparedFields = (isPaused, gaFieldDisabled) =>
     this.state.fields
       .map(this.disableSegmentsSelectorWhenPaused(isPaused))
-      .map(this.disableGAIfPremiumInactive(gaFieldDisabled))
+      .map(this.disableGAIfPremiumInactive(gaFieldDisabled));
 
   closePremiumModal = () => this.setState({ showPremiumModal: false });
 


### PR DESCRIPTION
## Description

This PR completely disables validation when saving a draft.
- Disables the validation
- Removes redundant codes for selectively disabling validation

## Code review notes
Please note that already have an acceptance test for the list-selector, which covers the change as well, so no new acceptance is added.

## Linked PRs

[Old PR](https://github.com/mailpoet/mailpoet/pull/4328) were we disabled the validation only for the list selector.

## Linked tickets

[MAILPOET-4591]



[MAILPOET-4591]: https://mailpoet.atlassian.net/browse/MAILPOET-4591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ