### PR TITLE
Create a new API method getSubscribersCount [MAILPOET-4717]

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -31,6 +31,7 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 - [Get Lists (getLists)](api_methods/GetLists.md)
 - [Get Subscriber (getSubscriber)](api_methods/GetSubscriber.md)
 - [Get Subscribers (getSubscribers)](api_methods/GetSubscribers.md)
+- [Get Subscribers Count (getSubscribersCount)](api_methods/GetSubscribersCount.md)
 - [Get Subscriber Fields (getSubscriberFields)](api_methods/GetSubscriberFields.md)
 - [Is Setup Complete (isSetupComplete)](api_methods/IsSetupComplete.md)
 - [Subscribe to List (subscribeToList)](api_methods/SubscribeToList.md)

--- a/doc/api_methods/GetSubscribersCount.md
+++ b/doc/api_methods/GetSubscribersCount.md
@@ -1,0 +1,17 @@
+[back to list](../Readme.md)
+
+# Get Subscribers Count
+
+## `int getSubscribersCount(array $filter = [])`
+
+This method returns the count of subscribers by a filter.
+
+## Arguments
+
+| Argument           | Type  | Default | Description                                  |
+| ------------------ | ----- | ------- | -------------------------------------------- |
+| $filter (optional) | array | empty   | Filters to retrieve the count of subscribers |
+
+### Filter
+
+To see supported filters, please check [getSubscribers()](GetSubscribers.md) documentation.

--- a/mailpoet/lib/API/MP/v1/API.php
+++ b/mailpoet/lib/API/MP/v1/API.php
@@ -88,6 +88,10 @@ class API {
     return $this->subscribers->getSubscribers($filter, $limit, $offset);
   }
 
+  public function getSubscribersCount(array $filter = []): int {
+    return $this->subscribers->getSubscribersCount($filter);
+  }
+
   public function isSetupComplete() {
     return !(
       $this->changelog->shouldShowWelcomeWizard()

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -247,18 +247,6 @@ class Subscribers {
     return $this->subscribersResponseBuilder->build($subscriber);
   }
 
-  /**
-   * @param array $filter {
-   *     Optional. Filters to retrieve subscribers.
-   *
-   *     @type string        $status       One of values: subscribed, unconfirmed, unsubscribed, inactive, bounced
-   *     @type int           $listId       id of a list or dynamic segment
-   *     @type \DateTime|int $minUpdatedAt DateTime object or timestamp of last update of subscriber.
-   * }
-   * @param int $limit
-   * @param int $offset
-   * @return array
-   */
   public function getSubscribers(array $filter, int $limit, int $offset): array {
     $listingDefinition = $this->buildListingDefinition($filter, $limit, $offset);
     $subscribers = $this->subscriberListingRepository->getData($listingDefinition);
@@ -269,21 +257,20 @@ class Subscribers {
     return $result;
   }
 
-  /**
-   * @param array $filter {
-   *     Optional. Filters to retrieve subscribers.
-   *
-   *     @type string        $status       One of values: subscribed, unconfirmed, unsubscribed, inactive, bounced
-   *     @type int           $listId       id of a list or dynamic segment
-   *     @type \DateTime|int $minUpdatedAt DateTime object or timestamp of last update of subscriber.
-   * }
-   * @return int
-   */
   public function getSubscribersCount(array $filter): int {
     $listingDefinition = $this->buildListingDefinition($filter);
     return $this->subscriberListingRepository->getCount($listingDefinition);
   }
 
+  /**
+   * @param array $filter {
+   *     Filters to retrieve subscribers.
+   *
+   *     @type string        $status       One of values: subscribed, unconfirmed, unsubscribed, inactive, bounced
+   *     @type int           $listId       id of a list or dynamic segment
+   *     @type \DateTime|int $minUpdatedAt DateTime object or timestamp of last update of subscriber.
+   * }
+   */
   private function buildListingDefinition(array $filter, int $limit = 50, int $offset = 0): ListingDefinition {
     $group = isset($filter['status']) && is_string($filter['status']) ? $filter['status'] : null;
     $listingFilters = [];

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -269,6 +269,21 @@ class Subscribers {
     return $result;
   }
 
+  /**
+   * @param array $filter {
+   *     Optional. Filters to retrieve subscribers.
+   *
+   *     @type string        $status       One of values: subscribed, unconfirmed, unsubscribed, inactive, bounced
+   *     @type int           $listId       id of a list or dynamic segment
+   *     @type \DateTime|int $minUpdatedAt DateTime object or timestamp of last update of subscriber.
+   * }
+   * @return int
+   */
+  public function getSubscribersCount(array $filter): int {
+    $listingDefinition = $this->buildListingDefinition($filter);
+    return $this->subscriberListingRepository->getCount($listingDefinition);
+  }
+
   private function buildListingDefinition(array $filter, int $limit = 50, int $offset = 0): ListingDefinition {
     $group = isset($filter['status']) && is_string($filter['status']) ? $filter['status'] : null;
     $listingFilters = [];

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -260,6 +260,16 @@ class Subscribers {
    * @return array
    */
   public function getSubscribers(array $filter, int $limit, int $offset): array {
+    $listingDefinition = $this->buildListingDefinition($filter, $limit, $offset);
+    $subscribers = $this->subscriberListingRepository->getData($listingDefinition);
+    $result = [];
+    foreach ($subscribers as $subscriber) {
+      $result[] = $this->subscribersResponseBuilder->build($subscriber);
+    }
+    return $result;
+  }
+
+  private function buildListingDefinition(array $filter, int $limit = 50, int $offset = 0): ListingDefinition {
     $group = isset($filter['status']) && is_string($filter['status']) ? $filter['status'] : null;
     $listingFilters = [];
     // Set filtering by listId
@@ -275,13 +285,7 @@ class Subscribers {
       }
     }
 
-    $listingDefinition = new ListingDefinition($group, $listingFilters, null, [], 'id', 'asc', $offset, $limit);
-    $subscribers = $this->subscriberListingRepository->getData($listingDefinition);
-    $result = [];
-    foreach ($subscribers as $subscriber) {
-      $result[] = $this->subscribersResponseBuilder->build($subscriber);
-    }
-    return $result;
+    return new ListingDefinition($group, $listingFilters, null, [], 'id', 'asc', $offset, $limit);
   }
 
   /**


### PR DESCRIPTION
## Description

As a part of the CRM Jetpack integration, we want to extend our API. This is the second method that could help the other developer integrate our plugin.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4717]

## After-merge notes

_N/A_


[MAILPOET-4717]: https://mailpoet.atlassian.net/browse/MAILPOET-4717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ