### PR TITLE
Add link from automation editor back to listing [MAILPOET-4675]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/header/more_menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/more_menu.tsx
@@ -1,9 +1,10 @@
-import { MenuGroup } from '@wordpress/components';
+import { MenuGroup, MenuItem } from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
 import { __, _x } from '@wordpress/i18n';
 import { MoreMenuDropdown } from '@wordpress/interface';
 import { PreferenceToggleMenuItem } from '@wordpress/preferences';
 import { storeName } from '../../store';
+import { MailPoet } from '../../../../mailpoet';
 
 // See:
 //   https://github.com/WordPress/gutenberg/blob/9601a33e30ba41bac98579c8d822af63dd961488/packages/edit-post/src/components/header/more-menu/index.js
@@ -18,17 +19,28 @@ export function MoreMenu(): JSX.Element {
       }}
     >
       {() => (
-        <MenuGroup label={_x('View', 'noun')}>
-          <PreferenceToggleMenuItem
-            scope={storeName}
-            name="fullscreenMode"
-            label={__('Fullscreen mode')}
-            info={__('Work without distraction')}
-            messageActivated={__('Fullscreen mode activated')}
-            messageDeactivated={__('Fullscreen mode deactivated')}
-            shortcut={displayShortcut.secondary('f')}
-          />
-        </MenuGroup>
+        <>
+          <MenuGroup label={_x('View', 'noun')}>
+            <PreferenceToggleMenuItem
+              scope={storeName}
+              name="fullscreenMode"
+              label={__('Fullscreen mode')}
+              info={__('Work without distraction')}
+              messageActivated={__('Fullscreen mode activated')}
+              messageDeactivated={__('Fullscreen mode deactivated')}
+              shortcut={displayShortcut.secondary('f')}
+            />
+          </MenuGroup>
+          <MenuGroup>
+            <MenuItem
+              onClick={() => {
+                window.location.href = MailPoet.urls.automationListing;
+              }}
+            >
+              {__('View all automations', 'mailpoet')}
+            </MenuItem>
+          </MenuGroup>
+        </>
       )}
     </MoreMenuDropdown>
   );


### PR DESCRIPTION
## Description

Simply adds this one link:

<img width="328" alt="Screen Shot 2022-10-14 at 11 23 43" src="https://user-images.githubusercontent.com/141436/195812074-a48b9ac9-9157-4657-a1d7-3cdc94d31def.png">


## Code review notes

_N/A_

## QA notes

Automation only, QA step can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4675]

## After-merge notes

_N/A_


[MAILPOET-4675]: https://mailpoet.atlassian.net/browse/MAILPOET-4675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4675]: https://mailpoet.atlassian.net/browse/MAILPOET-4675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ