### PR TITLE
Improve cron error logging [MAILPOET-4725]

### DIFF
--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -53,6 +53,10 @@ class Daemon {
           'message' => $e->getMessage(),
         ];
 
+        if ($e->getCode() === CronHelper::DAEMON_EXECUTION_LIMIT_REACHED) {
+          break;
+        }
+
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_CRON)->error($e->getMessage(), ['error' => $e, 'worker' => $workerName]);
       }
     }

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -53,10 +53,7 @@ class Daemon {
           'message' => $e->getMessage(),
         ];
 
-        /**
-         * ToDo: Use \LoggerFactory::TOPIC_CRON as logger topic, once it is available
-         */
-        $this->loggerFactory->getLogger()->error($e->getMessage(), ['error' => $e, 'worker' => $workerName]);
+        $this->loggerFactory->getLogger(LoggerFactory::TOPIC_CRON)->error($e->getMessage(), ['error' => $e, 'worker' => $workerName]);
       }
     }
 


### PR DESCRIPTION
## Description

This PR slightly improves logging on errors thrown by cron workers.

1. It sets the proper logger name so that errors are logged under the correct category (`cron`).
2. It doesn't log the execution limit reached exception as an error, as it is the expected state. Instead, the deamon stops and doesn't execute other workers.

## Code review notes
_N/A_

## QA notes

When you run sending to a larger list (500+) on the trunk branch, you may notice a lot of "MailPoet.ERROR: Maximum execution time has been reached." errors are logged in the error log (/wp-admin/admin.php?page=mailpoet-logs). 
<img width="1538" alt="Screenshot 2022-10-14 at 10 31 51" src="https://user-images.githubusercontent.com/1082140/195801278-fc42303b-6064-4549-94b6-84db689f2635.png">

On this branch, the `Maximum execution time has been reached` exception is no longer logged.

To see the logs go to the Settings > Advanced tab... scroll down to the bottom and click on `See logs` link.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4725]

## After-merge notes

_N/A_


[MAILPOET-4725]: https://mailpoet.atlassian.net/browse/MAILPOET-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ