### PR TITLE
Remove babel plugin typescript to proptypes [MAILPOET-4521]

### DIFF
--- a/mailpoet/.babelrc
+++ b/mailpoet/.babelrc
@@ -5,7 +5,6 @@
     "@babel/preset-env"
   ],
   "plugins": [
-    "babel-plugin-typescript-to-proptypes",
     [
       "@babel/plugin-transform-runtime",
       {

--- a/mailpoet/assets/js/src/common/authorize_sender_domain_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_domain_modal.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal';
 import {
@@ -99,7 +97,7 @@ function AuthorizeSenderDomainModal({
       if (res.data.ok) {
         // record verified, close the modal
         setErrorMessage('');
-        setVerifiedSenderDomain(senderDomain);
+        setVerifiedSenderDomain?.(senderDomain);
         onRequestClose();
       }
     } catch (e) {
@@ -184,15 +182,5 @@ function AuthorizeSenderDomainModal({
     <div>{content}</div>
   );
 }
-
-AuthorizeSenderDomainModal.propTypes = {
-  senderDomain: PropTypes.string.isRequired,
-  useModal: PropTypes.bool,
-};
-
-AuthorizeSenderDomainModal.defaultProps = {
-  setVerifiedSenderDomain: noop,
-  useModal: true,
-};
 
 export { AuthorizeSenderDomainModal };

--- a/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_modal.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import ReactStringReplace from 'react-string-replace';
-import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import moment from 'moment';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal';
@@ -117,7 +115,7 @@ function AuthorizeSenderEmailModal({
         setCreateEmailApiResponse(null);
         setShowLoader(false);
         setConfirmEmailApiResponse(true);
-        setAuthorizedAddress(senderEmailAddress);
+        setAuthorizedAddress?.(senderEmailAddress);
         removeUnauthorizedEmailNotices();
       })
       .catch(() => {
@@ -237,15 +235,5 @@ function AuthorizeSenderEmailModal({
     <div>{content}</div>
   );
 }
-
-AuthorizeSenderEmailModal.propTypes = {
-  senderEmail: PropTypes.string.isRequired,
-  useModal: PropTypes.bool,
-};
-
-AuthorizeSenderEmailModal.defaultProps = {
-  setAuthorizedAddress: noop,
-  useModal: true,
-};
 
 export { AuthorizeSenderEmailModal };

--- a/mailpoet/assets/js/src/common/form/tokenField/tokenField.tsx
+++ b/mailpoet/assets/js/src/common/form/tokenField/tokenField.tsx
@@ -6,13 +6,13 @@ type Event = {
   name: string;
 };
 
-type Props = {
+export type TokenFieldProps = {
   id?: string;
   label?: string;
   name?: string;
   placeholder?: string;
   onChange: (event: Event) => void;
-  selectedValues?: FormTokenField.Value[];
+  selectedValues?: FormTokenField.Value[] | [];
   suggestedValues?: readonly string[];
 };
 
@@ -24,7 +24,7 @@ export function TokenField({
   selectedValues,
   suggestedValues,
   onChange,
-}: Props) {
+}: TokenFieldProps) {
   const args = {
     id,
     label,

--- a/mailpoet/assets/js/src/common/set_from_address_modal.tsx
+++ b/mailpoet/assets/js/src/common/set_from_address_modal.tsx
@@ -99,6 +99,7 @@ function SetFromAddressModal({ onRequestClose, setAuthorizedAddress }: Props) {
     >
       {showAuthorizedEmailModal && (
         <AuthorizeSenderEmailModal
+          useModal
           senderEmail={address}
           onRequestClose={() => {
             setShowAuthorizedEmailModal(false);

--- a/mailpoet/assets/js/src/form/fields/tokenField.tsx
+++ b/mailpoet/assets/js/src/form/fields/tokenField.tsx
@@ -1,7 +1,16 @@
-import PropTypes from 'prop-types';
-import { TokenField } from 'common/form/tokenField/tokenField';
+import { TokenFieldProps, TokenField } from 'common/form/tokenField/tokenField';
+import { FormTokenItem } from '../../automation/integrations/mailpoet/components/form-token-field';
 
-function getItems(endpoint: string) {
+interface TokenFormFieldProps {
+  onValueChange: TokenFieldProps['onChange'];
+  item?: Record<string, FormTokenItem[]>;
+  field: Omit<TokenFieldProps, 'id' | 'onChange' | 'selectedValues'> & {
+    endpoint: string;
+    getName: (item: FormTokenItem) => string;
+  };
+}
+
+function getItems(endpoint: string): FormTokenItem[] {
   let items = [];
   if (typeof window[`mailpoet_${endpoint}`] !== 'undefined') {
     items = window[`mailpoet_${endpoint}`];
@@ -10,12 +19,15 @@ function getItems(endpoint: string) {
   return items;
 }
 
-function FormFieldTokenField(props) {
-  const selectedValues = Array.isArray(props.item[props.field.name])
-    ? props.item[props.field.name].map((item) => props.field.getName(item))
+function FormFieldTokenField(props: TokenFormFieldProps) {
+  const selectedValues: TokenFieldProps['selectedValues'] = Array.isArray(
+    props.item[props.field.name],
+  )
+    ? props.field.name &&
+      props.item[props.field.name].map((item) => props.field.getName(item))
     : [];
 
-  let suggestedValues = [];
+  let suggestedValues;
   if (props.field.endpoint) {
     const items = getItems(String(props.field.endpoint));
     suggestedValues = items.map((item) => props.field.getName(item));
@@ -34,17 +46,5 @@ function FormFieldTokenField(props) {
     />
   );
 }
-
-FormFieldTokenField.propTypes = {
-  onValueChange: PropTypes.func,
-  item: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  field: PropTypes.shape({
-    name: PropTypes.string,
-    label: PropTypes.string,
-    suggestedValues: PropTypes.arrayOf(PropTypes.string),
-    placeholder: PropTypes.string,
-    getName: PropTypes.func,
-  }).isRequired,
-};
 
 export { FormFieldTokenField };

--- a/mailpoet/assets/js/src/form/fields/tokenField.tsx
+++ b/mailpoet/assets/js/src/form/fields/tokenField.tsx
@@ -27,7 +27,7 @@ function FormFieldTokenField(props: TokenFormFieldProps) {
       props.item[props.field.name].map((item) => props.field.getName(item))
     : [];
 
-  let suggestedValues;
+  let suggestedValues: readonly string[] = [];
   if (props.field.endpoint) {
     const items = getItems(String(props.field.endpoint));
     suggestedValues = items.map((item) => props.field.getName(item));

--- a/mailpoet/assets/js/src/form_editor/blocks/input_styles_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/blocks/input_styles_settings.tsx
@@ -12,7 +12,23 @@ import { partial } from 'lodash';
 import PropTypes from 'prop-types';
 import { ColorGradientSettings } from '../components/color_gradient_settings';
 
-function InputStylesSettings({ styles, onChange }) {
+type InputStyles = {
+  fullWidth: boolean;
+  inheritFromTheme: boolean;
+  bold: boolean;
+  backgroundColor: string;
+  borderSize: number;
+  borderRadius: number;
+  borderColor: string;
+  fontColor: string;
+};
+
+type InputStylesSettingsProps = {
+  styles: InputStyles;
+  onChange: (styles: InputStyles) => void;
+};
+
+function InputStylesSettings({ styles, onChange }: InputStylesSettingsProps) {
   const localStylesRef = useRef(styles);
   const localStyles = localStylesRef.current;
 
@@ -132,6 +148,10 @@ function InputStylesSettings({ styles, onChange }) {
   );
 }
 
+/**
+ * @deprecated since removal of propTypes for InputStylesSettings
+ * Remove when TextInputEdit is converted to tsx
+ */
 export const inputStylesPropTypes = PropTypes.shape({
   fullWidth: PropTypes.bool.isRequired,
   inheritFromTheme: PropTypes.bool.isRequired,
@@ -141,10 +161,5 @@ export const inputStylesPropTypes = PropTypes.shape({
   borderRadius: PropTypes.number,
   borderColor: PropTypes.string,
 });
-
-InputStylesSettings.propTypes = {
-  styles: inputStylesPropTypes.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
 
 export { InputStylesSettings };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/styles_settings_panel.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/styles_settings_panel.tsx
@@ -6,7 +6,6 @@ import {
   SelectControl,
 } from '@wordpress/components';
 import { MailPoet } from 'mailpoet';
-import PropTypes from 'prop-types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { partial } from 'lodash';
 import { HorizontalAlignment } from 'common/styles';
@@ -18,7 +17,12 @@ import { CloseButtonsSettings } from 'form_editor/components/close_button_settin
 import { formStyles as defaultFormStyles } from 'form_editor/store/defaults';
 import { FontFamilySettings } from '../font_family_settings';
 
-function StylesSettingsPanel({ onToggle, isOpened }) {
+type StylesSettingsPanelProps = {
+  onToggle: PanelBody.Props['onToggle'];
+  isOpened: boolean;
+};
+
+function StylesSettingsPanel({ onToggle, isOpened }: StylesSettingsPanelProps) {
   const { changeFormSettings } = useDispatch('mailpoet-form-editor');
   const settings = useSelect(
     (select) => select('mailpoet-form-editor').getFormSettings(),
@@ -164,10 +168,5 @@ function StylesSettingsPanel({ onToggle, isOpened }) {
     </Panel>
   );
 }
-
-StylesSettingsPanel.propTypes = {
-  onToggle: PropTypes.func.isRequired,
-  isOpened: PropTypes.bool.isRequired,
-};
 
 export { StylesSettingsPanel };

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -161,7 +161,6 @@
     "autoprefixer": "^10.4.4",
     "babel-loader": "^8.2.4",
     "babel-plugin-transform-commonjs": "^1.1.6",
-    "babel-plugin-typescript-to-proptypes": "^2.0.0",
     "browserslist": "^4.20.2",
     "buffer": "^6.0.3",
     "chai": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,6 @@ importers:
       autoprefixer: ^10.4.4
       babel-loader: ^8.2.4
       babel-plugin-transform-commonjs: ^1.1.6
-      babel-plugin-typescript-to-proptypes: ^2.0.0
       backbone: 1.3.3
       backbone.marionette: 3.2.0
       backbone.radio: 2.0.0
@@ -318,7 +317,6 @@ importers:
       autoprefixer: 10.4.4_postcss@8.4.14
       babel-loader: 8.2.4_vuct2yjaylhfkatulzrh5yzzye
       babel-plugin-transform-commonjs: 1.1.6_@babel+core@7.17.8
-      babel-plugin-typescript-to-proptypes: 2.0.0_vy5zir67me7gk6f3w3iih67tqe
       browserslist: 4.20.2
       buffer: 6.0.3
       chai: 4.3.6
@@ -9126,20 +9124,6 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /babel-plugin-typescript-to-proptypes/2.0.0_vy5zir67me7gk6f3w3iih67tqe:
-    resolution: {integrity: sha512-LmXrkeqg4bzq0CiCOV/zN3hrvAvJOvoP9sEw0YgtkU6lIbqA5/RAY0bA6C6+i5/e5Wp/taJ68XKp2i8pkU+Qmw==}
-    engines: {node: '>=12.17.0', npm: '>=6.13.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      typescript: ^4.0.0
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/plugin-syntax-typescript': 7.16.7_@babel+core@7.17.8
-      '@babel/types': 7.17.0
-      typescript: 4.6.3
     dev: true
 
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.17.8:


### PR DESCRIPTION
## Description

This PR removes `babel-plugin-typescript-to-proptypes` and updates the `tsx` files to remove usages `propTypes`.



## QA notes
Updated areas are as follows:

- Authorized sender email and domain modal 
- Forms that have `Tags` 
- Forms with inline styling that's used in form editor

 for the above-mentioned areas, the rendering and functionality should be checked.

## Linked PRs

The same changes on the premium plugin  [635](https://github.com/mailpoet/mailpoet-premium/pull/635)

## Linked tickets

[MAILPOET-4521]


[MAILPOET-4521]: https://mailpoet.atlassian.net/browse/MAILPOET-4521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ