### PR TITLE
Automation email workflow acceptance test [MAILPOET-4530]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_panel.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_panel.scss
@@ -12,6 +12,10 @@
   font-weight: 500;
   line-height: normal;
   padding: 16px 48px 16px 16px;
+
+  label & {
+    padding: 0;
+  }
 }
 
 .mailpoet-automation-panel-plain-body-title-action {

--- a/mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx
@@ -19,6 +19,7 @@ function PreStep({ onClose }): JSX.Element {
             variant="primary"
             disabled={isActivating}
             isBusy={isActivating}
+            autoFocus={!isActivating}
             onClick={() => {
               setIsActivating(true);
               activate();

--- a/mailpoet/assets/js/src/automation/editor/components/workflow/step.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/workflow/step.tsx
@@ -51,6 +51,7 @@ export function Step({ step, isSelected }: Props): JSX.Element {
   const compositeState = useContext(WorkflowCompositeContext);
   const { batch } = useRegistry();
 
+  const compositeItemId = `step-${step.id}`;
   const stepTypeData = stepType ?? getUnknownStepType(step);
   return (
     <div className="mailpoet-automation-editor-step-wrapper">
@@ -63,6 +64,7 @@ export function Step({ step, isSelected }: Props): JSX.Element {
           'is-selected-step': isSelected,
           'is-unknown-step': !stepType,
         })}
+        id={compositeItemId}
         key={step.id}
         focusable
         onClick={() =>
@@ -82,11 +84,14 @@ export function Step({ step, isSelected }: Props): JSX.Element {
           />
         </div>
         <div>
-          <div className="mailpoet-automation-editor-step-title">
+          <label
+            htmlFor={compositeItemId}
+            className="mailpoet-automation-editor-step-title"
+          >
             {step.type !== 'trigger'
               ? stepTypeData.title
               : __('Trigger', 'mailpoet')}
-          </div>
+          </label>
           <div className="mailpoet-automation-editor-step-subtitle">
             {step.type !== 'trigger'
               ? stepTypeData.subtitle(step)

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/delay/edit.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/delay/edit.tsx
@@ -6,6 +6,7 @@ import {
   FlexItem,
 } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { PlainBodyTitle } from '../../../../editor/components/panel';
 import { storeName } from '../../../../editor/store';
 import { DelayTypeOptions } from './types/delayTypes';
@@ -18,13 +19,16 @@ export function Edit(): JSX.Element {
     [],
   );
 
+  const delayValueInputId = `delay-number-${selectedStep.id}`;
   return (
     <PanelBody opened>
-      <PlainBodyTitle title="Wait for" />
+      <label htmlFor={delayValueInputId}>
+        <PlainBodyTitle title={__('Wait for', 'mailpoet')} />
+      </label>
       <Flex align="top">
         <FlexItem style={{ flex: '1 1 0' }}>
           <TextControl
-            label=""
+            id={delayValueInputId}
             type="number"
             placeholder="Number"
             value={(selectedStep.args.delay as string) ?? ''}

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStatisticsStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStatisticsStorage.php
@@ -26,6 +26,9 @@ class WorkflowStatisticsStorage {
    * @throws \MailPoet\Automation\Engine\Exceptions\InvalidStateException
    */
   public function getWorkflowStatisticsForWorkflows(Workflow ...$workflows): array {
+    if (empty($workflows)) {
+      return [];
+    }
     $workflowIds = array_map(
       function(Workflow $workflow): int {
         return $workflow->getId();

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -706,6 +706,15 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['action-scheduler', 'run', '--force']);
   }
 
+  public function triggerAutomationActionScheduler(): void {
+    $i = $this;
+    // Reschedule automation trigger action to run immediately
+    $i->importSql([
+      "UPDATE mp_actionscheduler_actions SET scheduled_date_gmt = SUBTIME(now(), '01:00:00'), scheduled_date_local = SUBTIME(now(), '01:00:00') WHERE hook = 'mailpoet/automation/workflow/step' AND status = 'pending';",
+    ]);
+    $i->cli(['action-scheduler', 'run', '--force']);
+  }
+
   public function isWooCustomOrdersTableEnabled(): bool {
     return (bool)getenv('ENABLE_COT');
   }

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use Facebook\WebDriver\WebDriverKeys;
+use MailPoet\Automation\Engine\Migrations\Migrator;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Test\DataFactories\Features;
+use MailPoet\Test\DataFactories\Settings;
+
+class CreateEmailAutomationAndWalkThroughCest
+{
+  public function _before() {
+    // @ToDo Remove once MVP is released.
+    $features = new Features();
+    $features->withFeatureEnabled(FeaturesController::AUTOMATION);
+    $container = ContainerWrapper::getInstance();
+    $migrator = $container->get(Migrator::class);
+    $migrator->createSchema();
+
+    $settings = new Settings();
+    $settings->withCronTriggerMethod('Action Scheduler');
+  }
+
+  public function createEmailWorkflowAndReceiveAnAutomatedEmail(\AcceptanceTester $i) {
+    $i->wantTo('Create a workflow to send an email after a user subscribed');
+    $i->login();
+
+    $i->amOnMailpoetPage('Automation');
+    $i->see('Automations');
+    $i->waitForText('Scale your business with advanced automations');
+    $i->dontSee('Simple welcome email');
+    $i->dontSee('Active');
+    $i->dontSee('Entered');
+
+    $i->click('New automation');
+    $i->see('Choose your automation template');
+    $i->click('Simple welcome email');
+
+    $i->waitForText('Draft');
+    $i->click('Trigger');
+    $i->fillField('When someone subscribers to the following list(s):', 'Newsletter mailing list');
+    $i->click('Delay');
+    $i->fillField('Wait for', '5');
+
+    $i->click('Send email');
+    $i->fillField('“From” name','From');
+    $i->fillField('“From” email address','test@mailpoet.com');
+    $i->fillField('Subject','Automation-Test-Subject');
+
+    $i->click('Design email');
+    $i->waitForText('Newsletters');
+    $i->click('Newsletters');
+    $i->click('button[data-automation-id="select_template_0"]');
+    $i->waitForText('Design');
+    $i->click('Save and continue');
+
+    $i->waitForText('Draft');
+
+    $i->click('Send email');
+    $i->click('Reply to');
+    $i->fillField('“Reply to” name', 'Reply');
+    $i->fillField('“Reply to” email address', 'reply@mailpoet.com');
+
+    $i->click('Activate');
+    $i->waitForText('Are you ready to activate?');
+
+    // We use a selector to be specific about which Activate button we want to click.
+    $panelActivateButton = '.mailpoet-automation-activate-panel__header-activate-button button';
+    $i->click($panelActivateButton);
+
+    // Check workflow is activated
+    $i->waitForText('"Simple welcome email" is now live.');
+    $i->click('View all automations');
+    $i->waitForText('Name');
+    $i->see('Simple welcome email');
+    $i->see('Active');
+    $i->see('Entered 0'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
+    $i->dontSeeInDatabase('mp_actionscheduler_actions', ['hook' => 'mailpoet/automation/workflow/step']);
+
+    $i->wantTo('Check a new subscriber gets the automation email.');
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/new');
+    $i->fillField('#field_email', 'test@mailpoet.com');
+    $i->fillField('#field_first_name', 'automation-tester-firstname');
+    $i->selectOptionInSelect2('Newsletter mailing list');
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('Automation');
+    $i->seeInDatabase('mp_actionscheduler_actions', ['hook' => 'mailpoet/automation/workflow/step', 'status' => 'pending']);
+    $i->waitForText('Simple welcome email');
+    $i->see('Entered 1'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
+    $i->see('Processing 1');
+    $i->see('Exited 0');
+    $i->amOnMailboxAppPage();
+    $i->see('Inbox (0)');
+
+    // Jump the waiting time by scheduling the delay action to now.
+    $i->triggerAutomationActionScheduler(); // Initialize the run, creates the delay step
+    $i->triggerAutomationActionScheduler(); // Set delay scheduled at to now, runs delay and send email
+    $i->triggerMailPoetActionScheduler(); // Runs the email queue
+
+    $i->amOnUrl('http://test.local/wp-admin/');
+    $i->amOnMailpoetPage('Automation');
+    $i->waitForText('Simple welcome email');
+    $i->see('Entered 1'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
+    $i->see('Processing 0');
+    $i->see('Exited 1');
+    $i->amOnMailboxAppPage();
+    $i->see('Inbox (1)');
+    $i->see('Automation-Test-Subject');
+  }
+}


### PR DESCRIPTION
## Description
Adds an acceptance test.
1. Creates a "simple-welcome-email" workflow and activates it
2. Adds a new subscriber and checks if the email is received.

## Code review notes
*Two bugs needed to be fixed:*
d081fa1bd0d379c6b84179dda8ce8fc04103dec9: If you do not have any workflows, the statistics queries would produce an SQL error and the page would not load properly.

9a6bf39e33d5f6ffca66145905c41336699a705f: I think this was basically a mix up what `Workflow::getStep()` actually returns. It returns a `Data\Step`, but an `Integration\Step` was needed to receive the subjectKeys.

*A11Y*
I added some labels so I was able to address a button in the acceptance test: 8f89fc1d521204b6ed59520055c225c587af1d94

## QA notes
This is an automation ticket and can be merged without QA.

## Linked tickets

[MAILPOET-4530]
[MAILPOET-4732] - I wrote an issue for the SQL error, but I think we can quickly handle it in this PR together.


[MAILPOET-4530]: https://mailpoet.atlassian.net/browse/MAILPOET-4530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4732]: https://mailpoet.atlassian.net/browse/MAILPOET-4732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ