### PR TITLE
Feat/personalize the default subscription confirmation email - MAILPOET-4599

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -136,6 +136,7 @@ interface Window {
   mailpoet_email_editor_tutorial_seen: number;
   mailpoet_email_editor_tutorial_url: string;
   mailpoet_deactivate_subscriber_after_inactive_days: string;
+  mailpoet_current_site_title?: string;
   mailpoet_tags?: {
     id: number;
     name: string;

--- a/mailpoet/assets/js/src/settings/pages/signup_confirmation/email_content.tsx
+++ b/mailpoet/assets/js/src/settings/pages/signup_confirmation/email_content.tsx
@@ -9,6 +9,7 @@ export function EmailContent() {
 
   if (!enabled) return null;
   const descriptionLines = t('emailContentDescription')
+    .replace('[current_site_title]', window.mailpoet_current_site_title || '')
     .split('<br />')
     .filter((x) => x);
   return (

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -84,6 +84,7 @@ class Settings {
         'plugin' => dirname(dirname(dirname(__DIR__))),
       ],
       'built_in_captcha_supported' => $this->captcha->isSupported(),
+      'current_site_title' => $this->wp->getBloginfo('name'),
     ];
 
     $data['authorized_emails'] = [];

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -10,6 +10,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
 use MailPoet\Newsletter\Shortcodes\Categories\Link;
 use MailPoet\Newsletter\Shortcodes\Categories\Newsletter;
+use MailPoet\Newsletter\Shortcodes\Categories\Site;
 use MailPoet\Newsletter\Shortcodes\Categories\Subscriber as SubscriberCategory;
 use MailPoet\Newsletter\Shortcodes\Shortcodes as NewsletterShortcodes;
 use MailPoet\Newsletter\Url as NewsletterUrl;
@@ -49,6 +50,9 @@ class Shortcodes {
   /** @var SubscriberCategory */
   private $subscriberCategory;
 
+  /** @var Site */
+  private $siteCategory;
+
   public function __construct(
     Pages $subscriptionPages,
     WPFunctions $wp,
@@ -59,7 +63,8 @@ class Shortcodes {
     Date $dateCategory,
     Link $linkCategory,
     Newsletter $newsletterCategory,
-    SubscriberCategory $subscriberCategory
+    SubscriberCategory $subscriberCategory,
+    Site $siteCategory
   ) {
     $this->subscriptionPages = $subscriptionPages;
     $this->wp = $wp;
@@ -71,6 +76,7 @@ class Shortcodes {
     $this->linkCategory = $linkCategory;
     $this->newsletterCategory = $newsletterCategory;
     $this->subscriberCategory = $subscriberCategory;
+    $this->siteCategory = $siteCategory;
   }
 
   public function init() {
@@ -216,6 +222,7 @@ class Shortcodes {
       $this->linkCategory,
       $this->newsletterCategory,
       $this->subscriberCategory,
+      $this->siteCategory,
       $this->wp
     );
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -454,6 +454,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Link::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Newsletter::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Subscriber::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\AutomationEmailScheduler::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -8,6 +8,15 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Site implements CategoryInterface {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
   public function process(
     array $shortcodeDetails,
     NewsletterEntity $newsletter = null,
@@ -16,14 +25,12 @@ class Site implements CategoryInterface {
     string $content = '',
     bool $wpUserPreview = false
   ): ?string {
-    $wp = new WPFunctions();
-
     switch ($shortcodeDetails['action']) {
       case 'title':
-        return $wp->getBloginfo('name');
+        return $this->wp->getBloginfo('name');
 
       case 'homepage_link':
-        return $wp->getBloginfo('url');
+        return $this->wp->getBloginfo('url');
 
       default:
         return null;

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MailPoet\Newsletter\Shortcodes\Categories;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Site implements CategoryInterface {
+  public function process(
+    array $shortcodeDetails,
+    NewsletterEntity $newsletter = null,
+    SubscriberEntity $subscriber = null,
+    SendingQueueEntity $queue = null,
+    string $content = '',
+    bool $wpUserPreview = false
+  ): ?string {
+    $wp = new WPFunctions();
+
+    switch ($shortcodeDetails['action']) {
+      case 'title':
+        return $wp->getBloginfo('name');
+
+      case 'homepage_link':
+        return $wp->getBloginfo('url');
+
+      default:
+        return null;
+    }
+  }
+}

--- a/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -9,6 +9,7 @@ use MailPoet\Newsletter\Shortcodes\Categories\CategoryInterface;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
 use MailPoet\Newsletter\Shortcodes\Categories\Link;
 use MailPoet\Newsletter\Shortcodes\Categories\Newsletter;
+use MailPoet\Newsletter\Shortcodes\Categories\Site;
 use MailPoet\Newsletter\Shortcodes\Categories\Subscriber;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -37,6 +38,9 @@ class Shortcodes {
   /** @var Subscriber */
   private $subscriberCategory;
 
+  /** @var Site */
+  private $siteCategory;
+
   /** @var WPFunctions */
   private $wp;
 
@@ -45,12 +49,14 @@ class Shortcodes {
     Link $linkCategory,
     Newsletter $newsletterCategory,
     Subscriber $subscriberCategory,
+    Site $siteCategory,
     WPFunctions $wp
   ) {
     $this->dateCategory = $dateCategory;
     $this->linkCategory = $linkCategory;
     $this->newsletterCategory = $newsletterCategory;
     $this->subscriberCategory = $subscriberCategory;
+    $this->siteCategory = $siteCategory;
     $this->wp = $wp;
   }
 
@@ -210,6 +216,8 @@ class Shortcodes {
       return $this->newsletterCategory;
     } elseif ($category === 'subscriber') {
       return $this->subscriberCategory;
+    } elseif ($category === 'site') {
+      return $this->siteCategory;
     }
     return null;
   }

--- a/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -111,6 +111,16 @@ class ShortcodesHelper {
           ),
         ],
       ],
+      __('Site', 'mailpoet') => [
+        [
+          'text' => __('Site title', 'mailpoet'),
+          'shortcode' => '[site:title]',
+        ],
+        [
+          'text' => __('Homepage link', 'mailpoet'),
+          'shortcode' => '[site:homepage_link]',
+        ],
+      ],
     ];
     $customFields = $this->getCustomFields();
     if (count($customFields) > 0) {

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -15,8 +15,8 @@ class ViewInBrowserRenderer {
   /** @var Emoji */
   private $emoji;
 
-  /** @var bool */
-  private $isTrackingEnabled;
+  /** @var TrackingConfig */
+  private $trackingConfig;
 
   /** @var Renderer */
   private $renderer;
@@ -35,7 +35,7 @@ class ViewInBrowserRenderer {
     Links $links
   ) {
     $this->emoji = $emoji;
-    $this->isTrackingEnabled = $trackingConfig->isEmailTrackingEnabled();
+    $this->trackingConfig = $trackingConfig;
     $this->renderer = $renderer;
     $this->shortcodes = $shortcodes;
     $this->links = $links;
@@ -48,6 +48,8 @@ class ViewInBrowserRenderer {
     SendingQueueEntity $queue = null
   ) {
     $wpUserPreview = $isPreview;
+    $isTrackingEnabled = $this->trackingConfig->isEmailTrackingEnabled();
+
     if ($queue && $queue->getNewsletterRenderedBody()) {
       $body = $queue->getNewsletterRenderedBody();
       if (is_array($body)) {
@@ -83,7 +85,7 @@ class ViewInBrowserRenderer {
       $wpUserPreview
     );
     $renderedNewsletter = $this->shortcodes->replace($newsletterBody);
-    if (!$wpUserPreview && $queue && $subscriber && $this->isTrackingEnabled) {
+    if (!$wpUserPreview && $queue && $subscriber && $isTrackingEnabled) {
       $renderedNewsletter = $this->links->replaceSubscriberData(
         $subscriber->getId(),
         $queue->getId(),

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -4,7 +4,6 @@ namespace MailPoet\Settings;
 
 use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\WP\Functions as WPFunctions;
 
 class SettingsController {
 
@@ -67,9 +66,8 @@ class SettingsController {
         ],
         'signup_confirmation' => [
           'enabled' => true,
-          // translators: %1$s is the name of the blog
-          'subject' => sprintf(__('Confirm your subscription to %1$s', 'mailpoet'), WPFunctions::get()->getOption('blogname')),
-          'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target='_blank' href='[site:homepage_link]'>[site:title]</a>", 'mailpoet'),
+          'subject' => __('Confirm your subscription to [site:title]', 'mailpoet'),
+          'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_link]\">[site:title]</a>", 'mailpoet'),
         ],
         'tracking' => [
           'level' => TrackingConfig::LEVEL_FULL,

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -69,7 +69,7 @@ class SettingsController {
           'enabled' => true,
           // translators: %1$s is the name of the blog
           'subject' => sprintf(__('Confirm your subscription to %1$s', 'mailpoet'), WPFunctions::get()->getOption('blogname')),
-          'body' => __("Hello,\n\nWelcome to our newsletter!\n\nPlease confirm your subscription to our list by clicking the link below: \n\n[activation_link]I confirm my subscription![/activation_link]\n\nThank you,\n\nThe Team", 'mailpoet'),
+          'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target='_blank' href='[site:homepage_link]'>[site:title]</a>", 'mailpoet'),
         ],
         'tracking' => [
           'level' => TrackingConfig::LEVEL_FULL,

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Subscribers;
 
 use Html2Text\Html2Text;
+use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\MailerFactory;
@@ -106,6 +107,9 @@ class ConfirmationEmailMailer {
       ['target' => '_blank'],
       'activation_link'
     );
+
+
+    $body = Shortcodes::process($body, null, null, $subscriber, null);
 
     //create a text version. @ is important here, Html2Text throws warnings
     $text = @Html2Text::convert(

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -108,6 +108,7 @@ class ConfirmationEmailMailer {
       'activation_link'
     );
 
+    $subject = Shortcodes::process($signupConfirmation['subject'], null, null, $subscriber, null);
 
     $body = Shortcodes::process($body, null, null, $subscriber, null);
 
@@ -119,7 +120,7 @@ class ConfirmationEmailMailer {
 
     // build email data
     $email = [
-      'subject' => $signupConfirmation['subject'],
+      'subject' => $subject,
       'body' => [
         'html' => $body,
         'text' => $text,

--- a/mailpoet/tests/acceptance/Newsletters/ReceiveWelcomeEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ReceiveWelcomeEmailCest.php
@@ -49,7 +49,7 @@ class ReceiveWelcomeEmailCest {
     $i->checkEmailWasReceived($confirmationEmailName);
     $i->click(Locator::contains('span.subject', $confirmationEmailName));
     $i->switchToIframe('#preview-html');
-    $i->click('I confirm my subscription!');
+    $i->click('Click here to confirm your subscription.');
     $i->switchToNextTab();
     $i->reloadPage();
     $i->triggerMailPoetActionScheduler();

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -42,7 +42,7 @@ class CreateNewWordPressUserCest {
     $i->checkEmailWasReceived($emailTitle);
     $i->click(Locator::contains('span.subject', $emailTitle));
     $i->switchToIframe('#preview-html');
-    $i->click('I confirm my subscription!');
+    $i->click('Click here to confirm your subscription.');
     $i->switchToNextTab();
     $i->see('You have subscribed to');
     $i->see('Newsletter mailing list');

--- a/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
@@ -75,7 +75,7 @@ class SubscribeOnRegistrationPageCest {
     $i->checkEmailWasReceived('Confirm your subscription');
     $i->click(Locator::contains('span.subject', 'Confirm your subscription'));
     $i->switchToIframe('#preview-html');
-    $i->click('I confirm my subscription!');
+    $i->click('Click here to confirm your subscription.');
     $i->switchToNextTab();
     if (!getenv('MULTISITE')) {
       $i->see('You have subscribed');

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -108,7 +108,7 @@ class SubscriberCookieCest {
     $i->checkEmailWasReceived('Confirm your subscription to MP Dev');
     $i->click(Locator::contains('span.subject', 'Confirm your subscription to MP Dev'));
     $i->switchToIframe('#preview-html');
-    $i->click('I confirm my subscription!');
+    $i->click('Click here to confirm your subscription.');
     $i->switchToNextTab();
 
     // subscriber cookie should be set after subscription confirmation

--- a/mailpoet/tests/integration/Newsletter/ShortcodesHelperTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesHelperTest.php
@@ -23,6 +23,7 @@ class ShortcodesHelperTest extends \MailPoetTest {
         'Post Notifications',
         'Date',
         'Links',
+        'Site',
       ]
     );
   }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -408,6 +408,26 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result[0])->equals('[link:shortcode]');
   }
 
+  public function testItCanProcessSiteTitleShortcode() {
+    $optionName = 'blogname';
+    $siteName = get_option($optionName);
+
+    $shortcode = '[site:title]';
+    $shortcodesObject = $this->shortcodesObject;
+    $result = $shortcodesObject->process([$shortcode]);
+    expect($result[0])->equals($siteName);
+  }
+
+  public function testItCanProcessSiteHomepageLinkShortcode() {
+    $optionName = 'home';
+    $siteUrl = get_option($optionName);
+
+    $shortcode = '[site:homepage_link]';
+    $shortcodesObject = $this->shortcodesObject;
+    $result = $shortcodesObject->process([$shortcode]);
+    expect($result[0])->equals($siteUrl);
+  }
+
   public function _createWPPost() {
     $data = [
       'post_title' => 'Sample Post',

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -66,7 +66,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       'send' =>
         Stub\Expected::once(function($email, $subscriber, $extraParams) {
           expect($email['body']['html'])->stringContainsString('<strong>Test segment</strong>');
-          expect($email['body']['html'])->stringContainsString('<a target="_blank" href="http://example.com">I confirm my subscription!</a>');
+          expect($email['body']['html'])->stringContainsString('<a target="_blank" href="http://example.com">Click here to confirm your subscription.</a>');
           expect($extraParams['meta'])->equals([
             'email_type' => 'confirmation',
             'subscriber_status' => 'unconfirmed',

--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -19,6 +19,7 @@
       var mailpoet_free_plan_url = "<%= add_referral_id('https://www.mailpoet.com/free-plan') %>";
       var mailpoet_current_user_email = "<%= current_user.user_email %>";
       var mailpoet_hosts = <%= json_encode(hosts) %>;
+      var mailpoet_current_site_title = <%= json_encode(current_site_title) %>;
     <% endautoescape %>
     var mailpoet_beacon_articles = [
       '57f71d49c697911f2d323486',
@@ -107,7 +108,7 @@
     'signupConfirmationIsMandatory': __('Sign-up confirmation is mandatory when using the MailPoet Sending Service.'),
     'emailSubject':  __('Email subject'),
     'emailContent':  __('Email content'),
-    'emailContentDescription': __("Don't forget to include:<br /><br />[activation_link]Confirm your subscription.[/activation_link]<br /><br />Optional:<br /><br /> [lists_to_confirm] - comma separated subscriber's list names<br /><br />[subscriber:firstname | default: there] - Subscriber's first name, defaults to 'there' if not available<br /><br />[subscriber:lastname | default: there] - Subscriber's last name, defaults to 'there' if not available<br /><br />[subscriber:email] - Subscriber's email address<br /><br />[subscriber:count] - Total number of subscribers<br /><br />[site:title] - Your WordPress site title<br /><br />[site:homepage_link] - Link to your site's homepage."),
+    'emailContentDescription': __("Don't forget to include:<br /><br />[activation_link]Confirm your subscription.[/activation_link]<br /><br />Optional:<br /><br /> [lists_to_confirm] - comma separated subscriber's list names<br /><br />[subscriber:firstname | default: there] - Subscriber's first name, defaults to 'there' if not available<br /><br />[subscriber:lastname | default: there] - Subscriber's last name, defaults to 'there' if not available<br /><br />[subscriber:email] - Subscriber's email address<br /><br />[subscriber:count] - Total number of subscribers<br /><br />[site:title] - Your WordPress site title (currently '[current_site_title]')<br /><br />[site:homepage_link] - Link to your site's homepage."),
     'confirmationPage': __('Confirmation page'),
     'confirmationPageDescription': __('When subscribers click on the activation link, they will be redirected to this page.'),
     'subscribersNeedToActivateSub': __('Subscribers will need to activate their subscription via email in order to receive your newsletters. This is highly recommended!'),

--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -107,7 +107,7 @@
     'signupConfirmationIsMandatory': __('Sign-up confirmation is mandatory when using the MailPoet Sending Service.'),
     'emailSubject':  __('Email subject'),
     'emailContent':  __('Email content'),
-    'emailContentDescription': __("Don't forget to include:<br /><br />[activation_link]Confirm your subscription.[/activation_link]<br /><br />Optional: [lists_to_confirm]."),
+    'emailContentDescription': __("Don't forget to include:<br /><br />[activation_link]Confirm your subscription.[/activation_link]<br /><br />Optional:<br /><br /> [lists_to_confirm] - comma separated subscriber's list names<br /><br />[subscriber:firstname | default: there] - Subscriber's first name, defaults to 'there' if not available<br /><br />[subscriber:lastname | default: there] - Subscriber's last name, defaults to 'there' if not available<br /><br />[subscriber:email] - Subscriber's email address<br /><br />[subscriber:count] - Total number of subscribers<br /><br />[site:title] - Your WordPress site title<br /><br />[site:homepage_link] - Link to your site's homepage."),
     'confirmationPage': __('Confirmation page'),
     'confirmationPageDescription': __('When subscribers click on the activation link, they will be redirected to this page.'),
     'subscribersNeedToActivateSub': __('Subscribers will need to activate their subscription via email in order to receive your newsletters. This is highly recommended!'),


### PR DESCRIPTION
## Description

Personalize the default subscription confirmation email

Update default confirmation emails and allow more customisation with optional shortcodes

## Code review notes

Circleci is [Flaky](https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=feat%2Fpersonalize-the-default-subscription-confirmation-email). Would retry build later

## QA notes

* You may update your confirmation email here: http://mp3.localhost/wp-admin/admin.php?page=mailpoet-settings#/signup
* Subscribe to any form on the site. You should receive the confirmation email
* To test the default confirmation email, open your database, select `wp_mailpoet_settings` table, locate `signup_confirmation` and delete that row. Refresh the MailPoet admin page. You should get the default content


## Linked tickets

[MAILPOET-4599](https://mailpoet.atlassian.net/browse/MAILPOET-4599)


