### PR TITLE
Close ActivatePanel when there are errors

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Spinner } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
@@ -108,6 +108,12 @@ export function ActivatePanel({ onClose }): JSX.Element {
     }),
     [],
   );
+
+  useEffect(() => {
+    if (errors) {
+      onClose();
+    }
+  }, [errors, onClose]);
 
   if (errors) {
     return null;

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -9,6 +9,7 @@ import { storeName } from './constants';
 import { Feature, State } from './types';
 import { LISTING_NOTICE_PARAMETERS } from '../../listing/workflow-listing-notices';
 import { MailPoet } from '../../../mailpoet';
+import { WorkflowStatus } from '../../listing/workflow';
 
 export const openSidebar =
   (key) =>
@@ -82,13 +83,15 @@ export function* activate() {
   });
 
   const { createNotice } = dispatch(noticesStore as StoreDescriptor);
-  void createNotice(
-    'success',
-    __('Well done! Automation is now activated!', 'mailpoet'),
-    {
-      type: 'snackbar',
-    },
-  );
+  if (data?.data.status === WorkflowStatus.ACTIVE) {
+    void createNotice(
+      'success',
+      __('Well done! Automation is now activated!', 'mailpoet'),
+      {
+        type: 'snackbar',
+      },
+    );
+  }
 
   return {
     type: 'ACTIVATE',


### PR DESCRIPTION
## Description
When I click "Activate" in the Panel and get errors, the Panel stops to render and just returns `null` because `if (errors)`. We need to actively close the Panel so it does not automatically show up once those errors are no longer in the redux store.

A second issue, which is addressed in this PR: The "Workflow is now activated" message is always shown, even when there where errors. This message does show now only in case the status of the workflow is `active`.


## Linked tickets
[MAILPOET-4737]



[MAILPOET-4737]: https://mailpoet.atlassian.net/browse/MAILPOET-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ