### PR TITLE
Check for CircleCI results file existence [MAILPOET-4738]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,7 +410,9 @@ jobs:
           name: Group acceptance tests
           command: |
             # Convert test result filename values to be relative paths because the circleci CLI's split command requires exact matches
-            sed -i.bak 's#/wp-core/wp-content/plugins/mailpoet/##g' $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json
+            if [ -e $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json ]; then
+              sed -i.bak 's#/wp-core/wp-content/plugins/mailpoet/##g' $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json
+            fi
             # `circleci tests split` returns different values based on the container it's run on
             # in case group is defined find only tests containing the group
             if [[ -n '<< parameters.group >>' ]]; then


### PR DESCRIPTION
## Description

Fixes:

```shell
#!/bin/bash -eo pipefail
# Convert test result filename values to be relative paths because the circleci CLI's split command requires exact matches
sed -i.bak 's#/wp-core/wp-content/plugins/mailpoet/##g' $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json
# `circleci tests split` returns different values based on the container it's run on
# in case group is defined find only tests containing the group
if [[ -n '' ]]; then
  grep -rw 'tests/acceptance' -e '@group ' | sed -e "s/:.*//" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
else
  circleci tests glob "tests/acceptance/**/*Cest.php" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
fi
cat tests/acceptance/_groups/circleci_split_group

sed: can't read /tmp/.circleci-task-data-6350e463a8a6c73079281f7b-0-build/circle-test-results/results.json: No such file or directory

Exited with code exit status 2
CircleCI received exit code 2
```

## Code review notes

See also: https://support.circleci.com/hc/en-us/articles/360000376788-How-to-troubleshoot-Test-Splitting

## QA notes

Tests only, QA can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4738]

## After-merge notes

_N/A_


[MAILPOET-4738]: https://mailpoet.atlassian.net/browse/MAILPOET-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ