### PR TITLE
Add new Subscriber hooks [MAILPOET-4727]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -442,7 +442,7 @@ class Hooks {
     return array_merge($customLinks, $actionLinks);
   }
 
-  private function setupChangeNotifications(): void {
+  public function setupChangeNotifications(): void {
     $this->wp->addAction(
       'shutdown',
       [$this->subscriberChangesNotifier, 'notify']

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -51,6 +51,9 @@ class Hooks {
   /** @var HooksWooCommerce */
   private $hooksWooCommerce;
 
+  /** @var SubscriberChangesNotifier */
+  private $subscriberChangesNotifier;
+
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -63,6 +66,7 @@ class Hooks {
     DisplayFormInWPContent $displayFormInWPContent,
     HooksWooCommerce $hooksWooCommerce,
     SubscriberHandler $subscriberHandler,
+    SubscriberChangesNotifier $subscriberChangesNotifier,
     WP $wpSegment
   ) {
     $this->subscriptionForm = $subscriptionForm;
@@ -77,6 +81,7 @@ class Hooks {
     $this->wpSegment = $wpSegment;
     $this->subscriberHandler = $subscriberHandler;
     $this->hooksWooCommerce = $hooksWooCommerce;
+    $this->subscriberChangesNotifier = $subscriberChangesNotifier;
   }
 
   public function init() {
@@ -92,6 +97,7 @@ class Hooks {
     $this->setupWooCommerceSettings();
     $this->setupFooter();
     $this->setupSettingsLinkInPluginPage();
+    $this->setupChangeNotifications();
   }
 
   public function initEarlyHooks() {
@@ -434,5 +440,12 @@ class Hooks {
     ];
 
     return array_merge($customLinks, $actionLinks);
+  }
+
+  private function setupChangeNotifications(): void {
+    $this->wp->addAction(
+      'shutdown',
+      [$this->subscriberChangesNotifier, 'notify']
+    );
   }
 }

--- a/mailpoet/lib/Config/SubscriberChangesNotifier.php
+++ b/mailpoet/lib/Config/SubscriberChangesNotifier.php
@@ -68,4 +68,22 @@ class SubscriberChangesNotifier {
     // store id as a key and timestamp change as the value
     $this->deletedSubscriberIds[$subscriberId] = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'), 'UTC');
   }
+
+  public function subscribersCreated(array $subscriberIds): void {
+    foreach ($subscriberIds as $subscriberId) {
+      $this->subscriberCreated($subscriberId);
+    }
+  }
+
+  public function subscribersUpdated(array $subscriberIds): void {
+    foreach ($subscriberIds as $subscriberId) {
+      $this->subscriberUpdated($subscriberId);
+    }
+  }
+
+  public function subscribersDeleted(array $subscriberIds): void {
+    foreach ($subscriberIds as $subscriberId) {
+      $this->subscriberDeleted($subscriberId);
+    }
+  }
 }

--- a/mailpoet/lib/Config/SubscriberChangesNotifier.php
+++ b/mailpoet/lib/Config/SubscriberChangesNotifier.php
@@ -90,19 +90,19 @@ class SubscriberChangesNotifier {
 
   public function subscribersCreated(array $subscriberIds): void {
     foreach ($subscriberIds as $subscriberId) {
-      $this->subscriberCreated($subscriberId);
+      $this->subscriberCreated((int)$subscriberId);
     }
   }
 
   public function subscribersUpdated(array $subscriberIds): void {
     foreach ($subscriberIds as $subscriberId) {
-      $this->subscriberUpdated($subscriberId);
+      $this->subscriberUpdated((int)$subscriberId);
     }
   }
 
   public function subscribersDeleted(array $subscriberIds): void {
     foreach ($subscriberIds as $subscriberId) {
-      $this->subscriberDeleted($subscriberId);
+      $this->subscriberDeleted((int)$subscriberId);
     }
   }
 

--- a/mailpoet/lib/Config/SubscriberChangesNotifier.php
+++ b/mailpoet/lib/Config/SubscriberChangesNotifier.php
@@ -107,7 +107,7 @@ class SubscriberChangesNotifier {
   }
 
   private function getTimestamp(): int {
-    $dateTime = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'), 'UTC');
+    $dateTime = Carbon::createFromTimestamp($this->wp->currentTime('timestamp', true), 'UTC');
     return $dateTime->getTimestamp();
   }
 }

--- a/mailpoet/lib/Config/SubscriberChangesNotifier.php
+++ b/mailpoet/lib/Config/SubscriberChangesNotifier.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\WP\Functions as WPFunctions;
+
+class SubscriberChangesNotifier {
+
+  /** @var int[] */
+  private $createdSubscriberIds = [];
+
+  /** @var int[] */
+  private $deletedSubscriberIds = [];
+
+  /** @var int[] */
+  private $updatedSubscriberIds = [];
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function notify() {
+    $this->notifyCreations();
+    $this->notifyUpdates();
+    $this->notifyDeletes();
+  }
+
+  private function notifyCreations(): void {
+    foreach ($this->createdSubscriberIds as $subscriberId) {
+      $this->wp->doAction(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, $subscriberId);
+    }
+  }
+
+  private function notifyUpdates(): void {
+    foreach ($this->updatedSubscriberIds as $subscriberId) {
+      // do not notify about changes when subscriber is new
+      if (in_array($subscriberId, $this->createdSubscriberIds, true)) {
+        continue;
+      }
+      $this->wp->doAction(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, $subscriberId);
+    }
+  }
+
+  private function notifyDeletes(): void {
+    foreach ($this->deletedSubscriberIds as $subscriberId) {
+      $this->wp->doAction(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, $subscriberId);
+    }
+  }
+
+  public function subscriberCreated(int $subscriberId): void {
+    // to avoid duplicities we use id as a key
+    $this->createdSubscriberIds[$subscriberId] = $subscriberId;
+  }
+
+  public function subscriberUpdated(int $subscriberId): void {
+    // to avoid duplicities we use id as a key
+    $this->updatedSubscriberIds[$subscriberId] = $subscriberId;
+  }
+
+  public function subscriberDeleted(int $subscriberId): void {
+    // to avoid duplicities we use id as a key
+    $this->deletedSubscriberIds[$subscriberId] = $subscriberId;
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -201,6 +201,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Doctrine\EventListeners\LastSubscribedAtListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\TimestampListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\ValidationListener::class);
+    $container->autowire(\MailPoet\Doctrine\EventListeners\SubscriberListener::class);
     $container->autowire(\MailPoet\Doctrine\Validator\ValidatorFactory::class);
     $container->autowire(\MailPoetVendor\Symfony\Component\Validator\Validator\ValidatorInterface::class)
       ->setFactory([new Reference(\MailPoet\Doctrine\Validator\ValidatorFactory::class), 'createValidator']);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -176,6 +176,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Config\RendererFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\ServicesChecker::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Router::class)->setPublic(true);
+    $container->autowire(\MailPoet\Config\SubscriberChangesNotifier::class);
     $container->autowire(\MailPoet\Config\Shortcodes::class)
       ->setShared(false) // Get a new instance each time $container->get() is called, needed for tests
       ->setPublic(true);

--- a/mailpoet/lib/Doctrine/EventListeners/SubscriberListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/SubscriberListener.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Doctrine\EventListeners;
+
+use MailPoet\Config\SubscriberChangesNotifier;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\Persistence\Event\LifecycleEventArgs;
+
+class SubscriberListener {
+
+  /** @var SubscriberChangesNotifier */
+  private $subscriberChangesNotifier;
+
+  public function __construct(
+    SubscriberChangesNotifier $subscriberChangesNotifier
+  ) {
+    $this->subscriberChangesNotifier = $subscriberChangesNotifier;
+  }
+
+  public function postPersist(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
+    $this->subscriberChangesNotifier->subscriberCreated((int)$subscriber->getId());
+  }
+
+  public function postUpdate(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
+    $this->subscriberChangesNotifier->subscriberUpdated((int)$subscriber->getId());
+  }
+
+  public function postRemove(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
+    $this->subscriberChangesNotifier->subscriberDeleted((int)$subscriber->getId());
+  }
+}

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -25,6 +25,9 @@ class SubscriberEntity {
   public const HOOK_SUBSCRIBER_CREATED = 'mailpoet_subscriber_created';
   public const HOOK_SUBSCRIBER_DELETED = 'mailpoet_subscriber_deleted';
   public const HOOK_SUBSCRIBER_UPDATED = 'mailpoet_subscriber_updated';
+  public const HOOK_MULTIPLE_SUBSCRIBERS_CREATED = 'mailpoet_multiple_subscribers_created';
+  public const HOOK_MULTIPLE_SUBSCRIBERS_DELETED = 'mailpoet_multiple_subscribers_deleted';
+  public const HOOK_MULTIPLE_SUBSCRIBERS_UPDATED = 'mailpoet_multiple_subscribers_updated';
 
   // statuses
   const STATUS_BOUNCED = 'bounced';

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -20,6 +20,11 @@ use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
  * @ORM\HasLifecycleCallbacks
  */
 class SubscriberEntity {
+  // hook names
+  public const HOOK_SUBSCRIBER_CREATED = 'mailpoet_subscriber_created';
+  public const HOOK_SUBSCRIBER_DELETED = 'mailpoet_subscriber_deleted';
+  public const HOOK_SUBSCRIBER_UPDATED = 'mailpoet_subscriber_updated';
+
   // statuses
   const STATUS_BOUNCED = 'bounced';
   const STATUS_INACTIVE = 'inactive';

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -18,6 +18,7 @@ use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(name="subscribers")
  * @ORM\HasLifecycleCallbacks
+ * @ORM\EntityListeners({"\MailPoet\Doctrine\EventListeners\SubscriberListener"})
  */
 class SubscriberEntity {
   // hook names

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -215,6 +215,10 @@ class WP {
   }
 
   public function synchronizeUsers(): bool {
+    // Save timestamp about changes and update before insert
+    $this->subscriberChangesNotifier->subscribersBatchCreate();
+    $this->subscriberChangesNotifier->subscribersBatchUpdate();
+
     $updatedUsersEmails = $this->updateSubscribersEmails();
     $insertedUsersEmails = $this->insertSubscribers();
     $this->removeUpdatedSubscribersWithInvalidEmail(array_merge($updatedUsersEmails, $insertedUsersEmails));

--- a/mailpoet/tests/integration/Config/HooksTest.php
+++ b/mailpoet/tests/integration/Config/HooksTest.php
@@ -2,13 +2,38 @@
 
 namespace MailPoet\Test\Config;
 
+use Helper\WordPressHooks as WPHooksHelper;
 use MailPoet\Config\Hooks;
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\WP\Functions as WPFunctions;
 
 class HooksTest extends \MailPoetTest {
   public function testItHooksSchedulerToMultiplePostTypes() {
     $hooks = ContainerWrapper::getInstance()->get(Hooks::class);
     $hooks->setupPostNotifications();
     expect(has_filter('transition_post_status'))->notEmpty();
+  }
+
+  public function testItHooksSubscriberChangesNotifier() {
+    $wp = $this->make(new WPFunctions(), [
+      'addAction' => asCallable([WPHooksHelper::class, 'addAction']),
+      'doAction' => asCallable([WPHooksHelper::class, 'doAction']),
+    ]);
+    $subscriberChangesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $wp,
+      'notify' => 'success',
+    ]);
+    $hooks = $this->getServiceWithOverrides(Hooks::class, [
+      'wp' => $wp,
+      'subscriberChangesNotifier' => $subscriberChangesNotifier,
+    ]);
+    $hooks->setupChangeNotifications();
+
+    // check that shutdown hooks was added
+    $this->assertEquals(true, WPHooksHelper::isActionAdded('shutdown'));
+    // manual hook execution and check with mocked return value
+    $shutdownHook = WPHooksHelper::getActionAdded('shutdown');
+    $this->assertEquals('success', call_user_func($shutdownHook[0]));
   }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
@@ -20,4 +20,9 @@ class EventListenersBaseTest extends \MailPoetTest {
       $replacement
     );
   }
+
+  protected function replaceEntityListener($replacement): void {
+    $this->entityManager->getConfiguration()->getEntityListenerResolver()->clear((string)get_class($replacement));
+    $this->entityManager->getConfiguration()->getEntityListenerResolver()->register($replacement);
+  }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace MailPoet\Test\Doctrine\EventListeners;
+
+use Codeception\Stub\Expected;
+use MailPoet\Config\SubscriberChangesNotifier;
+use MailPoet\Doctrine\EventListeners\SubscriberListener;
+use MailPoet\Doctrine\EventListeners\TimestampListener;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\ORM\Events;
+
+require_once __DIR__ . '/EventListenersBaseTest.php';
+require_once __DIR__ . '/TimestampEntity.php';
+
+class SubscriberListenerTest extends EventListenersBaseTest {
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SubscriberListener */
+  private $subscriberListener;
+
+  public function _before() {
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+  }
+
+  public function testItNotifiesAboutNewSubscriber(): void {
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $this->wp,
+      'subscriberCreated' => Expected::once(),
+    ]);
+    $this->subscriberListener = new SubscriberListener($changesNotifier);
+    $this->replaceEntityListener($this->subscriberListener);
+
+    (new SubscriberFactory())->create();
+  }
+
+  public function testItNotifiesAboutUpdatedSubscriber(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $this->wp,
+      'subscriberUpdated' => Expected::once(),
+    ]);
+    $this->subscriberListener = new SubscriberListener($changesNotifier);
+    $this->replaceEntityListener($this->subscriberListener);
+
+    $subscriber->setFirstName('John');
+    $subscriber->setLastName('Doe');
+    $this->entityManager->flush();
+  }
+
+  public function testItNotifiesAboutDeletedSubscriber(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $this->wp,
+      'subscriberDeleted' => Expected::once(),
+    ]);
+    $this->subscriberListener = new SubscriberListener($changesNotifier);
+    $this->replaceEntityListener($this->subscriberListener);
+
+    $this->entityManager->remove($subscriber);
+    $this->entityManager->flush();
+  }
+
+  public function _after() {
+    parent::_after();
+    $originalListener = $this->diContainer->get(TimestampListener::class);
+    $this->replaceEntityListener($originalListener);
+    $this->truncateEntity(SubscriberEntity::class);
+  }
+}

--- a/mailpoet/tests/integration/Doctrine/EventListeners/ValidationTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/ValidationTest.php
@@ -2,12 +2,14 @@
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Doctrine\Annotations\AnnotationReaderProvider;
 use MailPoet\Doctrine\ArrayCache;
 use MailPoet\Doctrine\ConfigurationFactory;
 use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Doctrine\EventListeners\EmojiEncodingListener;
 use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
+use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
 use MailPoet\Doctrine\EventListeners\ValidationListener;
 use MailPoet\Doctrine\Validator\ValidationException;
@@ -80,13 +82,15 @@ class ValidationTest extends \MailPoetTest {
     $validationListener = new ValidationListener($validatorFactory->createValidator());
     $emojiEncodingListener = new EmojiEncodingListener(new Emoji($this->wp));
     $lastSubscribedAtListener = new LastSubscribedAtListener($this->wp);
+    $subscriberListener = new SubscriberListener(new SubscriberChangesNotifier($this->wp));
     $entityManagerFactory = new EntityManagerFactory(
       $this->connection,
       $configuration,
       $timestampListener,
       $validationListener,
       $emojiEncodingListener,
-      $lastSubscribedAtListener
+      $lastSubscribedAtListener,
+      $subscriberListener
     );
     return $entityManagerFactory->createEntityManager();
   }

--- a/mailpoet/tests/integration/Doctrine/Types/JsonTypesTest.php
+++ b/mailpoet/tests/integration/Doctrine/Types/JsonTypesTest.php
@@ -3,12 +3,14 @@
 namespace MailPoet\Test\Doctrine\EventListeners;
 
 use Exception;
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Doctrine\Annotations\AnnotationReaderProvider;
 use MailPoet\Doctrine\ArrayCache;
 use MailPoet\Doctrine\ConfigurationFactory;
 use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Doctrine\EventListeners\EmojiEncodingListener;
 use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
+use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
 use MailPoet\Doctrine\EventListeners\ValidationListener;
 use MailPoet\Doctrine\Validator\ValidatorFactory;
@@ -189,13 +191,15 @@ class JsonTypesTest extends \MailPoetTest {
     $validationListener = new ValidationListener($validatorFactory->createValidator());
     $emojiEncodingListener = new EmojiEncodingListener(new Emoji($this->wp));
     $lastSubscribedAtListener = new LastSubscribedAtListener($this->wp);
+    $subscriberListener = new SubscriberListener(new SubscriberChangesNotifier($this->wp));
     $entityManagerFactory = new EntityManagerFactory(
       $this->connection,
       $configuration,
       $timestampListener,
       $validationListener,
       $emojiEncodingListener,
-      $lastSubscribedAtListener
+      $lastSubscribedAtListener,
+      $subscriberListener
     );
     return $entityManagerFactory->createEntityManager();
   }

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -423,13 +423,7 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP(
-      $wp,
-      $this->diContainer->get(WelcomeScheduler::class),
-      $this->diContainer->get(Helper::class),
-      $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(FeaturesController::class)
-    );
+    $wpSegment = $this->getServiceWithOverrides(WP::class, ['wp' => $wp]);
     $wpSegment->synchronizeUser($id);
     $subscriber = Subscriber::where("wp_user_id", $id)->findOne();
     $deletedAt = Carbon::createFromFormat('Y-m-d H:i:s', $subscriber->deletedAt);
@@ -447,13 +441,7 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP(
-      $wp,
-      $this->diContainer->get(WelcomeScheduler::class),
-      $this->diContainer->get(Helper::class),
-      $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(FeaturesController::class)
-    );
+    $wpSegment = $this->getServiceWithOverrides(WP::class, ['wp' => $wp]);
     $_POST[Subscription::CHECKOUT_OPTIN_PRESENCE_CHECK_INPUT_NAME] = 1;
     $wpSegment->synchronizeUser($id);
     $subscriber = Subscriber::where("wp_user_id", $id)->findOne();
@@ -478,13 +466,7 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP(
-      $wp,
-      $this->diContainer->get(WelcomeScheduler::class),
-      $this->diContainer->get(Helper::class),
-      $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(FeaturesController::class)
-    );
+    $wpSegment = $this->getServiceWithOverrides(WP::class, ['wp' => $wp]);
     $wpSegment->synchronizeUser($id);
     $wpSubscriber = Segment::getWPSegment()->subscribers()->where('wp_user_id', $id)->findOne();
     expect($wpSubscriber->countConfirmations)->equals(0);
@@ -556,13 +538,7 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP(
-      $wp,
-      $this->diContainer->get(WelcomeScheduler::class),
-      $this->diContainer->get(Helper::class),
-      $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(FeaturesController::class)
-    );
+    $wpSegment = $this->getServiceWithOverrides(WP::class, ['wp' => $wp]);
     $wpSegment->synchronizeUser($id);
     $subscriber1 = Subscriber::where("wp_user_id", $id)->findOne();
     expect($subscriber1->status)->equals(SubscriberEntity::STATUS_SUBSCRIBED);
@@ -592,13 +568,10 @@ class WPTest extends \MailPoetTest {
       ],
       $this
     );
-    $wpSegment = new WP(
-      $wp,
-      $this->diContainer->get(WelcomeScheduler::class),
-      $wooHelper,
-      $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(FeaturesController::class)
-    );
+    $wpSegment = $this->getServiceWithOverrides(WP::class, [
+      'wp' => $wp,
+      'wooHelper' => $wooHelper
+    ]);
     $wpSegment->synchronizeUser($id);
     $subscriber1 = Subscriber::where("wp_user_id", $id)->findOne();
     expect($subscriber1->status)->equals(SubscriberEntity::STATUS_UNCONFIRMED);

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Statistics\Track;
 
 use Codeception\Stub;
 use Codeception\Stub\Expected;
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -511,7 +512,7 @@ class ClicksTest extends \MailPoetTest {
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
     $data = $this->trackData;
     $data->userAgent = 'User Agent';
-    $subscribersRepository = new SubscribersRepository($this->entityManager, $wpMock);
+    $subscribersRepository = new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock);
     $statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
     $opens = new Opens(
       $statisticsOpensRepository,
@@ -546,7 +547,7 @@ class ClicksTest extends \MailPoetTest {
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
     $data = $this->trackData;
     $data->userAgent = null;
-    $subscribersRepository = new SubscribersRepository($this->entityManager, $wpMock);
+    $subscribersRepository = new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock);
     $statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
     $opens = new Opens(
       $statisticsOpensRepository,
@@ -581,7 +582,7 @@ class ClicksTest extends \MailPoetTest {
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
     $data = $this->trackData;
     $data->userAgent = UserAgentEntity::MACHINE_USER_AGENTS[0];
-    $subscribersRepository = new SubscribersRepository($this->entityManager, $wpMock);
+    $subscribersRepository = new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock);
     $statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
     $opens = new Opens(
       $statisticsOpensRepository,

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Statistics\Track;
 
 use Codeception\Stub;
 use Codeception\Stub\Expected;
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -367,7 +368,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
-      new SubscribersRepository($this->entityManager, $wpMock),
+      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -388,7 +389,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
-      new SubscribersRepository($this->entityManager, $wpMock),
+      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -409,7 +410,7 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
-      new SubscribersRepository($this->entityManager, $wpMock),
+      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock),
     ], [
       'returnResponse' => null,
     ], $this);

--- a/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WP\Functions as WPFunctions;
@@ -28,7 +29,7 @@ class SubscriberEngagementTest extends \MailPoetTest {
     $this->wpMock = $this->createMock(WPFunctions::class);
     $this->subscriberEngagement = new SubscriberEngagement(
       $this->wooCommerceHelperMock,
-      new SubscribersRepository($this->entityManager, $this->wpMock)
+      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($this->wpMock), $this->wpMock)
     );
     $this->truncateEntity(SubscriberEntity::class);
   }

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
+
+  /** @var WPFunctions & MockObject */
+  private $wpFunctions;
+
+  public function _before() {
+    parent::_before();
+    $this->wpFunctions = $this->createMock(WPFunctions::class);
+  }
+
+  public function testItNotifyCreatedSubscriberIds(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 6)
+      ->willReturn(true);
+
+    $this->wpFunctions->expects($this->at(1))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 10)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberCreated(6);
+    $notifier->subscriberCreated(10);
+    $notifier->notify();
+  }
+
+  public function testItNotifyUpdatedSubscriberIds(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 2)
+      ->willReturn(true);
+
+    $this->wpFunctions->expects($this->at(1))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 11)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberUpdated(2);
+    $notifier->subscriberUpdated(11);
+    $notifier->notify();
+  }
+
+  public function testItNotifyDeletedSubscriberIds(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 1)
+      ->willReturn(true);
+
+    $this->wpFunctions->expects($this->at(1))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 12)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberDeleted(1);
+    $notifier->subscriberDeleted(12);
+    $notifier->notify();
+  }
+
+  public function testItNotifyDifferentSubscriberChanges(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 1)
+      ->willReturn(true);
+
+    $this->wpFunctions->expects($this->at(1))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 3)
+      ->willReturn(true);
+
+    $this->wpFunctions->expects($this->at(2))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 5)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberDeleted(5);
+    $notifier->subscriberUpdated(3);
+    $notifier->subscriberCreated(1);
+    $notifier->notify();
+  }
+
+  public function testItNotifyUpdateForCreatedSubscriber(): void {
+    $this->wpFunctions->expects($this->once())
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 11)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberCreated(11);
+    $notifier->subscriberUpdated(11);
+    $notifier->notify();
+  }
+}

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -16,55 +16,91 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
     $this->wpFunctions = $this->createMock(WPFunctions::class);
   }
 
-  public function testItNotifyCreatedSubscriberIds(): void {
+  public function testItNotifyCreatedSubscriberId(): void {
     $this->wpFunctions->method('currentTime')
       ->willReturn(1234);
-    $this->wpFunctions->expects($this->at(2))
+    $this->wpFunctions->expects($this->at(1))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 6, 1234)
-      ->willReturn(true);
-
-    $this->wpFunctions->expects($this->at(3))
-      ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 10, 1234)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 6)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
     $notifier->subscriberCreated(6);
-    $notifier->subscriberCreated(10);
     $notifier->notify();
   }
 
-  public function testItNotifyUpdatedSubscriberIds(): void {
-    $this->wpFunctions->method('currentTime')
-      ->willReturn(4567);
+  public function testItNotifyMultipleSubscribersCreated(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('currentTime')
+      ->willReturn(1234);
+    $this->wpFunctions->expects($this->at(1))
+      ->method('currentTime')
+      ->willReturn(3456);
     $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 2, 4567)
+      ->with(SubscriberEntity::HOOK_MULTIPLE_SUBSCRIBERS_CREATED, 1234)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(3))
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberCreated(4);
+    $notifier->subscriberCreated(6);
+    $notifier->notify();
+  }
+
+  public function testItNotifyUpdatedSubscriberId(): void {
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(4567);
+    $this->wpFunctions->expects($this->at(1))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 11, 4567)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 2)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
     $notifier->subscriberUpdated(2);
-    $notifier->subscriberUpdated(11);
     $notifier->notify();
   }
 
-  public function testItNotifyDeletedSubscriberIds(): void {
-    $this->wpFunctions->method('currentTime')
-      ->willReturn(3456);
+  public function testItNotifyMultipleSubscribersUpdated(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('currentTime')
+      ->willReturn(12345);
+    $this->wpFunctions->expects($this->at(1))
+      ->method('currentTime')
+      ->willReturn(1234);
     $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 1, 3456)
+      ->with(SubscriberEntity::HOOK_MULTIPLE_SUBSCRIBERS_UPDATED, 1234)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(3))
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberUpdated(2);
+    $notifier->subscriberUpdated(41);
+    $notifier->notify();
+  }
+
+  public function testItNotifyDeletedSubscriberId(): void {
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(3456);
+    $this->wpFunctions->expects($this->at(1))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 12, 3456)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 1)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberDeleted(1);
+    $notifier->notify();
+  }
+
+  public function testItNotifyMultipleSubscribersDeleted(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('currentTime')
+      ->willReturn(3456);
+    $this->wpFunctions->expects($this->at(1))
+      ->method('currentTime')
+      ->willReturn(98712);
+    $this->wpFunctions->expects($this->at(2))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_MULTIPLE_SUBSCRIBERS_DELETED, [1, 12])
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
@@ -78,17 +114,17 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
       ->willReturn(12345);
     $this->wpFunctions->expects($this->at(3))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 1, 12345)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 1)
       ->willReturn(true);
 
     $this->wpFunctions->expects($this->at(4))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 3, 12345)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 3)
       ->willReturn(true);
 
     $this->wpFunctions->expects($this->at(5))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 5, 12345)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 5)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
@@ -103,7 +139,7 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
       ->willReturn(1235);
     $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 11, 1235)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 11)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -17,14 +17,16 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
   }
 
   public function testItNotifyCreatedSubscriberIds(): void {
-    $this->wpFunctions->expects($this->at(0))
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(1234);
+    $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 6)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 6, 1234)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(1))
+    $this->wpFunctions->expects($this->at(3))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 10)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 10, 1234)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
@@ -34,14 +36,16 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
   }
 
   public function testItNotifyUpdatedSubscriberIds(): void {
-    $this->wpFunctions->expects($this->at(0))
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(4567);
+    $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 2)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 2, 4567)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(1))
+    $this->wpFunctions->expects($this->at(3))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 11)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 11, 4567)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
@@ -51,14 +55,16 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
   }
 
   public function testItNotifyDeletedSubscriberIds(): void {
-    $this->wpFunctions->expects($this->at(0))
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(3456);
+    $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 1)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 1, 3456)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(1))
+    $this->wpFunctions->expects($this->at(3))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 12)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 12, 3456)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
@@ -68,19 +74,21 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
   }
 
   public function testItNotifyDifferentSubscriberChanges(): void {
-    $this->wpFunctions->expects($this->at(0))
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(12345);
+    $this->wpFunctions->expects($this->at(3))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 1)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 1, 12345)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(1))
+    $this->wpFunctions->expects($this->at(4))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 3)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_UPDATED, 3, 12345)
       ->willReturn(true);
 
-    $this->wpFunctions->expects($this->at(2))
+    $this->wpFunctions->expects($this->at(5))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 5)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_DELETED, 5, 12345)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);
@@ -91,9 +99,11 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
   }
 
   public function testItNotifyUpdateForCreatedSubscriber(): void {
-    $this->wpFunctions->expects($this->once())
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(1235);
+    $this->wpFunctions->expects($this->at(2))
       ->method('doAction')
-      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 11)
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_CREATED, 11, 1235)
       ->willReturn(true);
 
     $notifier = new SubscriberChangesNotifier($this->wpFunctions);

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -147,4 +147,40 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
     $notifier->subscriberUpdated(11);
     $notifier->notify();
   }
+
+  public function testItNotifySubscribersBatchCreate(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('currentTime')
+      ->willReturn(3456);
+    $this->wpFunctions->expects($this->at(1))
+      ->method('currentTime')
+      ->willReturn(98712);
+    $this->wpFunctions->expects($this->at(2))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_MULTIPLE_SUBSCRIBERS_CREATED, 3456)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscribersBatchCreate();
+    $notifier->subscribersBatchCreate();
+    $notifier->notify();
+  }
+
+  public function testItNotifySubscribersBatchUpdate(): void {
+    $this->wpFunctions->expects($this->at(0))
+      ->method('currentTime')
+      ->willReturn(1234);
+    $this->wpFunctions->expects($this->at(1))
+      ->method('currentTime')
+      ->willReturn(123);
+    $this->wpFunctions->expects($this->at(2))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_MULTIPLE_SUBSCRIBERS_UPDATED, 123)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscribersBatchUpdate();
+    $notifier->subscribersBatchUpdate();
+    $notifier->notify();
+  }
 }


### PR DESCRIPTION
## Description

This PR adds new hooks for better integration with other plugins. Here is a list:
- `mailpoet_subscriber_created(int $subscriberId)`
- `mailpoet_subscriber_updated(int $subscriberId)`
- `mailpoet_subscriber_deleted(int $subscriberId)`
- `mailpoet_multiple_subscribers_created(int $minCreatedAtTimestamp)`
- `mailpoet_multiple_subscribers_updated(int $minUpdatedAtTimestamp)`
- `mailpoet_multiple_subscribers_deleted(array $subscriberIds)`

## Code review notes

A new layer was created that contains stored changes from a repository and a listener, which are fired in the WP `shutdown` hook. The new layer should prevent multiple calls of update hooks. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4727]

## After-merge notes

_N/A_


[MAILPOET-4727]: https://mailpoet.atlassian.net/browse/MAILPOET-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ