### PR TITLE
Update getSubscribers filter arguments

### DIFF
--- a/doc/api_methods/GetSubscribers.md
+++ b/doc/api_methods/GetSubscribers.md
@@ -21,5 +21,5 @@ Filter argument supports following array keys.
 | Key            | Type         | Description                                                                                                       |
 | -------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
 | status         | string       | Specific status of subscribers. One of values: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive` |
-| listID         | int          | List id or dynamic segment id                                                                                     |
+| listId         | int          | List id or dynamic segment id                                                                                     |
 | minUpdatedAt   | DateTime\int | DateTime object or timestamp of the minimal last update of subscribers                                            |

--- a/doc/api_methods/GetSubscribers.md
+++ b/doc/api_methods/GetSubscribers.md
@@ -21,5 +21,5 @@ Filter argument supports following array keys.
 | Key            | Type         | Description                                                                                                       |
 | -------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
 | status         | string       | Specific status of subscribers. One of values: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive` |
-| list_id        | int          | List id or dynamic segment id                                                                                     |
-| min_updated_at | DateTime\int | DateTime object or timestamp of the minimal last update of subscribers                                            |
+| listID         | int          | List id or dynamic segment id                                                                                     |
+| minUpdatedAt   | DateTime\int | DateTime object or timestamp of the minimal last update of subscribers                                            |


### PR DESCRIPTION
Filter arguments 'list_id' and 'min_updated_at' do not work. These arguments currently only work with lowerCamelCase.

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_
