### PR TITLE
Fix canceling multiple automatic emails [MAILPOET-4741]

### DIFF
--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -347,6 +347,7 @@ class AbandonedCartTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $scheduledTask->setScheduledAt($scheduleAt);
+    $scheduledTask->setSendingQueue($sendingQueue);
     $scheduledTask->setStatus(($this->currentTime < $scheduleAt) ? ScheduledTaskEntity::STATUS_SCHEDULED : ScheduledTaskEntity::STATUS_COMPLETED);
     $this->entityManager->flush();
 


### PR DESCRIPTION
## Description
This PR fixes the error coming from Doctrine when we cancel multiple scheduled automatic emails for a subscriber.
```
[MailPoetVendor\Doctrine\ORM\ORMInvalidArgumentException] A new entity was found through the relationship 'MailPoet\Entities\ScheduledTaskSubscriberEntity#task' that was not configured to cascade persist operations for entity: MailPoet\Entities\ScheduledTaskEntity@7813. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'MailPoet\Entities\ScheduledTaskEntity#__toString()' to get a clue. 
```

## Code review notes

Please see the commit note

## QA notes

#### Replication

1. Set up two abandoned cart emails
3. Login to a shop as a registered customer who is also a **subscribed** subscriber (you can use admin user)
5. Try to make an order
7. Observe error


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4741]

Fixes #4451

## After-merge notes

_N/A_


[MAILPOET-4741]: https://mailpoet.atlassian.net/browse/MAILPOET-4741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ