### PR TITLE
Deactivate workflow part one [MAILPOET-4730]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_deactivate-modal.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_deactivate-modal.scss
@@ -1,0 +1,44 @@
+.mailpoet-automatoin-deactivate-modal {
+  color: #1d2327;
+  font-size: 13px;
+  line-height: 21px;
+  max-width: 480px;
+
+  .mailpoet-automation-options {
+    li {
+      margin-bottom: 12px;
+    }
+  }
+
+  .mailpoet-automation-option {
+    border: 2px solid #dcdcde;
+    border-radius: 4px;
+    color: #646970;
+    display: grid;
+    font-size: 12px;
+    grid-gap: 8px;
+    grid-template-columns: 20px auto;
+    line-height: 16px;
+    padding: 8px;
+
+    &.active {
+      border-color: #2271b1;
+    }
+
+    strong {
+      color: #1d2327;
+      display: block;
+      font-size: 13px;
+      font-weight: normal;
+      line-height: 21px;
+    }
+  }
+
+  .components-button {
+    float: right;
+
+    &.is-tertiary {
+      margin-right: 12px;
+    }
+  }
+}

--- a/mailpoet/assets/css/src/mailpoet-automation-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-editor.scss
@@ -23,6 +23,7 @@
 @import './components-automation-editor/step-card';
 @import './components-automation-editor/workflow';
 @import './components-automation-editor/notices';
+@import './components-automation-editor/deactivate-modal';
 
 // integrations
 

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -70,12 +70,9 @@ function DeactivateButton(): JSX.Element {
     [],
   );
 
-  const toggleModal = () => {
-    setShowDeactivateModal(!showDeactivateModal);
-  };
   const deactivateOrShowModal = () => {
     if (hasUsersInProgress) {
-      toggleModal();
+      setShowDeactivateModal(true);
       return;
     }
     setIsBusy(true);
@@ -84,7 +81,13 @@ function DeactivateButton(): JSX.Element {
 
   return (
     <>
-      {showDeactivateModal && <DeactivateModal onClose={toggleModal} />}
+      {showDeactivateModal && (
+        <DeactivateModal
+          onClose={() => {
+            setShowDeactivateModal(false);
+          }}
+        />
+      )}
       <Button
         isBusy={isBusy}
         variant="tertiary"

--- a/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Button, Modal } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { dispatch, useSelect } from '@wordpress/data';
+import { storeName } from '../../store';
+import { WorkflowStatus } from '../../../listing/workflow';
+
+export function DeactivateModal({ onClose }): JSX.Element {
+  const { workflowName } = useSelect(
+    (select) => ({
+      workflowName: select(storeName).getWorkflowData().name,
+    }),
+    [],
+  );
+  const [selected, setSelected] = useState<
+    WorkflowStatus.INACTIVE | WorkflowStatus.DEACTIVATING
+  >(WorkflowStatus.DEACTIVATING);
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+  // translators: %s is the name of the automation.
+  const title = sprintf(
+    __('Deactivate the "%s" automation?', 'mailpoet'),
+    workflowName,
+  );
+
+  return (
+    <Modal
+      className="mailpoet-automatoin-deactivate-modal"
+      title={title}
+      onRequestClose={onClose}
+    >
+      {__(
+        "Some subscribers entered but have not finished the flow. Let's decide what to do in this case.",
+        'mailpoet',
+      )}
+      <ul className="mailpoet-automation-options">
+        <li>
+          <label
+            className={
+              selected === WorkflowStatus.DEACTIVATING
+                ? 'mailpoet-automation-option active'
+                : 'mailpoet-automation-option'
+            }
+          >
+            <span>
+              <input
+                type="radio"
+                disabled={isBusy}
+                name="deactivation-method"
+                checked={selected === WorkflowStatus.DEACTIVATING}
+                onChange={() => setSelected(WorkflowStatus.DEACTIVATING)}
+              />
+            </span>
+            <span>
+              <strong>
+                {__('Let entered subscribers finish the flow', 'mailpoet')}
+              </strong>
+              {__(
+                "New subscribers won't enter, but recently entered could proceed.",
+                'mailpoet',
+              )}
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            className={
+              selected === WorkflowStatus.INACTIVE
+                ? 'mailpoet-automation-option active'
+                : 'mailpoet-automation-option'
+            }
+          >
+            <span>
+              <input
+                type="radio"
+                disabled={isBusy}
+                name="deactivation-method"
+                checked={selected === WorkflowStatus.INACTIVE}
+                onChange={() => setSelected(WorkflowStatus.INACTIVE)}
+              />
+            </span>
+            <span>
+              <strong>
+                {__('Stop automation for all subscribers', 'mailpoet')}
+              </strong>
+              {__(
+                'Automation will be deactivated for all the subscribers immediately.',
+                'mailpoet',
+              )}
+            </span>
+          </label>
+        </li>
+      </ul>
+
+      <Button
+        isBusy={isBusy}
+        variant="primary"
+        onClick={() => {
+          setIsBusy(true);
+          if (selected === WorkflowStatus.DEACTIVATING) {
+            // @ToDo Use the correct method provided in MAILPOET-4731
+            dispatch(storeName).deactivate();
+            return;
+          }
+          dispatch(storeName).deactivate();
+        }}
+      >
+        {__('Deactivate automation', 'mailpoet')}
+      </Button>
+
+      <Button disabled={isBusy} variant="tertiary" onClick={onClose}>
+        {__('Cancel', 'mailpoet')}
+      </Button>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -99,6 +99,35 @@ export function* activate() {
   } as const;
 }
 
+// @ToDo: Decide on best naming once MAILPOET-4731 decides about the "deactivating" status name
+export function* deactivate() {
+  const workflow = select(storeName).getWorkflowData();
+  const data = yield apiFetch({
+    path: `/workflows/${workflow.id}`,
+    method: 'PUT',
+    data: {
+      ...workflow,
+      status: 'inactive',
+    },
+  });
+
+  const { createNotice } = dispatch(noticesStore as StoreDescriptor);
+  if (data?.data.status === WorkflowStatus.INACTIVE) {
+    void createNotice(
+      'success',
+      __('Automation is now deactivated!', 'mailpoet'),
+      {
+        type: 'snackbar',
+      },
+    );
+  }
+
+  return {
+    type: 'DEACTIVATE',
+    workflow: data?.data ?? workflow,
+  } as const;
+}
+
 export function* trash(onTrashed: () => void = undefined) {
   const workflow = select(storeName).getWorkflowData();
   const data = yield apiFetch({

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -39,6 +39,12 @@ export function reducer(state: State, action: Action): State {
         workflowData: action.workflow,
         workflowSaved: true,
       };
+    case 'DEACTIVATE':
+      return {
+        ...state,
+        workflowData: action.workflow,
+        workflowSaved: true,
+      };
     case 'TRASH':
       return {
         ...state,

--- a/mailpoet/assets/js/src/automation/listing/workflow.ts
+++ b/mailpoet/assets/js/src/automation/listing/workflow.ts
@@ -3,6 +3,8 @@ export enum WorkflowStatus {
   INACTIVE = 'inactive',
   DRAFT = 'draft',
   TRASH = 'trash',
+  // @ToDo: Needs to be aligned with MAILPOET-4731
+  DEACTIVATING = 'deactivating',
 }
 
 export type Workflow = {


### PR DESCRIPTION
## Description
This implements the first part of the deactivation workflow. To my understanding MAILPOET-4731 will implement the backend logic (I think we need a different status for `deactivating`) as well as the missing pieces of the frontend for the deactivation workflow

## Code review notes
Because both issues (4730 and 4731) are so close aligned, I left some ToDo comments, where I think the decision about e.g. naming should be made in 4731.

## Linked tickets
[MAILPOET-4730]


[MAILPOET-4730]: https://mailpoet.atlassian.net/browse/MAILPOET-4730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ