### PR TITLE
Deactivate workflow part two [MAILPOET-4731]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
@@ -4,6 +4,7 @@ import {
   Button,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
 import { storeName } from '../../store';
 
 export function TrashButton(): JSX.Element {
@@ -30,7 +31,12 @@ export function TrashButton(): JSX.Element {
         onCancel={() => setShowConfirmDialog(false)}
         __experimentalHideHeader={false}
       >
-        You are about to delete the “{workflow.name}” workflow.
+        {sprintf(
+          __('You are about to delete the “%s” workflow.', 'mailpoet'),
+          workflow.name,
+        )}
+        <br />
+        {__(' This will stop it for all subscribers immediately.', 'mailpoet')}
       </ConfirmDialog>
 
       <Button

--- a/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
@@ -32,7 +32,7 @@ export function TrashButton(): JSX.Element {
         __experimentalHideHeader={false}
       >
         {sprintf(
-          __('You are about to delete the “%s” workflow.', 'mailpoet'),
+          __('You are about to delete the "%s" workflow.', 'mailpoet'),
           workflow.name,
         )}
         <br />

--- a/mailpoet/assets/js/src/automation/editor/components/header/document_actions.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/document_actions.tsx
@@ -1,9 +1,9 @@
 import { ComponentProps, ComponentType, Ref } from 'react';
 import {
-  Dropdown as WpDropdown,
-  Button,
-  VisuallyHidden,
   __experimentalText as Text,
+  Button,
+  Dropdown as WpDropdown,
+  VisuallyHidden,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
@@ -38,7 +38,11 @@ export function DocumentActions({ children }): JSX.Element {
   let chipClass = 'mailpoet-automation-editor-chip-gray';
   if (workflowStatus === WorkflowStatus.ACTIVE) {
     chipClass = 'mailpoet-automation-editor-chip-success';
-  } else if (workflowStatus === WorkflowStatus.INACTIVE) {
+  } else if (
+    [WorkflowStatus.INACTIVE, WorkflowStatus.DEACTIVATING].includes(
+      workflowStatus,
+    )
+  ) {
     chipClass = 'mailpoet-automation-editor-chip-danger';
   }
 
@@ -73,10 +77,14 @@ export function DocumentActions({ children }): JSX.Element {
                     size="body"
                     className={`edit-site-document-actions__secondary-item ${chipClass}`}
                   >
-                    {workflowStatus === WorkflowStatus.ACTIVE && __('Active')}
+                    {workflowStatus === WorkflowStatus.ACTIVE &&
+                      __('Active', 'mailpoet')}
                     {workflowStatus === WorkflowStatus.INACTIVE &&
-                      __('Inactive')}
-                    {workflowStatus === WorkflowStatus.DRAFT && __('Draft')}
+                      __('Inactive', 'mailpoet')}
+                    {workflowStatus === WorkflowStatus.DEACTIVATING &&
+                      __('Deactivating', 'mailpoet')}
+                    {workflowStatus === WorkflowStatus.DRAFT &&
+                      __('Draft', 'mailpoet')}
                   </Text>
                 </a>
                 <Button

--- a/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
@@ -5,7 +5,12 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { storeName } from '../../store';
 import { WorkflowStatus } from '../../../listing/workflow';
 
-export function DeactivateImmediatelyModal({ onClose }): JSX.Element {
+type DeactivateImmediatelyModalProps = {
+  onClose: () => void;
+};
+export function DeactivateImmediatelyModal({
+  onClose,
+}: DeactivateImmediatelyModalProps): JSX.Element {
   const [isBusy, setIsBusy] = useState<boolean>(false);
   return (
     <Modal
@@ -38,7 +43,12 @@ export function DeactivateImmediatelyModal({ onClose }): JSX.Element {
   );
 }
 
-export function DeactivateModal({ onClose }): JSX.Element {
+type DeactivateModalProps = {
+  onClose: () => void;
+};
+export function DeactivateModal({
+  onClose,
+}: DeactivateModalProps): JSX.Element {
   const { workflowName } = useSelect(
     (select) => ({
       workflowName: select(storeName).getWorkflowData().name,

--- a/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
@@ -5,6 +5,39 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { storeName } from '../../store';
 import { WorkflowStatus } from '../../../listing/workflow';
 
+export function DeactivateImmediatelyModal({ onClose }): JSX.Element {
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+  return (
+    <Modal
+      className="mailpoet-automatoin-deactivate-modal"
+      title={__('Stop automatoin for all subscribers?', 'mailpoet')}
+      onRequestClose={onClose}
+    >
+      <p>
+        {__(
+          'Are you sure you want to deactivate now? This would stop this automation for all subscribers immediately.',
+          'mailpoet',
+        )}
+      </p>
+
+      <Button
+        isBusy={isBusy}
+        variant="primary"
+        onClick={() => {
+          setIsBusy(true);
+          dispatch(storeName).deactivate(true);
+        }}
+      >
+        {__('Deactivate now', 'mailpoet')}
+      </Button>
+
+      <Button disabled={isBusy} variant="tertiary" onClick={onClose}>
+        {__('Cancel', 'mailpoet')}
+      </Button>
+    </Modal>
+  );
+}
+
 export function DeactivateModal({ onClose }): JSX.Element {
   const { workflowName } = useSelect(
     (select) => ({

--- a/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
@@ -96,11 +96,9 @@ export function DeactivateModal({ onClose }): JSX.Element {
         variant="primary"
         onClick={() => {
           setIsBusy(true);
-          if (selected === WorkflowStatus.DEACTIVATING) {
-            dispatch(storeName).deactivate(false);
-            return;
-          }
-          dispatch(storeName).deactivate();
+          dispatch(storeName).deactivate(
+            selected !== WorkflowStatus.DEACTIVATING,
+          );
         }}
       >
         {__('Deactivate automation', 'mailpoet')}

--- a/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
@@ -97,8 +97,7 @@ export function DeactivateModal({ onClose }): JSX.Element {
         onClick={() => {
           setIsBusy(true);
           if (selected === WorkflowStatus.DEACTIVATING) {
-            // @ToDo Use the correct method provided in MAILPOET-4731
-            dispatch(storeName).deactivate();
+            dispatch(storeName).deactivate(false);
             return;
           }
           dispatch(storeName).deactivate();

--- a/mailpoet/assets/js/src/automation/editor/components/workflow/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/workflow/types.ts
@@ -1,3 +1,5 @@
+import { WorkflowStatus } from '../../../listing/workflow';
+
 export type NextStep = {
   id: string;
 };
@@ -13,7 +15,7 @@ export type Step = {
 export type Workflow = {
   id: number;
   name: string;
-  status: 'active' | 'inactive' | 'draft' | 'trash';
+  status: WorkflowStatus;
   created_at: string;
   updated_at: string;
   activated_at: string;

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -78,7 +78,7 @@ export function* activate() {
     method: 'PUT',
     data: {
       ...workflow,
-      status: 'active',
+      status: WorkflowStatus.ACTIVE,
     },
   });
 
@@ -107,7 +107,7 @@ export function* deactivate() {
     method: 'PUT',
     data: {
       ...workflow,
-      status: 'inactive',
+      status: WorkflowStatus.INACTIVE,
     },
   });
 
@@ -135,13 +135,13 @@ export function* trash(onTrashed: () => void = undefined) {
     method: 'PUT',
     data: {
       ...workflow,
-      status: 'trash',
+      status: WorkflowStatus.TRASH,
     },
   });
 
   onTrashed?.();
 
-  if (data?.status === 'trash') {
+  if (data?.status === WorkflowStatus.TRASH) {
     window.location.href = addQueryArgs(MailPoet.urls.automationListing, {
       [LISTING_NOTICE_PARAMETERS.workflowDeleted]: workflow.id,
     });

--- a/mailpoet/assets/js/src/automation/listing/workflow.ts
+++ b/mailpoet/assets/js/src/automation/listing/workflow.ts
@@ -3,7 +3,6 @@ export enum WorkflowStatus {
   INACTIVE = 'inactive',
   DRAFT = 'draft',
   TRASH = 'trash',
-  // @ToDo: Needs to be aligned with MAILPOET-4731
   DEACTIVATING = 'deactivating',
 }
 

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -44,7 +44,7 @@ class StepHandler {
   private $workflowStorage;
 
   /** @var array<string, StepRunner> */
-  private $stepRunners;
+  private $stepRunners = [];
 
   /** @var WorkflowRunLogStorage */
   private $workflowRunLogStorage;
@@ -85,6 +85,17 @@ class StepHandler {
 
   public function addStepRunner(string $stepType, StepRunner $stepRunner): void {
     $this->stepRunners[$stepType] = $stepRunner;
+  }
+
+  public function getStepRunners(): array {
+    return $this->stepRunners;
+  }
+
+  /**
+   * @param array<string, StepRunner> $stepRunners
+   */
+  public function setStepRunners(array $stepRunners): void {
+    $this->stepRunners = $stepRunners;
   }
 
   /** @param mixed $args */

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -100,7 +100,7 @@ class StepHandler {
       $this->handleStep($args);
     } catch (Throwable $e) {
       $status = $e instanceof InvalidStateException && $e->getErrorCode() === 'mailpoet_automation_workflow_not_active' ? WorkflowRun::STATUS_CANCELLED : WorkflowRun::STATUS_FAILED;
-      $this->workflowRunStorage->updateStatus((int)$args['workflow_run_id'], $status);
+      $this->workflowRunStorage->updateStatus($status, (int)$args['workflow_run_id']);
       if (!$e instanceof Exception) {
         throw new Exception($e->getMessage(), intval($e->getCode()), $e);
       }
@@ -131,7 +131,7 @@ class StepHandler {
 
     // complete workflow run
     if (!$stepId) {
-      $this->workflowRunStorage->updateStatus($workflowRunId, WorkflowRun::STATUS_COMPLETE);
+      $this->workflowRunStorage->updateStatus(WorkflowRun::STATUS_COMPLETE, $workflowRunId);
       return;
     }
 
@@ -183,7 +183,7 @@ class StepHandler {
 
     // no need to schedule a new step if the next step is null, complete the run
     if (!$nextStep) {
-      $this->workflowRunStorage->updateStatus($workflowRunId, WorkflowRun::STATUS_COMPLETE);
+      $this->workflowRunStorage->updateStatus(WorkflowRun::STATUS_COMPLETE, $workflowRunId);
       return;
     }
 

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -100,7 +100,7 @@ class StepHandler {
       $this->handleStep($args);
     } catch (Throwable $e) {
       $status = $e instanceof InvalidStateException && $e->getErrorCode() === 'mailpoet_automation_workflow_not_active' ? WorkflowRun::STATUS_CANCELLED : WorkflowRun::STATUS_FAILED;
-      $this->workflowRunStorage->updateStatus($status, (int)$args['workflow_run_id']);
+      $this->workflowRunStorage->updateStatus((int)$args['workflow_run_id'], $status);
       $this->postProcessWorkflowRun((int)$args['workflow_run_id']);
       if (!$e instanceof Exception) {
         throw new Exception($e->getMessage(), intval($e->getCode()), $e);
@@ -133,7 +133,7 @@ class StepHandler {
 
     // complete workflow run
     if (!$stepId) {
-      $this->workflowRunStorage->updateStatus(WorkflowRun::STATUS_COMPLETE, $workflowRunId);
+      $this->workflowRunStorage->updateStatus($workflowRunId, WorkflowRun::STATUS_COMPLETE);
       return;
     }
 
@@ -185,7 +185,7 @@ class StepHandler {
 
     // no need to schedule a new step if the next step is null, complete the run
     if (!$nextStep) {
-      $this->workflowRunStorage->updateStatus(WorkflowRun::STATUS_COMPLETE, $workflowRunId);
+      $this->workflowRunStorage->updateStatus($workflowRunId, WorkflowRun::STATUS_COMPLETE);
       return;
     }
 

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -228,15 +228,10 @@ class StepHandler {
 
   private function postProcessWorkflow(Workflow $workflow): void {
     if ($workflow->getStatus() === Workflow::STATUS_DEACTIVATING) {
-      $activeRuns = array_filter(
-        $this->workflowRunStorage->getWorkflowRunsForWorkflow($workflow),
-        function(WorkflowRun $run): bool {
-          return $run->getStatus() === WorkflowRun::STATUS_RUNNING;
-        }
-      );
+      $activeRuns = $this->workflowRunStorage->getCountForWorkflow($workflow, WorkflowRun::STATUS_RUNNING);
 
       // Set a deactivating Workflow to inactive once all workflow runs are finished.
-      if (!$activeRuns) {
+      if ($activeRuns === 0) {
         $workflow->setStatus(Workflow::STATUS_INACTIVE);
         $this->workflowStorage->updateWorkflow($workflow);
       }

--- a/mailpoet/lib/Automation/Engine/Data/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Data/Workflow.php
@@ -8,11 +8,13 @@ use MailPoet\Automation\Engine\Utils\Json;
 
 class Workflow {
   public const STATUS_ACTIVE = 'active';
+  public const STATUS_DEACTIVATING = 'deactivating';
   public const STATUS_INACTIVE = 'inactive';
   public const STATUS_DRAFT = 'draft';
   public const STATUS_TRASH = 'trash';
   public const STATUS_ALL = [
     self::STATUS_ACTIVE,
+    self::STATUS_DEACTIVATING,
     self::STATUS_INACTIVE,
     self::STATUS_DRAFT,
     self::STATUS_TRASH,

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -14,6 +14,7 @@ class Exceptions {
   private const JSON_NOT_OBJECT = 'mailpoet_automation_json_not_object';
   private const WORKFLOW_NOT_FOUND = 'mailpoet_automation_workflow_not_found';
   private const WORKFLOW_VERSION_NOT_FOUND = 'mailpoet_automation_workflow_version_not_found';
+  private const WORKFLOW_NOT_ACTIVE = 'mailpoet_automation_workflow_not_active';
   private const WORKFLOW_RUN_NOT_FOUND = 'mailpoet_automation_workflow_run_not_found';
   private const WORKFLOW_STEP_NOT_FOUND = 'mailpoet_automation_workflow_step_not_found';
   private const WORKFLOW_TRIGGER_NOT_FOUND = 'mailpoet_automation_workflow_trigger_not_found';
@@ -70,6 +71,13 @@ class Exceptions {
       ->withErrorCode(self::WORKFLOW_VERSION_NOT_FOUND)
       // translators: %1$s is the ID of the workflow, %2$s the version.
       ->withMessage(sprintf(__('Workflow with ID "%1$s" in version "%2$s" not found.', 'mailpoet'), $workflow, $version));
+  }
+
+  public static function workflowNotActive(int $workflow): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::WORKFLOW_NOT_ACTIVE)
+      // translators: %1$s is the ID of the workflow.
+      ->withMessage(sprintf(__('Workflow with ID "%1$s" in no longer active.', 'mailpoet'), $workflow));
   }
 
   public static function workflowRunNotFound(int $id): NotFoundException {

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunLogStorage.php
@@ -77,4 +77,10 @@ class WorkflowRunLogStorage {
 
     return [];
   }
+
+  public function truncate(): void {
+    $table = esc_sql($this->table);
+    $sql = "truncate $table";
+    $this->wpdb->query($sql);
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -52,13 +52,9 @@ class WorkflowRunStorage {
     ) : [];
   }
 
-  public function updateStatus(string $status, int ...$ids): void {
-    if (!$ids) {
-      return;
-    }
+  public function updateStatus(int $id, string $status): void {
     $table = esc_sql($this->table);
-    $ids = esc_sql(implode(',', $ids));
-    $query = (string)$this->wpdb->prepare("UPDATE $table SET status = %s WHERE id IN ($ids)", $status);
+    $query = (string)$this->wpdb->prepare("UPDATE $table SET status = %s WHERE id = %d", $status, $id);
     $result = $this->wpdb->query($query);
     if ($result === false) {
       throw Exceptions::databaseError($this->wpdb->last_error);

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -34,9 +34,13 @@ class WorkflowRunStorage {
     return $result ? WorkflowRun::fromArray((array)$result) : null;
   }
 
-  public function updateStatus(int $id, string $status): void {
+  public function updateStatus(string $status, int ...$ids): void {
+    if (!$ids) {
+      return;
+    }
     $table = esc_sql($this->table);
-    $query = (string)$this->wpdb->prepare("UPDATE $table SET status = %s WHERE id = %d", $status, $id);
+    $ids = esc_sql(implode(',', $ids));
+    $query = (string)$this->wpdb->prepare("UPDATE $table SET status = %s WHERE id IN ($ids)", $status);
     $result = $this->wpdb->query($query);
     if ($result === false) {
       throw Exceptions::databaseError($this->wpdb->last_error);

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -64,4 +64,9 @@ class WorkflowRunStorage {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }
   }
+
+  public function truncate(): void {
+    $table = esc_sql($this->table);
+    $this->wpdb->query("truncate $table");
+  }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -38,7 +38,6 @@ class WorkflowRunStorage {
   /**
    * @param Workflow $workflow
    * @return WorkflowRun[]
-   * @throws Exceptions\InvalidStateException
    */
   public function getWorkflowRunsForWorkflow(Workflow $workflow): array {
     $table = esc_sql($this->table);
@@ -50,6 +49,18 @@ class WorkflowRunStorage {
       },
       $result
     ) : [];
+  }
+
+  public function getCountForWorkflow(Workflow $workflow, string ...$status): int {
+    if (!count($status)) {
+      return 0;
+    }
+
+    $table = esc_sql($this->table);
+    $statusSql = (string)$this->wpdb->prepare(implode(',', array_fill(0, count($status), '%s')), ...$status);
+    $query = (string)$this->wpdb->prepare( "SELECT count(id) as count from $table where workflow_id = %d and status IN ($statusSql)", $workflow->getId());
+    $result = $this->wpdb->get_col($query);
+    return $result ? (int)current($result) : 0;
   }
 
   public function updateStatus(int $id, string $status): void {

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowRunStorage.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\Storage;
 
+use MailPoet\Automation\Engine\Data\Workflow;
 use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Exceptions;
 use wpdb;
@@ -32,6 +33,23 @@ class WorkflowRunStorage {
     $query = (string)$this->wpdb->prepare("SELECT * FROM $table WHERE id = %d", $id);
     $result = $this->wpdb->get_row($query, ARRAY_A);
     return $result ? WorkflowRun::fromArray((array)$result) : null;
+  }
+
+  /**
+   * @param Workflow $workflow
+   * @return WorkflowRun[]
+   * @throws Exceptions\InvalidStateException
+   */
+  public function getWorkflowRunsForWorkflow(Workflow $workflow): array {
+    $table = esc_sql($this->table);
+    $query = (string)$this->wpdb->prepare("SELECT * FROM $table WHERE workflow_id = %d", $workflow->getId());
+    $result = $this->wpdb->get_results($query, ARRAY_A);
+    return is_array($result) ? array_map(
+      function(array $runData): WorkflowRun {
+        return WorkflowRun::fromArray($runData);
+      },
+      $result
+    ) : [];
   }
 
   public function updateStatus(string $status, int ...$ids): void {

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -46,7 +46,7 @@ parameters:
     - '/Class Automattic\\WooCommerce\\StoreApi\\Schemas\\ExtendSchema not found./'
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 2
+      count: 3
       path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -46,7 +46,7 @@ parameters:
     - '/Class Automattic\\WooCommerce\\StoreApi\\Schemas\\ExtendSchema not found./'
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 3
+      count: 5
       path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -31,11 +31,15 @@ class StepHandlerTest extends \MailPoetTest
   /** @var StepHandler */
   private $testee;
 
+  /** @var array<string, StepRunner> */
+  private $originalRunners = [];
+
   public function _before() {
     $this->testee = $this->diContainer->get(StepHandler::class);
     $this->workflowStorage = $this->diContainer->get(WorkflowStorage::class);
     $this->workflowRunStorage = $this->diContainer->get(WorkflowRunStorage::class);
     $this->workflowRunLogStorage = $this->diContainer->get(WorkflowRunLogStorage::class);
+    $this->originalRunners = $this->testee->getStepRunners();
   }
 
   public function testItDoesOnlyProcessActiveAndDeactivatingWorkflows() {
@@ -158,6 +162,7 @@ class StepHandlerTest extends \MailPoetTest
     $this->workflowStorage->truncate();
     $this->workflowRunStorage->truncate();
     $this->workflowRunLogStorage->truncate();
+    $this->testee->setStepRunners($this->originalRunners);
   }
 
 }

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -11,6 +11,7 @@ use MailPoet\Automation\Engine\Data\WorkflowRun;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Exceptions\NotFoundException;
+use MailPoet\Automation\Engine\Storage\WorkflowRunLogStorage;
 use MailPoet\Automation\Engine\Storage\WorkflowRunStorage;
 use MailPoet\Automation\Engine\Storage\WorkflowStorage;
 use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
@@ -24,6 +25,9 @@ class StepHandlerTest extends \MailPoetTest
   /** @var WorkflowRunStorage */
   private $workflowRunStorage;
 
+  /** @var WorkflowRunLogStorage */
+  private $workflowRunLogStorage;
+
   /** @var StepHandler */
   private $testee;
 
@@ -31,6 +35,7 @@ class StepHandlerTest extends \MailPoetTest
     $this->testee = $this->diContainer->get(StepHandler::class);
     $this->workflowStorage = $this->diContainer->get(WorkflowStorage::class);
     $this->workflowRunStorage = $this->diContainer->get(WorkflowRunStorage::class);
+    $this->workflowRunLogStorage = $this->diContainer->get(WorkflowRunLogStorage::class);
   }
 
   public function testItDoesOnlyProcessActiveAndDeactivatingWorkflows() {
@@ -152,6 +157,7 @@ class StepHandlerTest extends \MailPoetTest
   public function _after() {
     $this->workflowStorage->truncate();
     $this->workflowRunStorage->truncate();
+    $this->workflowRunLogStorage->truncate();
   }
 
 }

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace MailPoet\Test\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Control\StepHandler;
+use MailPoet\Automation\Engine\Control\StepRunner;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Data\WorkflowRun;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Exceptions\NotFoundException;
+use MailPoet\Automation\Engine\Storage\WorkflowRunStorage;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+
+class StepHandlerTest extends \MailPoetTest
+{
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  /** @var WorkflowRunStorage */
+  private $workflowRunStorage;
+
+  /** @var StepHandler */
+  private $testee;
+
+  public function _before() {
+    $this->testee = $this->diContainer->get(StepHandler::class);
+    $this->workflowStorage = $this->diContainer->get(WorkflowStorage::class);
+    $this->workflowRunStorage = $this->diContainer->get(WorkflowRunStorage::class);
+  }
+
+  public function testItDoesOnlyProcessActiveAndDeactivatingWorkflows() {
+    $workflow = $this->createWorkflow();
+    $this->assertInstanceOf(Workflow::class, $workflow);
+    $steps = $workflow->getSteps();
+    $workflowRun = $this->createWorkflowRun($workflow);
+    $this->assertInstanceOf(WorkflowRun::class, $workflowRun);
+
+    $currentStep = current($steps);
+    $this->assertInstanceOf(Step::class, $currentStep);
+    $runner = $this->createMock(StepRunner::class);
+
+    $runner->expects(self::exactly(2))->method('run'); // The run method will be called twice: Once for the active workflow and once for the deactivating workflow.
+
+    $this->testee->addStepRunner($currentStep->getType(), $runner);
+    $this->assertSame(Workflow::STATUS_ACTIVE, $workflow->getStatus());
+    $this->testee->handle(['workflow_run_id' => $workflowRun->getId(), 'step_id' => $currentStep->getId()]);
+    // no exception thrown.
+    $newWorkflowRun = $this->workflowRunStorage->getWorkflowRun($workflowRun->getId());
+    $this->assertInstanceOf(WorkflowRun::class, $newWorkflowRun);
+    $this->assertSame(WorkflowRun::STATUS_RUNNING, $newWorkflowRun->getStatus());
+
+    $workflow->setStatus(Workflow::STATUS_DEACTIVATING);
+    $this->workflowStorage->updateWorkflow($workflow);
+    $this->testee->handle(['workflow_run_id' => $workflowRun->getId(), 'step_id' => $currentStep->getId()]);
+    // no exception thrown.
+    $newWorkflowRun = $this->workflowRunStorage->getWorkflowRun($workflowRun->getId());
+    $this->assertInstanceOf(WorkflowRun::class, $newWorkflowRun);
+    $this->assertSame(WorkflowRun::STATUS_RUNNING, $newWorkflowRun->getStatus());
+
+    $invalidStati = array_filter(
+      Workflow::STATUS_ALL,
+      function(string $status) : bool {
+        return !in_array($status, [Workflow::STATUS_ACTIVE, Workflow::STATUS_DEACTIVATING], true);
+      }
+    );
+
+    foreach ($invalidStati as $status) {
+      $workflow->setStatus($status);
+      $this->workflowStorage->updateWorkflow($workflow);
+      $workflowRun = $this->createWorkflowRun($workflow);
+      $this->assertInstanceOf(WorkflowRun::class, $workflowRun);
+      $error = null;
+      try {
+        $this->testee->handle(['workflow_run_id' => $workflowRun->getId(), 'step_id' => $currentStep->getId()]);
+      } catch (InvalidStateException $error) {
+        $this->assertSame('mailpoet_automation_workflow_not_active', $error->getErrorCode(), "Workflow with '$status' did not return expected error code.");
+      }
+      $this->assertInstanceOf(InvalidStateException::class, $error);
+
+      $newWorkflowRun = $this->workflowRunStorage->getWorkflowRun($workflowRun->getId());
+      $this->assertInstanceOf(WorkflowRun::class, $newWorkflowRun);
+
+      $this->assertSame(WorkflowRun::STATUS_CANCELLED, $newWorkflowRun->getStatus());
+    }
+  }
+
+  private function createWorkflow(): ?Workflow {
+    $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
+    $delay = $this->diContainer->get(DelayAction::class);
+    $steps = [
+      'root' => new Step('root', Step::TYPE_ROOT, 'root', [], [new NextStep('someone-subscribes')]),
+      'someone-subscribes' => new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
+      'delay' => new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], []),
+    ];
+    $workflow = new Workflow('test', $steps, wp_get_current_user());
+    $workflow->setStatus(Workflow::STATUS_ACTIVE);
+    return $this->workflowStorage->getWorkflow($this->workflowStorage->createWorkflow($workflow));
+  }
+
+  private function createWorkflowRun(Workflow $workflow, $subjects = []) : ?WorkflowRun {
+    $trigger = array_filter($workflow->getSteps(), function(Step $step) : bool { return $step->getType() === Step::TYPE_TRIGGER;});
+    $triggerKeys = array_map(function(Step $step) : string { return $step->getKey();}, $trigger);
+    $triggerKey = count($triggerKeys)>0?current($triggerKeys):'';
+
+    $workflowRun = new WorkflowRun(
+      $workflow->getId(),
+      $workflow->getVersionId(),
+      $triggerKey,
+      $subjects
+    );
+    return $this->workflowRunStorage->getWorkflowRun($this->workflowRunStorage->createWorkflowRun($workflowRun));
+  }
+
+}

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -223,15 +223,9 @@ class WorkflowRunLogTest extends \MailPoetTest {
   }
 
   public function _after() {
-    global $wpdb;
-    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_run_logs';
-    $wpdb->query($sql);
-    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflows';
-    $wpdb->query($sql);
-    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_versions';
-    $wpdb->query($sql);
-    $sql = 'truncate ' . $wpdb->prefix . 'mailpoet_workflow_runs';
-    $wpdb->query($sql);
+    $this->workflowRunStorage->truncate();
+    $this->workflowStorage->truncate();
+    $this->workflowRunLogStorage->truncate();
   }
 
   private function getLogsForAction($callback = null) {

--- a/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/WorkflowRunLogTest.php
@@ -156,6 +156,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
     $testAction = $this->getRegisteredTestAction();
     $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey(), [], []);
     $workflow = new Workflow('test_workflow', [$actionStep->getId() => $actionStep], new \WP_User());
+    $workflow->setStatus(Workflow::STATUS_ACTIVE);
     $workflowId = $this->workflowStorage->createWorkflow($workflow);
     // Reload to get additional data post-save
     $workflow = $this->workflowStorage->getWorkflow($workflowId);
@@ -242,6 +243,7 @@ class WorkflowRunLogTest extends \MailPoetTest {
     $testAction = $this->getRegisteredTestAction($callback);
     $actionStep = new Step('action-step-id', Step::TYPE_ACTION, $testAction->getKey(), [], []);
     $workflow = new Workflow('test_workflow', [$actionStep->getId() => $actionStep], new \WP_User());
+    $workflow->setStatus(Workflow::STATUS_ACTIVE);
     $workflowId = $this->workflowStorage->createWorkflow($workflow);
     // Reload to get additional data post-save
     $workflow = $this->workflowStorage->getWorkflow($workflowId);


### PR DESCRIPTION
Updates the deactivation logic and the button's in the Workflow Editor.

This PR also ensures that only WorkflowRuns from Workflows which are `active` or `deactivating` to be executed. The StepHandler has been extended to set a deactivating Workflow to `inactive` once all runs are executed.

## Linked tickets
[MAILPOET-4731]


[MAILPOET-4731]: https://mailpoet.atlassian.net/browse/MAILPOET-4731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ