### PR TITLE
Prevent duplicate post notifications [MAILPOET-4750]

### DIFF
--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -20,7 +20,6 @@ use MailPoet\Newsletter\Scheduler\Scheduler as NewsletterScheduler;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -55,9 +54,6 @@ class Scheduler {
   /** @var NewsletterSegmentRepository */
   private $newsletterSegmentRepository;
 
-  /** @var SendingQueuesRepository */
-  private $sendingQueuesRepository;
-
   /** @var WPFunctions */
   private $wp;
 
@@ -76,7 +72,6 @@ class Scheduler {
     NewslettersRepository $newslettersRepository,
     SegmentsRepository $segmentsRepository,
     NewsletterSegmentRepository $newsletterSegmentRepository,
-    SendingQueuesRepository $sendingQueuesRepository,
     WPFunctions $wp,
     Security $security,
     NewsletterScheduler $scheduler
@@ -89,7 +84,6 @@ class Scheduler {
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newsletterSegmentRepository = $newsletterSegmentRepository;
-    $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->wp = $wp;
     $this->security = $security;
     $this->scheduler = $scheduler;
@@ -220,7 +214,7 @@ class Scheduler {
 
     // Because there is mixed usage of the old and new model, we want to be sure about the correct state
     $this->newslettersRepository->refresh($notificationHistory);
-    $this->sendingQueuesRepository->refresh($queue->getSendingQueueEntity());
+    $queue->getSendingQueueEntity(); // This call refreshes sending queue entity
 
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
       'post notification set status to sending',

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -168,8 +168,8 @@ class Sending {
   }
 
   public function save() {
-    $this->task->save();
     $this->queue->save();
+    $this->task->save();
     $errors = $this->getErrors();
     if ($errors) {
       $loggerFactory = LoggerFactory::getInstance();

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -194,6 +194,7 @@ class Sending {
   public function getSendingQueueEntity(): SendingQueueEntity {
     $sendingQueuesRepository = ContainerWrapper::getInstance()->get(SendingQueuesRepository::class);
     $sendingQueueEntity = $sendingQueuesRepository->findOneById($this->queue->id);
+    $sendingQueuesRepository->refresh($sendingQueueEntity);
 
     return $sendingQueueEntity;
   }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -31,7 +31,6 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -73,9 +72,6 @@ class SchedulerTest extends \MailPoetTest {
   /** @var NewsletterSegmentRepository */
   private $newsletterSegmentRepository;
 
-  /** @var SendingQueuesRepository */
-  private $sendingQueuesRepository;
-
   /** @var Security */
   private $security;
 
@@ -91,7 +87,6 @@ class SchedulerTest extends \MailPoetTest {
     $this->newsletterScheduler = $this->diContainer->get(NewsletterScheduler::class);
     $this->newsletterOptionFactory = new NewsletterOptionFactory();
     $this->newsletterSegmentRepository = $this->diContainer->get(NewsletterSegmentRepository::class);
-    $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->security = $this->diContainer->get(Security::class);
   }
 
@@ -541,7 +536,6 @@ class SchedulerTest extends \MailPoetTest {
         $this->newslettersRepository,
         $this->segmentsRepository,
         $this->newsletterSegmentRepository,
-        $this->sendingQueuesRepository,
         WPFunctions::get(),
         $this->security,
         $this->newsletterScheduler,


### PR DESCRIPTION
## Description

This PR adds two improvements that should prevent sending duplicate post notifications.

## Code review notes
Please see the commit descriptions.

## QA notes
Please verify that the plugin works with multiple active post-notification emails (both immediate and scheduled).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4750]

## After-merge notes

_N/A_


[MAILPOET-4750]: https://mailpoet.atlassian.net/browse/MAILPOET-4750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ