### PR TITLE
Let users display forms on the product lists - MAILPOET-4663

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -202,6 +202,10 @@ class Hooks {
       'the_content',
       [$this->displayFormInWPContent, 'display']
     );
+    $this->wp->addFilter(
+      'woocommerce_product_loop_end',
+      [$this->displayFormInWPContent, 'display']
+    );
   }
 
   public function setupMailer() {

--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -117,12 +117,11 @@ class DisplayFormInWPContent {
   private function displayFormInListingPage(): bool {
     $displayCheck = $this->wp->applyFilters('mailpoet_display_form_in_product_listing', true);
 
-    if (function_exists('wc_get_page_id')) {
-      $shopPageId = wc_get_page_id('shop');
-      $this->wooShopPageId = $shopPageId && $shopPageId >= 0 ? $shopPageId : null;
-      if ($displayCheck && !is_null($this->wooShopPageId) && $this->wp->isPage($shopPageId)) {
-        return true;
-      }
+    $shopPageId = $this->wp->wcGetPageId('shop');
+    $this->wooShopPageId = $shopPageId && $shopPageId >= 0 ? $shopPageId : null;
+
+    if ($displayCheck && !is_null($this->wooShopPageId) && $this->wp->isPage($this->wooShopPageId)) {
+      return true;
     }
 
     return $displayCheck && $this->wp->isArchive() && $this->wp->isPostTypeArchive('product');

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -769,13 +769,6 @@ class Functions {
     return wp_set_script_translations($handle, $domain, $path);
   }
 
-  public function wcGetPageId(string $page): ?int {
-    if (function_exists('wc_get_page_id')) {
-      return wc_get_page_id($page);
-    }
-    return null;
-  }
-
   /**
    * @return \WP_Scripts
    */

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -769,6 +769,13 @@ class Functions {
     return wp_set_script_translations($handle, $domain, $path);
   }
 
+  public function wcGetPageId(string $page): ?int {
+    if (function_exists('wc_get_page_id')) {
+      return wc_get_page_id($page);
+    }
+    return null;
+  }
+
   /**
    * @return \WP_Scripts
    */

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -658,6 +658,29 @@ class Functions {
   }
 
   /**
+   * Determines whether the query is for an existing archive page.
+   *
+   * Archive pages include category, tag, author, date, custom post type,
+   * and custom taxonomy based archives.
+   *
+   * @return bool Whether the query is for an existing archive page.
+   */
+  public function isArchive(): bool {
+    return is_archive();
+  }
+
+  /**
+   * Determines whether the query is for an existing post type archive page.
+   *
+   * @param string|string[] $postTypes Optional. Post type or array of posts types
+   *                                    to check against. Default empty.
+   * @return bool Whether the query is for an existing post type archive page.
+   */
+  public function isPostTypeArchive($postTypes = ''): bool {
+    return is_post_type_archive($postTypes);
+  }
+
+  /**
    * @param string $package
    * @param array $args
    * @return bool|WP_Error

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -61,6 +61,13 @@ class Helper {
     return wc_get_product($theProduct);
   }
 
+  public function wcGetPageId(string $page): ?int {
+    if (function_exists('wc_get_page_id')) {
+      return wc_get_page_id($page);
+    }
+    return null;
+  }
+
   public function getWoocommerceCurrency() {
     return get_woocommerce_currency();
   }

--- a/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
+++ b/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\SubscriberSubscribeController;
+use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -36,6 +37,9 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
   /** @var SubscriberSubscribeController & MockObject */
   private $subscriberSubscribeController;
 
+  /** @var WCHelper & MockObject */
+  private $woocommerceHelper;
+
   // fix for method return override
   private $applyFiltersValue = false;
 
@@ -56,6 +60,7 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
     $this->renderer->expects($this->any())->method('renderHTML')->willReturn('<form></form>');
     $this->subscribersRepository = $this->createMock( SubscribersRepository::class);
     $this->subscriberSubscribeController = $this->createMock(SubscriberSubscribeController::class);
+    $this->woocommerceHelper = $this->createMock(WCHelper::class);
     $this->hook = new DisplayFormInWPContent(
       $this->wp,
       $this->repository,
@@ -63,7 +68,8 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
       $this->assetsController,
       $this->templateRenderer,
       $this->subscriberSubscribeController,
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->woocommerceHelper
     );
   }
 
@@ -317,9 +323,9 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
     $this->wp->expects($this->once())->method('isSingle')->willReturn(false);
     $this->wp->expects($this->any())->method('isSingular')->willReturn(false);
     $this->wp->expects($this->any())->method('isArchive')->willReturn(true);
-    $this->wp->expects($this->any())->method('wcGetPageId')->willReturn(1);
     $this->wp->expects($this->any())->method('isPostTypeArchive')->willReturn(true);
     $this->wp->expects($this->any())->method('getPost')->willReturn(['ID' => 1]);
+    $this->woocommerceHelper->expects($this->any())->method('wcGetPageId')->willReturn(1);
     $this->assetsController->expects($this->once())->method('setupFrontEndDependencies');
     $this->templateRenderer->expects($this->once())->method('render')->willReturn($renderedForm);
 
@@ -348,9 +354,9 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
     $this->wp->expects($this->once())->method('isSingle')->willReturn(false);
     $this->wp->expects($this->any())->method('isSingular')->willReturn(false);
     $this->wp->expects($this->any())->method('isArchive')->willReturn(true);
-    $this->wp->expects($this->any())->method('wcGetPageId')->willReturn(1);
     $this->wp->expects($this->any())->method('isPostTypeArchive')->willReturn(true);
     $this->wp->expects($this->any())->method('getPost')->willReturn(['ID' => 1]);
+    $this->woocommerceHelper->expects($this->any())->method('wcGetPageId')->willReturn(1);
     $this->assetsController->expects($this->once())->method('setupFrontEndDependencies');
     $this->templateRenderer->expects($this->once())->method('render')->willReturn($renderedForm);
 
@@ -379,9 +385,9 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
     $this->wp->expects($this->once())->method('isSingle')->willReturn(false);
     $this->wp->expects($this->any())->method('isSingular')->willReturn(false);
     $this->wp->expects($this->any())->method('isArchive')->willReturn(true);
-    $this->wp->expects($this->any())->method('wcGetPageId')->willReturn(1);
     $this->wp->expects($this->any())->method('isPostTypeArchive')->willReturn(true);
     $this->wp->expects($this->any())->method('getPost')->willReturn(['ID' => 1]);
+    $this->woocommerceHelper->expects($this->any())->method('wcGetPageId')->willReturn(1);
     $this->assetsController->expects($this->never())->method('setupFrontEndDependencies');
     $this->templateRenderer->expects($this->never())->method('render')->willReturn($renderedForm);
 


### PR DESCRIPTION
## Description

Add support for displaying forms on the WooCommerce Shop product listing page


## QA notes

* Make sure to select the Shop product listing page or show forms on all pages


## Linked tickets

[MAILPOET-4663](https://mailpoet.atlassian.net/browse/MAILPOET-4663)


