### PR TITLE
Fix issue of site-url in none-lowercase failing validation [MAILPOET-4754]

### DIFF
--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -57,7 +57,7 @@ class API {
   public function checkMSSKey() {
     $result = $this->request(
       $this->urlMe,
-      ['site' => WPFunctions::get()->homeUrl()]
+      ['site' => strtolower(WPFunctions::get()->homeUrl())]
     );
 
     $code = $this->wp->wpRemoteRetrieveResponseCode($result);
@@ -77,7 +77,7 @@ class API {
   public function checkPremiumKey() {
     $result = $this->request(
       $this->urlPremium,
-      ['site' => WPFunctions::get()->homeUrl()]
+      ['site' => strtolower(WPFunctions::get()->homeUrl())]
     );
 
     $code = $this->wp->wpRemoteRetrieveResponseCode($result);


### PR DESCRIPTION
## Description

When validating the MSS/Premium keys sending a none-lowercase site-url would cause the bridge to correctly validating

## QA notes

To reproduce the issue:
1) Using the master branch, change the `Site Address (URL)` in `wp-admin/options-general.php`  to camelcase or all caps of your current site address 
2) Try to verify a valid MailPoet key and see the failure


## Linked tickets

[MAILPOET-4754]



[MAILPOET-4754]: https://mailpoet.atlassian.net/browse/MAILPOET-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ