### PR TITLE
Add new API list methods [MAILPOET-4752]

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -38,6 +38,7 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 - [Subscribe to Lists (subscribeToLists)](api_methods/SubscribeToLists.md)
 - [Unsubscribe from List (unsubscribeFromList)](api_methods/UnsubscribeFromList.md)
 - [Unsubscribe from Lists (unsubscribeFromLists)](api_methods/UnsubscribeFromLists.md)
+- [Update List (updateList)](api_methods/UpdateList.md)
 
 ### Usage examples
 

--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -28,6 +28,7 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 - [Add List (addList)](api_methods/AddList.md)
 - [Add Subscriber (addSubscriber)](api_methods/AddSubscriber.md)
 - [Add Subscriber Field (addSubscriberField)](api_methods/AddSubscriberField.md)
+- [Delete List (deleteList)](api_methods/DeleteList.md)
 - [Get Lists (getLists)](api_methods/GetLists.md)
 - [Get Subscriber (getSubscriber)](api_methods/GetSubscriber.md)
 - [Get Subscribers (getSubscribers)](api_methods/GetSubscribers.md)

--- a/doc/api_methods/DeleteList.md
+++ b/doc/api_methods/DeleteList.md
@@ -1,0 +1,26 @@
+[back to list](../Readme.md)
+
+# Delete List
+
+## `bool deleteList(string $list_id)`
+
+This method provides functionality for deleting a new list.
+
+It returns a boolean value.
+
+## Error handling
+
+All expected errors from the API are exceptions of class `\MailPoet\API\MP\v1\APIException`.
+Code of the exception is populated to distinguish between different errors.
+
+An exception of base class `\Exception` can be thrown when something unexpected happens.
+
+Codes description:
+
+| Code | Description                                                     |
+| ---- | --------------------------------------------------------------- |
+| 5    | List does not exist                                             |
+| 18   | List id is empty                                                |
+| 20   | List cannot be deleted because it’s used for an automatic email |
+| 21   | List cannot be deleted because it’s used for a form             |
+| 22   | The list couldn’t be deleted from the database                  |

--- a/doc/api_methods/DeleteList.md
+++ b/doc/api_methods/DeleteList.md
@@ -4,7 +4,7 @@
 
 ## `bool deleteList(string $list_id)`
 
-This method provides functionality for deleting a new list.
+This method provides functionality for deleting a list that is of the type 'default'.
 
 It returns a boolean value.
 
@@ -24,3 +24,4 @@ Codes description:
 | 20   | List cannot be deleted because it’s used for an automatic email |
 | 21   | List cannot be deleted because it’s used for a form             |
 | 22   | The list couldn’t be deleted from the database                  |
+| 23   | Only lists of the type 'default' can be deleted                 |

--- a/doc/api_methods/UpdateList.md
+++ b/doc/api_methods/UpdateList.md
@@ -1,0 +1,38 @@
+[back to list](../Readme.md)
+
+# Add Subscriber
+
+## `array updateList(array $list)`
+
+This method provides functionality for updating a list name or description.
+
+It returns the updated list. See [Get Lists](GetLists.md) for a list data structure description.
+
+## Arguments
+
+### `$list` (required)
+
+An associative array which contains list data.
+
+| Property               | Type         | Limits    | Description                |
+| ---------------------- | ------------ | --------- | -------------------------- |
+| id (required)          | string       | 11 chars  | A id of the list.          |
+| name (required)        | string       | 90 chars  | A name of the list.        |
+| description (optional) | string\|null | 250 chars | A description of the list. |
+
+## Error handling
+
+All expected errors from the API are exceptions of class `\MailPoet\API\MP\v1\APIException`.
+Code of the exception is populated to distinguish between different errors.
+
+An exception of base class `\Exception` can be thrown when something unexpected happens.
+
+Codes description:
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 5    | The list was not found by id                 |
+| 14   | Missing list name                            |
+| 15   | Trying to use a list that is already used    |
+| 18   | Missing list id                              |
+| 19   | The list couldn’t be updated in the database |

--- a/doc/api_methods/UpdateList.md
+++ b/doc/api_methods/UpdateList.md
@@ -4,7 +4,7 @@
 
 ## `array updateList(array $list)`
 
-This method provides functionality for updating a list name or description.
+This method provides functionality for updating a list name or description. Only lists of type 'default' are supported.
 
 It returns the updated list. See [Get Lists](GetLists.md) for a list data structure description.
 
@@ -29,10 +29,11 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                  |
-| ---- | -------------------------------------------- |
-| 5    | The list was not found by id                 |
-| 14   | Missing list name                            |
-| 15   | Trying to use a list that is already used    |
-| 18   | Missing list id                              |
-| 19   | The list couldn’t be updated in the database |
+| Code | Description                                     |
+| ---- | ----------------------------------------------- |
+| 5    | The list was not found by id                    |
+| 14   | Missing list name                               |
+| 15   | Trying to use a list name that is already used  |
+| 18   | Missing list id                                 |
+| 19   | The list couldn’t be updated in the database    |
+| 23   | Only lists of the type 'default' can be updated |

--- a/mailpoet/lib/API/MP/v1/API.php
+++ b/mailpoet/lib/API/MP/v1/API.php
@@ -80,6 +80,10 @@ class API {
     return $this->segments->addList($list);
   }
 
+  public function deleteList(string $listId): bool {
+    return $this->segments->deleteList($listId);
+  }
+
   public function updateList(array $list): array {
     return $this->segments->updateList($list);
   }

--- a/mailpoet/lib/API/MP/v1/API.php
+++ b/mailpoet/lib/API/MP/v1/API.php
@@ -80,6 +80,10 @@ class API {
     return $this->segments->addList($list);
   }
 
+  public function updateList(array $list): array {
+    return $this->segments->updateList($list);
+  }
+
   public function getSubscriber($subscriberEmail) {
     return $this->subscribers->getSubscriber($subscriberEmail);
   }

--- a/mailpoet/lib/API/MP/v1/APIException.php
+++ b/mailpoet/lib/API/MP/v1/APIException.php
@@ -20,4 +20,7 @@ class APIException extends \Exception {
   const WELCOME_FAILED_TO_SEND = 17;
   const LIST_ID_REQUIRED = 18;
   const FAILED_TO_UPDATE_LIST = 19;
+  const LIST_USED_IN_EMAIL = 20;
+  const LIST_USED_IN_FORM = 21;
+  const FAILED_TO_DELETE_LIST = 22;
 }

--- a/mailpoet/lib/API/MP/v1/APIException.php
+++ b/mailpoet/lib/API/MP/v1/APIException.php
@@ -18,4 +18,6 @@ class APIException extends \Exception {
   const LIST_EXISTS = 15;
   const FAILED_TO_SAVE_LIST = 16;
   const WELCOME_FAILED_TO_SEND = 17;
+  const LIST_ID_REQUIRED = 18;
+  const FAILED_TO_UPDATE_LIST = 19;
 }

--- a/mailpoet/lib/API/MP/v1/APIException.php
+++ b/mailpoet/lib/API/MP/v1/APIException.php
@@ -23,4 +23,5 @@ class APIException extends \Exception {
   const LIST_USED_IN_EMAIL = 20;
   const LIST_USED_IN_FORM = 21;
   const FAILED_TO_DELETE_LIST = 22;
+  const LIST_TYPE_IS_NOT_SUPPORTED = 23;
 }

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -43,19 +43,7 @@ class Segments {
 
   public function updateList(array $data): array {
     // firstly validation on list id
-    if (empty($data['id'])) {
-      throw new APIException(
-        __('List id is required.', 'mailpoet'),
-        APIException::LIST_ID_REQUIRED
-      );
-    }
-
-    if (!$this->segmentsRepository->findOneById((string)$data['id'])) {
-      throw new APIException(
-        __('The list does not exist.', 'mailpoet'),
-        APIException::LIST_NOT_EXISTS
-      );
-    }
+    $this->validateSegmentId((string)($data['id'] ?? ''));
 
     // secondly validation on list name
     $this->validateSegmentName($data);
@@ -76,6 +64,22 @@ class Segments {
     }
 
     return $this->buildItem($segment);
+  }
+
+  private function validateSegmentId(string $segmentId): void {
+    if (empty($segmentId)) {
+      throw new APIException(
+        __('List id is required.', 'mailpoet'),
+        APIException::LIST_ID_REQUIRED
+      );
+    }
+
+    if (!$this->segmentsRepository->findOneById($segmentId)) {
+      throw new APIException(
+        __('The list does not exist.', 'mailpoet'),
+        APIException::LIST_NOT_EXISTS
+      );
+    }
   }
 
   /**

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -84,6 +84,9 @@ class Segments {
   public function deleteList(string $listId): bool {
     $this->validateSegmentId($listId);
 
+    // delete is supported only for default segment type
+    $this->validateSegmentType($listId);
+
     $activelyUsedNewslettersSubjects = $this->newsletterSegmentRepository->getSubjectsOfActivelyUsedEmailsForSegments([$listId]);
     if (isset($activelyUsedNewslettersSubjects[$listId])) {
       throw new APIException(

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -27,6 +27,26 @@ class Segments {
   }
 
   public function addList(array $data): array {
+    $this->validateSegmentName($data);
+
+    try {
+      $segment = $this->segmentsRepository->createOrUpdate($data['name'], $data['description'] ?? '');
+    } catch (\Exception $e) {
+      throw new APIException(
+        // translators: %s is the error message
+        sprintf(__('Failed to add subscriber: %s', 'mailpoet'), $e->getMessage()),
+        APIException::FAILED_TO_SAVE_LIST
+      );
+    }
+
+    return $this->buildItem($segment);
+  }
+
+  /**
+   * Throws an exception when the segment's name is invalid
+   * @return void
+   */
+  private function validateSegmentName(array $data): void {
     if (empty($data['name'])) {
       throw new APIException(
         __('List name is required.', 'mailpoet'),
@@ -40,18 +60,6 @@ class Segments {
         APIException::LIST_EXISTS
       );
     }
-
-    try {
-      $segment = $this->segmentsRepository->createOrUpdate($data['name'], $data['description'] ?? '');
-    } catch (\Exception $e) {
-      throw new APIException(
-        // translators: %s is the error message
-        sprintf(__('Failed to add subscriber: %s', 'mailpoet'), $e->getMessage()),
-        APIException::FAILED_TO_SAVE_LIST
-      );
-    }
-
-    return $this->buildItem($segment);
   }
 
   /**

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -33,8 +33,7 @@ class Segments {
       $segment = $this->segmentsRepository->createOrUpdate($data['name'], $data['description'] ?? '');
     } catch (\Exception $e) {
       throw new APIException(
-        // translators: %s is the error message
-        sprintf(__('Failed to add subscriber: %s', 'mailpoet'), $e->getMessage()),
+        __('The list couldn’t be created in the database', 'mailpoet'),
         APIException::FAILED_TO_SAVE_LIST
       );
     }

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -60,6 +60,9 @@ class Segments {
     // secondly validation on list name
     $this->validateSegmentName($data);
 
+    // update is supported only for default segment type
+    $this->validateSegmentType((string)$data['id']);
+
     try {
       $segment = $this->segmentsRepository->createOrUpdate(
         $data['name'],
@@ -156,6 +159,21 @@ class Segments {
       throw new APIException(
         __('This list already exists.', 'mailpoet'),
         APIException::LIST_EXISTS
+      );
+    }
+  }
+
+  private function validateSegmentType(string $segmentId): void {
+    $segment = $this->segmentsRepository->findOneById($segmentId);
+    if ($segment && $segment->getType() !== SegmentEntity::TYPE_DEFAULT) {
+      throw new APIException(
+        str_replace(
+          '%1$s',
+          "'" . $segment->getType() . "'",
+          // translators: %1$s is an invalid segment type.
+          __('List of the type %1$s is not supported for this action.', 'mailpoet')
+        ),
+        APIException::LIST_TYPE_IS_NOT_SUPPORTED
       );
     }
   }

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -66,7 +66,7 @@ class Segments {
         $data['description'] ?? '',
         SegmentEntity::TYPE_DEFAULT,
         [],
-        $data['id']
+        (int)$data['id']
       );
     } catch (\Exception $e) {
       throw new APIException(

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -41,6 +41,43 @@ class Segments {
     return $this->buildItem($segment);
   }
 
+  public function updateList(array $data): array {
+    // firstly validation on list id
+    if (empty($data['id'])) {
+      throw new APIException(
+        __('List id is required.', 'mailpoet'),
+        APIException::LIST_ID_REQUIRED
+      );
+    }
+
+    if (!$this->segmentsRepository->findOneById((string)$data['id'])) {
+      throw new APIException(
+        __('The list does not exist.', 'mailpoet'),
+        APIException::LIST_NOT_EXISTS
+      );
+    }
+
+    // secondly validation on list name
+    $this->validateSegmentName($data);
+
+    try {
+      $segment = $this->segmentsRepository->createOrUpdate(
+        $data['name'],
+        $data['description'] ?? '',
+        SegmentEntity::TYPE_DEFAULT,
+        [],
+        $data['id']
+      );
+    } catch (\Exception $e) {
+      throw new APIException(
+        __('The list couldn’t be updated in the database', 'mailpoet'),
+        APIException::FAILED_TO_UPDATE_LIST
+      );
+    }
+
+    return $this->buildItem($segment);
+  }
+
   /**
    * Throws an exception when the segment's name is invalid
    * @return void

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -3,17 +3,29 @@
 namespace MailPoet\API\MP\v1;
 
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Form\FormsRepository;
+use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Segments\SegmentsRepository;
 
 class Segments {
   private const DATE_FORMAT = 'Y-m-d H:i:s';
 
+  /** @var NewsletterSegmentRepository */
+  private $newsletterSegmentRepository;
+
+  /** @var FormsRepository */
+  private $formsRepository;
+
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
   public function __construct (
+    NewsletterSegmentRepository $newsletterSegmentRepository,
+    FormsRepository $formsRepository,
     SegmentsRepository $segmentsRepository
   ) {
+    $this->newsletterSegmentRepository = $newsletterSegmentRepository;
+    $this->formsRepository = $formsRepository;
     $this->segmentsRepository = $segmentsRepository;
   }
 
@@ -64,6 +76,52 @@ class Segments {
     }
 
     return $this->buildItem($segment);
+  }
+
+  public function deleteList(string $listId): bool {
+    $this->validateSegmentId($listId);
+
+    $activelyUsedNewslettersSubjects = $this->newsletterSegmentRepository->getSubjectsOfActivelyUsedEmailsForSegments([$listId]);
+    if (isset($activelyUsedNewslettersSubjects[$listId])) {
+      throw new APIException(
+        str_replace(
+          '%1$s',
+          "'" . join("', '", $activelyUsedNewslettersSubjects[$listId] ) . "'",
+          // translators: %1$s is a comma-seperated list of emails for which the segment is used.
+          _x('List cannot be deleted because it’s used for %1$s email', 'Alert shown when trying to delete segment, which is assigned to any automatic emails.', 'mailpoet')
+        ),
+        APIException::LIST_USED_IN_EMAIL
+      );
+    }
+
+    $activelyUsedFormNames = $this->formsRepository->getNamesOfFormsForSegments();
+    if (isset($activelyUsedFormNames[$listId])) {
+      throw new APIException(
+        str_replace(
+          '%1$s',
+          "'" . join("', '", $activelyUsedFormNames[$listId] ) . "'",
+          // translators: %1$s is a comma-seperated list of forms for which the segment is used.
+          _nx(
+            'List cannot be deleted because it’s used for %1$s form',
+            'List cannot be deleted because it’s used for %1$s forms',
+            count($activelyUsedFormNames[$listId]),
+            'Alert shown when trying to delete segment, when it is assigned to a form.',
+            'mailpoet'
+          )
+        ),
+        APIException::LIST_USED_IN_FORM
+      );
+    }
+
+    try {
+      $this->segmentsRepository->bulkDelete([$listId]);
+      return true;
+    } catch (\Exception $e) {
+      throw new APIException(
+        __('The list couldn’t be deleted from the database', 'mailpoet'),
+        APIException::FAILED_TO_DELETE_LIST
+      );
+    }
   }
 
   private function validateSegmentId(string $segmentId): void {

--- a/mailpoet/tests/integration/API/MP/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/MP/SegmentsTest.php
@@ -168,6 +168,18 @@ class SegmentsTest extends \MailPoetTest {
     expect($result['description'])->equals($data['description']);
   }
 
+  public function testItDoesNotAllowUpdateWPSegment(): void {
+    $wpSegment = $this->segmentsRepository->getWPUsersSegment();
+    $this->assertInstanceOf(SegmentEntity::class, $wpSegment);
+    try {
+      $this->getApi()->updateList(['id' => $wpSegment->getId(), 'name' => 'Test']);
+      $this->fail('WP list cannot be updated.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('List of the type \'' . $wpSegment->getType() . '\' is not supported for this action.');
+      expect($e->getCode())->equals(APIException::LIST_TYPE_IS_NOT_SUPPORTED);
+    }
+  }
+
   public function testItRequiresIdToDeleteList(): void {
     try {
       $this->getApi()->deleteList('');

--- a/mailpoet/tests/integration/API/MP/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/MP/SegmentsTest.php
@@ -229,6 +229,18 @@ class SegmentsTest extends \MailPoetTest {
     }
   }
 
+  public function testItDoesNotAllowDeletingWPSegment(): void {
+    $wpSegment = $this->segmentsRepository->getWPUsersSegment();
+    $this->assertInstanceOf(SegmentEntity::class, $wpSegment);
+    try {
+      $this->getApi()->deleteList((string)$wpSegment->getId());
+      $this->fail('WP list cannot be updated.');
+    } catch (\Exception $e) {
+      expect($e->getMessage())->equals('List of the type \'' . $wpSegment->getType() . '\' is not supported for this action.');
+      expect($e->getCode())->equals(APIException::LIST_TYPE_IS_NOT_SUPPORTED);
+    }
+  }
+
   public function testItDeletesList(): void {
     $segment = $this->createOrUpdateSegment('Test Segment');
     $subscriber = (new Subscriber())

--- a/mailpoet/tests/integration/API/MP/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/MP/SegmentsTest.php
@@ -17,7 +17,6 @@ use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Newsletter;
-use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber;
 
@@ -159,7 +158,7 @@ class SegmentsTest extends \MailPoetTest {
     );
 
     $data = [
-      'id' => $segment->getId(),
+      'id' => (string)$segment->getId(),
       'name' => 'new name',
       'description' => 'updated description',
     ];


### PR DESCRIPTION
## Description

Add new MP API methods `listDelete` and `listUpdate` for easier integration with Jetpack CRM.

## Linked tickets

[MAILPOET-4752]


[MAILPOET-4752]: https://mailpoet.atlassian.net/browse/MAILPOET-4752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ