### PR TITLE
Enforce user selection for welcome wizard privacy and data sharing - MAILPOET-4681

### DIFF
--- a/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
@@ -6,13 +6,25 @@ import { Button } from 'common/button/button';
 import { Heading } from 'common/typography/heading/heading';
 import { YesNo } from 'common/form/yesno/yesno';
 
+const checkForNullOrUndefined = (value) =>
+  value === null || value === undefined;
+
 function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
   const [state, setState] = useState({
     tracking: undefined,
     libs3rdParty: undefined,
   });
+  const [submitted, setSubmitted] = useState(false);
+
   function submit(event) {
     event.preventDefault();
+    setSubmitted(true);
+    if (
+      checkForNullOrUndefined(state.libs3rdParty) ||
+      checkForNullOrUndefined(state.tracking)
+    ) {
+      return false;
+    }
 
     submitForm(state.tracking, state.libs3rdParty);
     return false;
@@ -30,6 +42,9 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
         <div className="mailpoet-wizard-woocommerce-option">
           <div className="mailpoet-wizard-woocommerce-toggle">
             <YesNo
+              showError={
+                submitted && checkForNullOrUndefined(state.libs3rdParty)
+              }
               onCheck={(value) => {
                 const newState = {
                   libs3rdParty: value,
@@ -79,6 +94,7 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
         <div className="mailpoet-wizard-woocommerce-option">
           <div className="mailpoet-wizard-woocommerce-toggle">
             <YesNo
+              showError={submitted && checkForNullOrUndefined(state.tracking)}
               onCheck={(value) => {
                 const newState = {
                   tracking: value,

--- a/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
@@ -6,8 +6,7 @@ import { Button } from 'common/button/button';
 import { Heading } from 'common/typography/heading/heading';
 import { YesNo } from 'common/form/yesno/yesno';
 
-const checkForNullOrUndefined = (value) =>
-  value === null || value === undefined;
+const isNullOrUndefined = (value) => value === null || value === undefined;
 
 function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
   const [state, setState] = useState({
@@ -20,8 +19,8 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
     event.preventDefault();
     setSubmitted(true);
     if (
-      checkForNullOrUndefined(state.libs3rdParty) ||
-      checkForNullOrUndefined(state.tracking)
+      isNullOrUndefined(state.libs3rdParty) ||
+      isNullOrUndefined(state.tracking)
     ) {
       return false;
     }
@@ -42,9 +41,7 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
         <div className="mailpoet-wizard-woocommerce-option">
           <div className="mailpoet-wizard-woocommerce-toggle">
             <YesNo
-              showError={
-                submitted && checkForNullOrUndefined(state.libs3rdParty)
-              }
+              showError={submitted && isNullOrUndefined(state.libs3rdParty)}
               onCheck={(value) => {
                 const newState = {
                   libs3rdParty: value,
@@ -94,7 +91,7 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
         <div className="mailpoet-wizard-woocommerce-option">
           <div className="mailpoet-wizard-woocommerce-toggle">
             <YesNo
-              showError={submitted && checkForNullOrUndefined(state.tracking)}
+              showError={submitted && isNullOrUndefined(state.tracking)}
               onCheck={(value) => {
                 const newState = {
                   tracking: value,


### PR DESCRIPTION
## Description

Enforce user selection for welcome wizard privacy and data sharing page

We are making the two buttons mandatory. Users have to select either yes or no before they can proceed with the welcome wizard.


## Code review notes

Kind reminder to run `./do compile:js`

## QA notes

Check ticket description


## Linked tickets

[MAILPOET-4681](https://mailpoet.atlassian.net/browse/MAILPOET-4681)


