### PR TITLE
Mailpoet  confirmation before delete

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
@@ -7,6 +7,7 @@ import { PremiumModal } from 'common/premium_modal';
 import { Inserter } from '../inserter';
 import { Item } from '../inserter/item';
 import { storeName } from '../../store';
+import { AddStepCallbackType } from '../../../types/filters';
 
 export function InserterPopover(): JSX.Element | null {
   const popoverRef = useRef<HTMLDivElement>();
@@ -20,7 +21,7 @@ export function InserterPopover(): JSX.Element | null {
   const { setInserterPopover } = useDispatch(storeName);
 
   const onInsert = useCallback((item: Item) => {
-    const addStepCallback = Hooks.applyFilters(
+    const addStepCallback: AddStepCallbackType = Hooks.applyFilters(
       'mailpoet.automation.workflow.add_step_callback',
       () => {
         setShowModal(true);

--- a/mailpoet/assets/js/src/automation/editor/components/workflow/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/workflow/index.tsx
@@ -16,6 +16,10 @@ import { InserterPopover } from '../inserter-popover';
 import { storeName } from '../../store';
 import { AddTrigger } from './add-trigger';
 import { Statistics } from './statistics';
+import {
+  RenderStepSeparatorType,
+  RenderStepType,
+} from '../../../types/filters';
 
 export function Workflow(): JSX.Element {
   const { workflowData, selectedStep } = useSelect(
@@ -50,7 +54,7 @@ export function Workflow(): JSX.Element {
   }, [stepMap]);
 
   const renderStep = useMemo(
-    () =>
+    (): RenderStepType =>
       Hooks.applyFilters(
         'mailpoet.automation.workflow.render_step',
         (stepData: StepData) =>
@@ -67,7 +71,7 @@ export function Workflow(): JSX.Element {
   );
 
   const renderSeparator = useMemo(
-    () =>
+    (): RenderStepSeparatorType =>
       Hooks.applyFilters(
         'mailpoet.automation.workflow.render_step_separator',
         (previousStepData: StepData) => (

--- a/mailpoet/assets/js/src/automation/editor/components/workflow/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/workflow/step-more-menu.tsx
@@ -1,25 +1,16 @@
-import { useState } from 'react';
-import { Dropdown, DropdownMenu, MenuItem } from '@wordpress/components';
+import { useState, Fragment } from 'react';
+import { DropdownMenu } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical, trash } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import { PremiumModal } from 'common/premium_modal';
 import { Step as StepData } from './types';
-import { storeName } from '../../store';
+import { MoreControls, storeName } from '../../store';
 
 type Props = {
   step: StepData;
 };
-
-// I do not like this hack.
-// What I want to achieve: With the lazyOnClose method, I want to be able to control to close
-// the menu from within a menuitem.
-// But there must be a better way then storing currentProps like that.
-let currentProps: Dropdown.RenderProps | null = null;
-function setCurrentProps(current) {
-  currentProps = current;
-}
 
 export function StepMoreMenu({ step }: Props): JSX.Element {
   const { stepType } = useSelect(
@@ -30,52 +21,56 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
   );
   const [showModal, setShowModal] = useState(false);
 
-  const lazyOnClose = () => {
-    currentProps?.onClose();
-  };
-  type MoreControls = Record<string, JSX.Element>;
-  const controls: MoreControls = Hooks.applyFilters(
+  const moreControls: MoreControls = Hooks.applyFilters(
     'mailpoet.automation.workflow.step.more-controls',
     {
-      delete: (
-        <MenuItem key="delete" icon={trash} onClick={() => setShowModal(true)}>
-          {__('Delete step', 'mailpoet')}
-        </MenuItem>
-      ),
+      delete: {
+        key: 'delete',
+        control: {
+          title: __('Delete step', 'mailpoet'),
+          icon: trash,
+          onClick: () => setShowModal(true),
+        },
+        slot: () => {
+          if (!showModal) {
+            return false;
+          }
+          return (
+            <PremiumModal
+              onRequestClose={() => {
+                setShowModal(false);
+              }}
+              tracking={{
+                utm_medium: 'upsell_modal',
+                utm_campaign: 'remove_automation_step',
+              }}
+            >
+              {__('You cannot remove a step from the automation.', 'mailpoet')}
+            </PremiumModal>
+          );
+        },
+      },
     },
     step,
     stepType,
-    lazyOnClose,
   );
-  return (
-    <>
-      <div className="mailpoet-automation-step-more-menu">
-        <DropdownMenu
-          label={__('More', 'mailpoet')}
-          icon={moreVertical}
-          popoverProps={{ position: 'bottom right' }}
-          toggleProps={{ isSmall: true }}
-        >
-          {(props) => {
-            setCurrentProps(props);
-            return <>{Object.values(controls)}</>;
-          }}
-        </DropdownMenu>
-      </div>
 
-      {showModal && (
-        <PremiumModal
-          onRequestClose={() => {
-            setShowModal(false);
-          }}
-          tracking={{
-            utm_medium: 'upsell_modal',
-            utm_campaign: 'remove_automation_step',
-          }}
-        >
-          {__('You cannot remove a step from the automation.', 'mailpoet')}
-        </PremiumModal>
-      )}
-    </>
+  const slots = Object.values(moreControls).filter(
+    (item) => item.slot !== undefined,
+  );
+  const controls = Object.values(moreControls).map((item) => item.control);
+  return (
+    <div className="mailpoet-automation-step-more-menu">
+      {slots.map(({ key, slot }) => (
+        <Fragment key={key}>{slot()}</Fragment>
+      ))}
+      <DropdownMenu
+        label={__('More', 'mailpoet')}
+        icon={moreVertical}
+        popoverProps={{ position: 'bottom right' }}
+        toggleProps={{ isSmall: true }}
+        controls={Object.values(controls)}
+      />
+    </div>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/workflow/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/workflow/step-more-menu.tsx
@@ -1,44 +1,66 @@
-import { useCallback, useState } from 'react';
-import { DropdownMenu } from '@wordpress/components';
+import { useState } from 'react';
+import { Dropdown, DropdownMenu, MenuItem } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { moreVertical, trash } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import { PremiumModal } from 'common/premium_modal';
 import { Step as StepData } from './types';
+import { storeName } from '../../store';
 
 type Props = {
   step: StepData;
 };
 
+// I do not like this hack.
+// What I want to achieve: With the lazyOnClose method, I want to be able to control to close
+// the menu from within a menuitem.
+// But there must be a better way then storing currentProps like that.
+let currentProps: Dropdown.RenderProps | null = null;
+function setCurrentProps(current) {
+  currentProps = current;
+}
+
 export function StepMoreMenu({ step }: Props): JSX.Element {
+  const { stepType } = useSelect(
+    (select) => ({
+      stepType: select(storeName).getStepType(step.key),
+    }),
+    [step],
+  );
   const [showModal, setShowModal] = useState(false);
 
-  const onDelete = useCallback((stepData: StepData) => {
-    const deleteStepCallback = Hooks.applyFilters(
-      'mailpoet.automation.workflow.delete_step_callback',
-      () => {
-        setShowModal(true);
-      },
-    );
-    deleteStepCallback(stepData);
-  }, []);
-
+  const lazyOnClose = () => {
+    currentProps?.onClose();
+  };
+  type MoreControls = Record<string, JSX.Element>;
+  const controls: MoreControls = Hooks.applyFilters(
+    'mailpoet.automation.workflow.step.more-controls',
+    {
+      delete: (
+        <MenuItem key="delete" icon={trash} onClick={() => setShowModal(true)}>
+          {__('Delete step', 'mailpoet')}
+        </MenuItem>
+      ),
+    },
+    step,
+    stepType,
+    lazyOnClose,
+  );
   return (
     <>
       <div className="mailpoet-automation-step-more-menu">
         <DropdownMenu
           label={__('More', 'mailpoet')}
           icon={moreVertical}
-          controls={[
-            {
-              title: __('Delete step', 'mailpoet'),
-              icon: trash,
-              onClick: () => onDelete(step),
-            },
-          ]}
           popoverProps={{ position: 'bottom right' }}
           toggleProps={{ isSmall: true }}
-        />
+        >
+          {(props) => {
+            setCurrentProps(props);
+            return <>{Object.values(controls)}</>;
+          }}
+        </DropdownMenu>
       </div>
 
       {showModal && (

--- a/mailpoet/assets/js/src/automation/editor/components/workflow/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/workflow/step-more-menu.tsx
@@ -6,7 +6,8 @@ import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import { PremiumModal } from 'common/premium_modal';
 import { Step as StepData } from './types';
-import { MoreControls, storeName } from '../../store';
+import { storeName } from '../../store';
+import { StepMoreControlsType } from '../../../types/filters';
 
 type Props = {
   step: StepData;
@@ -21,7 +22,7 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
   );
   const [showModal, setShowModal] = useState(false);
 
-  const moreControls: MoreControls = Hooks.applyFilters(
+  const moreControls: StepMoreControlsType = Hooks.applyFilters(
     'mailpoet.automation.workflow.step.more-controls',
     {
       delete: {

--- a/mailpoet/assets/js/src/automation/editor/store/store.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/store.ts
@@ -1,9 +1,4 @@
-import {
-  createReduxStore,
-  register,
-  StoreConfig,
-  StoreDescriptor,
-} from '@wordpress/data';
+import { createReduxStore, register, StoreDescriptor } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import { Hooks } from 'wp-js-hooks';
 import * as actions from './actions';
@@ -13,6 +8,7 @@ import { reducer } from './reducer';
 import * as selectors from './selectors';
 import { State } from './types';
 import { OmitFirstArgs } from '../../../types';
+import { EditorStoreConfigType } from '../../types/filters';
 
 type StoreType = Omit<StoreDescriptor, 'name'> & {
   name: typeof storeName;
@@ -28,8 +24,8 @@ export const createStore = (): StoreType => {
       selectors,
       reducer,
       initialState: getInitialState(),
-    } as StoreConfig<State>,
-  ) as StoreConfig<State>;
+    } as EditorStoreConfigType,
+  ) as EditorStoreConfigType;
 
   const store = createReduxStore<State>(storeName, storeConfig) as StoreType;
   register(store);

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -1,4 +1,5 @@
 import { ComponentType } from 'react';
+import { DropdownMenu } from '@wordpress/components';
 import { Step, Workflow } from '../components/workflow/types';
 
 export interface AutomationEditorWindow extends Window {
@@ -61,3 +62,14 @@ export type State = {
 };
 
 export type Feature = 'fullscreenMode' | 'showIconLabels';
+
+export type MoreControl = {
+  key: string;
+  control: DropdownMenu.Control;
+  slot: () => JSX.Element | undefined;
+};
+
+/**
+ * Used in the "mailpoet.automation.workflow.step.more-controls" filter
+ */
+export type MoreControls = Record<string, MoreControl>;

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -1,5 +1,4 @@
 import { ComponentType } from 'react';
-import { DropdownMenu } from '@wordpress/components';
 import { Step, Workflow } from '../components/workflow/types';
 
 export interface AutomationEditorWindow extends Window {
@@ -62,14 +61,3 @@ export type State = {
 };
 
 export type Feature = 'fullscreenMode' | 'showIconLabels';
-
-export type MoreControl = {
-  key: string;
-  control: DropdownMenu.Control;
-  slot: () => JSX.Element | undefined;
-};
-
-/**
- * Used in the "mailpoet.automation.workflow.step.more-controls" filter
- */
-export type MoreControls = Record<string, MoreControl>;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/google_analytics_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/google_analytics_panel.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { PremiumModal } from 'common/premium_modal';
 import { Hooks } from 'wp-js-hooks';
 import { storeName } from '../../../../../editor/store';
+import { GoogleAnalyticsPanelBodyType } from '../../../types/filters';
 
 export function GoogleAnalyticsPanel(): JSX.Element {
   const { selectedStep } = useSelect(
@@ -12,7 +13,7 @@ export function GoogleAnalyticsPanel(): JSX.Element {
   );
 
   const enabled = typeof selectedStep.args?.ga_campaign !== 'undefined';
-  const panelBody = Hooks.applyFilters(
+  const panelBody: GoogleAnalyticsPanelBodyType = Hooks.applyFilters(
     'mailpoet.automation.send_email.google_analytics_panel',
     <PremiumModal
       onRequestClose={() =>

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/types/filters.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/types/filters.tsx
@@ -1,0 +1,7 @@
+/**
+ * The types in this file document the expected return types of specific
+ * filters.
+ */
+
+// mailpoet.automation.send_email.google_analytics_panel
+export type GoogleAnalyticsPanelBodyType = JSX.Element;

--- a/mailpoet/assets/js/src/automation/templates/components/from-scratch.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/from-scratch.tsx
@@ -5,6 +5,7 @@ import { Hooks } from 'wp-js-hooks';
 import { Icon, plusCircleFilled } from '@wordpress/icons';
 import { PremiumModal } from '../../../common/premium_modal';
 import { Notice } from '../../../notices/notice';
+import { FromScratchHookType } from '../../types/filters';
 
 type FromScratchPremiumModalProps = {
   showModal: boolean;
@@ -34,7 +35,7 @@ function FromScratchPremiumModal({
 }
 
 function fromScratchHook(callback: () => void, errorHandler: Dispatch<string>) {
-  const fromScratchCallback = Hooks.applyFilters(
+  const fromScratchCallback: FromScratchHookType = Hooks.applyFilters(
     'mailpoet.automation.templates.from_scratch_button',
     () => {
       callback();

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -1,0 +1,39 @@
+/**
+ * The types in this file document the expected return types of specific
+ * filters.
+ */
+
+import { Dispatch } from 'react';
+import { DropdownMenu } from '@wordpress/components';
+import { StoreConfig } from '@wordpress/data';
+import { Item } from '../editor/components/inserter/item';
+import { Step } from '../editor/components/workflow/types';
+import { State } from '../editor/store/types';
+
+export type MoreControlType = {
+  key: string;
+  control: DropdownMenu.Control;
+  slot: () => JSX.Element | undefined;
+};
+
+/**
+ * APPLICATION HOOKS
+ */
+
+// mailpoet.automation.workflow.step.more-controls
+export type StepMoreControlsType = Record<string, MoreControlType>;
+
+// mailpoet.automation.workflow.add_step_callback
+export type AddStepCallbackType = (item?: Item) => void;
+
+// mailpoet.automation.workflow.render_step
+export type RenderStepType = (step: Step) => JSX.Element;
+
+// mailpoet.automation.workflow.render_step_separator
+export type RenderStepSeparatorType = (step: Step) => JSX.Element;
+
+// mailpoet.automation.editor.create_store
+export type EditorStoreConfigType = StoreConfig<State>;
+
+// mailpoet.automation.templates.from_scratch_button
+export type FromScratchHookType = (errorHandler: Dispatch<string>) => void;

--- a/mailpoet/assets/js/src/webpack_admin_expose.js
+++ b/mailpoet/assets/js/src/webpack_admin_expose.js
@@ -16,6 +16,7 @@ export { MenuItem as WordpressComponentsMenuItem } from '@wordpress/components';
 export * as WordPressData from '@wordpress/data';
 export * as WordPressUrl from '@wordpress/url';
 export * as WordPressI18n from '@wordpress/i18n';
+export * as WordPressIcons from '@wordpress/icons';
 
 // assets
 export * as Automation from 'automation';

--- a/mailpoet/assets/js/src/webpack_admin_expose.js
+++ b/mailpoet/assets/js/src/webpack_admin_expose.js
@@ -11,6 +11,8 @@ export * as ReactTooltip from 'react-tooltip';
 export * as ReactStringReplace from 'react-string-replace';
 export * as Slugify from 'slugify';
 export { TextControl as WordpressComponentsTextControl } from '@wordpress/components';
+export { __experimentalConfirmDialog as WordpressComponentsConfirmDialog } from '@wordpress/components';
+export { MenuItem as WordpressComponentsMenuItem } from '@wordpress/components';
 export * as WordPressData from '@wordpress/data';
 export * as WordPressUrl from '@wordpress/url';
 export * as WordPressI18n from '@wordpress/i18n';


### PR DESCRIPTION
## Description
This PR remove the `mailpoet.automation.workflow.delete_step_callback` filter and adds the `mailpoet.automation.workflow.step.more-controls` filter.

The `mailpoet.automation.workflow.step.more-controls` filters an `Record<string,JSX.Element>`, so that third parties can alter and add items to the More menu of a single step.

This enables us to realize [MAILPOET-4674]

## Code review notes
This PR suggests to render the items of the `DropdownMenu` in a different way. My current problem is: I want to be able to close the menu in within a menu item. If a user clicks cancel, not only the delete dialog is supposed to go away, but the menu should close. I did not find a proper way to realize that and hope, there is a better way :)


## Linked PRs
https://github.com/mailpoet/mailpoet-premium/pull/641

## Linked tickets
[MAILPOET-4674]

[MAILPOET-4674]: https://mailpoet.atlassian.net/browse/MAILPOET-4674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4674]: https://mailpoet.atlassian.net/browse/MAILPOET-4674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ