### PR TITLE
Add WooCommerce Subscriptions integration tests to the list of tests that can be skipped [MAILPOET-4765]

### DIFF
--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -15,7 +15,12 @@ class CheckSkippedTestsExtension extends Extension {
     $testName = $event->getTest()->getMetadata()->getName();
 
     // list of tests that are allowed to be skipped on trunk and release branches
-    $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
+    $allowedToSkipList = [
+      'createSubscriptionSegmentForActiveSubscriptions',
+      'testAllSubscribersFoundWithOperatorAny',
+      'testAllSubscribersFoundWithOperatorNoneOf',
+      'testAllSubscribersFoundWithOperatorAllOf',
+    ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
       throw new \PHPUnit\Framework\ExpectationFailedException("Failed, cannot skip tests on branch $branch.");

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -18,7 +18,7 @@ class CheckSkippedTestsExtension extends Extension {
     $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
-      throw new \PHPUnit\Framework\ExpectationFailedException("Failed, Cannot skip tests on branch $branch.");
+      throw new \PHPUnit\Framework\ExpectationFailedException("Failed, cannot skip tests on branch $branch.");
     }
   }
 }

--- a/mailpoet/tests/integration.suite.yml
+++ b/mailpoet/tests/integration.suite.yml
@@ -10,3 +10,6 @@ modules:
     - \Helper\Unit
     - \Helper\WordPress
 error_level: E_ALL
+extensions:
+  enabled:
+    - CheckSkippedTestsExtension

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -172,15 +172,6 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     return Stub::copy($instance, $overrides);
   }
 
-  public static function markTestSkipped(string $message = ''): void {
-    $branchName = getenv('CIRCLE_BRANCH');
-    if ($branchName === 'trunk' || $branchName === 'release') {
-      self::fail('Cannot skip tests on this branch.');
-    } else {
-      parent::markTestSkipped($message);
-    }
-  }
-
   public function truncateEntity(string $entityName) {
     $classMetadata = $this->entityManager->getClassMetadata($entityName);
     $tableName = $classMetadata->getTableName();


### PR DESCRIPTION
## Description

When we started skipping the WooCommerce Subscriptions tests, we forgot to add them to the list of tests that can be skipped when running the tests using the trunk and release branches. This PR adds those tests to this list. Please see the ticket description and the commit messages for more details.

I created a temporary branch to show that skipping the tests is actually working:

https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=cot-allow-tests-to-be-skipped-delme

It contains the following commit:

https://github.com/mailpoet/mailpoet/commit/9512c2001336f89cba677b3b33d923cd4c953171

The branch can be deleted after the reviewer checks the result of its CircleCI build.

## Code review notes

_N/A_

## QA notes

I don't think QA is needed for this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4765]

## After-merge notes

_N/A_


[MAILPOET-4765]: https://mailpoet.atlassian.net/browse/MAILPOET-4765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ