### PR TITLE
Use the new api for unsubscribe headers [MAILPOET-4702]

### DIFF
--- a/mailpoet/lib/Mailer/MailerFactory.php
+++ b/mailpoet/lib/Mailer/MailerFactory.php
@@ -16,6 +16,7 @@ use MailPoet\Mailer\Methods\SendGrid;
 use MailPoet\Mailer\Methods\SMTP;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Url;
 use MailPoet\WP\Functions as WPFunctions;
 
 class MailerFactory {
@@ -67,7 +68,8 @@ class MailerFactory {
           $sender,
           $replyTo,
           ContainerWrapper::getInstance()->get(MailPoetMapper::class),
-          ContainerWrapper::getInstance()->get(AuthorizedEmailsController::class)
+          ContainerWrapper::getInstance()->get(AuthorizedEmailsController::class),
+          ContainerWrapper::getInstance()->get(Url::class)
         );
         break;
       case Mailer::METHOD_SENDGRID:

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -10,7 +10,7 @@ use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
-use MailPoet\Util\Url as UrlUtil;
+use MailPoet\Util\Url;
 
 class MailPoet implements MailerMethod {
   public $api;
@@ -27,8 +27,8 @@ class MailPoet implements MailerMethod {
   /** @var BlacklistCheck */
   private $blacklist;
 
-  /*** @var UrlUtil */
-  private $urlUtil;
+  /*** @var Url */
+  private $url;
 
   public function __construct(
     $apiKey,
@@ -36,7 +36,7 @@ class MailPoet implements MailerMethod {
     $replyTo,
     MailPoetMapper $errorMapper,
     AuthorizedEmailsController $authorizedEmailsController,
-    UrlUtil $urlUtil
+    Url $url
   ) {
     $this->api = new API($apiKey);
     $this->sender = $sender;
@@ -45,7 +45,7 @@ class MailPoet implements MailerMethod {
     $this->errorMapper = $errorMapper;
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->blacklist = new BlacklistCheck();
-    $this->urlUtil = $urlUtil;
+    $this->url = $url;
   }
 
   public function send($newsletter, $subscriber, $extraParams = []): array {
@@ -152,7 +152,7 @@ class MailPoet implements MailerMethod {
     if ($unsubscribeUrl) {
       $body['unsubscribe'] = [
         'url' => $unsubscribeUrl,
-        'post' => $this->urlUtil->isUsingHttps($unsubscribeUrl),
+        'post' => $this->url->isUsingHttps($unsubscribeUrl),
       ];
     }
     if ($meta) {

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -10,6 +10,7 @@ use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
+use MailPoet\Util\Url as UrlUtil;
 
 class MailPoet implements MailerMethod {
   public $api;
@@ -26,12 +27,16 @@ class MailPoet implements MailerMethod {
   /** @var BlacklistCheck */
   private $blacklist;
 
+  /*** @var UrlUtil */
+  private $urlUtil;
+
   public function __construct(
     $apiKey,
     $sender,
     $replyTo,
     MailPoetMapper $errorMapper,
-    AuthorizedEmailsController $authorizedEmailsController
+    AuthorizedEmailsController $authorizedEmailsController,
+    UrlUtil $urlUtil
   ) {
     $this->api = new API($apiKey);
     $this->sender = $sender;
@@ -40,6 +45,7 @@ class MailPoet implements MailerMethod {
     $this->errorMapper = $errorMapper;
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->blacklist = new BlacklistCheck();
+    $this->urlUtil = $urlUtil;
   }
 
   public function send($newsletter, $subscriber, $extraParams = []): array {
@@ -144,7 +150,10 @@ class MailPoet implements MailerMethod {
       $body['text'] = $newsletter['body']['text'];
     }
     if ($unsubscribeUrl) {
-      $body['list_unsubscribe'] = $unsubscribeUrl;
+      $body['unsubscribe'] = [
+        'url' => $unsubscribeUrl,
+        'post' => $this->urlUtil->isUsingHttps($unsubscribeUrl),
+      ];
     }
     if ($meta) {
       $body['meta'] = $meta;

--- a/mailpoet/lib/Util/Url.php
+++ b/mailpoet/lib/Util/Url.php
@@ -69,4 +69,8 @@ class Url {
     }
     exit();
   }
+
+  public function isUsingHttps(string $url): bool {
+    return wp_parse_url($url, PHP_URL_SCHEME) === 'https';
+  }
 }

--- a/mailpoet/lib/Util/Url.php
+++ b/mailpoet/lib/Util/Url.php
@@ -71,6 +71,6 @@ class Url {
   }
 
   public function isUsingHttps(string $url): bool {
-    return wp_parse_url($url, PHP_URL_SCHEME) === 'https';
+    return $this->wp->wpParseUrl($url, PHP_URL_SCHEME) === 'https';
   }
 }

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -11,6 +11,7 @@ use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Mailer\Methods\MailPoet;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge\API;
+use MailPoet\Util\Url;
 
 class MailPoetAPITest extends \MailPoetTest {
   public $metaInfo;
@@ -45,7 +46,8 @@ class MailPoetAPITest extends \MailPoetTest {
       $this->sender,
       $this->replyTo,
       $this->diContainer->get(MailPoetMapper::class),
-      $this->makeEmpty(AuthorizedEmailsController::class)
+      $this->makeEmpty(AuthorizedEmailsController::class),
+      $this->diContainer->get(Url::class)
     );
     $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
@@ -86,7 +88,8 @@ class MailPoetAPITest extends \MailPoetTest {
       $this->sender,
       $replyTo,
       $this->diContainer->get(MailPoetMapper::class),
-      $this->makeEmpty(AuthorizedEmailsController::class)
+      $this->makeEmpty(AuthorizedEmailsController::class),
+      $this->diContainer->get(Url::class)
     );
     $body = $mailer->getBody($this->newsletter, $this->subscriber);
     expect($body[0]['reply_to'])->equals([
@@ -275,7 +278,8 @@ class MailPoetAPITest extends \MailPoetTest {
       $this->sender,
       $this->replyTo,
       $this->diContainer->get(MailPoetMapper::class),
-      $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::once()])
+      $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::once()]),
+      $this->diContainer->get(Url::class)
     );
     $mailer->api = $this->makeEmpty(
       API::class,

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -116,11 +116,11 @@ class MailPoetAPITest extends \MailPoetTest {
 
   public function testItCanAddExtraParametersToSingleMessage() {
     $extraParams = [
-      'unsubscribe_url' => 'http://example.com',
+      'unsubscribe_url' => 'https://example.com',
       'meta' => $this->metaInfo,
     ];
     $body = $this->mailer->getBody($this->newsletter, $this->subscriber, $extraParams);
-    expect($body[0]['list_unsubscribe'])->equals($extraParams['unsubscribe_url']);
+    expect($body[0]['unsubscribe'])->equals(['url' => $extraParams['unsubscribe_url'], 'post' => true]);
     expect($body[0]['meta'])->equals($extraParams['meta']);
   }
 
@@ -134,8 +134,8 @@ class MailPoetAPITest extends \MailPoetTest {
 
     $body = $this->mailer->getBody($newsletters, $subscribers, $extraParams);
     expect(count($body))->equals(10);
-    expect($body[0]['list_unsubscribe'])->equals($extraParams['unsubscribe_url'][0]);
-    expect($body[9]['list_unsubscribe'])->equals($extraParams['unsubscribe_url'][9]);
+    expect($body[0]['unsubscribe'])->equals(['url' => $extraParams['unsubscribe_url'][0], 'post' => false]);
+    expect($body[9]['unsubscribe'])->equals(['url' => $extraParams['unsubscribe_url'][9], 'post' => false]);
     expect($body[0]['meta'])->equals($extraParams['meta'][0]);
     expect($body[9]['meta'])->equals($extraParams['meta'][9]);
   }


### PR DESCRIPTION
## Description

This PR replaces the `list_unsubscribe` with the new `unsubscribe` object when sending the email body to MSS for sending.

## QA notes

Send a newsletter email and verify you see the `unsubscribe` button/link provided by your email viewer.

## Linked tickets

[MAILPOET-4702]



[MAILPOET-4702]: https://mailpoet.atlassian.net/browse/MAILPOET-4702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


## Notes:
Please refrain from merging this PR once approved, get in touch with @samnajian before merging