### PR TITLE
Add 'Give feedback' beacon [MAILPOET-4755]

### DIFF
--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -114,6 +114,7 @@ class PageRenderer {
     $subscribersCacheCreatedAt = $this->transientCache->getOldestCreatedAt(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY) ?: Carbon::now();
 
     $defaults = [
+      'current_page' => sanitize_text_field(wp_unslash($_GET['page'] ?? '')),
       'site_name' => $this->wp->wpSpecialcharsDecode($this->wp->getOption('blogname'), ENT_QUOTES),
       'site_url' => $this->wp->siteUrl(),
       'site_address' => $this->wp->wpParseUrl($this->wp->homeUrl(), PHP_URL_HOST),

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -423,8 +423,8 @@ class Hooks {
     );
   }
 
-  public function setFooter($text) {
-    return '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">Give feedback</a>';
+  public function setFooter() {
+    return '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">' . esc_html__('Give feedback', 'mailpoet') . '</a>';
   }
 
   public function setupSettingsLinkInPluginPage() {

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -423,7 +423,11 @@ class Hooks {
     );
   }
 
-  public function setFooter() {
+  public function setFooter(): string {
+
+    if (Menu::isOnMailPoetAutomationPage()) {
+      return '';
+    }
     return '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">' . esc_html__('Give feedback', 'mailpoet') . '</a>';
   }
 

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -561,6 +561,20 @@ class Menu {
     );
   }
 
+  public static function isOnMailPoetAutomationPage(): bool {
+    $screenId = isset($_REQUEST['page']) ? sanitize_text_field(wp_unslash($_REQUEST['page'])) : '';
+    $automationPages = [
+        'mailpoet-automation',
+        'mailpoet-automation-templates',
+        'mailpoet-automation-editor',
+      ];
+    return in_array(
+      $screenId,
+      $automationPages,
+      true
+    );
+  }
+
   public static function isOnMailPoetAdminPage(array $exclude = null, $screenId = null) {
     if (is_null($screenId)) {
       if (empty($_REQUEST['page'])) {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -249,6 +249,9 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   <%if mailpoet_api_key_state.data.support_tier == 'premium' or premium_key_state.data.support_tier == 'premium' %>
     <% set helpscout_form_id = 'e93d0423-1fa6-4bbc-9df9-c174f823c35f' %>
   <% endif %>
+  <%if current_page == 'mailpoet-automation' or current_page == 'mailpoet-automation-editor' or current_page == 'mailpoet-automation-templates'%>
+    <% set helpscout_form_id = '69b66c7a-e9e9-4544-9d2a-5eb0ddc74959' %>
+  <% endif %>
 
   <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script>
 


### PR DESCRIPTION
## Code review notes
This PR adds a new `current_page` variable to be used in twig. It then compares if the current page is an automation page and replaces the existing beacon ID with the "Give feedback" beacon ID.


## Linked tickets
[MAILPOET-4755]


[MAILPOET-4755]: https://mailpoet.atlassian.net/browse/MAILPOET-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ