### PR TITLE
Feat/move the list management from settings - MAILPOET-4669

### DIFF
--- a/mailpoet/assets/js/src/form/form.jsx
+++ b/mailpoet/assets/js/src/form/form.jsx
@@ -24,8 +24,19 @@ class FormComponent extends Component {
       this.loadItem(this.props.params.id);
     } else {
       setImmediate(() => {
+        const defaultValues =
+          jQuery('.mailpoet_form').mailpoetSerializeObject();
+        const checkboxField =
+          Array.isArray(this.props.fields) &&
+          this.props.fields.length > 0 &&
+          this.props.fields.find(
+            (field) => field?.type === 'checkbox' && field?.isChecked,
+          );
+        if (checkboxField && checkboxField.name) {
+          defaultValues[checkboxField.name] = '1';
+        }
         this.setState({
-          item: jQuery('.mailpoet_form').mailpoetSerializeObject(),
+          item: defaultValues,
         });
       });
     }

--- a/mailpoet/assets/js/src/segments/form.jsx
+++ b/mailpoet/assets/js/src/segments/form.jsx
@@ -28,6 +28,7 @@ const fields = [
         'showInManageSubscriptionPageTip',
       ),
     },
+    isChecked: true, // default checked state
   },
 ];
 

--- a/mailpoet/assets/js/src/segments/form.jsx
+++ b/mailpoet/assets/js/src/segments/form.jsx
@@ -19,6 +19,16 @@ const fields = [
     type: 'textarea',
     tip: MailPoet.I18n.t('segmentDescriptionTip'),
   },
+  {
+    name: 'showInManageSubscriptionPage',
+    label: MailPoet.I18n.t('showInManageSubscriptionPage'),
+    type: 'checkbox',
+    values: {
+      showInManageSubscriptionPage: MailPoet.I18n.t(
+        'showInManageSubscriptionPageTip',
+      ),
+    },
+  },
 ];
 
 const messages = {

--- a/mailpoet/assets/js/src/settings/pages/basics/manage_subscription.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/manage_subscription.tsx
@@ -1,11 +1,10 @@
 import ReactStringReplace from 'react-string-replace';
 import { t } from 'common/functions';
 import { useSetting } from 'settings/store/hooks';
-import { Inputs, Label, PageSelect, SegmentsSelect } from 'settings/components';
+import { Inputs, Label, PageSelect } from 'settings/components';
 
 export function ManageSubscription() {
   const [page, setPage] = useSetting('subscription', 'pages', 'manage');
-  const [segments, setSegments] = useSetting('subscription', 'segments');
   return (
     <>
       <Label
@@ -42,18 +41,24 @@ export function ManageSubscription() {
           automationId="subscription-manage-page-selection"
           linkAutomationId="preview_manage_subscription_page_link"
         />
-        <label
-          className="mailpoet-settings-inputs-row"
-          htmlFor="subscription-segments"
-        >
-          {t('subscribersCanChooseFrom')}
-        </label>
-        <SegmentsSelect
-          id="subscription-segments"
-          value={segments}
-          setValue={setSegments}
-          placeholder={t('leaveEmptyToDisplayAll')}
-        />
+
+        <p>
+          {ReactStringReplace(
+            t('hideListFromManageSubPage'),
+            /\[link\](.*?)\[\/link\]/,
+            (text) => (
+              <a
+                className="mailpoet-link"
+                key={text}
+                href="/wp-admin/admin.php?page=mailpoet-segments#/lists"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {text}
+              </a>
+            ),
+          )}
+        </p>
       </Inputs>
     </>
   );

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -34,7 +34,7 @@ class SegmentsResponseBuilder {
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'average_engagement_score' => $segment->getAverageEngagementScore(),
       'filters_connect' => $segment->getFiltersConnectOperator(),
-      'showInManageSubscriptionPage' => $segment->getDisplayInManageSubscriptionPage(),
+      'showInManageSubscriptionPage' => (int)$segment->getDisplayInManageSubscriptionPage(),
     ];
   }
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -34,6 +34,7 @@ class SegmentsResponseBuilder {
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'average_engagement_score' => $segment->getAverageEngagementScore(),
       'filters_connect' => $segment->getFiltersConnectOperator(),
+      'showInManageSubscriptionPage' => $segment->getDisplayInManageSubscriptionPage(),
     ];
   }
 

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -68,10 +68,10 @@ class SegmentEntity {
   private $averageEngagementScoreUpdatedAt;
 
   /**
-   * @ORM\Column(type="integer", nullable=true, options={"default" : 0})
-   * @var int|null
+   * @ORM\Column(type="boolean")
+   * @var bool
    */
-  private $displayInManageSubscriptionPage;
+  private $displayInManageSubscriptionPage = false;
 
   public function __construct(
     string $name,
@@ -162,12 +162,12 @@ class SegmentEntity {
     $this->averageEngagementScoreUpdatedAt = $averageEngagementScoreUpdatedAt;
   }
 
-  public function getDisplayInManageSubscriptionPage(): ?int {
+  public function getDisplayInManageSubscriptionPage(): bool {
     return $this->displayInManageSubscriptionPage;
   }
 
-  public function setDisplayInManageSubscriptionPage(int $value): void {
-    $this->displayInManageSubscriptionPage = $value;
+  public function setDisplayInManageSubscriptionPage(bool $state): void {
+    $this->displayInManageSubscriptionPage = $state;
   }
 
   /**

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -67,6 +67,12 @@ class SegmentEntity {
    */
   private $averageEngagementScoreUpdatedAt;
 
+  /**
+   * @ORM\Column(type="integer", nullable=true, options={"default" : 0})
+   * @var int|null
+   */
+  private $displayInManageSubscriptionPage;
+
   public function __construct(
     string $name,
     string $type,
@@ -154,6 +160,14 @@ class SegmentEntity {
 
   public function setAverageEngagementScoreUpdatedAt(?\DateTimeInterface $averageEngagementScoreUpdatedAt): void {
     $this->averageEngagementScoreUpdatedAt = $averageEngagementScoreUpdatedAt;
+  }
+
+  public function getDisplayInManageSubscriptionPage(): ?int {
+    return $this->displayInManageSubscriptionPage;
+  }
+
+  public function setDisplayInManageSubscriptionPage(int $value): void {
+    $this->displayInManageSubscriptionPage = $value;
   }
 
   /**

--- a/mailpoet/lib/Migrations/Migration_20221108_140545.php
+++ b/mailpoet/lib/Migrations/Migration_20221108_140545.php
@@ -35,7 +35,7 @@ class Migration_20221108_140545 extends Migration {
     if (empty($displayInManageSubscriptionPageColumnExists)) {
       $addNewColumnQuery = "
         ALTER TABLE `$segmentsTable`
-        ADD `display_in_manage_subscription_page` tinyint(1) DEFAULT 0;
+        ADD `display_in_manage_subscription_page` tinyint(1) NOT NULL DEFAULT 0;
       ";
       $wpdb->query($addNewColumnQuery);
     }

--- a/mailpoet/lib/Migrations/Migration_20221108_140545.php
+++ b/mailpoet/lib/Migrations/Migration_20221108_140545.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Config\Env;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Migrator\Migration;
+use MailPoet\Settings\SettingsController;
+
+class Migration_20221108_140545 extends Migration {
+  /** @var string */
+  private $prefix;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function run(): void {
+    $this->prefix = Env::$dbPrefix;
+    $this->settings = $this->container->get(SettingsController::class);
+
+    $this->migrateSegmentDisplaySettingsOnManageSubscriptionPage();
+  }
+
+  private function migrateSegmentDisplaySettingsOnManageSubscriptionPage(): bool {
+    global $wpdb;
+    $segmentsTable = esc_sql("{$this->prefix}segments");
+
+    // Add display_in_manage_subscription_page column in case it doesn't exist
+    $displayInManageSubscriptionPageColumnExists = $wpdb->get_results($wpdb->prepare("
+      SELECT COLUMN_NAME
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE table_name = %s AND column_name = 'display_in_manage_subscription_page';
+     ", $segmentsTable));
+
+    if (empty($displayInManageSubscriptionPageColumnExists)) {
+      $addNewColumnQuery = "
+        ALTER TABLE `$segmentsTable`
+        ADD `display_in_manage_subscription_page` tinyint(1) DEFAULT 0;
+      ";
+      $wpdb->query($addNewColumnQuery);
+    }
+
+    $segmentIds = $this->settings->get('subscription.segments', []);
+
+    if (!empty($segmentIds)) {
+      // when a segment exist in the list (subscription.segments), show only that segment, do not display the other segments
+      foreach ($segmentIds as $segmentId) {
+        $wpdb->update($segmentsTable, [
+          'display_in_manage_subscription_page' => 1,
+        ], ['id' => $segmentId]);
+      }
+
+      $this->settings->set('subscription.segments', []);
+    } else {
+      $wpdb->update($segmentsTable, [
+        'display_in_manage_subscription_page' => 1,
+      ], ['type' => SegmentEntity::TYPE_DEFAULT]);
+    }
+
+    return true;
+  }
+}

--- a/mailpoet/lib/Segments/SegmentSaveController.php
+++ b/mailpoet/lib/Segments/SegmentSaveController.php
@@ -33,8 +33,9 @@ class SegmentSaveController {
     $id = isset($data['id']) ? (int)$data['id'] : null;
     $name = $data['name'] ?? '';
     $description = $data['description'] ?? '';
+    $displayInManageSubPage = $data['showInManageSubscriptionPage'] ?? null;
 
-    return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id);
+    return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id, $displayInManageSubPage);
   }
 
   /**

--- a/mailpoet/lib/Segments/SegmentSaveController.php
+++ b/mailpoet/lib/Segments/SegmentSaveController.php
@@ -33,9 +33,9 @@ class SegmentSaveController {
     $id = isset($data['id']) ? (int)$data['id'] : null;
     $name = $data['name'] ?? '';
     $description = $data['description'] ?? '';
-    $displayInManageSubPage = $data['showInManageSubscriptionPage'] ?? null;
+    $displayInManageSubPage = isset($data['showInManageSubscriptionPage']) ? (int)$data['showInManageSubscriptionPage'] : false;
 
-    return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id, $displayInManageSubPage);
+    return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id, (bool)$displayInManageSubPage);
   }
 
   /**

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -133,8 +133,10 @@ class SegmentsRepository extends Repository {
     string $description = '',
     string $type = SegmentEntity::TYPE_DEFAULT,
     array $filtersData = [],
-    ?int $id = null
+    ?int $id = null,
+    ?int $displayInManageSubscriptionPage = 1
   ): SegmentEntity {
+    $displayInManageSubPage = $type === SegmentEntity::TYPE_DEFAULT ? $displayInManageSubscriptionPage ?? 1 : 0;
     if ($id) {
       $segment = $this->findOneById($id);
       if (!$segment instanceof SegmentEntity) {
@@ -145,9 +147,11 @@ class SegmentsRepository extends Repository {
         $segment->setName($name);
       }
       $segment->setDescription($description);
+      $segment->setDisplayInManageSubscriptionPage($displayInManageSubPage);
     } else {
       $this->verifyNameIsUnique($name, $id);
       $segment = new SegmentEntity($name, $type, $description);
+      $segment->setDisplayInManageSubscriptionPage($displayInManageSubPage);
       $this->persist($segment);
     }
 

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -134,9 +134,9 @@ class SegmentsRepository extends Repository {
     string $type = SegmentEntity::TYPE_DEFAULT,
     array $filtersData = [],
     ?int $id = null,
-    ?int $displayInManageSubscriptionPage = 1
+    bool $displayInManageSubscriptionPage = true
   ): SegmentEntity {
-    $displayInManageSubPage = $type === SegmentEntity::TYPE_DEFAULT ? $displayInManageSubscriptionPage ?? 1 : 0;
+    $displayInManageSubPage = $type === SegmentEntity::TYPE_DEFAULT ? $displayInManageSubscriptionPage : false;
     if ($id) {
       $segment = $this->findOneById($id);
       if (!$segment instanceof SegmentEntity) {

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\SegmentsRepository;
-use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
@@ -28,9 +27,6 @@ class Manage {
 
   /** @var LinkTokens */
   private $linkTokens;
-
-  /** @var SettingsController */
-  private $settings;
 
   /** @var Unsubscribes */
   private $unsubscribesTracker;
@@ -61,7 +57,6 @@ class Manage {
     FieldNameObfuscator $fieldNameObfuscator,
     LinkTokens $linkTokens,
     Unsubscribes $unsubscribesTracker,
-    SettingsController $settings,
     NewSubscriberNotificationMailer $newSubscriberNotificationMailer,
     WelcomeScheduler $welcomeScheduler,
     CustomFieldsRepository $customFieldsRepository,
@@ -74,7 +69,6 @@ class Manage {
     $this->fieldNameObfuscator = $fieldNameObfuscator;
     $this->unsubscribesTracker = $unsubscribesTracker;
     $this->linkTokens = $linkTokens;
-    $this->settings = $settings;
     $this->newSubscriberNotificationMailer = $newSubscriberNotificationMailer;
     $this->welcomeScheduler = $welcomeScheduler;
     $this->segmentsRepository = $segmentsRepository;
@@ -140,7 +134,6 @@ class Manage {
     if (isset($subscriberData['segments']) && is_array($subscriberData['segments'])) {
       $segmentsIds = $subscriberData['segments'];
     }
-    $allowedSegments = $this->settings->get('subscription.segments', false);
 
     // Unsubscribe from all other segments already subscribed to
     // but don't change disallowed segments
@@ -150,7 +143,7 @@ class Manage {
         continue;
       }
 
-      if ($allowedSegments && !in_array($segment->getId(), $allowedSegments)) {
+      if (empty($segment->getDisplayInManageSubscriptionPage())) {
         continue;
       }
       if (!in_array($segment->getId(), $segmentsIds)) {
@@ -173,13 +166,13 @@ class Manage {
     }, $subscriberSegments));
     $newSegmentIds = array_diff($segmentsIds, $currentSegmentIds);
 
-    // Allow subscribing only to allowed segments
-    if ($allowedSegments) {
-      $segmentsIds = array_intersect($segmentsIds, $allowedSegments);
-    }
     foreach ($segmentsIds as $segmentId) {
       $segment = $this->segmentsRepository->findOneById($segmentId);
       if (!$segment) {
+        continue;
+      }
+      // Allow subscribing only to allowed segments
+      if (empty($segment->getDisplayInManageSubscriptionPage())) {
         continue;
       }
       $this->subscriberSegmentRepository->createOrUpdate(

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -225,7 +225,7 @@ class ManageSubscriptionFormRenderer {
     $criteria = [
       'type' => SegmentEntity::TYPE_DEFAULT,
       'deletedAt' => null,
-      'displayInManageSubscriptionPage' => 1,
+      'displayInManageSubscriptionPage' => true,
       ];
     $segments = $this->segmentsRepository->findBy($criteria, ['name' => Criteria::ASC]);
 

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -10,7 +10,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Block\Date as FormBlockDate;
 use MailPoet\Form\Renderer as FormRenderer;
 use MailPoet\Segments\SegmentsRepository;
-use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Url as UrlHelper;
@@ -20,9 +19,6 @@ use MailPoetVendor\Doctrine\Common\Collections\Criteria;
 class ManageSubscriptionFormRenderer {
   const FORM_STATE_SUCCESS = 'success';
   const FORM_STATE_NOT_SUBMITTED = 'not_submitted';
-
-  /** @var SettingsController */
-  private $settings;
 
   /** @var UrlHelper */
   private $urlHelper;
@@ -50,7 +46,6 @@ class ManageSubscriptionFormRenderer {
 
   public function __construct(
     WPFunctions $wp,
-    SettingsController $settings,
     UrlHelper $urlHelper,
     LinkTokens $linkTokens,
     FormRenderer $formRenderer,
@@ -60,7 +55,6 @@ class ManageSubscriptionFormRenderer {
     SegmentsRepository $segmentsRepository
   ) {
     $this->wp = $wp;
-    $this->settings = $settings;
     $this->urlHelper = $urlHelper;
     $this->linkTokens = $linkTokens;
     $this->formRenderer = $formRenderer;
@@ -227,13 +221,12 @@ class ManageSubscriptionFormRenderer {
   }
 
   private function getSegmentField(SubscriberEntity $subscriber): array {
-    $segmentIds = $this->settings->get('subscription.segments', []);
-
     // Get default segments
-    $criteria = ['type' => SegmentEntity::TYPE_DEFAULT, 'deletedAt' => null];
-    if (!empty($segmentIds)) {
-      $criteria['id'] = $segmentIds;
-    }
+    $criteria = [
+      'type' => SegmentEntity::TYPE_DEFAULT,
+      'deletedAt' => null,
+      'displayInManageSubscriptionPage' => 1,
+      ];
     $segments = $this->segmentsRepository->findBy($criteria, ['name' => Criteria::ASC]);
 
     $subscribedSegmentIds = [];

--- a/mailpoet/tests/DataFactories/Segment.php
+++ b/mailpoet/tests/DataFactories/Segment.php
@@ -26,7 +26,7 @@ class Segment {
       'type' => SegmentEntity::TYPE_DEFAULT,
       'name' => 'List ' . bin2hex(random_bytes(7)), // phpcs:ignore
       'description' => '',
-      'display_in_manage_subscription_page' => 1,
+      'display_in_manage_subscription_page' => true,
     ];
   }
 
@@ -61,8 +61,8 @@ class Segment {
   /**
    * @return $this
    */
-  public function withDisplayInManageSubscriptionPage(int $value) {
-    return $this->update('display_in_manage_subscription_page', $value);
+  public function withDisplayInManageSubscriptionPage(bool $state) {
+    return $this->update('display_in_manage_subscription_page', $state);
   }
 
   public function create(): SegmentEntity {

--- a/mailpoet/tests/DataFactories/Segment.php
+++ b/mailpoet/tests/DataFactories/Segment.php
@@ -26,6 +26,7 @@ class Segment {
       'type' => SegmentEntity::TYPE_DEFAULT,
       'name' => 'List ' . bin2hex(random_bytes(7)), // phpcs:ignore
       'description' => '',
+      'display_in_manage_subscription_page' => 1,
     ];
   }
 
@@ -57,11 +58,21 @@ class Segment {
     return $this->update('type', $type);
   }
 
+  /**
+   * @return $this
+   */
+  public function withDisplayInManageSubscriptionPage(int $value) {
+    return $this->update('display_in_manage_subscription_page', $value);
+  }
+
   public function create(): SegmentEntity {
     $segment = $this->segmentsRepository->createOrUpdate(
       $this->data['name'],
       $this->data['description'],
-      $this->data['type']
+      $this->data['type'],
+      [],
+      null,
+      $this->data['display_in_manage_subscription_page']
     );
     if (($this->data['deleted_at'] ?? null) instanceof \DateTimeInterface) {
       $segment->setDeletedAt($this->data['deleted_at']);

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -54,6 +54,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
 
   private function getSegment(): SegmentEntity {
     $segment = new SegmentEntity('Test segment', SegmentEntity::TYPE_DEFAULT, 'Description');
+    $segment->setDisplayInManageSubscriptionPage(1);
     $this->entityManager->persist($segment);
     $this->entityManager->flush();
     return $segment;

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -54,7 +54,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
 
   private function getSegment(): SegmentEntity {
     $segment = new SegmentEntity('Test segment', SegmentEntity::TYPE_DEFAULT, 'Description');
-    $segment->setDisplayInManageSubscriptionPage(1);
+    $segment->setDisplayInManageSubscriptionPage(true);
     $this->entityManager->persist($segment);
     $this->entityManager->flush();
     return $segment;

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -7,7 +7,6 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
-use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Manage;
@@ -16,9 +15,6 @@ use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\Url as UrlHelper;
 
 class ManageTest extends \MailPoetTest {
-  /** @var SettingsController */
-  private $settings;
-
   /** @var SegmentEntity */
   private $segmentB;
 
@@ -38,12 +34,10 @@ class ManageTest extends \MailPoetTest {
     parent::_before();
     $this->_after();
     $segmentFactory = new SegmentFactory();
-    $this->settings = $this->diContainer->get(SettingsController::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentA = $segmentFactory->withName('List A')->create();
     $this->segmentB = $segmentFactory->withName('List B')->create();
-    $this->hiddenSegment = $segmentFactory->withName('Hidden List')->create();
-    $this->settings->set('subscription.segments', [$this->segmentA->getId(), $this->segmentB->getId()]);
+    $this->hiddenSegment = $segmentFactory->withName('Hidden List')->withDisplayInManageSubscriptionPage(0)->create();
     $this->subscriber = (new SubscriberFactory())
       ->withFirstName('John')
       ->withLastName('John')
@@ -66,8 +60,7 @@ class ManageTest extends \MailPoetTest {
         'verifyToken' => function($token) {
           return true;
         },
-      ]),
-      'settings' => $this->settings,
+      ])
     ]);
     $_POST['action'] = 'mailpoet_subscription_update';
     $_POST['token'] = 'token';

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -37,7 +37,7 @@ class ManageTest extends \MailPoetTest {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentA = $segmentFactory->withName('List A')->create();
     $this->segmentB = $segmentFactory->withName('List B')->create();
-    $this->hiddenSegment = $segmentFactory->withName('Hidden List')->withDisplayInManageSubscriptionPage(0)->create();
+    $this->hiddenSegment = $segmentFactory->withName('Hidden List')->withDisplayInManageSubscriptionPage(false)->create();
     $this->subscriber = (new SubscriberFactory())
       ->withFirstName('John')
       ->withLastName('John')

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -96,6 +96,9 @@
     'segmentDescriptionTip': __('This text box is for your own use and is never shown to your subscribers.'),
     'backToList': __('Back'),
 
+    'showInManageSubscriptionPage': __('Show this list on the “Manage Subscription” page'),
+    'showInManageSubscriptionPageTip': __('Uncheck to hide this list from the Manage Subscription page.'),
+
     'subscribersInPlanCount': _x('%1$d / %2$d', 'count / total subscribers'),
     'subscribersInPlan': _x('%s subscribers in your plan', 'number of subscribers in a sending plan'),
     'subscribersInPlanTooltip': __('This is the total of subscribed, unconfirmed and inactive subscribers we count when you are sending with MailPoet Sending Service. The count excludes unsubscribed and bounced (invalid) email addresses.'),

--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -62,7 +62,7 @@
     'previewPage': __('Preview page'),
     'preview': __('Preview'),
     'leaveEmptyToDisplayAll': __('Leave this field empty to display all lists'),
-    'hideListFromManageSubPage': __('To hide a list from the Manage Subscription page, go to [link]Lists[/link] and edit the one you want to hide'),
+    'hideListFromManageSubPage': __('To hide a list from the Manage Subscription page, go to [link]Lists[/link] and edit the one you want to hide.'),
 
     'reEngagementTitle': __('Re-engagement page'),
     'reEngagementDescription': __('Thank your subscribers reactivated by the Re-engagement email for their continued interest in your emails.'),

--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -61,8 +61,8 @@
     'manageSubDescription2': __('Want to use a custom Subscription page? Check out our [link]Knowledge Base[/link] for instructions.'),
     'previewPage': __('Preview page'),
     'preview': __('Preview'),
-    'subscribersCanChooseFrom': __('Subscribers can choose from these lists:'),
     'leaveEmptyToDisplayAll': __('Leave this field empty to display all lists'),
+    'hideListFromManageSubPage': __('To hide a list from the Manage Subscription page, go to [link]Lists[/link] and edit the one you want to hide'),
 
     'reEngagementTitle': __('Re-engagement page'),
     'reEngagementDescription': __('Thank your subscribers reactivated by the Re-engagement email for their continued interest in your emails.'),


### PR DESCRIPTION
## Description

Move the list management from the settings page.

* Remove the field “Subscribers can choose from these lists:” from settings.
* Add new checkbox “Show this list on the Manage Subscription page” to the list edit page
* Migrate previous data

## Code review notes

Note: This PR includes a DB migration


## Linked tickets

[MAILPOET-4669](https://mailpoet.atlassian.net/browse/MAILPOET-4669)


