### PR TITLE
Implement 1 click post unsubscribe [MAILPOET-4703]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -274,6 +274,7 @@ class SendingQueue {
     $unsubscribeUrls = [];
     $statistics = [];
     $metas = [];
+    $oneClickUnsubscribeUrls = [];
 
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
 
@@ -301,7 +302,8 @@ class SendingQueue {
       );
       $preparedSubscribersIds[] = $subscriber->id;
       // create personalized instant unsubsribe link
-      $unsubscribeUrls[] = $this->links->getUnsubscribeUrl($queue, $subscriber->id);
+      $unsubscribeUrls[] = $this->links->getUnsubscribeUrl($queue->id, $subscriberEntity);
+      $oneClickUnsubscribeUrls[] = $this->links->getOneClickUnsubscribeUrl($queue->id, $subscriberEntity);
 
       $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriberEntity);
 
@@ -319,12 +321,17 @@ class SendingQueue {
           $preparedSubscribers[0],
           $statistics[0],
           $timer,
-          ['unsubscribe_url' => $unsubscribeUrls[0], 'meta' => $metas[0]]
+          [
+            'unsubscribe_url' => $unsubscribeUrls[0],
+            'meta' => $metas[0],
+            'one_click_unsubscribe' => $oneClickUnsubscribeUrls,
+          ]
         );
         $preparedNewsletters = [];
         $preparedSubscribers = [];
         $preparedSubscribersIds = [];
         $unsubscribeUrls = [];
+        $oneClickUnsubscribeUrls = [];
         $statistics = [];
         $metas = [];
       }
@@ -337,7 +344,7 @@ class SendingQueue {
         $preparedSubscribers,
         $statistics,
         $timer,
-        ['unsubscribe_url' => $unsubscribeUrls, 'meta' => $metas]
+        ['unsubscribe_url' => $unsubscribeUrls, 'meta' => $metas, 'one_click_unsubscribe' => $oneClickUnsubscribeUrls]
       );
     }
     return $queue;

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -11,7 +11,6 @@ use MailPoet\Router\Endpoints\Track;
 use MailPoet\Router\Router;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\LinkTokens;
-use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\SubscriptionUrlFactory;
 use MailPoet\Util\Helpers;
 
@@ -22,9 +21,6 @@ class Links {
   /** @var NewsletterLinks */
   private $newsletterLinks;
 
-  /** @var SubscribersRepository */
-  private $subscribersRepository;
-
   /** @var NewsletterLinkRepository */
   private $newsletterLinkRepository;
 
@@ -34,13 +30,11 @@ class Links {
   public function __construct(
     LinkTokens $linkTokens,
     NewsletterLinks $newsletterLinks,
-    SubscribersRepository $subscribersRepository,
     NewsletterLinkRepository $newsletterLinkRepository,
     TrackingConfig $trackingConfig
   ) {
     $this->linkTokens = $linkTokens;
     $this->newsletterLinks = $newsletterLinks;
-    $this->subscribersRepository = $subscribersRepository;
     $this->newsletterLinkRepository = $newsletterLinkRepository;
     $this->trackingConfig = $trackingConfig;
   }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -491,6 +491,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setFactory([__CLASS__, 'getCdnAssetsUrl']);
     $container->autowire(\MailPoet\Util\DmarcPolicyChecker::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\Scheduler::class)->setPublic(true);
+    $container->autowire(\MailPoet\Util\Request::class)->setPublic(true);
     // Validator
     $container->autowire(Validator::class)->setPublic(true);
     // WooCommerce

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -111,6 +111,7 @@ class MailPoet implements MailerMethod {
           $newsletter[$record],
           $this->processSubscriber($subscriber[$record]),
           (!empty($extraParams['unsubscribe_url'][$record])) ? $extraParams['unsubscribe_url'][$record] : false,
+          (!empty($extraParams['one_click_unsubscribe'][$record])) ? $extraParams['one_click_unsubscribe'][$record] : false,
           (!empty($extraParams['meta'][$record])) ? $extraParams['meta'][$record] : false
         );
       }
@@ -119,13 +120,14 @@ class MailPoet implements MailerMethod {
         $newsletter,
         $this->processSubscriber($subscriber),
         (!empty($extraParams['unsubscribe_url'])) ? $extraParams['unsubscribe_url'] : false,
+        (!empty($extraParams['one_click_unsubscribe'])) ? $extraParams['one_click_unsubscribe'] : false,
         (!empty($extraParams['meta'])) ? $extraParams['meta'] : false
       );
     }
     return $body;
   }
 
-  private function composeBody($newsletter, $subscriber, $unsubscribeUrl, $meta): array {
+  private function composeBody($newsletter, $subscriber, $unsubscribeUrl, $oneClickUnsubscribeUrl, $meta): array {
     $body = [
       'to' => ([
         'address' => $subscriber['email'],
@@ -150,9 +152,10 @@ class MailPoet implements MailerMethod {
       $body['text'] = $newsletter['body']['text'];
     }
     if ($unsubscribeUrl) {
+      $oneClickIsPossible = $this->url->isUsingHttps($unsubscribeUrl);
       $body['unsubscribe'] = [
-        'url' => $unsubscribeUrl,
-        'post' => $this->url->isUsingHttps($unsubscribeUrl),
+        'url' => $oneClickIsPossible ? $oneClickUnsubscribeUrl : $unsubscribeUrl,
+        'post' => $oneClickIsPossible,
       ];
     }
     if ($meta) {

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -108,7 +108,7 @@ class Subscription {
   }
 
   private function applyOneClickUnsubscribeStrategy($data): void {
-    if (!$this->wp->isSiteUsingHttps()) {
+    if (!$this->wp->wpIsSiteUrlUsingHttps()) {
       return;
     }
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -4,6 +4,7 @@ namespace MailPoet\Router\Endpoints;
 
 use MailPoet\Config\AccessControl;
 use MailPoet\Subscription as UserSubscription;
+use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Subscription {
@@ -39,14 +40,19 @@ class Subscription {
   /** @var UserSubscription\Captcha */
   private $captcha;
 
+  /*** @var Request */
+  private $request;
+
   public function __construct(
     UserSubscription\Pages $subscriptionPages,
     WPFunctions $wp,
-    UserSubscription\Captcha $captcha
+    UserSubscription\Captcha $captcha,
+    Request $request
   ) {
     $this->subscriptionPages = $subscriptionPages;
     $this->wp = $wp;
     $this->captcha = $captcha;
+    $this->request = $request;
   }
 
   public function captcha($data) {
@@ -67,6 +73,11 @@ class Subscription {
 
   public function confirmUnsubscribe($data) {
     $enableUnsubscribeConfirmation = $this->wp->applyFilters('mailpoet_unsubscribe_confirmation_enabled', true);
+    if ($this->request->isPost()) {
+      $this->applyOneClickUnsubscribeStrategy($data);
+      exit;
+    }
+
     if ($enableUnsubscribeConfirmation) {
       $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM_UNSUBSCRIBE, $data);
     } else {
@@ -79,8 +90,13 @@ class Subscription {
   }
 
   public function unsubscribe($data) {
-    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
-    $subscription->unsubscribe();
+    if ($this->request->isPost()) {
+      $this->applyOneClickUnsubscribeStrategy($data);
+      exit;
+    } else {
+      $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
+      $subscription->unsubscribe();
+    }
   }
 
   public function reEngagement($data) {
@@ -89,5 +105,13 @@ class Subscription {
 
   private function initSubscriptionPage($action, $data) {
     return $this->subscriptionPages->init($action, $data, true, true);
+  }
+
+  private function applyOneClickUnsubscribeStrategy($data): void {
+    if (!$this->wp->isSiteUsingHttps()) {
+      return;
+    }
+    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
+    $subscription->unsubscribe();
   }
 }

--- a/mailpoet/lib/Util/Request.php
+++ b/mailpoet/lib/Util/Request.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MailPoet\Util;
+
+class Request {
+  public function isPost(): bool {
+    return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' || count($_POST) > 0;
+  }
+}

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -848,7 +848,7 @@ class Functions {
     return is_wp_error($value);
   }
 
-  public function isSiteUsingHttps(): bool {
+  public function wpIsSiteUrlUsingHttps(): bool {
     return wp_is_site_url_using_https();
   }
 }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -847,4 +847,8 @@ class Functions {
   public function isWpError($value): bool {
     return is_wp_error($value);
   }
+
+  public function isSiteUsingHttps(): bool {
+    return wp_is_site_url_using_https();
+  }
 }

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -117,10 +117,11 @@ class MailPoetAPITest extends \MailPoetTest {
   public function testItCanAddExtraParametersToSingleMessage() {
     $extraParams = [
       'unsubscribe_url' => 'https://example.com',
+      'one_click_unsubscribe' => 'https://oneclick.com',
       'meta' => $this->metaInfo,
     ];
     $body = $this->mailer->getBody($this->newsletter, $this->subscriber, $extraParams);
-    expect($body[0]['unsubscribe'])->equals(['url' => $extraParams['unsubscribe_url'], 'post' => true]);
+    expect($body[0]['unsubscribe'])->equals(['url' => $extraParams['one_click_unsubscribe'], 'post' => true]);
     expect($body[0]['meta'])->equals($extraParams['meta']);
   }
 
@@ -129,6 +130,7 @@ class MailPoetAPITest extends \MailPoetTest {
     $subscribers = array_fill(0, 10, $this->subscriber);
     $extraParams = [
       'unsubscribe_url' => array_fill(0, 10, 'http://example.com'),
+      'one_click_unsubscribe' => array_fill(0, 10, 'http://oneclick.com'),
       'meta' => array_fill(0, 10, $this->metaInfo),
     ];
 

--- a/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
@@ -7,6 +7,7 @@ use Codeception\Stub\Expected;
 use MailPoet\Router\Endpoints\Subscription;
 use MailPoet\Subscription\Captcha;
 use MailPoet\Subscription\Pages;
+use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SubscriptionTest extends \MailPoetTest {
@@ -18,10 +19,14 @@ class SubscriptionTest extends \MailPoetTest {
   /** @var Captcha */
   private $captcha;
 
+  /*** @var Request */
+  private $request;
+
   public function _before() {
     $this->data = [];
     $this->wp = WPFunctions::get();
     $this->captcha = $this->diContainer->get(Captcha::class);
+    $this->request = $this->diContainer->get(Request::class);
   }
 
   public function testItDisplaysConfirmPage() {
@@ -29,7 +34,7 @@ class SubscriptionTest extends \MailPoetTest {
       'wp' => $this->wp,
       'confirm' => Expected::exactly(1),
     ], $this);
-    $subscription = new Subscription($pages, $this->wp, $this->captcha);
+    $subscription = new Subscription($pages, $this->wp, $this->captcha, $this->request);
     $subscription->confirm($this->data);
   }
 
@@ -39,7 +44,7 @@ class SubscriptionTest extends \MailPoetTest {
       'getManageLink' => Expected::exactly(1),
       'getManageContent' => Expected::exactly(1),
     ], $this);
-    $subscription = new Subscription($pages, $this->wp, $this->captcha);
+    $subscription = new Subscription($pages, $this->wp, $this->captcha, $this->request);
     $subscription->manage($this->data);
     do_shortcode('[mailpoet_manage]');
     do_shortcode('[mailpoet_manage_subscription]');
@@ -50,7 +55,7 @@ class SubscriptionTest extends \MailPoetTest {
       'wp' => new WPFunctions,
       'unsubscribe' => Expected::exactly(1),
     ], $this);
-    $subscription = new Subscription($pages, $this->wp, $this->captcha);
+    $subscription = new Subscription($pages, $this->wp, $this->captcha, $this->request);
     $subscription->unsubscribe($this->data);
   }
 }


### PR DESCRIPTION
## Description

This PR makes the unsubscription endpoint acknowledge POST requests for 1-click unsubscribe and unsubscribe the user without confirmation

## QA notes

1) Send out a newsletter using MSS ( sending preview to email won't work )
2) Using the unsubscribe button shown by the email viewer application of your choice you should be able to unsubscribe.

- Please note that for this test your website should be using HTTPS
- Ther showing of unsubscribe button/link in the email viewer is added in https://github.com/mailpoet/mailpoet/pull/4475

## Linked PRs
[4475](https://github.com/mailpoet/mailpoet/pull/4475)

## Linked tickets

[MAILPOET-4703]


[MAILPOET-4703]: https://mailpoet.atlassian.net/browse/MAILPOET-4703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Notes:
Please refrain from merging this PR once approved, get in touch with @samnajian before merging