### PR TITLE
Prefix polyfilled normalizer functions [MAILPOET-4770]

### DIFF
--- a/mailpoet/prefixer/fix-symfony-polyfill.php
+++ b/mailpoet/prefixer/fix-symfony-polyfill.php
@@ -17,6 +17,13 @@ $data = str_replace('\\Normalizer::', '\\MailPoetVendor\\Normalizer::', $data);
 $data = str_replace('\'Normalizer::', '\'\\MailPoetVendor\\Normalizer::', $data); // for use in strings like defined('...')
 file_put_contents($file, $data);
 
+$file = __DIR__ . '/../vendor-prefixed/symfony/polyfill-intl-normalizer/bootstrap.php';
+$data = file_get_contents($file);
+// These unprefixed functions break WP 6.1 compatibility, we don't seem to use them, let's prefix them.
+$data = str_replace('function normalizer_is_normalized', 'function mailpoet_normalizer_is_normalized', $data);
+$data = str_replace('function normalizer_normalize', 'function mailpoet_normalizer_normalize', $data);
+file_put_contents($file, $data);
+
 $file = __DIR__ . '/../vendor-prefixed/symfony/polyfill-iconv/Iconv.php';
 $data = file_get_contents($file);
 $data = str_replace('\\Normalizer::', '\\MailPoetVendor\\Normalizer::', $data);


### PR DESCRIPTION
[MAILPOET-4770]

**For QA**:

Testing instructions:
1. Use the built release ZIP.
2. Install WP 6.1.
3. Disable PHP Intl extension.
4. Activate plugins: MailPoet, WooCommerce, WooCommerce Blocks.
5. Go to post edit page for any post.
6. Alternatively, activate MailPoet, add a new post which contains accented characters, publish it, go to its edit page.
7. Observe if there are fatal errors.

[MAILPOET-4770]: https://mailpoet.atlassian.net/browse/MAILPOET-4770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ