### PR TITLE
Update Woo Blocks integration code [MAILPOET-4774]

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -473,7 +473,7 @@ class Initializer {
 
   private function setupWoocommerceBlocksIntegration() {
     $wcEnabled = $this->wcHelper->isWooCommerceActive();
-    $wcBlocksEnabled = $this->wcHelper->isWooCommerceBlocksActive('6.3.0-dev');
+    $wcBlocksEnabled = $this->wcHelper->isWooCommerceBlocksActive('8.0.0');
     if ($wcEnabled && $wcBlocksEnabled) {
       $this->woocommerceBlocksIntegration->init();
     }

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -4,8 +4,8 @@ namespace MailPoet\PostEditorBlocks;
 
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CheckoutSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use MailPoet\Config\Env;
 use MailPoet\Entities\SubscriberEntity;

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\PostEditorBlocks;
 
-use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
-use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
 use Automattic\WooCommerce\StoreApi\StoreApi;
@@ -113,9 +111,7 @@ class WooCommerceBlocksIntegration {
       return;
     }
 
-    $extend = $this->wooHelper->isWooCommerceBlocksActive('7.2') ?
-      StoreApi::container()->get(ExtendSchema::class) :
-      Package::container()->get(ExtendRestApi::class);
+    $extend = StoreApi::container()->get(ExtendSchema::class);
     $extend->register_endpoint_data(
       [
         'endpoint' => CheckoutSchema::IDENTIFIER,

--- a/mailpoet/tasks/phpstan/composer.json
+++ b/mailpoet/tasks/phpstan/composer.json
@@ -1,28 +1,27 @@
 {
-    "require": {
-        "php-stubs/woocommerce-stubs": "^6.0",
-        "phpstan/phpstan": "1.4.10",
-        "phpstan/phpstan-doctrine": "1.2.11",
-        "phpstan/phpstan-phpunit": "1.0.0",
-        "szepeviktor/phpstan-wordpress": "1.0.3"
-    },
-    "autoload": {
-        "psr-4": {
-            "MailPoet\\PHPStan\\Extensions\\": "extensions"
-        }
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "php prefix-phpstan-doctrine.php",
-            "php fix-WPStubs-for-PHP-8_1.php"
-
-        ],
-        "post-update-cmd": [
-            "php prefix-phpstan-doctrine.php",
-            "php fix-WPStubs-for-PHP-8_1.php"
-        ]
+  "require": {
+    "php-stubs/woocommerce-stubs": "^7.0",
+    "phpstan/phpstan": "1.4.10",
+    "phpstan/phpstan-doctrine": "1.2.11",
+    "phpstan/phpstan-phpunit": "1.0.0",
+    "szepeviktor/phpstan-wordpress": "1.0.3"
+  },
+  "autoload": {
+    "psr-4": {
+      "MailPoet\\PHPStan\\Extensions\\": "extensions"
     }
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "scripts": {
+    "post-install-cmd": [
+      "php prefix-phpstan-doctrine.php",
+      "php fix-WPStubs-for-PHP-8_1.php"
+    ],
+    "post-update-cmd": [
+      "php prefix-phpstan-doctrine.php",
+      "php fix-WPStubs-for-PHP-8_1.php"
+    ]
+  }
 }

--- a/mailpoet/tasks/phpstan/composer.lock
+++ b/mailpoet/tasks/phpstan/composer.lock
@@ -4,28 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff830b6e9cbe937699c148d8d53b907b",
+    "content-hash": "f4ffe233f34ce17c0d21212db84abf08",
     "packages": [
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v6.0.0",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "65e6be8a1b74b7be5d0d5591262342ff116f93db"
+                "reference": "2bbe0ba67081cfad17d33ac503883fdc6e68a386"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/65e6be8a1b74b7be5d0d5591262342ff116f93db",
-                "reference": "65e6be8a1b74b7be5d0d5591262342ff116f93db",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/2bbe0ba67081cfad17d33ac503883fdc6e68a386",
+                "reference": "2bbe0ba67081cfad17d33ac503883fdc6e68a386",
                 "shasum": ""
             },
             "require": {
-                "php-stubs/wordpress-stubs": "^5.3.0"
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
             },
             "require-dev": {
-                "giacocorsiglia/stubs-generator": "^0.5.0",
-                "php": "~7.1"
+                "php": "~7.1 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
             },
             "suggest": {
                 "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
@@ -46,9 +46,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v6.0.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.0.0"
             },
-            "time": "2022-01-04T22:00:24+00:00"
+            "time": "2022-10-12T08:25:57+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -435,5 +435,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -42,8 +42,6 @@ parameters:
     - '/Parameter #1 \$cssOrXPath of method AcceptanceTester::moveMouseOver\(\) expects string\|null, array<string, string> given./'
     - '/Function expect invoked with 1 parameter, 0 required\./'
     - '/Call to method getName\(\) on an unknown class _generated\\([a-zA-Z])*Cookie/' # codeception generate incorrect return type in ../../tests/_support/_generated
-    - '/Call to static method container\(\) on an unknown class/'
-    - '/Class Automattic\\WooCommerce\\StoreApi\\Schemas\\ExtendSchema not found./'
     -
       message: "#^Cannot cast string|void to string\\.$#"
       count: 5
@@ -52,10 +50,6 @@ parameters:
       message: "#^Cannot cast string|void to string\\.$#"
       count: 5
       path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
-    -
-      message: '/^Call to static method custom_orders_table_usage_is_enabled\(\) on an unknown class Automattic\\WooCommerce\\Utilities\\OrderUtil\.$/'
-      count: 1
-      path: ../../lib/WooCommerce/Helper.php
     -
       message: '/^Call to static method get_orders_table_name\(\) on an unknown class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore\.$/'
       count: 1
@@ -66,7 +60,7 @@ parameters:
       path: ../../lib/WooCommerce/Helper.php
     -
       message: '/^Call to function method_exists\(\) with/'
-      count: 3
+      count: 2
       path: ../../lib/WooCommerce/Helper.php
     - # WooCommerce stubs contains stubs for older ActionScheduler version
       message: '/^Function as_schedule_recurring_action invoked with 6 parameters, 3-5 required.$/'

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -70,6 +70,10 @@ parameters:
       message: '/^Function as_schedule_single_action invoked with 5 parameters, 2-4 required.$/'
       count: 1
       path: ../../lib/Cron/ActionScheduler/ActionScheduler.php
+    -
+      message: '/^Cannot call method get\(\) on mixed.$/'
+      count: 1
+      path: ../../lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED


### PR DESCRIPTION
## Description
We were using some deprecated classes in the Woo Blocks integration code. 
This PR updates classes used in the integration and also prevents enabling the integration for older versions of Woo Blocks plugin.

Some [users reported that they get errors ](https://wordpress.org/support/topic/fatal-error-after-update-to-3-102-0/)when the plugin was trying to load the deprecated ChecknoutSchema class. We were not able to replicate the error, but assuming that because the other WooCommerce Blocks classes used in the code did not throw the error, the issue might be related to [backward compatible aliases](https://github.com/woocommerce/woocommerce-blocks/blob/ecc423ea0ec94009369d495dd4494b06405bdc85/src/StoreApi/deprecated.php#L28) that, for some unknown reason, don't work for some users.

To prevent Fatal errors in case someone is using the old WooCommerce blocks plugin, I updated the version check when we activate the integration. I chose the oldest supported Woo Blocks version (8.0.0) to be the same as [the WooCommerce Blocks version used in WooCommerce 6.8.0](https://plugins.trac.wordpress.org/browser/woocommerce/tags/6.8.0/packages/woocommerce-blocks/readme.txt), which is the oldest Woo we support by L-2 rule.


## Code review notes
I also needed to update Woo Stubs for PHP stan. When updating it I manually changed composer.json and prettier reformated whitespaces. I noticed it after I prepared the PR, but I guess that is not a big issue.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4774]

## After-merge notes

_N/A_


[MAILPOET-4774]: https://mailpoet.atlassian.net/browse/MAILPOET-4774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ