### PR TITLE
Revert "Add WooCommerce Subscriptions integration tests to the list of tests that can be skipped [MAILPOET-4765]"

### DIFF
--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -15,12 +15,7 @@ class CheckSkippedTestsExtension extends Extension {
     $testName = $event->getTest()->getMetadata()->getName();
 
     // list of tests that are allowed to be skipped on trunk and release branches
-    $allowedToSkipList = [
-      'createSubscriptionSegmentForActiveSubscriptions',
-      'testAllSubscribersFoundWithOperatorAny',
-      'testAllSubscribersFoundWithOperatorNoneOf',
-      'testAllSubscribersFoundWithOperatorAllOf',
-    ];
+    $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
       throw new \PHPUnit\Framework\ExpectationFailedException("Failed, cannot skip tests on branch $branch.");

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -18,7 +18,7 @@ class CheckSkippedTestsExtension extends Extension {
     $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
-      throw new \PHPUnit\Framework\ExpectationFailedException("Failed, cannot skip tests on branch $branch.");
+      throw new \PHPUnit\Framework\ExpectationFailedException("Failed, Cannot skip tests on branch $branch.");
     }
   }
 }

--- a/mailpoet/tests/integration.suite.yml
+++ b/mailpoet/tests/integration.suite.yml
@@ -10,6 +10,3 @@ modules:
     - \Helper\Unit
     - \Helper\WordPress
 error_level: E_ALL
-extensions:
-  enabled:
-    - CheckSkippedTestsExtension

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -172,6 +172,15 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     return Stub::copy($instance, $overrides);
   }
 
+  public static function markTestSkipped(string $message = ''): void {
+    $branchName = getenv('CIRCLE_BRANCH');
+    if ($branchName === 'trunk' || $branchName === 'release') {
+      self::fail('Cannot skip tests on this branch.');
+    } else {
+      parent::markTestSkipped($message);
+    }
+  }
+
   public function truncateEntity(string $entityName) {
     $classMetadata = $this->entityManager->getClassMetadata($entityName);
     $tableName = $classMetadata->getTableName();


### PR DESCRIPTION
Reverting mailpoet/mailpoet#4474 as it broke trunk: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/11939/workflows/676f247e-c3b2-4d69-ab92-d191ffd06150/jobs/203672

On a quick look, it seems that for some reason Codeception returns `null` when `$event->getTest()->getMetadata()->getName()` is called for integration tests and that is making the code that was added in this PR always return an error when there is a skipped test in the integration tests. I will investigate this more carefully, but reverting the PR meanwhile to restore the CircleCI builds.