### PR TITLE
Automation: Fatal error in user registration [MAILPOET-4773] [MAILPOET-4772]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role_panel.tsx
@@ -1,10 +1,30 @@
 import { PanelBody } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import ReactStringReplace from 'react-string-replace';
 import { storeName } from '../../../../../editor/store';
 import { PlainBodyTitle } from '../../../../../editor/components/panel';
 import { userRoles } from './role';
 import { FormTokenField } from '../../../components/form-token-field';
+
+function SettingsInfoText(): JSX.Element {
+  return (
+    <p>
+      {ReactStringReplace(
+        __(
+          '[link]Subscribe in registration form[/link] setting must be enabled.',
+          'mailpoet',
+        ),
+        /\[link\](.*?)\[\/link\]/g,
+        (match) => (
+          <a href="admin.php?page=mailpoet-settings#/basics" target="_blank">
+            {match}
+          </a>
+        ),
+      )}
+    </p>
+  );
+}
 
 export function RolePanel(): JSX.Element {
   const { selectedStep } = useSelect(
@@ -20,9 +40,11 @@ export function RolePanel(): JSX.Element {
   const selected = userRoles.filter((role): boolean =>
     rawSelected.includes(role.id as string),
   );
+
   return (
     <PanelBody opened>
       <PlainBodyTitle title={__('Trigger settings', 'mailpoet')} />
+      <SettingsInfoText />
       <FormTokenField
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SubscriberPayload.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Payloads/SubscriberPayload.php
@@ -39,4 +39,8 @@ class SubscriberPayload implements Payload {
   public function getWpUserId(): ?int {
     return $this->subscriber->getWpUserId();
   }
+
+  public function getSubscriber(): SubscriberEntity {
+    return $this->subscriber;
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
@@ -14,6 +14,7 @@ use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\InvalidStateException;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
 use MailPoet\WP\Functions as WPFunctions;
@@ -23,10 +24,14 @@ class UserRegistrationTrigger implements Trigger {
   /** @var WPFunctions */
   private $wp;
 
+  private $subscribersRepository;
+
   public function __construct(
-    WPFunctions $wp
+    WPFunctions $wp,
+    SubscribersRepository $subscribersRepository
   ) {
     $this->wp = $wp;
+    $this->subscribersRepository = $subscribersRepository;
   }
 
   public function getKey(): string {
@@ -78,6 +83,7 @@ class UserRegistrationTrigger implements Trigger {
     }
 
     $subscriberPayload = $args->getSinglePayloadByClass(SubscriberPayload::class);
+    $this->subscribersRepository->refresh($subscriberPayload->getSubscriber());
     if (!$subscriberPayload->isWPUser()) {
       return false;
     }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
@@ -12,27 +12,20 @@ use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\InvalidStateException;
-use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Doctrine\Common\Collections\Criteria;
 
 class UserRegistrationTrigger implements Trigger {
-
-  /** @var SegmentsRepository  */
-  private $segmentsRepository;
 
   /** @var WPFunctions */
   private $wp;
 
   public function __construct(
-    SegmentsRepository $segmentsRepository,
     WPFunctions $wp
   ) {
-    $this->segmentsRepository = $segmentsRepository;
     $this->wp = $wp;
   }
 
@@ -61,11 +54,17 @@ class UserRegistrationTrigger implements Trigger {
   }
 
   public function registerHooks(): void {
-    $this->wp->addAction('mailpoet_user_registered', [$this, 'handleSubscription']);
+    $this->wp->addAction('mailpoet_segment_subscribed', [$this, 'handleSubscription']);
   }
 
-  public function handleSubscription(SubscriberEntity $subscriber): void {
-    $segment = $this->getWpSegment($subscriber);
+  public function handleSubscription(SubscriberSegmentEntity $subscriberSegment): void {
+    $segment = $subscriberSegment->getSegment();
+    $subscriber = $subscriberSegment->getSubscriber();
+
+    if (!$segment || !$subscriber) {
+      throw new InvalidStateException();
+    }
+
     $this->wp->doAction(Hooks::TRIGGER, $this, [
       new Subject(SegmentSubject::KEY, ['segment_id' => $segment->getId()]),
       new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]),
@@ -91,16 +90,5 @@ class UserRegistrationTrigger implements Trigger {
     $triggerArgs = $args->getStep()->getArgs();
     $roles = $triggerArgs['roles'] ?? [];
     return !is_array($roles) || !$roles || count(array_intersect($user->roles, $roles)) > 0;
-  }
-
-  private function getWpSegment(SubscriberEntity $subscriber): SegmentEntity {
-    $wpUserSegment = $this->segmentsRepository->getWPUsersSegment();
-
-    $criteria = Criteria::create()->where(Criteria::expr()->eq('segment', $wpUserSegment));
-    $segment = $subscriber->getSubscriberSegments()->matching($criteria)->first() ?: null;
-    if (!$segment || !$segment->getSegment()) {
-      throw new InvalidStateException();
-    }
-    return $segment->getSegment();
   }
 }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -6,7 +6,6 @@ use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Models\ModelValidator;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
@@ -37,9 +36,6 @@ class WP {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
-  /** @var FeaturesController */
-  private $featuresController;
-
   /** @var SubscriberChangesNotifier */
   private $subscriberChangesNotifier;
 
@@ -51,7 +47,6 @@ class WP {
     WooCommerceHelper $wooHelper,
     SubscribersRepository $subscribersRepository,
     SubscriberSegmentRepository $subscriberSegmentRepository,
-    FeaturesController $featuresController,
     SubscriberChangesNotifier $subscriberChangesNotifier
   ) {
     $this->wp = $wp;
@@ -59,7 +54,6 @@ class WP {
     $this->wooHelper = $wooHelper;
     $this->subscribersRepository = $subscribersRepository;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
-    $this->featuresController = $featuresController;
     $this->subscriberChangesNotifier = $subscriberChangesNotifier;
   }
 
@@ -215,17 +209,6 @@ class WP {
           (array)$wpUser,
           (array)$oldWpUserData
         );
-      }
-
-      // fire user registered hook for new WP segment subscribers
-      if (
-        $this->featuresController->isSupported(FeaturesController::AUTOMATION)
-        && $currentFilter === 'user_register'
-      ) {
-        $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
-        if ($subscriberEntity instanceof SubscriberEntity) {
-          $this->wp->doAction('mailpoet_user_registered', $subscriberEntity);
-        }
       }
     }
   }

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -215,9 +215,11 @@ class Pages {
     // when global status changes to subscribed, fire subscribed hook for all subscribed segments
     if ($this->featuresController->isSupported(FeaturesController::AUTOMATION)) {
       $segments = $this->subscriber->getSubscriberSegments();
-      foreach ($segments as $subscriberSegment) {
-        if ($subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED) {
-          $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
+      if ($originalStatus !== SubscriberEntity::STATUS_SUBSCRIBED) {
+        foreach ($segments as $subscriberSegment) {
+          if ($subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED) {
+            $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
+          }
         }
       }
     }

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -17,6 +17,7 @@ class CreateEmailAutomationAndWalkThroughCest
     $features->withFeatureEnabled(FeaturesController::AUTOMATION);
     $container = ContainerWrapper::getInstance();
     $migrator = $container->get(Migrator::class);
+    $migrator->deleteSchema();
     $migrator->createSchema();
 
     $settings = new Settings();

--- a/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
+++ b/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use Codeception\Util\Locator;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Workflow;
+use MailPoet\Automation\Engine\Migrations\Migrator;
+use MailPoet\Automation\Engine\Storage\WorkflowRunLogStorage;
+use MailPoet\Automation\Engine\Storage\WorkflowRunStorage;
+use MailPoet\Automation\Engine\Storage\WorkflowStorage;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\UserRegistrationTrigger;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Test\DataFactories\Features;
+use MailPoet\Test\DataFactories\Settings;
+
+class UserRegistrationTriggerCest
+{
+  /** @var Settings */
+  private $settingsFactory;
+
+  /** @var ContainerWrapper */
+  private $container;
+
+  /** @var WorkflowStorage */
+  private $workflowStorage;
+
+  /** @var WorkflowRunStorage */
+  private $workflowRunStorage;
+
+  /** @var WorkflowRunLogStorage */
+  private $workflowRunLogStorage;
+
+  public function _before(\AcceptanceTester $i) {
+    // @ToDo Remove once MVP is released.
+    $features = new Features();
+    $features->withFeatureEnabled(FeaturesController::AUTOMATION);
+    $this->container = ContainerWrapper::getInstance();
+    $migrator = $this->container->get(Migrator::class);
+    $migrator->deleteSchema();
+    $migrator->createSchema();
+
+    $this->settingsFactory = new Settings();
+
+    $this->settingsFactory->withCronTriggerMethod('Action Scheduler');
+    $this->workflowStorage = $this->container->get(WorkflowStorage::class);
+    $this->workflowRunStorage = $this->container->get(WorkflowRunStorage::class);
+    $this->workflowRunLogStorage = $this->container->get(WorkflowRunLogStorage::class);
+  }
+
+  public function workflowTriggeredByRegistrationWithoutConfirmationNeeded(\AcceptanceTester $i) {
+    $i->wantTo("Activate a trigger by registering.");
+    $this->settingsFactory
+      ->withSubscribeOnRegisterEnabled()
+      ->withConfirmationEmailDisabled();
+    $this->createWorkflow();
+
+    $i->login();
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->see('Entered 0'); //The visible text is 0 Entered, but in the DOM it's the other way around.
+    $i->dontSee('Entered 1');
+    $i->logOut();
+
+    $this->registerWith($i,'workflow-triggered-by-registration', 'test@mailpoet.com');
+
+    $i->login();
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->dontSee('Entered 0');
+    $i->see('Entered 1'); //The visible text is 1 Entered, but in the DOM it's the other way around.
+  }
+
+  public function workflowTriggeredByRegistrationWitConfirmationNeeded(\AcceptanceTester $i) {
+    $i->wantTo("Activate a trigger by registering.");
+    $this->settingsFactory
+      ->withSubscribeOnRegisterEnabled()
+      ->withConfirmationEmailEnabled();
+    $this->createWorkflow();
+
+    $i->login();
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->see('Entered 0'); //The visible text is 0 Entered, but in the DOM it's the other way around.
+    $i->dontSee('Entered 1');
+    $i->logOut();
+
+    $this->registerWith($i,'workflow-triggered-by-registration', 'test@mailpoet.com');
+
+    $i->login();
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->see('Entered 0'); //The visible text is 0 Entered, but in the DOM it's the other way around.
+    $i->dontSee('Entered 1');
+
+    $i->amOnMailboxAppPage();
+    $i->click(Locator::contains('span.subject', 'Confirm your subscription'));
+    $i->switchToIframe('#preview-html');
+    $i->click('Click here to confirm your subscription.');
+
+    $i->amonUrl('http://test.local');
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->dontSee('Entered 0');
+    $i->see('Entered 1'); //The visible text is 1 Entered, but in the DOM it's the other way around.
+  }
+
+  private function registerWith(\AcceptanceTester $i, string $username, string $email, bool $signup = true) {
+    $i->amOnPage("/wp-login.php?action=register");
+    $i->wait(1);// this needs to be here, Username is not filled properly without this line
+    $i->fillField('Username', $username);
+    $i->fillField('Email', $email);
+    if ($signup) {
+      $i->click('#mailpoet_subscribe_on_register');
+    }
+    $i->click('Register');
+    $i->waitForText('Registration complete.', 10);
+  }
+
+  private function createWorkflow(): Workflow {
+    $someoneSubscribesTrigger = $this->container->get(UserRegistrationTrigger::class);
+    $delayStep = $this->container->get(DelayAction::class);
+    $steps = [
+      'root' => new Step('root', Step::TYPE_ROOT, 'root', [], [new NextStep('t')]),
+      't' => new Step('t', Step::TYPE_TRIGGER, $someoneSubscribesTrigger->getKey(), ['roles' => []], [new NextStep('a1')]),
+      'a1' => new Step('a1', Step::TYPE_ACTION, $delayStep->getKey(), ['delay' => 1, 'delay_type' => 'HOURS'], []),
+    ];
+    $workflow = new Workflow(
+      'test',
+      $steps,
+      new \WP_User(1)
+    );
+    $workflow->setStatus(Workflow::STATUS_ACTIVE);
+    $id = $this->workflowStorage->createWorkflow($workflow);
+    $storedWorkflow = $this->workflowStorage->getWorkflow($id);
+    if (!$storedWorkflow) {
+      throw new \Exception("Workflow not found.");
+    }
+    return $storedWorkflow;
+  }
+
+  public function _after() {
+    $this->workflowStorage->truncate();
+    $this->workflowRunStorage->truncate();
+    $this->workflowRunLogStorage->truncate();
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
@@ -62,7 +62,8 @@ class UserRegistrationTriggerTest extends \MailPoetTest {
   public function testCanHandleRegistration() {
     $wpMock = $this->createMock(Functions::class);
     $testee = new UserRegistrationTrigger(
-      $wpMock
+      $wpMock,
+      $this->diContainer->get(SubscribersRepository::class)
     );
 
     $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $this->userId]);


### PR DESCRIPTION
## Description
This PR solves two issues at once.

The User Registered Trigger gets rewritten. It will now trigger, once a registered users confirms his subscription. This solved both issues at once.

## Code review notes

I was not sure about the best way to place `<a>` elements in a translated string. I used `ReactStringReplace` which I found in our code base as a solution.

I needed to extend the Segments\WP class. The problem was: When the confirmation email option was `false` our hook would not fire. I added the hook in [c74925a](https://github.com/mailpoet/mailpoet/pull/4483/commits/c74925aac375b6526d239bcc99cc7c837f945125).

I also needed to refresh the copy of the subscriber of the database in the trigger here: [148301c](https://github.com/mailpoet/mailpoet/pull/4483/commits/148301c482213dc4e602e607f7a5dadd84ddc464)

I think probably some model/doctrine issue again. The WP class runs on multiple hooks, which are fired during user registration. In some of those (add_role) the user does not yet exist and so I needed a fresh copy from the database once the WPUser was correctly set.


## Linked tickets
[MAILPOET-4773] [MAILPOET-4772]




[MAILPOET-4773]: https://mailpoet.atlassian.net/browse/MAILPOET-4773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4772]: https://mailpoet.atlassian.net/browse/MAILPOET-4772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ