### PR TITLE
Update Woo HPOS build in tests to the latest version [MAILPOET-4704]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,7 +667,7 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 1
           allow_fail: 1
-          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           requires:
             - unit_tests
             - static_analysis_php8
@@ -681,7 +681,7 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 0
           allow_fail: 1
-          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           requires:
             - unit_tests
             - static_analysis_php8
@@ -692,7 +692,7 @@ workflows:
           <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_off
           group: woo
-          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           requires:
             - unit_tests
             - static_analysis_php8
@@ -718,7 +718,7 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 1
           allow_fail: 1
-          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           name: integration_test_woo_cot_sync
           requires:
             - unit_tests
@@ -732,7 +732,7 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 0
           allow_fail: 1
-          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           name: integration_test_woo_cot_no_sync
           requires:
             - unit_tests
@@ -743,7 +743,7 @@ workflows:
           <<: *slack-fail-post-step
           <<: *only_trunk_and_cot
           group: woo
-          woo_core_version: woo-cot-beta # Temporarily force COT beta version
+          woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           name: integration_test_woo_cot_off
           requires:
             - unit_tests

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1121,18 +1121,8 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function downloadWooCommerceZip($tag = null) {
-    if ($tag === 'woo-cot-beta') {
-      $this->downloadWooCommerceCotZip();
-      return;
-    }
     $this->createWpOrgDownloader('woocommerce')
     ->downloadPluginZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
-  }
-
-  public function downloadWooCommerceCotZip() {
-    $cotBuildUrl = 'https://github.com/woocommerce/woocommerce/files/9706609/woocommerce.zip';
-    file_put_contents(__DIR__ . '/tests/plugins/woocommerce.zip', file_get_contents($cotBuildUrl));
-    file_put_contents(__DIR__ . '/tests/plugins/woocommerce.zip-info', $cotBuildUrl);
   }
 
   public function generateData($generatorName = null, $threads = 1) {


### PR DESCRIPTION
The latest version is 7.1.0-rc.2. Since this build is available on WP.org, this commit also removes the custom code that we had to download builds from GitHub. We can now use \RoboFile::downloadWooCommerceZip() to download builds to test Woo HPOS.

After adding this new version of WooCommerce, all of the Woo related integration and acceptance tests should pass (with the exception of the WooCommerce Subscriptions tests that are currently skipped when Woo HPOS is enabled). Before this update, about 20 integration tests were failing when HPOS was enabled and sync was disabled.

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4704]

## After-merge notes

_N/A_


[MAILPOET-4704]: https://mailpoet.atlassian.net/browse/MAILPOET-4704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ