### PR TITLE
Add WooCommerce Subscriptions integration tests to the list of tests that can be skipped [MAILPOET-4765]

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -74,6 +74,10 @@ parameters:
       message: '/^Cannot call method get\(\) on mixed.$/'
       count: 1
       path: ../../lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+    -
+      message: '/^Call to an undefined method Codeception\\TestInterface::getName()./'
+      count: 1
+      path: ../../tests/_support/CheckSkippedTestsExtension.php
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -12,7 +12,7 @@ class CheckSkippedTestsExtension extends Extension {
 
   public function checkSkippedTests(FailEvent $event) {
     $branch = getenv('CIRCLE_BRANCH');
-    $testName = $event->getTest()->getMetadata()->getName();
+    $testName = $event->getTest()->getName();
 
     // list of tests that are allowed to be skipped on trunk and release branches
     $allowedToSkipList = [

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -15,7 +15,12 @@ class CheckSkippedTestsExtension extends Extension {
     $testName = $event->getTest()->getMetadata()->getName();
 
     // list of tests that are allowed to be skipped on trunk and release branches
-    $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
+    $allowedToSkipList = [
+      'createSubscriptionSegmentForActiveSubscriptions',
+      'testAllSubscribersFoundWithOperatorAny',
+      'testAllSubscribersFoundWithOperatorNoneOf',
+      'testAllSubscribersFoundWithOperatorAllOf',
+    ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
       throw new \PHPUnit\Framework\ExpectationFailedException("Failed, cannot skip tests on branch $branch.");

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -18,7 +18,7 @@ class CheckSkippedTestsExtension extends Extension {
     $allowedToSkipList = ['createSubscriptionSegmentForActiveSubscriptions'];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {
-      throw new \PHPUnit\Framework\ExpectationFailedException("Failed, Cannot skip tests on branch $branch.");
+      throw new \PHPUnit\Framework\ExpectationFailedException("Failed, cannot skip tests on branch $branch.");
     }
   }
 }

--- a/mailpoet/tests/integration.suite.yml
+++ b/mailpoet/tests/integration.suite.yml
@@ -10,3 +10,6 @@ modules:
     - \Helper\Unit
     - \Helper\WordPress
 error_level: E_ALL
+extensions:
+  enabled:
+    - CheckSkippedTestsExtension

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -172,15 +172,6 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     return Stub::copy($instance, $overrides);
   }
 
-  public static function markTestSkipped(string $message = ''): void {
-    $branchName = getenv('CIRCLE_BRANCH');
-    if ($branchName === 'trunk' || $branchName === 'release') {
-      self::fail('Cannot skip tests on this branch.');
-    } else {
-      parent::markTestSkipped($message);
-    }
-  }
-
   public function truncateEntity(string $entityName) {
     $classMetadata = $this->entityManager->getClassMetadata($entityName);
     $tableName = $classMetadata->getTableName();


### PR DESCRIPTION
## Description

This is the second attempt to add WooCommerce Subscriptions integration tests to the list of tests that can be skipped. The first attempt (#4474) had to be reverted (#4482) because it was causing errors in the CircleCI build in trunk.

When we started skipping the WooCommerce Subscriptions tests, we forgot to add them to the list of tests that can be skipped when running the tests using the trunk and release branches. This PR adds those tests to this list. Please see the ticket description and the commit messages for more details.

I created a temporary branch to show that the error when we try to skip tests is actually working:

https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=cot-allow-tests-to-be-skipped-second-try-delme

It contains the following commit:

https://github.com/mailpoet/mailpoet/commit/11031b90277288b372e1705398d2d36af0a0f94f

The branch can be deleted after the reviewer checks the result of its CircleCI build.

This PR uses the same commits from the original PR, but adds one more: https://github.com/mailpoet/mailpoet/commit/c8a7e52b5275d7e0de71858ff7caa755e0a2e78e. For some reason that I did not investigate due to lack of time, `$event->getTest()->getMetadata()->getName()` returns the test name for acceptance tests but it doesn't for integration tests. In the commit, I replaced `$event->getTest()->getMetadata()->getName()` with `$event->getTest()->getName()` that works for both types of tests. See the commit message for more details.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

#4474 and #4482

## Linked tickets

[MAILPOET-4765]

## After-merge notes

Delete the branch `cot-allow-tests-to-be-skipped-second-try-delme`


[MAILPOET-4765]: https://mailpoet.atlassian.net/browse/MAILPOET-4765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ