### PR TITLE
Enable failure checks of COT related jobs on CI and allow them on all branches [MAILPOET-4648]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,9 +356,6 @@ jobs:
       enable_cot_sync:
         type: integer
         default: 0
-      allow_fail:
-        type: integer
-        default: 0
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
@@ -434,9 +431,6 @@ jobs:
               --xml
               -g circleci_split_group
             )
-            if [[ << parameters.allow_fail >> == 1 ]]; then
-              args+=(--no-exit)
-            fi
             docker-compose run -e SKIP_DEPS=1 \
             -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
             -e CIRCLE_JOB=${CIRCLE_JOB} \
@@ -444,18 +438,13 @@ jobs:
             -e ENABLE_COT=<< parameters.enable_cot >> \
             -e ENABLE_COT_SYNC=<< parameters.enable_cot_sync >> \
             codeception_acceptance "${args[@]}"
-      - when:
-          condition:
-            not:
-              equal: [1, << parameters.allow_fail >>]
-          steps:
-            - run:
-                name: Check exceptions
-                command: |
-                  if [ "$(ls tests/_output/exceptions/*.html)" ]; then
-                    echo "There were some exceptions during the tests run"
-                    exit 1
-                  fi
+      - run:
+          name: Check exceptions
+          command: |
+            if [ "$(ls tests/_output/exceptions/*.html)" ]; then
+              echo "There were some exceptions during the tests run"
+              exit 1
+            fi
       - store_artifacts:
           path: tests/_output
       - store_test_results:
@@ -522,9 +511,6 @@ jobs:
       woo_core_version:
         type: string
         default: ''
-      allow_fail:
-        type: integer
-        default: 0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -557,9 +543,6 @@ jobs:
             fi
             if [[ -n '<< parameters.skip_group >>' ]]; then
               args+=(--skip-group << parameters.skip_group >>)
-            fi
-            if [[ << parameters.allow_fail >> == 1 ]]; then
-              args+=(--no-exit)
             fi
             docker-compose run -e SKIP_DEPS=1 \
               -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
@@ -666,7 +649,6 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 1
-          allow_fail: 1
           woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           requires:
             - unit_tests
@@ -680,7 +662,6 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 0
-          allow_fail: 1
           woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           requires:
             - unit_tests
@@ -717,7 +698,6 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 1
-          allow_fail: 1
           woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           name: integration_test_woo_cot_sync
           requires:
@@ -731,7 +711,6 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 0
-          allow_fail: 1
           woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           name: integration_test_woo_cot_no_sync
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,13 +71,6 @@ anchors:
           - trunk
           - release
 
-  only_trunk_and_cot: &only_trunk_and_cot
-    filters:
-      branches:
-        only:
-          - trunk
-          - /^cot-.*/
-
   multisite_acceptance_config: &multisite_acceptance_config
     multisite: 1
     requires:
@@ -644,7 +637,6 @@ workflows:
             - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
-          <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_sync
           group: woo
           enable_cot: 1
@@ -657,7 +649,6 @@ workflows:
             - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
-          <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_no_sync
           group: woo
           enable_cot: 1
@@ -670,7 +661,6 @@ workflows:
             - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
-          <<: *only_trunk_and_cot
           name: acceptance_tests_woo_cot_off
           group: woo
           woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
@@ -694,7 +684,6 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
-          <<: *only_trunk_and_cot
           group: woo
           enable_cot: 1
           enable_cot_sync: 1
@@ -707,7 +696,6 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
-          <<: *only_trunk_and_cot
           group: woo
           enable_cot: 1
           enable_cot_sync: 0
@@ -720,7 +708,6 @@ workflows:
             - qa_php
       - integration_tests:
           <<: *slack-fail-post-step
-          <<: *only_trunk_and_cot
           group: woo
           woo_core_version: 7.1.0-rc.2 # Temporarily force COT beta version
           name: integration_test_woo_cot_off


### PR DESCRIPTION
## Description

This PR changes the CircleCI configuration to remove the code that allowed Woo HPOS tests to fail and to make sure those tests are executed in all the branches instead of just the `cot-` branches and trunk. See commit messages for more details.

The branch of this PR was based on the branch of PR #4484. It should be merged after #4484 is merged.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

#4484

## Linked tickets

[MAILPOET-4648]

## After-merge notes

_N/A_


[MAILPOET-4648]: https://mailpoet.atlassian.net/browse/MAILPOET-4648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ