### PR TITLE
Link the default privacy policy from the default form templates - MAILPOET-4651

### DIFF
--- a/mailpoet/lib/Form/Templates/FormTemplate.php
+++ b/mailpoet/lib/Form/Templates/FormTemplate.php
@@ -151,4 +151,17 @@ EOL;
   protected function replaceLinkTags($source, $link, $attributes = [], $linkTag = false): string {
     return Helpers::replaceLinkTags($source, $link, $attributes, $linkTag);
   }
+
+  protected function replacePrivacyLinkTags($source, $link = '#'): string {
+    $privacyPolicyUrl = $this->wp->getPrivacyPolicyUrl();
+    $attributes = [];
+    $linkTag = false;
+
+    if (!empty($privacyPolicyUrl)) {
+      $link = $this->wp->escUrl($privacyPolicyUrl);
+      $attributes = ['target' => '_blank'];
+      $linkTag = 'link';
+    }
+    return $this->replaceLinkTags($source, $link, $attributes, $linkTag);
+  }
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template10BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10BelowPages.php
@@ -160,7 +160,7 @@ class Template10BelowPages extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template10FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10FixedBar.php
@@ -60,7 +60,7 @@ class Template10FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We’d love to keep you updated with our latest news! We promise we’ll never spam. Take a look at our [link]Privacy Policy[/link] for more details.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We’d love to keep you updated with our latest news! We promise we’ll never spam. Take a look at our [link]Privacy Policy[/link] for more details.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '20',

--- a/mailpoet/lib/Form/Templates/Templates/Template10Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10Popup.php
@@ -131,7 +131,7 @@ class Template10Popup extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template10SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10SlideIn.php
@@ -128,7 +128,7 @@ class Template10SlideIn extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template10Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10Widget.php
@@ -131,7 +131,7 @@ class Template10Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Concert One" data-font="Concert One" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template11BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11BelowPages.php
@@ -185,7 +185,7 @@ class Template11BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '15',

--- a/mailpoet/lib/Form/Templates/Templates/Template11FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11FixedBar.php
@@ -138,7 +138,7 @@ class Template11FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template11Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11Popup.php
@@ -153,7 +153,7 @@ class Template11Popup extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template11SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11SlideIn.php
@@ -153,7 +153,7 @@ class Template11SlideIn extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template11Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11Widget.php
@@ -142,7 +142,7 @@ class Template11Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Fira Sans" data-font="Fira Sans" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template12BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12BelowPages.php
@@ -154,7 +154,7 @@ class Template12BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '15',

--- a/mailpoet/lib/Form/Templates/Templates/Template12FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12FixedBar.php
@@ -198,7 +198,7 @@ class Template12FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'right',
                   'font_size' => '15',

--- a/mailpoet/lib/Form/Templates/Templates/Template12Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12Popup.php
@@ -168,7 +168,7 @@ class Template12Popup extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '15',

--- a/mailpoet/lib/Form/Templates/Templates/Template12SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12SlideIn.php
@@ -168,7 +168,7 @@ class Template12SlideIn extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '15',

--- a/mailpoet/lib/Form/Templates/Templates/Template12Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12Widget.php
@@ -111,7 +111,7 @@ class Template12Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'left',
           'font_size' => '15',

--- a/mailpoet/lib/Form/Templates/Templates/Template13BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13BelowPages.php
@@ -161,7 +161,7 @@ class Template13BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template13FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13FixedBar.php
@@ -109,7 +109,7 @@ class Template13FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . _x('SUBSCRIBE TO OUR NEWSLETTER AND SAVE 10% NEXT TIME YOU DINE IN', 'Text in a web form', 'mailpoet') . '</span><br>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#'),
+                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . _x('SUBSCRIBE TO OUR NEWSLETTER AND SAVE 10% NEXT TIME YOU DINE IN', 'Text in a web form', 'mailpoet') . '</span><br>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#'),
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template13Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13Popup.php
@@ -161,7 +161,7 @@ class Template13Popup extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template13SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13SlideIn.php
@@ -161,7 +161,7 @@ class Template13SlideIn extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template13Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13Widget.php
@@ -156,7 +156,7 @@ class Template13Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Titillium Web" data-font="Titillium Web" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template14BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14BelowPages.php
@@ -147,7 +147,7 @@ class Template14BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template14FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14FixedBar.php
@@ -95,7 +95,7 @@ class Template14FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . _x('SIGN UP TO RECEIVE THE LATEST LIFESTYLE TIPS & TRICKS, PLUS SOME EXCLUSIVE GOODIES!', 'Text in a web form', 'mailpoet') . '</span><br><span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . _x('SIGN UP TO RECEIVE THE LATEST LIFESTYLE TIPS & TRICKS, PLUS SOME EXCLUSIVE GOODIES!', 'Text in a web form', 'mailpoet') . '</span><br><span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template14Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14Popup.php
@@ -147,7 +147,7 @@ class Template14Popup extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template14SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14SlideIn.php
@@ -147,7 +147,7 @@ class Template14SlideIn extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template14Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14Widget.php
@@ -142,7 +142,7 @@ class Template14Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Karla" data-font="Karla" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template17BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17BelowPages.php
@@ -125,7 +125,7 @@ class Template17BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font"><strong>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</strong></span>',
+                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font"><strong>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</strong></span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template17FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17FixedBar.php
@@ -113,7 +113,7 @@ class Template17FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font"><strong>' . _x('There aren’t any tricks here, only treats!', 'Text in a web form.', 'mailpoet') . ' ' . _x('Subscribe to claim your exclusive Halloween offer from us.', 'Text in a web form.', 'mailpoet') . '</strong><br><strong>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</strong></span>',
+                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font"><strong>' . _x('There aren’t any tricks here, only treats!', 'Text in a web form.', 'mailpoet') . ' ' . _x('Subscribe to claim your exclusive Halloween offer from us.', 'Text in a web form.', 'mailpoet') . '</strong><br><strong>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</strong></span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '16',

--- a/mailpoet/lib/Form/Templates/Templates/Template17Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17Popup.php
@@ -147,7 +147,7 @@ class Template17Popup extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template17SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17SlideIn.php
@@ -147,7 +147,7 @@ class Template17SlideIn extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template17Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17Widget.php
@@ -128,7 +128,7 @@ class Template17Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Oxygen" data-font="Oxygen" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template18BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18BelowPages.php
@@ -227,7 +227,7 @@ class Template18BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template18FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18FixedBar.php
@@ -241,7 +241,7 @@ class Template18FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template18Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18Popup.php
@@ -165,7 +165,7 @@ class Template18Popup extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template18SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18SlideIn.php
@@ -165,7 +165,7 @@ class Template18SlideIn extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template18Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18Widget.php
@@ -151,7 +151,7 @@ class Template18Widget extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Heebo" data-font="Heebo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'center',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template1BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1BelowPages.php
@@ -127,7 +127,7 @@ class Template1BelowPages extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read more in our [link]privacy policy[/link]', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
+          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read more in our [link]privacy policy[/link]', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template1FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1FixedBar.php
@@ -64,7 +64,7 @@ class Template1FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
+                  'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template1Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1Popup.php
@@ -101,7 +101,7 @@ class Template1Popup extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
+          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template1SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1SlideIn.php
@@ -101,7 +101,7 @@ class Template1SlideIn extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
+          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template1Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1Widget.php
@@ -101,7 +101,7 @@ class Template1Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
+          'content' => '<em><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), "#") . '</span></em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template3BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3BelowPages.php
@@ -147,7 +147,7 @@ class Template3BelowPages extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'left',
           'font_size' => '',

--- a/mailpoet/lib/Form/Templates/Templates/Template3FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3FixedBar.php
@@ -65,7 +65,7 @@ class Template3FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+                  'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template3Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3Popup.php
@@ -108,7 +108,7 @@ class Template3Popup extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template3SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3SlideIn.php
@@ -108,7 +108,7 @@ class Template3SlideIn extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template3Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3Widget.php
@@ -108,7 +108,7 @@ class Template3Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'left',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template4BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4BelowPages.php
@@ -64,7 +64,7 @@ class Template4BelowPages extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+                  'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template4FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4FixedBar.php
@@ -64,7 +64,7 @@ class Template4FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+                  'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template4Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4Popup.php
@@ -144,7 +144,7 @@ class Template4Popup extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template4SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4SlideIn.php
@@ -144,7 +144,7 @@ class Template4SlideIn extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template4Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4Widget.php
@@ -107,7 +107,7 @@ class Template4Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<em>' . $this->replaceLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
+          'content' => '<em>' . $this->replacePrivacyLinkTags(_x('We don’t spam! Read our [link]privacy policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</em>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template6BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6BelowPages.php
@@ -141,7 +141,7 @@ class Template6BelowPages extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
+          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template6FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6FixedBar.php
@@ -50,7 +50,7 @@ class Template6FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('Sign up to start your fitness program. We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
+                  'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('Sign up to start your fitness program. We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template6Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6Popup.php
@@ -94,7 +94,7 @@ class Template6Popup extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
+          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template6SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6SlideIn.php
@@ -93,7 +93,7 @@ class Template6SlideIn extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
+          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '14',

--- a/mailpoet/lib/Form/Templates/Templates/Template6Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6Widget.php
@@ -93,7 +93,7 @@ class Template6Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
+          'content' => '<strong><span style="font-family: Montserrat" data-font="Montserrat" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We promise we’ll never spam! Take a look at our [link]Privacy Policy[/link] for more info.', 'Text in a web form.', 'mailpoet'), '#') . '</span></strong>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template7BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7BelowPages.php
@@ -169,7 +169,7 @@ class Template7BelowPages extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template7FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7FixedBar.php
@@ -50,7 +50,7 @@ class Template7FixedBar extends FormTemplate {
                 'type' => 'paragraph',
                 'id' => 'paragraph',
                 'params' => [
-                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('Let us do the hard work for you. Sign up to receive our latest deals directly in your inbox. We’ll never send you spam - promise. Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
+                  'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('Let us do the hard work for you. Sign up to receive our latest deals directly in your inbox. We’ll never send you spam - promise. Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
                   'drop_cap' => '0',
                   'align' => 'left',
                   'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
@@ -153,7 +153,7 @@ class Template7Popup extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
@@ -153,7 +153,7 @@ class Template7SlideIn extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/Form/Templates/Templates/Template7Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Widget.php
@@ -107,7 +107,7 @@ class Template7Widget extends FormTemplate {
         'type' => 'paragraph',
         'id' => 'paragraph',
         'params' => [
-          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replaceLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
+          'content' => '<span style="font-family: Cairo" data-font="Cairo" class="mailpoet-has-font">' . $this->replacePrivacyLinkTags(_x('We’ll never send you spam or share your email address.<br>Find out more in our [link]Privacy Policy[/link].', 'Text in a web form. Keep HTML tags!', 'mailpoet'), '#') . '</span>',
           'drop_cap' => '0',
           'align' => 'center',
           'font_size' => '13',

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -140,6 +140,10 @@ class Functions {
     return esc_sql($sql);
   }
 
+  public function escUrl($url): string {
+    return esc_url($url);
+  }
+
   public function getBloginfo($show = '', $filter = 'raw') {
     return get_bloginfo($show, $filter);
   }
@@ -621,6 +625,10 @@ class Functions {
 
   public function isMainQuery(): bool {
     return is_main_query();
+  }
+
+  public function getPrivacyPolicyUrl(): string {
+    return get_privacy_policy_url();
   }
 
   /**


### PR DESCRIPTION

## Description

Link the default privacy policy from the default form templates

Add the replacePrivacyLinkTags method for Form Templates. 


## QA notes

Set privacy policy page here: /wp-admin/options-privacy.php



## Linked tickets

[MAILPOET-4651](https://mailpoet.atlassian.net/browse/MAILPOET-4651)


