### PR TITLE
Declare MailPoet as compatible with Woo HPOS [MAILPOET-4726]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -312,6 +312,11 @@ class Hooks {
       $this->hooksWooCommerce,
       'disableWooCommerceSettings',
     ]);
+
+    $this->wp->addAction('before_woocommerce_init', [
+      $this->hooksWooCommerce,
+      'declareHposCompatibility',
+    ]);
   }
 
   public function setupWooCommerceUsers() {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -133,6 +133,16 @@ class HooksWooCommerce {
     }
   }
 
+  public function declareHposCompatibility() {
+    try {
+      if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', Env::$pluginPath);
+      }
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce HPOS Compatibility');
+    }
+  }
+
   private function logError(\Throwable $e, $name) {
     $logger = $this->loggerFactory->getLogger($name);
     $logger->error($e->getMessage(), [

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,6 +11,9 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
+ * WC requires at least: 6.9.0
+ * WC tested up to: 7.1.0
+ *
  * @package WordPress
  * @author MailPoet
  * @since 3.0.0-beta.1


### PR DESCRIPTION
## Description

As discussed in this pcNwfB-1lW-p2 P2 post, this PR adds the Woo tags `WC requires at least` and `WC tested up to` to MailPoet main file and it explicitly declares MailPoet as compatible with Woo HPOS following the instructions published in pcShBQ-oY-p2. Adding the `WC tested up to` tag is a requirement to declare compatibility with HPOS.

I used the following snippet to test and it seems the code in this PR is working as expected:

```
add_action('admin_init', function() {
  var_dump(
    wc_get_container()
      ->get( \Automattic\WooCommerce\Internal\Features\FeaturesController::class )
      ->get_compatible_plugins_for_feature('custom_order_tables')
  );
  die;
});
```

Another way to test is to declare MailPoet as incompatible by passing `false` as the third parameter of the call to `declare_compatibility()`. If you do that, you should see a warning at the top of the plugins page like the one below:

![Screenshot from 2022-11-04 18-18-47](https://user-images.githubusercontent.com/77215/200076431-c3d71699-1e5b-4e80-9010-ae29afcbbc75.png)


## Code review notes

_N/A_

## QA notes

This PR shouldn't change any behavior and declaring compatibility should not change anything in the UI. IMO, just the automated tests are enough in the case of this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4726]

## After-merge notes

_N/A_


[MAILPOET-4726]: https://mailpoet.atlassian.net/browse/MAILPOET-4726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ