### PR TITLE
Update minimal required WP version to 5.8 [MAILPOET-4668]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -807,14 +807,14 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 6.2.2
+          woo_core_version: 6.8.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
-          woo_blocks_version: 5.3.2
+          woo_blocks_version: 6.8.0
           mysql_command: --max_allowed_packet=100M
           mysql_image_version: 5.7.36
-          codeception_image_version: 7.4-cli_20210126.1
-          wordpress_image_version: wp-5.6_php7.2_20220406.1
+          codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: wp-5.8_php7.3_20221104.1
           requires:
             - build
       - unit_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,10 +186,10 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 6.8.2
-            ./do download:woo-commerce-subscriptions-zip 4.5.1
-            ./do download:woo-commerce-memberships-zip 1.23.0
-            ./do download:woo-commerce-blocks-zip 8.4.0
+            ./do download:woo-commerce-zip 7.0.1
+            ./do download:woo-commerce-subscriptions-zip 4.6.0
+            ./do download:woo-commerce-memberships-zip 1.23.1
+            ./do download:woo-commerce-blocks-zip 8.8.2
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 5.3
+ * Requires at least: 5.8
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -32,7 +32,7 @@ function mailpoet_deactivate_plugin() {
 }
 
 // Check for minimum supported WP version
-if (version_compare(get_bloginfo('version'), '5.6', '<')) {
+if (version_compare(get_bloginfo('version'), '5.8', '<')) {
   add_action('admin_notices', 'mailpoet_wp_version_notice');
   // deactivate the plugin
   add_action('admin_init', 'mailpoet_deactivate_plugin');
@@ -52,7 +52,7 @@ function mailpoet_wp_version_notice() {
   $notice = str_replace(
     '[link]',
     '<a href="https://kb.mailpoet.com/article/152-minimum-requirements-for-mailpoet-3#wp_version" target="_blank">',
-    __('MailPoet plugin requires WordPress version 5.6 or newer. Please read our [link]instructions[/link] on how to resolve this issue.', 'mailpoet')
+    __('MailPoet plugin requires WordPress version 5.8 or newer. Please read our [link]instructions[/link] on how to resolve this issue.', 'mailpoet')
   );
   $notice = str_replace('[/link]', '</a>', $notice);
   printf(

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,7 +1,7 @@
 === MailPoet - emails and newsletters in WordPress ===
 Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
-Requires at least: 5.6
+Requires at least: 5.8
 Tested up to: 6.0
 Stable tag: 3.102.1
 Requires PHP: 7.2

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -406,6 +406,11 @@ class AcceptanceTester extends \Codeception\Actor {
     return $i->cliToString(['plugin', 'get', self::WOO_COMMERCE_PLUGIN, '--field=version']);
   }
 
+  public function getWooCommerceBlocksVersion(): string {
+    $i = $this;
+    return $i->cliToString(['plugin', 'get', self::WOO_COMMERCE_BLOCKS_PLUGIN, '--field=version']);
+  }
+
   public function getWordPressVersion(): string {
     $i = $this;
     return $i->cliToString(['core', 'version']);

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -263,7 +263,11 @@ class WooCheckoutBlocksCest {
 
   private function checkMinimalPluginVersions(\AcceptanceTester $i): bool {
     $wooCommerceVersion = $i->getWooCommerceVersion();
-    if (version_compare($wooCommerceVersion, '5.5.0', '<')) {
+    if (version_compare($wooCommerceVersion, '6.8.0', '<')) {
+      return false;
+    }
+    $wooCommerceBlocksVersion = $i->getWooCommerceBlocksVersion();
+    if (version_compare($wooCommerceBlocksVersion, '8.0.0', '<')) {
       return false;
     }
     $wordPressVersion = $i->getWordPressVersion();

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -53,6 +53,9 @@ else
   wp site create --slug=$WP_TEST_MULTISITE_SLUG
 fi
 
+echo "WORDPRESS VERSION:"
+wp core version
+
 # Load Composer dependencies
 # Set SKIP_DEPS environment flag to not download them. E.g. you have downloaded them yourself
 # Example: docker-compose run -e SKIP_DEPS=1 codeception ...


### PR DESCRIPTION
## Description

After this PR is merged, users with WP below 5.8 won't be able to activate the plugin.

## Code review notes
I split the original commit into more commits to be able to give more context to their messages. 
In the end, I found we already had a code for skipping Woo Blocks test on the oldest, so I just updated the code.

I created an extra branch to test the acceptance_test_oldest job. You can see [build is green here](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/11993/workflows/c4caabc2-da3b-4ff7-bc83-1f1cef134c97).

## QA notes
I guess with this change, you can test the plugin indeed requires at least WP5.8.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4668]

## After-merge notes

Inform Zeon team about the changed requirements. Maybe they will need to update some wiki pages.
Please delete branch https://github.com/mailpoet/mailpoet/tree/upgrade-to-5.8-oldest-test-delme It was used only to show that acceptance tests are passing.


[MAILPOET-4668]: https://mailpoet.atlassian.net/browse/MAILPOET-4668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ