### PR TITLE
Prevent flakiness when comparing time in AbandonedCartTest [MAILPOET-4781]

### DIFF
--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -205,7 +205,9 @@ class AbandonedCartTest extends \MailPoetTest {
     $scheduledTasks = $this->scheduledTasksRepository->findAll();
     $this->assertCount(1, $scheduledTasks);
     $this->assertEquals($scheduledTasks[0]->getStatus(), ScheduledTaskEntity::STATUS_SCHEDULED);
-    $this->assertEquals($scheduledTasks[0]->getScheduledAt(), $expectedTime);
+    $scheduledAt = $scheduledTasks[0]->getScheduledAt();
+    $this->assertInstanceOf(\DateTime::class, $scheduledAt);
+    $this->assertEqualsWithDelta($scheduledAt->getTimestamp(), $expectedTime->getTimestamp(), 1);
     $sendingQueue = $this->sendingQueuesRepository->findOneBy(['task' => $scheduledTasks[0]]);
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
     $this->assertEquals($sendingQueue->getMeta(), [AbandonedCart::TASK_META_NAME => [123, 456]]);
@@ -229,7 +231,9 @@ class AbandonedCartTest extends \MailPoetTest {
     $scheduledTasks = $this->scheduledTasksRepository->findAll();
     $this->assertCount(1, $scheduledTasks);
     $this->assertEquals($scheduledTasks[0]->getStatus(), ScheduledTaskEntity::STATUS_SCHEDULED);
-    $this->assertEquals($scheduledTasks[0]->getScheduledAt(), $expectedTime);
+    $scheduledAt = $scheduledTasks[0]->getScheduledAt();
+    $this->assertInstanceOf(\DateTime::class, $scheduledAt);
+    $this->assertEqualsWithDelta($scheduledAt->getTimestamp(), $expectedTime->getTimestamp(), 1);
   }
 
   public function testItCancelsEmailWhenCartEmpty() {
@@ -269,11 +273,15 @@ class AbandonedCartTest extends \MailPoetTest {
 
     $completed = $this->scheduledTasksRepository->findOneBy(['status' => ScheduledTaskEntity::STATUS_COMPLETED]);
     $this->assertInstanceOf(ScheduledTaskEntity::class, $completed);
-    $this->assertEquals($completed->getScheduledAt(), $scheduledInPast);
+    $scheduledAt = $completed->getScheduledAt();
+    $this->assertInstanceOf(\DateTime::class, $scheduledAt);
+    $this->assertEqualsWithDelta($scheduledAt->getTimestamp(), $scheduledInPast->getTimestamp(), 1);
 
     $scheduled = $this->scheduledTasksRepository->findOneBy(['status' => ScheduledTaskEntity::STATUS_SCHEDULED]);
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduled);
-    $this->assertEquals($scheduled->getScheduledAt(), $expectedTime);
+    $scheduledAt = $scheduled->getScheduledAt();
+    $this->assertInstanceOf(\DateTime::class, $scheduledAt);
+    $this->assertEqualsWithDelta($scheduledAt->getTimestamp(), $expectedTime->getTimestamp(), 1);
   }
 
   public function testItPostponesEmailWhenSubscriberIsActiveOnSite() {
@@ -296,7 +304,9 @@ class AbandonedCartTest extends \MailPoetTest {
     $scheduledTasks = $this->scheduledTasksRepository->findAll();
     $this->assertCount(1, $scheduledTasks);
     $this->assertEquals($scheduledTasks[0]->getStatus(), ScheduledTaskEntity::STATUS_SCHEDULED);
-    $this->assertEquals($scheduledTasks[0]->getScheduledAt(), $expectedTime);
+    $scheduledAt = $scheduledTasks[0]->getScheduledAt();
+    $this->assertInstanceOf(\DateTime::class, $scheduledAt);
+    $this->assertEqualsWithDelta($scheduledAt->getTimestamp(), $expectedTime->getTimestamp(), 1);
   }
 
   private function createAbandonedCartEmail() {


### PR DESCRIPTION
## Description

When comparing scheduledAt dates there might be one second difference.

This commit fixes the flakiness by comparing timestamps with delta 1 second instead of comparing date time strings.

Recently, we have seen two of the modified tests fail because of this problem:

https://app.circleci.com/pipelines/github/mailpoet/mailpoet/11995

I'm opting to update all four tests that compared the value of scheduledAt for good measure as they all could suffer from the same problem.

## Code review notes

_N/A_

## QA notes

I don't think QA is needed for this PR as it only changes a couple of integration tests.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4781]

## After-merge notes

_N/A_


[MAILPOET-4781]: https://mailpoet.atlassian.net/browse/MAILPOET-4781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ