### PR TITLE
Flaky scheduler test fix [MAILPOET-4780]

### DIFF
--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -423,9 +423,7 @@ class SchedulerTest extends \MailPoetTest {
     /** @var SendingQueue $updatedQueue */
     $updatedQueue = SendingQueue::findOne($queue->id);
     $updatedQueue = SendingTask::createFromQueue($updatedQueue);
-    expect(Carbon::parse($updatedQueue->scheduledAt))->equals(
-      $currentTime->addMinutes(ScheduledTask::BASIC_RESCHEDULE_TIMEOUT)
-    );
+    $this->tester->assertEqualDateTimes(Carbon::parse($updatedQueue->scheduledAt), $currentTime->addMinutes(ScheduledTask::BASIC_RESCHEDULE_TIMEOUT), 1);
     WPFunctions::set(new WPFunctions());
   }
 


### PR DESCRIPTION
## Description

This PR fixes a flaky test by adding an allowed delta 1 second to time comparison.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

This PR builds on top of https://github.com/mailpoet/mailpoet/pull/4490 and should be reviewed and merged after it.

## Linked tickets

[MAILPOET-4780]

## After-merge notes

_N/A_


[MAILPOET-4780]: https://mailpoet.atlassian.net/browse/MAILPOET-4780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ