### PR TITLE
Fix acceptance test UserRegistrationTriggered [MAILPOET-4782]

### DIFF
--- a/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
+++ b/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
@@ -120,7 +120,7 @@ class UserRegistrationTriggerCest
       $i->click('#mailpoet_subscribe_on_register');
     }
     $i->click('Next');
-    $i->waitForText($username + ' is your new username', 10);
+    $i->waitForText($username . ' is your new username', 10);
   }
 
   private function createWorkflow(): Workflow {

--- a/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
+++ b/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
@@ -119,8 +119,14 @@ class UserRegistrationTriggerCest
     if ($signup) {
       $i->click('#mailpoet_subscribe_on_register');
     }
-    $i->click('Next');
-    $i->waitForText($username . ' is your new username', 10);
+    $i->click('input[type=submit]');
+
+    // Waiting text in Try is for normal WP site, Catch is for multi-site as they differ in UI
+    try {
+      $i->waitForText('Registration complete.', 10);
+    } catch (\Exception $e) {
+      $i->waitForText($username . ' is your new username', 10);
+    }
   }
 
   private function createWorkflow(): Workflow {

--- a/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
+++ b/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
@@ -66,7 +66,7 @@ class UserRegistrationTriggerCest
     $i->dontSee('Entered 1');
     $i->logOut();
 
-    $this->registerWith($i,'workflow-triggered-by-registration', 'test@mailpoet.com');
+    $this->registerWith($i,'workflowtriggeredbyregistration', 'test@mailpoet.com');
 
     $i->login();
     $i->amOnMailpoetPage('automation');
@@ -90,7 +90,7 @@ class UserRegistrationTriggerCest
     $i->dontSee('Entered 1');
     $i->logOut();
 
-    $this->registerWith($i,'workflow-triggered-by-registration', 'test@mailpoet.com');
+    $this->registerWith($i,'workflowtriggeredbyregistration', 'test@mailpoet.com');
 
     $i->login();
 
@@ -119,8 +119,8 @@ class UserRegistrationTriggerCest
     if ($signup) {
       $i->click('#mailpoet_subscribe_on_register');
     }
-    $i->click('Register');
-    $i->waitForText('Registration complete.', 10);
+    $i->click('Next');
+    $i->waitForText($username + ' is your new username', 10);
   }
 
   private function createWorkflow(): Workflow {


### PR DESCRIPTION
## Description

Fixing acceptance test for both single and multi-site scenarios as multi-site require now different approach due to the different design of the registration flow. Now, in multi-site, there's different text on the `Submit` button and after registering different text to verify. Additionally removed - from the username names as this is another different rule for multi-side registering to include only letters and numbers.

## Code review notes

This approach works, but I was using try/catch method and I hope it's fine.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4782](https://mailpoet.atlassian.net/browse/MAILPOET-4782)

## After-merge notes

_N/A_
