### PR TITLE
Use `workflow_triggers` table instead of an inline JSON

### DIFF
--- a/mailpoet/lib/Automation/Engine/Data/Workflow.php
+++ b/mailpoet/lib/Automation/Engine/Data/Workflow.php
@@ -167,14 +167,6 @@ class Workflow {
           return $step->toArray();
         }, $this->steps)
       ),
-      'trigger_keys' => Json::encode(
-        array_reduce($this->steps, function (array $triggerKeys, Step $step): array {
-          if ($step->getType() === Step::TYPE_TRIGGER) {
-            $triggerKeys[] = $step->getKey();
-          }
-          return $triggerKeys;
-        }, [])
-      ),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
+++ b/mailpoet/lib/Automation/Engine/Migrations/Migrator.php
@@ -39,12 +39,19 @@ class Migrator {
       CREATE TABLE {$this->prefix}workflow_versions (
         id int(11) unsigned NOT NULL AUTO_INCREMENT,
         workflow_id int(11) unsigned NOT NULL,
-        trigger_keys longtext NOT NULL,
         steps longtext,
         created_at timestamp NOT NULL,
         updated_at timestamp NOT NULL,
         PRIMARY KEY (id),
         INDEX (workflow_id)
+      );
+    ");
+
+    $this->runQuery("
+      CREATE TABLE {$this->prefix}workflow_triggers (
+        workflow_id int(11) unsigned NOT NULL,
+        trigger_key varchar(255),
+        PRIMARY KEY (workflow_id, trigger_key)
       );
     ");
 
@@ -86,6 +93,7 @@ class Migrator {
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_runs");
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_run_logs");
     $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_versions");
+    $this->runQuery("DROP TABLE IF EXISTS {$this->prefix}workflow_triggers");
 
     // clean Action Scheduler data
     $this->runQuery("

--- a/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/WorkflowStorage.php
@@ -19,6 +19,9 @@ class WorkflowStorage {
   /** @var string */
   private $triggersTable;
 
+  /** @var string */
+  private $runsTable;
+
   /** @var wpdb */
   private $wpdb;
 
@@ -27,6 +30,7 @@ class WorkflowStorage {
     $this->workflowsTable = $wpdb->prefix . 'mailpoet_workflows';
     $this->versionsTable = $wpdb->prefix . 'mailpoet_workflow_versions';
     $this->triggersTable = $wpdb->prefix . 'mailpoet_workflow_triggers';
+    $this->runsTable = $wpdb->prefix . 'mailpoet_workflow_runs';
     $this->wpdb = $wpdb;
   }
 
@@ -152,9 +156,7 @@ class WorkflowStorage {
   }
 
   public function deleteWorkflow(Workflow $workflow): void {
-    $workflowsTable = esc_sql($this->workflowsTable);
-    $versionsTable = esc_sql($this->versionsTable);
-    $workflowRunsTable = esc_sql($this->wpdb->prefix . 'mailpoet_workflow_runs');
+    $workflowRunsTable = esc_sql($this->runsTable);
     $workflowRunLogsTable = esc_sql($this->wpdb->prefix . 'mailpoet_workflow_run_logs');
     $workflowId = $workflow->getId();
     $runLogsQuery = (string)$this->wpdb->prepare(
@@ -173,12 +175,12 @@ class WorkflowStorage {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }
 
-    $runsDeleted = $this->wpdb->delete($this->wpdb->prefix . 'mailpoet_workflow_runs', ['workflow_id' => $workflowId]);
+    $runsDeleted = $this->wpdb->delete($this->runsTable, ['workflow_id' => $workflowId]);
     if ($runsDeleted === false) {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }
 
-    $versionsDeleted = $this->wpdb->delete($versionsTable, ['workflow_id' => $workflowId]);
+    $versionsDeleted = $this->wpdb->delete($this->versionsTable, ['workflow_id' => $workflowId]);
     if ($versionsDeleted === false) {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }
@@ -188,7 +190,7 @@ class WorkflowStorage {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }
 
-    $workflowDeleted = $this->wpdb->delete($workflowsTable, ['id' => $workflowId]);
+    $workflowDeleted = $this->wpdb->delete($this->workflowsTable, ['id' => $workflowId]);
     if ($workflowDeleted === false) {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -48,7 +48,7 @@ parameters:
       path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 8
+      count: 9
       path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
     -
       message: '/^Call to static method get_orders_table_name\(\) on an unknown class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore\.$/'

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -48,7 +48,7 @@ parameters:
       path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 5
+      count: 7
       path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
     -
       message: '/^Call to static method get_orders_table_name\(\) on an unknown class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore\.$/'

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -48,7 +48,7 @@ parameters:
       path: ../../lib/Automation/Engine/Storage/WorkflowRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 7
+      count: 8
       path: ../../lib/Automation/Engine/Storage/WorkflowStorage.php
     -
       message: '/^Call to static method get_orders_table_name\(\) on an unknown class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore\.$/'


### PR DESCRIPTION
## Description

Use `workflow_triggers` table instead of an inline JSON array that is not indexable.

## Code review notes

_N/A_

## QA notes

Automations only.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4778]

## After-merge notes

_N/A_


[MAILPOET-4778]: https://mailpoet.atlassian.net/browse/MAILPOET-4778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ