### PR TITLE
Reduce size of a database field to avoid error in some MySQL versions [MAILPOET-4790]

### DIFF
--- a/mailpoet/lib/Migrator/Store.php
+++ b/mailpoet/lib/Migrator/Store.php
@@ -64,7 +64,7 @@ class Store {
     $this->connection->executeStatement("
       CREATE TABLE IF NOT EXISTS {$this->table} (
         id int(11) unsigned NOT NULL AUTO_INCREMENT,
-        name varchar(255) NOT NULL,
+        name varchar(191) NOT NULL,
         started_at timestamp NOT NULL,
         completed_at timestamp NULL,
         retries int(11) unsigned NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Description

This PR reduces the size of the `name` field from varchar(255) to varchar(191) to avoid the following fatal error in some MySQL versions:

```
SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes
```

See the ticket descriptions and the links in it for more information.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4790]

## After-merge notes

_N/A_


[MAILPOET-4790]: https://mailpoet.atlassian.net/browse/MAILPOET-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ