### PR TITLE
Update CircleCI to wait for Woo jobs to complete before starting `build_release_zip` [MAILPOET-4791]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,6 +749,12 @@ workflows:
             - js_tests
             - integration_test_woocommerce
             - integration_test_base
+            - integration_test_woo_cot_no_sync
+            - integration_test_woo_cot_off
+            - integration_test_woo_cot_sync
+            - acceptance_tests_woo_cot_sync
+            - acceptance_tests_woo_cot_off
+            - acceptance_tests_woo_cot_no_sync
 
   nightly:
     triggers:


### PR DESCRIPTION
In [MAILPOET-4572] we added new CircleCI jobs to run WooCommerce tests in different scenarios. But we forgot to add those jobs to the list of jobs that need to finish before starting the build_release_zip job.

This can be problematic as we don’t want the build_release_zip to start before all the test jobs have finished and, even worst, we don’t want it to run if one of the test jobs failed.

This commit adds the following jobs to the list of jobs that are required to finish before running build_release_zip:

- integration_test_woo_cot_no_sync
- integration_test_woo_cot_off
- integration_test_woo_cot_sync
- acceptance_tests_woo_cot_sync
- acceptance_tests_woo_cot_off
- acceptance_tests_woo_cot_no_sync

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4791]

## After-merge notes

_N/A_


[MAILPOET-4572]: https://mailpoet.atlassian.net/browse/MAILPOET-4572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4791]: https://mailpoet.atlassian.net/browse/MAILPOET-4791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ