### PR TITLE
Fix user registration test [MAILPOET-4785]

### DIFF
--- a/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
+++ b/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
@@ -49,10 +49,12 @@ class UserRegistrationTriggerCest
     $this->workflowStorage = $this->container->get(WorkflowStorage::class);
     $this->workflowRunStorage = $this->container->get(WorkflowRunStorage::class);
     $this->workflowRunLogStorage = $this->container->get(WorkflowRunLogStorage::class);
+
+    //In a multisite, for the plugin to be active on wp-activate.php, it needs to be activated network wide.
+    getenv('MULTISITE') && $i->cli(['plugin','activate','mailpoet','--network']);
   }
 
-  public function workflowTriggeredByRegistrationWithoutConfirmationNeeded(\AcceptanceTester $i, $scenario) {
-    $scenario->skip('Temporally skip this test as it is failing when testing with WP multisite');
+  public function workflowTriggeredByRegistrationWithoutConfirmationNeeded(\AcceptanceTester $i) {
     $i->wantTo("Activate a trigger by registering.");
     $this->settingsFactory
       ->withSubscribeOnRegisterEnabled()
@@ -76,8 +78,8 @@ class UserRegistrationTriggerCest
     $i->see('Entered 1'); //The visible text is 1 Entered, but in the DOM it's the other way around.
   }
 
-  public function workflowTriggeredByRegistrationWitConfirmationNeeded(\AcceptanceTester $i, $scenario) {
-    $scenario->skip('Temporally skip this test as it is failing when testing with WP multisite');
+
+  public function workflowTriggeredByRegistrationWitConfirmationNeeded(\AcceptanceTester $i) {
     $i->wantTo("Activate a trigger by registering.");
     $this->settingsFactory
       ->withSubscribeOnRegisterEnabled()
@@ -105,6 +107,8 @@ class UserRegistrationTriggerCest
     $i->click(Locator::contains('span.subject', 'Confirm your subscription'));
     $i->switchToIframe('#preview-html');
     $i->click('Click here to confirm your subscription.');
+    $i->switchToNextTab();
+    $i->waitForText('You have subscribed to MP Dev');
 
     $i->amonUrl('http://test.local');
     $i->amOnMailpoetPage('automation');
@@ -123,12 +127,22 @@ class UserRegistrationTriggerCest
     }
     $i->click('input[type=submit]');
 
-    // Waiting text in Try is for normal WP site, Catch is for multi-site as they differ in UI
-    try {
-      $i->waitForText('Registration complete.', 10);
-    } catch (\Exception $e) {
-      $i->waitForText($username . ' is your new username', 10);
+    $registrationComplete = (!getenv('MULTISITE')) ? 'Registration complete' : $username . ' is your new username';
+    $i->waitForText($registrationComplete);
+
+    if (getenv('MULTISITE')) {
+      $i->amOnMailboxAppPage();
+      $i->waitForText('Activate');
+
+      $i->click(Locator::contains('span.subject', 'Activate'));
+      $i->waitForText('To activate your user, please click the following link:');
+
+      $i->click(Locator::contains('a', 'wp-activate.php'));
+      $i->switchToNextTab();
+      $i->waitForText('Your account is now active!');
     }
+
+    $i->amOnUrl('http://test.local');
   }
 
   private function createWorkflow(): Workflow {

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -63,7 +63,7 @@ if [[ -z "${SKIP_DEPS}" ]]; then
 fi
 
 # Install a fix plugin for PHPMailer on WP 5.6
-cp /project/tests/docker/codeception/wp-56-phpmailer-fix.php /wp-core/wp-content/plugins/wp-56-phpmailer-fix.php
+cp /project/tests/docker/codeception/send-wp-mail-with-smtp.php /wp-core/wp-content/plugins/send-wp-mail-with-smtp.php
 wp plugin activate wp-56-phpmailer-fix
 
 # Install, activate and print info about plugins that we want to use in tests runtime.

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -64,7 +64,7 @@ fi
 
 # Install a fix plugin for PHPMailer on WP 5.6
 cp /project/tests/docker/codeception/send-wp-mail-with-smtp.php /wp-core/wp-content/plugins/send-wp-mail-with-smtp.php
-wp plugin activate wp-56-phpmailer-fix
+wp plugin activate send-wp-mail-with-smtp
 
 # Install, activate and print info about plugins that we want to use in tests runtime.
 # The plugin activation could be skipped by setting env. variable SKIP_PLUGINS

--- a/mailpoet/tests/docker/codeception/send-wp-mail-with-smtp.php
+++ b/mailpoet/tests/docker/codeception/send-wp-mail-with-smtp.php
@@ -1,7 +1,6 @@
 <?php
-
 /*
-Plugin Name: MailPoet Testing Fix: Use SMTP In PHPMailer on WP 5.6
+Plugin Name: Send wp_mail with SMTP
 Version: 0.1
 */
 
@@ -9,10 +8,6 @@ add_action('phpmailer_init', 'mailpoet_test_phpmailer_use_smtp');
 
 function mailpoet_test_phpmailer_use_smtp($phpmailer) {
     global $wp_version;
-
-    if (!getenv('CIRCLE_BRANCH') || !preg_match('/^5\.6/', $wp_version)) {
-      return;
-    }
 
     $phpmailer->isSMTP();
     $phpmailer->Host = 'mailhog';


### PR DESCRIPTION
## Description

When you register as a user in a multisite, you need to activate your account, before a `WP_User` is created. Actions like `user_register` fire only after you have activated your account. This PR therefore goes through the whole registration process.

The second change that was needed: The activation takes place on `wp-activate.php`, but there only network-wide plugins can be active, as you are not in the context of a specific site/blog. So, the test ensures, mailpoet is active network-wide.

The last change: The activation email gets send with `wp_mail()`. For some reason `wp_mail()` did not send. We had already a plugin in place, which made sure `wp_mail()` would send with SMTP in a WP 5.6 environment. I changed this to always send via SMTP.

## QA notes

run `./do test:acceptance-multisite --skip-deps --file=tests/acceptance/Automation/UserRegistrationTriggerCest.php` to verify the test works on multisite.

## Linked tickets

[MAILPOET-4785]


[MAILPOET-4785]: https://mailpoet.atlassian.net/browse/MAILPOET-4785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ