### PR TITLE
Prevent leaving unsaved automation

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -72,6 +72,25 @@ function updatingActiveWorkflowNotPossible() {
   );
 }
 
+function onUnload(event) {
+  if (!globalSelect(storeName).getWorkflowSaved()) {
+    // eslint-disable-next-line no-param-reassign
+    event.returnValue = __(
+      'There are unsaved changes that will be lost. Do you want to continue?',
+      'mailpoet',
+    );
+    return event.returnValue;
+  }
+  return '';
+}
+
+function useConfirmUnsaved() {
+  useEffect(() => {
+    window.addEventListener('beforeunload', onUnload);
+    return () => window.removeEventListener('beforeunload', onUnload);
+  }, []);
+}
+
 function Editor(): JSX.Element {
   const {
     isFullscreenActive,
@@ -91,6 +110,8 @@ function Editor(): JSX.Element {
   );
   const [showActivatePanel, setShowActivatePanel] = useState(false);
   const [isBooting, setIsBooting] = useState(true);
+
+  useConfirmUnsaved();
 
   useEffect(() => {
     if (!isBooting) {

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Automation\Engine\Migrations\Migrator;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Test\DataFactories\Features;
+
+class ConfirmLeaveWhenUnsavedChangesCest
+{
+  public function _before() {
+    // @ToDo Remove once MVP is released.
+    $features = new Features();
+    $features->withFeatureEnabled(FeaturesController::AUTOMATION);
+    $container = ContainerWrapper::getInstance();
+    $migrator = $container->get(Migrator::class);
+    $migrator->deleteSchema();
+    $migrator->createSchema();
+  }
+
+  public function confirmationIsRequiredIfWorkflowNotSaved(\AcceptanceTester $i) {
+    $i->wantTo('Edit a new workflow draft');
+    $i->login();
+
+    $i->amOnMailpoetPage('Automation');
+    $i->see('Automations');
+    $i->waitForText('Better engagement begins with automation');
+    $i->dontSee('Active');
+    $i->dontSee('Entered');
+
+    $i->click('Start with a template');
+    $i->see('Choose your automation template');
+    $i->click('Simple welcome email');
+
+    $i->waitForText('Draft');
+    $i->click('Trigger');
+    $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
+    $i->click('Delay');
+    $i->fillField('Wait for', '5');
+
+    $i->wantTo('Leave the page without saving.');
+    $i->reloadPage();
+    $i->cancelPopup();
+
+    $i->wantTo('Leave the page after saving.');
+    $i->click('Save');
+    $i->waitForText('saved');
+    $i->reloadPage();
+    $i->waitForText('Draft');
+  }
+}


### PR DESCRIPTION
## Description

Add a pop-up requesting confirmation if leaving the workflow editor with unsaved changes

## Code review notes

_N/A_

## QA notes

To test:
- With feature flag
- Edit a workflow or create a new one
- Make a modification
- Reload the page or click on another page
- Check there is a pop up asking for confirmation to leave with unsaved changes

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4776]

## After-merge notes

_N/A_


[MAILPOET-4776]: https://mailpoet.atlassian.net/browse/MAILPOET-4776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ