### PR TITLE
Do not activate MSS unless key is valid for sending [MAILPOET-4767]

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
 import { MailPoet } from 'mailpoet';
+import { STORE_NAME } from 'settings/store/store_name';
+import { select } from '@wordpress/data';
 import { useAction, useSelector, useSetting } from 'settings/store/hooks';
 import { GlobalContext } from 'context';
 import { Button } from 'common/button/button';
@@ -123,7 +125,11 @@ export function KeyActivation() {
     MailPoet.Modal.loading(true);
     setState({ inProgress: true });
     await verifyMssKey(state.key);
-    await sendCongratulatoryMssEmail();
+    const currentMssStatus =
+      select(STORE_NAME).getKeyActivationState().mssStatus;
+    if (currentMssStatus === MssStatus.VALID_MSS_ACTIVE) {
+      await sendCongratulatoryMssEmail();
+    }
     await verifyPremiumKey(state.key);
     setState({ inProgress: false });
     MailPoet.Modal.loading(false);

--- a/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -9,7 +9,7 @@ import {
   PremiumStatus,
 } from 'settings/store/types';
 import { updateKeyActivationState } from './key_activation';
-import { setSettings, setSetting } from './settings';
+import { setSetting, setSettings } from './settings';
 import { getMssStatus } from '../make_default_state';
 
 export function* verifyMssKey(key: string) {
@@ -28,6 +28,11 @@ export function* verifyMssKey(key: string) {
   const fields: Partial<KeyActivationState> = {
     mssMessage: res.data.message || null,
   };
+
+  if (res.data.state === 'valid_underprivileged') {
+    fields.mssStatus = MssStatus.VALID_UNDERPRIVILEGED;
+    return updateKeyActivationState(fields);
+  }
 
   const data = select(STORE_NAME).getSettings();
   data.mta_group = 'mailpoet';

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -126,7 +126,7 @@ class Services extends APIEndpoint {
     }
 
     if ($successMessage) {
-      return $this->successResponse(['message' => $successMessage]);
+      return $this->successResponse(['message' => $successMessage, 'state' => $state]);
     }
 
     switch ($state) {


### PR DESCRIPTION
## Description

This PR stops the plugin from activating the MSS sending method when a user verifies a key that does not include MSS sending (i.e. creator plans).

It also stops us from making an unnecessary API call attempting to send a congratulatory email in those cases.

## Code review notes

_N/A_

## QA notes

This ticket does not include disabling MSS upon verification or other UI changes we might want to make when a user has a creator plan activated. I will create a new ticket or tickets to track some of these other changes.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4767](https://mailpoet.atlassian.net/browse/MAILPOET-4767)

## After-merge notes

_N/A_
