### PR TITLE
Revert broken test fix [MAILPOET-4796]

### DIFF
--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -31,7 +31,7 @@ class ConfirmLeaveWhenUnsavedChangesCest
 
     $i->click('Start with a template');
     $i->see('Choose your automation template');
-    $i->click('Simple welcome email');
+    $i->click('Welcome new subscribers');
 
     $i->waitForText('Draft');
     $i->click('Trigger');

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -63,8 +63,8 @@ if [[ -z "${SKIP_DEPS}" ]]; then
 fi
 
 # Install a fix plugin for PHPMailer on WP 5.6
-cp /project/tests/docker/codeception/send-wp-mail-with-smtp.php /wp-core/wp-content/plugins/send-wp-mail-with-smtp.php
-wp plugin activate send-wp-mail-with-smtp
+cp /project/tests/docker/codeception/wp-56-phpmailer-fix.php /wp-core/wp-content/plugins/wp-56-phpmailer-fix.php
+wp plugin activate wp-56-phpmailer-fix
 
 # Install, activate and print info about plugins that we want to use in tests runtime.
 # The plugin activation could be skipped by setting env. variable SKIP_PLUGINS

--- a/mailpoet/tests/docker/codeception/wp-56-phpmailer-fix.php
+++ b/mailpoet/tests/docker/codeception/wp-56-phpmailer-fix.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
-Plugin Name: Send wp_mail with SMTP
+Plugin Name: MailPoet Testing Fix: Use SMTP In PHPMailer on WP 5.6
 Version: 0.1
 */
 
@@ -8,6 +9,10 @@ add_action('phpmailer_init', 'mailpoet_test_phpmailer_use_smtp');
 
 function mailpoet_test_phpmailer_use_smtp($phpmailer) {
     global $wp_version;
+
+    if (!getenv('CIRCLE_BRANCH') || !preg_match('/^5\.6/', $wp_version)) {
+      return;
+    }
 
     $phpmailer->isSMTP();
     $phpmailer->Host = 'mailhog';


### PR DESCRIPTION
## Description

Reverts https://github.com/mailpoet/mailpoet/pull/4511.

Fixes a failing test trying to click on an outdated string.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4796]

## After-merge notes

_N/A_

[MAILPOET-4796]: https://mailpoet.atlassian.net/browse/MAILPOET-4796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ