### PR TITLE
Prevent Store API validation errors when the 'optin' field has a null value

### DIFF
--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -120,7 +120,7 @@ class WooCommerceBlocksIntegration {
           return [
             'optin' => [
               'description' => __('Subscribe to marketing opt-in.', 'mailpoet'),
-              'type' => 'boolean',
+              'type' => array( 'boolean', 'null'),
             ],
           ];
         },


### PR DESCRIPTION
## Description

This PR is intended to solve an issue between [WooPay](https://woocommerce.com/woopay/) and Mailpoet for WooCommerce so that merchants can use both products together.

When an order gets created via the Store API from WooPay, the 'optin' field expected by Mailpoet will be null. Right now, mailpoet only accepts boolean values, so the validation fails. This results in the order not being created.

Mailpoet already handles null value inputs and correctly sanitizes them as false values. 

More info on this issue can be found here: https://wp.me/pdpOw2-1uq#comment-1687


## Code review notes

_N/A_

## QA notes

This PR has been tested along with WooPay to make sure the WooPay order flow is functional. 
To make there are no regressions in the Marketing Opt-In option, please follow the functional testing instructions in this PR: https://github.com/mailpoet/mailpoet/pull/3813 
## Linked PRs

_N/A_

## Linked tickets

https://github.com/Automattic/woopay/issues/1416

## After-merge notes

_N/A_
