### PR TITLE
Fix unknown storage engine 'InnoDB' error [MAILPOET-4802]

### DIFF
--- a/mailpoet/lib/Migrator/Store.php
+++ b/mailpoet/lib/Migrator/Store.php
@@ -71,7 +71,7 @@ class Store {
         error text NULL,
         PRIMARY KEY (id),
         UNIQUE KEY (name)
-      ) Engine=InnoDB {$collate};
+      ) {$collate};
     ");
   }
 }


### PR DESCRIPTION
## Description

Fixes `PDOException: SQLSTATE[42000]: Syntax error or access violation: 1286 Unknown storage engine 'InnoDB' in ...`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4802]

## After-merge notes

_N/A_


[MAILPOET-4802]: https://mailpoet.atlassian.net/browse/MAILPOET-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ