### PR TITLE
Update sales banner for Black Friday 2022 [MAILPOET-4712]

### DIFF
--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -34,7 +34,7 @@ class BlackFridayNotice {
     $subscribers = $this->subscribersRepository->countBy(['deletedAt' => null]);
     $header = '<h3 class="mailpoet-h3">' . __('Our Black Friday sale is live! Save 40% for a limited time.', 'mailpoet') . '</h3>';
     $body = '<h5 class="mailpoet-h5">' . __('Get a 40% discount on all MailPoet plans and upgrades until 3 PM UTC on 29 November. Terms & conditions apply.', 'mailpoet') . '</h5>';
-    $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers&billing=yearly&ref=sale-bfcm-2022-plugin&utm_source=MP&utm_medium=plugin&utm_campaign=mp_bfcm' class='mailpoet-button button-primary' target='_blank'>"
+    $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers&billing=yearly&ref=sale-bfcm-2022-plugin&utm_source=MP&utm_medium=plugin&utm_campaign=mp_bfcm22' class='mailpoet-button button-primary' target='_blank'>"
       . __('Shop Now', 'mailpoet')
       . '</a></p>';
 

--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -22,8 +22,8 @@ class BlackFridayNotice {
 
   public function init($shouldDisplay) {
     $shouldDisplay = $shouldDisplay
-      && (time() >= strtotime('2022-10-03 14:00:00 UTC'))
-      && (time() <= strtotime('2022-10-07 14:00:00 UTC'))
+      && (time() >= strtotime('2022-11-23 15:00:00 UTC'))
+      && (time() <= strtotime('2022-11-29 15:00:00 UTC'))
       && !get_transient(self::OPTION_NAME);
     if ($shouldDisplay) {
       $this->display();
@@ -32,9 +32,9 @@ class BlackFridayNotice {
 
   private function display() {
     $subscribers = $this->subscribersRepository->countBy(['deletedAt' => null]);
-    $header = '<h3 class="mailpoet-h3">' . __('Get ready for Black Friday with 40% off MailPoet plans', 'mailpoet') . '</h3>';
-    $body = '<h5 class="mailpoet-h5">' . __('Save 40% on all annual plans until 2 pm UTC, October 7. Terms & conditions apply.', 'mailpoet') . '</h5>';
-    $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers&billing=yearly&ref=sale-october-2022-plugin&utm_source=MP&utm_medium=plugin&utm_campaign=mp_prebfcm' class='mailpoet-button button-primary' target='_blank'>"
+    $header = '<h3 class="mailpoet-h3">' . __('Our Black Friday sale is live! Save 40% for a limited time.', 'mailpoet') . '</h3>';
+    $body = '<h5 class="mailpoet-h5">' . __('Get a 40% discount on all MailPoet plans and upgrades until 3 PM UTC on 29 November. Terms & conditions apply.', 'mailpoet') . '</h5>';
+    $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers&billing=yearly&ref=sale-bfcm-2022-plugin&utm_source=MP&utm_medium=plugin&utm_campaign=mp_bfcm' class='mailpoet-button button-primary' target='_blank'>"
       . __('Shop Now', 'mailpoet')
       . '</a></p>';
 


### PR DESCRIPTION
## Description

This PR updates the Black Friday banner, and it's display conditions for 2022 Black Friday.

<img width="1222" alt="Screenshot 2022-11-10 at 10 24 25" src="https://user-images.githubusercontent.com/1082140/201072132-e589b5e4-e658-467e-b483-d08fb1710055.png">

## Code review notes

_N/A_

## QA notes

To display the banner, you can edit dates in the [display conditions](https://github.com/mailpoet/mailpoet/compare/trunk...bfcm-banner#diff-53170429e3e13f729d6b3cc61518ccf33dd42d3fa49bf4333c0b653d0dec2c5bR25) in `mailpoet/lib/Util/Notices/BlackFridayNotice.php`.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4712]

## After-merge notes

_N/A_


[MAILPOET-4712]: https://mailpoet.atlassian.net/browse/MAILPOET-4712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ