### PR TITLE
Fix [subscriber:count] counts only subscribed subscribers - MAILPOET-4527

### DIFF
--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -54,7 +54,7 @@ class Subscriber implements CategoryInterface {
         }
         return $defaultValue;
       case 'count':
-        return (string)$this->subscribersRepository->getTotalSubscribers();
+        return (string)$this->getSubscribersCountWithSubscribedStatus();
       default:
         if (
           preg_match('/cf_(\d+)/', $shortcodeDetails['action'], $customField) &&
@@ -68,5 +68,9 @@ class Subscriber implements CategoryInterface {
         }
         return null;
     }
+  }
+
+  private function getSubscribersCountWithSubscribedStatus(): int {
+    return $this->subscribersRepository->countBy(['status' => SubscriberEntity::STATUS_SUBSCRIBED, 'deletedAt' => null]);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -236,9 +236,7 @@ class ShortcodesTest extends \MailPoetTest {
     $subscriberCount = $subscribersRepository->countBy(
       [
         'status' =>[
-          SubscriberEntity::STATUS_SUBSCRIBED,
-          SubscriberEntity::STATUS_UNCONFIRMED,
-          SubscriberEntity::STATUS_INACTIVE
+          SubscriberEntity::STATUS_SUBSCRIBED
         ]
       ]
     );


### PR DESCRIPTION


## Description

The shortcode [subscriber:count] is used in the newsletter editor and currently counts subscribed, unconfirmed and inactive subscribers.

We have updated the shortcode to count only subscribed subscribers.


## QA notes

Check the ticket


## Linked tickets

[MAILPOET-4527](https://mailpoet.atlassian.net/browse/MAILPOET-4527)


