### PR TITLE
Accept null opt-in values for in Woo Blocks integration [MAILPOET-4804]

### DIFF
--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -120,7 +120,7 @@ class WooCommerceBlocksIntegration {
           return [
             'optin' => [
               'description' => __('Subscribe to marketing opt-in.', 'mailpoet'),
-              'type' => 'boolean',
+              'type' => ['boolean', 'null'],
             ],
           ];
         },


### PR DESCRIPTION
## Description

Note: This PR is a copy of https://github.com/mailpoet/mailpoet/pull/4517 made by @malithsen. I needed to make the copy to get the build pass.

This PR is intended to solve an issue between [WooPay](https://woocommerce.com/woopay/) and Mailpoet for WooCommerce so that merchants can use both products together.

When an order gets created via the Store API from WooPay, the 'optin' field expected by Mailpoet will be null. Right now, mailpoet only accepts boolean values, so the validation fails. This results in the order not being created.

Mailpoet already handles null value inputs and correctly sanitizes them as false values. 

More info on this issue can be found here: pdpOw2-1uq-p2#comment-1687


## Code review notes

_N/A_

## QA notes

This PR has been tested along with WooPay to make sure the WooPay order flow is functional. 
To make there are no regressions in the Marketing Opt-In option, please follow the functional testing instructions in this PR: https://github.com/mailpoet/mailpoet/pull/3813 
## Linked PRs

Original PR: https://github.com/mailpoet/mailpoet/pull/4517

## Linked tickets

https://github.com/Automattic/woopay/issues/1416
[MAILPOET-4804]

## After-merge notes

_N/A_

[MAILPOET-4804]: https://mailpoet.atlassian.net/browse/MAILPOET-4804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ