### PR TITLE
Open automations Beacon links in a new tab instead of HelpScout Beacon [MAILPOET-4809]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/shortcode_help_text.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/shortcode_help_text.tsx
@@ -8,7 +8,6 @@ export function ShortcodeHelpText(): JSX.Element {
         href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes"
         target="_blank"
         rel="noopener noreferrer"
-        data-beacon-article="59d662ef042863379ddc6faa"
       >
         {__('MailPoet shortcodes', 'mailpoet')}
       </a>


### PR DESCRIPTION
## Description

During the beta period, KB links will be open in a new tab instead of HelpScout Beacon because we use different Beacon to gather direct feedback, which doesn't include KB articles.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4809]

## After-merge notes

_N/A_


[MAILPOET-4809]: https://mailpoet.atlassian.net/browse/MAILPOET-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ