### PR TITLE
Rename "Not active" state to "Draft" on automations listing page [MAILPOET-4810]

### DIFF
--- a/mailpoet/assets/js/src/automation/listing/components/cells/status.tsx
+++ b/mailpoet/assets/js/src/automation/listing/components/cells/status.tsx
@@ -10,7 +10,7 @@ export function Status({ automation }: Props): JSX.Element {
     <div className="mailpoet-automation-listing-cell-status">
       {automation.status === AutomationStatus.ACTIVE
         ? __('Active', 'mailpoet')
-        : __('Not active', 'mailpoet')}
+        : __('Draft', 'mailpoet')}
     </div>
   );
 }


### PR DESCRIPTION
## Description

In the Automations MVP, we only operate with "Active" and "Draft" states. This ticket replaces "Not active" state on the listing page with "Draft", to unify it with the listing filters.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4810]

## After-merge notes

_N/A_


[MAILPOET-4810]: https://mailpoet.atlassian.net/browse/MAILPOET-4810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ