### PR TITLE
Add check for mail function and display notice if disabled - MAILPOET-4760

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -372,7 +372,7 @@ class Settings extends APIEndpoint {
         // when the user switch to a new sending method
         // do not display the DisabledMailFunctionNotice
         $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, false);
-        $this->settings->set(DisabledMailFunctionNotice::OPTION_NAME, false); // do not display notice
+        $this->settings->set(DisabledMailFunctionNotice::DISABLED_MAIL_FUNCTION_CHECK, false); // do not display notice
       }
     }
 

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -148,17 +148,6 @@ class Settings extends APIEndpoint {
         $this->messageController->updateSuccessMessages();
       }
 
-      $sendingMethodSet = $settings['mta']['method'] ?? null;
-      if ($sendingMethodSet === 'PHPMail') {
-        // check for valid mail function
-        $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
-      } else {
-        // when the user switch to a new sending method
-        // do not display the DisabledMailFunctionNotice
-        $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, false);
-        $this->settings->set(DisabledMailFunctionNotice::OPTION_NAME, false); // do not display notice
-      }
-
       // Tracking and re-engagement Emails
       $meta['showNotice'] = false;
       if ($oldSettings['tracking'] !== $this->settings->get('tracking')) {
@@ -372,6 +361,19 @@ class Settings extends APIEndpoint {
     $newSendingMethod = $newSettings['mta_group'];
     if (($oldSendingMethod !== $newSendingMethod) && ($newSendingMethod === 'mailpoet')) {
       $this->settingsChangeHandler->onMSSActivate($newSettings);
+    }
+
+    if (($oldSendingMethod !== $newSendingMethod)) {
+      $sendingMethodSet = $newSettings['mta']['method'] ?? null;
+      if ($sendingMethodSet === 'PHPMail') {
+        // check for valid mail function
+        $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
+      } else {
+        // when the user switch to a new sending method
+        // do not display the DisabledMailFunctionNotice
+        $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, false);
+        $this->settings->set(DisabledMailFunctionNotice::OPTION_NAME, false); // do not display notice
+      }
     }
 
     // Sync WooCommerce Customers list

--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -134,7 +134,7 @@ class Activator {
   private function checkForDisabledMailFunction() {
     $sendingMethodSet = $this->settings->get('mta.method', false);
 
-    if ($sendingMethodSet === 'PHPMail' || is_bool($sendingMethodSet)) {
+    if ($sendingMethodSet === 'PHPMail') {
       // check for valid mail function
       $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
     }

--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -7,6 +7,7 @@ use MailPoet\Cron\CronTrigger;
 use MailPoet\InvalidStateException;
 use MailPoet\Migrator\Migrator;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Notices\DisabledMailFunctionNotice;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 
@@ -81,6 +82,8 @@ class Activator {
 
     $localizer = new Localizer();
     $localizer->forceInstallLanguagePacks($this->wp);
+
+    $this->checkForDisabledMailFunction();
   }
 
   public function deactivate() {
@@ -125,6 +128,15 @@ class Activator {
         'date' => date('Y-m-d H:i:s'),
       ];
       $this->settings->set('updates_log', $updatesLog);
+    }
+  }
+
+  private function checkForDisabledMailFunction() {
+    $sendingMethodSet = $this->settings->get('mta.method', false);
+
+    if ($sendingMethodSet === 'PHPMail' || is_bool($sendingMethodSet)) {
+      // check for valid mail function
+      $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
     }
   }
 

--- a/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Mailer\Mailer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class DisabledMailFunctionNotice {
+
+  const OPTION_NAME = 'disabled-mail-function';
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SubscribersFeature */
+  private $subscribersFeature;
+
+  public function __construct(
+    WPFunctions $wp,
+    SettingsController $settings,
+    SubscribersFeature $subscribersFeature
+  ) {
+    $this->settings = $settings;
+    $this->wp = $wp;
+    $this->subscribersFeature = $subscribersFeature;
+  }
+
+  public function init($shouldDisplay) {
+    $shouldDisplay = $shouldDisplay && $this->checkRequirements();
+    if ($shouldDisplay) {
+      $this->display();
+    }
+  }
+
+  private function checkRequirements(): bool {
+    $sendingMethod = $this->settings->get('mta.method', false);
+    $isPhpMailSendingMethod = $sendingMethod === Mailer::METHOD_PHPMAIL;
+
+    $functionName = 'mail';
+    $isMailFunctionDisabled = $this->isFunctionDisabled($functionName);
+
+    return $isPhpMailSendingMethod && $isMailFunctionDisabled;
+  }
+
+  private function isFunctionDisabled(string $function): bool {
+    $result = function_exists($function) && is_callable($function, false);
+    return !$result;
+  }
+
+  private function display() {
+    $header = $this->getHeader();
+
+    $body = $this->getBody();
+
+    $button = $this->getConnectMailPoetButton();
+
+    $message = $header . $body . $button;
+
+     Notice::displayWarning($message, '', self::OPTION_NAME, false);
+  }
+
+  private function getHeader(): string {
+    return '<h4>' . __('Get ready to send your first campaign.', 'mailpoet') . '</h4>';
+  }
+
+  private function getBody(): string {
+    $bodyText = __('Connect your website with MailPoet, and start sending for free. Reach inboxes, not spam boxes. [link]Why am I seeing this?[/link]', 'mailpoet');
+
+    $bodyWithReplacedLink = Helpers::replaceLinkTags($bodyText, 'https://kb.mailpoet.com/article/396-disabled-mail-function', [
+      'target' => '_blank',
+    ]);
+
+    return '<p>' . $bodyWithReplacedLink . '</p>';
+  }
+
+  private function getConnectMailPoetButton(): string {
+    $subscribersCount = $this->subscribersFeature->getSubscribersCount();
+    $buttonLink = "https://account.mailpoet.com/?s={$subscribersCount}&utm_source=mailpoet&utm_medium=plugin&utm_campaign=disabled_mail_function";
+    $link = $this->wp->escAttr($buttonLink);
+    return '<p><a target="_blank" href="' . $link . '" class="button button-primary">' . __('Connect MailPoet', 'mailpoet') . '</a></p>';
+  }
+}

--- a/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
@@ -12,7 +12,7 @@ use MailPoet\WP\Notice;
 
 class DisabledMailFunctionNotice {
 
-  const OPTION_NAME = 'disabled_mail_function_check';
+  const DISABLED_MAIL_FUNCTION_CHECK = 'disabled_mail_function_check';
 
   const QUEUE_DISABLED_MAIL_FUNCTION_CHECK = 'queue_disabled_mail_function_check';
 
@@ -43,7 +43,7 @@ class DisabledMailFunctionNotice {
   }
 
   public function init($shouldDisplay): ?string {
-    $shouldDisplay = $shouldDisplay && $this->checkMisConfiguredFunction() && $this->checkRequirements();
+    $shouldDisplay = $shouldDisplay && $this->shouldCheckMisconfiguredFunction() && $this->checkRequirements();
     if (!$shouldDisplay) {
       return null;
     }
@@ -67,7 +67,7 @@ class DisabledMailFunctionNotice {
     $isMailFunctionDisabled = $this->isFunctionDisabled($functionName);
 
     if ($isMailFunctionDisabled) {
-      $this->settings->set(DisabledMailFunctionNotice::OPTION_NAME, true);
+      $this->settings->set(DisabledMailFunctionNotice::DISABLED_MAIL_FUNCTION_CHECK, true);
       return true;
     }
 
@@ -86,9 +86,9 @@ class DisabledMailFunctionNotice {
    * queue_disabled_mail_function_check === true
    *
    */
-  public function checkMisConfiguredFunction(): bool {
+  public function shouldCheckMisconfiguredFunction(): bool {
     $this->isInQueueForChecking = $this->settings->get(self::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, false);
-    return $this->settings->get(self::OPTION_NAME, false) || $this->isInQueueForChecking;
+    return $this->settings->get(self::DISABLED_MAIL_FUNCTION_CHECK, false) || $this->isInQueueForChecking;
   }
 
   public function isFunctionDisabled(string $function): bool {
@@ -105,7 +105,7 @@ class DisabledMailFunctionNotice {
 
     $message = $header . $body . $button;
 
-    Notice::displayWarning($message, '', self::OPTION_NAME, false);
+    Notice::displayWarning($message, '', self::DISABLED_MAIL_FUNCTION_CHECK, false);
 
     return $message;
   }
@@ -137,7 +137,7 @@ class DisabledMailFunctionNotice {
    * This is a workaround for detecting the user PHP mail() function is Correctly Configured and not disabled by the host
    */
   private function testMailFunctionIsCorrectlyConfigured(): bool {
-    if ($this->settings->get(DisabledMailFunctionNotice::OPTION_NAME, false)) {
+    if ($this->settings->get(DisabledMailFunctionNotice::DISABLED_MAIL_FUNCTION_CHECK, false)) {
       return false; // skip sending mail again
     }
 
@@ -159,7 +159,7 @@ class DisabledMailFunctionNotice {
     if (!$sendMailResult) {
       // Error with PHP mail() function
       // keep displaying notice
-      $this->settings->set(DisabledMailFunctionNotice::OPTION_NAME, true);
+      $this->settings->set(DisabledMailFunctionNotice::DISABLED_MAIL_FUNCTION_CHECK, true);
     }
 
     return $sendMailResult;

--- a/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
@@ -32,11 +32,13 @@ class DisabledMailFunctionNotice {
     $this->subscribersFeature = $subscribersFeature;
   }
 
-  public function init($shouldDisplay) {
+  public function init($shouldDisplay): ?string {
     $shouldDisplay = $shouldDisplay && $this->checkRequirements();
-    if ($shouldDisplay) {
-      $this->display();
+    if (!$shouldDisplay) {
+      return null;
     }
+
+    return $this->display();
   }
 
   private function checkRequirements(): bool {
@@ -49,12 +51,12 @@ class DisabledMailFunctionNotice {
     return $isPhpMailSendingMethod && $isMailFunctionDisabled;
   }
 
-  private function isFunctionDisabled(string $function): bool {
+  public function isFunctionDisabled(string $function): bool {
     $result = function_exists($function) && is_callable($function, false);
     return !$result;
   }
 
-  private function display() {
+  private function display(): string {
     $header = $this->getHeader();
 
     $body = $this->getBody();
@@ -63,7 +65,9 @@ class DisabledMailFunctionNotice {
 
     $message = $header . $body . $button;
 
-     Notice::displayWarning($message, '', self::OPTION_NAME, false);
+    Notice::displayWarning($message, '', self::OPTION_NAME, false);
+
+    return $message;
   }
 
   private function getHeader(): string {

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Menu;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
 
 class PermanentNotices {
@@ -43,11 +44,15 @@ class PermanentNotices {
   /** @var DeprecatedFilterNotice */
   private $deprecatedFilterNotice;
 
+  /** @var DisabledMailFunctionNotice */
+  private $disabledMailFunctionNotice;
+
   public function __construct(
     WPFunctions $wp,
     TrackingConfig $trackingConfig,
     SubscribersRepository $subscribersRepository,
-    SettingsController $settings
+    SettingsController $settings,
+    SubscribersFeature $subscribersFeature
   ) {
     $this->wp = $wp;
     $this->phpVersionWarnings = new PHPVersionWarnings();
@@ -60,6 +65,7 @@ class PermanentNotices {
     $this->emailWithInvalidListNotice = new EmailWithInvalidSegmentNotice($wp);
     $this->changedTrackingNotice = new ChangedTrackingNotice($wp);
     $this->deprecatedFilterNotice = new DeprecatedFilterNotice($wp);
+    $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature);
   }
 
   public function init() {
@@ -101,6 +107,9 @@ class PermanentNotices {
       Menu::isOnMailPoetAdminPage($excludeWizard)
     );
     $this->deprecatedFilterNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeWizard)
+    );
+    $this->disabledMailFunctionNotice->init(
       Menu::isOnMailPoetAdminPage($excludeWizard)
     );
   }

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Util\Notices;
 
 use MailPoet\Config\Menu;
+use MailPoet\Mailer\MailerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -52,7 +53,8 @@ class PermanentNotices {
     TrackingConfig $trackingConfig,
     SubscribersRepository $subscribersRepository,
     SettingsController $settings,
-    SubscribersFeature $subscribersFeature
+    SubscribersFeature $subscribersFeature,
+    MailerFactory $mailerFactory
   ) {
     $this->wp = $wp;
     $this->phpVersionWarnings = new PHPVersionWarnings();
@@ -65,7 +67,7 @@ class PermanentNotices {
     $this->emailWithInvalidListNotice = new EmailWithInvalidSegmentNotice($wp);
     $this->changedTrackingNotice = new ChangedTrackingNotice($wp);
     $this->deprecatedFilterNotice = new DeprecatedFilterNotice($wp);
-    $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature);
+    $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature, $mailerFactory);
   }
 
   public function init() {

--- a/mailpoet/tests/integration/Util/Notices/DisabledMailFunctionNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/DisabledMailFunctionNoticeTest.php
@@ -24,7 +24,7 @@ class DisabledMailFunctionNoticeTest extends \MailPoetTest
     $this->wp = new WPFunctions;
     $this->settings->set('mta.method', Mailer::METHOD_PHPMAIL);
     $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
-    $this->settings->set(DisabledMailFunctionNotice::OPTION_NAME, false);
+    $this->settings->set(DisabledMailFunctionNotice::DISABLED_MAIL_FUNCTION_CHECK, false);
     $this->wp->setTransient(SubscribersFeature::SUBSCRIBERS_COUNT_CACHE_KEY, 50, SubscribersFeature::SUBSCRIBERS_COUNT_CACHE_EXPIRATION_MINUTES * 60);
   }
 
@@ -111,7 +111,7 @@ class DisabledMailFunctionNoticeTest extends \MailPoetTest
 
     expect($notice)->stringContainsString('Get ready to send your first campaign');
 
-    $status = $this->settings->get(DisabledMailFunctionNotice::OPTION_NAME, false);
+    $status = $this->settings->get(DisabledMailFunctionNotice::DISABLED_MAIL_FUNCTION_CHECK, false);
     expect($status)->equals(true);
   }
 

--- a/mailpoet/tests/integration/Util/Notices/DisabledMailFunctionNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/DisabledMailFunctionNoticeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace MailPoet\Util\Notices;
+
+use Codeception\Util\Stub;
+use MailPoet\Mailer\Mailer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WP\Functions as WPFunctions;
+
+class DisabledMailFunctionNoticeTest extends \MailPoetTest
+{
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->settings = SettingsController::getInstance();
+    $this->wp = new WPFunctions;
+    $this->settings->set('mta.method', Mailer::METHOD_PHPMAIL);
+    $this->wp->setTransient(SubscribersFeature::SUBSCRIBERS_COUNT_CACHE_KEY, 50, SubscribersFeature::SUBSCRIBERS_COUNT_CACHE_EXPIRATION_MINUTES * 60);
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->cleanup();
+  }
+
+  private function cleanup() {
+    $this->settings->delete('mta.method');
+    $this->wp->deleteTransient(SubscribersFeature::SUBSCRIBERS_COUNT_CACHE_KEY);
+  }
+
+  private function generateNotice($methodOverride = []) {
+    return Stub::construct(
+      DisabledMailFunctionNotice::class,
+      [$this->wp, $this->settings, $this->diContainer->get(SubscribersFeature::class)],
+      $methodOverride
+    );
+  }
+
+  public function testItDoesNotDisplayNoticeForOtherSendingMethods() {
+    $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
+
+    $disabledMailFunctionNotice = $this->generateNotice(['isFunctionDisabled' => true]);
+    $notice = $disabledMailFunctionNotice->init(true);
+
+    expect($notice)->equals(null);
+  }
+
+  public function testItDisplaysNoticeForPhpMailSendingMethod() {
+    $disabledMailFunctionNotice = $this->generateNotice(['isFunctionDisabled' => true]);
+    $notice = $disabledMailFunctionNotice->init(true);
+
+    expect($notice)->stringContainsString('Get ready to send your first campaign');
+    expect($notice)->stringContainsString('Connect your website with MailPoet');
+    expect($notice)->stringContainsString('account.mailpoet.com/?s=50&amp;utm_source=mailpoet&amp;utm_medium=plugin&amp;utm_campaign=disabled_mail_function');
+  }
+
+  public function testItDoesNotDisplaysNoticeWhenMailFunctionIsEnabled() {
+    $disabledMailFunctionNotice = $this->generateNotice();
+    $notice = $disabledMailFunctionNotice->init(true);
+
+    expect($notice)->equals(null);
+  }
+
+  public function testItReturnsTrueWhenFunctionDoesNotExist() {
+    $disabledMailFunctionNotice = $this->generateNotice();
+    $result = $disabledMailFunctionNotice->isFunctionDisabled('mp_undefined_function');
+
+    expect($result)->equals(true);
+  }
+
+  public function testItReturnsFalseWhenFunctionExist() {
+    $disabledMailFunctionNotice = $this->generateNotice();
+    $result = $disabledMailFunctionNotice->isFunctionDisabled('in_array');
+
+    expect($result)->equals(false);
+  }
+
+}


### PR DESCRIPTION
## Description

Check if the `mail` function is available and display a notice if not.

**Note**: We only display the notice if the user is sending with the host method (**PHPMail**) and the `mail` function is disabled

## Code review notes

How to disable `mail` function.

The mail function can be disabled from the php.ini file.

On the MailPoet Dev environment, you may do that here: [dev/php.ini](https://github.com/mailpoet/mailpoet/blob/trunk/dev/php.ini#L5)
By setting `disable_functions = 'mail'`

```
upload_max_filesize = 500M
memory_limit = 1024M
post_max_size = 500M
sendmail_path = /usr/bin/msmtp -C /etc/msmtprc -t
sendmail_from = 'wordpress@mp3.localhost'
disable_functions = 'mail'
```

Note: Remember to rebuild your docker image: `docker-compose build wordpress`

## QA notes

Test on a site with a restricted `mail` function (e.g., Pressable) and others without restriction (e.g., Jurassic ninja)

* Activate the plugin, and check MailPoet pages.
* Switch the sending method from settings (/wp-admin/admin.php?page=mailpoet-settings#/mta/other)
* Select SMTP, Click on Activate button
* Reload the page. 
* Confirm Notice is not displayed.
* Switch the sending method back to "Your web host/web server", Click on the Activate button
* Reload the page. 


## Linked tickets

[MAILPOET-4760](https://mailpoet.atlassian.net/browse/MAILPOET-4760)

## After-merge notes

_N/A_
