### PR TITLE
Fix tasks count on the Status page [MAILPOET-4664]

### DIFF
--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -237,6 +237,7 @@ class ScheduledTasksRepository extends Repository {
       $tasks = $tasksQuery
         ->setParameter('status', $status)
         ->setMaxResults($limit)
+        ->orderBy('st.id', 'desc')
         ->getQuery()
         ->getResult();
       $result = array_merge($result, $tasks);

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -225,7 +225,7 @@ class ScheduledTasksRepository extends Repository {
         ->where('st.deletedAt IS NULL')
         ->where('st.status = :status');
 
-      if (in_array(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, $statuses)) {
+      if ($status === ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING) {
         $tasksQuery = $tasksQuery->orWhere('st.status IS NULL');
       }
 

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -218,26 +218,31 @@ class ScheduledTasksRepository extends Repository {
     ],
     $limit = Scheduler::TASK_BATCH_SIZE
   ) {
+    $result = [];
+    foreach ($statuses as $status) {
+      $tasksQuery = $this->doctrineRepository->createQueryBuilder('st')
+        ->select('st')
+        ->where('st.deletedAt IS NULL')
+        ->where('st.status = :status');
 
-    $tasksQuery = $this->doctrineRepository->createQueryBuilder('st')
-      ->select('st')
-      ->where('st.deletedAt IS NULL')
-      ->where('st.status IN (:statuses)');
+      if (in_array(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, $statuses)) {
+        $tasksQuery = $tasksQuery->orWhere('st.status IS NULL');
+      }
 
-    if (in_array(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, $statuses)) {
-      $tasksQuery = $tasksQuery->orWhere('st.status IS NULL');
+      if ($type) {
+        $tasksQuery = $tasksQuery->andWhere('st.type = :type')
+          ->setParameter('type', $type);
+      }
+
+      $tasks = $tasksQuery
+        ->setParameter('status', $status)
+        ->setMaxResults($limit)
+        ->getQuery()
+        ->getResult();
+      $result = array_merge($result, $tasks);
     }
 
-    if ($type) {
-      $tasksQuery = $tasksQuery->andWhere('st.type = :type')
-        ->setParameter('type', $type);
-    }
-
-    return $tasksQuery
-      ->setParameter('statuses', $statuses)
-      ->setMaxResults($limit)
-      ->getQuery()
-      ->getResult();
+    return $result;
   }
 
   /**


### PR DESCRIPTION
## Description

This PR fixes the count of tasks and their order on the status page.

## Code review notes

The issue was caused by [this refactor](https://github.com/mailpoet/mailpoet/pull/4307/files).

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4664]

## After-merge notes

_N/A_


[MAILPOET-4664]: https://mailpoet.atlassian.net/browse/MAILPOET-4664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ