### PR TITLE
Prefix forgotten Twig call in generated template code [MAILPOET-4718]

### DIFF
--- a/mailpoet/prefixer/fix-twig.php
+++ b/mailpoet/prefixer/fix-twig.php
@@ -300,6 +300,15 @@ $replacements = [
       '\'\\\\MailPoetVendor\\\\twig_call_macro(',
     ],
   ],
+  [
+    'file' => '../vendor-prefixed/twig/twig/src/Node/CheckSecurityCallNode.php',
+    'find' => [
+      '\'\\\\Twig\\\\Extension\\\\SandboxExtension',
+    ],
+    'replace' => [
+      '\'\\\\MailPoetVendor\\\\Twig\\\\Extension\\\\SandboxExtension',
+    ],
+  ],
 ];
 
 foreach ($replacements as $singleFile) {


### PR DESCRIPTION
## Description

The Twig library [was already updated by the Dependabot](https://github.com/mailpoet/mailpoet/pull/4407). I double-checked the prefixed code and found one place where we forgot to add a prefix. I'm not sure if that was related to this or some of the previous updates. 
The code is probably not used in the MailPoet plugin because otherwise, we would see some issues. I updated the fix-twig.php to cover this file so that we are fine in case some change we make causes the twig code to be executed.

## Code review notes

_N/A_

## QA notes

I think automated tests should be enough.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/4407

## Linked tickets

[MAILPOET-4718]

## After-merge notes

_N/A_


[MAILPOET-4718]: https://mailpoet.atlassian.net/browse/MAILPOET-4718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ