### PR TITLE
Add command for rerunning the latest project workflow on CircleCI [PREMIUM-207]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1116,21 +1116,15 @@ class RoboFile extends \Robo\Tasks {
     $this->say("Release '$version[name]' info was published on Slack.");
   }
 
-  public function releaseRerunCircleWorkflow(string $project) {
-    $project = strtoupper($project);
-    $supportedProjects = [
-      \MailPoetTasks\Release\CircleCiController::PROJECT_PREMIUM,
-      \MailPoetTasks\Release\CircleCiController::PROJECT_MAILPOET,
-    ];
-    if (!in_array($project, $supportedProjects, true)) {
-      throw new \Exception('Unsupported project');
-    }
+  public function releaseRerunCircleWorkflow(string $project = null) {
     $circleciController = $this->createCircleCiController();
     $result = $circleciController->rerunLatestWorkflow($project);
+    // Sometimes can be useful to know which Circle project workflow was restarted
+    $project = $project ? " for the project '{$project}'" : '';
     if (!$result) {
-      $this->yell("Circle Workflow for the project '{$project}' was not restarted", 40, 'red');
+      $this->yell("Circle Workflow{$project} was not restarted", 40, 'red');
     }
-    $this->say("Circle Workflow for the project '{$project}' was started from the beginning");
+    $this->say("Circle Workflow{$project} was started from the beginning");
   }
 
   public function downloadWooCommerceBlocksZip($tag = null) {

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1116,6 +1116,23 @@ class RoboFile extends \Robo\Tasks {
     $this->say("Release '$version[name]' info was published on Slack.");
   }
 
+  public function releaseRerunCircleWorkflow(string $project) {
+    $project = strtoupper($project);
+    $supportedProjects = [
+      \MailPoetTasks\Release\CircleCiController::PROJECT_PREMIUM,
+      \MailPoetTasks\Release\CircleCiController::PROJECT_MAILPOET,
+    ];
+    if (!in_array($project, $supportedProjects, true)) {
+      throw new \Exception('Unsupported project');
+    }
+    $circleciController = $this->createCircleCiController();
+    $result = $circleciController->rerunLatestWorkflow($project);
+    if (!$result) {
+      $this->yell("Circle Workflow for the project '{$project}' was not restarted", 40, 'red');
+    }
+    $this->say("Circle Workflow for the project '{$project}' was started from the beginning");
+  }
+
   public function downloadWooCommerceBlocksZip($tag = null) {
     $this->createWpOrgDownloader('woo-gutenberg-products-block')
       ->downloadPluginZip('woo-gutenberg-products-block.zip', __DIR__ . '/tests/plugins/', $tag);

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -800,6 +800,9 @@ class RoboFile extends \Robo\Tasks {
         $this->releaseCreatePullRequest($version);
       })
       ->addCode(function () use ($version) {
+        $this->releaseRerunCircleWorkflow(\MailPoetTasks\Release\CircleCiController::PROJECT_PREMIUM);
+      })
+      ->addCode(function () use ($version) {
         $this->translationsPrepareLanguagePacks($version);
       })
       ->run();

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1126,8 +1126,9 @@ class RoboFile extends \Robo\Tasks {
     $project = $project ? " for the project '{$project}'" : '';
     if (!$result) {
       $this->yell("Circle Workflow{$project} was not restarted", 40, 'red');
+    } else {
+      $this->say("Circle Workflow{$project} was started from the beginning");
     }
-    $this->say("Circle Workflow{$project} was started from the beginning");
   }
 
   public function downloadWooCommerceBlocksZip($tag = null) {

--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -69,8 +69,20 @@ class CircleCiController {
    * Returns true when the Circle workflow was started from the beginning
    * and false when the last workflow was successful.
    */
-  public function rerunLatestWorkflow(string $project): bool {
-    $circleCiProject = $this->getCircleCiProject($project);
+  public function rerunLatestWorkflow(?string $project = null): bool {
+    $circleCiProject = null;
+    // We use the current project if the project parameter is null
+    if ($project) {
+      $project = strtoupper($project);
+      $supportedProjects = [
+        \MailPoetTasks\Release\CircleCiController::PROJECT_PREMIUM,
+        \MailPoetTasks\Release\CircleCiController::PROJECT_MAILPOET,
+      ];
+      if (!in_array($project, $supportedProjects, true)) {
+        throw new \Exception('Unsupported project');
+      }
+      $circleCiProject = $this->getCircleCiProject($project);
+    }
     $pipeline = $this->getLatestPipeline($circleCiProject);
     if (!$pipeline) {
       throw new \Exception('No pipeline found');

--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -19,6 +19,9 @@ class CircleCiController {
   private $token;
 
   /** @var string */
+  private $username;
+
+  /** @var string */
   private $zipFilename;
 
   /** @var Client */
@@ -33,8 +36,9 @@ class CircleCiController {
     $project,
     GitHubController $githubController
   ) {
+    $this->username = $username;
     $this->token = $token;
-    $circleCiProject = $project === self::PROJECT_MAILPOET ? 'mailpoet' : 'mailpoet-premium';
+    $circleCiProject = $this->getCircleCiProject($project);
     $this->zipFilename = $project === self::PROJECT_MAILPOET ? self::FREE_ZIP_FILENAME : self::PREMIUM_ZIP_FILENAME;
     $this->httpClient = new Client([
       'auth' => [$token, null],
@@ -61,15 +65,36 @@ class CircleCiController {
     return $targetPath;
   }
 
+  /**
+   * Returns true when the Circle workflow was started from the beginning
+   * and false when the last workflow was successful.
+   */
+  public function rerunLatestWorkflow(string $project): bool {
+    $circleCiProject = $this->getCircleCiProject($project);
+    $pipeline = $this->getLatestPipeline($circleCiProject);
+    if (!$pipeline) {
+      throw new \Exception('No pipeline found');
+    }
+    $workflow = $this->getWorkflowByPipelineId($pipeline['id']);
+    if (!$workflow) {
+      throw new \Exception('No workflow found');
+    }
+    $workflowStatus = $workflow['status'] ?? null;
+
+    if (in_array($workflowStatus, ['running', 'failed', 'failing', 'canceled'], true)) {
+      if ($workflowStatus === 'running') {
+        $this->cancelWorkflow($workflow['id']);
+      }
+      $this->rerunWorkflow($workflow['id']);
+      return true;
+    }
+    return false;
+  }
+
   private function getLatestZipBuildJob(): array {
-    // Latest Pipeline for release branch
-    $params = [
-      'query' => ['branch' => urlencode(self::RELEASE_BRANCH)],
-    ];
-    $response = $this->httpClient->get('pipeline', $params);
-    $pipelines = json_decode($response->getBody()->getContents(), true);
-    $latestPipelineId = $pipelines['items'][0]['id'] ?? null;
-    $latestPipelineRevision = $pipelines['items'][0]['vcs']['revision'] ?? null;
+    $latestPipeline = $this->getLatestPipeline();
+    $latestPipelineId = $latestPipeline['id'] ?? null;
+    $latestPipelineRevision = $latestPipeline['vcs']['revision'] ?? null;
 
     if ($latestPipelineId === null) {
       throw new \Exception('No release ZIP build found');
@@ -86,9 +111,8 @@ class CircleCiController {
       );
     }
 
-    $responseWorkflows = $this->httpClient->get('https://circleci.com/api/v2/pipeline/' . urlencode($latestPipelineId) . '/workflow');
-    $workflows = json_decode($responseWorkflows->getBody()->getContents(), true);
-    $latestWorkFlowId = $workflows['items'][0]['id'] ?? null;
+    $latestWorkflow = $this->getWorkflowByPipelineId($latestPipelineId);
+    $latestWorkFlowId = $latestWorkflow['id'] ?? null;
     if ($latestWorkFlowId === null) {
       throw new \Exception('No release ZIP build found');
     }
@@ -122,5 +146,54 @@ class CircleCiController {
       }
     }
     throw new \Exception('No ZIP file found in build artifacts');
+  }
+
+  /**
+   * Returns the latest pipeline for the current project or the for the specific when is set in the project argument
+   * @param string|null $project
+   * @return array|null
+   */
+  private function getLatestPipeline(?string $project = null): ?array {
+    // Latest Pipeline for release branch
+    $params = [
+      'query' => ['branch' => urlencode(self::RELEASE_BRANCH)],
+    ];
+
+    if ($project) {
+      $username = urlencode($this->username);
+      $circleCiProject = urlencode($project);
+      $response = $this->httpClient->get("https://circleci.com/api/v2/project/gh/{$username}/{$circleCiProject}/pipeline", $params);
+    } else {
+      $response = $this->httpClient->get('pipeline', $params);
+    }
+
+    $pipelines = json_decode($response->getBody()->getContents(), true);
+    return reset($pipelines['items']) ?: null;
+  }
+
+  private function getWorkflowByPipelineId(string $pipelineId): ?array {
+    $responseWorkflows = $this->httpClient->get('https://circleci.com/api/v2/pipeline/' . urlencode($pipelineId) . '/workflow');
+    $workflows = json_decode($responseWorkflows->getBody()->getContents(), true);
+    $workflows = $workflows['items'] ?? [];
+    return reset($workflows) ?: null;
+  }
+
+  private function rerunWorkflow(string $workflowId, bool $fromFailed = false): void {
+    $this->httpClient->post(
+      'https://circleci.com/api/v2/workflow/' . urlencode($workflowId) . '/rerun',
+      [
+        'json' => [
+          'from_failed' => $fromFailed,
+        ],
+      ]
+    );
+  }
+
+  private function cancelWorkflow(string $workflowId): void {
+    $this->httpClient->post('https://circleci.com/api/v2/workflow/' . urlencode($workflowId) . '/cancel');
+  }
+
+  private function getCircleCiProject(string $project): string {
+    return $project === self::PROJECT_MAILPOET ? 'mailpoet' : 'mailpoet-premium';
   }
 }


### PR DESCRIPTION
## Description

When we release premium and free plugins together, our first builds for the premium plugin on Circle CI fail. This PR adds a command that reruns the latest Circle CI workflow for a specific project. The new command is also used in the prepare command.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[PREMIUM-207](https://mailpoet.atlassian.net/browse/PREMIUM-207)

## After-merge notes

_N/A_
