### PR TITLE
Fix Manage Sender Domain modal hides underneath the Preview newsletter modal - MAILPOET-4812

### DIFF
--- a/mailpoet/assets/css/src/components/_modal.scss
+++ b/mailpoet/assets/css/src/components/_modal.scss
@@ -112,3 +112,11 @@
   max-width: 100%;
   width: 100%;
 }
+
+.authorize-sender-email-and-domain-modal {
+  z-index: 30; // overlay other modals
+}
+
+.authorize-sender-email-and-domain-modal-overlay {
+  z-index: $modal-screen-overlay-z-index + 4; // overlay other modals
+}

--- a/mailpoet/assets/js/src/common/authorize_sender_email_and_domain_modal.tsx
+++ b/mailpoet/assets/js/src/common/authorize_sender_email_and_domain_modal.tsx
@@ -92,6 +92,7 @@ function AuthorizeSenderEmailAndDomainModal({
     <Modal
       onRequestClose={onRequestClose}
       contentClassName="authorize-sender-email-and-domain-modal"
+      overlayClassName="authorize-sender-email-and-domain-modal-overlay"
     >
       <Tabs activeKey={initialTab}>
         <Tab


### PR DESCRIPTION


## Description

Fix Manage Sender Domain modal hides underneath the Preview newsletter modal



## QA notes

On ticket description.



## Linked tickets

[MAILPOET-4812](https://mailpoet.atlassian.net/browse/MAILPOET-4812)


