### PR TITLE
Strict types

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // phpcs:disable PSR1.Classes.ClassDeclaration
 // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace

--- a/mailpoet/index.php
+++ b/mailpoet/index.php
@@ -1,3 +1,3 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // Silence is golden

--- a/mailpoet/lib-3rd-party/CSS.php
+++ b/mailpoet/lib-3rd-party/CSS.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoetVendor;
 
 use MailPoet\Util\pQuery\DomNode;

--- a/mailpoet/lib-3rd-party/Idiorm/idiorm.php
+++ b/mailpoet/lib-3rd-party/Idiorm/idiorm.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor\Idiorm;
 

--- a/mailpoet/lib-3rd-party/Paris/paris.php
+++ b/mailpoet/lib-3rd-party/Paris/paris.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor\Paris;
 

--- a/mailpoet/lib-3rd-party/Sudzy/Engine.php
+++ b/mailpoet/lib-3rd-party/Sudzy/Engine.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor\Sudzy;
 

--- a/mailpoet/lib-3rd-party/Sudzy/ValidModel.php
+++ b/mailpoet/lib-3rd-party/Sudzy/ValidModel.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoetVendor\Sudzy;
 
 use MailPoetVendor\Paris\Model;

--- a/mailpoet/lib-3rd-party/Sudzy/ValidationException.php
+++ b/mailpoet/lib-3rd-party/Sudzy/ValidationException.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor\Sudzy;
 

--- a/mailpoet/lib-3rd-party/XLSXWriter.php
+++ b/mailpoet/lib-3rd-party/XLSXWriter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor;
 

--- a/mailpoet/lib-3rd-party/pquery/IQuery.php
+++ b/mailpoet/lib-3rd-party/pquery/IQuery.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor\pQuery;
 

--- a/mailpoet/lib-3rd-party/pquery/gan_formatter.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_formatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/gan_node_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_node_html.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/gan_parser_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_parser_html.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/gan_selector_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_selector_html.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/gan_tokenizer.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_tokenizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/gan_xml2array.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_xml2array.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/ganon.php
+++ b/mailpoet/lib-3rd-party/pquery/ganon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/pQuery.php
+++ b/mailpoet/lib-3rd-party/pquery/pQuery.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * @author Niels A.D.
  * @author Todd Burry <todd@vanillaforums.com>

--- a/mailpoet/lib-3rd-party/pquery/third_party/jsminplus.php
+++ b/mailpoet/lib-3rd-party/pquery/third_party/jsminplus.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetVendor\pQuery;
 

--- a/mailpoet/lib/API/API.php
+++ b/mailpoet/lib/API/API.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API;
 

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON;
 

--- a/mailpoet/lib/API/JSON/Endpoint.php
+++ b/mailpoet/lib/API/JSON/Endpoint.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON;
 

--- a/mailpoet/lib/API/JSON/Error.php
+++ b/mailpoet/lib/API/JSON/Error.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON;
 

--- a/mailpoet/lib/API/JSON/ErrorResponse.php
+++ b/mailpoet/lib/API/JSON/ErrorResponse.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON;
 

--- a/mailpoet/lib/API/JSON/Response.php
+++ b/mailpoet/lib/API/JSON/Response.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/CustomFieldsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/CustomFieldsResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewsletterTemplatesResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewsletterTemplatesResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/ScheduledTaskSubscriberResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/ScheduledTaskSubscriberResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/lib/API/JSON/SuccessResponse.php
+++ b/mailpoet/lib/API/JSON/SuccessResponse.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON;
 

--- a/mailpoet/lib/API/JSON/v1/Analytics.php
+++ b/mailpoet/lib/API/JSON/v1/Analytics.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/AutomaticEmails.php
+++ b/mailpoet/lib/API/JSON/v1/AutomaticEmails.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/CustomFields.php
+++ b/mailpoet/lib/API/JSON/v1/CustomFields.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/FeatureFlags.php
+++ b/mailpoet/lib/API/JSON/v1/FeatureFlags.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Forms.php
+++ b/mailpoet/lib/API/JSON/v1/Forms.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/ImportExport.php
+++ b/mailpoet/lib/API/JSON/v1/ImportExport.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Mailer.php
+++ b/mailpoet/lib/API/JSON/v1/Mailer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/NewsletterTemplates.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterTemplates.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Premium.php
+++ b/mailpoet/lib/API/JSON/v1/Premium.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Segments.php
+++ b/mailpoet/lib/API/JSON/v1/Segments.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/mailpoet/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/Setup.php
+++ b/mailpoet/lib/API/JSON/v1/Setup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/SubscriberStats.php
+++ b/mailpoet/lib/API/JSON/v1/SubscriberStats.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/UserFlags.php
+++ b/mailpoet/lib/API/JSON/v1/UserFlags.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/JSON/v1/WoocommerceSettings.php
+++ b/mailpoet/lib/API/JSON/v1/WoocommerceSettings.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/lib/API/MP/v1/API.php
+++ b/mailpoet/lib/API/MP/v1/API.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\MP\v1;
 

--- a/mailpoet/lib/API/MP/v1/APIException.php
+++ b/mailpoet/lib/API/MP/v1/APIException.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\MP\v1;
 

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\API\MP\v1;
 

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages;
 

--- a/mailpoet/lib/AdminPages/Pages/Automation.php
+++ b/mailpoet/lib/AdminPages/Pages/Automation.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/ExperimentalFeatures.php
+++ b/mailpoet/lib/AdminPages/Pages/ExperimentalFeatures.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/FormEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/FormEditor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Forms.php
+++ b/mailpoet/lib/AdminPages/Pages/Forms.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/SubscribersExport.php
+++ b/mailpoet/lib/AdminPages/Pages/SubscribersExport.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
+++ b/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/Upgrade.php
+++ b/mailpoet/lib/AdminPages/Pages/Upgrade.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/WooCommerceSetup.php
+++ b/mailpoet/lib/AdminPages/Pages/WooCommerceSetup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/Analytics/Analytics.php
+++ b/mailpoet/lib/Analytics/Analytics.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Analytics;
 

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Analytics;
 

--- a/mailpoet/lib/AutomaticEmails/AutomaticEmailFactory.php
+++ b/mailpoet/lib/AutomaticEmails/AutomaticEmailFactory.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AutomaticEmails;
 

--- a/mailpoet/lib/AutomaticEmails/AutomaticEmails.php
+++ b/mailpoet/lib/AutomaticEmails/AutomaticEmails.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AutomaticEmails;
 

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AutomaticEmails\WooCommerce\Events;
 

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AutomaticEmails\WooCommerce\Events;
 

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AutomaticEmails\WooCommerce\Events;
 

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/WooCommerce.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/WooCommerce.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\AutomaticEmails\WooCommerce;
 

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/WooCommerceEventFactory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/WooCommerceEventFactory.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AutomaticEmails\WooCommerce;
 

--- a/mailpoet/lib/Config/AccessControl.php
+++ b/mailpoet/lib/Config/AccessControl.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/AssetsLoader.php
+++ b/mailpoet/lib/Config/AssetsLoader.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Capabilities.php
+++ b/mailpoet/lib/Config/Capabilities.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Changelog.php
+++ b/mailpoet/lib/Config/Changelog.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Database.php
+++ b/mailpoet/lib/Config/Database.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/DeferredAdminNotices.php
+++ b/mailpoet/lib/Config/DeferredAdminNotices.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Installer.php
+++ b/mailpoet/lib/Config/Installer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Localizer.php
+++ b/mailpoet/lib/Config/Localizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/PersonalDataErasers.php
+++ b/mailpoet/lib/Config/PersonalDataErasers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/PersonalDataExporters.php
+++ b/mailpoet/lib/Config/PersonalDataExporters.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/PluginActivatedHook.php
+++ b/mailpoet/lib/Config/PluginActivatedHook.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/AppWelcome.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/AppWelcome.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Birds.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Birds.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/BrandingAgencyNews.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BrandingAgencyNews.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/BuddhistTemple.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BuddhistTemple.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/Charity.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Charity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/CityLocalNews.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/CityLocalNews.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/ClearNews.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/ClearNews.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Coffee.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Coffee.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/College.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/College.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/ComputerRepair.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/ComputerRepair.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/DogFood.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/DogFood.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Drone.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Drone.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Engineering.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Engineering.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Faith.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Faith.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/FarmersMarket.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FarmersMarket.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/FashionBlog.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FashionBlog.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/FashionBlogA.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FashionBlogA.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/FashionShop.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FashionShop.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/FashionStore.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FashionStore.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/FestivalEvent.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FestivalEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/FoodBox.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FoodBox.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/GiftWelcome.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/GiftWelcome.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Guitarist.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Guitarist.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/HealthyFoodBlog.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/HealthyFoodBlog.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Hotels.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Hotels.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/IndustryConference.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/IndustryConference.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/JazzClub.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/JazzClub.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/KidsClothing.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/KidsClothing.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/LifestyleBlogA.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/LifestyleBlogA.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/LifestyleBlogB.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/LifestyleBlogB.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/Minimal.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Minimal.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/ModularStyleStories.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/ModularStyleStories.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Mosque.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Mosque.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/Motor.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Motor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/Music.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Music.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/NewsDay.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NewsDay.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank121Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank121Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank12Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank13Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank13Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank1Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NewsletterBlank1Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/NewspaperTraditional.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NewspaperTraditional.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/NotSoMedium.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NotSoMedium.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Painter.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Painter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/Phone.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Phone.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Photography.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Photography.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/PieceOfCake.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/PieceOfCake.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/Poet.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Poet.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/PostNotificationsBlank1Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/PostNotificationsBlank1Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/PrimarySchool.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/PrimarySchool.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/RealEstate.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/RealEstate.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/RenewableEnergy.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/RenewableEnergy.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Retro.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Retro.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/RetroComputingMagazine.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/RetroComputingMagazine.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/RockBand.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/RockBand.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/RssSimpleNews.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/RssSimpleNews.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/ScienceWeekly.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/ScienceWeekly.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Shoes.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Shoes.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/SimpleText.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/SimpleText.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Software.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Software.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Sunglasses.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Sunglasses.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Synagogue.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Synagogue.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/TakeAHike.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/TakeAHike.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/Vlogger.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Vlogger.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/WelcomeBlank12Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WelcomeBlank12Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/WelcomeBlank1Column.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WelcomeBlank1Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 namespace MailPoet\Config\PopulatorData\Templates;
 
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/WideStoryLayout.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WideStoryLayout.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/WordPressTheme.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WordPressTheme.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 

--- a/mailpoet/lib/Config/PopulatorData/Templates/WorldCup.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WorldCup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PopulatorData/Templates/YogaStudio.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/YogaStudio.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config\PopulatorData\Templates;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Config/PrivacyPolicy.php
+++ b/mailpoet/lib/Config/PrivacyPolicy.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Renderer.php
+++ b/mailpoet/lib/Config/Renderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/RendererFactory.php
+++ b/mailpoet/lib/Config/RendererFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/RequirementsChecker.php
+++ b/mailpoet/lib/Config/RequirementsChecker.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Router.php
+++ b/mailpoet/lib/Config/Router.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/SilentUpgraderSkin.php
+++ b/mailpoet/lib/Config/SilentUpgraderSkin.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/TwigEnvironment.php
+++ b/mailpoet/lib/Config/TwigEnvironment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/TwigFileSystemCache.php
+++ b/mailpoet/lib/Config/TwigFileSystemCache.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Config/Updater.php
+++ b/mailpoet/lib/Config/Updater.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Config;
 

--- a/mailpoet/lib/Cron/CronHelper.php
+++ b/mailpoet/lib/Cron/CronHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/CronTrigger.php
+++ b/mailpoet/lib/Cron/CronTrigger.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/CronWorkerInterface.php
+++ b/mailpoet/lib/Cron/CronWorkerInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/CronWorkerRunner.php
+++ b/mailpoet/lib/Cron/CronWorkerRunner.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/CronWorkerScheduler.php
+++ b/mailpoet/lib/Cron/CronWorkerScheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/DaemonActionSchedulerRunner.php
+++ b/mailpoet/lib/Cron/DaemonActionSchedulerRunner.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/DaemonHttpRunner.php
+++ b/mailpoet/lib/Cron/DaemonHttpRunner.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/Supervisor.php
+++ b/mailpoet/lib/Cron/Supervisor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Triggers;
 

--- a/mailpoet/lib/Cron/Workers/AuthorizedSendingEmailsCheck.php
+++ b/mailpoet/lib/Cron/Workers/AuthorizedSendingEmailsCheck.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/Beamer.php
+++ b/mailpoet/lib/Cron/Workers/Beamer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/Bounce.php
+++ b/mailpoet/lib/Cron/Workers/Bounce.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/ExportFilesCleanup.php
+++ b/mailpoet/lib/Cron/Workers/ExportFilesCleanup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/InactiveSubscribers.php
+++ b/mailpoet/lib/Cron/Workers/InactiveSubscribers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/KeyCheck/KeyCheckWorker.php
+++ b/mailpoet/lib/Cron/Workers/KeyCheck/KeyCheckWorker.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\KeyCheck;
 

--- a/mailpoet/lib/Cron/Workers/KeyCheck/PremiumKeyCheck.php
+++ b/mailpoet/lib/Cron/Workers/KeyCheck/PremiumKeyCheck.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\KeyCheck;
 

--- a/mailpoet/lib/Cron/Workers/KeyCheck/SendingServiceKeyCheck.php
+++ b/mailpoet/lib/Cron/Workers/KeyCheck/SendingServiceKeyCheck.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\KeyCheck;
 

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Migration.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Migration.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingThrottlingHandler.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingThrottlingHandler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Mailer.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Mailer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Posts.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Posts.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Shortcodes.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Shortcodes.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/lib/Cron/Workers/SimpleWorker.php
+++ b/mailpoet/lib/Cron/Workers/SimpleWorker.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Scheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/StatsNotificationsRepository.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/StatsNotificationsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/lib/Cron/Workers/SubscriberLinkTokens.php
+++ b/mailpoet/lib/Cron/Workers/SubscriberLinkTokens.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/SubscribersEngagementScore.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersEngagementScore.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/SubscribersLastEngagement.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersLastEngagement.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/SubscribersStatsReport.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersStatsReport.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
+++ b/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
+++ b/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/lib/CustomFields/ApiDataSanitizer.php
+++ b/mailpoet/lib/CustomFields/ApiDataSanitizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\CustomFields;
 

--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\CustomFields;
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\DI;
 

--- a/mailpoet/lib/DI/ContainerFactory.php
+++ b/mailpoet/lib/DI/ContainerFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\DI;
 

--- a/mailpoet/lib/DI/ContainerWrapper.php
+++ b/mailpoet/lib/DI/ContainerWrapper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\DI;
 

--- a/mailpoet/lib/DI/IContainerConfigurator.php
+++ b/mailpoet/lib/DI/IContainerConfigurator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\DI;
 

--- a/mailpoet/lib/Doctrine/Annotations/AnnotationReaderProvider.php
+++ b/mailpoet/lib/Doctrine/Annotations/AnnotationReaderProvider.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Annotations;
 

--- a/mailpoet/lib/Doctrine/ArrayCache.php
+++ b/mailpoet/lib/Doctrine/ArrayCache.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/CacheOnlyMappingDriver.php
+++ b/mailpoet/lib/Doctrine/CacheOnlyMappingDriver.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/ConfigurationFactory.php
+++ b/mailpoet/lib/Doctrine/ConfigurationFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/ConnectionFactory.php
+++ b/mailpoet/lib/Doctrine/ConnectionFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/EntityManagerFactory.php
+++ b/mailpoet/lib/Doctrine/EntityManagerFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/EntityTraits/AutoincrementedIdTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/AutoincrementedIdTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EntityTraits;
 

--- a/mailpoet/lib/Doctrine/EntityTraits/CreatedAtTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/CreatedAtTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EntityTraits;
 

--- a/mailpoet/lib/Doctrine/EntityTraits/DeletedAtTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/DeletedAtTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EntityTraits;
 

--- a/mailpoet/lib/Doctrine/EntityTraits/SafeToOneAssociationLoadTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/SafeToOneAssociationLoadTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EntityTraits;
 

--- a/mailpoet/lib/Doctrine/EntityTraits/UpdatedAtTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/UpdatedAtTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EntityTraits;
 

--- a/mailpoet/lib/Doctrine/EventListeners/EmojiEncodingListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/EmojiEncodingListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EventListeners;
 

--- a/mailpoet/lib/Doctrine/EventListeners/LastSubscribedAtListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/LastSubscribedAtListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EventListeners;
 

--- a/mailpoet/lib/Doctrine/EventListeners/TimestampListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/TimestampListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EventListeners;
 

--- a/mailpoet/lib/Doctrine/EventListeners/ValidationListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/ValidationListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\EventListeners;
 

--- a/mailpoet/lib/Doctrine/MetadataCache.php
+++ b/mailpoet/lib/Doctrine/MetadataCache.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/PSRArrayCache.php
+++ b/mailpoet/lib/Doctrine/PSRArrayCache.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/PSRCacheInvalidArgumentException.php
+++ b/mailpoet/lib/Doctrine/PSRCacheInvalidArgumentException.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/PSRCacheItem.php
+++ b/mailpoet/lib/Doctrine/PSRCacheItem.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/PSRMetadataCache.php
+++ b/mailpoet/lib/Doctrine/PSRMetadataCache.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/ProxyClassNameResolver.php
+++ b/mailpoet/lib/Doctrine/ProxyClassNameResolver.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/SerializableConnection.php
+++ b/mailpoet/lib/Doctrine/SerializableConnection.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/TablePrefixMetadataFactory.php
+++ b/mailpoet/lib/Doctrine/TablePrefixMetadataFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine;
 

--- a/mailpoet/lib/Doctrine/Types/BigIntType.php
+++ b/mailpoet/lib/Doctrine/Types/BigIntType.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Types;
 

--- a/mailpoet/lib/Doctrine/Types/DateTimeTzToStringType.php
+++ b/mailpoet/lib/Doctrine/Types/DateTimeTzToStringType.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Types;
 

--- a/mailpoet/lib/Doctrine/Types/JsonOrSerializedType.php
+++ b/mailpoet/lib/Doctrine/Types/JsonOrSerializedType.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Types;
 

--- a/mailpoet/lib/Doctrine/Types/JsonType.php
+++ b/mailpoet/lib/Doctrine/Types/JsonType.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Types;
 

--- a/mailpoet/lib/Doctrine/Types/SerializedArrayType.php
+++ b/mailpoet/lib/Doctrine/Types/SerializedArrayType.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Types;
 

--- a/mailpoet/lib/Doctrine/Validator/Translator.php
+++ b/mailpoet/lib/Doctrine/Validator/Translator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Validator;
 

--- a/mailpoet/lib/Doctrine/Validator/ValidationException.php
+++ b/mailpoet/lib/Doctrine/Validator/ValidationException.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Validator;
 

--- a/mailpoet/lib/Doctrine/Validator/ValidatorFactory.php
+++ b/mailpoet/lib/Doctrine/Validator/ValidatorFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Doctrine\Validator;
 

--- a/mailpoet/lib/Entities/CustomFieldEntity.php
+++ b/mailpoet/lib/Entities/CustomFieldEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/DynamicSegmentFilterEntity.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/FeatureFlagEntity.php
+++ b/mailpoet/lib/Entities/FeatureFlagEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/FormEntity.php
+++ b/mailpoet/lib/Entities/FormEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/LogEntity.php
+++ b/mailpoet/lib/Entities/LogEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterLinkEntity.php
+++ b/mailpoet/lib/Entities/NewsletterLinkEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterOptionEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterPostEntity.php
+++ b/mailpoet/lib/Entities/NewsletterPostEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterSegmentEntity.php
+++ b/mailpoet/lib/Entities/NewsletterSegmentEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/NewsletterTemplateEntity.php
+++ b/mailpoet/lib/Entities/NewsletterTemplateEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SendingQueueEntity.php
+++ b/mailpoet/lib/Entities/SendingQueueEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SettingEntity.php
+++ b/mailpoet/lib/Entities/SettingEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsBounceEntity.php
+++ b/mailpoet/lib/Entities/StatisticsBounceEntity.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsClickEntity.php
+++ b/mailpoet/lib/Entities/StatisticsClickEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsFormEntity.php
+++ b/mailpoet/lib/Entities/StatisticsFormEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
+++ b/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsOpenEntity.php
+++ b/mailpoet/lib/Entities/StatisticsOpenEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
+++ b/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatisticsWooCommercePurchaseEntity.php
+++ b/mailpoet/lib/Entities/StatisticsWooCommercePurchaseEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/StatsNotificationEntity.php
+++ b/mailpoet/lib/Entities/StatsNotificationEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SubscriberCustomFieldEntity.php
+++ b/mailpoet/lib/Entities/SubscriberCustomFieldEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SubscriberIPEntity.php
+++ b/mailpoet/lib/Entities/SubscriberIPEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/SubscriberSegmentEntity.php
+++ b/mailpoet/lib/Entities/SubscriberSegmentEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/UserAgentEntity.php
+++ b/mailpoet/lib/Entities/UserAgentEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Entities/UserFlagEntity.php
+++ b/mailpoet/lib/Entities/UserFlagEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/lib/Features/FeatureFlagsController.php
+++ b/mailpoet/lib/Features/FeatureFlagsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Features;
 

--- a/mailpoet/lib/Features/FeatureFlagsRepository.php
+++ b/mailpoet/lib/Features/FeatureFlagsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Features;
 

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Features;
 

--- a/mailpoet/lib/Form/ApiDataSanitizer.php
+++ b/mailpoet/lib/Form/ApiDataSanitizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Checkbox.php
+++ b/mailpoet/lib/Form/Block/Checkbox.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Column.php
+++ b/mailpoet/lib/Form/Block/Column.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Columns.php
+++ b/mailpoet/lib/Form/Block/Columns.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Date.php
+++ b/mailpoet/lib/Form/Block/Date.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Divider.php
+++ b/mailpoet/lib/Form/Block/Divider.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Heading.php
+++ b/mailpoet/lib/Form/Block/Heading.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Html.php
+++ b/mailpoet/lib/Form/Block/Html.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Image.php
+++ b/mailpoet/lib/Form/Block/Image.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Paragraph.php
+++ b/mailpoet/lib/Form/Block/Paragraph.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Radio.php
+++ b/mailpoet/lib/Form/Block/Radio.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Segment.php
+++ b/mailpoet/lib/Form/Block/Segment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Select.php
+++ b/mailpoet/lib/Form/Block/Select.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Submit.php
+++ b/mailpoet/lib/Form/Block/Submit.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Text.php
+++ b/mailpoet/lib/Form/Block/Text.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/Block/Textarea.php
+++ b/mailpoet/lib/Form/Block/Textarea.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Block;
 

--- a/mailpoet/lib/Form/BlockStylesRenderer.php
+++ b/mailpoet/lib/Form/BlockStylesRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/BlockWrapperRenderer.php
+++ b/mailpoet/lib/Form/BlockWrapperRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/BlocksRenderer.php
+++ b/mailpoet/lib/Form/BlocksRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/FormHtmlSanitizer.php
+++ b/mailpoet/lib/Form/FormHtmlSanitizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/FormSaveController.php
+++ b/mailpoet/lib/Form/FormSaveController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/FormsRepository.php
+++ b/mailpoet/lib/Form/FormsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/Listing/FormListingRepository.php
+++ b/mailpoet/lib/Form/Listing/FormListingRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Listing;
 

--- a/mailpoet/lib/Form/PreviewPage.php
+++ b/mailpoet/lib/Form/PreviewPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/PreviewWidget.php
+++ b/mailpoet/lib/Form/PreviewWidget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/Renderer.php
+++ b/mailpoet/lib/Form/Renderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Form/Templates/FormTemplate.php
+++ b/mailpoet/lib/Form/Templates/FormTemplate.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates;
 

--- a/mailpoet/lib/Form/Templates/TemplateRepository.php
+++ b/mailpoet/lib/Form/Templates/TemplateRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/InitialForm.php
+++ b/mailpoet/lib/Form/Templates/Templates/InitialForm.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template10BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template10FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template10Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template10SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template10Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template11BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template11FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template11Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template11SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template11Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template12BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template12FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template12Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template12SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template12Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template13BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template13FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template13Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template13SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template13Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template14BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template14FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template14Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template14SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template14Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template17BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template17FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template17Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template17SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template17Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template18BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template18FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template18Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template18SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template18Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template1BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template1FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template1Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template1SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template1Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template3BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template3FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template3Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template3SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template3Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template4BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template4FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template4Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template4SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template4Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template6BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template6FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template6Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template6SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template6Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template7BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7BelowPages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template7FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7FixedBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Templates/Templates/Template7Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/lib/Form/Util/CustomFonts.php
+++ b/mailpoet/lib/Form/Util/CustomFonts.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Util;
 

--- a/mailpoet/lib/Form/Util/Export.php
+++ b/mailpoet/lib/Form/Util/Export.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Util;
 

--- a/mailpoet/lib/Form/Util/FieldNameObfuscator.php
+++ b/mailpoet/lib/Form/Util/FieldNameObfuscator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Util;
 

--- a/mailpoet/lib/Form/Util/Styles.php
+++ b/mailpoet/lib/Form/Util/Styles.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Util;
 

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form;
 

--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Helpscout;
 

--- a/mailpoet/lib/Listing/Handler.php
+++ b/mailpoet/lib/Listing/Handler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Listing;
 

--- a/mailpoet/lib/Listing/PageLimit.php
+++ b/mailpoet/lib/Listing/PageLimit.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Listing;
 

--- a/mailpoet/lib/Logging/LogHandler.php
+++ b/mailpoet/lib/Logging/LogHandler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Logging;
 

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Logging;
 

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Logging;
 

--- a/mailpoet/lib/Mailer/Mailer.php
+++ b/mailpoet/lib/Mailer/Mailer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer;
 

--- a/mailpoet/lib/Mailer/MailerError.php
+++ b/mailpoet/lib/Mailer/MailerError.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer;
 

--- a/mailpoet/lib/Mailer/MailerFactory.php
+++ b/mailpoet/lib/Mailer/MailerFactory.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Mailer;
 

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer;
 

--- a/mailpoet/lib/Mailer/MetaInfo.php
+++ b/mailpoet/lib/Mailer/MetaInfo.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer;
 

--- a/mailpoet/lib/Mailer/Methods/Common/BlacklistCheck.php
+++ b/mailpoet/lib/Mailer/Methods/Common/BlacklistCheck.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods\Common;
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/BlacklistErrorMapperTrait.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/BlacklistErrorMapperTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/ConnectionErrorMapperTrait.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/ConnectionErrorMapperTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/SendGridMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/SendGridMapper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods;
 

--- a/mailpoet/lib/Mailer/Methods/MailerMethod.php
+++ b/mailpoet/lib/Mailer/Methods/MailerMethod.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Mailer\Methods;
 

--- a/mailpoet/lib/Mailer/Methods/SendGrid.php
+++ b/mailpoet/lib/Mailer/Methods/SendGrid.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\Methods;
 

--- a/mailpoet/lib/Mailer/SubscriberError.php
+++ b/mailpoet/lib/Mailer/SubscriberError.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer;
 

--- a/mailpoet/lib/Mailer/WordPress/WordPressMailer.php
+++ b/mailpoet/lib/Mailer/WordPress/WordPressMailer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\WordPress;
 

--- a/mailpoet/lib/Mailer/WordPress/WordpressMailerReplacer.php
+++ b/mailpoet/lib/Mailer/WordPress/WordpressMailerReplacer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Mailer\WordPress;
 

--- a/mailpoet/lib/Models/CustomField.php
+++ b/mailpoet/lib/Models/CustomField.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/DynamicSegmentFilter.php
+++ b/mailpoet/lib/Models/DynamicSegmentFilter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/MappingToExternalEntities.php
+++ b/mailpoet/lib/Models/MappingToExternalEntities.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/Model.php
+++ b/mailpoet/lib/Models/Model.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/ModelValidator.php
+++ b/mailpoet/lib/Models/ModelValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/Newsletter.php
+++ b/mailpoet/lib/Models/Newsletter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/NewsletterOption.php
+++ b/mailpoet/lib/Models/NewsletterOption.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/NewsletterOptionField.php
+++ b/mailpoet/lib/Models/NewsletterOptionField.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/NewsletterSegment.php
+++ b/mailpoet/lib/Models/NewsletterSegment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/ScheduledTask.php
+++ b/mailpoet/lib/Models/ScheduledTask.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/ScheduledTaskSubscriber.php
+++ b/mailpoet/lib/Models/ScheduledTaskSubscriber.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/Segment.php
+++ b/mailpoet/lib/Models/Segment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/SendingQueue.php
+++ b/mailpoet/lib/Models/SendingQueue.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/StatisticsClicks.php
+++ b/mailpoet/lib/Models/StatisticsClicks.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/StatisticsNewsletters.php
+++ b/mailpoet/lib/Models/StatisticsNewsletters.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/StatisticsOpens.php
+++ b/mailpoet/lib/Models/StatisticsOpens.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/StatisticsWooCommercePurchases.php
+++ b/mailpoet/lib/Models/StatisticsWooCommercePurchases.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/Subscriber.php
+++ b/mailpoet/lib/Models/Subscriber.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/SubscriberCustomField.php
+++ b/mailpoet/lib/Models/SubscriberCustomField.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Models/SubscriberSegment.php
+++ b/mailpoet/lib/Models/SubscriberSegment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Models;
 

--- a/mailpoet/lib/Newsletter/ApiDataSanitizer.php
+++ b/mailpoet/lib/Newsletter/ApiDataSanitizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/AutomatedLatestContent.php
+++ b/mailpoet/lib/Newsletter/AutomatedLatestContent.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/AutomaticEmailsRepository.php
+++ b/mailpoet/lib/Newsletter/AutomaticEmailsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/BlockPostQuery.php
+++ b/mailpoet/lib/Newsletter/BlockPostQuery.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/Editor/LayoutHelper.php
+++ b/mailpoet/lib/Newsletter/Editor/LayoutHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/MetaInformationManager.php
+++ b/mailpoet/lib/Newsletter/Editor/MetaInformationManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/PostListTransformer.php
+++ b/mailpoet/lib/Newsletter/Editor/PostListTransformer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/PostTransformer.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/StructureTransformer.php
+++ b/mailpoet/lib/Newsletter/Editor/StructureTransformer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/TitleListTransformer.php
+++ b/mailpoet/lib/Newsletter/Editor/TitleListTransformer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Editor/Transformer.php
+++ b/mailpoet/lib/Newsletter/Editor/Transformer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Editor;
 

--- a/mailpoet/lib/Newsletter/Links/Links.php
+++ b/mailpoet/lib/Newsletter/Links/Links.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Links;
 

--- a/mailpoet/lib/Newsletter/NewsletterHtmlSanitizer.php
+++ b/mailpoet/lib/Newsletter/NewsletterHtmlSanitizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/NewsletterPostsRepository.php
+++ b/mailpoet/lib/Newsletter/NewsletterPostsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/Options/NewsletterOptionFieldsRepository.php
+++ b/mailpoet/lib/Newsletter/Options/NewsletterOptionFieldsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Options;
 

--- a/mailpoet/lib/Newsletter/Options/NewsletterOptionsRepository.php
+++ b/mailpoet/lib/Newsletter/Options/NewsletterOptionsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Options;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AutomatedLatestContentBlock.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AutomatedLatestContentBlock.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Divider.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Divider.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Footer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Footer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Header.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Header.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Image.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Social.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Social.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Spacer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Spacer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/lib/Newsletter/Renderer/Columns/ColumnsHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/Columns/ColumnsHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Columns;
 

--- a/mailpoet/lib/Newsletter/Renderer/Columns/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Columns/Renderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\Columns;
 

--- a/mailpoet/lib/Newsletter/Renderer/EscapeHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/EscapeHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer;
 

--- a/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
+++ b/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer\PostProcess;
 

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer;
 

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer;
 

--- a/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Renderer;
 

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/lib/Newsletter/Scheduler/Scheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/Scheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/lib/Newsletter/Segment/NewsletterSegmentRepository.php
+++ b/mailpoet/lib/Newsletter/Segment/NewsletterSegmentRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Segment;
 

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Sending;
 

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Sending;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/CategoryInterface.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/CategoryInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Date.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Date.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Newsletter.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Newsletter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Shortcodes;
 

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatistics.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatistics.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Statistics;
 

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Statistics;
 

--- a/mailpoet/lib/Newsletter/Statistics/WooCommerceRevenue.php
+++ b/mailpoet/lib/Newsletter/Statistics/WooCommerceRevenue.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\Statistics;
 

--- a/mailpoet/lib/Newsletter/Url.php
+++ b/mailpoet/lib/Newsletter/Url.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 

--- a/mailpoet/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
+++ b/mailpoet/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\NewsletterTemplates;
 

--- a/mailpoet/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/mailpoet/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\NewsletterTemplates;
 

--- a/mailpoet/lib/PostEditorBlocks/MarketingOptinBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/MarketingOptinBlock.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\PostEditorBlocks;
 

--- a/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\PostEditorBlocks;
 

--- a/mailpoet/lib/PostEditorBlocks/SubscriptionFormBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/SubscriptionFormBlock.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\PostEditorBlocks;
 

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\PostEditorBlocks;
 

--- a/mailpoet/lib/Referrals/ReferralDetector.php
+++ b/mailpoet/lib/Referrals/ReferralDetector.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Referrals;
 

--- a/mailpoet/lib/Referrals/UrlDecorator.php
+++ b/mailpoet/lib/Referrals/UrlDecorator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Referrals;
 

--- a/mailpoet/lib/Router/Endpoints/CronDaemon.php
+++ b/mailpoet/lib/Router/Endpoints/CronDaemon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Router\Endpoints;
 

--- a/mailpoet/lib/Router/Endpoints/FormPreview.php
+++ b/mailpoet/lib/Router/Endpoints/FormPreview.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Router\Endpoints;
 

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Router\Endpoints;
 

--- a/mailpoet/lib/Router/Endpoints/Track.php
+++ b/mailpoet/lib/Router/Endpoints/Track.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Router\Endpoints;
 

--- a/mailpoet/lib/Router/Endpoints/ViewInBrowser.php
+++ b/mailpoet/lib/Router/Endpoints/ViewInBrowser.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Router\Endpoints;
 

--- a/mailpoet/lib/Router/Router.php
+++ b/mailpoet/lib/Router/Router.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Router;
 

--- a/mailpoet/lib/Segments/DynamicSegments/DynamicSegmentsListingRepository.php
+++ b/mailpoet/lib/Segments/DynamicSegments/DynamicSegmentsListingRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Exceptions;
 

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailActionClickAny.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailActionClickAny.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/Filter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/Filter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberScore.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberScore.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceMembership.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceMembership.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/lib/Segments/DynamicSegments/SegmentSaveController.php
+++ b/mailpoet/lib/Segments/DynamicSegments/SegmentSaveController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments\DynamicSegments;
 

--- a/mailpoet/lib/Segments/SegmentDependencyValidator.php
+++ b/mailpoet/lib/Segments/SegmentDependencyValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Segments/SegmentListingRepository.php
+++ b/mailpoet/lib/Segments/SegmentListingRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Segments/SegmentSaveController.php
+++ b/mailpoet/lib/Segments/SegmentSaveController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
+++ b/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Services;
 

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Services;
 

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Services\Bridge;
 

--- a/mailpoet/lib/Services/Release/API.php
+++ b/mailpoet/lib/Services/Release/API.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Services\Release;
 

--- a/mailpoet/lib/Settings/Charsets.php
+++ b/mailpoet/lib/Settings/Charsets.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/Hosts.php
+++ b/mailpoet/lib/Settings/Hosts.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/Pages.php
+++ b/mailpoet/lib/Settings/Pages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/SettingsChangeHandler.php
+++ b/mailpoet/lib/Settings/SettingsChangeHandler.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/SettingsRepository.php
+++ b/mailpoet/lib/Settings/SettingsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/TrackingConfig.php
+++ b/mailpoet/lib/Settings/TrackingConfig.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/UserFlagsController.php
+++ b/mailpoet/lib/Settings/UserFlagsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Settings/UserFlagsRepository.php
+++ b/mailpoet/lib/Settings/UserFlagsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/StatisticsBouncesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsBouncesRepository.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/StatisticsClicksRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsClicksRepository.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/StatisticsFormsRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsFormsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/StatisticsOpensRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsOpensRepository.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/StatisticsUnsubscribesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsUnsubscribesRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/Track/Opens.php
+++ b/mailpoet/lib/Statistics/Track/Opens.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/Track/PageViewCookie.php
+++ b/mailpoet/lib/Statistics/Track/PageViewCookie.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/Track/SubscriberActivityTracker.php
+++ b/mailpoet/lib/Statistics/Track/SubscriberActivityTracker.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/Track/SubscriberCookie.php
+++ b/mailpoet/lib/Statistics/Track/SubscriberCookie.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/Track/Unsubscribes.php
+++ b/mailpoet/lib/Statistics/Track/Unsubscribes.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
+++ b/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/lib/Statistics/UserAgentsRepository.php
+++ b/mailpoet/lib/Statistics/UserAgentsRepository.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\Export;
 

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\Import;
 

--- a/mailpoet/lib/Subscribers/ImportExport/Import/MailChimp.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/MailChimp.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\Import;
 

--- a/mailpoet/lib/Subscribers/ImportExport/Import/MailChimpDataMapper.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/MailChimpDataMapper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\Import;
 

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport;
 

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport;
 

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterStatsBaseExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewsletterStatsBaseExporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/lib/Subscribers/LinkTokens.php
+++ b/mailpoet/lib/Subscribers/LinkTokens.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/NewSubscriberNotificationMailer.php
+++ b/mailpoet/lib/Subscribers/NewSubscriberNotificationMailer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/RequiredCustomFieldValidator.php
+++ b/mailpoet/lib/Subscribers/RequiredCustomFieldValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/Source.php
+++ b/mailpoet/lib/Subscribers/Source.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/Statistics/SubscriberStatistics.php
+++ b/mailpoet/lib/Subscribers/Statistics/SubscriberStatistics.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\Statistics;
 

--- a/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
+++ b/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers\Statistics;
 

--- a/mailpoet/lib/Subscribers/SubscriberActions.php
+++ b/mailpoet/lib/Subscribers/SubscriberActions.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscriberCustomFieldRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberCustomFieldRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscriberIPsRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberIPsRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscriberPersonalDataEraser.php
+++ b/mailpoet/lib/Subscribers/SubscriberPersonalDataEraser.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/lib/Subscription/Blacklist.php
+++ b/mailpoet/lib/Subscription/Blacklist.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Captcha/CaptchaConstants.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaConstants.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha;
 

--- a/mailpoet/lib/Subscription/Captcha/CaptchaPhrase.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaPhrase.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha;
 

--- a/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha;
 

--- a/mailpoet/lib/Subscription/Captcha/CaptchaSession.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaSession.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha;
 

--- a/mailpoet/lib/Subscription/Captcha/Validator/BuiltInCaptchaValidator.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/BuiltInCaptchaValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha\Validator;
 

--- a/mailpoet/lib/Subscription/Captcha/Validator/CaptchaValidator.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/CaptchaValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha\Validator;
 

--- a/mailpoet/lib/Subscription/Captcha/Validator/RecaptchaValidator.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/RecaptchaValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha\Validator;
 

--- a/mailpoet/lib/Subscription/Captcha/Validator/ValidationError.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/ValidationError.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription\Captcha\Validator;
 

--- a/mailpoet/lib/Subscription/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Subscription/CaptchaFormRenderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Comment.php
+++ b/mailpoet/lib/Subscription/Comment.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Form.php
+++ b/mailpoet/lib/Subscription/Form.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
+++ b/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Subscription/Throttling.php
+++ b/mailpoet/lib/Subscription/Throttling.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/lib/Tasks/Bounce.php
+++ b/mailpoet/lib/Tasks/Bounce.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tasks;
 

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tasks;
 

--- a/mailpoet/lib/Tasks/Subscribers.php
+++ b/mailpoet/lib/Tasks/Subscribers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tasks;
 

--- a/mailpoet/lib/Tasks/Subscribers/BatchIterator.php
+++ b/mailpoet/lib/Tasks/Subscribers/BatchIterator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tasks\Subscribers;
 

--- a/mailpoet/lib/Tracy/ApiPanel/ApiPanel.php
+++ b/mailpoet/lib/Tracy/ApiPanel/ApiPanel.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tracy\ApiPanel;
 

--- a/mailpoet/lib/Tracy/ApiPanel/api-panel.phtml
+++ b/mailpoet/lib/Tracy/ApiPanel/api-panel.phtml
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tracy\ApiPanel;
 

--- a/mailpoet/lib/Tracy/DIPanel/DIPanel.php
+++ b/mailpoet/lib/Tracy/DIPanel/DIPanel.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tracy\DIPanel;
 

--- a/mailpoet/lib/Tracy/DIPanel/di-panel.phtml
+++ b/mailpoet/lib/Tracy/DIPanel/di-panel.phtml
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tracy\DIPanel;
 

--- a/mailpoet/lib/Tracy/DoctrinePanel/DoctrinePanel.php
+++ b/mailpoet/lib/Tracy/DoctrinePanel/DoctrinePanel.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tracy\DoctrinePanel;
 

--- a/mailpoet/lib/Tracy/DoctrinePanel/doctrine-panel.phtml
+++ b/mailpoet/lib/Tracy/DoctrinePanel/doctrine-panel.phtml
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Tracy\DoctrinePanel;
 

--- a/mailpoet/lib/Twig/Analytics.php
+++ b/mailpoet/lib/Twig/Analytics.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Twig/Assets.php
+++ b/mailpoet/lib/Twig/Assets.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Twig/Filters.php
+++ b/mailpoet/lib/Twig/Filters.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Twig/Handlebars.php
+++ b/mailpoet/lib/Twig/Handlebars.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Twig/Helpscout.php
+++ b/mailpoet/lib/Twig/Helpscout.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Twig/I18n.php
+++ b/mailpoet/lib/Twig/I18n.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Twig;
 

--- a/mailpoet/lib/Util/APIPermissionHelper.php
+++ b/mailpoet/lib/Util/APIPermissionHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/CdnAssetUrl.php
+++ b/mailpoet/lib/Util/CdnAssetUrl.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/Cookies.php
+++ b/mailpoet/lib/Util/Cookies.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/DOM.php
+++ b/mailpoet/lib/Util/DOM.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/DateConverter.php
+++ b/mailpoet/lib/Util/DateConverter.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/FreeDomains.php
+++ b/mailpoet/lib/Util/FreeDomains.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/Installation.php
+++ b/mailpoet/lib/Util/Installation.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\License\Features;
 

--- a/mailpoet/lib/Util/License/License.php
+++ b/mailpoet/lib/Util/License/License.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\License;
 

--- a/mailpoet/lib/Util/Notices/AfterMigrationNotice.php
+++ b/mailpoet/lib/Util/Notices/AfterMigrationNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/ChangedTrackingNotice.php
+++ b/mailpoet/lib/Util/Notices/ChangedTrackingNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/EmailWithInvalidSegmentNotice.php
+++ b/mailpoet/lib/Util/Notices/EmailWithInvalidSegmentNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/HeadersAlreadySentNotice.php
+++ b/mailpoet/lib/Util/Notices/HeadersAlreadySentNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/InactiveSubscribersNotice.php
+++ b/mailpoet/lib/Util/Notices/InactiveSubscribersNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
+++ b/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/lib/Util/ProgressBar.php
+++ b/mailpoet/lib/Util/ProgressBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/Request.php
+++ b/mailpoet/lib/Util/Request.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/SecondLevelDomainNames.php
+++ b/mailpoet/lib/Util/SecondLevelDomainNames.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/Security.php
+++ b/mailpoet/lib/Util/Security.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/Url.php
+++ b/mailpoet/lib/Util/Url.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util;
 

--- a/mailpoet/lib/Util/pQuery/DomNode.php
+++ b/mailpoet/lib/Util/pQuery/DomNode.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\pQuery;
 

--- a/mailpoet/lib/Util/pQuery/Html5Parser.php
+++ b/mailpoet/lib/Util/pQuery/Html5Parser.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\pQuery;
 

--- a/mailpoet/lib/Util/pQuery/pQuery.php
+++ b/mailpoet/lib/Util/pQuery/pQuery.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Util\pQuery;
 

--- a/mailpoet/lib/WP/AutocompletePostListLoader.php
+++ b/mailpoet/lib/WP/AutocompletePostListLoader.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WP/DateTime.php
+++ b/mailpoet/lib/WP/DateTime.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WP/Emoji.php
+++ b/mailpoet/lib/WP/Emoji.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WP/Notice.php
+++ b/mailpoet/lib/WP/Notice.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WP/Posts.php
+++ b/mailpoet/lib/WP/Posts.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WP/Readme.php
+++ b/mailpoet/lib/WP/Readme.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WP;
 

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/lib/WooCommerce/Settings.php
+++ b/mailpoet/lib/WooCommerce/Settings.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/lib/WooCommerce/TransactionalEmailHooks.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmailHooks.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/lib/WooCommerce/TransactionalEmails.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/lib/WooCommerce/TransactionalEmails/ContentPreprocessor.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/ContentPreprocessor.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce\TransactionalEmails;
 

--- a/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce\TransactionalEmails;
 

--- a/mailpoet/lib/WooCommerce/TransactionalEmails/Template.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/Template.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\WooCommerce\TransactionalEmails;
 

--- a/mailpoet/mailpoet-cron.php
+++ b/mailpoet/mailpoet-cron.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 /**
  * This file may be used by MailPoet to run a cron daemon that sends emails and perform other periodic tasks. It is

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 /*
  * Plugin Name: MailPoet

--- a/mailpoet/mailpoet_initializer.php
+++ b/mailpoet/mailpoet_initializer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 use MailPoet\Config\Env;
 use MailPoet\Config\RequirementsChecker;

--- a/mailpoet/prefixer/Parser.php
+++ b/mailpoet/prefixer/Parser.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 // phpcs:disable
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/mailpoet/prefixer/fix-attributes.php
+++ b/mailpoet/prefixer/fix-attributes.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/fix-captcha.php
+++ b/mailpoet/prefixer/fix-captcha.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {
   throw new ErrorException($message, 0, $severity, $file, $line);

--- a/mailpoet/prefixer/fix-carbon.php
+++ b/mailpoet/prefixer/fix-carbon.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/fix-doctrine.php
+++ b/mailpoet/prefixer/fix-doctrine.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/fix-monolog.php
+++ b/mailpoet/prefixer/fix-monolog.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/fix-symfony-di.php
+++ b/mailpoet/prefixer/fix-symfony-di.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/fix-symfony-polyfill.php
+++ b/mailpoet/prefixer/fix-symfony-polyfill.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/fix-twig.php
+++ b/mailpoet/prefixer/fix-twig.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {
   throw new ErrorException($message, 0, $severity, $file, $line);

--- a/mailpoet/prefixer/fix-validator.php
+++ b/mailpoet/prefixer/fix-validator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/prefixer/scoper.inc.php
+++ b/mailpoet/prefixer/scoper.inc.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 use Isolated\Symfony\Component\Finder\Finder;
 

--- a/mailpoet/tasks/GithubClient.php
+++ b/mailpoet/tasks/GithubClient.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks;
 

--- a/mailpoet/tasks/WPOrgPluginDownloader.php
+++ b/mailpoet/tasks/WPOrgPluginDownloader.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks;
 

--- a/mailpoet/tasks/code_sniffer/MailPoet/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/mailpoet/tasks/code_sniffer/MailPoet/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Sniffs;
 

--- a/mailpoet/tasks/code_sniffer/MailPoet/Sniffs/ControlStructures/FunctionDeclarationSniff.php
+++ b/mailpoet/tasks/code_sniffer/MailPoet/Sniffs/ControlStructures/FunctionDeclarationSniff.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 /**
  * Ensure multi-line function declarations are defined correctly.
  * Copy from PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionDeclarationSniff

--- a/mailpoet/tasks/code_sniffer/MailPoet/ruleset.xml
+++ b/mailpoet/tasks/code_sniffer/MailPoet/ruleset.xml
@@ -18,7 +18,6 @@
       <property name="declareOnFirstLine" value="true" />
       <property name="spacesCountAroundEqualsSign" value="1" />
     </properties>
-    <include-pattern>lib/Automation</include-pattern>
   </rule>
 
   <!-- Namespaces -->

--- a/mailpoet/tasks/fix-codeception-stub.php
+++ b/mailpoet/tasks/fix-codeception-stub.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/tasks/fix-full-path-disclosure.php
+++ b/mailpoet/tasks/fix-full-path-disclosure.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // inject the following code to all PHP files in given directory to prevent full path disclosure
 // (directly used PHP file may output path-leaking errors, such as some used symbols are missing)

--- a/mailpoet/tasks/fix-guzzle.php
+++ b/mailpoet/tasks/fix-guzzle.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/tasks/fix-phpunit.php
+++ b/mailpoet/tasks/fix-phpunit.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/tasks/fix-requests.php
+++ b/mailpoet/tasks/fix-requests.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/tasks/form-export/Template.php
+++ b/mailpoet/tasks/form-export/Template.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Form\Templates\Templates;
 

--- a/mailpoet/tasks/form-export/form-export.php
+++ b/mailpoet/tasks/form-export/form-export.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 /*
 Plugin Name: MailPoet Form Template Export

--- a/mailpoet/tasks/phpstan/PremiumContainerConfigurator.php
+++ b/mailpoet/tasks/phpstan/PremiumContainerConfigurator.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\Premium\DI;
 

--- a/mailpoet/tasks/phpstan/bootstrap.php
+++ b/mailpoet/tasks/phpstan/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // Constants
 define('WPINC', 'wp-includes');

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 // phpcs:ignoreFile - This file contains stubs for 3rd party functions and classes that might break our PHPCS rules
 
 namespace {

--- a/mailpoet/tasks/phpstan/extensions/CodeceptionExtension/Type/StubDynamicReturnTypeExtension.php
+++ b/mailpoet/tasks/phpstan/extensions/CodeceptionExtension/Type/StubDynamicReturnTypeExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\PHPStan\Extensions\CodeceptionExtension\Type;
 

--- a/mailpoet/tasks/phpstan/extensions/CodeceptionExtension/Type/TestCaseDynamicReturnTypeExtension.php
+++ b/mailpoet/tasks/phpstan/extensions/CodeceptionExtension/Type/TestCaseDynamicReturnTypeExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoet\PHPStan\Extensions\CodeceptionExtension\Type;
 

--- a/mailpoet/tasks/phpstan/fix-WPStubs-for-PHP-8_1.php
+++ b/mailpoet/tasks/phpstan/fix-WPStubs-for-PHP-8_1.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/tasks/phpstan/php-version-dependent-config.php
+++ b/mailpoet/tasks/phpstan/php-version-dependent-config.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 $config = [];
 $phpVersion = (int)getenv('ANALYSIS_PHP_VERSION') ?: PHP_VERSION_ID;

--- a/mailpoet/tasks/phpstan/phpstan-baseline-fix-lib.php
+++ b/mailpoet/tasks/phpstan/phpstan-baseline-fix-lib.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types = 1);
+<?php declare(strict_types = 1);
 
 $config = [];
 $phpVersion = (int)getenv('ANALYSIS_PHP_VERSION') ?: PHP_VERSION_ID;

--- a/mailpoet/tasks/phpstan/prefix-phpstan-doctrine.php
+++ b/mailpoet/tasks/phpstan/prefix-phpstan-doctrine.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // throw exception if anything fails
 set_error_handler(function ($severity, $message, $file, $line) {

--- a/mailpoet/tasks/release/ChangelogController.php
+++ b/mailpoet/tasks/release/ChangelogController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/GitHubController.php
+++ b/mailpoet/tasks/release/GitHubController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/JiraController.php
+++ b/mailpoet/tasks/release/JiraController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/ReleaseVersionController.php
+++ b/mailpoet/tasks/release/ReleaseVersionController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/SlackNotifier.php
+++ b/mailpoet/tasks/release/SlackNotifier.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/TranslationsController.php
+++ b/mailpoet/tasks/release/TranslationsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/release/VersionHelper.php
+++ b/mailpoet/tasks/release/VersionHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 namespace MailPoetTasks\Release;
 

--- a/mailpoet/tasks/strip-whitespaces.php
+++ b/mailpoet/tasks/strip-whitespaces.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 // Strip comments and whitespaces from php files in folder
 

--- a/mailpoet/tests/DataFactories/CustomField.php
+++ b/mailpoet/tests/DataFactories/CustomField.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/DynamicSegment.php
+++ b/mailpoet/tests/DataFactories/DynamicSegment.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/Features.php
+++ b/mailpoet/tests/DataFactories/Features.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/Form.php
+++ b/mailpoet/tests/DataFactories/Form.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/NewsletterLink.php
+++ b/mailpoet/tests/DataFactories/NewsletterLink.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/ScheduledTask.php
+++ b/mailpoet/tests/DataFactories/ScheduledTask.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/ScheduledTaskSubscriber.php
+++ b/mailpoet/tests/DataFactories/ScheduledTaskSubscriber.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/Segment.php
+++ b/mailpoet/tests/DataFactories/Segment.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/StatisticsBounces.php
+++ b/mailpoet/tests/DataFactories/StatisticsBounces.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/StatisticsClicks.php
+++ b/mailpoet/tests/DataFactories/StatisticsClicks.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/StatisticsOpens.php
+++ b/mailpoet/tests/DataFactories/StatisticsOpens.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
+++ b/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
+++ b/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
@@ -45,7 +45,7 @@ class StatisticsWooCommercePurchases {
       $this->click,
       $this->data['order_id'],
       $this->data['order_currency'],
-      $this->data['order_price_total']
+      (float)$this->data['order_price_total']
     );
     $entity->setSubscriber($this->subscriber);
 

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/User.php
+++ b/mailpoet/tests/DataFactories/User.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/UserFlags.php
+++ b/mailpoet/tests/DataFactories/UserFlags.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/WooCommerceCustomer.php
+++ b/mailpoet/tests/DataFactories/WooCommerceCustomer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/WooCommerceMembership.php
+++ b/mailpoet/tests/DataFactories/WooCommerceMembership.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/WooCommerceOrder.php
+++ b/mailpoet/tests/DataFactories/WooCommerceOrder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/WooCommerceProduct.php
+++ b/mailpoet/tests/DataFactories/WooCommerceProduct.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataFactories/WooCommerceSubscription.php
+++ b/mailpoet/tests/DataFactories/WooCommerceSubscription.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataFactories;
 

--- a/mailpoet/tests/DataGenerator/DataGenerator.php
+++ b/mailpoet/tests/DataGenerator/DataGenerator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataGenerator;
 

--- a/mailpoet/tests/DataGenerator/Generators/Generator.php
+++ b/mailpoet/tests/DataGenerator/Generators/Generator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataGenerator\Generators;
 

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DataGenerator\Generators;
 

--- a/mailpoet/tests/DataGenerator/_bootstrap.php
+++ b/mailpoet/tests/DataGenerator/_bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 // Turn off transaction emails by defining dummy wp_mail
 if (!function_exists('wp_mail')) {

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 use Facebook\WebDriver\Exception\UnrecognizedExceptionException;
 use Facebook\WebDriver\Exception\WebDriverException;

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 use Codeception\Event\FailEvent;
 use Codeception\Events;

--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;

--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;

--- a/mailpoet/tests/_support/ErrorsExtension.php
+++ b/mailpoet/tests/_support/ErrorsExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;

--- a/mailpoet/tests/_support/Helper/Acceptance.php
+++ b/mailpoet/tests/_support/Helper/Acceptance.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Helper;
 

--- a/mailpoet/tests/_support/Helper/Functional.php
+++ b/mailpoet/tests/_support/Helper/Functional.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Helper;
 

--- a/mailpoet/tests/_support/Helper/Unit.php
+++ b/mailpoet/tests/_support/Helper/Unit.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Helper;
 

--- a/mailpoet/tests/_support/Helper/WordPress.php
+++ b/mailpoet/tests/_support/Helper/WordPress.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Helper;
 

--- a/mailpoet/tests/_support/Helper/WordPressHooks.php
+++ b/mailpoet/tests/_support/Helper/WordPressHooks.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Helper;
 

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore;
 use MailPoet\DI\ContainerWrapper;

--- a/mailpoet/tests/_support/PluginsExtension.php
+++ b/mailpoet/tests/_support/PluginsExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\TestsSupport;
 

--- a/mailpoet/tests/_support/StatisticsExtension.php
+++ b/mailpoet/tests/_support/StatisticsExtension.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types = 1);
+
 /**
  * @package     teststatistics
  * @subpackage

--- a/mailpoet/tests/_support/UnitTester.php
+++ b/mailpoet/tests/_support/UnitTester.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * Inherited Methods

--- a/mailpoet/tests/_support/woo_cot_helper_plugin.php
+++ b/mailpoet/tests/_support/woo_cot_helper_plugin.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /*
 Plugin Name: MailPoet Woo COT Helper

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Automation/SomeoneSubscribesAutomationTriggeredByCheckoutCest.php
+++ b/mailpoet/tests/acceptance/Automation/SomeoneSubscribesAutomationTriggeredByCheckoutCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
+++ b/mailpoet/tests/acceptance/Automation/UserRegistrationTriggerCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/CreateFormUsingTemplateCest.php
+++ b/mailpoet/tests/acceptance/Forms/CreateFormUsingTemplateCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/DisplayFormBellowPostCest.php
+++ b/mailpoet/tests/acceptance/Forms/DisplayFormBellowPostCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorAddDividerCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddDividerCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorAddListSelectionCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddListSelectionCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorAddNamesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddNamesCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorCreateBlankFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateBlankFormCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorCustomClassesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCustomClassesCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorFormPreviewCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorFormPreviewCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorPlaceFormOnSpecifiedPageCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorPlaceFormOnSpecifiedPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorTutorialCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTutorialCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorUndoAndRedoCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUndoAndRedoCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateMandatoryFieldsCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateMandatoryFieldsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/FormWithColumnsCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormWithColumnsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/FormsDeletingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsDeletingCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/FormsDuplicatingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsDuplicatingCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/FormsListingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsListingCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Misc/MailpoetMenuCest.php
+++ b/mailpoet/tests/acceptance/Misc/MailpoetMenuCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ConfirmNewsletterAutosaveCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ConfirmNewsletterAutosaveCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ConfirmNotificationAutosaveCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ConfirmNotificationAutosaveCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ConfirmTitleAlignmentSettingsInALCBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ConfirmTitleAlignmentSettingsInALCBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/CreateWelcomeEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/CreateWelcomeEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/CreateWooCommerceNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/CreateWooCommerceNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DeleteAutomaticWooCommerceEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteAutomaticWooCommerceEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNotificationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNotificationHistoryCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNotificationHistoryCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DuplicateAutomaticEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicateAutomaticEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DuplicateNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicateNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/DuplicatePostNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicatePostNotificationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditAutomaticWooCommerceEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditAutomaticWooCommerceEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditExistingNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditExistingNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditExistingPostNotificationEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditExistingPostNotificationEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorDividerBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorDividerBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorFooterBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorFooterBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorHeaderBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorHeaderBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorHistoryCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorHistoryCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorImageBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorImageBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorLineHeightCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorLineHeightCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorProductsCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorProductsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorSettingsBehaviourCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorSettingsBehaviourCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorSocialBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorSocialBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorSpacerBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorSpacerBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorTextBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorTextBlockCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ManageWelcomeEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ManageWelcomeEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/NewsletterCreationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewsletterCreationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/NewsletterSendingErrorCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewsletterSendingErrorCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/NewsletterStatisticsCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewsletterStatisticsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/NewslettersListingCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewslettersListingCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/PreviewPostNotificationNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/PreviewPostNotificationNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/PreviewStandardNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/PreviewStandardNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ReceivePostNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ReceivePostNotificationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ReceiveStandardEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ReceiveStandardEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ReceiveWelcomeEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ReceiveWelcomeEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SaveNewsletterAsDraftCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SaveNewsletterAsDraftCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SaveNewsletterAsTemplateCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SaveNewsletterAsTemplateCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SaveNotificationAsDraftCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SaveNotificationAsDraftCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SavePostNotificationEmailAsTemplateCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SavePostNotificationEmailAsTemplateCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SearchForNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SearchForNotificationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SearchForStandardNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SearchForStandardNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SendPageSenderDomainCheckCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendPageSenderDomainCheckCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SendingStatusCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendingStatusCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/SentNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SentNewsletterCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/StatsPageCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/StatsPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/TemplatesPagesLoadCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/TemplatesPagesLoadCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Newsletters/UnauthorizedEmailNoticesCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/UnauthorizedEmailNoticesCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/CreateSubscriberScoreSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSubscriberScoreSegmentCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/AdvancedSettingsCest.php
+++ b/mailpoet/tests/acceptance/Settings/AdvancedSettingsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/AuthorizedEmailAddressesValidationCest.php
+++ b/mailpoet/tests/acceptance/Settings/AuthorizedEmailAddressesValidationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/BuiltInCaptchaSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Settings/BuiltInCaptchaSubscriptionCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
  namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/CustomUnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/CustomUnsubscribePageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
+++ b/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/EnableAndDisableSignupConfirmationCest.php
+++ b/mailpoet/tests/acceptance/Settings/EnableAndDisableSignupConfirmationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/FreeEmailAsFromAddressTriggersAlertCest.php
+++ b/mailpoet/tests/acceptance/Settings/FreeEmailAsFromAddressTriggersAlertCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/InactiveSubscribersChangeCest.php
+++ b/mailpoet/tests/acceptance/Settings/InactiveSubscribersChangeCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
+++ b/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/RevenueTrackingCookieCest.php
+++ b/mailpoet/tests/acceptance/Settings/RevenueTrackingCookieCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/SenderDomainCheckCest.php
+++ b/mailpoet/tests/acceptance/Settings/SenderDomainCheckCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
+++ b/mailpoet/tests/acceptance/Settings/TransactionalEmailsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/WooCommerceEmailCustomizationCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceEmailCustomizationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/ExportSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ExportSubscribersCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/ManageImportExportCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageImportExportCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/PageViewTrackingCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/PageViewTrackingCookieCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooMyAccountRegistrationCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooMyAccountRegistrationCest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Acceptance;
 

--- a/mailpoet/tests/acceptance/_bootstrap.php
+++ b/mailpoet/tests/acceptance/_bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 ini_set('max_execution_time', '900');
 

--- a/mailpoet/tests/docker/codeception/wp-56-phpmailer-fix.php
+++ b/mailpoet/tests/docker/codeception/wp-56-phpmailer-fix.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /*
 Plugin Name: MailPoet Testing Fix: Use SMTP In PHPMailer on WP 5.6

--- a/mailpoet/tests/integration/API/APITest.php
+++ b/mailpoet/tests/integration/API/APITest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API;
 

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON;
 

--- a/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV1.php
+++ b/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV1.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV2.php
+++ b/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV2.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\v2;
 

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/FormsResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/FormsResponseBuilderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SegmentsResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SegmentsResponseBuilderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 

--- a/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/AutomaticEmailsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomaticEmailsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/CustomFieldsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/CustomFieldsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/FeatureFlagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/FeatureFlagsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/FormsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/FormsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/ImportExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ImportExportTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/NewsletterTemplatesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewsletterTemplatesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SegmentsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/UserFlagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/UserFlagsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/JSON/v1/WoocommerceSettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/WoocommerceSettingsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/integration/API/MP/APITest.php
+++ b/mailpoet/tests/integration/API/MP/APITest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\MP;
 

--- a/mailpoet/tests/integration/API/MP/CustomFieldsTest.php
+++ b/mailpoet/tests/integration/API/MP/CustomFieldsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\MP;
 

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\MP;
 

--- a/mailpoet/tests/integration/AdminPages/HelpTest.php
+++ b/mailpoet/tests/integration/AdminPages/HelpTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace integration\AdminPages;
 

--- a/mailpoet/tests/integration/Analytics/AnalyticsTest.php
+++ b/mailpoet/tests/integration/Analytics/AnalyticsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Analytics;
 

--- a/mailpoet/tests/integration/AutomaticEmails/AutomaticEmailsTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/AutomaticEmailsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AutomaticEmails;
 

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceStubs/ItemDetails.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceStubs/ItemDetails.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AutomaticEmails\WooCommerce\WooCommerceStubs;
 

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceStubs/OrderDetails.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceStubs/OrderDetails.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AutomaticEmails\WooCommerce\WooCommerceStubs;
 

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AutomaticEmails\WooCommerce;
 

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Engine\Control;
 

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Engine\Storage;
 

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Engine\Storage;
 

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Engine\Storage;
 

--- a/mailpoet/tests/integration/Automation/Integrations/Core/Actions/DelayActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/Core/Actions/DelayActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Integrations\Core\Actions;
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Automation\Integrations\MailPoet\Actions;
 

--- a/mailpoet/tests/integration/Config/AccessControlTest.php
+++ b/mailpoet/tests/integration/Config/AccessControlTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/CapabilitiesTest.php
+++ b/mailpoet/tests/integration/Config/CapabilitiesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/DatabaseTest.php
+++ b/mailpoet/tests/integration/Config/DatabaseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/HooksTest.php
+++ b/mailpoet/tests/integration/Config/HooksTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/InitializerTest.php
+++ b/mailpoet/tests/integration/Config/InitializerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/InstallerTest.php
+++ b/mailpoet/tests/integration/Config/InstallerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/MenuTest.php
+++ b/mailpoet/tests/integration/Config/MenuTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/PluginActivatedHookTest.php
+++ b/mailpoet/tests/integration/Config/PluginActivatedHookTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Config;
 

--- a/mailpoet/tests/integration/Config/RendererTest.php
+++ b/mailpoet/tests/integration/Config/RendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/ServicesCheckerTest.php
+++ b/mailpoet/tests/integration/Config/ServicesCheckerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Config;
 

--- a/mailpoet/tests/integration/Config/UpdaterTest.php
+++ b/mailpoet/tests/integration/Config/UpdaterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Cron/ActionScheduler/ActionSchedulerTestHelper.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/ActionSchedulerTestHelper.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\ActionScheduler;
 

--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\ActionScheduler\Actions;
 

--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonTriggerTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonTriggerTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\ActionScheduler\Actions;
 

--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron;
 

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -34,7 +34,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       []
     );
     $daemon = $this->diContainer->get(DaemonHttpRunner::class);
-    expect(strlen($daemon->timer))->greaterOrEquals(5);
+    expect(strlen((string)$daemon->timer))->greaterOrEquals(5);
     expect(strlen($daemon->token))->greaterOrEquals(5);
   }
 

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/integration/Cron/SupervisorTest.php
+++ b/mailpoet/tests/integration/Cron/SupervisorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
+++ b/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Triggers;
 

--- a/mailpoet/tests/integration/Cron/Workers/AuthorizedSendingEmailsCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/AuthorizedSendingEmailsCheckTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/BeamerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BeamerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/BounceTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/BounceTestMockAPI.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTestMockAPI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers\Bounce;
 

--- a/mailpoet/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/InactiveSubscribersTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/InactiveSubscribersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerMockImplementation.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerMockImplementation.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers\KeyCheck;
 

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\KeyCheck;
 

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\KeyCheck;
 

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\KeyCheck;
 

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingErrorHandlerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingErrorHandlerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -158,7 +158,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   private function getDirectUnsubscribeURL() {
-    return SubscriptionUrlFactory::getInstance()->getUnsubscribeUrl($this->subscriber, $this->queue->id);
+    return SubscriptionUrlFactory::getInstance()->getUnsubscribeUrl($this->subscriber, (int)$this->queue->id);
   }
 
   private function getTrackedUnsubscribeURL() {
@@ -494,7 +494,7 @@ class SendingQueueTest extends \MailPoetTest {
             $subscriberId = (int)$subscriberId[0];
             $subscriber = $subscribersRepository->findOneById($subscriberId);
             $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
-            $unsubscribeUrl = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber, $queue->id);
+            $unsubscribeUrl = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber, (int)$queue->id);
             expect($newsletter['subject'])->equals('News for ' . $subscriberEmail);
             expect($newsletter['body']['html'])->equals('<p>Hello ' . $subscriberEmail . '</p>');
             expect($newsletter['body']['text'])->equals('Hello ' . $subscriberEmail);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\SendingQueue;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingThrottlingHandlerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingThrottlingHandlerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/PostsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/PostsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/ShortcodesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 

--- a/mailpoet/tests/integration/Cron/Workers/SimpleWorkerMockImplementation.php
+++ b/mailpoet/tests/integration/Cron/Workers/SimpleWorkerMockImplementation.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SimpleWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SimpleWorkerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/NewsletterLinkRepositoryTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/NewsletterLinkRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscriberLinkTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscriberLinkTokensTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersStatsReportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersStatsReportTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron\Workers;
 

--- a/mailpoet/tests/integration/Doctrine/ConfigurationFactoryTest.php
+++ b/mailpoet/tests/integration/Doctrine/ConfigurationFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Doctrine/ConnectionFactoryTest.php
+++ b/mailpoet/tests/integration/Doctrine/ConnectionFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Config;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/EmojiEncodingListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/EmojiEncodingListenerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/TimestampEntity.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/TimestampEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/TimestampListenerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/ValidatedEntity.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/ValidatedEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/EventListeners/ValidationTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/ValidationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Doctrine/Types/JsonEntity.php
+++ b/mailpoet/tests/integration/Doctrine/Types/JsonEntity.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\Types;
 

--- a/mailpoet/tests/integration/Doctrine/Types/JsonTypesTest.php
+++ b/mailpoet/tests/integration/Doctrine/Types/JsonTypesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/tests/integration/Entities/SubscriberEntityIntegrationTest.php
+++ b/mailpoet/tests/integration/Entities/SubscriberEntityIntegrationTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/tests/integration/Form/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Form/ApiDataSanitizerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form;
 

--- a/mailpoet/tests/integration/Form/FormHtmlSanitizerTest.php
+++ b/mailpoet/tests/integration/Form/FormHtmlSanitizerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form;
 

--- a/mailpoet/tests/integration/Form/FormSaveControllerTest.php
+++ b/mailpoet/tests/integration/Form/FormSaveControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form;
 

--- a/mailpoet/tests/integration/Form/FormsRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/FormsRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form;
 

--- a/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form\Listing;
 

--- a/mailpoet/tests/integration/Form/RendererTest.php
+++ b/mailpoet/tests/integration/Form/RendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form;
 

--- a/mailpoet/tests/integration/Form/WidgetTest.php
+++ b/mailpoet/tests/integration/Form/WidgetTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form;
 

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Helpscout;
 

--- a/mailpoet/tests/integration/Logging/LogHandlerTest.php
+++ b/mailpoet/tests/integration/Logging/LogHandlerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Logging;
 

--- a/mailpoet/tests/integration/Mailer/MailerFactoryTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerFactoryTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer;
 

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer;
 

--- a/mailpoet/tests/integration/Mailer/MailerTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer;
 

--- a/mailpoet/tests/integration/Mailer/MetaInfoTest.php
+++ b/mailpoet/tests/integration/Mailer/MetaInfoTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer;
 

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods;
 

--- a/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods;
 

--- a/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods;
 

--- a/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
+++ b/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Mailer\WordPress;
 

--- a/mailpoet/tests/integration/Migrations/Migration_20221028_105818_Test.php
+++ b/mailpoet/tests/integration/Migrations/Migration_20221028_105818_Test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Migrations;
 

--- a/mailpoet/tests/integration/Migrator/TestMigrations/index.php
+++ b/mailpoet/tests/integration/Migrator/TestMigrations/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use MailPoet\Migrator\Migrator;
 

--- a/mailpoet/tests/integration/Models/CustomFieldTest.php
+++ b/mailpoet/tests/integration/Models/CustomFieldTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/ModelTest.php
+++ b/mailpoet/tests/integration/Models/ModelTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/ModelValidatorTest.php
+++ b/mailpoet/tests/integration/Models/ModelValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/NewsletterTest.php
+++ b/mailpoet/tests/integration/Models/NewsletterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/ScheduledTaskSubscriberTest.php
+++ b/mailpoet/tests/integration/Models/ScheduledTaskSubscriberTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/ScheduledTaskTest.php
+++ b/mailpoet/tests/integration/Models/ScheduledTaskTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/SegmentTest.php
+++ b/mailpoet/tests/integration/Models/SegmentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Models/SendingQueueTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/SubscriberCustomFieldTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberCustomFieldTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberSegmentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Models/SubscriberTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Models;
 

--- a/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/integration/Newsletter/Blocks/AutomatedLatestContentBlockTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AutomatedLatestContentBlockTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter\Editor;
 

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentTransformerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentTransformerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter\Editor;
 

--- a/mailpoet/tests/integration/Newsletter/Links/LinksTest.php
+++ b/mailpoet/tests/integration/Newsletter/Links/LinksTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter\Links;
 

--- a/mailpoet/tests/integration/Newsletter/NewsletterHtmlSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterHtmlSanitizerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter\Scheduler;
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Scheduler;
 

--- a/mailpoet/tests/integration/Newsletter/ShortcodesHelperTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesHelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 

--- a/mailpoet/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
+++ b/mailpoet/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\NewsletterTemplates;
 

--- a/mailpoet/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
+++ b/mailpoet/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\NewsletterTemplates;
 

--- a/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\PostEditorBlocks;
 

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\REST\Automation\Automations;
 

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\REST\Automation\Automations;
 

--- a/mailpoet/tests/integration/Referrals/UrlDecoratorTest.php
+++ b/mailpoet/tests/integration/Referrals/UrlDecoratorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Router;
 

--- a/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Router\Endpoints;
 

--- a/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Router\Endpoints;
 

--- a/mailpoet/tests/integration/Router/RouterTest.php
+++ b/mailpoet/tests/integration/Router/RouterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Router;
 

--- a/mailpoet/tests/integration/Router/RouterTestMockEndpoint.php
+++ b/mailpoet/tests/integration/Router/RouterTestMockEndpoint.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Router\Endpoints;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 

--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments;
 

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Segments;
 

--- a/mailpoet/tests/integration/Segments/WPTestUser.php
+++ b/mailpoet/tests/integration/Segments/WPTestUser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Segments;
 

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Services;
 

--- a/mailpoet/tests/integration/Services/BridgeApiTest.php
+++ b/mailpoet/tests/integration/Services/BridgeApiTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Services\Bridge;
 

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Services;
 

--- a/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
+++ b/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Services\Bridge;
 

--- a/mailpoet/tests/integration/Settings/SettingsChangeHandlerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsChangeHandlerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Settings;
 

--- a/mailpoet/tests/integration/Settings/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Settings;
 

--- a/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Settings;
 

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics;
 

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Statistics\Track;
 

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Statistics\Track;
 

--- a/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Statistics\Track;
 

--- a/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -57,7 +57,7 @@ class UnsubscribesTest extends \MailPoetTest {
     $this->unsubscribes->track(
       $subscriberId,
       'source',
-      $this->queue->id,
+      (int)$this->queue->id,
       null,
       StatisticsUnsubscribeEntity::METHOD_ONE_CLICK
     );
@@ -69,12 +69,12 @@ class UnsubscribesTest extends \MailPoetTest {
   public function testItDoesNotTrackRepeatedUnsubscribeEvents() {
     $subscriberId = $this->subscriber->getId();
     $this->assertIsInt($subscriberId);
-    
+
     for ($count = 0; $count <= 2; $count++) {
       $this->unsubscribes->track(
         $subscriberId,
         'source',
-        $this->queue->id
+        (int)$this->queue->id
       );
     }
     expect(count($this->statisticsUnsubscribesRepository->findAll()))->equals(1);

--- a/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Statistics\Track;
 

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Statistics\Track;
 

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Export/ExportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Export/ExportTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\Export;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\Import;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscribers\ImportExport\Import;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscribers\ImportExport;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewslettersExporterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SegmentsExporterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 

--- a/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/integration/Subscribers/RequiredCustomFieldValidatorTest.php
+++ b/mailpoet/tests/integration/Subscribers/RequiredCustomFieldValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/integration/Subscribers/SourceTest.php
+++ b/mailpoet/tests/integration/Subscribers/SourceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/integration/Subscribers/SubscriberPersonalDataEraserTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberPersonalDataEraserTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/integration/Subscription/Captcha/CaptchaRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/Captcha/CaptchaRendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription\Captcha;
 

--- a/mailpoet/tests/integration/Subscription/Captcha/CaptchaSessionTest.php
+++ b/mailpoet/tests/integration/Subscription/Captcha/CaptchaSessionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription\Captcha;
 

--- a/mailpoet/tests/integration/Subscription/Captcha/Validator/BuiltInCaptchaValidatorTest.php
+++ b/mailpoet/tests/integration/Subscription/Captcha/Validator/BuiltInCaptchaValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Mailpoet\Test\Subscription\Captcha\Validator;
 

--- a/mailpoet/tests/integration/Subscription/CaptchaFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/CaptchaFormRendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -111,7 +111,7 @@ class PagesTest extends \MailPoetTest {
     $subscriber->setFirstName('First name');
     $subscriber->setUnconfirmedData(null);
     $subscriber->setLastSubscribedAt(Carbon::createFromTimestamp($this->wp->currentTime('timestamp'))->subDays(10));
-    $subscriber->setConfirmedIp(Carbon::createFromTimestamp($this->wp->currentTime('timestamp'))->subDays(10));
+    $subscriber->setConfirmedIp('111.111.111.111');
     $this->entityManager->flush();
     $subscription = $pages->init(false, $this->testData, false, false);
     $subscription->confirm();

--- a/mailpoet/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
+++ b/mailpoet/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/ThrottlingTest.php
+++ b/mailpoet/tests/integration/Subscription/ThrottlingTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/tests/integration/Subscription/UrlTest.php
+++ b/mailpoet/tests/integration/Subscription/UrlTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Subscription;
 

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Tasks;
 

--- a/mailpoet/tests/integration/Tasks/Subscribers/BatchIteratorTest.php
+++ b/mailpoet/tests/integration/Tasks/Subscribers/BatchIteratorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Tasks\Subscribers;
 

--- a/mailpoet/tests/integration/Twig/AssetsTest.php
+++ b/mailpoet/tests/integration/Twig/AssetsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Twig;
 

--- a/mailpoet/tests/integration/Twig/FunctionsTest.php
+++ b/mailpoet/tests/integration/Twig/FunctionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Twig;
 

--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/integration/Util/Notices/AfterMigrationNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/AfterMigrationNoticeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/tests/integration/Util/Notices/InactiveSubscribersNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/InactiveSubscribersNoticeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Util\Notices;
 

--- a/mailpoet/tests/integration/WP/EmojiTest.php
+++ b/mailpoet/tests/integration/WP/EmojiTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\WP;
 

--- a/mailpoet/tests/integration/WP/FunctionsTest.php
+++ b/mailpoet/tests/integration/WP/FunctionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\WP;
 

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce\TransactionalEmails;
 

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailsTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Codeception\Stub;
 use MailPoet\Cache\TransientCache;

--- a/mailpoet/tests/integration/_fixtures.php
+++ b/mailpoet/tests/integration/_fixtures.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Codeception\Util\Fixtures;
 

--- a/mailpoet/tests/unit/API/JSON/ErrorResponseTest.php
+++ b/mailpoet/tests/unit/API/JSON/ErrorResponseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON;
 

--- a/mailpoet/tests/unit/API/JSON/PremiumTest.php
+++ b/mailpoet/tests/unit/API/JSON/PremiumTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON;
 

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/AtLeastOneTriggerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/AtLeastOneTriggerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Automation\Engine\Validation\AutomationRules;
 

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/TriggerNeedsNextStepsRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/TriggerNeedsNextStepsRuleTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Automation\Engine\Validation\AutomationRules;
 

--- a/mailpoet/tests/unit/Cron/CronTriggerTest.php
+++ b/mailpoet/tests/unit/Cron/CronTriggerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Cron;
 

--- a/mailpoet/tests/unit/Cron/Workers/StatsNotifications/SchedulerTest.php
+++ b/mailpoet/tests/unit/Cron/Workers/StatsNotifications/SchedulerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 

--- a/mailpoet/tests/unit/CustomFields/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/unit/CustomFields/ApiDataSanitizerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\CustomFields;
 

--- a/mailpoet/tests/unit/DI/ContainerWrapperTest.php
+++ b/mailpoet/tests/unit/DI/ContainerWrapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DI;
 

--- a/mailpoet/tests/unit/DI/TestService.php
+++ b/mailpoet/tests/unit/DI/TestService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\DI;
 

--- a/mailpoet/tests/unit/Entities/FormEntityTest.php
+++ b/mailpoet/tests/unit/Entities/FormEntityTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/tests/unit/Entities/SubscriberCustomFieldEntityTest.php
+++ b/mailpoet/tests/unit/Entities/SubscriberCustomFieldEntityTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/tests/unit/Entities/SubscriberEntityTest.php
+++ b/mailpoet/tests/unit/Entities/SubscriberEntityTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Entities;
 

--- a/mailpoet/tests/unit/Features/FeaturesControllerTest.php
+++ b/mailpoet/tests/unit/Features/FeaturesControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\API\JSON\v1;
 

--- a/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/CheckboxTest.php
+++ b/mailpoet/tests/unit/Form/Block/CheckboxTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/ColumnTest.php
+++ b/mailpoet/tests/unit/Form/Block/ColumnTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/ColumnsTest.php
+++ b/mailpoet/tests/unit/Form/Block/ColumnsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/DateTest.php
+++ b/mailpoet/tests/unit/Form/Block/DateTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/DividerTest.php
+++ b/mailpoet/tests/unit/Form/Block/DividerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/HeadingTest.php
+++ b/mailpoet/tests/unit/Form/Block/HeadingTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/HtmlTest.php
+++ b/mailpoet/tests/unit/Form/Block/HtmlTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/ImageTest.php
+++ b/mailpoet/tests/unit/Form/Block/ImageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/ParagraphTest.php
+++ b/mailpoet/tests/unit/Form/Block/ParagraphTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/RadioTest.php
+++ b/mailpoet/tests/unit/Form/Block/RadioTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/SegmentTest.php
+++ b/mailpoet/tests/unit/Form/Block/SegmentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/SelectTest.php
+++ b/mailpoet/tests/unit/Form/Block/SelectTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/SubmitTest.php
+++ b/mailpoet/tests/unit/Form/Block/SubmitTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/TextTest.php
+++ b/mailpoet/tests/unit/Form/Block/TextTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/Block/TextareaTest.php
+++ b/mailpoet/tests/unit/Form/Block/TextareaTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Block;
 

--- a/mailpoet/tests/unit/Form/BlockStylesRendererTest.php
+++ b/mailpoet/tests/unit/Form/BlockStylesRendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form;
 

--- a/mailpoet/tests/unit/Form/BlockWrapperRendererTest.php
+++ b/mailpoet/tests/unit/Form/BlockWrapperRendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form;
 

--- a/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
+++ b/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form;
 

--- a/mailpoet/tests/unit/Form/HtmlParser.php
+++ b/mailpoet/tests/unit/Form/HtmlParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form;
 

--- a/mailpoet/tests/unit/Form/RendererTest.php
+++ b/mailpoet/tests/unit/Form/RendererTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form;
 

--- a/mailpoet/tests/unit/Form/Templates/TemplatesRepositoryTest.php
+++ b/mailpoet/tests/unit/Form/Templates/TemplatesRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Templates;
 

--- a/mailpoet/tests/unit/Form/Util/FieldNameObfuscatorTest.php
+++ b/mailpoet/tests/unit/Form/Util/FieldNameObfuscatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Form\Util;
 

--- a/mailpoet/tests/unit/Form/Util/StylesTest.php
+++ b/mailpoet/tests/unit/Form/Util/StylesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Form\Util;
 

--- a/mailpoet/tests/unit/Listing/HandlerTest.php
+++ b/mailpoet/tests/unit/Listing/HandlerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Listing;
 

--- a/mailpoet/tests/unit/Logging/LoggerFactoryTest.php
+++ b/mailpoet/tests/unit/Logging/LoggerFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Logging;
 

--- a/mailpoet/tests/unit/Mailer/MailerErrorTest.php
+++ b/mailpoet/tests/unit/Mailer/MailerErrorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer;
 

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/AmazonSESMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/AmazonSESMapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/PHPMailMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/PHPMailMapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/SendGridMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/SendGridMapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Mailer\Methods\ErrorMappers;
 

--- a/mailpoet/tests/unit/Newsletter/Editor/StructureTransformerTest.php
+++ b/mailpoet/tests/unit/Newsletter/Editor/StructureTransformerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter\Editor;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/DividerTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/DividerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/FooterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/FooterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/HeaderTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/HeaderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ImageTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ImageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/SocialTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/SocialTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/SpacerTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/SpacerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Newsletter\Renderer\Blocks;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/EscapeHelperTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/EscapeHelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Newsletter;
 

--- a/mailpoet/tests/unit/Referrals/ReferralDetectorTest.php
+++ b/mailpoet/tests/unit/Referrals/ReferralDetectorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Referrals;
 

--- a/mailpoet/tests/unit/Settings/CharsetsTest.php
+++ b/mailpoet/tests/unit/Settings/CharsetsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Settings;
 

--- a/mailpoet/tests/unit/Settings/HostsTest.php
+++ b/mailpoet/tests/unit/Settings/HostsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Settings;
 

--- a/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscribers;
 

--- a/mailpoet/tests/unit/Subscription/BlacklistTest.php
+++ b/mailpoet/tests/unit/Subscription/BlacklistTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscription;
 

--- a/mailpoet/tests/unit/Subscription/Captcha/CaptchaPhraseTest.php
+++ b/mailpoet/tests/unit/Subscription/Captcha/CaptchaPhraseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscription\Captcha;
 

--- a/mailpoet/tests/unit/Subscription/Captcha/Validator/BuiltInCaptchaValidatorTest.php
+++ b/mailpoet/tests/unit/Subscription/Captcha/Validator/BuiltInCaptchaValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscription\Captcha\Validator;
 

--- a/mailpoet/tests/unit/Subscription/Captcha/Validator/RecaptchaValidatorTest.php
+++ b/mailpoet/tests/unit/Subscription/Captcha/Validator/RecaptchaValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Subscription\Captcha\Validator;
 

--- a/mailpoet/tests/unit/Util/CSSTest.php
+++ b/mailpoet/tests/unit/Util/CSSTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/DOMTest.php
+++ b/mailpoet/tests/unit/Util/DOMTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/DateConverterTest.php
+++ b/mailpoet/tests/unit/Util/DateConverterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/HelpersTest.php
+++ b/mailpoet/tests/unit/Util/HelpersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/License/Features/SubscribersTest.php
+++ b/mailpoet/tests/unit/Util/License/Features/SubscribersTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util\License\Features;
 

--- a/mailpoet/tests/unit/Util/License/LicenseTest.php
+++ b/mailpoet/tests/unit/Util/License/LicenseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util\License;
 

--- a/mailpoet/tests/unit/Util/PQueryTest.php
+++ b/mailpoet/tests/unit/Util/PQueryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/SecondLevelDomainNamesTest.php
+++ b/mailpoet/tests/unit/Util/SecondLevelDomainNamesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Util;
 

--- a/mailpoet/tests/unit/Util/SecurityTest.php
+++ b/mailpoet/tests/unit/Util/SecurityTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/UrlTest.php
+++ b/mailpoet/tests/unit/Util/UrlTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/Util/XlsxWriterTest.php
+++ b/mailpoet/tests/unit/Util/XlsxWriterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\Util;
 

--- a/mailpoet/tests/unit/WP/DateTimeTest.php
+++ b/mailpoet/tests/unit/WP/DateTimeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\WP;
 

--- a/mailpoet/tests/unit/WP/ReadmeTest.php
+++ b/mailpoet/tests/unit/WP/ReadmeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Test\WP;
 

--- a/mailpoet/tests/unit/WooCommerce/TransactionalEmailsUnitTest.php
+++ b/mailpoet/tests/unit/WooCommerce/TransactionalEmailsUnitTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace MailPoet\WooCommerce;
 

--- a/mailpoet/tests/unit/_bootstrap.php
+++ b/mailpoet/tests/unit/_bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 if (!function_exists('__')) {
   function __($text, $domain) {

--- a/mailpoet/tests/unit/_fixtures.php
+++ b/mailpoet/tests/unit/_fixtures.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 use Codeception\Util\Fixtures;
 

--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
 $tools = [
   'https://github.com/composer/composer/releases/download/2.3.5/composer.phar' => 'composer.phar',


### PR DESCRIPTION
## Description

This enforces declaring `strict_types` in all new PHP files. It does so this way:
1. Current files without strict types have new ignore comments for CodeSniffer.
2. The CodeSniffer rule to enforce strict types was enabled for all files.

## Code review notes

See the commit messages. The large updates were done using find & replace and manually verified.

## QA notes

There are no changes in the plugin code, nothing to test.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/656

## Linked tickets

[MAILPOET-2688]

## After-merge notes

_N/A_


[MAILPOET-2688]: https://mailpoet.atlassian.net/browse/MAILPOET-2688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ