### PR TITLE
Fix container name in use error in acceptance tests [MAILPOET-4833]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
     parallelism: 20
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
     parameters:
       multisite:
         type: integer
@@ -476,7 +476,7 @@ jobs:
   integration_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
     environment:
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
     parameters:


### PR DESCRIPTION
## Description
This PR should fix the error:  `Error response from daemon: Conflict. The container name "/docker-wordpress-1" is already in use by container "xyz". You have to remove (or rename) that container to be able to reuse that name.` It appears quite often in acceptance tests.


I tried adding a cleanup of containers before the test run, and it didn't help. 
[There is a build where I tried just to print existing containers before tests start](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/12205/workflows/3a82f334-70bf-4757-bedf-e8bf70cf3aaa/jobs/208270). In result you can observe that there were no containers and the test still failed with the error.

In the end, I tried to update the image of the machine executor. This means we also get updated docker and docker-compose. After the update, I ran[ nine consecutive builds](https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=fix-container-in-use), and none of them failed with this error. So hopefully, the update could resolve the error. There are some failed builds, but for different reasons.

## Code review notes

_N/A_

## QA notes
I think this doesn't need QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4833]

## After-merge notes

_N/A_


[MAILPOET-4833]: https://mailpoet.atlassian.net/browse/MAILPOET-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ