### PR TITLE
Prevent errors due to wrapped WC function [MAILPOET-4834]

### DIFF
--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -124,7 +124,7 @@ class DisplayFormInWPContent {
     $displayCheck = $this->wp->applyFilters('mailpoet_display_form_in_product_listing', true);
 
     $shopPageId = $this->woocommerceHelper->wcGetPageId('shop');
-    $this->wooShopPageId = $shopPageId && $shopPageId >= 0 ? $shopPageId : null;
+    $this->wooShopPageId = $shopPageId && $shopPageId > 0 ? $shopPageId : null;
 
     if ($displayCheck && !is_null($this->wooShopPageId) && $this->wp->isPage($this->wooShopPageId)) {
       return true;

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -63,8 +63,8 @@ class Helper {
   }
 
   public function wcGetPageId(string $page): ?int {
-    if (function_exists('wc_get_page_id')) {
-      return wc_get_page_id($page);
+    if ($this->isWooCommerceActive()) {
+      return (int)wc_get_page_id($page);
     }
     return null;
   }


### PR DESCRIPTION
## Description

This PR ensures that our WC helper's wrapped version of `wc_get_page_id` will never throw an error due to an incorrect return value. See the linked ticket for an example of how this was affecting a user.

## Code review notes

_N/A_

## QA notes

This shouldn't have any effect on functionality, but it might still be best to test the functionality from MAILPOET-4663, which introduced this code.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/4459 introduced some of this code

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-4834

## After-merge notes

_N/A_
