### PR TITLE
Automations migration fix [MAILPOET-4835]

### DIFF
--- a/mailpoet/lib/Migrations/Migration_20221110_151621.php
+++ b/mailpoet/lib/Migrations/Migration_20221110_151621.php
@@ -5,6 +5,15 @@ namespace MailPoet\Migrations;
 use MailPoet\Config\Env;
 use MailPoet\Migrator\Migration;
 
+/**
+ * The "created_at" column must be NULL in some tables to avoid "there can be only one
+ * TIMESTAMP column with CURRENT_TIMESTAMP" error on MySQL version < 5.6.5 that occurs
+ * even when other timestamp is simply "NOT NULL".
+ *
+ * Additionally, having multiple timestamp columns with "NOT NULL" seems to produce the
+ * following error in some SQL modes:
+ *   SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'updated_at'"
+ */
 class Migration_20221110_151621 extends Migration {
   public function run(): void {
     $prefix = Env::$dbPrefix;

--- a/mailpoet/lib/Migrations/Migration_20221110_151621.php
+++ b/mailpoet/lib/Migrations/Migration_20221110_151621.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Migrations;
 
-use MailPoet\Config\Env;
 use MailPoet\Migrator\Migration;
 
 /**
@@ -16,72 +15,59 @@ use MailPoet\Migrator\Migration;
  */
 class Migration_20221110_151621 extends Migration {
   public function run(): void {
-    $prefix = Env::$dbPrefix;
-    $charsetCollate = Env::$dbCharsetCollate;
+    $this->createTable('automations', [
+      'id int(11) unsigned NOT NULL AUTO_INCREMENT',
+      'name varchar(191) NOT NULL',
+      'author bigint NOT NULL',
+      'status varchar(191) NOT NULL',
+      'created_at timestamp NULL', // must be NULL, see comment at the top
+      'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'activated_at timestamp NULL',
+      'deleted_at timestamp NULL',
+      'PRIMARY KEY (id)',
+    ]);
 
-    $this->connection->executeStatement("
-      CREATE TABLE {$prefix}automations (
-        id int(11) unsigned NOT NULL AUTO_INCREMENT,
-        name varchar(191) NOT NULL,
-        author bigint NOT NULL,
-        status varchar(191) NOT NULL,
-        created_at timestamp NULL, -- must be NULL, see comment at the top
-        updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        activated_at timestamp NULL,
-        deleted_at timestamp NULL,
-        PRIMARY KEY (id)
-      ) {$charsetCollate};
-    ");
+    $this->createTable('automation_versions', [
+      'id int(11) unsigned NOT NULL AUTO_INCREMENT',
+      'automation_id int(11) unsigned NOT NULL',
+      'steps longtext',
+      'created_at timestamp NULL', // must be NULL, see comment at the top
+      'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'PRIMARY KEY (id)',
+      'INDEX (automation_id)',
+    ]);
 
-    $this->connection->executeStatement("
-      CREATE TABLE {$prefix}automation_versions (
-        id int(11) unsigned NOT NULL AUTO_INCREMENT,
-        automation_id int(11) unsigned NOT NULL,
-        steps longtext,
-        created_at timestamp NULL, -- must be NULL, see comment at the top
-        updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        PRIMARY KEY (id),
-        INDEX (automation_id)
-      ) {$charsetCollate};
-    ");
+    $this->createTable('automation_triggers', [
+      'automation_id int(11) unsigned NOT NULL',
+      'trigger_key varchar(191)',
+      'PRIMARY KEY (automation_id, trigger_key)',
+    ]);
 
-    $this->connection->executeStatement("
-      CREATE TABLE {$prefix}automation_triggers (
-        automation_id int(11) unsigned NOT NULL,
-        trigger_key varchar(191),
-        PRIMARY KEY (automation_id, trigger_key)
-      );
-    ");
+    $this->createTable('automation_runs', [
+      'id int(11) unsigned NOT NULL AUTO_INCREMENT',
+      'automation_id int(11) unsigned NOT NULL',
+      'version_id int(11) unsigned NOT NULL',
+      'trigger_key varchar(191) NOT NULL',
+      'status varchar(191) NOT NULL',
+      'created_at timestamp NULL', // must be NULL, see comment at the top
+      'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'subjects longtext',
+      'next_step_id varchar(191)',
+      'PRIMARY KEY (id)',
+      'INDEX (automation_id, status)',
+    ]);
 
-    $this->connection->executeStatement("
-      CREATE TABLE {$prefix}automation_runs (
-        id int(11) unsigned NOT NULL AUTO_INCREMENT,
-        automation_id int(11) unsigned NOT NULL,
-        version_id int(11) unsigned NOT NULL,
-        trigger_key varchar(191) NOT NULL,
-        status varchar(191) NOT NULL,
-        created_at timestamp NULL, -- must be NULL, see comment at the top
-        updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        subjects longtext,
-        next_step_id varchar(191),
-        PRIMARY KEY (id),
-        INDEX (automation_id, status)
-      ) {$charsetCollate};
-    ");
-
-    $this->connection->executeStatement("
-      CREATE TABLE {$prefix}automation_run_logs (
-        id int(11) unsigned NOT NULL AUTO_INCREMENT,
-        automation_run_id int(11) unsigned NOT NULL,
-        step_id varchar(191) NOT NULL,
-        status varchar(191) NOT NULL,
-        started_at timestamp NOT NULL,
-        completed_at timestamp NULL DEFAULT NULL,
-        error longtext,
-        data longtext,
-        PRIMARY KEY (id),
-        INDEX (automation_run_id)
-      ) {$charsetCollate};
-    ");
+    $this->createTable('automation_run_logs', [
+      'id int(11) unsigned NOT NULL AUTO_INCREMENT',
+      'automation_run_id int(11) unsigned NOT NULL',
+      'step_id varchar(191) NOT NULL',
+      'status varchar(191) NOT NULL',
+      'started_at timestamp NOT NULL',
+      'completed_at timestamp NULL DEFAULT NULL',
+      'error longtext',
+      'data longtext',
+      'PRIMARY KEY (id)',
+      'INDEX (automation_run_id)',
+    ]);
   }
 }

--- a/mailpoet/lib/Migrator/Migration.php
+++ b/mailpoet/lib/Migrator/Migration.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Migrator;
 
+use MailPoet\Config\Env;
 use MailPoet\DI\ContainerWrapper;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -25,4 +26,15 @@ abstract class Migration {
   }
 
   abstract public function run(): void;
+
+  protected function createTable(string $tableName, array $attributes): void {
+    $prefix = Env::$dbPrefix;
+    $charsetCollate = Env::$dbCharsetCollate;
+    $sql = implode(",\n", $attributes);
+    $this->connection->executeStatement("
+      CREATE TABLE IF NOT EXISTS {$prefix}{$tableName} (
+        $sql
+      ) {$charsetCollate};
+    ");
+  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -16,15 +16,6 @@ use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscription\Captcha;
 use MailPoet\WP\Functions as WPFunctions;
 
-/**
- * The "created_at" column must be NULL in some tables to avoid "there can be only one
- * TIMESTAMP column with CURRENT_TIMESTAMP" error on MySQL version < 5.6.5 that occurs
- * even when other timestamp is simply "NOT NULL".
- *
- * Additionally, having multiple timestamp columns with "NOT NULL" seems to produce the
- * following error in some SQL modes:
- *   SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'updated_at'"
- */
 class SetupTest extends \MailPoetTest {
   public function _before() {
     parent::_before();


### PR DESCRIPTION
## Description

In some rare cases, the automations migration seems to be retried even though it was already partly applied. That causes errors because some of the tables already exist.

This PR adds a helper function with `IF NOT EXISTS` to make sure any retry of the migration will pass.

## Code review notes

_N/A_

## QA notes

You can replicate the issue by truncating table `wp_mailpoet_migrations` and reactivating the plugin.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4835]

## After-merge notes

_N/A_


[MAILPOET-4835]: https://mailpoet.atlassian.net/browse/MAILPOET-4835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ