### PR TITLE
Add empty homepage [MAILPOET-4824]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -142,4 +142,5 @@ interface Window {
     name: string;
   }[];
   mailpoet_cdn_url: string;
+  mailpoet_main_page_slug: string;
 }

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -65,6 +65,7 @@ export const MailPoet = {
     window.mailpoet_deactivate_subscriber_after_inactive_days,
   tags: window.mailpoet_tags,
   cdnUrl: window.mailpoet_cdn_url,
+  mainPageSlug: window.mailpoet_main_page_slug,
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -15,7 +15,7 @@ const renderHeading = (newsletterType, newsletterOptions) => {
 
     let buttons = null;
     let onLogoClick = () => {
-      window.location = `admin.php?page=mailpoet-newsletters`;
+      window.location = `admin.php?page=${MailPoet.mainPageSlug}`;
     };
     if (newsletterType === 'automation') {
       const automationId = newsletterOptions.automationId;

--- a/mailpoet/assets/js/src/newsletters/send/congratulate/congratulate.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/congratulate/congratulate.jsx
@@ -18,7 +18,7 @@ function successPageClosed() {
     action: 'set',
     data: { show_congratulate_after_first_newsletter: false },
   }).always(() => {
-    window.location = window.mailpoet_main_page;
+    window.location = window.mailpoet_emails_page;
   });
 }
 
@@ -60,7 +60,7 @@ function renderFail() {
   return (
     <Fail
       failClicked={() => {
-        window.location = window.mailpoet_main_page;
+        window.location = window.mailpoet_emails_page;
       }}
     />
   );

--- a/mailpoet/assets/js/src/settings/pages/advanced/reinstall.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/reinstall.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 
+import { MailPoet } from 'mailpoet';
 import { Button } from 'common/button/button';
 import { t } from 'common/functions';
 import { GlobalContext } from 'context';
@@ -24,7 +25,7 @@ export function Reinstall() {
           { scroll: true },
         );
       } else {
-        window.location.href = 'admin.php?page=mailpoet-newsletters';
+        window.location.href = `admin.php?page=${MailPoet.mainPageSlug}`;
       }
     }
   };

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages;
 
 use MailPoet\Cache\TransientCache;
 use MailPoet\Config\Installer;
+use MailPoet\Config\Menu;
 use MailPoet\Config\Renderer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\Workers\SubscribersCountCacheRecalculation;
@@ -116,6 +117,7 @@ class PageRenderer {
     $defaults = [
       'current_page' => sanitize_text_field(wp_unslash($_GET['page'] ?? '')),
       'site_name' => $this->wp->wpSpecialcharsDecode($this->wp->getOption('blogname'), ENT_QUOTES),
+      'main_page' => Menu::$mainPageSlug,
       'site_url' => $this->wp->siteUrl(),
       'site_address' => $this->wp->wpParseUrl($this->wp->homeUrl(), PHP_URL_HOST),
       'feature_flags' => $this->featuresController->getAllFlags(),

--- a/mailpoet/lib/AdminPages/Pages/Homepage.php
+++ b/mailpoet/lib/AdminPages/Pages/Homepage.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+
+class Homepage {
+  /** @var PageRenderer */
+  private $pageRenderer;
+
+  public function __construct(
+    PageRenderer $pageRenderer
+  ) {
+    $this->pageRenderer = $pageRenderer;
+  }
+
+  public function render() {
+    $this->pageRenderer->displayPage('homepage.html');
+  }
+}

--- a/mailpoet/lib/AdminPages/Pages/Homepage.php
+++ b/mailpoet/lib/AdminPages/Pages/Homepage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace MailPoet\AdminPages\Pages;
 

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -111,7 +111,7 @@ class NewsletterEditor {
       'settings' => $this->settings->getAll(),
       'editor_tutorial_seen' => $this->userFlags->get('editor_tutorial_seen'),
       'current_wp_user' => array_merge($subscriberData, $this->wp->wpGetCurrentUser()->to_array()),
-      'sub_menu' => Menu::MAIN_PAGE_SLUG,
+      'sub_menu' => Menu::EMAILS_PAGE_SLUG,
       'woocommerce' => $woocommerceData,
       'is_wc_transactional_email' => $newsletterId === $woocommerceTemplateId,
     ];

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -111,7 +111,7 @@ class Newsletters {
       '+1 hour',
       24
     );
-    $data['mailpoet_main_page'] = $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
+    $data['mailpoet_emails_page'] = $this->wp->adminUrl('admin.php?page=' . Menu::EMAILS_PAGE_SLUG);
     $data['show_congratulate_after_first_newsletter'] = isset($data['settings']['show_congratulate_after_first_newsletter']) ? $data['settings']['show_congratulate_after_first_newsletter'] : 'false';
 
     $data['is_mailpoet_update_available'] = array_key_exists(Env::$pluginPath, $this->wp->getPluginUpdates());

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -36,7 +36,7 @@ class WelcomeWizard {
   public function render() {
     if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
     $data = [
-      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
+      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::$mainPageSlug),
       'sender' => $this->settings->get('sender'),
       'admin_email' => $this->wp->getOption('admin_email'),
       'current_wp_user' => $this->wp->wpGetCurrentUser()->to_array(),

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -29,6 +29,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class Menu {
   const MAIN_PAGE_SLUG = 'mailpoet-newsletters';
+  public static $mainPageSlug = 'mailpoet-newsletters';
 
   const EMAILS_PAGE_SLUG = 'mailpoet-newsletters';
   const FORMS_PAGE_SLUG = 'mailpoet-forms';
@@ -175,7 +176,7 @@ class Menu {
       'MailPoet',
       'MailPoet',
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       null,
       self::ICON_BASE64_SVG,
       30
@@ -183,7 +184,7 @@ class Menu {
 
     // Emails page
     $newslettersPage = $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Emails', 'mailpoet')),
       esc_html__('Emails', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_EMAILS,
@@ -197,7 +198,7 @@ class Menu {
     // Homepage
     if ($this->featuresController->isSupported(FeaturesController::FEATURE_HOMEPAGE)) {
       $this->wp->addSubmenuPage(
-        self::MAIN_PAGE_SLUG,
+        self::$mainPageSlug,
         $this->setPageTitle(__('Home', 'mailpoet')),
         esc_html__('Home', 'mailpoet'),
         AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -238,7 +239,7 @@ class Menu {
 
     // Forms page
     $formsPage = $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Forms', 'mailpoet')),
       esc_html__('Forms', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_FORMS,
@@ -304,7 +305,7 @@ class Menu {
 
     // Subscribers page
     $subscribersPage = $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Subscribers', 'mailpoet')),
       esc_html__('Subscribers', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
@@ -355,7 +356,7 @@ class Menu {
 
     // Segments page
     $segmentsPage = $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Lists', 'mailpoet')),
       esc_html__('Lists', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SEGMENTS,
@@ -380,7 +381,7 @@ class Menu {
 
     // Settings page
     $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Settings', 'mailpoet')),
       esc_html__('Settings', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SETTINGS,
@@ -393,7 +394,7 @@ class Menu {
 
     // Help page
     $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Help', 'mailpoet')),
       esc_html__('Help', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -407,7 +408,7 @@ class Menu {
     // Upgrade page
     // Only show this page in menu if the Premium plugin is not activated
     $this->wp->addSubmenuPage(
-      License::getLicense() ? true : self::MAIN_PAGE_SLUG,
+      License::getLicense() ? true : self::$mainPageSlug,
       $this->setPageTitle(__('Upgrade', 'mailpoet')),
       esc_html__('Upgrade', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -468,7 +469,7 @@ class Menu {
 
   private function registerAutomationMenu() {
     $automationPage = $this->wp->addSubmenuPage(
-      self::MAIN_PAGE_SLUG,
+      self::$mainPageSlug,
       $this->setPageTitle(__('Automations', 'mailpoet')),
       // @ToDo Remove Beta once Automation is no longer beta.
       '<span>' . esc_html__('Automations', 'mailpoet') . '</span><span class="mailpoet-beta-badge">Beta</span>',
@@ -647,7 +648,7 @@ class Menu {
     // Check if page already exists
     if (
       get_plugin_page_hook($page, '')
-      || WPFunctions::get()->getPluginPageHook($page, self::MAIN_PAGE_SLUG)
+      || WPFunctions::get()->getPluginPageHook($page, self::$mainPageSlug)
     ) {
       return false;
     }

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -97,6 +97,9 @@ class Menu {
   }
 
   public function init() {
+    if ($this->featuresController->isSupported(FeaturesController::FEATURE_HOMEPAGE)) {
+      self::$mainPageSlug = self::HOMEPAGE_PAGE_SLUG;
+    }
     $this->checkPremiumKey();
 
     $this->wp->addAction(

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -9,6 +9,7 @@ use MailPoet\AdminPages\Pages\ExperimentalFeatures;
 use MailPoet\AdminPages\Pages\FormEditor;
 use MailPoet\AdminPages\Pages\Forms;
 use MailPoet\AdminPages\Pages\Help;
+use MailPoet\AdminPages\Pages\Homepage;
 use MailPoet\AdminPages\Pages\Logs;
 use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
@@ -21,6 +22,7 @@ use MailPoet\AdminPages\Pages\Upgrade;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceSetup;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
@@ -51,13 +53,17 @@ class Menu {
   /** @var CustomFonts  */
   private $customFonts;
 
+  /** @var FeaturesController */
+  private $featuresController;
+
   public function __construct(
     AccessControl $accessControl,
     WPFunctions $wp,
     ServicesChecker $servicesChecker,
     ContainerWrapper $container,
     Router $router,
-    CustomFonts $customFonts
+    CustomFonts $customFonts,
+    FeaturesController $featuresController
   ) {
     $this->accessControl = $accessControl;
     $this->wp = $wp;
@@ -65,6 +71,7 @@ class Menu {
     $this->container = $container;
     $this->router = $router;
     $this->customFonts = $customFonts;
+    $this->featuresController = $featuresController;
   }
 
   public function init() {
@@ -165,6 +172,21 @@ class Menu {
         'newsletters',
       ]
     );
+
+    // Homepage
+    if ($this->featuresController->isSupported(FeaturesController::FEATURE_HOMEPAGE)) {
+      $this->wp->addSubmenuPage(
+        self::MAIN_PAGE_SLUG,
+        $this->setPageTitle(__('Home', 'mailpoet')),
+        esc_html__('Home', 'mailpoet'),
+        AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
+        'mailpoet-homepage',
+        [
+          $this,
+          'homepage',
+        ]
+      );
+    }
 
     // add limit per page to screen options
     $this->wp->addAction('load-' . $newslettersPage, function() {
@@ -490,6 +512,10 @@ class Menu {
 
   public function help() {
     $this->container->get(Help::class)->render();
+  }
+
+  public function homepage() {
+    $this->container->get(Homepage::class)->render();
   }
 
   public function automation() {

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -185,19 +185,6 @@ class Menu {
       30
     );
 
-    // Emails page
-    $newslettersPage = $this->wp->addSubmenuPage(
-      self::$mainPageSlug,
-      $this->setPageTitle(__('Emails', 'mailpoet')),
-      esc_html__('Emails', 'mailpoet'),
-      AccessControl::PERMISSION_MANAGE_EMAILS,
-      self::EMAILS_PAGE_SLUG,
-      [
-        $this,
-        'newsletters',
-      ]
-    );
-
     // Homepage
     if ($this->featuresController->isSupported(FeaturesController::FEATURE_HOMEPAGE)) {
       $this->wp->addSubmenuPage(
@@ -212,6 +199,19 @@ class Menu {
         ]
       );
     }
+
+    // Emails page
+    $newslettersPage = $this->wp->addSubmenuPage(
+      self::$mainPageSlug,
+      $this->setPageTitle(__('Emails', 'mailpoet')),
+      esc_html__('Emails', 'mailpoet'),
+      AccessControl::PERMISSION_MANAGE_EMAILS,
+      self::EMAILS_PAGE_SLUG,
+      [
+        $this,
+        'newsletters',
+      ]
+    );
 
     // add limit per page to screen options
     $this->wp->addAction('load-' . $newslettersPage, function() {

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -30,6 +30,27 @@ use MailPoet\WP\Functions as WPFunctions;
 class Menu {
   const MAIN_PAGE_SLUG = 'mailpoet-newsletters';
 
+  const EMAILS_PAGE_SLUG = 'mailpoet-newsletters';
+  const FORMS_PAGE_SLUG = 'mailpoet-forms';
+  const EMAIL_EDITOR_PAGE_SLUG = 'mailpoet-newsletter-editor';
+  const FORM_EDITOR_PAGE_SLUG = 'mailpoet-form-editor';
+  const HOMEPAGE_PAGE_SLUG = 'mailpoet-homepage';
+  const FORM_TEMPLATES_PAGE_SLUG = 'mailpoet-form-editor-template-selection';
+  const SUBSCRIBERS_PAGE_SLUG = 'mailpoet-subscribers';
+  const IMPORT_PAGE_SLUG = 'mailpoet-import';
+  const EXPORT_PAGE_SLUG = 'mailpoet-export';
+  const SEGMENTS_PAGE_SLUG = 'mailpoet-segments';
+  const SETTINGS_PAGE_SLUG = 'mailpoet-settings';
+  const HELP_PAGE_SLUG = 'mailpoet-help';
+  const UPGRADE_PAGE_SLUG = 'mailpoet-upgrade';
+  const WELCOME_WIZARD_PAGE_SLUG = 'mailpoet-welcome-wizard';
+  const WOOCOMMERCE_SETUP_PAGE_SLUG = 'mailpoet-woocommerce-setup';
+  const EXPERIMENTS_PAGE_SLUG = 'mailpoet-experimental';
+  const LOGS_PAGE_SLUG = 'mailpoet-logs';
+  const AUTOMATIONS_PAGE_SLUG = 'mailpoet-automation';
+  const AUTOMATION_EDITOR_PAGE_SLUG = 'mailpoet-automation-editor';
+  const AUTOMATION_TEMPLATES_PAGE_SLUG = 'mailpoet-automation-templates';
+
   const ICON_BASE64_SVG = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNTIuMDIgMTU2LjQiPjx0aXRsZT5NYWlsUG9ldCBpY29uPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTM3LjcxLDg5LjFjMy41LDAsNS45LS44LDcuMi0yLjNhOCw4LDAsMCwwLDItNS40VjM1LjdsMTcsNDUuMWExMi42OCwxMi42OCwwLDAsMCwzLjcsNS40YzEuNiwxLjMsNCwyLDcuMiwyYTEyLjU0LDEyLjU0LDAsMCwwLDUuOS0xLjQsOC40MSw4LjQxLDAsMCwwLDMuOS01bDE4LjEtNTBWODFhOC41Myw4LjUzLDAsMCwwLDIuMSw2LjFjMS40LDEuNCwzLjcsMi4yLDYuOSwyLjIsMy41LDAsNS45LS44LDcuMi0yLjNhOCw4LDAsMCwwLDItNS40VjguN2E3LjQ4LDcuNDgsMCwwLDAtMy4zLTYuNmMtMi4xLTEuNC01LTIuMS04LjYtMi4xYTE5LjMsMTkuMywwLDAsMC05LjQsMiwxMS42MywxMS42MywwLDAsMC01LjEsNi44TDc0LjkxLDY3LjEsNTQuNDEsOC40YTEyLjQsMTIuNCwwLDAsMC00LjUtNi4yYy0yLjEtMS41LTUtMi4yLTguOC0yLjJhMTYuNTEsMTYuNTEsMCwwLDAtOC45LDIuMWMtMi4zLDEuNS0zLjUsMy45LTMuNSw3LjJWODAuOGMwLDIuOC43LDQuOCwyLDYuMkMzMi4yMSw4OC40LDM0LjQxLDg5LjEsMzcuNzEsODkuMVoiLz48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik0xNDksMTE2LjZsLTIuNC0xLjlhNy40LDcuNCwwLDAsMC05LjQuMywxOS42NSwxOS42NSwwLDAsMS0xMi41LDQuNmgtMjEuNEEzNy4wOCwzNy4wOCwwLDAsMCw3NywxMzAuNWwtMS4xLDEuMi0xLjEtMS4xYTM3LjI1LDM3LjI1LDAsMCwwLTI2LjMtMTAuOUgyN2ExOS41OSwxOS41OSwwLDAsMS0xMi40LTQuNiw3LjI4LDcuMjgsMCwwLDAtOS40LS4zbC0yLjQsMS45QTcuNDMsNy40MywwLDAsMCwwLDEyMi4yYTcuMTQsNy4xNCwwLDAsMCwyLjQsNS43QTM3LjI4LDM3LjI4LDAsMCwwLDI3LDEzNy40aDIxLjZhMTkuNTksMTkuNTksMCwwLDEsMTguOSwxNC40di4yYy4xLjcsMS4yLDQuNCw4LjUsNC40czguNC0zLjcsOC41LTQuNHYtLjJhMTkuNTksMTkuNTksMCwwLDEsMTguOS0xNC40SDEyNWEzNy4yOCwzNy4yOCwwLDAsMCwyNC42LTkuNSw3LjQyLDcuNDIsMCwwLDAsMi40LTUuN0E3Ljg2LDcuODYsMCwwLDAsMTQ5LDExNi42WiIvPjwvZz48L2c+PC9zdmc+';
 
   public $mpApiKeyValid;
@@ -166,7 +187,7 @@ class Menu {
       $this->setPageTitle(__('Emails', 'mailpoet')),
       esc_html__('Emails', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_EMAILS,
-      self::MAIN_PAGE_SLUG,
+      self::EMAILS_PAGE_SLUG,
       [
         $this,
         'newsletters',
@@ -180,7 +201,7 @@ class Menu {
         $this->setPageTitle(__('Home', 'mailpoet')),
         esc_html__('Home', 'mailpoet'),
         AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-        'mailpoet-homepage',
+        self::HOMEPAGE_PAGE_SLUG,
         [
           $this,
           'homepage',
@@ -206,7 +227,7 @@ class Menu {
       $this->setPageTitle(__('Newsletter', 'mailpoet')),
       esc_html__('Newsletter Editor', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_EMAILS,
-      'mailpoet-newsletter-editor',
+      self::EMAIL_EDITOR_PAGE_SLUG,
       [
         $this,
         'newletterEditor',
@@ -221,7 +242,7 @@ class Menu {
       $this->setPageTitle(__('Forms', 'mailpoet')),
       esc_html__('Forms', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_FORMS,
-      'mailpoet-forms',
+      self::FORMS_PAGE_SLUG,
       [
         $this,
         'forms',
@@ -246,7 +267,7 @@ class Menu {
       $this->setPageTitle(__('Form Editor', 'mailpoet')),
       esc_html__('Form Editor', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_FORMS,
-      'mailpoet-form-editor',
+      self::FORM_EDITOR_PAGE_SLUG,
       [
         $this,
         'formEditor',
@@ -266,7 +287,7 @@ class Menu {
       $this->setPageTitle(__('Select Form Template', 'mailpoet')),
       esc_html__('Select Form Template', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_FORMS,
-      'mailpoet-form-editor-template-selection',
+      self::FORM_TEMPLATES_PAGE_SLUG,
       [
         $this,
         'formEditorTemplateSelection',
@@ -287,7 +308,7 @@ class Menu {
       $this->setPageTitle(__('Subscribers', 'mailpoet')),
       esc_html__('Subscribers', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
-      'mailpoet-subscribers',
+      self::SUBSCRIBERS_PAGE_SLUG,
       [
         $this,
         'subscribers',
@@ -312,7 +333,7 @@ class Menu {
       $this->setPageTitle(__('Import', 'mailpoet')),
       esc_html__('Import', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
-      'mailpoet-import',
+      self::IMPORT_PAGE_SLUG,
       [
         $this,
         'import',
@@ -325,7 +346,7 @@ class Menu {
       $this->setPageTitle(__('Export', 'mailpoet')),
       esc_html__('Export', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
-      'mailpoet-export',
+      self::EXPORT_PAGE_SLUG,
       [
         $this,
         'export',
@@ -338,7 +359,7 @@ class Menu {
       $this->setPageTitle(__('Lists', 'mailpoet')),
       esc_html__('Lists', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SEGMENTS,
-      'mailpoet-segments',
+      self::SEGMENTS_PAGE_SLUG,
       [
         $this,
         'segments',
@@ -363,7 +384,7 @@ class Menu {
       $this->setPageTitle(__('Settings', 'mailpoet')),
       esc_html__('Settings', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SETTINGS,
-      'mailpoet-settings',
+      self::SETTINGS_PAGE_SLUG,
       [
         $this,
         'settings',
@@ -376,7 +397,7 @@ class Menu {
       $this->setPageTitle(__('Help', 'mailpoet')),
       esc_html__('Help', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      'mailpoet-help',
+      self::HELP_PAGE_SLUG,
       [
         $this,
         'help',
@@ -390,7 +411,7 @@ class Menu {
       $this->setPageTitle(__('Upgrade', 'mailpoet')),
       esc_html__('Upgrade', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      'mailpoet-upgrade',
+      self::UPGRADE_PAGE_SLUG,
       [
         $this,
         'upgrade',
@@ -403,7 +424,7 @@ class Menu {
       $this->setPageTitle(__('Welcome Wizard', 'mailpoet')),
       esc_html__('Welcome Wizard', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      'mailpoet-welcome-wizard',
+      self::WELCOME_WIZARD_PAGE_SLUG,
       [
         $this,
         'welcomeWizard',
@@ -416,7 +437,7 @@ class Menu {
       $this->setPageTitle(__('WooCommerce Setup', 'mailpoet')),
       esc_html__('WooCommerce Setup', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      'mailpoet-woocommerce-setup',
+      self::WOOCOMMERCE_SETUP_PAGE_SLUG,
       [
         $this,
         'wooCommerceSetup',
@@ -429,7 +450,7 @@ class Menu {
       $this->setPageTitle(__('Experimental Features', 'mailpoet')),
       '',
       AccessControl::PERMISSION_MANAGE_FEATURES,
-      'mailpoet-experimental',
+      self::EXPERIMENTS_PAGE_SLUG,
       [$this, 'experimentalFeatures']
     );
 
@@ -439,7 +460,7 @@ class Menu {
       $this->setPageTitle(__('Logs', 'mailpoet')),
       '',
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      'mailpoet-logs',
+      self::LOGS_PAGE_SLUG,
       [$this, 'logs']
     );
 
@@ -452,7 +473,7 @@ class Menu {
       // @ToDo Remove Beta once Automation is no longer beta.
       '<span>' . esc_html__('Automations', 'mailpoet') . '</span><span class="mailpoet-beta-badge">Beta</span>',
       AccessControl::PERMISSION_MANAGE_EMAILS,
-      'mailpoet-automation',
+      self::AUTOMATIONS_PAGE_SLUG,
       [$this, 'automation']
     );
 
@@ -462,7 +483,7 @@ class Menu {
       $this->setPageTitle(__('Automation Editor', 'mailpoet')),
       esc_html__('Automation Editor', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_AUTOMATIONS,
-      'mailpoet-automation-editor',
+      self::AUTOMATION_EDITOR_PAGE_SLUG,
       [$this, 'automationEditor']
     );
 
@@ -472,7 +493,7 @@ class Menu {
       $this->setPageTitle(__('Automation Templates', 'mailpoet')),
       esc_html__('Automation Templates', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_AUTOMATIONS,
-      'mailpoet-automation-templates',
+      self::AUTOMATION_TEMPLATES_PAGE_SLUG,
       [$this, 'automationTemplates']
     );
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -38,6 +38,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Forms::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Help::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Homepage::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Logs::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\NewsletterEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Newsletters::class)->setPublic(true);

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -5,9 +5,12 @@ namespace MailPoet\Features;
 use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
+  const FEATURE_HOMEPAGE = 'homepage';
+
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
+    self::FEATURE_HOMEPAGE => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
@@ -56,7 +56,7 @@ class UnauthorizedEmailInNewslettersNotice {
       // translators: %s is the newsletter subject.
       $linkText = _x('Update the from address of %s', '%s will be replaced by a newsletter subject', 'mailpoet');
       $linkText = str_replace('%s', EscapeHelper::escapeHtmlText($error['subject']), $linkText);
-      $linkUrl = $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG . '#/send/' . $error['newsletter_id']);
+      $linkUrl = $this->wp->adminUrl('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/send/' . $error['newsletter_id']);
       $link = Helpers::replaceLinkTags("[link]{$linkText}[/link]", $linkUrl, ['target' => '_blank']);
       $links .= "<p>$link</p>";
     }

--- a/mailpoet/tests/integration/Config/MenuTest.php
+++ b/mailpoet/tests/integration/Config/MenuTest.php
@@ -8,6 +8,7 @@ use MailPoet\Config\Menu;
 use MailPoet\Config\Router;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -70,7 +71,8 @@ class MenuTest extends \MailPoetTest {
       new ServicesChecker,
       ContainerWrapper::getInstance(),
       $this->diContainer->get(Router::class),
-      $this->diContainer->get(CustomFonts::class)
+      $this->diContainer->get(CustomFonts::class),
+      $this->diContainer->get(FeaturesController::class)
     );
   }
 }

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -1,0 +1,5 @@
+<% extends 'layout.html' %>
+
+<% block content %>
+<h1>MailPoet Homepage</h1>
+<% endblock %>

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -58,6 +58,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   var mailpoet_wp_week_starts_on = "<%= wp_start_of_week() %>";
   var mailpoet_urls = <%= json_encode(urls) %>;
   var mailpoet_premium_version = <%= json_encode(mailpoet_premium_version()) %>;
+  var mailpoet_main_page_slug =   <%= json_encode(main_page) %>;
   var mailpoet_3rd_party_libs_enabled = <%= is_loading_3rd_party_enabled() | json_encode %>;
   var mailpoet_analytics_enabled = <%= is_analytics_enabled() | json_encode %>;
   var mailpoet_analytics_data = <%= json_encode(get_analytics_data()) %>;

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -42,7 +42,7 @@
       ];
       var mailpoet_congratulations_error_image = '<%= cdn_url('newsletter/error.png') %>';
       var mailpoet_congratulations_loading_image = '<%= cdn_url('newsletter/congratulation-page-illustration-transparent-LQ.20181121-1440.png') %>';
-      var mailpoet_main_page = '<%= mailpoet_main_page %>';
+      var mailpoet_emails_page = '<%= mailpoet_email_page %>';
       var mailpoet_review_request_illustration_url = '<%= cdn_url('review-request/review-request-illustration.20190815-1427.svg') %>';
       var mailpoet_installed_at = '<%= settings.installed_at %>';
       var mailpoet_editor_javascript_url = '<%= getJavascriptScriptUrl("newsletter_editor.js") %>';


### PR DESCRIPTION
## Description

This PR adds a feature switch and an empty homepage.

![Screenshot 2022-11-21 at 11 18 12](https://user-images.githubusercontent.com/1082140/203026744-9557aff7-1345-4050-9d11-5d05ebe6ef52.png)

Apart from these changes, I updated some links (e.g. in logo or redirect after reinstalling, redirect after finishing wizard) to go to the Homepage instead of the Emails page


## Code review notes

I updated the final ticket for removing the feature flag to include also a refactoring of the `public static $mainPageSlug` back to constant. We will no longer need to dynamically its value.

## QA notes

To activate the homepage go to /wp-admin/admin.php?page=mailpoet-experimental and activate the feature called `homepage`

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4824]

## After-merge notes

_N/A_


[MAILPOET-4824]: https://mailpoet.atlassian.net/browse/MAILPOET-4824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ