### PR TITLE
Bump WP version tested up to 6.1 and using in tests [MAILPOET-4841]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 5.8
-Tested up to: 6.0
+Tested up to: 6.1
 Stable tag: 4.0.1
 Requires PHP: 7.2
 License: GPLv3

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.0_php8.0_20220609.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.1_php8.0_20201122.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       - smtp

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -634,9 +634,10 @@ class WPTest extends \MailPoetTest {
     $numberSql = !is_null($number) ? (int)$number : 'rand()';
     $db->exec(sprintf('
          INSERT INTO
-           %s (user_login, user_email, user_registered)
+           %s (user_login, user_nicename, user_email, user_registered)
            VALUES
            (
+             CONCAT("user-sync-test", ' . $numberSql . '),
              CONCAT("user-sync-test", ' . $numberSql . '),
              CONCAT("user-sync-test", ' . $numberSql . ', "@example.com"),
              "2017-01-02 12:31:12"

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -685,8 +685,9 @@ class WooCommerceTest extends \MailPoetTest {
     $numberSql = !is_null($number) ? (int)$number : mt_rand();
     // add user
     $connection->executeQuery("
-      INSERT INTO {$wpdb->users} (user_login, user_email, user_registered)
+      INSERT INTO {$wpdb->users} (user_login, user_nicename, user_email, user_registered)
       VALUES (
+        CONCAT('user-sync-test', :number),
         CONCAT('user-sync-test', :number),
         CONCAT('user-sync-test', :number, '@example.com'),
         '2017-01-02 12:31:12'


### PR DESCRIPTION
## Description

This PR increases the WP version in the readme file and uses the latest WP version in our acceptance tests.

## Code review notes

I wanted to use the last WP with PHP 8.1, but there are some errors in WP with this PHP version.

## Linked PRs

https://github.com/mailpoet/wordpress-images/pull/39

## Linked tickets

[MAILPOET-4841]



[MAILPOET-4841]: https://mailpoet.atlassian.net/browse/MAILPOET-4841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ