### PR TITLE
Do not wrap automations beta badge, make it a bit smaller [MAILPOET-4840]

### DIFF
--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -89,9 +89,12 @@ class Menu {
     // @ToDo Remove Beta once Automation is no longer beta.
     $this->wp->addAction('admin_head', function () {
       echo '<style>
+#adminmenu .toplevel_page_mailpoet-newsletters a[href="admin.php?page=mailpoet-automation"] {
+  white-space: nowrap;
+}
 .mailpoet-beta-badge {
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: 9px;
   position: relative;
   top: -5px;
   color: #ffab66;


### PR DESCRIPTION
## Description

Fixing the badge also for Deutsche Sprache:

![](https://files.slack.com/files-pri/T024FN1V2-F04BUFC1ALE/screenshot_2022-11-22_at_14.49.26.png)


## Code review notes

Just fixing the previous fix https://github.com/mailpoet/mailpoet/pull/4547.

## QA notes

Please check that the automations beta badge looks fine in German.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4840]

## After-merge notes

_N/A_


[MAILPOET-4840]: https://mailpoet.atlassian.net/browse/MAILPOET-4840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ