### PR TITLE
Use comparison with delta in SettingsChangeHandlerTest [MAILPOET-4847]

### DIFF
--- a/mailpoet/tests/integration/Settings/SettingsChangeHandlerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsChangeHandlerTest.php
@@ -31,11 +31,9 @@ class SettingsChangeHandlerTest extends \MailPoetTest {
     $this->entityManager->clear();
     $task = $this->getScheduledTaskByType(WooCommerceSync::TASK_TYPE);
     assert($task instanceof ScheduledTaskEntity);
-    $scheduledAt = $task->getScheduledAt();
-    assert($scheduledAt instanceof \DateTime);
     $expectedScheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $expectedScheduledAt->subMinute();
-    expect($scheduledAt)->equals($expectedScheduledAt);
+    $this->tester->assertEqualDateTimes($task->getScheduledAt(), $expectedScheduledAt, 1);
     expect($newTask->getId())->equals($task->getId());
   }
 
@@ -54,11 +52,9 @@ class SettingsChangeHandlerTest extends \MailPoetTest {
 
     $task = $this->getScheduledTaskByType(InactiveSubscribers::TASK_TYPE);
     assert($task instanceof ScheduledTaskEntity);
-    $scheduledAt = $task->getScheduledAt();
-    assert($scheduledAt instanceof \DateTime);
     $expectedScheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     $expectedScheduledAt->subMinute();
-    expect($scheduledAt)->equals($expectedScheduledAt);
+    $this->tester->assertEqualDateTimes($task->getScheduledAt(), $expectedScheduledAt, 1);
     expect($newTask->getId())->equals($task->getId());
   }
 


### PR DESCRIPTION
## Description

This PR should improve our SettingsChangeHandlerTest stability.

## Linked tickets

[MAILPOET-4847]



[MAILPOET-4847]: https://mailpoet.atlassian.net/browse/MAILPOET-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ