### PR TITLE
Ensure that docker caching on CircleCi is disabled [MAILPOET-4851]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,6 +312,7 @@ jobs:
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
       image: ubuntu-2204:2022.10.2
+      docker_layer_caching: false
     parameters:
       multisite:
         type: integer
@@ -477,6 +478,7 @@ jobs:
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
       image: ubuntu-2204:2022.10.2
+      docker_layer_caching: false
     environment:
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
     parameters:


### PR DESCRIPTION
## Description

We sometimes have a problem with the existing container ID. One step to prevent it is disabling the docker layer cache. The default value should be false, but we want to be sure about it.

## Code review notes

There is nothing to test, we can merge when PR is approved.

## Linked tickets

[MAILPOET-4851]


[MAILPOET-4851]: https://mailpoet.atlassian.net/browse/MAILPOET-4851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ