### PR TITLE
Update nesbot/carbon to the latest version [MAILPOET-4838]

### DIFF
--- a/mailpoet/prefixer/composer.json
+++ b/mailpoet/prefixer/composer.json
@@ -7,7 +7,7 @@
     "doctrine/orm": "2.11.2",
     "gregwar/captcha": "^1.1",
     "monolog/monolog": "2.4.0",
-    "nesbot/carbon": "2.57.0",
+    "nesbot/carbon": "2.63.0",
     "psr/cache": "^1.0",
     "sabberworm/php-css-parser": "^8.1",
     "symfony/dependency-injection": "5.4.7",

--- a/mailpoet/prefixer/composer.lock
+++ b/mailpoet/prefixer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81a1a7a65fc12511e11db7a80781230d",
+    "content-hash": "0d687dfb23cc33266defd12abc2ae098",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -1140,16 +1140,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.57.0",
+            "version": "2.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "4a54375c21eea4811dbd1149fe6b246517554e78"
+                "reference": "ad35dd71a6a212b98e4b87e97389b6fa85f0e347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4a54375c21eea4811dbd1149fe6b246517554e78",
-                "reference": "4a54375c21eea4811dbd1149fe6b246517554e78",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/ad35dd71a6a212b98e4b87e97389b6fa85f0e347",
+                "reference": "ad35dd71a6a212b98e4b87e97389b6fa85f0e347",
                 "shasum": ""
             },
             "require": {
@@ -1164,10 +1164,12 @@
                 "doctrine/orm": "^2.7",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "kylekatarnls/multi-tester": "^2.0",
+                "ondrejmirtes/better-reflection": "*",
                 "phpmd/phpmd": "^2.9",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.54 || ^1.0",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
+                "phpstan/phpstan": "^0.12.99 || ^1.7.14",
+                "phpunit/php-file-iterator": "^2.0.5 || ^3.0.6",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "bin": [
@@ -1224,15 +1226,19 @@
             },
             "funding": [
                 {
-                    "url": "https://opencollective.com/Carbon",
-                    "type": "open_collective"
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-13T18:13:33+00:00"
+            "time": "2022-10-30T18:34:28+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
## Description

We need to update nesbot/carbon for MailPoet to work well with the upcoming PHP 8.2.

nesbot/carbon versions previous to 2.62.1 could cause issues when used with PHP 8.2, see this PR for more information:
https://github.com/briannesbitt/Carbon/pull/2663

Without this update MailPoet users will see the following fatal error when using PHP 8.2:

```
TypeError
MailPoetVendor\Carbon\Carbon::setLastErrors(): Argument #1 ($lastErrors) must be of type array, bool given, called in /srv/www/mp/public_html/wp-content/plugins/mailpoet/vendor-prefixed/nesbot/carbon/src/Carbon/Traits/Creator.php on line 567
```

## Code review and QA notes

I first tried to find or create a Docker image that used PHP 8.2 and that would allow us to use our dev environment and run the automated tests using this version of PHP. Unfortunately, I did not succeed and I plan to revisit this approach as soon as possible.

I'm currently using VVV with a PR that I created that added PHP 8.2 support:

https://github.com/Varying-Vagrant-Vagrants/vvv-utilities/pull/104

Happy to help anyone set up a VVV environment. I will update this PR if we find a way to run our Docker environment with PHP 8.2.

For QA, maybe just the automated tests are enough to check this change.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4838]

## After-merge notes

_N/A_


[MAILPOET-4838]: https://mailpoet.atlassian.net/browse/MAILPOET-4838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ