### PR TITLE
Fix filename that is removed by fix-monolog.php

### DIFF
--- a/mailpoet/prefixer/fix-monolog.php
+++ b/mailpoet/prefixer/fix-monolog.php
@@ -35,7 +35,7 @@ exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handl
 exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/DeduplicationHandler.php');
 exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/DoctrineCouchDBHandler.php');
 exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/DynamoDbHandler.php');
-exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/ElasticSearchHandler.php');
+exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/ElasticsearchHandler.php');
 exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/ElasticaHandler.php');
 exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/ErrorLogHandler.php');
 exec('rm -r ' . __DIR__ . '/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/FilterHandler.php');


### PR DESCRIPTION
## Description

The following error is being thrown when running composer commands:

```
> php fix-monolog.php
rm: cannot remove 'mailpoet/mailpoet/prefixer/../vendor-prefixed/monolog/monolog/src/Monolog/Handler/ElasticSearchHandler.php': No such file or directory
```

This is happening because in commit 9b71a7804cd7d3c8724c9ac877cc62def4d3a697 we updated Monolog from v1 to v2. v2 renamed the file ElasticSearchHandler.php to ElasticsearchHandler.php (see
https://github.com/Seldaek/monolog/commit/4c7795d310a591ef6d6149d32280f43fbe4d95a5). Note that search is not spelled with a capital S anymore. We didn’t update fix-monolog.php to reflect this change.

This PR updates fix-monolog.php to use the new file name and to remove the error.

## Code review notes

_N/A_

## QA notes

I don't think QA is needed for this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4856]

## After-merge notes

_N/A_


[MAILPOET-4856]: https://mailpoet.atlassian.net/browse/MAILPOET-4856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ