### PR TITLE
Update cerdic/css-tidy to version 2.0.3 to remove PHP 8.2 warnings

### DIFF
--- a/mailpoet/prefixer/composer.json
+++ b/mailpoet/prefixer/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
     "php": ">=7.2",
-    "cerdic/css-tidy": "2.0.1",
+    "cerdic/css-tidy": "2.0.3",
     "doctrine/common": "3.2.2",
     "doctrine/dbal": "2.13.8",
     "doctrine/orm": "2.11.2",

--- a/mailpoet/prefixer/composer.lock
+++ b/mailpoet/prefixer/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d687dfb23cc33266defd12abc2ae098",
+    "content-hash": "f9fb589de68793fa51d825fdefa26330",
     "packages": [
         {
             "name": "cerdic/css-tidy",
-            "version": "v2.0.1",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Cerdic/CSSTidy.git",
-                "reference": "9efced88f9fc31ecbd52c798b6c01283966c0e48"
+                "reference": "436c69db9e0951760ca54b6b123d61c89ab3e918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Cerdic/CSSTidy/zipball/9efced88f9fc31ecbd52c798b6c01283966c0e48",
-                "reference": "9efced88f9fc31ecbd52c798b6c01283966c0e48",
+                "url": "https://api.github.com/repos/Cerdic/CSSTidy/zipball/436c69db9e0951760ca54b6b123d61c89ab3e918",
+                "reference": "436c69db9e0951760ca54b6b123d61c89ab3e918",
                 "shasum": ""
             },
             "require": {
@@ -51,9 +51,9 @@
             "description": "CSSTidy is a CSS minifier",
             "support": {
                 "issues": "https://github.com/Cerdic/CSSTidy/issues",
-                "source": "https://github.com/Cerdic/CSSTidy/tree/v2.0.1"
+                "source": "https://github.com/Cerdic/CSSTidy/tree/v2.0.3"
             },
-            "time": "2022-02-21T15:33:09+00:00"
+            "time": "2022-09-14T13:26:35+00:00"
         },
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
## Description

PHP 8.2 deprecates dynamic properties. The version of the Composer package cerdic/css-tidy that we are using relies on dynamic properties and thus MailPoet is generating a few deprecation warnings when running with PHP 8.2. Updating cerdic/css-tidy to the latest version remove those warnings as this was already fixed by the package maintainers.

Here is an example of a deprecation notice that is displayed in every page load:

```
PHP Deprecated: Creation of dynamic property MailPoetVendor\csstidy::$template is deprecated in .../mailpoet/vendor-prefixed/cerdic/css-tidy/class.csstidy.php:506
```

## Code review and QA notes

How to test this PR:

- You will need to use PHP 8.2 in the dev environment: https://github.com/mailpoet/mailpoet/pull/4564. Instructions on how to change the PHP version are here and can be adapted for 8.2: https://github.com/mailpoet/mailpoet#-testing-with-php-74-or-php-80
- You will also need the changes from https://github.com/mailpoet/mailpoet/pull/4562 or you will get a fatal error on every page load.
- Before applying the changes from this PR, check that you see the warnings mentioned above in any WordPress page.
- Run `./do install` to update the Composer packages and confirm that cerdic/css-tidy was updated to 2.0.3.
- Reload the page and confirm that you don't see the deprecation warnings from cerdic/css-tidy anymore.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4857]

## After-merge notes

_N/A_


[MAILPOET-4857]: https://mailpoet.atlassian.net/browse/MAILPOET-4857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ