### PR TITLE
Split test createEditTrashRestoreAndDeleteExistingSegment into three smaller [MAILPOET-4846]

### DIFF
--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -50,6 +50,9 @@ class DefaultsExtension extends Extension {
 
     // Make sure WP cron is not locked so that tests that rely on it don't timeout
     delete_transient('doing_cron');
+
+    // Hide black Friday notice, because it can cause tests flakiness
+    set_transient('dismissed-black-friday-notice', true, 3600 * 24);
   }
 
   private function setupWooCommerce() {

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -154,6 +154,7 @@ class ManageSegmentsCest {
     $i->waitForText($segmentTrashedTitle . ' 2');
 
     $i->wantTo('Empty trash from other (2) segments');
+    $i->waitForElementClickable('[data-automation-id="empty_trash"]');
     $i->click('[data-automation-id="empty_trash"]');
     $i->waitForText('2 segments were permanently deleted.');
     $listingAutomationSelector = '[data-automation-id="listing_item_' . $segment->getId() . '"]';


### PR DESCRIPTION
## Description

I tried to split the problematic test into more smaller that should help us to better debug if needed in the future.

## Linked tickets

[MAILPOET-4846]


[MAILPOET-4846]: https://mailpoet.atlassian.net/browse/MAILPOET-4846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ