### PR TITLE
Add healthcheck for mysql service in tests [MAILPOET-4851]

### DIFF
--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -4,12 +4,6 @@ wp() {
   command wp --allow-root "$@"
 }
 
-# wait for database container to be ready
-while ! mysqladmin ping -hmysql --silent; do
-  echo 'Waiting for the database'
-  sleep 1
-done
-
 # wait for WordPress container to be ready (otherwise tests may
 # try to run without 'wp-config.php' being properly configured)
 while ! bash -c "echo > /dev/tcp/wordpress/80" &>/dev/null; do

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -99,7 +99,7 @@ services:
           - test.local
 
   mysql:
-    image: cimg/mysql:${MYSQL_IMAGE_VERSION:-5.7.36}
+    image: cimg/mysql:${MYSQL_IMAGE_VERSION:-5.7.38}
     container_name: mysql_${CIRCLE_NODE_INDEX:-default}
     # Command used for MySQL 8+ because it needs default-authentication-plugin
     # parameter and there needs to be some fallback for other MySQL versions.

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -74,8 +74,10 @@ services:
     image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.0_php8.0_20220609.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
-      - smtp
-      - mysql
+      smtp:
+        condition: service_started
+      mysql:
+        condition: service_healthy
     volumes:
       - wp-core:/var/www/html
       - ../..:/var/www/html/wp-content/plugins/mailpoet
@@ -112,6 +114,11 @@ services:
       - /dev/shm:/dev/shm
     ports:
       - 4401:3306
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -hmysql --silent']
+      interval: 2s
+      timeout: 30s
+      retries: 10
 
   chrome:
     container_name: chrome_${CIRCLE_NODE_INDEX:-default}


### PR DESCRIPTION
## Description
Newer docker-compose (1.27.0+) reintroduced health check functionality. So I replaced the custom script for checking DB with the healthcheck. With this change, the WordPress service container will start a bit later and wait for DB to be ready. Hopefully this may have a positive effect on [the strange error](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/12311/workflows/e8a1a4fd-e492-461c-8a2c-b05a12c8a4bc/jobs/210106) we tried to address in [a couple of PRs](https://github.com/mailpoet/mailpoet/pulls?q=is%3Apr+is%3Aclosed++%5BMAILPOET-4851%5D).

When working on this, I also noticed a new image for mysql so I updated that as well.


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4851]

## After-merge notes

_N/A_


[MAILPOET-4851]: https://mailpoet.atlassian.net/browse/MAILPOET-4851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ