### PR TITLE
Add react error boundary into js applications in the admin [MAILPOET-4706]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/header/document_actions.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/document_actions.tsx
@@ -21,7 +21,7 @@ const Dropdown: ComponentType<
   }
 > = WpDropdown;
 
-export function DocumentActions({ children }): JSX.Element {
+function DocumentActions({ children }): JSX.Element {
   const { automationName, automationStatus, showIconLabels } = useSelect(
     (select) => ({
       automationName: select(storeName).getAutomationData().name,
@@ -101,3 +101,6 @@ export function DocumentActions({ children }): JSX.Element {
     </div>
   );
 }
+
+DocumentActions.displayName = 'DocumentActions';
+export { DocumentActions };

--- a/mailpoet/assets/js/src/automation/editor/components/header/errors.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/errors.tsx
@@ -9,6 +9,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ErrorBoundary } from 'common';
 import { Chip } from '../chip';
 import { ColoredIcon } from '../icons';
 import {
@@ -69,6 +70,8 @@ function StepError({ stepId }: StepErrorProps): JSX.Element {
     </CompositeItem>
   );
 }
+
+StepError.displayName = 'StepError';
 
 export function Errors(): JSX.Element | null {
   const [showPopover, setShowPopover] = useState(false);
@@ -160,9 +163,11 @@ export function Errors(): JSX.Element | null {
                   __('The following steps are not fully set:', 'mailpoet')
                 }
               </div>
-              {stepErrors.map((error) => (
-                <StepError key={error.step_id} stepId={error.step_id} />
-              ))}
+              <ErrorBoundary>
+                {stepErrors.map((error) => (
+                  <StepError key={error.step_id} stepId={error.step_id} />
+                ))}
+              </ErrorBoundary>
             </Composite>
           </ErrorsCompositeContext.Provider>
         </Popover>

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -8,6 +8,7 @@ import {
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
+import { ErrorBoundary } from 'common';
 import { DocumentActions } from './document_actions';
 import { Errors } from './errors';
 import { InserterToggle } from './inserter_toggle';
@@ -227,28 +228,32 @@ export function Header({ showInserterToggle }: Props): JSX.Element {
       </div>
 
       <div className="edit-site-header_center">
-        <DocumentActions>
-          {() => (
-            <div className="mailpoet-automation-editor-dropdown-name-edit">
-              <div className="mailpoet-automation-editor-dropdown-name-edit-title">
-                {__('Automation name', 'mailpoet')}
+        <ErrorBoundary>
+          <DocumentActions>
+            {() => (
+              <div className="mailpoet-automation-editor-dropdown-name-edit">
+                <div className="mailpoet-automation-editor-dropdown-name-edit-title">
+                  {__('Automation name', 'mailpoet')}
+                </div>
+                <TextControl
+                  value={automationName}
+                  onChange={(newName) => setAutomationName(newName)}
+                  help={__(
+                    `Give the automation a name that indicates its purpose. E.g. "Abandoned cart recovery"`,
+                    'mailpoet',
+                  )}
+                />
               </div>
-              <TextControl
-                value={automationName}
-                onChange={(newName) => setAutomationName(newName)}
-                help={__(
-                  `Give the automation a name that indicates its purpose. E.g. "Abandoned cart recovery"`,
-                  'mailpoet',
-                )}
-              />
-            </div>
-          )}
-        </DocumentActions>
+            )}
+          </DocumentActions>
+        </ErrorBoundary>
       </div>
 
       <div className="edit-site-header_end">
         <div className="edit-site-header__actions">
-          <Errors />
+          <ErrorBoundary>
+            <Errors />
+          </ErrorBoundary>
           {automationStatus === AutomationStatus.DRAFT && (
             <>
               <SaveDraftButton />

--- a/mailpoet/assets/js/src/common/categories/categories.tsx
+++ b/mailpoet/assets/js/src/common/categories/categories.tsx
@@ -6,7 +6,7 @@ type Props = {
   active: string;
 };
 
-export function Categories({ onSelect, categories, active }: Props) {
+function Categories({ onSelect, categories, active }: Props) {
   const cats = categories.map((category) => (
     <CategoriesItem
       {...category}
@@ -18,3 +18,6 @@ export function Categories({ onSelect, categories, active }: Props) {
 
   return <div className="mailpoet-categories">{cats}</div>;
 }
+
+Categories.displayName = 'Categories';
+export { Categories };

--- a/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
+++ b/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker';
 import { MailPoet } from 'mailpoet';
+import { withBoundary } from '../error_boundary';
 
 type Props = ReactDatePickerProps & {
   dimension?: 'small';
@@ -9,7 +10,7 @@ type Props = ReactDatePickerProps & {
   iconEnd?: JSX.Element;
 };
 
-export function Datepicker({
+function Datepicker({
   dimension,
   isFullWidth,
   iconStart,
@@ -34,3 +35,8 @@ export function Datepicker({
     </div>
   );
 }
+
+Datepicker.displayName = 'Datepicker';
+const DatepickerWithBoundary = withBoundary(Datepicker);
+
+export { DatepickerWithBoundary as Datepicker };

--- a/mailpoet/assets/js/src/common/error_boundary/error_boundary.tsx
+++ b/mailpoet/assets/js/src/common/error_boundary/error_boundary.tsx
@@ -1,0 +1,68 @@
+import { Children, Component } from '@wordpress/element';
+import { ComponentType } from 'react';
+import { getComponentDisplayName } from './utils';
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error?: string;
+};
+
+export type ErrorBoundaryProps = {
+  onError?: (Error_Boundary_State) => ComponentType;
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: '',
+    };
+  }
+
+  static getDerivedStateFromError(error: Error & { fileName?: string }) {
+    return {
+      hasError: true,
+      error: `${error?.toString()} \nFile name: ${
+        error?.fileName ?? 'No fileName reported'
+      } \nStack trace: ${error?.stack ?? 'No stack trace reported'}`,
+    };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // eslint-disable-next-line no-console
+    console.log('logging', { error, errorInfo });
+  }
+
+  render() {
+    const { onError } = this.props;
+    const { hasError, error } = this.state;
+    if (hasError) {
+      if (onError) {
+        return onError(this.state);
+      }
+      return (
+        <>
+          <h1>
+            The application{' '}
+            <strong>
+              {Children.map(this.props.children, (child) =>
+                getComponentDisplayName(child as ComponentType),
+              ).join(', ')}{' '}
+            </strong>
+            encountered an error
+          </h1>
+          <p>
+            Please report the following error to{' '}
+            <a href="https://www.mailpoet.com/support/">MailPoet support</a>
+          </p>
+          <pre>{error}</pre>
+        </>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/mailpoet/assets/js/src/common/error_boundary/index.ts
+++ b/mailpoet/assets/js/src/common/error_boundary/index.ts
@@ -1,0 +1,3 @@
+export * from './utils';
+export * from './error_boundary';
+export * from './with_boundary';

--- a/mailpoet/assets/js/src/common/error_boundary/utils.ts
+++ b/mailpoet/assets/js/src/common/error_boundary/utils.ts
@@ -1,0 +1,4 @@
+import { ComponentType } from 'react';
+
+export const getComponentDisplayName = (component: ComponentType): string =>
+  component.displayName || component.name || 'Unknown application/component';

--- a/mailpoet/assets/js/src/common/error_boundary/with_boundary.tsx
+++ b/mailpoet/assets/js/src/common/error_boundary/with_boundary.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, JSXElementConstructor } from 'react';
 import { ErrorBoundary, ErrorBoundaryProps } from './error_boundary';
 
-export const withBoundary = <P extends Record<string, unknown>>(
+export const withBoundary = <P extends Record<string, unknown> | unknown>(
   Bound: JSXElementConstructor<P>,
   props?: ErrorBoundaryProps,
 ): ComponentType<P> =>

--- a/mailpoet/assets/js/src/common/error_boundary/with_boundary.tsx
+++ b/mailpoet/assets/js/src/common/error_boundary/with_boundary.tsx
@@ -1,0 +1,14 @@
+import { ComponentType, JSXElementConstructor } from 'react';
+import { ErrorBoundary, ErrorBoundaryProps } from './error_boundary';
+
+export const withBoundary = <P extends Record<string, unknown>>(
+  Bound: JSXElementConstructor<P>,
+  props?: ErrorBoundaryProps,
+): ComponentType<P> =>
+  function bounder(boundProps: P) {
+    return (
+      <ErrorBoundary {...props}>
+        <Bound {...boundProps} />
+      </ErrorBoundary>
+    );
+  };

--- a/mailpoet/assets/js/src/common/form/toggle/toggle.tsx
+++ b/mailpoet/assets/js/src/common/form/toggle/toggle.tsx
@@ -7,7 +7,7 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
   automationId?: string;
 };
 
-export function Toggle({
+function Toggle({
   dimension,
   onCheck,
   automationId,
@@ -33,3 +33,7 @@ export function Toggle({
     </label>
   );
 }
+
+Toggle.displayName = 'FormToggle';
+
+export { Toggle };

--- a/mailpoet/assets/js/src/common/index.ts
+++ b/mailpoet/assets/js/src/common/index.ts
@@ -7,3 +7,4 @@ export * from './loading';
 export * from './form';
 export * from './tag';
 export * from './listings';
+export * from './error_boundary';

--- a/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
@@ -63,7 +63,7 @@ type NewsletterStatusProps = {
   status?: string;
 };
 
-export function NewsletterStatus({
+function NewsletterStatus({
   scheduledFor,
   processed,
   total,
@@ -150,3 +150,6 @@ export function NewsletterStatus({
     </div>
   );
 }
+
+NewsletterStatus.displayName = 'NewsletterStatus';
+export { NewsletterStatus };

--- a/mailpoet/assets/js/src/common/notices/unsaved_changes_notice.jsx
+++ b/mailpoet/assets/js/src/common/notices/unsaved_changes_notice.jsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import { useSelect } from '@wordpress/data';
 import { MailPoet } from 'mailpoet';
+import { withBoundary } from '../error_boundary';
 
-export function UnsavedChangesNotice({ storeName }) {
+function UnsavedChangesNotice({ storeName }) {
   const hasUnsavedChanges = useSelect(
     (sel) => sel(storeName).hasUnsavedChanges(),
     [],
@@ -24,3 +25,7 @@ export function UnsavedChangesNotice({ storeName }) {
 
   return null;
 }
+
+UnsavedChangesNotice.displayName = 'UnsavedChangesNotice';
+const UnsavedChangesNoticeWithBoundary = withBoundary(UnsavedChangesNotice);
+export { UnsavedChangesNoticeWithBoundary as UnsavedChangesNotice };

--- a/mailpoet/assets/js/src/common/premium_modal/index.tsx
+++ b/mailpoet/assets/js/src/common/premium_modal/index.tsx
@@ -23,6 +23,7 @@ import {
   UtmParams,
 } from './upgrade_info';
 import { storeName } from '../../automation/editor/store';
+import { withBoundary } from '../error_boundary';
 
 export const premiumValidAndActive =
   premiumFeaturesEnabled && MailPoet.premiumActive;
@@ -51,11 +52,7 @@ const getCta = (state: State, upgradeInfo: UpgradeInfo): string => {
   return cta;
 };
 
-export function PremiumModal({
-  children,
-  tracking,
-  ...props
-}: Props): JSX.Element {
+function PremiumModal({ children, tracking, ...props }: Props): JSX.Element {
   const [state, setState] = useState<State>();
   const upgradeInfo = useUpgradeInfo(tracking);
 
@@ -129,8 +126,11 @@ export function PremiumModal({
   );
 }
 
+PremiumModal.displayName = 'PremiumModal';
+
 type EditProps = Omit<Props, 'onRequestClose'>;
-export function PremiumModalForStepEdit({
+
+function PremiumModalForStepEdit({
   children,
   ...props
 }: EditProps): JSX.Element {
@@ -157,3 +157,12 @@ export function PremiumModalForStepEdit({
     </PremiumModal>
   );
 }
+
+PremiumModalForStepEdit.displayName = 'PremiumModalForStepEdit';
+const PremiumModalForStepEditWithBoundary = withBoundary(
+  PremiumModalForStepEdit,
+);
+export {
+  PremiumModal,
+  PremiumModalForStepEditWithBoundary as PremiumModalForStepEdit,
+};

--- a/mailpoet/assets/js/src/common/preview/preview.jsx
+++ b/mailpoet/assets/js/src/common/preview/preview.jsx
@@ -77,5 +77,5 @@ Preview.defaultProps = {
   onDisplayTypeChange: () => {},
   selectedDisplayType: 'desktop',
 };
-
+Preview.displayName = 'FormEditorPreview';
 export { Preview };

--- a/mailpoet/assets/js/src/common/scroll_to_top.jsx
+++ b/mailpoet/assets/js/src/common/scroll_to_top.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { withRouter } from 'react-router-dom';
+import { withBoundary } from './error_boundary';
 
 function ScrollToTopComponent({ children, location: { pathname } }) {
   useEffect(() => {
@@ -9,4 +10,5 @@ function ScrollToTopComponent({ children, location: { pathname } }) {
   return children || null;
 }
 
-export const ScrollToTop = withRouter(ScrollToTopComponent);
+ScrollToTopComponent.displayName = 'ScrollToTopComponent';
+export const ScrollToTop = withRouter(withBoundary(ScrollToTopComponent));

--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -163,5 +163,5 @@ SenderEmailAddressWarning.defaultProps = {
   showSenderDomainWarning: false,
   onSuccessfulEmailOrDomainAuthorization: noop,
 };
-
+SenderEmailAddressWarning.displayName = 'SenderEmailAddressWarning';
 export { SenderEmailAddressWarning };

--- a/mailpoet/assets/js/src/common/steps/steps.tsx
+++ b/mailpoet/assets/js/src/common/steps/steps.tsx
@@ -1,5 +1,6 @@
 import range from 'lodash/range';
 import classnames from 'classnames';
+import { withBoundary } from 'common';
 import { ContentWrapperFix } from './content_wrapper_fix';
 
 type Props = {
@@ -8,7 +9,7 @@ type Props = {
   titles?: string[];
 };
 
-function Steps({ count, current, titles }: Props) {
+function StepsComponent({ count, current, titles }: Props) {
   return (
     <div className="mailpoet-steps">
       <ContentWrapperFix />
@@ -35,8 +36,9 @@ function Steps({ count, current, titles }: Props) {
   );
 }
 
-Steps.defaultProps = {
+StepsComponent.defaultProps = {
   titles: [],
 };
-
+StepsComponent.displayName = 'StepsComponent';
+const Steps = withBoundary(StepsComponent);
 export { Steps };

--- a/mailpoet/assets/js/src/common/tabs/routed_tabs.tsx
+++ b/mailpoet/assets/js/src/common/tabs/routed_tabs.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-router-dom';
 import { noop } from 'lodash';
 
-import { Tabs, Props as TabProps } from './tabs';
+import { Props as TabProps, Tabs } from './tabs';
 
 function RouterAwareTabs(
   props: TabProps & {
@@ -104,5 +104,7 @@ function RoutedTabs({
     <HashRouter>{routedTabs}</HashRouter>
   );
 }
+
+RoutedTabs.displayName = 'RoutedTabs';
 
 export { RoutedTabs };

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -82,6 +82,8 @@ function Tags({ children, tags, dimension, variant, isInverted }: TagProps) {
   );
 }
 
+Tags.displayName = 'Tags';
+
 function StringTags({ children, strings, ...props }: StringTagsProps) {
   const tags: TagData[] = strings.map((item) => ({
     name: item,
@@ -92,6 +94,8 @@ function StringTags({ children, strings, ...props }: StringTagsProps) {
     </Tags>
   );
 }
+
+StringTags.displayName = 'StringTags';
 
 function SegmentTags({ children, segments, ...props }: SegmentTagsProps) {
   const tags: TagData[] = segments.map((segment) => ({
@@ -107,6 +111,8 @@ function SegmentTags({ children, segments, ...props }: SegmentTagsProps) {
     </Tags>
   );
 }
+
+SegmentTags.displayName = 'SegmentTags';
 
 function SubscriberTags({
   children,
@@ -125,4 +131,5 @@ function SubscriberTags({
   );
 }
 
+SubscriberTags.displayName = 'SubscriberTags';
 export { SegmentTags, StringTags, SubscriberTags };

--- a/mailpoet/assets/js/src/common/top_bar/top_bar.tsx
+++ b/mailpoet/assets/js/src/common/top_bar/top_bar.tsx
@@ -5,6 +5,7 @@ import { withFeatureAnnouncement } from 'announcements/with_feature_announcement
 import { MailPoetLogoResponsive } from './mailpoet_logo_responsive';
 import { BeamerIcon } from './beamer_icon';
 import { ScreenOptionsFix } from './screen_options_fix';
+import { withBoundary } from '../error_boundary';
 
 type Props = {
   children?: ReactNode;
@@ -57,4 +58,5 @@ export function TopBar({
   );
 }
 
-export const TopBarWithBeamer = withFeatureAnnouncement(TopBar);
+TopBar.displayName = 'TopBar';
+export const TopBarWithBeamer = withFeatureAnnouncement(withBoundary(TopBar));

--- a/mailpoet/assets/js/src/experimental_features/experimental_features.jsx
+++ b/mailpoet/assets/js/src/experimental_features/experimental_features.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { MailPoet } from 'mailpoet';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
+import { ErrorBoundary } from 'common';
 
 function ExperimentalFeatures() {
   const [flags, setFlags] = useState(null);
@@ -106,6 +107,14 @@ function ExperimentalFeatures() {
 const experimentalFeaturesContainer = document.getElementById(
   'experimental_features_container',
 );
+
+ExperimentalFeatures.displayName = 'ExperimentalFeatures';
+
 if (experimentalFeaturesContainer) {
-  ReactDOM.render(<ExperimentalFeatures />, experimentalFeaturesContainer);
+  ReactDOM.render(
+    <ErrorBoundary>
+      <ExperimentalFeatures />
+    </ErrorBoundary>,
+    experimentalFeaturesContainer,
+  );
 }

--- a/mailpoet/assets/js/src/form_editor/components/color_gradient_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/color_gradient_settings.tsx
@@ -1,5 +1,6 @@
 import PanelColorGradientSettings from '@wordpress/block-editor/build-module/components/colors-gradients/panel-color-gradient-settings';
 import { useSetting } from '@wordpress/block-editor';
+import { withBoundary } from 'common';
 
 type Setting = {
   label: string;
@@ -14,7 +15,7 @@ type Props = {
   settings: Setting[];
 };
 
-export function ColorGradientSettings({ title, settings }: Props): JSX.Element {
+function ColorGradientSettings({ title, settings }: Props): JSX.Element {
   const settingsColors = useSetting('color.palette');
   const settingsGradients = useSetting('color.gradients');
   return (
@@ -28,3 +29,7 @@ export function ColorGradientSettings({ title, settings }: Props): JSX.Element {
     </div>
   );
 }
+
+ColorGradientSettings.displayName = 'ColorGradientSettings';
+const ColorGradientSettingsWithBoundary = withBoundary(ColorGradientSettings);
+export { ColorGradientSettingsWithBoundary as ColorGradientSettings };

--- a/mailpoet/assets/js/src/form_editor/components/editor.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/editor.jsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Popover, SlotFillProvider } from '@wordpress/components';
 import { uploadMedia } from '@wordpress/media-utils';
 import {
@@ -9,13 +9,14 @@ import {
   BlockList,
   BlockSelectionClearer,
   BlockTools,
-  WritingFlow,
   ObserveTyping,
   SETTINGS_DEFAULTS,
+  WritingFlow,
 } from '@wordpress/block-editor';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 
 import { UnsavedChangesNotice } from 'common/notices/unsaved_changes_notice.jsx';
+import { ErrorBoundary } from 'common';
 import { fetchLinkSuggestions } from '../utils/link_suggestions';
 import { Header } from './header.jsx';
 import { Tutorial } from './tutorial';
@@ -113,10 +114,12 @@ export function Editor() {
           <div className={layoutClass}>
             <div className="interface-interface-skeleton__editor">
               <div className="interface-interface-skeleton__header">
-                <Header
-                  isInserterOpened={isInserterOpened}
-                  setIsInserterOpened={toggleInserter}
-                />
+                <ErrorBoundary>
+                  <Header
+                    isInserterOpened={isInserterOpened}
+                    setIsInserterOpened={toggleInserter}
+                  />
+                </ErrorBoundary>
               </div>
               <div className="interface-interface-skeleton__body">
                 <BlockEditorProvider
@@ -132,7 +135,9 @@ export function Editor() {
                     </div>
                   )}
                   <div className="interface-interface-skeleton__content">
-                    <Notices />
+                    <ErrorBoundary>
+                      <Notices />
+                    </ErrorBoundary>
                     <UnsavedChangesNotice storeName="mailpoet-form-editor" />
                     <BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
                       <BlockTools>
@@ -141,9 +146,11 @@ export function Editor() {
                         <div className="mailpoet_form">
                           <WritingFlow>
                             <ObserveTyping>
-                              <FormStylingBackground>
-                                <BlockList />
-                              </FormStylingBackground>
+                              <ErrorBoundary>
+                                <FormStylingBackground>
+                                  <BlockList />
+                                </FormStylingBackground>
+                              </ErrorBoundary>
                             </ObserveTyping>
                           </WritingFlow>
                         </div>
@@ -152,19 +159,27 @@ export function Editor() {
                   </div>
                   {sidebarOpened && (
                     <div className="interface-interface-skeleton__sidebar">
-                      <Sidebar />
+                      <ErrorBoundary>
+                        <Sidebar />
+                      </ErrorBoundary>
                     </div>
                   )}
                 </BlockEditorProvider>
               </div>
-              <FormStyles />
-              <Fullscreen />
+              <ErrorBoundary>
+                <FormStyles />
+              </ErrorBoundary>
+              <ErrorBoundary>
+                <Fullscreen />
+              </ErrorBoundary>
             </div>
             <Popover.Slot />
           </div>
         </SlotFillProvider>
       </ShortcutProvider>
-      <FormPreview />
+      <ErrorBoundary>
+        <FormPreview />
+      </ErrorBoundary>
       <Tutorial />
     </>
   );

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/basic_settings_panel.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/basic_settings_panel.jsx
@@ -3,9 +3,9 @@ import {
   Panel,
   PanelBody,
   RadioControl,
+  SelectControl,
   TextareaControl,
   ToggleControl,
-  SelectControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { MailPoet } from 'mailpoet';
@@ -168,5 +168,5 @@ BasicSettingsPanel.propTypes = {
   onToggle: PropTypes.func.isRequired,
   isOpened: PropTypes.bool.isRequired,
 };
-
+BasicSettingsPanel.displayName = 'FormEditorBasicSettingsPanel';
 export { BasicSettingsPanel };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panel.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panel.tsx
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from 'common';
 import { BelowPostsSettings } from './settings_panels/below_posts_settings';
 import { PopUpSettings } from './settings_panels/popup_settings';
 import { OtherSettings } from './settings_panels/other_settings';
@@ -11,11 +12,31 @@ type Props = {
 export function SettingsPanel({ activePanel }: Props): JSX.Element {
   return (
     <div className="mailpoet-styles-settings">
-      {activePanel === 'others' && <OtherSettings />}
-      {activePanel === 'below_posts' && <BelowPostsSettings />}
-      {activePanel === 'fixed_bar' && <FixedBarSettings />}
-      {activePanel === 'popup' && <PopUpSettings />}
-      {activePanel === 'slide_in' && <SlideInSettings />}
+      {activePanel === 'others' && (
+        <ErrorBoundary>
+          <OtherSettings />
+        </ErrorBoundary>
+      )}
+      {activePanel === 'below_posts' && (
+        <ErrorBoundary>
+          <BelowPostsSettings />
+        </ErrorBoundary>
+      )}
+      {activePanel === 'fixed_bar' && (
+        <ErrorBoundary>
+          <FixedBarSettings />
+        </ErrorBoundary>
+      )}
+      {activePanel === 'popup' && (
+        <ErrorBoundary>
+          <PopUpSettings />
+        </ErrorBoundary>
+      )}
+      {activePanel === 'slide_in' && (
+        <ErrorBoundary>
+          <SlideInSettings />
+        </ErrorBoundary>
+      )}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/animation_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/animation_settings.tsx
@@ -2,14 +2,13 @@ import { MailPoet } from 'mailpoet';
 import { __, assocPath, compose } from 'lodash/fp';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { SelectControl } from '@wordpress/components';
+import { withBoundary } from 'common';
 
 type Props = {
   settingsPlacementKey: string;
 };
 
-export function AnimationSettings({
-  settingsPlacementKey,
-}: Props): JSX.Element {
+function AnimationSettings({ settingsPlacementKey }: Props): JSX.Element {
   const formSettings = useSelect(
     (select) => select('mailpoet-form-editor').getFormSettings(),
     [],
@@ -42,3 +41,7 @@ export function AnimationSettings({
     />
   );
 }
+
+AnimationSettings.displayName = 'FormEditorAnimationSettings';
+const AnimationSettingsWithBoundary = withBoundary(AnimationSettings);
+export { AnimationSettingsWithBoundary as AnimationSettings };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/cookie_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/cookie_settings.tsx
@@ -2,12 +2,13 @@ import { MailPoet } from 'mailpoet';
 import { __, assocPath, compose } from 'lodash/fp';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { SelectControl } from '@wordpress/components';
+import { withBoundary } from 'common';
 
 type Props = {
   settingsPlacementKey: string;
 };
 
-export function CookieSettings({ settingsPlacementKey }: Props): JSX.Element {
+function CookieSettings({ settingsPlacementKey }: Props): JSX.Element {
   const cookieExpirationValues = [3, 7, 14, 30, 60, 90];
   const formSettings = useSelect(
     (select) => select('mailpoet-form-editor').getFormSettings(),
@@ -47,3 +48,7 @@ export function CookieSettings({ settingsPlacementKey }: Props): JSX.Element {
     />
   );
 }
+
+CookieSettings.displayName = 'FormEditorCookieSettings';
+const CookieSettingsWithBoundary = withBoundary(CookieSettings);
+export { CookieSettingsWithBoundary as CookieSettings };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/fixed_bar_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/fixed_bar_settings.tsx
@@ -1,11 +1,11 @@
 import { MailPoet } from 'mailpoet';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
-  SelectControl,
   RadioControl,
+  SelectControl,
   ToggleControl,
 } from '@wordpress/components';
-import { assocPath, compose, __ } from 'lodash/fp';
+import { __, assocPath, compose } from 'lodash/fp';
 import { SizeSettings } from 'form_editor/components/size_settings';
 import { AnimationSettings } from './animation_settings';
 import { PlacementSettings } from './placement_settings';
@@ -13,7 +13,7 @@ import { CookieSettings } from './cookie_settings';
 
 const delayValues = [0, 2, 5, 10, 15, 30, 45, 60, 120, 180, 240];
 
-export function FixedBarSettings(): JSX.Element {
+function FixedBarSettings(): JSX.Element {
   const formSettings = useSelect(
     (select) => select('mailpoet-form-editor').getFormSettings(),
     [],
@@ -96,3 +96,6 @@ export function FixedBarSettings(): JSX.Element {
     </>
   );
 }
+
+FixedBarSettings.displayName = 'FormEditorFixedBarSettings';
+export { FixedBarSettings };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/other_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/other_settings.tsx
@@ -7,7 +7,7 @@ import { assocPath } from 'lodash/fp';
 import { TextareaControl } from '@wordpress/components';
 import { SizeSettings } from 'form_editor/components/size_settings';
 
-export function OtherSettings(): JSX.Element {
+function OtherSettings(): JSX.Element {
   const [copyAreaContent, setCopyAreaContent] = useState(null);
 
   const formExports = useSelect(
@@ -117,3 +117,6 @@ export function OtherSettings(): JSX.Element {
     </>
   );
 }
+
+OtherSettings.displayName = 'FormEditorOtherSettings';
+export { OtherSettings };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/placement_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_placement_options/settings_panels/placement_settings.tsx
@@ -2,15 +2,14 @@ import { MailPoet } from 'mailpoet';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ToggleControl } from '@wordpress/components';
 import { assocPath, compose, cond, identity, isEqual, sortBy } from 'lodash/fp';
+import { withBoundary } from 'common';
 import { Selection } from '../../selection';
 
 type Props = {
   settingsPlacementKey: string;
 };
 
-export function PlacementSettings({
-  settingsPlacementKey,
-}: Props): JSX.Element {
+function PlacementSettings({ settingsPlacementKey }: Props): JSX.Element {
   const formSettings = useSelect(
     (select) => select('mailpoet-form-editor').getFormSettings(),
     [],
@@ -338,3 +337,7 @@ export function PlacementSettings({
     </>
   );
 }
+
+PlacementSettings.displayName = 'FormEditorPlacementSettings';
+const PlacementSettingsWithBoundary = withBoundary(PlacementSettings);
+export { PlacementSettingsWithBoundary as PlacementSettings };

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/form_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/form_settings.tsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { partial } from 'lodash';
+import { ErrorBoundary } from 'common';
 import { BasicSettingsPanel } from './basic_settings_panel';
 import { StylesSettingsPanel } from './styles_settings_panel';
 import { FormPlacementPanel } from './form_placement_panel';
@@ -17,10 +18,12 @@ export function FormSettings(): JSX.Element {
 
   return (
     <>
-      <BasicSettingsPanel
-        isOpened={openedPanels.includes('basic-settings')}
-        onToggle={partial(toggleSidebarPanel, 'basic-settings')}
-      />
+      <ErrorBoundary>
+        <BasicSettingsPanel
+          isOpened={openedPanels.includes('basic-settings')}
+          onToggle={partial(toggleSidebarPanel, 'basic-settings')}
+        />
+      </ErrorBoundary>
       <StylesSettingsPanel
         isOpened={openedPanels.includes('styles-settings')}
         onToggle={partial(toggleSidebarPanel, 'styles-settings')}

--- a/mailpoet/assets/js/src/form_editor/components/form_settings/selection.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_settings/selection.jsx
@@ -1,9 +1,10 @@
-import { createRef, Component } from 'react';
+import { Component, createRef } from 'react';
 import jQuery from 'jquery';
 import _ from 'underscore';
 import 'react-dom';
 import 'select2';
 import PropTypes from 'prop-types';
+import { withBoundary } from 'common';
 
 class Selection extends Component {
   constructor(props) {
@@ -372,5 +373,6 @@ Selection.defaultProps = {
   item: undefined,
   dropDownParent: undefined,
 };
-
-export { Selection };
+Selection.displayName = 'FormEditorSelection';
+const SelectionWithBoundary = withBoundary(Selection);
+export { SelectionWithBoundary as Selection };

--- a/mailpoet/assets/js/src/form_editor/components/form_styles.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_styles.jsx
@@ -3,7 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { transformStyles } from '@wordpress/block-editor';
 import css from 'css';
 
-export const FormStyles = () => {
+const FormStyles = () => {
   const element = document.getElementById('mailpoet-form-editor-form-styles');
 
   const formStyles = useSelect(
@@ -23,3 +23,6 @@ export const FormStyles = () => {
   );
   return ReactDOM.createPortal(transoformedStyles[0], element);
 };
+
+FormStyles.displayName = 'FormStyles';
+export { FormStyles };

--- a/mailpoet/assets/js/src/form_editor/components/form_styling_background.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/form_styling_background.jsx
@@ -129,5 +129,5 @@ function FormStylingBackground({ children }) {
 FormStylingBackground.propTypes = {
   children: PropTypes.node.isRequired,
 };
-
+FormStylingBackground.displayName = 'FormStylingBackground';
 export { FormStylingBackground };

--- a/mailpoet/assets/js/src/form_editor/components/fullscreen.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/fullscreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useSelect } from '@wordpress/data';
 
-export function Fullscreen(): null {
+function Fullscreen(): null {
   const isFullscreen = useSelect(
     (select) => select('mailpoet-form-editor').isFullscreenEnabled(),
     [],
@@ -17,3 +17,6 @@ export function Fullscreen(): null {
 
   return null;
 }
+
+Fullscreen.displayName = 'Fullscreen';
+export { Fullscreen };

--- a/mailpoet/assets/js/src/form_editor/components/header.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/header.jsx
@@ -117,5 +117,5 @@ Header.propTypes = {
   isInserterOpened: PropTypes.bool.isRequired,
   setIsInserterOpened: PropTypes.func.isRequired,
 };
-
+Header.displayName = 'FormEditorHeader';
 export { Header };

--- a/mailpoet/assets/js/src/form_editor/components/notices.jsx
+++ b/mailpoet/assets/js/src/form_editor/components/notices.jsx
@@ -2,7 +2,7 @@ import { memoize } from 'lodash';
 import { NoticeList } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 
-export function Notices() {
+function Notices() {
   const dismissibleNotices = useSelect(
     (select) => select('mailpoet-form-editor').getDismissibleNotices(),
     [],
@@ -33,3 +33,7 @@ export function Notices() {
     </>
   );
 }
+
+Notices.displayName = 'FormEditorNotices';
+
+export { Notices };

--- a/mailpoet/assets/js/src/form_editor/components/preview/preview.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/preview/preview.tsx
@@ -6,8 +6,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Modal } from 'common/modal/modal';
 import { Preview } from 'common/preview/preview.jsx';
 import { SettingsPanel } from 'form_editor/components/form_settings/form_placement_options/settings_panel';
+import { ErrorBoundary } from 'common';
 
-export function FormPreview(): JSX.Element {
+function FormPreview(): JSX.Element {
   const iframeElement = useRef(null);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const { hidePreview, changePreviewSettings } = useDispatch(
@@ -148,33 +149,38 @@ export function FormPreview(): JSX.Element {
             />
             <SettingsPanel activePanel={previewSettings.formType} />
           </div>
-          <Preview
-            onDisplayTypeChange={onPreviewTypeChange}
-            selectedDisplayType={previewSettings.displayType}
-          >
-            {!iframeLoaded && (
-              <div className="mailpoet_spinner_wrapper">
-                <Spinner />
-              </div>
-            )}
-            <iframe
-              ref={iframeElement}
-              className="mailpoet_form_preview_iframe"
-              src={iframeSrc}
-              title={MailPoet.I18n.t('formPreview')}
-              onLoad={(): void => setIframeLoaded(true)}
-              data-automation-id="form_preview_iframe"
-              scrolling={previewSettings.formType === 'others' ? 'no' : 'yes'}
-            />
-            {previewSettings.formType === 'others' &&
-              previewSettings.displayType === 'desktop' && (
-                <div className="mailpoet_form_preview_disclaimer">
-                  {MailPoet.I18n.t('formPreviewOthersDisclaimer')}
+          <ErrorBoundary>
+            <Preview
+              onDisplayTypeChange={onPreviewTypeChange}
+              selectedDisplayType={previewSettings.displayType}
+            >
+              {!iframeLoaded && (
+                <div className="mailpoet_spinner_wrapper">
+                  <Spinner />
                 </div>
               )}
-          </Preview>
+              <iframe
+                ref={iframeElement}
+                className="mailpoet_form_preview_iframe"
+                src={iframeSrc}
+                title={MailPoet.I18n.t('formPreview')}
+                onLoad={(): void => setIframeLoaded(true)}
+                data-automation-id="form_preview_iframe"
+                scrolling={previewSettings.formType === 'others' ? 'no' : 'yes'}
+              />
+              {previewSettings.formType === 'others' &&
+                previewSettings.displayType === 'desktop' && (
+                  <div className="mailpoet_form_preview_disclaimer">
+                    {MailPoet.I18n.t('formPreviewOthersDisclaimer')}
+                  </div>
+                )}
+            </Preview>
+          </ErrorBoundary>
         </div>
       )}
     </Modal>
   );
 }
+
+FormPreview.displayName = 'FormPreviewWrapper';
+export { FormPreview };

--- a/mailpoet/assets/js/src/form_editor/components/sidebar/sidebar.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/sidebar/sidebar.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { DefaultSidebar } from './default_sidebar';
 import { PlacementSettingsSidebar } from './placement_settings_sidebar';
 
-export function Sidebar(): JSX.Element {
+function Sidebar(): JSX.Element {
   const { toggleSidebar, changeActiveSidebar } = useDispatch(
     'mailpoet-form-editor',
   );
@@ -44,3 +44,6 @@ export function Sidebar(): JSX.Element {
     </div>
   );
 }
+
+Sidebar.displayName = 'FormEditorSidebar';
+export { Sidebar };

--- a/mailpoet/assets/js/src/form_editor/components/size_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/components/size_settings.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
-import { RangeControl, RadioControl, BaseControl } from '@wordpress/components';
+import { useEffect, useState } from 'react';
+import { BaseControl, RadioControl, RangeControl } from '@wordpress/components';
+import { withBoundary } from 'common';
 
 export type SizeDefinition = {
   value: number | undefined;
@@ -18,7 +19,7 @@ type Props = {
   onChange: (value: SizeDefinition) => void;
 };
 
-export function SizeSettings({
+function SizeSettings({
   label,
   minPercents = 0,
   maxPercents = 100,
@@ -76,3 +77,7 @@ export function SizeSettings({
     </div>
   );
 }
+
+SizeSettings.displayName = 'FormEditorSizeSettings';
+const SizeSettingsWithBoundary = withBoundary(SizeSettings);
+export { SizeSettingsWithBoundary as SizeSettings };

--- a/mailpoet/assets/js/src/forms/forms.jsx
+++ b/mailpoet/assets/js/src/forms/forms.jsx
@@ -1,7 +1,8 @@
 import ReactDOM from 'react-dom';
-import { Route, HashRouter } from 'react-router-dom';
+import { HashRouter, Route } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
+import { withBoundary } from 'common';
 import { FormList } from './list.jsx';
 
 function App() {
@@ -9,7 +10,7 @@ function App() {
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <HashRouter>
         <Notices />
-        <Route path="*" component={FormList} />
+        <Route path="*" render={withBoundary(FormList)} />
       </HashRouter>
     </GlobalContext.Provider>
   );

--- a/mailpoet/assets/js/src/forms/heading.jsx
+++ b/mailpoet/assets/js/src/forms/heading.jsx
@@ -11,7 +11,7 @@ export const onAddNewForm = () => {
   }, 200); // leave some time for the event to track
 };
 
-export function FormsHeading() {
+function FormsHeading() {
   const [loading, setLoading] = useState(false);
   return (
     <TopBarWithBeamer>
@@ -30,3 +30,7 @@ export function FormsHeading() {
     </TopBarWithBeamer>
   );
 }
+
+FormsHeading.displayName = 'FormsHeading';
+
+export { FormsHeading };

--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -304,5 +304,5 @@ FormListComponent.propTypes = {
     params: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }).isRequired,
 };
-
+FormListComponent.displayName = 'FormList';
 export const FormList = withNpsPoll(FormListComponent);

--- a/mailpoet/assets/js/src/listing/bulk_actions.jsx
+++ b/mailpoet/assets/js/src/listing/bulk_actions.jsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 
 import { MailPoet } from 'mailpoet';
 import PropTypes from 'prop-types';
+import { withBoundary } from '../common';
 
 class ListingBulkActions extends Component {
   constructor(props) {
@@ -109,5 +110,6 @@ ListingBulkActions.propTypes = {
   selected_ids: PropTypes.arrayOf(PropTypes.number).isRequired,
   onBulkAction: PropTypes.func.isRequired,
 };
-
-export { ListingBulkActions };
+ListingBulkActions.displayName = 'ListingBulkActions';
+const ListingBulkActionsWithBoundary = withBoundary(ListingBulkActions);
+export { ListingBulkActionsWithBoundary as ListingBulkActions };

--- a/mailpoet/assets/js/src/listing/filters.jsx
+++ b/mailpoet/assets/js/src/listing/filters.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Button } from 'common/button/button.tsx';
 import { MailPoet } from 'mailpoet';
 import { Select } from 'common/form/select/select.tsx';
+import { withBoundary } from '../common';
 
 class ListingFilters extends Component {
   componentDidUpdate() {
@@ -100,5 +101,6 @@ ListingFilters.propTypes = {
 ListingFilters.defaultProps = {
   onBeforeSelectFilter: undefined,
 };
-
-export { ListingFilters };
+ListingFilters.displayName = 'ListingFilters';
+const ListingFiltersWithBoundary = withBoundary(ListingFilters);
+export { ListingFiltersWithBoundary as ListingFilters };

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -790,4 +790,6 @@ ListingComponent.defaultProps = {
   className: undefined,
 };
 
+ListingComponent.displayName = 'Listing';
+
 export const Listing = withRouter(ListingComponent);

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -13,6 +13,7 @@ import { ListingItems } from 'listing/listing_items.jsx';
 import { MailerError } from 'listing/notices.jsx';
 import { withRouter } from 'react-router-dom';
 import { GlobalContext } from 'context/index.jsx';
+import { withBoundary } from '../common';
 
 class ListingComponent extends Component {
   constructor(props) {
@@ -792,4 +793,4 @@ ListingComponent.defaultProps = {
 
 ListingComponent.displayName = 'Listing';
 
-export const Listing = withRouter(ListingComponent);
+export const Listing = withRouter(withBoundary(ListingComponent));

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -84,7 +84,7 @@ type ListProps = {
   onFilter: (FilterType) => void;
 };
 
-export function List({
+function List({
   logs,
   onFilter,
   originalFrom,
@@ -219,3 +219,7 @@ export function List({
     </div>
   );
 }
+
+List.displayName = 'LogsList';
+
+export { List };

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -4,7 +4,7 @@ import { curry } from 'lodash';
 import { parseISO } from 'date-fns';
 
 import { Datepicker } from '../common/datepicker/datepicker';
-import { Button, Input } from '../common';
+import { Button, ErrorBoundary, Input } from '../common';
 import { Icon } from '../listing/assets/search_icon';
 
 type LogData = {
@@ -66,6 +66,7 @@ function Log({ log }: LogProps): JSX.Element {
   );
 }
 
+Log.displayName = 'Log';
 export type FilterType = {
   from?: string;
   to?: string;
@@ -153,21 +154,23 @@ function List({
         </div>
         <div className="mailpoet-listing-filters">
           {`${MailPoet.I18n.t('from')}:`}
-          <Datepicker
-            dateFormat="MMMM d, yyyy"
-            onChange={dateChanged(setFrom)}
-            maxDate={new Date()}
-            selected={from ? parseISO(from) : undefined}
-            dimension="small"
-          />
-          {`${MailPoet.I18n.t('to')}:`}
-          <Datepicker
-            dateFormat="MMMM d, yyyy"
-            onChange={dateChanged(setTo)}
-            maxDate={new Date()}
-            selected={to ? parseISO(to) : undefined}
-            dimension="small"
-          />
+          <ErrorBoundary>
+            <Datepicker
+              dateFormat="MMMM d, yyyy"
+              onChange={dateChanged(setFrom)}
+              maxDate={new Date()}
+              selected={from ? parseISO(from) : undefined}
+              dimension="small"
+            />
+            {`${MailPoet.I18n.t('to')}:`}
+            <Datepicker
+              dateFormat="MMMM d, yyyy"
+              onChange={dateChanged(setTo)}
+              maxDate={new Date()}
+              selected={to ? parseISO(to) : undefined}
+              dimension="small"
+            />
+          </ErrorBoundary>
         </div>
         <div className="mailpoet-logs-limit">
           <label htmlFor="offset_input" className="screen-reader-text">
@@ -211,9 +214,11 @@ function List({
           </tr>
         </thead>
         <tbody>
-          {logs.map((log) => (
-            <Log log={log} key={`log-${log.id}`} />
-          ))}
+          <ErrorBoundary>
+            {logs.map((log) => (
+              <Log log={log} key={`log-${log.id}`} />
+            ))}
+          </ErrorBoundary>
         </tbody>
       </table>
     </div>

--- a/mailpoet/assets/js/src/logs/logs.tsx
+++ b/mailpoet/assets/js/src/logs/logs.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
 
-import { List, Logs, FilterType } from './list';
+import { FilterType, List, Logs } from './list';
+import { ErrorBoundary } from 'common';
 
 interface LogsWindow extends Window {
   mailpoet_logs: Logs;
@@ -14,25 +15,27 @@ if (logsContainer) {
   const url = new URL(window.location.href);
 
   ReactDOM.render(
-    <List
-      logs={window.mailpoet_logs}
-      originalFrom={url.searchParams.get('from')}
-      originalTo={url.searchParams.get('to')}
-      originalSearch={url.searchParams.get('search')}
-      originalOffset={url.searchParams.get('offset')}
-      originalLimit={url.searchParams.get('limit')}
-      onFilter={(data: FilterType): void => {
-        url.searchParams.delete('from');
-        url.searchParams.delete('to');
-        url.searchParams.delete('search');
-        url.searchParams.delete('offset');
-        url.searchParams.delete('limit');
-        Object.entries(data).forEach(([key, value]) => {
-          url.searchParams.append(key, value);
-        });
-        window.location.href = url.href;
-      }}
-    />,
+    <ErrorBoundary>
+      <List
+        logs={window.mailpoet_logs}
+        originalFrom={url.searchParams.get('from')}
+        originalTo={url.searchParams.get('to')}
+        originalSearch={url.searchParams.get('search')}
+        originalOffset={url.searchParams.get('offset')}
+        originalLimit={url.searchParams.get('limit')}
+        onFilter={(data: FilterType): void => {
+          url.searchParams.delete('from');
+          url.searchParams.delete('to');
+          url.searchParams.delete('search');
+          url.searchParams.delete('offset');
+          url.searchParams.delete('limit');
+          Object.entries(data).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+          });
+          window.location.href = url.href;
+        }}
+      />
+    </ErrorBoundary>,
     logsContainer,
   );
 }

--- a/mailpoet/assets/js/src/logs/logs.tsx
+++ b/mailpoet/assets/js/src/logs/logs.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 
-import { FilterType, List, Logs } from './list';
 import { ErrorBoundary } from 'common';
+import { FilterType, List, Logs } from './list';
 
 interface LogsWindow extends Window {
   mailpoet_logs: Logs;

--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import { ListingHeadingSteps } from 'newsletters/listings/heading_steps';
 import { newsletterTypesWithActivation } from 'newsletters/listings/utils';
 import { fetchAutomaticEmailShortcodes } from 'newsletters/automatic_emails/fetch_editor_shortcodes.jsx';
+import { ErrorBoundary } from 'common';
 import { initTutorial } from './tutorial';
 
 const renderHeading = (newsletterType, newsletterOptions) => {
@@ -48,12 +49,14 @@ const renderHeading = (newsletterType, newsletterOptions) => {
     }
 
     const stepsHeading = (
-      <ListingHeadingSteps
-        emailType={newsletterType}
-        step={step}
-        buttons={buttons}
-        onLogoClick={onLogoClick}
-      />
+      <ErrorBoundary>
+        <ListingHeadingSteps
+          emailType={newsletterType}
+          step={step}
+          buttons={buttons}
+          onLogoClick={onLogoClick}
+        />
+      </ErrorBoundary>
     );
 
     ReactDOM.render(stepsHeading, stepsHeadingContainer);

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/events/event_options.tsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/events/event_options.tsx
@@ -1,5 +1,6 @@
 import { Selection } from 'form/fields/selection.jsx';
 import _ from 'underscore';
+import { withBoundary } from '../../../common';
 
 type EventOptionData = {
   values?: {
@@ -29,7 +30,7 @@ function getEventOptionsValues(eventOptions: EventOptionData) {
     : values;
 }
 
-export function EventOptions({
+function EventOptions({
   eventOptions,
   eventSlug,
   selected,
@@ -96,3 +97,7 @@ export function EventOptions({
     </div>
   );
 }
+
+EventOptions.displayName = 'EventOptions';
+const EventOptionsWithBoundary = withBoundary(EventOptions);
+export { EventOptionsWithBoundary as EventOptions };

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/events/event_scheduling.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/events/event_scheduling.jsx
@@ -199,5 +199,5 @@ EventScheduling.defaultProps = {
   afterTimeNumberSize: defaultAfterTimeNumberInputFieldSize,
   onValueChange: null,
 };
-
+EventScheduling.displayName = 'EventScheduling';
 export { EventScheduling };

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
@@ -13,6 +13,7 @@ import { EventScheduling } from 'newsletters/automatic_emails/events/event_sched
 import { EventOptions } from 'newsletters/automatic_emails/events/event_options';
 import { MailPoet } from 'mailpoet';
 import { Selection } from 'form/fields/selection.jsx';
+import { ErrorBoundary } from 'common';
 
 const defaultAfterTimeType = 'immediate';
 const defaultAfterTimeNumber = 1;
@@ -240,11 +241,13 @@ class EventsConditions extends Component {
     };
 
     return (
-      <EventScheduling
-        item={props.item}
-        event={props.event}
-        onValueChange={props.onValueChange}
-      />
+      <ErrorBoundary>
+        <EventScheduling
+          item={props.item}
+          event={props.event}
+          onValueChange={props.onValueChange}
+        />
+      </ErrorBoundary>
     );
   }
 

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/events_conditions.jsx
@@ -299,4 +299,6 @@ EventsConditions.propTypes = {
   }).isRequired,
 };
 
+EventsConditions.displayName = 'EventsConditions';
+
 export { EventsConditions };

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/listings.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/listings.jsx
@@ -13,7 +13,7 @@ import {
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { NewsletterTypes } from 'newsletters/types';
-import { ScheduledIcon, StringTags, Toggle } from 'common';
+import { ScheduledIcon, StringTags, Toggle, withBoundary } from 'common';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
@@ -488,5 +488,5 @@ ListingsComponent.propTypes = {
   }).isRequired,
   location: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
-
-export const Listings = withRouter(ListingsComponent);
+ListingsComponent.displayName = 'ListingsComponent';
+export const Listings = withRouter(withBoundary(ListingsComponent));

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/send_event_conditions.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/send_event_conditions.jsx
@@ -196,5 +196,5 @@ SendEventConditions.propTypes = {
 SendEventConditions.defaultProps = {
   onValueChange: null,
 };
-
+SendEventConditions.displayName = 'SendEventConditions';
 export { SendEventConditions };

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_general_stats.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_general_stats.tsx
@@ -37,10 +37,7 @@ const formatForStats = (value: number): number => {
   return +numValue.toFixed(1);
 };
 
-export function NewsletterGeneralStats({
-  newsletter,
-  isWoocommerceActive,
-}: Props) {
+function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
   const totalSent = newsletter.total_sent || 0;
 
   let percentageClicked = 0;
@@ -261,3 +258,6 @@ export function NewsletterGeneralStats({
     </div>
   );
 }
+
+NewsletterGeneralStats.displayName = 'NewsletterGeneralStats';
+export { NewsletterGeneralStats };

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_stats_info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_stats_info.tsx
@@ -8,7 +8,7 @@ type Props = {
   newsletter: NewsletterType;
 };
 
-export function NewsletterStatsInfo({ newsletter }: Props) {
+function NewsletterStatsInfo({ newsletter }: Props) {
   const newsletterDate =
     newsletter.queue.scheduled_at || newsletter.queue.created_at;
   return (
@@ -69,3 +69,6 @@ export function NewsletterStatsInfo({ newsletter }: Props) {
     </Grid.ThreeColumns>
   );
 }
+
+NewsletterStatsInfo.displayName = 'NewsletterStatsInfo';
+export { NewsletterStatsInfo };

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
@@ -9,7 +9,7 @@ import { RemoveWrapMargin } from 'common/remove_wrap_margin/remove_wrap_margin';
 import { Tabs } from 'common/tabs/tabs';
 import { Tab } from 'common/tabs/tab';
 import { Heading } from 'common/typography/heading/heading';
-
+import { ErrorBoundary } from 'common';
 import { NewsletterGeneralStats } from './newsletter_general_stats';
 import { NewsletterType } from './newsletter_type';
 import { NewsletterStatsInfo } from './newsletter_stats_info';
@@ -115,12 +115,16 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
           subscribersCount={window.mailpoet_subscribers_count}
         />
 
-        <NewsletterStatsInfo newsletter={newsletter} />
+        <ErrorBoundary>
+          <NewsletterStatsInfo newsletter={newsletter} />
+        </ErrorBoundary>
 
-        <NewsletterGeneralStats
-          newsletter={newsletter}
-          isWoocommerceActive={MailPoet.isWoocommerceActive}
-        />
+        <ErrorBoundary>
+          <NewsletterGeneralStats
+            newsletter={newsletter}
+            isWoocommerceActive={MailPoet.isWoocommerceActive}
+          />
+        </ErrorBoundary>
 
         <Tabs activeKey="clicked">
           <Tab key="clicked" title={MailPoet.I18n.t('clickedLinks')}>
@@ -165,4 +169,5 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
   );
 }
 
+CampaignStatsPageComponent.displayName = 'CampaignStatsPage';
 export const CampaignStatsPage = withRouter(CampaignStatsPageComponent);

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
@@ -1,6 +1,7 @@
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common/button/button';
 import { PremiumRequired } from 'common/premium_required/premium_required';
+import { withBoundary } from '../../common';
 
 function SkipDisplayingDetailedStats() {
   const ctaButton = (
@@ -39,7 +40,7 @@ function SkipDisplayingDetailedStats() {
   );
 }
 
-export function PremiumBanner() {
+function PremiumBanner() {
   if (!window.mailpoet_display_detailed_stats) {
     return <SkipDisplayingDetailedStats />;
   }
@@ -77,3 +78,8 @@ export function PremiumBanner() {
   }
   return null;
 }
+
+PremiumBanner.displayName = 'PremiumBanner';
+
+const PremiumBannerWithBoundary = withBoundary(PremiumBanner);
+export { PremiumBannerWithBoundary as PremiumBanner };

--- a/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
@@ -158,4 +158,5 @@ function ListingHeadingSteps({
   return null;
 }
 
+ListingHeadingSteps.displayName = 'ListingHeadingSteps';
 export { ListingHeadingSteps };

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -23,6 +23,7 @@ import {
   checkMailerStatus,
   confirmEdit,
 } from 'newsletters/listings/utils.jsx';
+import { withBoundary } from '../../common';
 
 const messages = {
   onNoItemsFound: (group, search) =>
@@ -404,7 +405,7 @@ NewsletterListNotificationComponent.propTypes = {
     params: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }).isRequired,
 };
-
+NewsletterListNotificationComponent.displayName = 'NewsletterListNotification';
 export const NewsletterListNotification = withRouter(
-  NewsletterListNotificationComponent,
+  withBoundary(NewsletterListNotificationComponent),
 );

--- a/mailpoet/assets/js/src/newsletters/listings/notification_history.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification_history.jsx
@@ -12,6 +12,7 @@ import {
   checkMailerStatus,
 } from 'newsletters/listings/utils.jsx';
 import { SegmentTags } from 'common/tag/tags';
+import { withBoundary } from '../../common';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
 
@@ -221,7 +222,8 @@ NewsletterListNotificationHistoryComponent.propTypes = {
     }).isRequired,
   }).isRequired,
 };
-
+NewsletterListNotificationHistoryComponent.displayName =
+  'NewsletterListNotificationHistory';
 export const NewsletterListNotificationHistory = withRouter(
-  NewsletterListNotificationHistoryComponent,
+  withBoundary(NewsletterListNotificationHistoryComponent),
 );

--- a/mailpoet/assets/js/src/newsletters/listings/queue_status.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue_status.jsx
@@ -6,6 +6,7 @@ import parseDate from 'date-fns/parse';
 import { APIErrorsNotice } from 'notices/api_errors_notice.tsx';
 import { Button } from 'common/button/button';
 import { NewsletterStatus } from 'common/listings/newsletter_status';
+import { withBoundary } from '../../common';
 
 const QueuePropType = PropTypes.shape({
   status: PropTypes.string,
@@ -69,6 +70,7 @@ function QueueSending({ newsletter }) {
     </>
   );
 }
+
 QueueSending.propTypes = {
   newsletter: NewsletterPropType.isRequired,
 };
@@ -121,11 +123,13 @@ function QueueStatus({ newsletter, mailerLog }) {
     </>
   );
 }
+
 QueueStatus.propTypes = {
   newsletter: NewsletterPropType.isRequired,
   mailerLog: PropTypes.shape({
     status: PropTypes.string,
   }).isRequired,
 };
-
-export { QueueStatus };
+QueueStatus.displayName = 'QueueStatus';
+const QueueStatusWithBoundary = withBoundary(QueueStatus);
+export { QueueStatusWithBoundary as QueueStatus };

--- a/mailpoet/assets/js/src/newsletters/listings/re_engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re_engagement.jsx
@@ -17,6 +17,7 @@ import {
   confirmEdit,
 } from 'newsletters/listings/utils.jsx';
 import { NewsletterTypes } from 'newsletters/types';
+import { withBoundary } from 'common';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
 
@@ -379,7 +380,7 @@ NewsletterListReEngagementComponent.propTypes = {
     params: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }).isRequired,
 };
-
+NewsletterListReEngagementComponent.displayName = 'NewsletterListReEngagement';
 export const NewsletterListReEngagement = withRouter(
-  NewsletterListReEngagementComponent,
+  withBoundary(NewsletterListReEngagementComponent),
 );

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -16,6 +16,7 @@ import {
 } from 'newsletters/listings/utils.jsx';
 import { NewsletterTypes } from 'newsletters/types';
 import { GlobalContext } from 'context/index.jsx';
+import { ErrorBoundary, withBoundary } from '../../common';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
 
@@ -218,7 +219,9 @@ class NewsletterListStandardComponent extends Component {
           className="column mailpoet-hide-on-mobile"
           data-colname={MailPoet.I18n.t('lists')}
         >
-          <SegmentTags segments={newsletter.segments} dimension="large" />
+          <ErrorBoundary>
+            <SegmentTags segments={newsletter.segments} dimension="large" />
+          </ErrorBoundary>
         </td>
         {mailpoetTrackingEnabled === true ? (
           <td
@@ -302,7 +305,7 @@ NewsletterListStandardComponent.propTypes = {
     params: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }).isRequired,
 };
-
+NewsletterListStandardComponent.displayName = 'NewsletterListStandard';
 export const NewsletterListStandard = withRouter(
-  NewsletterListStandardComponent,
+  withBoundary(NewsletterListStandardComponent),
 );

--- a/mailpoet/assets/js/src/newsletters/listings/statistics.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/statistics.jsx
@@ -3,7 +3,7 @@ import { MailPoet } from 'mailpoet';
 import { Hooks } from 'wp-js-hooks';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Tag } from 'common';
+import { Tag, withBoundary } from 'common';
 import { trackStatsCTAClicked } from 'newsletters/listings/utils.jsx';
 import { NewsletterStats } from 'common/listings/newsletter_stats';
 
@@ -204,5 +204,6 @@ Statistics.defaultProps = {
   isSent: undefined,
   currentTime: undefined,
 };
-
-export { Statistics };
+Statistics.displayName = 'NewsletterStatistics';
+const StatisticsWithBoundary = withBoundary(Statistics);
+export { StatisticsWithBoundary as Statistics };

--- a/mailpoet/assets/js/src/newsletters/listings/welcome.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/welcome.jsx
@@ -19,6 +19,7 @@ import {
 
 import { NewsletterTypes } from 'newsletters/types';
 import { MailPoet } from 'mailpoet';
+import { withBoundary } from 'common';
 
 const mailpoetRoles = window.mailpoet_roles || {};
 const mailpoetSegments = window.mailpoet_segments || {};
@@ -446,5 +447,7 @@ NewsletterListWelcomeComponent.propTypes = {
     params: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }).isRequired,
 };
-
-export const NewsletterListWelcome = withRouter(NewsletterListWelcomeComponent);
+NewsletterListWelcomeComponent.displayName = 'NewsletterListWelcome';
+export const NewsletterListWelcome = withRouter(
+  withBoundary(NewsletterListWelcomeComponent),
+);

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -243,23 +243,29 @@ function App() {
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <HashRouter>
         <Notices />
-
-        <SubscribersLimitNotice />
-        <EmailVolumeLimitNotice />
-        <TransactionalEmailsProposeOptInNotice
-          mailpoetInstalledDaysAgo={window.mailpoet_installed_days_ago}
-          sendTransactionalEmails={window.mailpoet_send_transactional_emails}
-          mtaMethod={window.mailpoet_mta_method}
-          apiVersion={window.mailpoet_api_version}
-          noticeDismissed={
-            window.mailpoet_transactional_emails_opt_in_notice_dismissed
-          }
-        />
-        <InvalidMssKeyNotice
-          mssKeyInvalid={window.mailpoet_mss_key_invalid}
-          subscribersCount={window.mailpoet_subscribers_count}
-        />
-
+        <ErrorBoundary>
+          <SubscribersLimitNotice />
+        </ErrorBoundary>
+        <ErrorBoundary>
+          <EmailVolumeLimitNotice />
+        </ErrorBoundary>
+        <ErrorBoundary>
+          <TransactionalEmailsProposeOptInNotice
+            mailpoetInstalledDaysAgo={window.mailpoet_installed_days_ago}
+            sendTransactionalEmails={window.mailpoet_send_transactional_emails}
+            mtaMethod={window.mailpoet_mta_method}
+            apiVersion={window.mailpoet_api_version}
+            noticeDismissed={
+              window.mailpoet_transactional_emails_opt_in_notice_dismissed
+            }
+          />
+        </ErrorBoundary>
+        <ErrorBoundary>
+          <InvalidMssKeyNotice
+            mssKeyInvalid={window.mailpoet_mss_key_invalid}
+            subscribersCount={window.mailpoet_subscribers_count}
+          />
+        </ErrorBoundary>
         <Switch>
           <Route
             exact

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -782,4 +782,6 @@ NewsletterSendComponent.propTypes = {
   }).isRequired,
 };
 
+NewsletterSendComponent.displayName = 'NewsletterSend';
+
 export const NewsletterSend = withRouter(NewsletterSendComponent);

--- a/mailpoet/assets/js/src/newsletters/send.jsx
+++ b/mailpoet/assets/js/src/newsletters/send.jsx
@@ -7,7 +7,7 @@ import slugify from 'slugify';
 import { withRouter } from 'react-router-dom';
 
 import { Background } from 'common/background/background';
-import { Button } from 'common';
+import { Button, ErrorBoundary } from 'common';
 import { Form } from 'form/form.jsx';
 import { Grid } from 'common/grid';
 import { ListingHeadingStepsRoute } from 'newsletters/listings/heading_steps_route';
@@ -680,90 +680,91 @@ class NewsletterSendComponent extends Component {
           emailType={emailType}
           automationId="newsletter_send_heading"
         />
-
-        <Form
-          id="mailpoet_newsletter"
-          fields={fields}
-          automationId="newsletter_send_form"
-          item={this.state.item}
-          loading={this.state.loading}
-          onChange={this.handleFormChange}
-          onSubmit={this.handleSave}
-        >
-          <Grid.CenteredRow className="send-newsletter-buttons">
-            <Button
-              variant="secondary"
-              type="submit"
-              automationId="email-save-draft"
-              onClick={this.handleSaveDraft}
-              isDisabled={this.state.loading}
-            >
-              {MailPoet.I18n.t('saveDraftAndClose')}
-            </Button>
-            {isPaused ? (
+        <ErrorBoundary>
+          <Form
+            id="mailpoet_newsletter"
+            fields={fields}
+            automationId="newsletter_send_form"
+            item={this.state.item}
+            loading={this.state.loading}
+            onChange={this.handleFormChange}
+            onSubmit={this.handleSave}
+          >
+            <Grid.CenteredRow className="send-newsletter-buttons">
               <Button
-                type="button"
-                onClick={this.handleResume}
-                isDisabled={sendingDisabled || this.state.loading}
-                automationId="email-resume"
+                variant="secondary"
+                type="submit"
+                automationId="email-save-draft"
+                onClick={this.handleSaveDraft}
+                isDisabled={this.state.loading}
               >
-                {MailPoet.I18n.t('resume')}
+                {MailPoet.I18n.t('saveDraftAndClose')}
               </Button>
-            ) : (
-              <Button
-                type="button"
-                onClick={this.handleSend}
-                {...sendButtonOptions}
-                isDisabled={sendingDisabled || this.state.loading}
-                automationId="email-submit"
-              >
-                {sendButtonOptions.value || MailPoet.I18n.t('send')}
-              </Button>
-            )}
-            {this.state.validationError !== undefined && (
-              <Tooltip
-                tooltip={<div>{this.state.validationError}</div>}
-                tooltipId="helpTooltipSendEmail"
-              />
-            )}
-          </Grid.CenteredRow>
-          <p>
-            {MailPoet.I18n.t('orSimply')}
-            &nbsp;
-            <a
-              className="mailpoet-link"
-              href={`?page=mailpoet-newsletter-editor&id=${this.props.match.params.id}`}
-              onClick={this.handleRedirectToDesign}
-            >
-              {MailPoet.I18n.t('goBackToDesign')}
-            </a>
-            .
-          </p>
-          {window.mailpoet_mss_key_pending_approval && (
-            <div className="mailpoet_error">
-              {ReactStringReplace(
-                MailPoet.I18n.t('pendingKeyApprovalNotice'),
-                /\[link\](.*?)\[\/link\]/g,
-                (match) => (
-                  <a
-                    key="pendingKeyApprovalNoticeLink"
-                    href="https://account.mailpoet.com/authorization"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {match}
-                  </a>
-                ),
+              {isPaused ? (
+                <Button
+                  type="button"
+                  onClick={this.handleResume}
+                  isDisabled={sendingDisabled || this.state.loading}
+                  automationId="email-resume"
+                >
+                  {MailPoet.I18n.t('resume')}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={this.handleSend}
+                  {...sendButtonOptions}
+                  isDisabled={sendingDisabled || this.state.loading}
+                  automationId="email-submit"
+                >
+                  {sendButtonOptions.value || MailPoet.I18n.t('send')}
+                </Button>
               )}
-            </div>
-          )}
+              {this.state.validationError !== undefined && (
+                <Tooltip
+                  tooltip={<div>{this.state.validationError}</div>}
+                  tooltipId="helpTooltipSendEmail"
+                />
+              )}
+            </Grid.CenteredRow>
+            <p>
+              {MailPoet.I18n.t('orSimply')}
+              &nbsp;
+              <a
+                className="mailpoet-link"
+                href={`?page=mailpoet-newsletter-editor&id=${this.props.match.params.id}`}
+                onClick={this.handleRedirectToDesign}
+              >
+                {MailPoet.I18n.t('goBackToDesign')}
+              </a>
+              .
+            </p>
+            {window.mailpoet_mss_key_pending_approval && (
+              <div className="mailpoet_error">
+                {ReactStringReplace(
+                  MailPoet.I18n.t('pendingKeyApprovalNotice'),
+                  /\[link\](.*?)\[\/link\]/g,
+                  (match) => (
+                    <a
+                      key="pendingKeyApprovalNoticeLink"
+                      href="https://account.mailpoet.com/authorization"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {match}
+                    </a>
+                  ),
+                )}
+              </div>
+            )}
 
-          {showPremiumModal && (
-            <PremiumModal onRequestClose={this.closePremiumModal}>
-              {MailPoet.I18n.t('gaOnlyAvailableForPremium')}
-            </PremiumModal>
-          )}
-        </Form>
+            {showPremiumModal && (
+              <PremiumModal onRequestClose={this.closePremiumModal}>
+                {MailPoet.I18n.t('gaOnlyAvailableForPremium')}
+              </PremiumModal>
+            )}
+          </Form>
+        </ErrorBoundary>
       </div>
     );
   }

--- a/mailpoet/assets/js/src/newsletters/send/automatic.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/automatic.jsx
@@ -1,6 +1,7 @@
 import { MailPoet } from 'mailpoet';
 import { SendEventConditions } from 'newsletters/automatic_emails/send_event_conditions.jsx';
 import { GATrackingField } from 'newsletters/send/ga_tracking';
+import { withBoundary } from 'common';
 
 const emails = window.mailpoet_woocommerce_automatic_emails || [];
 
@@ -53,7 +54,7 @@ const getAutomaticEmailFields = (newsletter) => {
         email.title,
       ),
       type: 'reactComponent',
-      component: SendEventConditions,
+      component: withBoundary(SendEventConditions),
       email,
       emailOptions,
     },

--- a/mailpoet/assets/js/src/newsletters/send/congratulate/congratulate.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/congratulate/congratulate.jsx
@@ -187,4 +187,6 @@ Congratulate.propTypes = {
   }).isRequired,
 };
 
+Congratulate.displayName = 'Congratulate';
+
 export { Congratulate };

--- a/mailpoet/assets/js/src/newsletters/send/date_text.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/date_text.jsx
@@ -156,5 +156,5 @@ DateText.defaultProps = {
   name: 'date',
   maxDate: null,
 };
-
+DateText.displayName = 'DateText';
 export { DateText };

--- a/mailpoet/assets/js/src/newsletters/send/date_time.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/date_time.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Grid } from 'common/grid';
 import { DateText } from 'newsletters/send/date_text.jsx';
 import { TimeSelect } from 'newsletters/send/time_select.jsx';
+import { ErrorBoundary } from '../../common';
 
 class DateTime extends Component {
   DATE_TIME_SEPARATOR = ' ';
@@ -58,24 +59,26 @@ class DateTime extends Component {
   render() {
     return (
       <Grid.Column className="mailpoet-datetime-container">
-        <DateText
-          name="date"
-          value={this.state.date}
-          onChange={this.handleChange}
-          displayFormat={this.props.dateDisplayFormat}
-          storageFormat={this.props.dateStorageFormat}
-          disabled={this.props.disabled}
-          validation={this.props.dateValidation}
-          maxDate={this.props.maxDate}
-        />
-        <TimeSelect
-          name="time"
-          value={this.state.time}
-          onChange={this.handleChange}
-          disabled={this.props.disabled}
-          validation={this.props.timeValidation}
-          timeOfDayItems={this.props.timeOfDayItems}
-        />
+        <ErrorBoundary>
+          <DateText
+            name="date"
+            value={this.state.date}
+            onChange={this.handleChange}
+            displayFormat={this.props.dateDisplayFormat}
+            storageFormat={this.props.dateStorageFormat}
+            disabled={this.props.disabled}
+            validation={this.props.dateValidation}
+            maxDate={this.props.maxDate}
+          />
+          <TimeSelect
+            name="time"
+            value={this.state.time}
+            onChange={this.handleChange}
+            disabled={this.props.disabled}
+            validation={this.props.timeValidation}
+            timeOfDayItems={this.props.timeOfDayItems}
+          />
+        </ErrorBoundary>
       </Grid.Column>
     );
   }

--- a/mailpoet/assets/js/src/newsletters/send/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/notification.jsx
@@ -4,6 +4,7 @@ import { Hooks } from 'wp-js-hooks';
 import { NotificationScheduling } from 'newsletters/types/notification/scheduling.jsx';
 import { SenderField } from 'newsletters/send/sender_address_field.jsx';
 import { GATrackingField } from 'newsletters/send/ga_tracking';
+import { withBoundary } from 'common';
 
 let fields = [
   {
@@ -95,7 +96,7 @@ let fields = [
       {
         name: 'sender_address',
         type: 'reactComponent',
-        component: SenderField,
+        component: withBoundary(SenderField),
         placeholder: MailPoet.I18n.t('senderAddressPlaceholder'),
         validation: {
           'data-parsley-required': true,

--- a/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender_address_field.jsx
@@ -178,5 +178,5 @@ SenderField.defaultProps = {
     // no-op
   },
 };
-
+SenderField.displayName = 'SenderField';
 export { SenderField };

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -7,6 +7,7 @@ import { DateTime } from 'newsletters/send/date_time.jsx';
 import { SenderField } from 'newsletters/send/sender_address_field.jsx';
 import { GATrackingField } from 'newsletters/send/ga_tracking';
 import { Toggle } from 'common/form/toggle/toggle';
+import { withBoundary } from 'common';
 import { NewsLetter, NewsletterStatus } from '../models';
 import { Field } from '../../form/types';
 
@@ -190,7 +191,7 @@ let fields: Array<Field> = [
     name: 'options',
     label: MailPoet.I18n.t('scheduleIt'),
     type: 'reactComponent',
-    component: StandardScheduling,
+    component: withBoundary(StandardScheduling),
   },
   {
     name: 'sender',
@@ -208,7 +209,7 @@ let fields: Array<Field> = [
       {
         name: 'sender_address',
         type: 'reactComponent',
-        component: SenderField,
+        component: withBoundary(SenderField),
         placeholder: MailPoet.I18n.t('senderAddressPlaceholder'),
         validation: {
           'data-parsley-required': true,

--- a/mailpoet/assets/js/src/newsletters/send/time_select.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/time_select.jsx
@@ -40,5 +40,5 @@ TimeSelect.defaultProps = {
   disabled: false,
   validation: {},
 };
-
+TimeSelect.displayName = 'TimeSelect';
 export { TimeSelect };

--- a/mailpoet/assets/js/src/newsletters/send/welcome.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/welcome.jsx
@@ -3,6 +3,7 @@ import { Hooks } from 'wp-js-hooks';
 import { WelcomeScheduling } from 'newsletters/types/welcome/scheduling.jsx';
 import { SenderField } from 'newsletters/send/sender_address_field.jsx';
 import { GATrackingField } from 'newsletters/send/ga_tracking';
+import { withBoundary } from 'common';
 
 let fields = [
   {
@@ -44,7 +45,7 @@ let fields = [
     name: 'options',
     label: MailPoet.I18n.t('selectEventToSendWelcomeEmail'),
     type: 'reactComponent',
-    component: WelcomeScheduling,
+    component: withBoundary(WelcomeScheduling),
   },
   GATrackingField,
   {
@@ -63,7 +64,7 @@ let fields = [
       {
         name: 'sender_address',
         type: 'reactComponent',
-        component: SenderField,
+        component: withBoundary(SenderField),
         placeholder: MailPoet.I18n.t('senderAddressPlaceholder'),
         validation: {
           'data-parsley-required': true,

--- a/mailpoet/assets/js/src/newsletters/sending_status.jsx
+++ b/mailpoet/assets/js/src/newsletters/sending_status.jsx
@@ -243,5 +243,6 @@ ListingItem.propTypes = {
 ListingItem.defaultProps = {
   error: '',
 };
-
+ListingItem.displayName = 'ListingItem';
+SendingStatus.displayName = 'SendingStatus';
 export { SendingStatus };

--- a/mailpoet/assets/js/src/newsletters/sending_status.jsx
+++ b/mailpoet/assets/js/src/newsletters/sending_status.jsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { useState, useEffect, memo } from 'react';
+import { memo, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Link } from 'react-router-dom';
@@ -78,6 +78,8 @@ SendingStatus.propTypes = {
     }).isRequired,
   }).isRequired,
 };
+
+SendingStatus.displayName = 'SendingStatus';
 
 const compareProps = (prev, next) =>
   prev.location.pathname === next.location.pathname &&

--- a/mailpoet/assets/js/src/newsletters/templates.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates.jsx
@@ -10,6 +10,7 @@ import { Loading } from 'common/loading.jsx';
 import { MailPoet } from 'mailpoet';
 import { TemplateBox } from 'newsletters/templates/template_box.jsx';
 import { ImportTemplate } from 'newsletters/templates/import_template.jsx';
+import { ErrorBoundary } from '../common';
 
 const getEditorUrl = (id) =>
   `admin.php?page=mailpoet-newsletter-editor&id=${id}`;
@@ -346,13 +347,14 @@ class NewsletterTemplates extends Component {
         />
 
         <div className="mailpoet-templates">
-          <Categories
-            categories={categories}
-            active={this.state.selectedTab}
-            onSelect={(name) => this.setState({ selectedTab: name })}
-          />
-
-          {content}
+          <ErrorBoundary>
+            <Categories
+              categories={categories}
+              active={this.state.selectedTab}
+              onSelect={(name) => this.setState({ selectedTab: name })}
+            />
+          </ErrorBoundary>
+          <ErrorBoundary>{content}</ErrorBoundary>
         </div>
       </div>
     );

--- a/mailpoet/assets/js/src/newsletters/templates.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates.jsx
@@ -369,4 +369,6 @@ NewsletterTemplates.propTypes = {
   }).isRequired,
 };
 
+NewsletterTemplates.display = 'NewsletterTemplates';
+
 export { NewsletterTemplates };

--- a/mailpoet/assets/js/src/newsletters/templates/template_box.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates/template_box.jsx
@@ -160,5 +160,5 @@ TemplateBox.propTypes = {
 TemplateBox.defaultProps = {
   thumbnail: null,
 };
-
+TemplateBox.displayName = 'TemplateBox';
 export { TemplateBox };

--- a/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
@@ -104,6 +104,8 @@ NewsletterNotificationComponent.propTypes = {
   }).isRequired,
 };
 
+NewsletterNotificationComponent.displayName = 'NewsletterNotification';
+
 export const NewsletterNotification = withRouter(
   NewsletterNotificationComponent,
 );

--- a/mailpoet/assets/js/src/newsletters/types/re_engagement/re_engagement.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/re_engagement/re_engagement.tsx
@@ -97,3 +97,5 @@ export function NewsletterTypeReEngagement(): JSX.Element {
     </div>
   );
 }
+
+NewsletterTypeReEngagement.displayName = 'NewsletterTypeReEngagement';

--- a/mailpoet/assets/js/src/newsletters/types/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/standard.jsx
@@ -56,4 +56,6 @@ NewsletterStandardComponent.propTypes = {
   }).isRequired,
 };
 
+NewsletterStandardComponent.displayName = 'NewsletterStandard';
+
 export const NewsletterTypeStandard = withRouter(NewsletterStandardComponent);

--- a/mailpoet/assets/js/src/newsletters/types/welcome/scheduling.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/welcome/scheduling.jsx
@@ -160,5 +160,5 @@ WelcomeSchedulingComponent.propTypes = {
   }).isRequired,
   onValueChange: PropTypes.func.isRequired,
 };
-
+WelcomeSchedulingComponent.displayName = 'WelcomeScheduling';
 export const WelcomeScheduling = withRouter(WelcomeSchedulingComponent);

--- a/mailpoet/assets/js/src/newsletters/types/welcome/welcome.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/welcome/welcome.jsx
@@ -123,4 +123,6 @@ NewsletterWelcome.propTypes = {
   }).isRequired,
 };
 
+NewsletterWelcome.displayName = 'NewsletterWelcome';
+
 export { NewsletterWelcome };

--- a/mailpoet/assets/js/src/notices/email_volume_limit_notice.tsx
+++ b/mailpoet/assets/js/src/notices/email_volume_limit_notice.tsx
@@ -2,8 +2,9 @@ import ReactStringReplace from 'react-string-replace';
 import ReactHtmlParser from 'react-html-parser';
 import { MailPoet } from 'mailpoet';
 import { Notice } from 'notices/notice';
+import { withBoundary } from 'common';
 
-export function EmailVolumeLimitNotice(): JSX.Element {
+function EmailVolumeLimitNotice(): JSX.Element {
   if (!MailPoet.emailVolumeLimitReached) return null;
 
   const title = MailPoet.I18n.t('emailVolumeLimitNoticeTitle').replace(
@@ -72,3 +73,7 @@ export function EmailVolumeLimitNotice(): JSX.Element {
     </Notice>
   );
 }
+
+EmailVolumeLimitNotice.displayName = 'EmailVolumeLimitNotice';
+const EmailVolumeLimitNoticeWithBoundary = withBoundary(EmailVolumeLimitNotice);
+export { EmailVolumeLimitNoticeWithBoundary as EmailVolumeLimitNotice };

--- a/mailpoet/assets/js/src/notices/invalid_mss_key_notice.tsx
+++ b/mailpoet/assets/js/src/notices/invalid_mss_key_notice.tsx
@@ -7,10 +7,7 @@ type Props = {
   subscribersCount: number;
 };
 
-export function InvalidMssKeyNotice({
-  mssKeyInvalid,
-  subscribersCount,
-}: Props) {
+function InvalidMssKeyNotice({ mssKeyInvalid, subscribersCount }: Props) {
   if (!mssKeyInvalid) return null;
   return (
     <Notice type="error" timeout={false} closable={false} renderInPlace>
@@ -39,3 +36,6 @@ export function InvalidMssKeyNotice({
     </Notice>
   );
 }
+
+InvalidMssKeyNotice.displayName = 'InvalidMssKeyNotice';
+export { InvalidMssKeyNotice };

--- a/mailpoet/assets/js/src/notices/notice.tsx
+++ b/mailpoet/assets/js/src/notices/notice.tsx
@@ -1,13 +1,14 @@
 import {
-  useState,
-  useRef,
+  ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
-  ReactNode,
+  useRef,
+  useState,
 } from 'react';
 import ReactDOM from 'react-dom';
 import { MailPoet } from 'mailpoet';
+import { withBoundary } from 'common';
 
 type Props = {
   type: 'success' | 'info' | 'warning' | 'error';
@@ -86,6 +87,7 @@ function Notice({
     document.getElementById('mailpoet_notices'),
   );
 }
+
 Notice.defaultProps = {
   timeout: 10000,
   scroll: false,
@@ -94,5 +96,6 @@ Notice.defaultProps = {
   onDisplay: undefined,
   onClose: undefined,
 };
-
-export { Notice };
+Notice.displayName = 'Notice';
+const NoticeWithBoundary = withBoundary(Notice);
+export { NoticeWithBoundary as Notice };

--- a/mailpoet/assets/js/src/notices/notices.jsx
+++ b/mailpoet/assets/js/src/notices/notices.jsx
@@ -2,9 +2,13 @@ import { useContext } from 'react';
 import { GlobalContext } from 'context/index.jsx';
 import { Notice } from './notice.tsx';
 
-export const Notices = () => {
+const Notices = () => {
   const { notices } = useContext(GlobalContext);
   return notices.items.map(({ id, ...props }) => (
     <Notice key={id} {...props} />
   ));
 };
+
+Notices.displayName = 'Notices';
+
+export { Notices };

--- a/mailpoet/assets/js/src/notices/notices.jsx
+++ b/mailpoet/assets/js/src/notices/notices.jsx
@@ -1,14 +1,15 @@
 import { useContext } from 'react';
 import { GlobalContext } from 'context/index.jsx';
+import { withBoundary } from 'common';
 import { Notice } from './notice.tsx';
 
-const Notices = () => {
+const NoticesComponent = () => {
   const { notices } = useContext(GlobalContext);
   return notices.items.map(({ id, ...props }) => (
     <Notice key={id} {...props} />
   ));
 };
 
-Notices.displayName = 'Notices';
-
+NoticesComponent.displayName = 'Notices';
+const Notices = withBoundary(NoticesComponent);
 export { Notices };

--- a/mailpoet/assets/js/src/notices/subscribers_limit_notice.jsx
+++ b/mailpoet/assets/js/src/notices/subscribers_limit_notice.jsx
@@ -2,7 +2,7 @@ import ReactStringReplace from 'react-string-replace';
 import { MailPoet } from 'mailpoet';
 import { Notice } from 'notices/notice.tsx';
 
-export function SubscribersLimitNotice() {
+function SubscribersLimitNotice() {
   if (!MailPoet.subscribersLimitReached) return null;
   const hasValidApiKey = MailPoet.hasValidApiKey;
   const title = MailPoet.I18n.t('subscribersLimitNoticeTitle').replace(
@@ -73,3 +73,6 @@ export function SubscribersLimitNotice() {
     </Notice>
   );
 }
+
+SubscribersLimitNotice.displayName = 'SubscribersLimitNotice';
+export { SubscribersLimitNotice };

--- a/mailpoet/assets/js/src/notices/transactional_emails_propose_opt_in_notice.tsx
+++ b/mailpoet/assets/js/src/notices/transactional_emails_propose_opt_in_notice.tsx
@@ -10,7 +10,7 @@ type Props = {
   apiVersion: string;
 };
 
-export function TransactionalEmailsProposeOptInNotice({
+function TransactionalEmailsProposeOptInNotice({
   mailpoetInstalledDaysAgo,
   sendTransactionalEmails,
   mtaMethod,
@@ -68,3 +68,7 @@ export function TransactionalEmailsProposeOptInNotice({
     </Notice>
   );
 }
+
+TransactionalEmailsProposeOptInNotice.displayName =
+  'TransactionalEmailsProposeOptInNotice';
+export { TransactionalEmailsProposeOptInNotice };

--- a/mailpoet/assets/js/src/segments/dynamic/editor.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/editor.tsx
@@ -40,3 +40,4 @@ export function Editor(): JSX.Element {
     </>
   );
 }
+Editor.displayName = 'SegmentEditor';

--- a/mailpoet/assets/js/src/segments/dynamic/list.jsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.jsx
@@ -225,4 +225,6 @@ DynamicSegmentListComponent.propTypes = {
   }).isRequired,
 };
 
+DynamicSegmentListComponent.displayName = 'DynamicSegmentList';
+
 export const DynamicSegmentList = withRouter(DynamicSegmentListComponent);

--- a/mailpoet/assets/js/src/segments/form.jsx
+++ b/mailpoet/assets/js/src/segments/form.jsx
@@ -78,4 +78,6 @@ SegmentForm.propTypes = {
   }).isRequired,
 };
 
+SegmentForm.displayName = 'SegmentForm';
+
 export { SegmentForm };

--- a/mailpoet/assets/js/src/segments/list.jsx
+++ b/mailpoet/assets/js/src/segments/list.jsx
@@ -374,4 +374,6 @@ SegmentListComponent.propTypes = {
   }).isRequired,
 };
 
+SegmentListComponent.displayName = 'SegmentList';
+
 export const SegmentList = withRouter(SegmentListComponent);

--- a/mailpoet/assets/js/src/segments/segments.jsx
+++ b/mailpoet/assets/js/src/segments/segments.jsx
@@ -8,6 +8,7 @@ import { SegmentList } from 'segments/list.jsx';
 import { SegmentForm } from 'segments/form.jsx';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
+import { withBoundary } from 'common';
 import { Editor } from './dynamic/editor';
 import { DynamicSegmentList } from './dynamic/list.jsx';
 import { ListHeading } from './heading';
@@ -39,6 +40,8 @@ function Tabs() {
   );
 }
 
+Tabs.displayName = 'SegmentTabs';
+
 function App() {
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
@@ -46,12 +49,12 @@ function App() {
         <Notices />
         <Switch>
           <Route exact path="/" render={() => <Redirect to="/lists" />} />
-          <Route path="/new" component={SegmentForm} />
-          <Route path="/edit/:id" component={SegmentForm} />
-          <Route path="/new-segment" component={Editor} />
-          <Route path="/edit-segment/:id" component={Editor} />
-          <Route path="/segments/(.*)?" component={Tabs} />
-          <Route path="/lists/(.*)?" component={Tabs} />
+          <Route path="/new" render={withBoundary(SegmentForm)} />
+          <Route path="/edit/:id" render={withBoundary(SegmentForm)} />
+          <Route path="/new-segment" render={withBoundary(Editor)} />
+          <Route path="/edit-segment/:id" render={withBoundary(Editor)} />
+          <Route path="/segments/(.*)?" render={withBoundary(Tabs)} />
+          <Route path="/lists/(.*)?" render={withBoundary(Tabs)} />
         </Switch>
       </HashRouter>
     </GlobalContext.Provider>

--- a/mailpoet/assets/js/src/subscribers/form.jsx
+++ b/mailpoet/assets/js/src/subscribers/form.jsx
@@ -276,4 +276,6 @@ SubscriberForm.propTypes = {
   }).isRequired,
 };
 
+SubscriberForm.displayName = 'SubscriberForm';
+
 export { SubscriberForm };

--- a/mailpoet/assets/js/src/subscribers/importExport/import.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import.jsx
@@ -5,6 +5,7 @@ import { ScrollToTop } from 'common/scroll_to_top.jsx';
 
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
+import { withBoundary } from 'common';
 import { StepMethodSelection } from './import/step_method_selection.jsx';
 import { StepInputValidation } from './import/step_input_validation.jsx';
 import { StepDataManipulation } from './import/step_data_manipulation.jsx';
@@ -28,7 +29,7 @@ function ImportSubscribers() {
           <Switch>
             <Route
               path="/step_clean_list"
-              render={(props) => <StepCleanList {...props} />}
+              render={withBoundary(StepCleanList)}
             />
             <Route
               path="/step_method_selection"

--- a/mailpoet/assets/js/src/subscribers/importExport/import/clean_list.tsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/clean_list.tsx
@@ -5,7 +5,7 @@ type Props = {
   onProceed?: () => void;
 };
 
-export function CleanList({ onProceed }: Props): JSX.Element {
+function CleanList({ onProceed }: Props): JSX.Element {
   return (
     <div className="mailpoet-clean-list-step-container">
       <p>{MailPoet.I18n.t('cleanListText1')}</p>
@@ -26,3 +26,6 @@ export function CleanList({ onProceed }: Props): JSX.Element {
     </div>
   );
 }
+
+CleanList.displayName = 'CleanList';
+export { CleanList };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/previous_next_step_buttons.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/previous_next_step_buttons.jsx
@@ -47,5 +47,5 @@ PreviousNextStepButtons.defaultProps = {
   onPreviousAction: () => {},
   onNextAction: () => {},
 };
-
+PreviousNextStepButtons.displayName = 'PreviousNextStepButtons';
 export { PreviousNextStepButtons };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_clean_list.tsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_clean_list.tsx
@@ -1,8 +1,11 @@
 import { RouteComponentProps } from 'react-router-dom';
 import { CleanList } from './clean_list';
 
-export function StepCleanList({ history }: RouteComponentProps): JSX.Element {
+function StepCleanList({ history }: RouteComponentProps): JSX.Element {
   return (
     <CleanList onProceed={(): void => history.push('step_method_selection')} />
   );
 }
+
+StepCleanList.displayName = 'StepCleanList';
+export { StepCleanList };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_input_validation.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_input_validation.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import { CleanList } from 'subscribers/importExport/import/clean_list';
+import { ErrorBoundary } from 'common';
 import { InitialQuestion } from './step_input_validation/initial_question.jsx';
 import { WrongSourceBlock } from './step_input_validation/wrong_source_block.jsx';
 import { LastSentQuestion } from './step_input_validation/last_sent_question.jsx';
@@ -30,17 +31,23 @@ function StepInputValidationComponent({ stepMethodSelectionData, history }) {
   return (
     <>
       {importSource === undefined && (
-        <InitialQuestion onSubmit={setImportSource} history={history} />
+        <ErrorBoundary>
+          <InitialQuestion onSubmit={setImportSource} history={history} />
+        </ErrorBoundary>
       )}
 
       {importSource === 'address-book' && <WrongSourceBlock />}
 
       {importSource === 'existing-list' && lastSent === undefined && (
-        <LastSentQuestion onSubmit={lastSentSubmit} />
+        <ErrorBoundary>
+          <LastSentQuestion onSubmit={lastSentSubmit} />
+        </ErrorBoundary>
       )}
 
       {importSource === 'existing-list' && lastSent === 'notRecently' && (
-        <CleanList />
+        <ErrorBoundary>
+          <CleanList />
+        </ErrorBoundary>
       )}
     </>
   );

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_input_validation/initial_question.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_input_validation/initial_question.jsx
@@ -57,5 +57,5 @@ InitialQuestion.propTypes = {
   }).isRequired,
   onSubmit: PropTypes.func.isRequired,
 };
-
+InitialQuestion.displayName = 'InitialQuestion';
 export { InitialQuestion };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_input_validation/last_sent_question.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_input_validation/last_sent_question.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common/button/button';
@@ -63,5 +63,5 @@ function LastSentQuestion({ onSubmit }) {
 LastSentQuestion.propTypes = {
   onSubmit: PropTypes.func.isRequired,
 };
-
+LastSentQuestion.displayName = 'LastSentQuestion';
 export { LastSentQuestion };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { MailPoet } from 'mailpoet';
+import { ErrorBoundary } from 'common';
 import { SelectImportMethod } from './step_method_selection/select_import_method.jsx';
 import { MethodPaste } from './step_method_selection/method_paste.jsx';
 import { MethodUpload } from './step_method_selection/method_upload.jsx';
@@ -57,41 +58,51 @@ function StepMethodSelectionComponent({
 
   return (
     <div className="mailpoet-settings-grid">
-      <SelectImportMethod activeMethod={method} onMethodChange={setMethod} />
+      <ErrorBoundary>
+        <SelectImportMethod activeMethod={method} onMethodChange={setMethod} />
+      </ErrorBoundary>
       {method === 'paste-method' && (
-        <MethodPaste
-          onPrevious={previousStep}
-          onValueChange={setPastedCsvData}
-          onFinish={processLocal}
-          canFinish={!!pastedCsvData.trim()}
-          data={pastedCsvData}
-        />
+        <ErrorBoundary>
+          <MethodPaste
+            onPrevious={previousStep}
+            onValueChange={setPastedCsvData}
+            onFinish={processLocal}
+            canFinish={!!pastedCsvData.trim()}
+            data={pastedCsvData}
+          />
+        </ErrorBoundary>
       )}
       {method === 'file-method' && (
-        <MethodUpload
-          onPrevious={previousStep}
-          onValueChange={setFile}
-          onFinish={processLocal}
-          canFinish={!!file}
-          data={file}
-        />
+        <ErrorBoundary>
+          <MethodUpload
+            onPrevious={previousStep}
+            onValueChange={setFile}
+            onFinish={processLocal}
+            canFinish={!!file}
+            data={file}
+          />
+        </ErrorBoundary>
       )}
       {method === 'mailchimp-method' && (
-        <MethodMailChimp
-          onPrevious={previousStep}
-          onFinish={(data) => {
-            MailPoet.trackEvent('Subscribers import started', {
-              source: 'MailChimp',
-            });
-            finish(data);
-          }}
-        />
+        <ErrorBoundary>
+          <MethodMailChimp
+            onPrevious={previousStep}
+            onFinish={(data) => {
+              MailPoet.trackEvent('Subscribers import started', {
+                source: 'MailChimp',
+              });
+              finish(data);
+            }}
+          />
+        </ErrorBoundary>
       )}
       {method === undefined && (
-        <PreviousNextStepButtons
-          canGoNext={false}
-          onPreviousAction={previousStep}
-        />
+        <ErrorBoundary>
+          <PreviousNextStepButtons
+            canGoNext={false}
+            onPreviousAction={previousStep}
+          />
+        </ErrorBoundary>
       )}
     </div>
   );
@@ -104,5 +115,5 @@ StepMethodSelectionComponent.propTypes = {
   setStepMethodSelectionData: PropTypes.func.isRequired,
   subscribersLimitForValidation: PropTypes.number.isRequired,
 };
-
+StepMethodSelectionComponent.diplayName = 'StepMethodSelection';
 export const StepMethodSelection = withRouter(StepMethodSelectionComponent);

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/method_mailchimp.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/method_mailchimp.jsx
@@ -160,4 +160,6 @@ MethodMailChimp.defaultProps = {
   onPrevious: () => {},
 };
 
+MethodMailChimp.displayName = 'MethodMailChimp';
+
 export { MethodMailChimp };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/method_paste.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/method_paste.jsx
@@ -70,5 +70,5 @@ MethodPaste.defaultProps = {
   onPrevious: () => {},
   data: '',
 };
-
+MethodPaste.displayName = 'MethodPaste';
 export { MethodPaste };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/method_upload.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/method_upload.jsx
@@ -71,5 +71,5 @@ MethodUpload.defaultProps = {
   onFinish: () => {},
   onPrevious: () => {},
 };
-
+MethodUpload.displayName = 'MethodUpload';
 export { MethodUpload };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/select_import_method.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_method_selection/select_import_method.jsx
@@ -78,5 +78,5 @@ SelectImportMethod.propTypes = {
 SelectImportMethod.defaultProps = {
   activeMethod: undefined,
 };
-
+SelectImportMethod.displayName = 'SelectImportMethod';
 export { SelectImportMethod };

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_results.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_results.jsx
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router-dom';
 import ReactStringReplace from 'react-string-replace';
 
 import { Button } from 'common/button/button';
+import { ErrorBoundary } from 'common';
 
 function ResultMessage({ subscribersCount, segments, initialMessage }) {
   if (subscribersCount) {
@@ -33,6 +34,7 @@ ResultMessage.defaultProps = {
   subscribersCount: 0,
   initialMessage: '',
 };
+ResultMessage.displayName = 'ResultMessage';
 
 function NoAction({ createdSubscribers, updatedSubscribers }) {
   if (!createdSubscribers && !updatedSubscribers) {
@@ -50,6 +52,7 @@ NoAction.defaultProps = {
   createdSubscribers: 0,
   updatedSubscribers: 0,
 };
+NoAction.displayName = 'NoAction';
 
 function SuppressionListReminder({ createdSubscribers, updatedSubscribers }) {
   if (createdSubscribers || updatedSubscribers) {
@@ -91,6 +94,7 @@ SuppressionListReminder.defaultProps = {
   createdSubscribers: 0,
   updatedSubscribers: 0,
 };
+SuppressionListReminder.displayName = 'SuppressionListReminder';
 
 function NoWelcomeEmail({ addedToSegmentWithWelcomeNotification }) {
   if (addedToSegmentWithWelcomeNotification) {
@@ -106,6 +110,7 @@ NoWelcomeEmail.propTypes = {
 NoWelcomeEmail.defaultProps = {
   addedToSegmentWithWelcomeNotification: false,
 };
+NoWelcomeEmail.diplayName = 'NoWelcomeEmail';
 
 function StepResultsComponent({
   errors,
@@ -136,31 +141,35 @@ function StepResultsComponent({
   }
   return (
     <>
-      <div className="updated">
-        <ResultMessage
-          subscribersCount={createdSubscribers}
-          segments={segments}
-          initialMessage={MailPoet.I18n.t('subscribersCreated')}
-        />
-        <ResultMessage
-          subscribersCount={updatedSubscribers}
-          segments={segments}
-          initialMessage={MailPoet.I18n.t('subscribersUpdated')}
-        />
-        <NoAction
+      <ErrorBoundary>
+        <div className="updated">
+          <ResultMessage
+            subscribersCount={createdSubscribers}
+            segments={segments}
+            initialMessage={MailPoet.I18n.t('subscribersCreated')}
+          />
+          <ResultMessage
+            subscribersCount={updatedSubscribers}
+            segments={segments}
+            initialMessage={MailPoet.I18n.t('subscribersUpdated')}
+          />
+          <NoAction
+            createdSubscribers={createdSubscribers}
+            updatedSubscribers={updatedSubscribers}
+          />
+          <NoWelcomeEmail
+            addedToSegmentWithWelcomeNotification={
+              addedToSegmentWithWelcomeNotification
+            }
+          />
+        </div>
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <SuppressionListReminder
           createdSubscribers={createdSubscribers}
           updatedSubscribers={updatedSubscribers}
         />
-        <NoWelcomeEmail
-          addedToSegmentWithWelcomeNotification={
-            addedToSegmentWithWelcomeNotification
-          }
-        />
-      </div>
-      <SuppressionListReminder
-        createdSubscribers={createdSubscribers}
-        updatedSubscribers={updatedSubscribers}
-      />
+      </ErrorBoundary>
       <div className="mailpoet-settings-grid">
         <div className="mailpoet-settings-save">
           <Button
@@ -203,5 +212,5 @@ StepResultsComponent.defaultProps = {
   updatedSubscribers: undefined,
   addedToSegmentWithWelcomeNotification: undefined,
 };
-
+StepResultsComponent.displayName = 'StepResultsComponent';
 export const StepResults = withRouter(StepResultsComponent);

--- a/mailpoet/assets/js/src/subscribers/list.jsx
+++ b/mailpoet/assets/js/src/subscribers/list.jsx
@@ -522,4 +522,5 @@ SubscriberList.propTypes = {
   }).isRequired,
 };
 
+SubscriberList.displayName = 'SubscriberList';
 export { SubscriberList };

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -99,3 +99,5 @@ export function SubscriberStats(): JSX.Element {
     </div>
   );
 }
+
+SubscriberStats.displayName = 'SubscriberStats';

--- a/mailpoet/assets/js/src/subscribers/subscribers.jsx
+++ b/mailpoet/assets/js/src/subscribers/subscribers.jsx
@@ -1,11 +1,12 @@
 import ReactDOM from 'react-dom';
-import { HashRouter, Switch, Route } from 'react-router-dom';
+import { HashRouter, Route, Switch } from 'react-router-dom';
 
 import { SubscriberList } from 'subscribers/list.jsx';
 import { SubscriberForm } from 'subscribers/form.jsx';
 import { SubscriberStats } from 'subscribers/stats';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
+import { withBoundary } from 'common';
 
 function App() {
   return (
@@ -13,10 +14,13 @@ function App() {
       <HashRouter>
         <Notices />
         <Switch>
-          <Route path="/new" component={SubscriberForm} />
-          <Route path="/edit/:id" component={SubscriberForm} />
-          <Route path="/stats/:id/(.*)?" component={SubscriberStats} />
-          <Route path="*" component={SubscriberList} />
+          <Route path="/new" render={withBoundary(SubscriberForm)} />
+          <Route path="/edit/:id" render={withBoundary(SubscriberForm)} />
+          <Route
+            path="/stats/:id/(.*)?"
+            component={withBoundary(SubscriberStats)}
+          />
+          <Route path="*" component={withBoundary(SubscriberList)} />
         </Switch>
       </HashRouter>
     </GlobalContext.Provider>

--- a/mailpoet/assets/js/src/wizard/steps/pitch_mss_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch_mss_step.jsx
@@ -111,6 +111,7 @@ function FreePlanSubscribers(props) {
 FreePlanSubscribers.propTypes = {
   next: PropTypes.func.isRequired,
 };
+FreePlanSubscribers.displayName = 'FreePlanSubscribers';
 
 function NotFreePlanSubscribers(props) {
   return (
@@ -136,6 +137,7 @@ NotFreePlanSubscribers.propTypes = {
   mailpoetAccountUrl: PropTypes.string.isRequired,
   next: PropTypes.func.isRequired,
 };
+NotFreePlanSubscribers.displayName = 'NotFreePlanSubscribers';
 
 function WelcomeWizardPitchMSSStep(props) {
   return props.subscribersCount < 1000 ? (

--- a/mailpoet/assets/js/src/wizard/steps/sender_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/sender_step.jsx
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import { MailPoet } from 'mailpoet';
 import jQuery from 'jquery';
-import { Button } from '../../common/button/button';
 import { Grid } from '../../common/grid';
 import { Heading } from '../../common/typography/heading/heading';
-import { Input } from '../../common/form/input/input';
+import { Button, Input } from '../../common';
 
 function WelcomeWizardSenderStep(props) {
   return (
@@ -94,5 +93,7 @@ WelcomeWizardSenderStep.propTypes = {
 WelcomeWizardSenderStep.defaultProps = {
   sender: null,
 };
+
+WelcomeWizardSenderStep.displayName = 'WelcomeWizardSenderStep';
 
 export { WelcomeWizardSenderStep };

--- a/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
@@ -154,5 +154,6 @@ WelcomeWizardUsageTrackingStep.propTypes = {
   loading: PropTypes.bool.isRequired,
   submitForm: PropTypes.func.isRequired,
 };
+WelcomeWizardUsageTrackingStep.displayName = 'WelcomeWizardUsageTrackingStep';
 
 export { WelcomeWizardUsageTrackingStep };

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
@@ -18,6 +18,7 @@ import {
 import { Steps } from '../common/steps/steps';
 import { StepsContent } from '../common/steps/steps_content';
 import { TopBar } from '../common/top_bar/top_bar';
+import { ErrorBoundary } from '../common';
 
 function WelcomeWizardStepsController(props) {
   const stepsCount = getStepsCount();
@@ -110,13 +111,15 @@ function WelcomeWizardStepsController(props) {
           <WelcomeWizardStepLayout
             illustrationUrl={window.wizard_sender_illustration_url}
           >
-            <WelcomeWizardSenderStep
-              update_sender={updateSender}
-              submit_sender={submitSender}
-              finish={skipSenderStep}
-              loading={loading}
-              sender={sender}
-            />
+            <ErrorBoundary>
+              <WelcomeWizardSenderStep
+                update_sender={updateSender}
+                submit_sender={submitSender}
+                finish={skipSenderStep}
+                loading={loading}
+                sender={sender}
+              />
+            </ErrorBoundary>
           </WelcomeWizardStepLayout>
         ) : null}
 
@@ -124,10 +127,12 @@ function WelcomeWizardStepsController(props) {
           <WelcomeWizardStepLayout
             illustrationUrl={window.wizard_tracking_illustration_url}
           >
-            <WelcomeWizardUsageTrackingStep
-              loading={loading}
-              submitForm={submitTracking}
-            />
+            <ErrorBoundary>
+              <WelcomeWizardUsageTrackingStep
+                loading={loading}
+                submitForm={submitTracking}
+              />
+            </ErrorBoundary>
           </WelcomeWizardStepLayout>
         ) : null}
 
@@ -135,25 +140,29 @@ function WelcomeWizardStepsController(props) {
           <WelcomeWizardStepLayout
             illustrationUrl={window.wizard_MSS_pitch_illustration_url}
           >
-            <WelcomeWizardPitchMSSStep
-              next={() => redirect(step)}
-              subscribersCount={window.mailpoet_subscribers_count}
-              mailpoetAccountUrl={window.mailpoet_account_url}
-              purchaseUrl={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
-                MailPoet.subscribersCount,
-                MailPoet.currentWpUserEmail,
-                'business',
-                { utm_medium: 'onboarding', utm_campaign: 'purchase' },
-              )}
-            />
+            <ErrorBoundary>
+              <WelcomeWizardPitchMSSStep
+                next={() => redirect(step)}
+                subscribersCount={window.mailpoet_subscribers_count}
+                mailpoetAccountUrl={window.mailpoet_account_url}
+                purchaseUrl={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
+                  MailPoet.subscribersCount,
+                  MailPoet.currentWpUserEmail,
+                  'business',
+                  { utm_medium: 'onboarding', utm_campaign: 'purchase' },
+                )}
+              />
+            </ErrorBoundary>
           </WelcomeWizardStepLayout>
         ) : null}
 
         {stepName === 'WizardWooCommerceStep' ? (
-          <WooCommerceController
-            isWizardStep
-            redirectToNextStep={() => redirect(step)}
-          />
+          <ErrorBoundary>
+            <WooCommerceController
+              isWizardStep
+              redirectToNextStep={() => redirect(step)}
+            />
+          </ErrorBoundary>
         ) : null}
       </StepsContent>
     </>
@@ -170,5 +179,5 @@ WelcomeWizardStepsController.propTypes = {
     push: PropTypes.func.isRequired,
   }).isRequired,
 };
-
+WelcomeWizardStepsController.displayName = 'WelcomeWizardStepsController';
 export { WelcomeWizardStepsController };

--- a/mailpoet/assets/js/src/wizard/wizard.jsx
+++ b/mailpoet/assets/js/src/wizard/wizard.jsx
@@ -1,9 +1,10 @@
 import ReactDOM from 'react-dom';
-import { Route, HashRouter, Redirect, Switch } from 'react-router-dom';
+import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
 import { WelcomeWizardStepsController } from './welcome_wizard_controller.jsx';
 import { WooCommerceController } from './woocommerce_controller';
+import { withBoundary } from '../common';
 
 function App() {
   let basePath = '/steps/1';
@@ -16,8 +17,14 @@ function App() {
       <HashRouter>
         <Notices />
         <Switch>
-          <Route path="/steps/:step" component={WelcomeWizardStepsController} />
-          <Route path="/woocommerce" component={WooCommerceController} />
+          <Route
+            path="/steps/:step"
+            render={withBoundary(WelcomeWizardStepsController)}
+          />
+          <Route
+            path="/woocommerce"
+            render={withBoundary(WooCommerceController)}
+          />
           <Route render={() => <Redirect to={basePath} />} />
         </Switch>
       </HashRouter>

--- a/mailpoet/assets/js/src/wizard/woocommerce_controller.tsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce_controller.tsx
@@ -3,6 +3,7 @@ import { MailPoet } from 'mailpoet';
 import { StepsContent } from 'common/steps/steps_content';
 import { WizardWooCommerceStep } from './steps/woocommerce_step';
 import { WelcomeWizardStepLayout } from './layout/step_layout.jsx';
+import { ErrorBoundary } from '../common';
 
 type WooCommerceControllerPropType = {
   isWizardStep: boolean;
@@ -68,12 +69,14 @@ function WooCommerceController({
     <WelcomeWizardStepLayout
       illustrationUrl={window.wizard_woocommerce_illustration_url}
     >
-      <WizardWooCommerceStep
-        loading={loading}
-        submitForm={submit}
-        isWizardStep={isWizardStep}
-        showCustomersImportSetting={window.mailpoet_show_customers_import}
-      />
+      <ErrorBoundary>
+        <WizardWooCommerceStep
+          loading={loading}
+          submitForm={submit}
+          isWizardStep={isWizardStep}
+          showCustomersImportSetting={window.mailpoet_show_customers_import}
+        />
+      </ErrorBoundary>
     </WelcomeWizardStepLayout>
   );
 
@@ -84,4 +87,5 @@ function WooCommerceController({
   return result;
 }
 
+WooCommerceController.displayName = 'WooCommerceController';
 export { WooCommerceController };


### PR DESCRIPTION
## Description

This PR introduces `ErrorBoundary` components and adds it to the following applications/modules:

-  subscribers/subscribers.jsx
-  newsletters/newsletters.jsx
-  newsletters_editor/initialize.jsx 
- segments/segments.jsx
- forms/forms.jsx
- form_editor/form_editor.jsx
- help/help.jsx
- subscribers/importExport/import.js
- subscribers/importExport/export.ts
- wizard/wizard.jsx
- experimental_features/experimental_features.jsx
- logs/logs
- automation/automation.tsx (very minimal, mostly left to MAILPOET-4907)

## Code review notes

The idea behind where to add and where not to add is as follows:
- The boundary is added to components that have a bit more complexity and are bug prone in case data or inputs are malformed
- For the components with multiple usages, using `withBoundary` in the definition source is favored.
- In most cases a custom `displayName` is added to components so to be able to customize the displayed name and make it easier to find the throwing component [despite React internally trying to infer it](https://reactjs.org/docs/react-component.html#displayname).

## QA notes

A casual walk-through should suffice, given the tests pass.


## Linked tickets

[MAILPOET-4706]


[MAILPOET-4706]: https://mailpoet.atlassian.net/browse/MAILPOET-4706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ