### PR TITLE
Create acceptance test containers upfront with one retry [MAILPOET-4851]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,12 @@ jobs:
             fi
             cat tests/acceptance/_groups/circleci_split_group
       - run:
+          name: Create docker containers for test
+          # We experienced some failures when creating containers so we do it explicitly with one retry
+          command: |
+            cd tests/docker
+            docker-compose create || docker-compose create
+      - run:
           name: Run acceptance tests
           command: |
             mkdir -m 777 -p tests/_output/exceptions


### PR DESCRIPTION
## Description

This is another attempt to fix the random issue with
Error response from daemon: Conflict. The container name "/wordpress_X" is already in use 

I've separated `docker-compose run` and failing `docker-compose create` and added one retry for the create command.
I tried to rerun the flow many times, but I had no luck replicating the issue, so I was not able to verify that the retry will solve the issue. It is also possible that the issue is gone because of the split. So I decided to move forward with this attempt and we will see what happens when we merge this into trunk.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4851]

## After-merge notes

_N/A_


[MAILPOET-4851]: https://mailpoet.atlassian.net/browse/MAILPOET-4851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ