### PR TITLE
Add default value for method to StatisticsUnsubscribeEntity [PREMIUM-211]

### DIFF
--- a/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
+++ b/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
@@ -24,6 +24,7 @@ class StatisticsUnsubscribeEntity {
 
   const METHOD_LINK = 'link';
   const METHOD_ONE_CLICK = 'one_click';
+  const METHOD_UNKNOWN = 'unknown';
 
   /**
    * @ORM\ManyToOne(targetEntity="MailPoet\Entities\NewsletterEntity")
@@ -62,7 +63,7 @@ class StatisticsUnsubscribeEntity {
    * @ORM\Column(type="string", nullable=false)
    * @var string
    */
-  private $method;
+  private $method = self::METHOD_UNKNOWN;
 
   public function __construct(
     NewsletterEntity $newsletter = null,
@@ -121,7 +122,7 @@ class StatisticsUnsubscribeEntity {
   public function setMethod(string $method) {
     $this->method = $method;
   }
-  
+
   public function getMethod(): string {
     return $this->method;
   }

--- a/mailpoet/lib/Statistics/Track/Unsubscribes.php
+++ b/mailpoet/lib/Statistics/Track/Unsubscribes.php
@@ -37,7 +37,7 @@ class Unsubscribes {
     string $source,
     int $queueId = null,
     string $meta = null,
-    string $method = 'unknown'
+    string $method = StatisticsUnsubscribeEntity::METHOD_UNKNOWN
   ) {
     $queue = null;
     $statistics = null;


### PR DESCRIPTION
## Description
When the entity is created, the default value is not set, and it may cause failures when it is not set additionally.
It caused [the premium builds are failing](https://github.com/mailpoet/mailpoet/compare/trunk...fix-unsubscribe-default-method).
This PR fixes it by setting the default value and also defines a constant for the default value. 

## Code review notes

Here is a premium build that ran on the branch with the same name. [You can see the previously failing `MailPoet\Premium\Test\API\JSON\v1\StatsTest::testItCanGetStatsForANewsletter` test is not passing](https://app.circleci.com/pipelines/github/mailpoet/mailpoet-premium/1968/workflows/b9f691ed-791a-42e8-8f44-2ff7f46f4d7d).

## QA notes
I think that [verification by automated acceptance tests for unsubscribe links should be enough](https://github.com/mailpoet/mailpoet/blob/f178ea5f7abfe83efdc24b39f6c993bb50fcddab/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php#L77-L117).

## Linked PRs

_N/A_

## Linked tickets

[PREMIUM-211]

## After-merge notes

_N/A_


[PREMIUM-211]: https://mailpoet.atlassian.net/browse/PREMIUM-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ