### PR TITLE
Run acceptance and integration tests with 8.2.0RC6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,6 +635,8 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_tests_base_and_woo_cot_off
+          codeception_image_version: 8.2RC6-cli_20221128.1
+          wordpress_image_version: wp-6.1_php8.2.0RC6_20221221.0
           requires:
             - unit_tests
             - static_analysis_php8
@@ -646,6 +648,8 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 1
+          codeception_image_version: 8.2RC6-cli_20221128.1
+          wordpress_image_version: wp-6.1_php8.2.0RC6_20221221.0
           requires:
             - unit_tests
             - static_analysis_php8
@@ -657,6 +661,8 @@ workflows:
           group: woo
           enable_cot: 1
           enable_cot_sync: 0
+          codeception_image_version: 8.2RC6-cli_20221128.1
+          wordpress_image_version: wp-6.1_php8.2.0RC6_20221221.0
           requires:
             - unit_tests
             - static_analysis_php8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,6 +672,7 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 1
           name: integration_test_woo_cot_sync
+          codeception_image_version: 8.2RC6-cli_20221128.1
           requires:
             - unit_tests
             - static_analysis_php8
@@ -683,6 +684,7 @@ workflows:
           enable_cot: 1
           enable_cot_sync: 0
           name: integration_test_woo_cot_no_sync
+          codeception_image_version: 8.2RC6-cli_20221128.1
           requires:
             - unit_tests
             - static_analysis_php8
@@ -692,6 +694,7 @@ workflows:
           <<: *slack-fail-post-step
           group: woo
           name: integration_test_woo_cot_off
+          codeception_image_version: 8.2RC6-cli_20221128.1
           requires:
             - unit_tests
             - static_analysis_php8
@@ -702,6 +705,7 @@ workflows:
           skip_group: woo
           skip_plugins: 1
           name: integration_test_base
+          codeception_image_version: 8.2RC6-cli_20221128.1
           requires:
             - unit_tests
             - static_analysis_php8

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       PHP_IDE_CONFIG: 'serverName=MailPoetTest'
 
   codeception_integration:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2RC6-cli_20221128.1}
     depends_on:
       - smtp
       - wordpress

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   codeception_acceptance:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2RC6-cli_20221128.1}
     depends_on:
       - smtp
       - wordpress
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.1_php8.0_20201122.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.1_php8.2.0RC6_20221221.0}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
## Description

This PR is to help test the upcoming version of PHP and is not planned to be merged into trunk. We will do that once the final version of PHP 8.2.0 is released.

It changes the version of PHP used for the integration and acceptance tests both on the local dev environments and on CircleCI. For the integration tests, we only need to change the PHP version used in the `codeception_integration` Docker service (Docker image `mailpoet/wordpress:8.2RC6-cli_20221128.1`). For the acceptance tests, we need to change the `codeception_acceptance` and `wordpress` services (Docker images `mailpoet/wordpress:8.2RC6-cli_20221128.1` and `mailpoet/wordpress:wp-6.1_php8.2.0RC6_20221221.0` respectively).

See https://github.com/mailpoet/wordpress-images/pull/40 for the PR with the Dockerfiles of the new images.

[MAILPOET-4619]

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_


[MAILPOET-4619]: https://mailpoet.atlassian.net/browse/MAILPOET-4619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ