### PR TITLE
Simplify <Tags> component and add wrapper components [MAILPOET-4628]

### DIFF
--- a/mailpoet/assets/js/src/common/tag/_stories/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/_stories/tags.tsx
@@ -1,5 +1,5 @@
 import { Heading } from 'common/typography/heading/heading';
-import { Tags } from '../tags';
+import { SegmentTags, StringTags } from '../tags';
 
 export default {
   title: 'Tags',
@@ -18,15 +18,20 @@ export function Segments() {
     <>
       <Heading level={1}>Tags</Heading>
       <Heading level={2}>Segments</Heading>
-      <Tags segments={segments} dimension="large" />
+      <SegmentTags segments={segments} dimension="large" />
       <div className="mailpoet-gap" />
-      <Tags segments={segments}>
+      <SegmentTags segments={segments}>
         <span>Prefix: </span>
-      </Tags>
+      </SegmentTags>
       <Heading level={2}>Strings</Heading>
-      <Tags strings={strings} dimension="large" variant="good" />
+      <StringTags strings={strings} dimension="large" variant="good" />
       <div className="mailpoet-gap" />
-      <Tags strings={strings} dimension="large" variant="good" isInverted />
+      <StringTags
+        strings={strings}
+        dimension="large"
+        variant="good"
+        isInverted
+      />
     </>
   );
 }

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -3,9 +3,34 @@ import { Tag, TagVariant } from './tag';
 import { Tooltip } from '../tooltip/tooltip';
 import { MailPoet } from '../../mailpoet';
 
+type SharedTagProps = {
+  children?: ReactNode;
+  dimension?: 'large';
+  variant?: TagVariant;
+  isInverted?: boolean;
+};
+
+type TagData = {
+  name: string;
+  target?: string;
+  tooltip?: string;
+};
+
+type TagProps = SharedTagProps & {
+  tags: TagData[];
+};
+
+type StringTagsProps = SharedTagProps & {
+  strings: string[];
+};
+
 type Segment = {
   name: string;
   id?: string;
+};
+
+type SegmentTagsProps = SharedTagProps & {
+  segments: Segment[];
 };
 
 type SubscriberTag = {
@@ -15,99 +40,89 @@ type SubscriberTag = {
   tag_id: string;
 };
 
-type Props = {
-  children?: ReactNode;
-  dimension?: 'large';
-  segments?: Segment[];
-  subscriberTags?: SubscriberTag[];
-  strings?: string[];
-  variant?: TagVariant;
-  isInverted?: boolean;
+type SubscriberTagsProps = SharedTagProps & {
+  subscribers: SubscriberTag[];
 };
 
-function Tags({
-  children,
-  dimension,
-  segments,
-  subscriberTags,
-  strings,
-  variant,
-  isInverted,
-}: Props) {
+function Tags({ children, tags, dimension, variant, isInverted }: TagProps) {
   return (
     <div className="mailpoet-tags">
       {children}
-      {segments &&
-        segments.map((segment) => {
-          const tag = (
-            <Tag key={segment.name} dimension={dimension} variant="list">
-              {segment.name}
-            </Tag>
-          );
-          if (!segment.id) {
-            return tag;
-          }
-          const randomId = Math.random().toString(36).substring(2, 15);
-          const tooltipId = `segment-tooltip-${randomId}`;
-
-          return (
-            <div key={randomId}>
-              <Tooltip id={tooltipId} place="top">
-                {MailPoet.I18n.t('viewFilteredSubscribersMessage')}
-              </Tooltip>
-              <a
-                data-tip=""
-                data-for={tooltipId}
-                href={`admin.php?page=mailpoet-subscribers#/filter[segment=${segment.id}]`}
-              >
-                {tag}
-              </a>
-            </div>
-          );
-        })}
-      {subscriberTags &&
-        subscriberTags.map((subscriberTag) => {
-          const randomId = Math.random().toString(36).substring(2, 15);
-          const tooltipId = `tag-tooltip-${randomId}`;
-          const tag = (
-            <Tag
-              key={subscriberTag.name}
-              dimension={dimension}
-              variant={variant || 'list'}
-              isInverted={isInverted}
-            >
-              {subscriberTag.name}
-            </Tag>
-          );
-
-          return (
-            <div key={randomId}>
-              <Tooltip id={tooltipId} place="top">
-                {MailPoet.I18n.t('viewFilteredSubscribersMessage')}
-              </Tooltip>
-              <a
-                data-tip=""
-                data-for={tooltipId}
-                href={`admin.php?page=mailpoet-subscribers#/filter[tag=${subscriberTag.tag_id}]`}
-              >
-                {tag}
-              </a>
-            </div>
-          );
-        })}
-      {strings &&
-        strings.map((string) => (
+      {tags.map((item) => {
+        const tag = (
           <Tag
-            key={string}
+            key={item.name}
             dimension={dimension}
-            variant={variant || 'list'} // due to backward compatibility we use `list` as the default value
+            variant={variant || 'list'}
             isInverted={isInverted}
           >
-            {string}
+            {item.name}
           </Tag>
-        ))}
+        );
+        if (!item.target) {
+          return tag;
+        }
+
+        const randomId = Math.random().toString(36).substring(2, 15);
+        const tooltipId = `segment-tooltip-${randomId}`;
+        return (
+          <div key={randomId}>
+            {item.tooltip && (
+              <Tooltip id={tooltipId} place="top">
+                {MailPoet.I18n.t('viewFilteredSubscribersMessage')}
+              </Tooltip>
+            )}
+            <a data-tip="" data-for={tooltipId} href={item.target}>
+              {tag}
+            </a>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-export { Tags };
+function StringTags({ children, strings, ...props }: StringTagsProps) {
+  const tags: TagData[] = strings.map((item) => ({
+    name: item,
+  }));
+  return (
+    <Tags tags={tags} {...props}>
+      {children}
+    </Tags>
+  );
+}
+
+function SegmentTags({ children, segments, ...props }: SegmentTagsProps) {
+  const tags: TagData[] = segments.map((segment) => ({
+    name: segment.name,
+    target: segment.id
+      ? `admin.php?page=mailpoet-subscribers#/filter[segment=${segment.id}]`
+      : undefined,
+    tooltip: MailPoet.I18n.t('viewFilteredSubscribersMessage'),
+  }));
+  return (
+    <Tags tags={tags} {...props}>
+      {children}
+    </Tags>
+  );
+}
+
+function SubscriberTags({
+  children,
+  subscribers,
+  ...props
+}: SubscriberTagsProps) {
+  const tags: TagData[] = subscribers.map((item) => ({
+    name: item.name,
+    target: `admin.php?page=mailpoet-subscribers#/filter[tag=${item.tag_id}]`,
+    tooltip: MailPoet.I18n.t('viewFilteredSubscribersMessage'),
+  }));
+  return (
+    <Tags tags={tags} {...props}>
+      {children}
+    </Tags>
+  );
+}
+
+export { SegmentTags, StringTags, SubscriberTags };

--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -7,7 +7,7 @@ import { Button } from 'common';
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { plusIcon } from 'common/button/icon/plus';
-import { Tags } from 'common/tag/tags';
+import { SegmentTags } from 'common/tag/tags';
 import { Toggle } from 'common/form/toggle/toggle';
 import { withNpsPoll } from 'nps_poll.jsx';
 import { FormsHeading, onAddNewForm } from './heading';
@@ -248,13 +248,13 @@ class FormListComponent extends Component {
           {actions}
         </td>
         <td className="column" data-colname={MailPoet.I18n.t('segments')}>
-          <Tags segments={segments} dimension="large">
+          <SegmentTags segments={segments} dimension="large">
             {form.settings.segments_selected_by === 'user' && (
               <span className="mailpoet-tags-prefix">
                 {MailPoet.I18n.t('userChoice')}
               </span>
             )}
-          </Tags>
+          </SegmentTags>
         </td>
         <td className="column" data-colname={MailPoet.I18n.t('type')}>
           {placement}

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/listings.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/listings.jsx
@@ -13,7 +13,7 @@ import {
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { NewsletterTypes } from 'newsletters/types';
-import { ScheduledIcon, Tags, Toggle } from 'common';
+import { ScheduledIcon, StringTags, Toggle } from 'common';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
@@ -269,13 +269,13 @@ class ListingsComponent extends Component {
       displayText = ReactStringReplace(
         event.listingScheduleDisplayTextPlural,
         '%s',
-        (match, i) => <Tags strings={metaOptionValues} key={i} />,
+        (match, i) => <StringTags strings={metaOptionValues} key={i} />,
       );
     } else {
       displayText = ReactStringReplace(
         event.listingScheduleDisplayText,
         '%s',
-        (match, i) => <Tags strings={metaOptionValues} key={i} />,
+        (match, i) => <StringTags strings={metaOptionValues} key={i} />,
       );
     }
 

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_stats_info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/newsletter_stats_info.tsx
@@ -1,7 +1,7 @@
 import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
-import { Button, Tags } from 'common';
+import { Button, SegmentTags } from 'common';
 import { NewsletterType } from './newsletter_type';
 
 type Props = {
@@ -28,7 +28,7 @@ export function NewsletterStatsInfo({ newsletter }: Props) {
               {MailPoet.I18n.t('statsToSegments')}
             </span>
             {': '}
-            <Tags dimension="large" segments={newsletter.segments} />
+            <SegmentTags dimension="large" segments={newsletter.segments} />
           </div>
         )}
       </div>

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -15,7 +15,7 @@ import {
   monthDayValues,
   nthWeekDayValues,
 } from 'newsletters/scheduling/common.jsx';
-import { Tags } from 'common/tag/tags';
+import { SegmentTags } from 'common/tag/tags';
 import { Toggle } from 'common/form/toggle/toggle';
 
 import {
@@ -227,7 +227,7 @@ class NewsletterListNotificationComponent extends Component {
     const sendingToSegments = ReactStringReplace(
       MailPoet.I18n.t('sendTo'),
       '%1$s',
-      (match, i) => <Tags segments={newsletter.segments} key={i} />,
+      (match, i) => <SegmentTags segments={newsletter.segments} key={i} />,
     );
 
     // set sending frequency

--- a/mailpoet/assets/js/src/newsletters/listings/notification_history.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification_history.jsx
@@ -11,7 +11,7 @@ import {
   checkCronStatus,
   checkMailerStatus,
 } from 'newsletters/listings/utils.jsx';
-import { Tags } from 'common/tag/tags';
+import { SegmentTags } from 'common/tag/tags';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
 
@@ -147,7 +147,7 @@ const renderItem = (newsletter, actions, meta) => {
         className="column mailpoet-hide-on-mobile"
         data-colname={MailPoet.I18n.t('lists')}
       >
-        <Tags segments={newsletter.segments} dimension="large" />
+        <SegmentTags segments={newsletter.segments} dimension="large" />
       </td>
       {mailpoetTrackingEnabled === true ? (
         <td

--- a/mailpoet/assets/js/src/newsletters/listings/re_engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re_engagement.jsx
@@ -5,7 +5,7 @@ import { Link, withRouter } from 'react-router-dom';
 import ReactStringReplace from 'react-string-replace';
 
 import { Toggle } from 'common/form/toggle/toggle';
-import { Tags } from 'common/tag/tags';
+import { SegmentTags } from 'common/tag/tags';
 import { ScheduledIcon } from 'common/listings/newsletter_status';
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
@@ -238,7 +238,7 @@ class NewsletterListReEngagementComponent extends Component {
     const sendingToSegments = ReactStringReplace(
       MailPoet.I18n.t('sendTo'),
       '%1$s',
-      (match, i) => <Tags segments={newsletter.segments} key={i} />,
+      (match, i) => <SegmentTags segments={newsletter.segments} key={i} />,
     );
 
     let frequencyKey = 'reEngagementFrequencyMonth';

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
 import { confirmAlert } from 'common/confirm_alert.jsx';
-import { Tags } from 'common/tag/tags';
+import { SegmentTags } from 'common/tag/tags';
 import { Listing } from 'listing/listing.jsx';
 import { QueueStatus } from 'newsletters/listings/queue_status.jsx';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
@@ -218,7 +218,7 @@ class NewsletterListStandardComponent extends Component {
           className="column mailpoet-hide-on-mobile"
           data-colname={MailPoet.I18n.t('lists')}
         >
-          <Tags segments={newsletter.segments} dimension="large" />
+          <SegmentTags segments={newsletter.segments} dimension="large" />
         </td>
         {mailpoetTrackingEnabled === true ? (
           <td

--- a/mailpoet/assets/js/src/subscribers/list.jsx
+++ b/mailpoet/assets/js/src/subscribers/list.jsx
@@ -3,7 +3,7 @@ import jQuery from 'jquery';
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-import { Button, Tags } from 'common';
+import { Button, SegmentTags, SubscriberTags } from 'common';
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal.tsx';
@@ -439,11 +439,11 @@ function SubscriberList({ match }) {
           {status}
         </td>
         <td className="column" data-colname={MailPoet.I18n.t('lists')}>
-          <Tags segments={subscribedSegments} dimension="large" />
+          <SegmentTags segments={subscribedSegments} dimension="large" />
         </td>
         <td className="column" data-colname={MailPoet.I18n.t('tags')}>
-          <Tags
-            subscriberTags={subscriber.tags}
+          <SubscriberTags
+            subscribers={subscriber.tags}
             variant="wordpress"
             isInverted
           />


### PR DESCRIPTION
## Description
To reduce the complexity of the `<Tags />` component, I decided only `tags` would be a valid property for the tags. I added `<StringTags>` which would transform `strings` to `tags` and use the `<Tags />` component. `<SegmentTags />` would transform `segments` to `tags` and `<SubscriberTags />` would transform `subscribers`. These new components are now used in the code base instead of the generic `<Tags />` component.

## QA notes
This PR touches the `<Tags />` element. The behavior/appearance should not change. Some examples for those `<Tags />`:
![image](https://user-images.githubusercontent.com/6458412/204757945-2fe9715b-e653-48f4-b3d4-d9fe2dac15f4.png)
![image](https://user-images.githubusercontent.com/6458412/204757961-44d51aea-59a3-469c-9c18-899db84850fb.png)

## Linked tickets
[MAILPOET-4628]


[MAILPOET-4628]: https://mailpoet.atlassian.net/browse/MAILPOET-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ