### PR TITLE
Remove unnecessary test jobs [MAILPOET-4880]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,7 +626,7 @@ workflows:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
-          name: acceptance_tests
+          name: acceptance_tests_base_and_woo_cot_off
           requires:
             - unit_tests
             - static_analysis_php8
@@ -736,7 +736,7 @@ workflows:
           <<: *slack-fail-post-step
           requires:
             - build
-            - acceptance_tests
+            - acceptance_tests_base_and_woo_cot_off
             - js_tests
             - integration_test_woocommerce
             - integration_test_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -654,15 +654,6 @@ workflows:
             - static_analysis_php8
             - qa_js
             - qa_php
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_tests_woo_cot_off
-          group: woo
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
       - js_tests:
           <<: *slack-fail-post-step
           requires:
@@ -744,7 +735,6 @@ workflows:
             - integration_test_woo_cot_off
             - integration_test_woo_cot_sync
             - acceptance_tests_woo_cot_sync
-            - acceptance_tests_woo_cot_off
             - acceptance_tests_woo_cot_no_sync
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,15 +661,6 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           group: woo
-          name: integration_test_woocommerce
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - integration_tests:
-          <<: *slack-fail-post-step
-          group: woo
           enable_cot: 1
           enable_cot_sync: 1
           name: integration_test_woo_cot_sync
@@ -729,7 +720,6 @@ workflows:
             - build
             - acceptance_tests_base_and_woo_cot_off
             - js_tests
-            - integration_test_woocommerce
             - integration_test_base
             - integration_test_woo_cot_no_sync
             - integration_test_woo_cot_off


### PR DESCRIPTION
## Description
We run acceptance tests for WooCommerce with HPOS (formerly COT) disabled within the main acceptance_test job.
Thi PR removes the unnecessary `acceptance_tests_woo_cot_off job` and renames the main `acceptance_test` to `acceptance_tests_base_and_woo_cot_off` so that it is obvious that the specific Woo configuration is tested in this job.

When working on the ticket, I also noticed that after we no longer install the special dev HPOS Woo build there are two integration test jobs with the very same configuration: `integration_test_woocommerce` and `integration_test_woo_cot_off`. So I also removed one of them.

## Code review notes

_N/A_

## QA notes
I think this doesn't require QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4880]

## After-merge notes

_N/A_


[MAILPOET-4880]: https://mailpoet.atlassian.net/browse/MAILPOET-4880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ