### PR TITLE
1-click unsubscribe should be recorded as click stat as well [MAILPOET-4862]

### DIFF
--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -190,6 +190,7 @@ class Worker {
   public static function getShortcodeLinksMapping() {
     return [
       NewsletterLinkEntity::UNSUBSCRIBE_LINK_SHORT_CODE => __('Unsubscribe link', 'mailpoet'),
+      NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE => __('Unsubscribe link (without confirmation)', 'mailpoet'),
       '[link:subscription_manage_url]' => __('Manage subscription link', 'mailpoet'),
       '[link:newsletter_view_in_browser_url]' => __('View in browser link', 'mailpoet'),
     ];

--- a/mailpoet/lib/Entities/NewsletterLinkEntity.php
+++ b/mailpoet/lib/Entities/NewsletterLinkEntity.php
@@ -21,6 +21,7 @@ class NewsletterLinkEntity {
 
   public const UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_unsubscribe_url]';
   public const INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE = '[link:subscription_instant_unsubscribe_url]';
+  public const UNSUBSCRIBE_LINK_SHORTCODES = [self::UNSUBSCRIBE_LINK_SHORT_CODE, self::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE];
 
   /**
    * @ORM\ManyToOne(targetEntity="MailPoet\Entities\NewsletterEntity")

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -3,12 +3,16 @@
 namespace MailPoet\Subscription;
 
 use MailPoet\Config\Renderer as TemplateRenderer;
+use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
+use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\AssetsController;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Settings\TrackingConfig;
+use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\Track\SubscriberHandler;
 use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Subscribers\LinkTokens;
@@ -82,6 +86,15 @@ class Pages {
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
+  /*** @var NewsletterLinkRepository */
+  private $newsletterLinkRepository;
+
+  /*** @var StatisticsClicksRepository */
+  private $statisticsClicksRepository;
+
+  /*** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
   public function __construct(
     NewSubscriberNotificationMailer $newSubscriberNotificationSender,
     WPFunctions $wp,
@@ -98,7 +111,10 @@ class Pages {
     TrackingConfig $trackingConfig,
     EntityManager $entityManager,
     SubscriberSaveController $subscriberSaveController,
-    SubscriberSegmentRepository $subscriberSegmentRepository
+    SubscriberSegmentRepository $subscriberSegmentRepository,
+    NewsletterLinkRepository $newsletterLinkRepository,
+    StatisticsClicksRepository $statisticsClicksRepository,
+    SendingQueuesRepository $sendingQueuesRepository
   ) {
     $this->wp = $wp;
     $this->newSubscriberNotificationSender = $newSubscriberNotificationSender;
@@ -116,6 +132,9 @@ class Pages {
     $this->entityManager = $entityManager;
     $this->subscriberSaveController = $subscriberSaveController;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
+    $this->newsletterLinkRepository = $newsletterLinkRepository;
+    $this->statisticsClicksRepository = $statisticsClicksRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
   }
 
   public function init($action = false, $data = [], $initShortcodes = false, $initPageFilters = false) {
@@ -230,14 +249,23 @@ class Pages {
   public function unsubscribe(string $method): void {
     if (
       !$this->isPreview()
-      && ($this->subscriber !== null)
-      && ($this->subscriber->status !== SubscriberEntity::STATUS_UNSUBSCRIBED)
+      && (!is_null($this->subscriber))
+      && ($this->subscriber->getStatus() !== SubscriberEntity::STATUS_UNSUBSCRIBED)
     ) {
       if ($this->trackingConfig->isEmailTrackingEnabled() && isset($this->data['queueId'])) {
+        $queueId = (int)$this->data['queueId'];
+
+        if ($method === StatisticsUnsubscribeEntity::METHOD_ONE_CLICK) {
+          /**
+           * With 1-click method, redirect shouldn't happen that's why the click state should be directly recorded
+           */
+          $this->updateClickStatistics($queueId);
+        }
+
         $this->unsubscribesTracker->track(
-          (int)$this->subscriber->id,
+          (int)$this->subscriber->getId(),
           StatisticsUnsubscribeEntity::SOURCE_NEWSLETTER,
-          (int)$this->data['queueId'],
+          $queueId,
           null,
           $method
         );
@@ -464,5 +492,28 @@ class Pages {
     );
 
     return '<a href="' . $this->subscriptionUrlFactory->getManageUrl($this->subscriber) . '">' . $text . '</a>';
+  }
+
+  private function updateClickStatistics(int $queueId): void {
+    $queue = $this->sendingQueuesRepository->findOneById($queueId);
+    if ($queue) {
+      $newsletter = $queue->getNewsletter();
+      $link = $this->newsletterLinkRepository->findOneBy([
+        'url' => NewsletterLinkEntity::INSTANT_UNSUBSCRIBE_LINK_SHORT_CODE,
+        'queue' => $queueId,
+      ]);
+    }
+
+
+    if ($queue && isset($link, $newsletter)) {
+      $this->statisticsClicksRepository->createOrUpdateClickCount(
+        $link,
+        $this->subscriber,
+        $newsletter,
+        $queue,
+        null
+      );
+      $this->statisticsClicksRepository->flush();
+    }
   }
 }


### PR DESCRIPTION
## Description

- With this PR a 1-click unsubscribe records a click stat
- Also some previous wrong tests for 1-click business logic are fixed
- Per talk with @flakas we decided to keep using `[link:subscription_instant_unsubscribe_url]` for 1-click unsubscribe as well and not introduce a new shortcode.

## Code review notes

Please note the PR created for the premium plugin as mentioned below.

## QA notes

- Send out newsletter using MSS
- Click the 1-click unsubscribe button in your email viewer application
- Make sure a click is recorded in the DB (`wp_mailpoet_statistics_clicks`) and on the stats page `Unsubscribe link` with `1` click count for the given newsletter is shown

## Linked PRs
[662](https://github.com/mailpoet/mailpoet-premium/pull/662)

## Linked tickets

[MAILPOET-4862]



[MAILPOET-4862]: https://mailpoet.atlassian.net/browse/MAILPOET-4862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ