### PR TITLE
Define language of newsletter [MAILPOET-3487]

### DIFF
--- a/mailpoet/lib/Config/Renderer.php
+++ b/mailpoet/lib/Config/Renderer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Config;
 
 use MailPoet\Twig;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Twig\Extension\DebugExtension;
 use MailPoetVendor\Twig\Lexer as TwigLexer;
 use MailPoetVendor\Twig\Loader\FilesystemLoader as TwigFileSystem;
@@ -78,7 +79,8 @@ class Renderer {
       'assets_url' => Env::$assetsUrl,
       'assets_manifest_js' => $this->assetsManifestJs,
       'assets_manifest_css' => $this->assetsManifestCss,
-    ]));
+    ],
+      WPFunctions::get()));
   }
 
   public function setupSyntax() {

--- a/mailpoet/lib/Config/Renderer.php
+++ b/mailpoet/lib/Config/Renderer.php
@@ -74,13 +74,17 @@ class Renderer {
   }
 
   public function setupGlobalVariables() {
-    $this->renderer->addExtension(new Twig\Assets([
-      'version' => Env::$version,
-      'assets_url' => Env::$assetsUrl,
-      'assets_manifest_js' => $this->assetsManifestJs,
-      'assets_manifest_css' => $this->assetsManifestCss,
-    ],
-      WPFunctions::get()));
+    $this->renderer->addExtension(
+      new Twig\Assets(
+        [
+          'version' => Env::$version,
+          'assets_url' => Env::$assetsUrl,
+          'assets_manifest_js' => $this->assetsManifestJs,
+          'assets_manifest_css' => $this->assetsManifestCss,
+        ],
+        WPFunctions::get()
+      )
+    );
   }
 
   public function setupSyntax() {

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -29,18 +29,23 @@ class Renderer {
   /** @var ServicesChecker */
   private $servicesChecker;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     Blocks\Renderer $blocksRenderer,
     Columns\Renderer $columnsRenderer,
     Preprocessor $preprocessor,
     \MailPoetVendor\CSS $cSSInliner,
-    ServicesChecker $servicesChecker
+    ServicesChecker $servicesChecker,
+    WPFunctions $wp
   ) {
     $this->blocksRenderer = $blocksRenderer;
     $this->columnsRenderer = $columnsRenderer;
     $this->preprocessor = $preprocessor;
     $this->cSSInliner = $cSSInliner;
     $this->servicesChecker = $servicesChecker;
+    $this->wp = $wp;
   }
 
   public function render(NewsletterEntity $newsletter, SendingTask $sendingTask = null, $type = false) {
@@ -194,7 +199,7 @@ class Renderer {
     // because tburry/pquery contains a bug and replaces the opening non mso condition incorrectly we have to replace the opening tag with correct value
     $template = $templateDom->__toString();
     $template = str_replace('<!--[if !mso]><![endif]-->', '<!--[if !mso]><!-- -->', $template);
-    $template = WPFunctions::get()->applyFilters(
+    $template = $this->wp->applyFilters(
       self::FILTER_POST_PROCESS,
       $template
     );

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -73,6 +73,7 @@ class Renderer {
       $content = $this->addMailpoetLogoContentBlock($content, $styles);
     }
 
+    $language = $this->wp->getBloginfo('language');
     $metaRobots = $preview ? '<meta name="robots" content="noindex, nofollow" />' : '';
     $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingTask);
     $renderedBody = $this->renderBody($newsletter, $content);
@@ -82,6 +83,7 @@ class Renderer {
     $template = $this->injectContentIntoTemplate(
       (string)file_get_contents(dirname(__FILE__) . '/' . self::NEWSLETTER_TEMPLATE),
       [
+        $language,
         $metaRobots,
         htmlspecialchars($subject ?: $newsletter->getSubject()),
         $renderedStyles,

--- a/mailpoet/lib/Newsletter/Renderer/Template.html
+++ b/mailpoet/lib/Newsletter/Renderer/Template.html
@@ -1,4 +1,4 @@
-<html lang="en">
+<html lang="{{newsletter_language}}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/mailpoet/lib/Twig/Assets.php
+++ b/mailpoet/lib/Twig/Assets.php
@@ -12,14 +12,19 @@ use MailPoetVendor\Twig\TwigFunction;
 class Assets extends AbstractExtension {
   private $globals;
 
+  /** @var WPFunctions  */
+  private $wp;
+
   /** @var CdnAssetUrl|null */
   private $cdnAssetsUrl;
 
   public function __construct(
     array $globals,
+    WPFunctions $wp,
     CdnAssetUrl $cdnAssetsUrl = null
   ) {
     $this->globals = $globals;
+    $this->wp = $wp;
     $this->cdnAssetsUrl = $cdnAssetsUrl;
   }
 
@@ -50,6 +55,11 @@ class Assets extends AbstractExtension {
         [$this, 'generateCdnUrl'],
         ['is_safe' => ['all']]
       ),
+      new TwigFunction(
+        'language',
+        [$this, 'language'],
+        ['is_safe' => ['all']]
+      ),
     ];
   }
 
@@ -66,6 +76,10 @@ class Assets extends AbstractExtension {
     }
 
     return join("\n", $output);
+  }
+
+  public function language() {
+    return $this->wp->getBlogInfo('language');
   }
 
   public function generateJavascript() {

--- a/mailpoet/lib/Twig/Assets.php
+++ b/mailpoet/lib/Twig/Assets.php
@@ -78,8 +78,17 @@ class Assets extends AbstractExtension {
     return join("\n", $output);
   }
 
+  /**
+   * Returns the language, which is currently loaded.
+   * This function is used to add the language tag for our system emails like stats notifications.
+   */
   public function language() {
-    return $this->wp->getBlogInfo('language');
+
+    // If we do not have a translation, the language of the mail will be English.
+    if (!is_textdomain_loaded('mailpoet')) {
+      return 'en';
+    }
+    return (string)$this->wp->getBlogInfo('language');
   }
 
   public function generateJavascript() {

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -17,6 +17,7 @@ use MailPoet\Newsletter\Renderer\Columns\Renderer as ColumnRenderer;
 use MailPoet\Newsletter\Renderer\Preprocessor;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Util\pQuery\pQuery;
+use MailPoet\WP\Functions as WPFunctions;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class RendererTest extends \MailPoetTest {
@@ -50,7 +51,8 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(ColumnRenderer::class),
       $this->diContainer->get(Preprocessor::class),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
-      $this->servicesChecker
+      $this->servicesChecker,
+      $this->diContainer->get(WPFunctions::class)
     );
     $this->columnRenderer = new ColumnRenderer();
     $this->dOMParser = new pQuery();

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -655,6 +655,28 @@ class RendererTest extends \MailPoetTest {
     wp_delete_post($postId, true);
   }
 
+  public function testItRendersLanguageAttribute() {
+    $currentLanguageOption = $this->currentGlobalLocale();
+    $this->setGlobalLocale('fr_FR');
+    $expectedLanguage = 'fr-FR';
+
+    $template = $this->renderer->render($this->newsletter);
+    $DOM = $this->dOMParser->parseStr($template['html']);
+    $html = $DOM->query('html');
+    $this->setGlobalLocale($currentLanguageOption);
+    $this->assertEquals($expectedLanguage, $html->attr('lang'));
+  }
+
+  private function currentGlobalLocale() {
+    global $locale;
+    return $locale;
+  }
+
+  private function setGlobalLocale($value) {
+    global $locale;
+    $locale = $value;
+  }
+
   public function makeAttachment($upload, $parentPostId = 0) {
     if (!function_exists( 'wp_crop_image' )) {
       include( ABSPATH . 'wp-admin/includes/image.php' );

--- a/mailpoet/tests/integration/Twig/AssetsTest.php
+++ b/mailpoet/tests/integration/Twig/AssetsTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Twig;
 use MailPoet\Config\Env;
 use MailPoet\Twig\Assets;
 use MailPoet\Util\CdnAssetUrl;
+use MailPoet\WP\Functions as WPFunctions;
 
 class AssetsTest extends \MailPoetTest {
   public $assetsExtension;
@@ -22,6 +23,7 @@ class AssetsTest extends \MailPoetTest {
         'assets_manifest_css' => false,
         'version' => $this->version,
       ],
+      WPFunctions::get(),
       new CdnAssetUrl('')
     );
   }
@@ -38,6 +40,7 @@ class AssetsTest extends \MailPoetTest {
         'assets_manifest_js' => $manifest,
         'version' => $this->version,
       ],
+      WPFunctions::get(),
       new CdnAssetUrl('')
     );
 
@@ -76,6 +79,7 @@ class AssetsTest extends \MailPoetTest {
         'assets_manifest_css' => $manifest,
         'version' => $this->version,
       ],
+      WPFunctions::get(),
       new CdnAssetUrl('')
     );
 

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -10,6 +10,7 @@ use MailPoet\Newsletter\Editor\LayoutHelper as L;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Preprocessor;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\csstidy;
 
 /**
@@ -111,7 +112,8 @@ class RendererTest extends \MailPoetTest {
         $wooPreprocessor
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
-      $this->diContainer->get(ServicesChecker::class)
+      $this->diContainer->get(ServicesChecker::class),
+      $this->diContainer->get(WPFunctions::class)
     );
   }
 }

--- a/mailpoet/views/emails/congratulatoryMssEmail.html
+++ b/mailpoet/views/emails/congratulatoryMssEmail.html
@@ -1,4 +1,4 @@
-<html lang="en" style="margin:0;padding:0">
+<html lang="<%= language() %>" style="margin:0;padding:0">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/mailpoet/views/emails/statsNotificationLayout.html
+++ b/mailpoet/views/emails/statsNotificationLayout.html
@@ -1,4 +1,4 @@
-<html lang="en" style="margin:0;padding:0">
+<html lang="<%= language() %>" style="margin:0;padding:0">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Description
Sets the correct `lang` attribute in the HTML newsletters. Before this PR we did set the `lang` attribute to English, regardless of the actual content.

Emails authored by the users like newsletters, welcome emails etc.:
We now use the website language (from Settings > General) to populate the `lang` attribute.

System emails like Stats notification:
We use the website language in case we have an existing translation for this language, otherwise we use English.

Special case: Confirmation email:
The confirmation email has no `<html>` tag, so we do not set a `lang` attribute.

This change improves the accessibility of our emails.

## Linked PRs
https://github.com/mailpoet/mailpoet-premium/pull/661

## Linked tickets

[MAILPOET-3487]


[MAILPOET-3487]: https://mailpoet.atlassian.net/browse/MAILPOET-3487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ