### PR TITLE
Improve switch languages acceptance test [MAILPOET-4863]

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -8,6 +8,11 @@ use Throwable;
 
 class SwitchingLanguagesCest {
   public function switchLanguage(AcceptanceTester $i): void {
+    // We don't want to run the test on release branch because in our release process
+    // the language packs are not prepared at the time we crate the branch
+    if (getenv('CIRCLE_BRANCH') === 'release') {
+      return;
+    }
     $i->login();
 
     $i->wantTo('Switch WordPress language to German');

--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -18,7 +18,7 @@ class SwitchingLanguagesCest {
     $i->wantTo('Update translations to make sure strings are downloaded');
 
     // translations may not be scheduled for update yet, retry multiple times in that case
-    for ($attemtps = 0; $attemtps < 3; $attemtps++) {
+    for ($attemtps = 0; $attemtps < 5; $attemtps++) {
       try {
         $i->wait($attemtps);
         $i->amOnAdminPage('update-core.php');


### PR DESCRIPTION
## Description
This is an attempt to improve the stability of the test. In the second commit, I disabled the test for the release branch because language packs are not ready at the time we run tests for the release branch.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4863]

## After-merge notes

_N/A_


[MAILPOET-4863]: https://mailpoet.atlassian.net/browse/MAILPOET-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ