### PR TITLE
Automation StepType can be undefined [MAILPOET-4889]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -1,12 +1,10 @@
 import { useState, Fragment } from 'react';
 import { DropdownMenu } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { moreVertical, trash } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import { PremiumModal } from 'common/premium_modal';
 import { Step as StepData } from './types';
-import { storeName } from '../../store';
 import { StepMoreControlsType } from '../../../types/filters';
 
 type Props = {
@@ -14,12 +12,6 @@ type Props = {
 };
 
 export function StepMoreMenu({ step }: Props): JSX.Element {
-  const { stepType } = useSelect(
-    (select) => ({
-      stepType: select(storeName).getStepType(step.key),
-    }),
-    [step],
-  );
   const [showModal, setShowModal] = useState(false);
 
   const moreControls: StepMoreControlsType = Hooks.applyFilters(
@@ -53,7 +45,6 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
       },
     },
     step,
-    stepType,
   );
 
   const slots = Object.values(moreControls).filter(

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import { Hooks } from 'wp-js-hooks';
 import { MoreControlType, StepMoreControlsType } from '../../../types/filters';
-import { StepType } from '../../../editor/store';
 import { Step } from '../../../editor/components/automation/types';
 
 const emailStatisticsControl = (step: Step): MoreControlType => {
@@ -30,12 +29,8 @@ export function registerStepControls() {
   Hooks.addFilter(
     'mailpoet.automation.step.more-controls',
     'mailpoet',
-    (
-      controls: StepMoreControlsType,
-      step: Step,
-      stepType: StepType,
-    ): StepMoreControlsType => {
-      if (stepType.key === 'mailpoet:send-email') {
+    (controls: StepMoreControlsType, step: Step): StepMoreControlsType => {
+      if (step.key === 'mailpoet:send-email') {
         return {
           statistics: emailStatisticsControl(step),
           ...controls,


### PR DESCRIPTION
## Description
When I open an automation with a third party step and the plugin, which provides this step is deactivated, the editor does not load properly:
![image](https://user-images.githubusercontent.com/6458412/205251129-18d70f65-5573-45d6-ad8f-3460cc7859b2.png)

This PR fixes the issue:
![image](https://user-images.githubusercontent.com/6458412/205251594-341faca3-bf95-4374-8b42-5cdf8ca192db.png)


## Code review notes

_N/A_

## QA notes
[hello-automation.zip](https://github.com/mailpoet/mailpoet/files/10139481/hello-automation.zip)

To reproduce:
You can install this plugin. It will provide you a "Hello Automation"-Action. Add this action to an automation and save the automation with your current `trunk`. Deactivate the plugin and reload the edtior: You should the the error.

Use the MailPoet version of this PR and the error should be gone.

Note:
There is a second problem. If you reload the editor with the plugin activated, you will run into a similar issue, which will not be addressed in this PR but subject of an upcoming P2 post.

## Linked tickets
[MAILPOET-4889]

## Linked PR
https://github.com/mailpoet/mailpoet-premium/pull/663


[MAILPOET-4889]: https://mailpoet.atlassian.net/browse/MAILPOET-4889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ