### PR TITLE
Stop checking if website is on HTTPS for 1-click-unsubscribe [MAILPOET-4859]

### DIFF
--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -116,9 +116,6 @@ class Subscription {
   }
 
   private function applyOneClickUnsubscribeStrategy($data): void {
-    if (!$this->wp->wpIsSiteUrlUsingHttps()) {
-      return;
-    }
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
     $subscription->unsubscribe(StatisticsUnsubscribeEntity::METHOD_ONE_CLICK);
   }


### PR DESCRIPTION
## Description

This PR removes the check to see if website is using HTTPS before performing 1-click-unsubscribe.


## QA notes

- From a test website that's using HTTPS,  send a newsletter to yourself.
- Remove HTTPS and convert it to HTTP {domain}/wp-admin/options-general.php
- Check it in and email viewer which supports 1-click unsubscribe
- Unsubscribe using the 1-click-unsubscribe button provided by your email viewer
- Verify the unsubscribe has worked.

## Linked tickets

[MAILPOET-4859]


[MAILPOET-4859]: https://mailpoet.atlassian.net/browse/MAILPOET-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ