### PR TITLE
Mention both forms and emails when describing 3rd-party libraries and Google Fonts [MAILPOET-4888]

### DIFF
--- a/mailpoet/views/settings.html
+++ b/mailpoet/views/settings.html
@@ -144,7 +144,7 @@
     'after12months': __('After 12 months (default)'),
     'after18months': __('After 18 months'),
     'libs3rdPartyTitle': __('Load 3rd-party libraries'),
-    'libs3rdPartyDescription': __('E.g. Google Fonts (used in Form Editor) and HelpScout (used for support). This needs to be enabled if you want to be able to contact support.'),
+    'libs3rdPartyDescription': __('E.g. Google Fonts (used in the Form editor and the Email editor) and HelpScout (used for support). This needs to be enabled if you want to be able to contact support.'),
     'shareDataTitle': __('Share anonymous data'),
     'shareDataDescription': __('Share anonymous data and help us improve the plugin. We appreciate your help!'),
     'captchaTitle': __('Protect your forms against spam signups'),

--- a/mailpoet/views/welcome_wizard.html
+++ b/mailpoet/views/welcome_wizard.html
@@ -33,7 +33,7 @@
 'welcomeWizardUsageTrackingStepTrackingLabelNoteNote': __('Note'),
 'welcomeWizardUsageTrackingStepLibs3rdPartyLabelNote': __('If enabled, we may load the Google Fonts library and [link]other 3rd-party libraries we use[/link].'),
 'welcomeWizardUsageTrackingStepLibs3rdPartyLabelNoteNote': __('Note'),
-'welcomeWizardUsageTrackingStepLibs3rdPartyLabel': __('Enable better-looking Google Fonts in emails and show contextual help articles in MailPoet?'),
+'welcomeWizardUsageTrackingStepLibs3rdPartyLabel': __('Enable better-looking Google Fonts in forms and emails and show contextual help articles in MailPoet?'),
 'seeVideoGuide': _x('See video guide', 'A label on a button'),
 'skip': _x('Skip', 'A label on a skip button'),
 'finishLater': _x('Finish later', 'A label on a skip button'),


### PR DESCRIPTION
## Description

Updated 3rd-party libraries description in Settings and Welcome Wizard to mention both Forms and Emails editors. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4888]

## After-merge notes

_N/A_


[MAILPOET-4888]: https://mailpoet.atlassian.net/browse/MAILPOET-4888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ