### PR TITLE
Prevent undefined function request_filesystem_credentials error [MAILPOET-4902]

### DIFF
--- a/mailpoet/lib/Config/Localizer.php
+++ b/mailpoet/lib/Config/Localizer.php
@@ -45,6 +45,7 @@ class Localizer {
     }
 
     if (!empty($mailpoetTranslations)) {
+      require_once ABSPATH . '/wp-admin/includes/file.php';
       require_once ABSPATH . '/wp-admin/includes/class-wp-upgrader.php';
       $upgrader = new \Language_Pack_Upgrader(new SilentUpgraderSkin());
       $upgrader->bulk_upgrade($mailpoetTranslations);


### PR DESCRIPTION
## Description

The function request_filesystem_credentials was not loaded when running the translation update during regular page load. 
I was not able to find out what change caused the error. The function [was used in the WP upgrade flow for more than four years](https://github.com/WordPress/WordPress/blame/master/wp-admin/includes/class-wp-upgrader.php#L189), so I assume that some change in the newer WP version caused that it some cases it is not loaded.

## Code review notes

_N/A_

## QA notes

Please see if installing the plugin on a site that uses a few languages works as expected.
There are replication instructions in the ticket.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4902]

## After-merge notes

_N/A_


[MAILPOET-4902]: https://mailpoet.atlassian.net/browse/MAILPOET-4902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ