### PR TITLE
Surface confirmation email sending errors to subscribers and admins [MAILPOET-4736]

### DIFF
--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -201,7 +201,7 @@ class MailerLog {
     $mailerLog['transactional_email_last_error_at'] = time();
     $mailerLog['transactional_email_error_count'] = ($mailerLog['transactional_email_error_count'] ?? 0) + 1;
     self::updateMailerLog($mailerLog);
-    if ($mailerLog['transactional_email_error_count'] > self::RETRY_ATTEMPTS_LIMIT) {
+    if ($mailerLog['transactional_email_error_count'] >= self::RETRY_ATTEMPTS_LIMIT) {
       self::pauseSending($mailerLog);
     }
   }

--- a/mailpoet/lib/Models/Subscriber.php
+++ b/mailpoet/lib/Models/Subscriber.php
@@ -700,6 +700,7 @@ class Subscriber extends Model {
   public static function subscribe($subscriberData = [], $segmentIds = []) {
     trigger_error('Calling Subscriber::subscribe() is deprecated and will be removed. Use MailPoet\API\MP\v1\API instead. ', E_USER_DEPRECATED);
     $service = ContainerWrapper::getInstance()->get(\MailPoet\Subscribers\SubscriberActions::class);
-    return $service->subscribe($subscriberData, $segmentIds);
+    [$subscriber] = $service->subscribe($subscriberData, $segmentIds);
+    return $subscriber;
   }
 }

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -142,7 +142,7 @@ class ConfirmationEmailMailer {
     }
 
     if ($result['response'] === false) {
-      if ($result['error'] instanceof MailerError) {
+      if ($result['error'] instanceof MailerError && $result['error']->getLevel() === MailerError::LEVEL_HARD) {
         MailerLog::processTransactionalEmailError($result['error']->getOperation(), (string)$result['error']->getMessage());
       }
       throw new \Exception(__('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet'));

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -138,14 +138,14 @@ class ConfirmationEmailMailer {
       $result = $defaultMailer->send($email, $subscriber, $extraParams);
     } catch (\Exception $e) {
       MailerLog::processTransactionalEmailError(MailerError::OPERATION_CONNECT, $e->getMessage(), $e->getCode());
-      throw new \Exception(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
+      throw new \Exception(__('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet'));
     }
 
     if ($result['response'] === false) {
       if ($result['error'] instanceof MailerError) {
         MailerLog::processTransactionalEmailError($result['error']->getOperation(), (string)$result['error']->getMessage());
       }
-      throw new \Exception(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
+      throw new \Exception(__('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet'));
     };
 
     // E-mail was successfully sent we need to update the MailerLog

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -6,7 +6,9 @@ use Html2Text\Html2Text;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerFactory;
+use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
@@ -135,12 +137,19 @@ class ConfirmationEmailMailer {
       $defaultMailer = $this->mailerFactory->getDefaultMailer();
       $result = $defaultMailer->send($email, $subscriber, $extraParams);
     } catch (\Exception $e) {
+      MailerLog::processTransactionalEmailError(MailerError::OPERATION_CONNECT, $e->getMessage(), $e->getCode());
       throw new \Exception(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
     }
 
     if ($result['response'] === false) {
+      if ($result['error'] instanceof MailerError) {
+        MailerLog::processTransactionalEmailError($result['error']->getOperation(), (string)$result['error']->getMessage());
+      }
       throw new \Exception(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
     };
+
+    // E-mail was successfully sent we need to update the MailerLog
+    MailerLog::incrementSentCount();
 
     if (!$this->wp->isUserLoggedIn()) {
       $subscriber->setConfirmationsCount($subscriber->getConfirmationsCount() + 1);

--- a/mailpoet/lib/Subscribers/SubscriberActions.php
+++ b/mailpoet/lib/Subscribers/SubscriberActions.php
@@ -54,7 +54,11 @@ class SubscriberActions {
     $this->segmentsRepository = $segmentsRepository;
   }
 
-  public function subscribe($subscriberData = [], $segmentIds = []): SubscriberEntity {
+  /**
+   * Returns SubscriberEntity and associative array with some metadata related to the subscription (e.g. ['confirmationEmailResult' => $exception])
+   * @return array{0: SubscriberEntity, 1: array{confirmationEmailResult: bool|\Exception}}
+   */
+  public function subscribe($subscriberData = [], $segmentIds = []): array {
     // filter out keys from the subscriber_data array
     // that should not be editable when subscribing
     $subscriberData = $this->subscriberSaveController->filterOutReservedColumns($subscriberData);
@@ -98,14 +102,16 @@ class SubscriberActions {
     }
 
     $this->subscribersRepository->flush();
+
+    $metaData = ['confirmationEmailResult' => false];
     // link subscriber to segments
     $segments = $this->segmentsRepository->findBy(['id' => $segmentIds]);
     $this->subscriberSegmentRepository->subscribeToSegments($subscriber, $segments);
 
     try {
-      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
+      $metaData['confirmationEmailResult'] = $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
     } catch (\Exception $e) {
-      // ignore errors
+      $metaData['confirmationEmailResult'] = $e;
     }
 
     // We want to send the notification on subscribe only when signupConfirmation is disabled
@@ -118,6 +124,6 @@ class SubscriberActions {
       );
     }
 
-    return $subscriber;
+    return [$subscriber, $metaData];
   }
 }

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -151,7 +151,7 @@ class SubscriberSubscribeController {
      */
     $this->wp->doAction('mailpoet_subscription_before_subscribe', $data, $segmentIds, $form);
 
-    $subscriber = $this->subscriberActions->subscribe($data, $segmentIds);
+    [$subscriber] = $this->subscriberActions->subscribe($data, $segmentIds);
 
     if (!empty($captchaSettings['type']) && $captchaSettings['type'] === CaptchaConstants::TYPE_BUILTIN) {
       // Captcha has been verified, invalidate the session vars

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -151,7 +151,7 @@ class SubscriberSubscribeController {
      */
     $this->wp->doAction('mailpoet_subscription_before_subscribe', $data, $segmentIds, $form);
 
-    [$subscriber] = $this->subscriberActions->subscribe($data, $segmentIds);
+    [$subscriber, $subscriptionMeta] = $this->subscriberActions->subscribe($data, $segmentIds);
 
     if (!empty($captchaSettings['type']) && $captchaSettings['type'] === CaptchaConstants::TYPE_BUILTIN) {
       // Captcha has been verified, invalidate the session vars
@@ -165,6 +165,12 @@ class SubscriberSubscribeController {
 
     // add tags to subscriber if they are filled
     $this->addTagsToSubscriber($formSettings['tags'] ?? [], $subscriber);
+
+    // Confirmation email failed. We want to show the error message
+    if ($subscriptionMeta['confirmationEmailResult'] instanceof \Exception) {
+      $meta['error'] = $subscriptionMeta['confirmationEmailResult']->getMessage();
+      return $meta;
+    }
 
     if (!empty($formSettings['on_success'])) {
       if ($formSettings['on_success'] === 'page') {

--- a/mailpoet/lib/Subscription/Comment.php
+++ b/mailpoet/lib/Subscription/Comment.php
@@ -106,7 +106,7 @@ class Comment {
     if (!empty($segmentIds)) {
       $comment = WPFunctions::get()->getComment($commentId);
 
-      $result = $this->subscriberActions->subscribe(
+      $this->subscriberActions->subscribe(
         [
           'email' => $comment->comment_author_email, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
           'first_name' => $comment->comment_author, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -311,7 +311,7 @@ class MailerLogTest extends \MailPoetTest {
     $mailerLog = MailerLog::createMailerLog();
     $moreThanTwoMinutesAgo = time() - 130;
     $mailerLog['transactional_email_last_error_at'] = $moreThanTwoMinutesAgo;
-    $mailerLog['transactional_email_error_count'] = MailerLog::RETRY_ATTEMPTS_LIMIT;
+    $mailerLog['transactional_email_error_count'] = MailerLog::RETRY_ATTEMPTS_LIMIT - 1;
     MailerLog::updateMailerLog($mailerLog);
     MailerLog::processTransactionalEmailError(MailerError::OPERATION_SEND, 'email rejected');
     $mailerLog = MailerLog::getMailerLog();

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -119,7 +119,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     );
 
     $this->expectException(\Exception::class);
-    $this->expectExceptionMessage(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
+    $this->expectExceptionMessage(__('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet'));
     $sender->sendConfirmationEmail($this->subscriber);
   }
 
@@ -143,7 +143,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     } catch (\Exception $e) {
       $exceptionMessage = $e->getMessage();
     }
-    expect($exceptionMessage)->equals(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
+    expect($exceptionMessage)->equals(__('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet'));
     $mailerLogError = MailerLog::getError();
     $this->assertIsArray($mailerLogError);
     expect($mailerLogError['operation'])->equals(MailerError::OPERATION_SEND);

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -7,7 +7,9 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerFactory;
+use MailPoet\Mailer\MailerLog;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscription\SubscriptionUrlFactory;
@@ -121,9 +123,9 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $sender->sendConfirmationEmail($this->subscriber);
   }
 
-  public function testSendConfirmationEmailThrowsWhenSendReturnsFalse() {
+  public function testSendConfirmationEmailThrowsAndLogHardErrorWhenSendReturnsFalse() {
     $mailer = Stub::makeEmpty(Mailer::class, [
-      'send' => ['response' => false],
+      'send' => ['response' => false, 'error' => new MailerError(MailerError::OPERATION_SEND, MailerError::LEVEL_HARD, 'Error message')],
     ], $this);
 
     $mailerFactory = $this->createMock(MailerFactory::class);
@@ -135,10 +137,17 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class)
     );
-
-    $this->expectException(\Exception::class);
-    $this->expectExceptionMessage(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
-    $sender->sendConfirmationEmail($this->subscriber);
+    $exceptionMessage = '';
+    try {
+      $sender->sendConfirmationEmail($this->subscriber);
+    } catch (\Exception $e) {
+      $exceptionMessage = $e->getMessage();
+    }
+    expect($exceptionMessage)->equals(__('Something went wrong with your subscription. Please contact the website owner.', 'mailpoet'));
+    $mailerLogError = MailerLog::getError();
+    $this->assertIsArray($mailerLogError);
+    expect($mailerLogError['operation'])->equals(MailerError::OPERATION_SEND);
+    expect($mailerLogError['error_message'])->equals('Error message');
   }
 
   public function testItDoesntSendWhenMSSIsActiveAndConfirmationEmailIsNotAuthorized() {

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -55,7 +55,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     $segment = $this->segmentsRepository->createOrUpdate('List #1');
     $segment2 = $this->segmentsRepository->createOrUpdate('List #2');
 
-    $subscriber = $this->subscriberActions->subscribe(
+    [$subscriber] = $this->subscriberActions->subscribe(
       $this->testData,
       [$segment->getId(), $segment2->getId()]
     );
@@ -86,7 +86,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     (new NewsletterOption())->createMultipleOptions($newsletter, $newsletterOptions);
 
     $this->settings->set('signup_confirmation.enabled', false);
-    $subscriber = $this->subscriberActions->subscribe($this->testData, [$segment->getId()]);
+    [$subscriber] = $this->subscriberActions->subscribe($this->testData, [$segment->getId()]);
     expect($subscriber->getId() > 0)->equals(true);
     expect($subscriber->getSegments())->count(1);
 
@@ -113,7 +113,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     (new NewsletterOption())->createMultipleOptions($newsletter, $newsletterOptions);
 
     $this->settings->set('signup_confirmation.enabled', true);
-    $subscriber = $this->subscriberActions->subscribe($this->testData, [$segment->getId()]);
+    [$subscriber] = $this->subscriberActions->subscribe($this->testData, [$segment->getId()]);
     expect($subscriber->getId() > 0)->equals(true);
     expect($subscriber->getSegments())->count(1);
     $scheduledNotification = $this->sendingQueuesRepository->findOneByNewsletterAndTaskStatus(
@@ -126,7 +126,7 @@ class SubscriberActionsTest extends \MailPoetTest {
   public function testItCannotSubscribeWithReservedColumns() {
     $segment = $this->segmentsRepository->createOrUpdate('List #1');
 
-    $subscriber = $this->subscriberActions->subscribe(
+    [$subscriber] = $this->subscriberActions->subscribe(
       [
         'email' => 'donald@mailpoet.com',
         'first_name' => 'Donald',
@@ -174,7 +174,7 @@ class SubscriberActionsTest extends \MailPoetTest {
       'last_name' => 'Example',
     ];
 
-    $subscriber = $this->subscriberActions->subscribe(
+    [$subscriber] = $this->subscriberActions->subscribe(
       $data,
       [$segment->getId()]
     );
@@ -189,7 +189,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     $data2['first_name'] = 'Aaa';
     $data2['last_name'] = 'Bbb';
 
-    $subscriber = $this->subscriberActions->subscribe(
+    [$subscriber] = $this->subscriberActions->subscribe(
       $data2,
       [$segment->getId(), $segment2->getId()]
     );
@@ -216,7 +216,7 @@ class SubscriberActionsTest extends \MailPoetTest {
       'last_name' => 'Example',
     ];
 
-    $subscriber = $this->subscriberActions->subscribe(
+    [$subscriber] = $this->subscriberActions->subscribe(
       $data,
       [$segment->getId()]
     );
@@ -233,7 +233,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     $data2['first_name'] = 'Aaa';
     $data2['last_name'] = 'Bbb';
 
-    $subscriber = $this->subscriberActions->subscribe(
+    [$subscriber] = $this->subscriberActions->subscribe(
       $data2,
       [$segment->getId(), $segment2->getId()]
     );

--- a/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
@@ -659,7 +659,7 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
 
           expect($receivedData)->equals($formFields);
           expect($receivedSegmentIds)->equals($segmentIds);
-          return $subscriber;
+          return [$subscriber, ['confirmationEmailResult' => true]];
         },
       ],
       $this


### PR DESCRIPTION
## Description
In the current version of the plugin, [we silently ignore errors when a confirmation email fails](https://github.com/mailpoet/mailpoet/blob/12afcfb656a825f8d30d1647d1fdd6b9be4b3db5/mailpoet/lib/Subscribers/SubscriberActions.php#L105-L109). So subscribers don't get any feedback that something went wrong when they submit a subscription form and site admin doesn't know that sending doesn't work. This PR addresses these two issues.

When confirmation email sending fails, a subscriber should see the following error.

<img width="477" alt="Screenshot 2022-12-07 at 16 13 59" src="https://user-images.githubusercontent.com/1082140/206219580-8f618d3e-7eb4-4430-88ed-bb789f9f2bf7.png">

When confirmation email sending fails three times (with at least 2 minutes interval in between those failures), the site admin should see a notice on the emails page.

<img width="1285" alt="Screenshot 2022-12-07 at 10 52 34" src="https://user-images.githubusercontent.com/1082140/206219951-dd0ba002-4f98-4d0b-bd2f-62fda47e1c9e.png">

## Code review notes

The PR should be easier to review going commit by commit

## QA notes

#### Testing instructions
1. Misconfigure sending (use an invalid MSS key or just point SMTP to an invalid host)
2. Make sure subscription confirmation is enabled in the plugin settings
3. Try to add a subscriber via a subscription form and verify the correct error message (Note that the subscriber still will be added to the DB but they will see the error message)
4. After adding fails wait 2 minutes (maybe more because of IP throttling) and try to add another one and verify the correct error message
5. Repeat the step for (4)
6. After three failed attempts, you should see in WP Admin MailPoet > Emails a notice with info about the sending issue

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4736]

## After-merge notes

_N/A_


[MAILPOET-4736]: https://mailpoet.atlassian.net/browse/MAILPOET-4736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ