### PR TITLE
Changes to the second step of the Welcome Wizard [MAILPOET-4816]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_welcome-wizard.scss
+++ b/mailpoet/assets/css/src/components-plugin/_welcome-wizard.scss
@@ -111,12 +111,16 @@
 
 .mailpoet-wizard-woocommerce-option {
   align-items: center;
-  box-shadow: 0 -1px 0 0 $color-tertiary-light;
+  box-shadow: 0 1px 0 0 $color-tertiary-light;
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
   padding-bottom: 25px;
   padding-top: 1px;
+
+  &:last-child {
+    box-shadow: 0 0;
+  }
 }
 
 .mailpoet-wizard-note {

--- a/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/usage_tracking_step.jsx
@@ -38,98 +38,100 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
       <div className="mailpoet-gap" />
 
       <form onSubmit={submit}>
-        <div className="mailpoet-wizard-woocommerce-option">
-          <div className="mailpoet-wizard-woocommerce-toggle">
-            <YesNo
-              showError={submitted && isNullOrUndefined(state.libs3rdParty)}
-              onCheck={(value) => {
-                const newState = {
-                  libs3rdParty: value,
-                };
-                setState((prevState) => ({ ...prevState, ...newState }));
-              }}
-              checked={state.libs3rdParty}
-              name="mailpoet_libs_3rdParty"
-            />
-          </div>
-          <div>
-            <p>
-              {MailPoet.I18n.t(
-                'welcomeWizardUsageTrackingStepLibs3rdPartyLabel',
-              )}{' '}
-            </p>
-            <div className="mailpoet-wizard-note">
-              <span>
+        <div>
+          <div className="mailpoet-wizard-woocommerce-option">
+            <div className="mailpoet-wizard-woocommerce-toggle">
+              <YesNo
+                showError={submitted && isNullOrUndefined(state.libs3rdParty)}
+                onCheck={(value) => {
+                  const newState = {
+                    libs3rdParty: value,
+                  };
+                  setState((prevState) => ({ ...prevState, ...newState }));
+                }}
+                checked={state.libs3rdParty}
+                name="mailpoet_libs_3rdParty"
+              />
+            </div>
+            <div>
+              <p>
                 {MailPoet.I18n.t(
-                  'welcomeWizardUsageTrackingStepLibs3rdPartyLabelNoteNote',
-                )}
-              </span>
+                  'welcomeWizardUsageTrackingStepLibs3rdPartyLabel',
+                )}{' '}
+              </p>
+              <div className="mailpoet-wizard-note">
+                <span>
+                  {MailPoet.I18n.t(
+                    'welcomeWizardUsageTrackingStepLibs3rdPartyLabelNoteNote',
+                  )}
+                </span>
 
-              {ReactStringReplace(
-                MailPoet.I18n.t(
-                  'welcomeWizardUsageTrackingStepLibs3rdPartyLabelNote',
-                ),
-                /\[link\](.*?)\[\/link\]/g,
-                (match, i) => (
-                  <a
-                    key={i}
-                    href="https://kb.mailpoet.com/article/338-what-3rd-party-libraries-we-use"
-                    data-beacon-article="5f7c7dd94cedfd0017dcece8"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {match}
-                  </a>
-                ),
-              )}
+                {ReactStringReplace(
+                  MailPoet.I18n.t(
+                    'welcomeWizardUsageTrackingStepLibs3rdPartyLabelNote',
+                  ),
+                  /\[link\](.*?)\[\/link\]/g,
+                  (match, i) => (
+                    <a
+                      key={i}
+                      href="https://kb.mailpoet.com/article/338-what-3rd-party-libraries-we-use"
+                      data-beacon-article="5f7c7dd94cedfd0017dcece8"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {match}
+                    </a>
+                  ),
+                )}
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="mailpoet-gap" />
+          <div className="mailpoet-gap" />
 
-        <div className="mailpoet-wizard-woocommerce-option">
-          <div className="mailpoet-wizard-woocommerce-toggle">
-            <YesNo
-              showError={submitted && isNullOrUndefined(state.tracking)}
-              onCheck={(value) => {
-                const newState = {
-                  tracking: value,
-                };
-                setState((prevState) => ({ ...prevState, ...newState }));
-              }}
-              checked={state.tracking}
-              name="mailpoet_tracking"
-            />
-          </div>
-          <div>
-            <p>
-              {MailPoet.I18n.t('welcomeWizardUsageTrackingStepTrackingLabel')}{' '}
-            </p>
-            <div className="mailpoet-wizard-note">
-              <span>
-                {MailPoet.I18n.t(
-                  'welcomeWizardUsageTrackingStepTrackingLabelNoteNote',
+          <div className="mailpoet-wizard-woocommerce-option">
+            <div className="mailpoet-wizard-woocommerce-toggle">
+              <YesNo
+                showError={submitted && isNullOrUndefined(state.tracking)}
+                onCheck={(value) => {
+                  const newState = {
+                    tracking: value,
+                  };
+                  setState((prevState) => ({ ...prevState, ...newState }));
+                }}
+                checked={state.tracking}
+                name="mailpoet_tracking"
+              />
+            </div>
+            <div>
+              <p>
+                {MailPoet.I18n.t('welcomeWizardUsageTrackingStepTrackingLabel')}{' '}
+              </p>
+              <div className="mailpoet-wizard-note">
+                <span>
+                  {MailPoet.I18n.t(
+                    'welcomeWizardUsageTrackingStepTrackingLabelNoteNote',
+                  )}
+                </span>
+
+                {ReactStringReplace(
+                  MailPoet.I18n.t(
+                    'welcomeWizardUsageTrackingStepTrackingLabelNote',
+                  ),
+                  /\[link\](.*?)\[\/link\]/g,
+                  (match, i) => (
+                    <a
+                      key={i}
+                      href="https://kb.mailpoet.com/article/130-sharing-your-data-with-us"
+                      data-beacon-article="57ce0aaac6979108399a0454"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {match}
+                    </a>
+                  ),
                 )}
-              </span>
-
-              {ReactStringReplace(
-                MailPoet.I18n.t(
-                  'welcomeWizardUsageTrackingStepTrackingLabelNote',
-                ),
-                /\[link\](.*?)\[\/link\]/g,
-                (match, i) => (
-                  <a
-                    key={i}
-                    href="https://kb.mailpoet.com/article/130-sharing-your-data-with-us"
-                    data-beacon-article="57ce0aaac6979108399a0454"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {match}
-                  </a>
-                ),
-              )}
+              </div>
             </div>
           </div>
         </div>

--- a/mailpoet/views/welcome_wizard.html
+++ b/mailpoet/views/welcome_wizard.html
@@ -27,7 +27,7 @@
 <%= localize({
 'welcomeWizardLetsStartTitle': __('Welcome! Let’s get you started on the right foot.'),
 'welcomeWizardSenderText': __('Who is the sender of the emails you’ll be creating with MailPoet?'),
-'welcomeWizardUsageTrackingStepTitle': __('Privacy and data sharing'),
+'welcomeWizardUsageTrackingStepTitle': __('Confirm privacy and data settings'),
 'welcomeWizardUsageTrackingStepTrackingLabel': __('Help improve MailPoet'),
 'welcomeWizardUsageTrackingStepTrackingLabelNote': __('Get improved features and fixes faster by sharing with us [link]non-sensitive data about how you use MailPoet[/link]. No personal data is tracked or stored.'),
 'welcomeWizardUsageTrackingStepTrackingLabelNoteNote': __('Note'),


### PR DESCRIPTION
## Description

This PR implements a few changes to the second step of the Welcome Wizard as described in the ticket. 

## Code review notes

_N/A_

## QA notes

Go to `/wp-admin/admin.php?page=mailpoet-welcome-wizard#/steps/2` to access the second step of the Welcome Wizard and see the changes proposed in this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4816]

## After-merge notes

_N/A_


[MAILPOET-4816]: https://mailpoet.atlassian.net/browse/MAILPOET-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ