### PR TITLE
Redesign the WooCommerce step of the welcome wizard [MAILPOET-4817]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -144,4 +144,7 @@ interface Window {
   }[];
   mailpoet_cdn_url: string;
   mailpoet_main_page_slug: string;
+  finish_wizard_url: string;
+  wizard_woocommerce_illustration_url: string;
+  mailpoet_show_customers_import: boolean;
 }

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -39,7 +39,7 @@ export const MailPoet = {
     window.mailpoet_subscribers_counts_cache_created_at,
   getShortcodeLinks: (): string[] =>
     window.mailpoet_shortcode_links ? window.mailpoet_shortcode_links : [],
-  trackingConfig: window.mailpoet_tracking_config || {},
+  trackingConfig: window.mailpoet_tracking_config,
   I18n: MailPoetI18n,
   Date: MailPoetDate,
   Ajax: MailPoetAjax,

--- a/mailpoet/assets/js/src/wizard/steps/woo_commerce_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/woo_commerce_step.jsx
@@ -41,29 +41,65 @@ function WizardWooCommerceStep(props) {
       <p>{MailPoet.I18n.t('wooCommerceSetupInfo')}</p>
       <div className="mailpoet-gap" />
       <form onSubmit={submit}>
-        {props.showCustomersImportSetting ? (
+        <div>
+          {props.showCustomersImportSetting ? (
+            <div className="mailpoet-wizard-woocommerce-option">
+              <div className="mailpoet-wizard-woocommerce-toggle">
+                <YesNo
+                  showError={submitted && importType === null}
+                  checked={importTypeChecked}
+                  onCheck={(value) =>
+                    setImportType(value ? 'subscribed' : 'unsubscribed')
+                  }
+                  name="mailpoet_woocommerce_import_type"
+                  automationId="woocommerce_import_type"
+                />
+              </div>
+              <div>
+                <p>
+                  {ReactStringReplace(
+                    MailPoet.I18n.t('wooCommerceSetupImportInfo'),
+                    /\[link\](.*?)\[\/link\]/,
+                    (match) => (
+                      <a
+                        key={match}
+                        href="https://kb.mailpoet.com/article/284-import-old-customers-to-the-woocommerce-customers-list"
+                        data-beacon-article="5d722c7104286364bc8ecf19"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        {match}
+                      </a>
+                    ),
+                  )}
+                </p>
+                <div className="mailpoet-wizard-note">
+                  <span>GDPR</span>
+                  {MailPoet.I18n.t('wooCommerceSetupImportGDPRInfo')}
+                </div>
+              </div>
+            </div>
+          ) : null}
           <div className="mailpoet-wizard-woocommerce-option">
             <div className="mailpoet-wizard-woocommerce-toggle">
               <YesNo
-                showError={submitted && importType === null}
-                checked={importTypeChecked}
-                onCheck={(value) =>
-                  setImportType(value ? 'subscribed' : 'unsubscribed')
-                }
-                name="mailpoet_woocommerce_import_type"
-                automationId="woocommerce_import_type"
+                showError={submitted && allowed === null}
+                checked={allowed}
+                onCheck={(value) => setAllowed(value)}
+                name="mailpoet_woocommerce_tracking"
+                automationId="woocommerce_tracking"
               />
             </div>
             <div>
               <p>
                 {ReactStringReplace(
-                  MailPoet.I18n.t('wooCommerceSetupImportInfo'),
+                  MailPoet.I18n.t('wooCommerceSetupTrackingInfo'),
                   /\[link\](.*?)\[\/link\]/,
                   (match) => (
                     <a
                       key={match}
-                      href="https://kb.mailpoet.com/article/284-import-old-customers-to-the-woocommerce-customers-list"
-                      data-beacon-article="5d722c7104286364bc8ecf19"
+                      href="https://kb.mailpoet.com/article/280-woocommerce-cookie-tracking"
+                      data-beacon-article="5d5fa44c2c7d3a7a4d778906"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -74,42 +110,8 @@ function WizardWooCommerceStep(props) {
               </p>
               <div className="mailpoet-wizard-note">
                 <span>GDPR</span>
-                {MailPoet.I18n.t('wooCommerceSetupImportGDPRInfo')}
+                {MailPoet.I18n.t('wooCommerceSetupTrackingGDPRInfo')}
               </div>
-            </div>
-          </div>
-        ) : null}
-        <div className="mailpoet-wizard-woocommerce-option">
-          <div className="mailpoet-wizard-woocommerce-toggle">
-            <YesNo
-              showError={submitted && allowed === null}
-              checked={allowed}
-              onCheck={(value) => setAllowed(value)}
-              name="mailpoet_woocommerce_tracking"
-              automationId="woocommerce_tracking"
-            />
-          </div>
-          <div>
-            <p>
-              {ReactStringReplace(
-                MailPoet.I18n.t('wooCommerceSetupTrackingInfo'),
-                /\[link\](.*?)\[\/link\]/,
-                (match) => (
-                  <a
-                    key={match}
-                    href="https://kb.mailpoet.com/article/280-woocommerce-cookie-tracking"
-                    data-beacon-article="5d5fa44c2c7d3a7a4d778906"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {match}
-                  </a>
-                ),
-              )}
-            </p>
-            <div className="mailpoet-wizard-note">
-              <span>GDPR</span>
-              {MailPoet.I18n.t('wooCommerceSetupTrackingGDPRInfo')}
             </div>
           </div>
         </div>

--- a/mailpoet/assets/js/src/wizard/steps/woo_commerce_step.jsx
+++ b/mailpoet/assets/js/src/wizard/steps/woo_commerce_step.jsx
@@ -23,8 +23,8 @@ function WizardWooCommerceStep(props) {
     return false;
   };
 
-  const finishButtonText = props.isWizardStep
-    ? MailPoet.I18n.t('wooCommerceSetupFinishButtonTextWizard')
+  const buttonText = props.isWizardStep
+    ? MailPoet.I18n.t('continue')
     : MailPoet.I18n.t('wooCommerceSetupFinishButtonTextStandalone');
 
   let importTypeChecked;
@@ -122,7 +122,7 @@ function WizardWooCommerceStep(props) {
           disabled={props.loading}
           automationId="submit_woocommerce_setup"
         >
-          {finishButtonText}
+          {buttonText}
         </Button>
       </form>
     </>

--- a/mailpoet/assets/js/src/wizard/steps/woocommerce_step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/woocommerce_step.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
@@ -6,10 +5,22 @@ import ReactStringReplace from 'react-string-replace';
 import { Button, TypographyHeading } from '../../common';
 import { YesNo } from '../../common/form/yesno/yesno';
 
-function WizardWooCommerceStep(props) {
+type WizardWooCommerceStepPropType = {
+  submitForm: (string, boolean) => void;
+  loading: boolean;
+  showCustomersImportSetting: boolean;
+  isWizardStep: boolean;
+};
+
+function WizardWooCommerceStep({
+  submitForm,
+  loading,
+  showCustomersImportSetting,
+  isWizardStep = false,
+}: WizardWooCommerceStepPropType): JSX.Element {
   const [allowed, setAllowed] = useState(null);
   const [importType, setImportType] = useState(
-    props.showCustomersImportSetting === false ? 'unsubscribed' : null,
+    showCustomersImportSetting === false ? 'unsubscribed' : null,
   );
   const [submitted, setSubmitted] = useState(false);
 
@@ -19,11 +30,11 @@ function WizardWooCommerceStep(props) {
     if (importType === null || allowed === null) {
       return false;
     }
-    props.submitForm(importType, allowed === 'true');
+    submitForm(importType, allowed === 'true');
     return false;
   };
 
-  const buttonText = props.isWizardStep
+  const buttonText = isWizardStep
     ? MailPoet.I18n.t('continue')
     : MailPoet.I18n.t('wooCommerceSetupFinishButtonTextStandalone');
 
@@ -42,7 +53,7 @@ function WizardWooCommerceStep(props) {
       <div className="mailpoet-gap" />
       <form onSubmit={submit}>
         <div>
-          {props.showCustomersImportSetting ? (
+          {showCustomersImportSetting ? (
             <div className="mailpoet-wizard-woocommerce-option">
               <div className="mailpoet-wizard-woocommerce-toggle">
                 <YesNo
@@ -120,8 +131,8 @@ function WizardWooCommerceStep(props) {
         <Button
           isFullWidth
           type="submit"
-          withSpinner={props.loading}
-          disabled={props.loading}
+          withSpinner={loading}
+          disabled={loading}
           automationId="submit_woocommerce_setup"
         >
           {buttonText}
@@ -130,16 +141,5 @@ function WizardWooCommerceStep(props) {
     </>
   );
 }
-
-WizardWooCommerceStep.propTypes = {
-  submitForm: PropTypes.func.isRequired,
-  loading: PropTypes.bool.isRequired,
-  showCustomersImportSetting: PropTypes.bool.isRequired,
-  isWizardStep: PropTypes.bool,
-};
-
-WizardWooCommerceStep.defaultProps = {
-  isWizardStep: false,
-};
 
 export { WizardWooCommerceStep };

--- a/mailpoet/assets/js/src/wizard/steps_numbers.jsx
+++ b/mailpoet/assets/js/src/wizard/steps_numbers.jsx
@@ -25,7 +25,7 @@ export const mapStepNumberToStepName = (stepNumber) => {
   if (stepNumber === 2) {
     return 'WelcomeWizardUsageTrackingStep';
   }
-  if (window.mailpoet_woocommerce_active && stepNumber === getStepsCount()) {
+  if (window.mailpoet_woocommerce_active && stepNumber === 3) {
     return 'WizardWooCommerceStep';
   }
   return 'WelcomeWizardPitchMSSStep';

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
@@ -6,7 +6,7 @@ import { MailPoet } from 'mailpoet';
 import { WelcomeWizardSenderStep } from './steps/sender_step.jsx';
 import { WelcomeWizardUsageTrackingStep } from './steps/usage_tracking_step.jsx';
 import { WelcomeWizardPitchMSSStep } from './steps/pitch_mss_step.jsx';
-import { WooCommerceController } from './woocommerce_controller.jsx';
+import { WooCommerceController } from './woocommerce_controller';
 import { WelcomeWizardStepLayout } from './layout/step_layout.jsx';
 
 import { createSenderSettings } from './create_sender_settings.jsx';

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
@@ -150,7 +150,11 @@ function WelcomeWizardStepsController(props) {
         ) : null}
 
         {stepName === 'WizardWooCommerceStep' ? (
-          <WooCommerceController isWizardStep />
+          <WooCommerceController
+            isWizardStep
+            currentStep={step}
+            redirectToNextStep={redirect}
+          />
         ) : null}
       </StepsContent>
     </>

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.jsx
@@ -152,8 +152,7 @@ function WelcomeWizardStepsController(props) {
         {stepName === 'WizardWooCommerceStep' ? (
           <WooCommerceController
             isWizardStep
-            currentStep={step}
-            redirectToNextStep={redirect}
+            redirectToNextStep={() => redirect(step)}
           />
         ) : null}
       </StepsContent>

--- a/mailpoet/assets/js/src/wizard/wizard.jsx
+++ b/mailpoet/assets/js/src/wizard/wizard.jsx
@@ -3,7 +3,7 @@ import { Route, HashRouter, Redirect, Switch } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { Notices } from 'notices/notices.jsx';
 import { WelcomeWizardStepsController } from './welcome_wizard_controller.jsx';
-import { WooCommerceController } from './woocommerce_controller.jsx';
+import { WooCommerceController } from './woocommerce_controller';
 
 function App() {
   let basePath = '/steps/1';

--- a/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
@@ -5,7 +5,11 @@ import { StepsContent } from 'common/steps/steps_content.tsx';
 import { WizardWooCommerceStep } from './steps/woo_commerce_step.jsx';
 import { WelcomeWizardStepLayout } from './layout/step_layout.jsx';
 
-function WooCommerceController({ isWizardStep = false }) {
+function WooCommerceController({
+  isWizardStep = false,
+  currentStep = null,
+  redirectToNextStep = null,
+}) {
   const [loading, setLoading] = useState(false);
 
   const handleApiError = (response) => {
@@ -46,7 +50,15 @@ function WooCommerceController({ isWizardStep = false }) {
       'tracking.level': newTrackingLevel,
       'woocommerce.accept_cookie_revenue_tracking.set': 1,
     };
-    updateSettings(settings).then(scheduleImport).then(finishWizard);
+    updateSettings(settings)
+      .then(scheduleImport)
+      .then(() => {
+        if (isWizardStep) {
+          redirectToNextStep(currentStep);
+        } else {
+          finishWizard();
+        }
+      });
   };
 
   const result = (
@@ -71,10 +83,14 @@ function WooCommerceController({ isWizardStep = false }) {
 
 WooCommerceController.propTypes = {
   isWizardStep: PropTypes.bool,
+  currentStep: PropTypes.number,
+  redirectToNextStep: PropTypes.shape,
 };
 
 WooCommerceController.defaultProps = {
   isWizardStep: false,
+  currentStep: null,
+  redirectToNextStep: null,
 };
 
 export { WooCommerceController };

--- a/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
@@ -7,7 +7,6 @@ import { WelcomeWizardStepLayout } from './layout/step_layout.jsx';
 
 function WooCommerceController({
   isWizardStep = false,
-  currentStep = null,
   redirectToNextStep = null,
 }) {
   const [loading, setLoading] = useState(false);
@@ -54,7 +53,7 @@ function WooCommerceController({
       .then(scheduleImport)
       .then(() => {
         if (isWizardStep) {
-          redirectToNextStep(currentStep);
+          redirectToNextStep();
         } else {
           finishWizard();
         }
@@ -83,13 +82,11 @@ function WooCommerceController({
 
 WooCommerceController.propTypes = {
   isWizardStep: PropTypes.bool,
-  currentStep: PropTypes.number,
   redirectToNextStep: PropTypes.shape,
 };
 
 WooCommerceController.defaultProps = {
   isWizardStep: false,
-  currentStep: null,
   redirectToNextStep: null,
 };
 

--- a/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce_controller.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { MailPoet } from 'mailpoet';
 import { StepsContent } from 'common/steps/steps_content.tsx';
-import { WizardWooCommerceStep } from './steps/woo_commerce_step.jsx';
+import { WizardWooCommerceStep } from './steps/woocommerce_step';
 import { WelcomeWizardStepLayout } from './layout/step_layout.jsx';
 
 function WooCommerceController({

--- a/mailpoet/assets/js/src/wizard/woocommerce_controller.tsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce_controller.tsx
@@ -1,14 +1,18 @@
-import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { MailPoet } from 'mailpoet';
-import { StepsContent } from 'common/steps/steps_content.tsx';
+import { StepsContent } from 'common/steps/steps_content';
 import { WizardWooCommerceStep } from './steps/woocommerce_step';
 import { WelcomeWizardStepLayout } from './layout/step_layout.jsx';
+
+type WooCommerceControllerPropType = {
+  isWizardStep: boolean;
+  redirectToNextStep: () => void;
+};
 
 function WooCommerceController({
   isWizardStep = false,
   redirectToNextStep = null,
-}) {
+}: WooCommerceControllerPropType): JSX.Element {
   const [loading, setLoading] = useState(false);
 
   const handleApiError = (response) => {
@@ -32,7 +36,7 @@ function WooCommerceController({
     }).fail(handleApiError);
 
   const finishWizard = () => {
-    window.location = window.finish_wizard_url;
+    window.location.href = window.finish_wizard_url;
   };
 
   const submit = (importType, allowed) => {
@@ -49,7 +53,7 @@ function WooCommerceController({
       'tracking.level': newTrackingLevel,
       'woocommerce.accept_cookie_revenue_tracking.set': 1,
     };
-    updateSettings(settings)
+    void updateSettings(settings)
       .then(scheduleImport)
       .then(() => {
         if (isWizardStep) {
@@ -79,15 +83,5 @@ function WooCommerceController({
 
   return result;
 }
-
-WooCommerceController.propTypes = {
-  isWizardStep: PropTypes.bool,
-  redirectToNextStep: PropTypes.shape,
-};
-
-WooCommerceController.defaultProps = {
-  isWizardStep: false,
-  redirectToNextStep: null,
-};
 
 export { WooCommerceController };

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
@@ -80,7 +80,7 @@ class WooCommerceSetupPageCest {
     $i->wantTo('Make sure we don‘t show import setting when there are no customers');
     $i->login();
     $i->amOnPage('wp-admin/admin.php?page=mailpoet-woocommerce-setup');
-    $i->see('Get ready to use MailPoet for WooCommerce');
+    $i->see('Power up your WooCommerce store');
     $importTypeToggle = '[data-automation-id="woocommerce_import_type"]';
     $trackingToggle = '[data-automation-id="woocommerce_tracking"]';
     $submitButton = '[data-automation-id="submit_woocommerce_setup"]';
@@ -101,7 +101,7 @@ class WooCommerceSetupPageCest {
     $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
 
     $i->amOnPage('wp-admin/admin.php?page=mailpoet-woocommerce-setup');
-    $i->see('Get ready to use MailPoet for WooCommerce');
+    $i->see('Power up your WooCommerce store');
     $importTypeToggle = '[data-automation-id="woocommerce_import_type"]';
     $trackingToggle = '[data-automation-id="woocommerce_tracking"]';
     $submitButton = '[data-automation-id="submit_woocommerce_setup"]';

--- a/mailpoet/views/woocommerce_setup_translations.html
+++ b/mailpoet/views/woocommerce_setup_translations.html
@@ -1,9 +1,9 @@
 <%= localize({
-  'wooCommerceSetupTitle': _x('Get ready to use MailPoet for WooCommerce', 'Title on the WooCommerce setup page'),
-  'wooCommerceSetupInfo': __('MailPoet Premium comes with powerful features for WooCommerce. Please complete this one-step setup to be ready to start using them.'),
+  'wooCommerceSetupTitle': _x('Power up your WooCommerce store', 'Title on the WooCommerce setup page'),
+  'wooCommerceSetupInfo': __('MailPoet comes with powerful features for WooCommerce. Select features that you would like to use with your store.'),
   'wooCommerceSetupGDPRTag': _x('GDPR', 'WooCommerce setup GDPR tag'),
-  'wooCommerceSetupImportInfo': __('MailPoet will import all your WooCommerce customers. Do you want to import your WooCommerce customers as subscribed? [link]Learn more[/link].'),
-  'wooCommerceSetupImportGDPRInfo': _x('To be compliant, your customers must have accepted to receive your emails.', 'GDPR compliance information'),
+  'wooCommerceSetupImportInfo': __('Do you want to import your WooCommerce customers as subscribed? [link]Learn more[/link].'),
+  'wooCommerceSetupImportGDPRInfo': _x('To be compliant with privacy regulations, your customers must have explicitly accepted to receive your marketing emails.', 'GDPR compliance information'),
   'wooCommerceSetupTrackingInfo': __('Collect more precise email and site engagement, and e-commerce metrics by enabling cookie tracking. [link]Learn more[/link].'),
   'wooCommerceSetupTrackingGDPRInfo': _x('To be compliant, you should display a cookie tracking banner on your website.', 'GDPR compliance information'),
   'wooCommerceSetupFinishButtonTextWizard': _x('Start using MailPoet', 'Submit button caption in the WooCommerce step in the wizard'),


### PR DESCRIPTION
## Description

This PR implements a few changes to the WooCommerce step of the Welcome Wizard as described in the Jira ticket.

## Code review notes

I'm unsure about the approach that I used in the commit to change the order of the steps (especially around the way that I'm passing the current step and redirectToNextStep to the WooCommerce controller). Please let me know if there is a more React way to achieve the same.

## QA notes

Go to /wp-admin/admin.php?page=mailpoet-welcome-wizard#/steps/3 to see the changes. Please note that the change to the horizontal line was made in a different PR (#4602) and is only visible in the WooCommerce step when this branch is combined with the from the other PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4817]

## After-merge notes

_N/A_


[MAILPOET-4817]: https://mailpoet.atlassian.net/browse/MAILPOET-4817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ