### PR TITLE
Improve tests for oldest configurations and add check for unique varchar index length [MAILPOET-4832]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
       mysql_command:
         type: string
         default: ''
-      mysql_image_version:
+      mysql_image:
         type: string
         default: ''
       codeception_image_version:
@@ -352,7 +352,7 @@ jobs:
         default: 0
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
-      MYSQL_IMAGE_VERSION: << parameters.mysql_image_version >>
+      MYSQL_IMAGE: << parameters.mysql_image >>
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
       WORDPRESS_IMAGE_VERSION: << parameters.wordpress_image_version >>
     steps:
@@ -755,7 +755,7 @@ workflows:
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0
           mysql_command: --max_allowed_packet=100M
-          mysql_image_version: 5.7.36
+          mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: wp-5.8_php7.3_20221104.1
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,7 +754,7 @@ workflows:
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0
-          mysql_command: --max_allowed_packet=100M
+          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: wp-5.8_php7.3_20221104.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,6 +487,8 @@ jobs:
       docker_layer_caching: false
     environment:
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
+      MYSQL_COMMAND: << parameters.mysql_command >>
+      MYSQL_IMAGE: << parameters.mysql_image >>
     parameters:
       codeception_image_version:
         type: string
@@ -509,6 +511,12 @@ jobs:
       multisite:
         type: integer
         default: 0
+      mysql_command:
+        type: string
+        default: ''
+      mysql_image:
+        type: string
+        default: ''
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -780,6 +788,8 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           codeception_image_version: 7.2-cli_20220605.0
+          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
+          mysql_image: mysql:5.5
           requires:
             - build
       - build_premium:

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -36,9 +36,6 @@ wp config set WP_AUTO_UPDATE_CORE false --raw
 mysqladmin --host=mysql --user=root --password=wordpress drop wordpress --force
 mysqladmin --host=mysql --user=root --password=wordpress create wordpress --force
 
-# print sql_mode
-mysql -u wordpress -pwordpress wordpress -h mysql -e "SELECT @@global.sql_mode"
-
 # install WordPress
 WP_CORE_INSTALL_PARAMS="--url=$HTTP_HOST --title=tests --admin_user=admin --admin_email=test@test.com --admin_password=password --skip-email"
 if [[ -z "$MULTISITE" || "$MULTISITE" -eq "0" ]]; then
@@ -199,6 +196,12 @@ if [[ $CIRCLE_JOB == *"_with_premium_"* ]]; then
   # Activate MailPoet Premium
   wp plugin activate mailpoet-premium || { echo "MailPoet Premium plugin activation failed!" ; exit 1; }
 fi
+
+echo "MySQL Configuration";
+# print sql_mode
+mysql -u wordpress -pwordpress wordpress -h mysql -e "SELECT @@global.sql_mode"
+# print tables info
+mysql -u wordpress -pwordpress wordpress -h mysql -e "SELECT TABLE_NAME, ENGINE, TABLE_COLLATION FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'wordpress'"
 
 cd /wp-core/wp-content/plugins/mailpoet
 /project/vendor/bin/codecept run $TEST_TYPE $@

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -99,7 +99,7 @@ services:
           - test.local
 
   mysql:
-    image: cimg/mysql:${MYSQL_IMAGE_VERSION:-5.7.38}
+    image: ${MYSQL_IMAGE:-cimg/mysql:5.7.38}
     container_name: mysql_${CIRCLE_NODE_INDEX:-default}
     # Command used for MySQL 8+ because it needs default-authentication-plugin
     # parameter and there needs to be some fallback for other MySQL versions.

--- a/mailpoet/tests/integration/Migrations/DbIndexesTest.php
+++ b/mailpoet/tests/integration/Migrations/DbIndexesTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Config;
+
+use MailPoet\Config\Env;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+
+class DbIndexesTest extends \MailPoetTest {
+  /**
+   * This test checks that we don't have an unique varchar index on a varchar column with a length bigger than 191.
+   * The length of 191 is the safe limit that works for all common MySQL configurations.
+   * We don't want to allow creating unique indexes on varchar columns with a length bigger than 191.
+   * @see https://stackoverflow.com/questions/15157227/mysql-varchar-index-length/16474039#16474039
+   */
+  public function testDbHasCorrectUniqueVarcharIndexes() {
+    $connection = $this->diContainer->get(Connection::class);
+    $incorrectIndexes = $connection->executeQuery("SELECT DISTINCT
+      ISS.TABLE_NAME,
+      ISS.INDEX_NAME,
+      ISS.COLUMN_NAME,
+      ISS.NON_UNIQUE,
+      ISC.CHARACTER_MAXIMUM_LENGTH,
+      ISC.DATA_TYPE
+    FROM INFORMATION_SCHEMA.STATISTICS ISS
+    JOIN INFORMATION_SCHEMA.COLUMNS ISC ON ISC.COLUMN_NAME = ISS.COLUMN_NAME AND ISC.TABLE_NAME = ISS.TABLE_NAME
+    WHERE ISS.TABLE_NAME LIKE :prefix
+      AND ISS.NON_UNIQUE = 0
+      AND ISC.DATA_TYPE = 'varchar'
+      AND ISC.CHARACTER_MAXIMUM_LENGTH > 191;",
+      ['prefix' => Env::$dbPrefix . '%']
+    )->fetchAllAssociative();
+    if (!empty($incorrectIndexes)) {
+      $this->fail("The following unique indexes use varchar column, but have incorrect length over 191 chars:\n " . json_encode($incorrectIndexes, JSON_PRETTY_PRINT));
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR adds the following changes:

1. Changes DB configuration for `acceptance_oldest` and `ingetration_oldest` from MySQL 5.7 to the lowest supported MySQL 5.5
2. Changes DB configuration for `acceptance_oldest` and `ingetration_oldest` to use MyISAM DB engine
3. Add printing of all DB tables with basic info about the DB engine and collation. You can see it in [a test output](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/12538/workflows/11f6df3c-06d8-40a0-ad98-1c4eb59b5e2f/jobs/214219/parallel-runs/0/steps/0-103) (you need to scroll up a bit). This was added so that it is easy to find/verify what the configuration of tests was.
4. Adds an integration test that checks if varchar columns with unique indexes have proper length. Here is an example of failed tests (Note: To take the screenshot I changed the tested length from 191 to 190)
<img width="803" alt="Screenshot 2022-12-13 at 15 00 40" src="https://user-images.githubusercontent.com/1082140/207372992-b4cddab0-42e9-49bb-a323-9471aa985eeb.png">


## Code review notes
There is [a testing branch](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/12537/workflows/07a74ca8-4e96-492b-abc2-ea5f364fa0ff) that runs `acceptance_oldest` and `ingetration_oldest` jobs where you can verify they pass.

## QA notes
I think this PR doesn't need QA. 

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-4832]

## After-merge notes
Please delete [varchar-index-check-delme](https://github.com/mailpoet/mailpoet/tree/varchar-index-check-delme) branch

[MAILPOET-4832]: https://mailpoet.atlassian.net/browse/MAILPOET-4832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ