### PR TITLE
Use database() value for column existing detection [MAILPOET-4916]

### DIFF
--- a/mailpoet/lib/Migrator/Migration.php
+++ b/mailpoet/lib/Migrator/Migration.php
@@ -43,10 +43,12 @@ abstract class Migration {
   }
 
   protected function columnExists(string $tableName, string $columnName): bool {
+    // We had a problem with the dbName value in ENV for some customers, because it doesn't match DB name in information schema.
+    // So we decided to use the DATABASE() value instead.
     return $this->connection->executeQuery("
       SELECT 1
       FROM information_schema.columns
-      WHERE table_schema = ?
+      WHERE table_schema = COALESCE(DATABASE(), ?)
       AND table_name = ?
       AND column_name = ?
     ", [Env::$dbName, $tableName, $columnName])->fetchOne() !== false;


### PR DESCRIPTION
## Description

We had some rare cases when our detection of an existing column didn't work well. As a consequence of it, some migrations couldn't be executed or were incorrectly marked as finished. This change should fix it.

## QA notes

Please test if all migrations work as expected.

## Linked tickets

[MAILPOET-4916]



[MAILPOET-4916]: https://mailpoet.atlassian.net/browse/MAILPOET-4916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ