### PR TITLE
Improve comparison stability in test [MAILPOET-4886]

### DIFF
--- a/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
@@ -65,8 +65,7 @@ class CronWorkerSchedulerTest extends \MailPoetTest {
     expect($tasks)->count(1);
     expect($tasks[0]->getType())->same('test');
     expect($tasks[0]->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
-    expect($tasks[0]->getScheduledAt())->greaterOrEquals(Carbon::now()->subSecond());
-    expect($tasks[0]->getScheduledAt())->lessOrEquals(Carbon::now()->addSecond());
+    $this->tester->assertEqualDateTimes($tasks[0]->getScheduledAt(), Carbon::now(), 1);
   }
 
   public function testItScheduleTaskImmediatelyIfNotRunning() {
@@ -75,8 +74,7 @@ class CronWorkerSchedulerTest extends \MailPoetTest {
     expect($tasks)->count(1);
     expect($tasks[0]->getType())->equals('test');
     expect($tasks[0]->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
-    expect($tasks[0]->getScheduledAt())->greaterOrEquals(Carbon::now()->subSecond());
-    expect($tasks[0]->getScheduledAt())->lessOrEquals(Carbon::now()->addSecond());
+    $this->tester->assertEqualDateTimes($tasks[0]->getScheduledAt(), Carbon::now(), 1);
   }
 
   public function testItReschedulesTask() {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I replaced two comparisons with one that should be more stable because it uses rounded seconds.

## QA notes

QA can be skipped because it's only a tiny change in a test.

## Linked tickets

[MAILPOET-4886]



[MAILPOET-4886]: https://mailpoet.atlassian.net/browse/MAILPOET-4886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ