### PR TITLE
Feat/create an empty landing page - MAILPOET-4795

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Landingpage.php
+++ b/mailpoet/lib/AdminPages/Pages/Landingpage.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\PageRenderer;
+
+class Landingpage {
+  /** @var PageRenderer */
+  private $pageRenderer;
+
+  public function __construct(
+    PageRenderer $pageRenderer
+  ) {
+    $this->pageRenderer = $pageRenderer;
+  }
+
+  public function render() {
+    $this->pageRenderer->displayPage('landingpage.html');
+  }
+}

--- a/mailpoet/lib/Config/Changelog.php
+++ b/mailpoet/lib/Config/Changelog.php
@@ -109,6 +109,8 @@ class Changelog {
   }
 
   public function redirectToLandingPage() {
+    if (isset($_GET['activate-multi'])) return; // do not redirect when activated with bulk activation mode
+
     if ($this->shouldShowLandingPage() && !$this->isLandingPage()) {
       $this->urlHelper->redirectTo(
         $this->wp->adminUrl('admin.php?page=mailpoet-landingpage')

--- a/mailpoet/lib/Config/Changelog.php
+++ b/mailpoet/lib/Config/Changelog.php
@@ -121,11 +121,26 @@ class Changelog {
   public function maybeRedirectToLandingPage() {
     if ($this->isWelcomeWizardPage()) return; // do not redirect when on welcome wizard page
 
-    $this->redirectToLandingPage();
+    if ($this->shouldShowLandingPage()) {
+      $this->redirectToLandingPage();
+      return;
+    }
+
+    $this->maybeRedirectToWelcomeWizard(); //TODO: Remove when landing page is out of experimental
   }
 
   private function setupNewInstallation() {
     $this->settings->set('show_congratulate_after_first_newsletter', true);
+  }
+
+  private function maybeRedirectToWelcomeWizard() {
+    if ($this->shouldShowWelcomeWizard() && !$this->isWelcomeWizardPage()) {
+      if ($this->isLandingPage()) return; // do not redirect when on landing page
+
+      $this->urlHelper->redirectWithReferer(
+        $this->wp->adminUrl('admin.php?page=mailpoet-welcome-wizard')
+      );
+    }
   }
 
   private function isWelcomeWizardPage() {

--- a/mailpoet/lib/Config/Changelog.php
+++ b/mailpoet/lib/Config/Changelog.php
@@ -74,7 +74,7 @@ class Changelog {
     $version = $this->settings->get('version');
     if ($version === null) {
       $this->setupNewInstallation();
-      $this->maybeRedirectToWelcomeWizard();
+      $this->maybeRedirectToLandingPage();
     }
     $this->checkWooCommerceListImportPage();
     $this->checkRevenueTrackingPermissionPage();
@@ -118,26 +118,22 @@ class Changelog {
     }
   }
 
+  public function maybeRedirectToLandingPage() {
+    if ($this->isWelcomeWizardPage()) return; // do not redirect when on welcome wizard page
+
+    $this->redirectToLandingPage();
+  }
+
   private function setupNewInstallation() {
     $this->settings->set('show_congratulate_after_first_newsletter', true);
   }
 
-  private function maybeRedirectToWelcomeWizard() {
-    if ($this->shouldShowWelcomeWizard() && !$this->isWelcomeWizardPage()) {
-      if ($this->isLandingPage()) return; // do not redirect when on landing page
-
-      $this->urlHelper->redirectWithReferer(
-        $this->wp->adminUrl('admin.php?page=mailpoet-welcome-wizard')
-      );
-    }
-  }
-
   private function isWelcomeWizardPage() {
-    return isset($_GET['page']) && $_GET['page'] === Menu::WELCOME_WIZARD_PAGE_SLUG;
+    return isset($_GET['page']) && sanitize_text_field(wp_unslash($_GET['page'])) === Menu::WELCOME_WIZARD_PAGE_SLUG;
   }
 
   private function isLandingPage() {
-    return isset($_GET['page']) && $_GET['page'] === Menu::LANDINGPAGE_PAGE_SLUG;
+    return isset($_GET['page']) && sanitize_text_field(wp_unslash($_GET['page'])) === Menu::LANDINGPAGE_PAGE_SLUG;
   }
 
   private function checkWooCommerceListImportPage() {

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -265,7 +265,7 @@ class Initializer {
 
   public function runActivator() {
     try {
-      $this->wpFunctions->addOption(self::PLUGIN_ACTIVATED, true);
+      $this->wpFunctions->addOption(self::PLUGIN_ACTIVATED, true); // used in afterPluginActivation
       $this->activator->activate();
     } catch (InvalidStateException $e) {
       return $this->handleRunningMigration($e);
@@ -327,12 +327,17 @@ class Initializer {
     define(self::INITIALIZED, true);
   }
 
+  /**
+   * Walk around for getting this to work correctly
+   *
+   * Read more here: https://developer.wordpress.org/reference/functions/register_activation_hook/
+   * and https://github.com/mailpoet/mailpoet/pull/4620#discussion_r1058210174
+   * @return void
+   */
   public function afterPluginActivation() {
     if (!$this->wpFunctions->isAdmin() || !defined(self::INITIALIZED) || !$this->wpFunctions->getOption(self::PLUGIN_ACTIVATED)) return;
 
-    if ($this->changelog->shouldShowLandingPage()) {
-       $this->changelog->redirectToLandingPage();
-    }
+    $this->changelog->redirectToLandingPage();
 
     // done with afterPluginActivation actions
     $this->wpFunctions->deleteOption(self::PLUGIN_ACTIVATED);

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -10,6 +10,7 @@ use MailPoet\AdminPages\Pages\FormEditor;
 use MailPoet\AdminPages\Pages\Forms;
 use MailPoet\AdminPages\Pages\Help;
 use MailPoet\AdminPages\Pages\Homepage;
+use MailPoet\AdminPages\Pages\Landingpage;
 use MailPoet\AdminPages\Pages\Logs;
 use MailPoet\AdminPages\Pages\NewsletterEditor;
 use MailPoet\AdminPages\Pages\Newsletters;
@@ -51,6 +52,8 @@ class Menu {
   const AUTOMATIONS_PAGE_SLUG = 'mailpoet-automation';
   const AUTOMATION_EDITOR_PAGE_SLUG = 'mailpoet-automation-editor';
   const AUTOMATION_TEMPLATES_PAGE_SLUG = 'mailpoet-automation-templates';
+
+  const LANDINGPAGE_PAGE_SLUG = 'mailpoet-landingpage';
 
   const ICON_BASE64_SVG = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNTIuMDIgMTU2LjQiPjx0aXRsZT5NYWlsUG9ldCBpY29uPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTM3LjcxLDg5LjFjMy41LDAsNS45LS44LDcuMi0yLjNhOCw4LDAsMCwwLDItNS40VjM1LjdsMTcsNDUuMWExMi42OCwxMi42OCwwLDAsMCwzLjcsNS40YzEuNiwxLjMsNCwyLDcuMiwyYTEyLjU0LDEyLjU0LDAsMCwwLDUuOS0xLjQsOC40MSw4LjQxLDAsMCwwLDMuOS01bDE4LjEtNTBWODFhOC41Myw4LjUzLDAsMCwwLDIuMSw2LjFjMS40LDEuNCwzLjcsMi4yLDYuOSwyLjIsMy41LDAsNS45LS44LDcuMi0yLjNhOCw4LDAsMCwwLDItNS40VjguN2E3LjQ4LDcuNDgsMCwwLDAtMy4zLTYuNmMtMi4xLTEuNC01LTIuMS04LjYtMi4xYTE5LjMsMTkuMywwLDAsMC05LjQsMiwxMS42MywxMS42MywwLDAsMC01LjEsNi44TDc0LjkxLDY3LjEsNTQuNDEsOC40YTEyLjQsMTIuNCwwLDAsMC00LjUtNi4yYy0yLjEtMS41LTUtMi4yLTguOC0yLjJhMTYuNTEsMTYuNTEsMCwwLDAtOC45LDIuMWMtMi4zLDEuNS0zLjUsMy45LTMuNSw3LjJWODAuOGMwLDIuOC43LDQuOCwyLDYuMkMzMi4yMSw4OC40LDM0LjQxLDg5LjEsMzcuNzEsODkuMVoiLz48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik0xNDksMTE2LjZsLTIuNC0xLjlhNy40LDcuNCwwLDAsMC05LjQuMywxOS42NSwxOS42NSwwLDAsMS0xMi41LDQuNmgtMjEuNEEzNy4wOCwzNy4wOCwwLDAsMCw3NywxMzAuNWwtMS4xLDEuMi0xLjEtMS4xYTM3LjI1LDM3LjI1LDAsMCwwLTI2LjMtMTAuOUgyN2ExOS41OSwxOS41OSwwLDAsMS0xMi40LTQuNiw3LjI4LDcuMjgsMCwwLDAtOS40LS4zbC0yLjQsMS45QTcuNDMsNy40MywwLDAsMCwwLDEyMi4yYTcuMTQsNy4xNCwwLDAsMCwyLjQsNS43QTM3LjI4LDM3LjI4LDAsMCwwLDI3LDEzNy40aDIxLjZhMTkuNTksMTkuNTksMCwwLDEsMTguOSwxNC40di4yYy4xLjcsMS4yLDQuNCw4LjUsNC40czguNC0zLjcsOC41LTQuNHYtLjJhMTkuNTksMTkuNTksMCwwLDEsMTguOS0xNC40SDEyNWEzNy4yOCwzNy4yOCwwLDAsMCwyNC42LTkuNSw3LjQyLDcuNDIsMCwwLDAsMi40LTUuN0E3Ljg2LDcuODYsMCwwLDAsMTQ5LDExNi42WiIvPjwvZz48L2c+PC9zdmc+';
 
@@ -201,6 +204,21 @@ class Menu {
         'welcomeWizard',
       ]
     );
+
+    // Landingpage
+    if ($this->featuresController->isSupported(FeaturesController::FEATURE_LANDINGPAGE)) {
+      $this->wp->addSubmenuPage(
+        true,
+        $this->setPageTitle(__('MailPoet', 'mailpoet')),
+        esc_html__('MailPoet', 'mailpoet'),
+        AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
+        self::LANDINGPAGE_PAGE_SLUG,
+        [
+          $this,
+          'landingPage',
+        ]
+      );
+    }
 
     // Hide sub-menu entries if the user still needs to complete the Welcome Wizard
     if (!$this->changelog->shouldShowWelcomeWizard()) {
@@ -531,6 +549,10 @@ class Menu {
 
   public function welcomeWizard() {
     $this->container->get(WelcomeWizard::class)->render();
+  }
+
+  public function landingPage() {
+    $this->container->get(Landingpage::class)->render();
   }
 
   public function wooCommerceSetup() {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -50,6 +50,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceSetup::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Landingpage::class)->setPublic(true);
     // Analytics
     $container->autowire(\MailPoet\Analytics\Analytics::class)->setPublic(true);
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -7,10 +7,13 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 class FeaturesController {
   const FEATURE_HOMEPAGE = 'homepage';
 
+  const FEATURE_LANDINGPAGE = 'landingpage';
+
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_HOMEPAGE => false,
+    self::FEATURE_LANDINGPAGE => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -120,6 +120,10 @@ class Functions {
     return delete_comment_meta($commentId, $metaKey, $metaValue);
   }
 
+  public function addOption($option, $value) {
+    return add_option($option, $value);
+  }
+
   public function deleteOption($option) {
     return delete_option($option);
   }

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -97,6 +97,10 @@ class Settings {
     $this->settings->set('version', Env::$version);
   }
 
+  public function withWelcomeWizard() {
+    $this->settings->set('version', null);
+  }
+
   public function withSendingMethod($sendingMethod) {
     $this->settings->set('mta.method', $sendingMethod);
     $this->settings->set('mta_group', $sendingMethod === Mailer::METHOD_SMTP ? 'smtp' : 'website');

--- a/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Features\FeaturesController;
+use MailPoet\Test\DataFactories\Features;
+use MailPoet\Test\DataFactories\Settings;
+
+class LandingpageBasicsCest {
+  public function _before() {
+    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_LANDINGPAGE);
+  }
+
+  public function landingpageRenders(\AcceptanceTester $i) {
+    $i->wantTo('Check landing page renders');
+    $i->login();
+
+    // show welcome wizard & landing page
+    $settings = new Settings();
+    $settings->withWelcomeWizard();
+
+    $i->amOnMailpoetPage('Emails');
+    // should redirect to landing page
+    $i->waitForText('Better email — without leaving WordPress');
+  }
+
+  public function homepageRendersAfterActivation(\AcceptanceTester $i) {
+    $i->wantTo('Check landingpage renders after plugin activation for new users');
+    $i->login();
+
+    // show welcome wizard & landing page
+    $settings = new Settings();
+    $settings->withWelcomeWizard();
+
+
+    $i->amOnPage('/wp-admin/plugins.php');
+    $i->waitForText('Create and send newsletters, post notifications and welcome emails from your WordPress.');
+
+    $i->click('#deactivate-mailpoet');
+    $i->waitForText('Plugin deactivated.');
+    $i->click('#activate-mailpoet');
+    $i->waitForText('Better email — without leaving WordPress');
+  }
+}

--- a/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
+++ b/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
@@ -35,7 +35,7 @@ class ReinstallFromScratchCest {
     $i->waitForElement('[data-automation-id="reinstall-button"]');
     $i->click('Reinstall now...');
     $i->acceptPopup();
-    $i->waitForText('Start by configuring your sender information');
+    $i->waitForText('Start by configuring your sender information'); //TODO: Update when landing page is out of experimental
 
     // Step 3 - skip all tutorials, which could interfere with other tests
     $settings = new Settings();

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -1,0 +1,6 @@
+<% extends 'layout.html' %>
+
+<% block content %>
+<h1>Better email — without leaving WordPress</h1>
+<h3>Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are</h3>
+<% endblock %>


### PR DESCRIPTION
## Description

This PR creates an empty landing page.

Content will be added in upcoming PRs.

## Code review notes

You can access the page here: `wp-admin/admin.php?page=mailpoet-landingpage`

You need to enable experimental features here: `/wp-admin/admin.php?page=mailpoet-experimental`


## QA notes

Hmm 🤔, The easiest way to test this PR would be with a new site (site without previous MailPoet install), but the feature is currently hidden behind an experimental flag, so it would not work straight out of the box.

Testing steps:
* Set `version` to NULL on `mailpoet-settings` table (from the Database) 
<details>
<summary>SQL query</summary>
<p>

```sql

 UPDATE `wp_mailpoet_settings` SET
`value` = NULL,
`updated_at` = now()
WHERE `name` = 'version';

```
</p>
</details>

* Visit `/wp-admin/admin.php?page=mailpoet-experimental`, enable **Landingpage**
* Visit the plugins page (`/wp-admin/plugins.php`). Deactivate the MailPoet plugin
* Activate the MailPoet plugin
* You should be redirected to the landing page

## Linked PRs

* **First**: https://github.com/mailpoet/mailpoet/pull/4620
* Second: https://github.com/mailpoet/mailpoet/pull/4626
* Third: https://github.com/mailpoet/mailpoet/pull/4628

## Linked tickets

[MAILPOET-4795](https://mailpoet.atlassian.net/browse/MAILPOET-4795)





[MAILPOET-4795]: https://mailpoet.atlassian.net/browse/MAILPOET-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ