### PR TITLE
Fix WC Checkout test by stoping to toggle removed setting [MAILPOET-4925]

### DIFF
--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -219,8 +219,12 @@ class WooCheckoutBlocksCest {
 
     // Enable registration during the checkout
     $i->click('[aria-label="Block: Contact Information"]');
-    $i->click('[aria-label="Settings"]');
-    $i->click(Locator::contains('label', 'Allow shoppers to sign up for a user account during checkout'));
+
+    if (version_compare($i->getWooCommerceVersion(), '7.2', '<')) {
+      $i->click('[aria-label="Settings"]');
+      // Starting from WC 7.2 this option is removed and only controlled from the settings page -> Accounts & Privacy tab
+      $i->click(Locator::contains('label', 'Allow shoppers to sign up for a user account during checkout'));
+    }
 
     $i->click('Update');
     $i->waitForText('Page updated.');


### PR DESCRIPTION
## Description

Starting from wc@7.2 the WC Blocks compatible version's Checkout block doesn't offer the option to enable/disable creating checkout on checkout, and this is only controlled via the WC settings page

## Linked tickets

[[MAILPOET-4925](https://mailpoet.atlassian.net/browse/MAILPOET-4925)]
