### PR TITLE
Add periods at the end of automation action descriptions [MAILPOET-4928]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
@@ -19,7 +19,7 @@ export const step: StepType = {
   foreground: '#7F54B3',
   background: '#f7edf7',
   description: __(
-    'Wait some time before proceeding with the steps below',
+    'Wait some time before proceeding with the steps below.',
     'mailpoet',
   ),
   subtitle: (data): string => {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove_tags/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove_tags/index.tsx
@@ -9,7 +9,7 @@ export const step: StepType = {
   group: 'actions',
   title: __('Remove tag', 'mailpoet'),
   description: __(
-    'Remove a tag or multiple tags from a subscriber',
+    'Remove a tag or multiple tags from a subscriber.',
     'mailpoet',
   ),
   subtitle: () => <LockedBadge text={__('Premium', 'mailpoet')} />,

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/index.tsx
@@ -9,7 +9,7 @@ export const step: StepType = {
   key: 'mailpoet:send-email',
   group: 'actions',
   title: __('Send email', 'mailpoet'),
-  description: __('An email will be sent to subscriber', 'mailpoet'),
+  description: __('An email will be sent to subscriber.', 'mailpoet'),
   subtitle: (data) =>
     (data.args.name as string) ?? __('Send email', 'mailpoet'),
   foreground: '#996800',


### PR DESCRIPTION
## Description

Unified format of automation action descriptions. There is an [accompanying PR](https://github.com/mailpoet/mailpoet-premium/pull/673) in the premium repo.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4928]

## After-merge notes

_N/A_


[MAILPOET-4928]: https://mailpoet.atlassian.net/browse/MAILPOET-4928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ