### PR TITLE
Feat/add a cta to the landing page - MAILPOET-4797

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_landingpage.scss
+++ b/mailpoet/assets/css/src/components-plugin/_landingpage.scss
@@ -1,0 +1,11 @@
+#mailpoet_landingpage_container {
+  .mailpoet-content-center {
+    text-align: center;
+  }
+
+  .landing-footer {
+    box-shadow: 0 -1px 0 0 $color-tertiary-light;
+    padding-bottom: 1px;
+    padding-top: 25px;
+  }
+}

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -85,3 +85,4 @@
 @import 'components-plugin/set-from-address-modal';
 @import 'components-plugin/stats';
 @import 'components-plugin/import-export';
+@import 'components-plugin/landingpage';

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -170,4 +170,5 @@ interface Window {
   mailpoet_listing: {
     forceUpdate: () => void;
   };
+  mailpoet_welcome_wizard_url: string;
 }

--- a/mailpoet/assets/js/src/landingpage/footer.tsx
+++ b/mailpoet/assets/js/src/landingpage/footer.tsx
@@ -1,16 +1,13 @@
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common';
 import { Heading } from 'common/typography/heading/heading';
+import { redirectToWelcomeWizard } from './util';
 
-function Footer(): JSX.Element {
+function Footer() {
   return (
     <div className="mailpoet-content-center landing-footer">
       <Heading level={4}> {MailPoet.I18n.t('readyToUseMailPoet')} </Heading>
-      <Button
-        onClick={() => {
-          window.location.href = window.mailpoet_welcome_wizard_url;
-        }}
-      >
+      <Button onClick={redirectToWelcomeWizard}>
         {' '}
         {MailPoet.I18n.t('beginSetup')}{' '}
       </Button>

--- a/mailpoet/assets/js/src/landingpage/footer.tsx
+++ b/mailpoet/assets/js/src/landingpage/footer.tsx
@@ -1,0 +1,22 @@
+import { MailPoet } from 'mailpoet';
+import { Button } from 'common';
+import { Heading } from 'common/typography/heading/heading';
+
+function Footer(): JSX.Element {
+  return (
+    <div className="mailpoet-content-center landing-footer">
+      <Heading level={4}> {MailPoet.I18n.t('readyToUseMailPoet')} </Heading>
+      <Button
+        onClick={() => {
+          window.location.href = window.mailpoet_welcome_wizard_url;
+        }}
+      >
+        {' '}
+        {MailPoet.I18n.t('beginSetup')}{' '}
+      </Button>
+    </div>
+  );
+}
+Footer.displayName = 'Landingpage Footer';
+
+export { Footer };

--- a/mailpoet/assets/js/src/landingpage/header.tsx
+++ b/mailpoet/assets/js/src/landingpage/header.tsx
@@ -1,8 +1,9 @@
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common';
 import { Heading } from 'common/typography/heading/heading';
+import { redirectToWelcomeWizard } from './util';
 
-function Header(): JSX.Element {
+function Header() {
   return (
     <div className="mailpoet-content-center">
       <Heading level={1}>
@@ -13,11 +14,7 @@ function Header(): JSX.Element {
         {' '}
         {MailPoet.I18n.t('startingOutOrEstablished')}{' '}
       </Heading>
-      <Button
-        onClick={() => {
-          window.location.href = window.mailpoet_welcome_wizard_url;
-        }}
-      >
+      <Button onClick={redirectToWelcomeWizard}>
         {' '}
         {MailPoet.I18n.t('beginSetup')}{' '}
       </Button>

--- a/mailpoet/assets/js/src/landingpage/header.tsx
+++ b/mailpoet/assets/js/src/landingpage/header.tsx
@@ -1,0 +1,28 @@
+import { MailPoet } from 'mailpoet';
+import { Button } from 'common';
+import { Heading } from 'common/typography/heading/heading';
+
+function Header(): JSX.Element {
+  return (
+    <div className="mailpoet-content-center">
+      <Heading level={1}>
+        {' '}
+        {MailPoet.I18n.t('betterEmailWithoutLeavingWordPress')}{' '}
+      </Heading>
+      <Heading level={3}>
+        {' '}
+        {MailPoet.I18n.t('startingOutOrEstablished')}{' '}
+      </Heading>
+      <Button
+        onClick={() => {
+          window.location.href = window.mailpoet_welcome_wizard_url;
+        }}
+      >
+        {' '}
+        {MailPoet.I18n.t('beginSetup')}{' '}
+      </Button>
+    </div>
+  );
+}
+Header.displayName = 'Landingpage Header';
+export { Header };

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -1,13 +1,28 @@
 import ReactDOM from 'react-dom';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
-import { MailPoet } from 'mailpoet';
 import { ErrorBoundary } from 'common';
+import { Background } from 'common/background/background';
+import { Header } from './header';
+import { Footer } from './footer';
 
 function Landingpage(): JSX.Element {
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
-      <h1> {MailPoet.I18n.t('betterEmailWithoutLeavingWordPress')} </h1>
-      <h3> {MailPoet.I18n.t('startingOutOrEstablished')} </h3>
+      <Background color="#fff" />
+
+      <Header />
+
+      <div className="mailpoet-gap" />
+
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+
+      <div className="mailpoet-gap" />
+
+      <Footer />
     </GlobalContext.Provider>
   );
 }

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -1,0 +1,27 @@
+import ReactDOM from 'react-dom';
+import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
+import { MailPoet } from 'mailpoet';
+import { ErrorBoundary } from 'common';
+
+function Landingpage(): JSX.Element {
+  return (
+    <GlobalContext.Provider value={useGlobalContextValue(window)}>
+      <h1> {MailPoet.I18n.t('betterEmailWithoutLeavingWordPress')} </h1>
+      <h3> {MailPoet.I18n.t('startingOutOrEstablished')} </h3>
+    </GlobalContext.Provider>
+  );
+}
+Landingpage.displayName = 'Landingpage';
+
+const landingpageContainer = document.getElementById(
+  'mailpoet_landingpage_container',
+);
+
+if (landingpageContainer) {
+  ReactDOM.render(
+    <ErrorBoundary>
+      <Landingpage />
+    </ErrorBoundary>,
+    landingpageContainer,
+  );
+}

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -5,7 +5,7 @@ import { Background } from 'common/background/background';
 import { Header } from './header';
 import { Footer } from './footer';
 
-function Landingpage(): JSX.Element {
+function Landingpage() {
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <Background color="#fff" />

--- a/mailpoet/assets/js/src/landingpage/util.ts
+++ b/mailpoet/assets/js/src/landingpage/util.ts
@@ -1,0 +1,3 @@
+export const redirectToWelcomeWizard = () => {
+  window.location.href = window.mailpoet_welcome_wizard_url;
+};

--- a/mailpoet/assets/js/src/webpack_admin_index.tsx
+++ b/mailpoet/assets/js/src/webpack_admin_index.tsx
@@ -18,3 +18,4 @@ import 'logs/logs'; // side effect - renders ReactDOM to document
 import 'sending-paused-notices-fix-button.tsx'; // side effect - renders ReactDOM to document
 import 'sending-paused-notices-resume-button.ts'; // side effect - executes on doc ready, adds events
 import 'sending-paused-notices-authorize-email.tsx'; // side effect - renders ReactDOM to document
+import 'landingpage/landingpage'; // side effect - renders ReactDOM to document

--- a/mailpoet/lib/AdminPages/Pages/Landingpage.php
+++ b/mailpoet/lib/AdminPages/Pages/Landingpage.php
@@ -3,18 +3,28 @@
 namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Config\Menu;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Landingpage {
   /** @var PageRenderer */
   private $pageRenderer;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
-    PageRenderer $pageRenderer
+    PageRenderer $pageRenderer,
+    WPFunctions $wp
   ) {
     $this->pageRenderer = $pageRenderer;
+    $this->wp = $wp;
   }
 
   public function render() {
-    $this->pageRenderer->displayPage('landingpage.html');
+    $data = [
+      'welcome_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG),
+    ];
+    $this->pageRenderer->displayPage('landingpage.html', $data);
   }
 }

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -71,9 +71,10 @@ class PermanentNotices {
   }
 
   public function init() {
-    $excludeWizard = [
+    $excludeSetupWizard = [
       'mailpoet-welcome-wizard',
       'mailpoet-woocommerce-setup',
+      'mailpoet-landingpage',
     ];
     $this->wp->addAction('wp_ajax_dismissed_notice_handler', [
       $this,
@@ -82,37 +83,37 @@ class PermanentNotices {
 
     $this->phpVersionWarnings->init(
       phpversion(),
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->afterMigrationNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->unauthorizedEmailsNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->unauthorizedEmailsInNewslettersNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->inactiveSubscribersNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->blackFridayNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->headersAlreadySentNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->emailWithInvalidListNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->changedTrackingNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->deprecatedFilterNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->disabledMailFunctionNotice->init(
-      Menu::isOnMailPoetAdminPage($excludeWizard)
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
   }
 

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -2,12 +2,20 @@
 
 <% block content %>
 <div id="mailpoet_landingpage_container"></div>
+
+<script type="text/javascript">
+  <% autoescape 'js' %>
+    var mailpoet_welcome_wizard_url = <%= json_encode(welcome_wizard_url) %>;
+  <% endautoescape %>
+</script>
 <% endblock %>
 
 <% block translations %>
 <%= localize({
   'betterEmailWithoutLeavingWordPress': __('Better email — without leaving WordPress'),
   'startingOutOrEstablished': __('Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are'),
+  'beginSetup': __('Begin setup'),
+  'readyToUseMailPoet': __('Ready to use MailPoet?'),
 }) %>
 <% endblock %>
 

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -1,6 +1,13 @@
 <% extends 'layout.html' %>
 
 <% block content %>
-<h1>Better email — without leaving WordPress</h1>
-<h3>Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are</h3>
+<div id="mailpoet_landingpage_container"></div>
 <% endblock %>
+
+<% block translations %>
+<%= localize({
+  'betterEmailWithoutLeavingWordPress': __('Better email — without leaving WordPress'),
+  'startingOutOrEstablished': __('Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are'),
+}) %>
+<% endblock %>
+

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -13,9 +13,9 @@
 <% block translations %>
 <%= localize({
   'betterEmailWithoutLeavingWordPress': __('Better email — without leaving WordPress'),
-  'startingOutOrEstablished': __('Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are'),
+  'startingOutOrEstablished': __('Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are.'),
   'beginSetup': __('Begin setup'),
-  'readyToUseMailPoet': __('Ready to use MailPoet?'),
+  'readyToUseMailPoet': __('Ready to start using MailPoet?'),
 }) %>
 <% endblock %>
 


### PR DESCRIPTION
## Description

This PR adds a Call to action (CTA) to the landing page.

This is a continuation of https://github.com/mailpoet/mailpoet/pull/4620

## Code review notes

Please start reviewing from https://github.com/mailpoet/mailpoet/commit/137e3c894ff20adbae2d731e652ce01ba912bc31

## QA notes

You can access the page here: `wp-admin/admin.php?page=mailpoet-landingpage`

You need to enable Landingpage experimental features here: `/wp-admin/admin.php?page=mailpoet-experimental`

Check https://github.com/mailpoet/mailpoet/pull/4620 for more QA information 

## Linked PRs

* First: https://github.com/mailpoet/mailpoet/pull/4620
* **Second**: https://github.com/mailpoet/mailpoet/pull/4626
* Third: https://github.com/mailpoet/mailpoet/pull/4628

## Linked tickets

[MAILPOET-4797](https://mailpoet.atlassian.net/browse/MAILPOET-4797)

## After-merge notes

**Note**: Please merge this https://github.com/mailpoet/mailpoet/pull/4620 First

[MAILPOET-4797]: https://mailpoet.atlassian.net/browse/MAILPOET-4797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ