### PR TITLE
Feat/add the faq section to the landing page - MAILPOET-4798

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_landingpage.scss
+++ b/mailpoet/assets/css/src/components-plugin/_landingpage.scss
@@ -16,4 +16,65 @@
   .landing-faq {
     background-color: #fbfbfb;
   }
+
+  .mailpoet-faq-accordion {
+    margin: 40px 0;
+  }
+}
+
+.mailpoet-faq-accordion {
+  details {
+    overflow: hidden;
+
+    &:not(:first-child) {
+      border-top: 1px solid $color-editor-border-structure;
+    }
+
+    summary {
+      cursor: pointer;
+      padding: 20px 5px;
+      position: relative;
+
+      &::-webkit-details-marker {   // remove default marker
+        content: '';
+        display: none;
+      }
+
+      &::marker {                   // remove default marker
+        content: '';
+        display: none;
+      }
+
+      &:after {
+        content: '›';
+        font-size: 30px;
+        position: absolute;
+        right: 20px;
+        top: 0;
+        transform: rotate(90deg);
+        transform-origin: center;
+        transition: .2s transform ease;
+      }
+    }
+
+    .content {
+      max-height: 0;
+      overflow: hidden;
+      padding: 10px 5px;
+      transition: max-height .3s ease;
+    }
+
+    // when accordion is opened
+    &[open] {
+      summary:after {
+        transform: rotate(-90deg);
+        transition: .5s transform ease;
+      }
+
+      .content {
+        max-height: 400px;
+        transition: max-height .5s ease-in;
+      }
+    }
+  }
 }

--- a/mailpoet/assets/css/src/components-plugin/_landingpage.scss
+++ b/mailpoet/assets/css/src/components-plugin/_landingpage.scss
@@ -1,24 +1,35 @@
 #mailpoet_landingpage_container {
+  $content-padding: 32px 65px;
+
   .mailpoet-content-center {
     text-align: center;
   }
 
   .mailpoet-content-padding {
-    padding: 32px 40px
+    padding: $content-padding;
+  }
+
+  .landing-header {
+    padding: $content-padding;
   }
 
   .landing-footer {
-    box-shadow: 0 -1px 0 0 $color-tertiary-light;
-    padding-bottom: 1px;
-    padding-top: 25px;
+    background-color: $color-landingpage-background-light;
+    padding: $content-padding;
+
+    .landing-footer-content {
+      box-shadow: 0 -1px 0 0 $color-tertiary-light;
+      padding: 25px 0;
+    }
   }
 
   .landing-faq {
-    background-color: #fbfbfb;
-  }
+    background-color: $color-landingpage-background-light;
+    padding: $content-padding;
 
-  .mailpoet-faq-accordion {
-    margin: 40px 0;
+    .mailpoet-faq-accordion {
+      margin: 25px 0;
+    }
   }
 }
 

--- a/mailpoet/assets/css/src/components-plugin/_landingpage.scss
+++ b/mailpoet/assets/css/src/components-plugin/_landingpage.scss
@@ -3,9 +3,17 @@
     text-align: center;
   }
 
+  .mailpoet-content-padding {
+    padding: 32px 40px
+  }
+
   .landing-footer {
     box-shadow: 0 -1px 0 0 $color-tertiary-light;
     padding-bottom: 1px;
     padding-top: 25px;
+  }
+
+  .landing-faq {
+    background-color: #fbfbfb;
   }
 }

--- a/mailpoet/assets/css/src/settings/_colors.scss
+++ b/mailpoet/assets/css/src/settings/_colors.scss
@@ -79,3 +79,5 @@ $color-chip-success-bg: #b8e6bf;
 $color-chip-success-text: #005c12;
 $color-chip-danger-bg: #facfd2;
 $color-chip-danger-text: #8a2424;
+
+$color-landingpage-background-light: #fbfbfb;

--- a/mailpoet/assets/js/src/landingpage/faq.tsx
+++ b/mailpoet/assets/js/src/landingpage/faq.tsx
@@ -1,8 +1,76 @@
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
+import { __ } from '@wordpress/i18n';
 import { Heading } from 'common/typography/heading/heading';
 
 function Faq() {
+  const list: {
+    slug: string;
+    title: string;
+    text: string;
+    readMoreText: string;
+    readMoreLink: string;
+  }[] = [
+    {
+      slug: 'item-1',
+      title: __(
+        'What types of campaigns can I create with MailPoet?',
+        'mailpoet',
+      ),
+      text: __(
+        'MailPoet allows you to create five different types of emails: Newsletter, Welcome Email, Latest Post Notifications, Re-engagement Emails and WooCommerce.',
+        'mailpoet',
+      ),
+      readMoreText: __('Read More', 'mailpoet'),
+      readMoreLink:
+        'https://kb.mailpoet.com/article/141-create-an-email-types-of-campaigns',
+    },
+    {
+      slug: 'item-2',
+      title: __('How do I send a newsletter?', 'mailpoet'),
+      text: __(
+        'You can manually create a standard newsletter to be sent immediately or scheduled to be sent at a later time. Simply go to MailPoet > Emails and click on the “+ New Email” button to select “Newsletter”.',
+        'mailpoet',
+      ),
+      readMoreText: __('Read More', 'mailpoet'),
+      readMoreLink:
+        'https://kb.mailpoet.com/article/344-create-a-standard-newsletter',
+    },
+    {
+      slug: 'item-3',
+      title: __('Do I need a paid plan?', 'mailpoet'),
+      text: __(
+        "When you install the MailPoet plugin, you can use it for free up to 1,000 subscribers. If you have more than 1,000 subscribers, you'll need one of our paid plans: Creator, Business, or Agency. The best choice of plan type will depend on whether you want to send with our MailPoet Sending Service or your own sending method, as well as the number of sites you will be using MailPoet on.",
+        'mailpoet',
+      ),
+      readMoreText: __('Read More', 'mailpoet'),
+      readMoreLink:
+        'https://kb.mailpoet.com/article/349-choosing-your-mailpoet-plan',
+    },
+    {
+      slug: 'item-4',
+      title: __('How do I import my customers from WooCommerce?', 'mailpoet'),
+      text: __(
+        'The WooCommerce Customers list is a list automatically created by MailPoet with all of your WooCommerce customers. It also includes “Guest" customers. If WooCommerce is active, users that installed or updated the plugin should have chosen if they wanted to add the customers as “Subscribed” or “Unsubscribed” to the WooCommerce Customers list.',
+        'mailpoet',
+      ),
+      readMoreText: __('Read More', 'mailpoet'),
+      readMoreLink:
+        'https://kb.mailpoet.com/article/284-import-old-customers-to-the-woocommerce-customers-list',
+    },
+    {
+      slug: 'item-5',
+      title: __('How do I customize emails for my store?', 'mailpoet'),
+      text: __(
+        'You can create and send the following 4 WooCommerce Automatic emails with MailPoet: Abandoned Shopping Cart, First Purchase, Purchased In This Category, Purchased This Product. You can read more about each in our article.',
+        'mailpoet',
+      ),
+      readMoreText: __('Read More', 'mailpoet'),
+      readMoreLink:
+        'https://kb.mailpoet.com/article/277-woocommerce-automatic-emails',
+    },
+  ];
+
   return (
     <div className="landing-faq mailpoet-content-padding">
       <div className="mailpoet-content-center">
@@ -25,7 +93,28 @@ function Faq() {
         </p>
       </div>
 
-      <p> FAQ here. Replace with FAQ </p>
+      <div className="mailpoet-faq-accordion">
+        {list.map((item) => (
+          <details key={item.slug}>
+            <summary>
+              {' '}
+              <strong> {item.title} </strong>{' '}
+            </summary>
+            <div className="content">
+              <p>{item.text}</p>
+              <p>
+                <a
+                  href={item.readMoreLink}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {item.readMoreText}
+                </a>
+              </p>
+            </div>
+          </details>
+        ))}
+      </div>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/landingpage/faq.tsx
+++ b/mailpoet/assets/js/src/landingpage/faq.tsx
@@ -1,4 +1,3 @@
-import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
 import { __ } from '@wordpress/i18n';
 import { Heading } from 'common/typography/heading/heading';
@@ -72,12 +71,18 @@ function Faq() {
   ];
 
   return (
-    <div className="landing-faq mailpoet-content-padding">
+    <div className="landing-faq">
       <div className="mailpoet-content-center">
-        <Heading level={2}> {MailPoet.I18n.t('faqHeader')} </Heading>
+        <Heading level={2}>
+          {' '}
+          {__('Frequently asked questions', 'mailpoet')}{' '}
+        </Heading>
         <p>
           {ReactStringReplace(
-            MailPoet.I18n.t('faqHeaderSubText'),
+            __(
+              "Here are some common questions on getting started. Can't find what you're looking for? [link]View all resources[/link]",
+              'mailpoet',
+            ),
             /\[link\](.*?)\[\/link\]/,
             (text) => (
               <a

--- a/mailpoet/assets/js/src/landingpage/faq.tsx
+++ b/mailpoet/assets/js/src/landingpage/faq.tsx
@@ -1,0 +1,34 @@
+import { MailPoet } from 'mailpoet';
+import ReactStringReplace from 'react-string-replace';
+import { Heading } from 'common/typography/heading/heading';
+
+function Faq() {
+  return (
+    <div className="landing-faq mailpoet-content-padding">
+      <div className="mailpoet-content-center">
+        <Heading level={2}> {MailPoet.I18n.t('faqHeader')} </Heading>
+        <p>
+          {ReactStringReplace(
+            MailPoet.I18n.t('faqHeaderSubText'),
+            /\[link\](.*?)\[\/link\]/,
+            (text) => (
+              <a
+                key={text}
+                href="https://kb.mailpoet.com/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {text}
+              </a>
+            ),
+          )}
+        </p>
+      </div>
+
+      <p> FAQ here. Replace with FAQ </p>
+    </div>
+  );
+}
+Faq.displayName = 'Landingpage FAQ';
+
+export { Faq };

--- a/mailpoet/assets/js/src/landingpage/footer.tsx
+++ b/mailpoet/assets/js/src/landingpage/footer.tsx
@@ -5,12 +5,14 @@ import { redirectToWelcomeWizard } from './util';
 
 function Footer() {
   return (
-    <div className="mailpoet-content-center landing-footer">
-      <Heading level={4}> {MailPoet.I18n.t('readyToUseMailPoet')} </Heading>
-      <Button onClick={redirectToWelcomeWizard}>
-        {' '}
-        {MailPoet.I18n.t('beginSetup')}{' '}
-      </Button>
+    <div className="mailpoet-content-padding">
+      <div className="mailpoet-content-center landing-footer">
+        <Heading level={4}> {MailPoet.I18n.t('readyToUseMailPoet')} </Heading>
+        <Button onClick={redirectToWelcomeWizard}>
+          {' '}
+          {MailPoet.I18n.t('beginSetup')}{' '}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/landingpage/footer.tsx
+++ b/mailpoet/assets/js/src/landingpage/footer.tsx
@@ -1,16 +1,18 @@
-import { MailPoet } from 'mailpoet';
+import { __ } from '@wordpress/i18n';
 import { Button } from 'common';
 import { Heading } from 'common/typography/heading/heading';
 import { redirectToWelcomeWizard } from './util';
 
 function Footer() {
   return (
-    <div className="mailpoet-content-padding">
-      <div className="mailpoet-content-center landing-footer">
-        <Heading level={4}> {MailPoet.I18n.t('readyToUseMailPoet')} </Heading>
-        <Button onClick={redirectToWelcomeWizard}>
+    <div className="landing-footer">
+      <div className="landing-footer-content mailpoet-content-center">
+        <Heading level={4}>
           {' '}
-          {MailPoet.I18n.t('beginSetup')}{' '}
+          {__('Ready to start using MailPoet?', 'mailpoet')}{' '}
+        </Heading>
+        <Button onClick={redirectToWelcomeWizard}>
+          {__('Begin setup', 'mailpoet')}
         </Button>
       </div>
     </div>

--- a/mailpoet/assets/js/src/landingpage/header.tsx
+++ b/mailpoet/assets/js/src/landingpage/header.tsx
@@ -1,23 +1,25 @@
-import { MailPoet } from 'mailpoet';
+import { __ } from '@wordpress/i18n';
 import { Button } from 'common';
 import { Heading } from 'common/typography/heading/heading';
 import { redirectToWelcomeWizard } from './util';
 
 function Header() {
   return (
-    <div className="mailpoet-content-center mailpoet-content-padding">
-      <Heading level={1}>
-        {' '}
-        {MailPoet.I18n.t('betterEmailWithoutLeavingWordPress')}{' '}
-      </Heading>
-      <Heading level={3}>
-        {' '}
-        {MailPoet.I18n.t('startingOutOrEstablished')}{' '}
-      </Heading>
-      <Button onClick={redirectToWelcomeWizard}>
-        {' '}
-        {MailPoet.I18n.t('beginSetup')}{' '}
-      </Button>
+    <div className="landing-header">
+      <div className="mailpoet-content-center">
+        <Heading level={0}>
+          {__('Better email — without leaving WordPress', 'mailpoet')}
+        </Heading>
+        <p>
+          {__(
+            'Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are.',
+            'mailpoet',
+          )}
+        </p>
+        <Button onClick={redirectToWelcomeWizard}>
+          {__('Begin setup', 'mailpoet')}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/landingpage/header.tsx
+++ b/mailpoet/assets/js/src/landingpage/header.tsx
@@ -5,7 +5,7 @@ import { redirectToWelcomeWizard } from './util';
 
 function Header() {
   return (
-    <div className="mailpoet-content-center">
+    <div className="mailpoet-content-center mailpoet-content-padding">
       <Heading level={1}>
         {' '}
         {MailPoet.I18n.t('betterEmailWithoutLeavingWordPress')}{' '}

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from 'common';
 import { Background } from 'common/background/background';
 import { Header } from './header';
 import { Footer } from './footer';
+import { Faq } from './faq';
 
 function Landingpage() {
   return (
@@ -21,6 +22,8 @@ function Landingpage() {
       <br />
 
       <div className="mailpoet-gap" />
+
+      <Faq />
 
       <Footer />
     </GlobalContext.Provider>

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -15,7 +15,9 @@
   'betterEmailWithoutLeavingWordPress': __('Better email — without leaving WordPress'),
   'startingOutOrEstablished': __('Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are.'),
   'beginSetup': __('Begin setup'),
-  'readyToUseMailPoet': __('Ready to start using MailPoet?'),
+  'readyToUseMailPoet': __('Ready to use MailPoet?'),
+  'faqHeader': __('Frequently asked questions'),
+  'faqHeaderSubText': __("Here are some common questions on getting started. Can't find what you're looking for? [link]View all resources[/link]"),
 }) %>
 <% endblock %>
 

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -9,15 +9,3 @@
   <% endautoescape %>
 </script>
 <% endblock %>
-
-<% block translations %>
-<%= localize({
-  'betterEmailWithoutLeavingWordPress': __('Better email — without leaving WordPress'),
-  'startingOutOrEstablished': __('Whether you’re just starting out or have already established your business, we’ve got what you need to reach customers where they are.'),
-  'beginSetup': __('Begin setup'),
-  'readyToUseMailPoet': __('Ready to use MailPoet?'),
-  'faqHeader': __('Frequently asked questions'),
-  'faqHeaderSubText': __("Here are some common questions on getting started. Can't find what you're looking for? [link]View all resources[/link]"),
-}) %>
-<% endblock %>
-


### PR DESCRIPTION
## Description

This PR adds a FAQ to the landing page.

This is a continuation of https://github.com/mailpoet/mailpoet/pull/4626

![mailpoet-landingpage FAQ](https://user-images.githubusercontent.com/30554163/211325059-9f6b7b0a-43e0-4435-ad1a-57580d36fd53.png)


## Code review notes

Please start reviewing from https://github.com/mailpoet/mailpoet/commit/21292802bd706f75ce6098d7315d4b912d444931

## QA notes

You can access the page here: `wp-admin/admin.php?page=mailpoet-landingpage`

You need to enable Landingpage experimental features here: `/wp-admin/admin.php?page=mailpoet-experimental`

Check https://github.com/mailpoet/mailpoet/pull/4620 for more QA information 

## Linked PRs

* First: https://github.com/mailpoet/mailpoet/pull/4620
* Second: https://github.com/mailpoet/mailpoet/pull/4626
* **Third**: https://github.com/mailpoet/mailpoet/pull/4628

## Linked tickets

[MAILPOET-4798](https://mailpoet.atlassian.net/browse/MAILPOET-4798)

## After-merge notes

**Note**: Please merge after https://github.com/mailpoet/mailpoet/pull/4626


[MAILPOET-4798]: https://mailpoet.atlassian.net/browse/MAILPOET-4798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ