### PR TITLE
Homepage Task List [MAILPOET-4826]

### DIFF
--- a/mailpoet/assets/css/src/components-homepage/_layout.scss
+++ b/mailpoet/assets/css/src/components-homepage/_layout.scss
@@ -1,4 +1,5 @@
 .mailpoet-homepage__container {
   margin: 0 auto;
+  margin-top: $grid-gap-xl;
   max-width: 680px;
 }

--- a/mailpoet/assets/css/src/components-homepage/_layout.scss
+++ b/mailpoet/assets/css/src/components-homepage/_layout.scss
@@ -1,0 +1,4 @@
+.mailpoet-homepage__container {
+  margin: 0 auto;
+  max-width: 680px;
+}

--- a/mailpoet/assets/css/src/components-homepage/_task-list.scss
+++ b/mailpoet/assets/css/src/components-homepage/_task-list.scss
@@ -18,7 +18,7 @@ $task-icon-size: 32px;
   }
 }
 
-.mailpoet-task-list__task-title {
+.mailpoet-task-list__task-content {
   align-content: center;
   color: var(--wp-admin-theme-color);
   display: flex;
@@ -26,10 +26,27 @@ $task-icon-size: 32px;
   font-size: 14px;
   justify-content: center;
   line-height: 20px;
+
+  p {
+    color: $color-text-light;
+    font-weight: normal;
+    margin: 3px 0 0;
+  }
+
+  a {
+    color: var(--wp-admin-theme-color);
+
+    &:hover {
+      color: var(--wp-admin-theme-color-darker-20);
+    }
+  }
 }
 
 .mailpoet-task-list__task-before {
   color: var(--wp-admin-theme-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .mailpoet-task-list__task-icon {

--- a/mailpoet/assets/css/src/components-homepage/_task-list.scss
+++ b/mailpoet/assets/css/src/components-homepage/_task-list.scss
@@ -6,6 +6,7 @@ $task-icon-size: 32px;
   box-sizing: border-box;
   cursor: pointer;
   display: grid;
+  font-weight: 600;
   grid-template-columns: $grid-gap-xl auto $grid-gap-xl;
   margin: 0;
   padding: $grid-gap $grid-gap-medium;
@@ -72,6 +73,15 @@ $task-icon-size: 32px;
   }
 }
 
+.mailpoet-task-list__heading p,
+.mailpoet-task-list__all-set {
+  color: $color-text-light;
+  font-size: $heading-font-size-h4;
+  line-height: 1.5;
+  margin-top: $grid-gap-large;
+  text-align: center;
+}
+
 .mailpoet-task-list__heading {
   margin-bottom: $grid-gap-large;
   position: relative;
@@ -81,10 +91,8 @@ $task-icon-size: 32px;
   }
 
   p {
-    color: $color-text-light;
-    font-size: $heading-font-size-h4;
-    line-height: 1.5;
     margin-top: $grid-gap-half;
+    text-align: left;
   }
 
   .components-dropdown {

--- a/mailpoet/assets/css/src/components-homepage/_task-list.scss
+++ b/mailpoet/assets/css/src/components-homepage/_task-list.scss
@@ -71,3 +71,25 @@ $task-icon-size: 32px;
     width: 100%;
   }
 }
+
+.mailpoet-task-list__heading {
+  margin-bottom: $grid-gap-large;
+  position: relative;
+
+  h1 {
+    margin: 0;
+  }
+
+  p {
+    color: $color-text-light;
+    font-size: $heading-font-size-h4;
+    line-height: 1.5;
+    margin-top: $grid-gap-half;
+  }
+
+  .components-dropdown {
+    position: absolute;
+    right: 0;
+    top: 6px;
+  }
+}

--- a/mailpoet/assets/css/src/components-homepage/_task-list.scss
+++ b/mailpoet/assets/css/src/components-homepage/_task-list.scss
@@ -1,0 +1,56 @@
+$task-icon-size: 32px;
+
+.mailpoet-task-list__task {
+  background-color: $color-white;
+  border-bottom: 1px solid $color-homepage-borders;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: $grid-gap-xl auto $grid-gap-xl;
+  margin: 0;
+  padding: $grid-gap $grid-gap-medium;
+  width: 100%;
+
+  &:hover {
+    background-color: $color-grey-0;
+  }
+}
+
+.mailpoet-task-list__task-title {
+  align-content: center;
+  color: var(--wp-admin-theme-color);
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  justify-content: center;
+  line-height: 20px;
+}
+
+.mailpoet-task-list__task-before {
+  color: var(--wp-admin-theme-color);
+}
+
+.mailpoet-task-list__task-icon {
+  border: 1px solid var(--wp-admin-theme-color);
+  border-radius: 50%;
+  box-sizing: border-box;
+  height: $task-icon-size;
+  line-height: $task-icon-size;
+  text-align: center;
+  width: $task-icon-size;
+
+  svg {
+    fill: var(--wp-admin-theme-color);
+    margin: 3px;
+  }
+}
+
+.mailpoet-task-list__task--completed {
+  .mailpoet-task-list__task-icon {
+    background-color: var(--wp-admin-theme-color);
+
+    svg {
+      fill: $color-white;
+    }
+  }
+}

--- a/mailpoet/assets/css/src/components-homepage/_task-list.scss
+++ b/mailpoet/assets/css/src/components-homepage/_task-list.scss
@@ -9,6 +9,7 @@ $task-icon-size: 32px;
   grid-template-columns: $grid-gap-xl auto $grid-gap-xl;
   margin: 0;
   padding: $grid-gap $grid-gap-medium;
+  position: relative;
   width: 100%;
 
   &:hover {
@@ -52,5 +53,21 @@ $task-icon-size: 32px;
     svg {
       fill: $color-white;
     }
+  }
+}
+
+.mailpoet-task-list__task--active {
+  box-shadow: inset 5px 0 0 0 var(--wp-admin-theme-color);
+
+  &:after {
+    background-color: var(--wp-admin-theme-color);
+    content: '';
+    height: 100%;
+    left: 0;
+    opacity: .1;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 100%;
   }
 }

--- a/mailpoet/assets/css/src/components-homepage/_task-list.scss
+++ b/mailpoet/assets/css/src/components-homepage/_task-list.scss
@@ -65,6 +65,12 @@ $task-icon-size: 32px;
 }
 
 .mailpoet-task-list__task--completed {
+  cursor: inherit;
+
+  &:hover {
+    background-color: $color-white;
+  }
+
   .mailpoet-task-list__task-icon {
     background-color: var(--wp-admin-theme-color);
 

--- a/mailpoet/assets/css/src/mailpoet-homepage.scss
+++ b/mailpoet/assets/css/src/mailpoet-homepage.scss
@@ -7,6 +7,7 @@
 @import 'settings/breakpoints';
 @import 'settings/colors';
 @import 'settings/grid';
+@import 'settings/typography';
 
 // Components
 // Actual UI components.

--- a/mailpoet/assets/css/src/mailpoet-homepage.scss
+++ b/mailpoet/assets/css/src/mailpoet-homepage.scss
@@ -1,0 +1,15 @@
+
+@import '../../../node_modules/@woocommerce/components/build-style/style'; // Needed to load WP admin themes color variables
+
+// Settings
+// Global variables, config switches. Not producing any CSS.
+
+@import 'settings/breakpoints';
+@import 'settings/colors';
+@import 'settings/grid';
+
+// Components
+// Actual UI components.
+
+@import 'components-homepage/_layout';
+@import 'components-homepage/_task-list';

--- a/mailpoet/assets/css/src/settings/_colors.scss
+++ b/mailpoet/assets/css/src/settings/_colors.scss
@@ -80,4 +80,8 @@ $color-chip-success-text: #005c12;
 $color-chip-danger-bg: #facfd2;
 $color-chip-danger-text: #8a2424;
 
+// Landing page
 $color-landingpage-background-light: #fbfbfb;
+
+// Homepage
+$color-homepage-borders: #f5f5f5;

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -171,4 +171,7 @@ interface Window {
     forceUpdate: () => void;
   };
   mailpoet_welcome_wizard_url: string;
+  mailpoet_homepage_data: {
+    task_list_dismissed: boolean;
+  };
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -173,5 +173,11 @@ interface Window {
   mailpoet_welcome_wizard_url: string;
   mailpoet_homepage_data: {
     task_list_dismissed: boolean;
+    task_list_status: {
+      senderSet: boolean;
+      mssConnected: boolean;
+      subscribersAdded: boolean;
+      wooSubscribersImported: boolean;
+    };
   };
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -180,5 +180,6 @@ interface Window {
       wooSubscribersImported: boolean;
     };
     woo_customers_count: number;
+    subscribers_count: number;
   };
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -179,5 +179,6 @@ interface Window {
       subscribersAdded: boolean;
       wooSubscribersImported: boolean;
     };
+    woo_customers_count: number;
   };
 }

--- a/mailpoet/assets/js/src/homepage/components/layout.tsx
+++ b/mailpoet/assets/js/src/homepage/components/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export function Layout({ children }: Props): JSX.Element {
+  return <div className="mailpoet-homepage__container">{children}</div>;
+}

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -6,11 +6,18 @@ import { storeName } from 'homepage/store/store';
 import { Task } from './task';
 
 export function TaskList(): JSX.Element {
-  const { isTaskListHidden, tasksStatus, currentTask } = useSelect(
+  const {
+    isTaskListHidden,
+    tasksStatus,
+    currentTask,
+    canImportWooCommerceSubscribers,
+  } = useSelect(
     (select) => ({
       isTaskListHidden: select(storeName).getIsTaskListHidden(),
       tasksStatus: select(storeName).getTasksStatus(),
       currentTask: select(storeName).getCurrentTask(),
+      canImportWooCommerceSubscribers:
+        select(storeName).getCanImportWooCommerceSubscribers(),
     }),
     [],
   );
@@ -37,7 +44,7 @@ export function TaskList(): JSX.Element {
       isActive={currentTask === 'mssConnected'}
     />,
   );
-  if (MailPoet.isWoocommerceActive) {
+  if (canImportWooCommerceSubscribers) {
     taskListItems.push(
       <Task
         key="wooSubscribersImported"
@@ -54,7 +61,7 @@ export function TaskList(): JSX.Element {
       key="subscribersAdded"
       title={MailPoet.I18n.t('subscribersAddedTask')}
       link="admin.php?page=mailpoet-import"
-      order={MailPoet.isWoocommerceActive ? 4 : 3}
+      order={canImportWooCommerceSubscribers ? 4 : 3}
       status={tasksStatus.subscribersAdded}
       isActive={currentTask === 'subscribersAdded'}
     />,

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -1,9 +1,17 @@
 import { MailPoet } from 'mailpoet';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { DropdownMenu } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
+import { storeName } from 'homepage/store/store';
 
 export function TaskList(): JSX.Element {
-  return (
+  const isTaskListHidden = useSelect(
+    (select) => select(storeName).getIsTaskListHidden(),
+    [],
+  );
+  const { hideTaskList } = useDispatch(storeName);
+
+  return isTaskListHidden ? null : (
     <>
       <h1>{MailPoet.I18n.t('welcomeToMailPoet')}</h1>
       <h2>{MailPoet.I18n.t('beginByCompletingSetup')}</h2>
@@ -13,7 +21,7 @@ export function TaskList(): JSX.Element {
         controls={[
           {
             title: MailPoet.I18n.t('hideList'),
-            onClick: () => {},
+            onClick: hideTaskList,
             icon: null,
           },
         ]}

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -85,6 +85,20 @@ export function TaskList(): JSX.Element {
         />
       </div>
       <ul>{taskListItems.map((item) => item)}</ul>
+      {!currentTask ? (
+        <p className="mailpoet-task-list__all-set">
+          {MailPoet.I18n.t('youAreSet')}{' '}
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              hideTaskList();
+            }}
+          >
+            {MailPoet.I18n.t('dismissList')}
+          </a>
+        </p>
+      ) : null}
     </>
   );
 }

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -10,12 +10,14 @@ export function TaskList(): JSX.Element {
     isTaskListHidden,
     tasksStatus,
     currentTask,
+    hasImportedSubscribers,
     canImportWooCommerceSubscribers,
   } = useSelect(
     (select) => ({
       isTaskListHidden: select(storeName).getIsTaskListHidden(),
       tasksStatus: select(storeName).getTasksStatus(),
       currentTask: select(storeName).getCurrentTask(),
+      hasImportedSubscribers: select(storeName).getHasImportedSubscribers(),
       canImportWooCommerceSubscribers:
         select(storeName).getCanImportWooCommerceSubscribers(),
     }),
@@ -28,6 +30,7 @@ export function TaskList(): JSX.Element {
     <Task
       key="senderSet"
       title={MailPoet.I18n.t('senderSetTask')}
+      titleCompleted={MailPoet.I18n.t('senderSetTaskDone')}
       link="admin.php?page=mailpoet-settings#/basics"
       order={1}
       status={tasksStatus.senderSet}
@@ -38,6 +41,7 @@ export function TaskList(): JSX.Element {
     <Task
       key="mssConnected"
       title={MailPoet.I18n.t('mssConnectedTask')}
+      titleCompleted={MailPoet.I18n.t('mssConnectedTaskDone')}
       link="admin.php?page=mailpoet-settings#/premium"
       order={2}
       status={tasksStatus.mssConnected}
@@ -49,6 +53,7 @@ export function TaskList(): JSX.Element {
       <Task
         key="wooSubscribersImported"
         title={MailPoet.I18n.t('wooSubscribersImportedTask')}
+        titleCompleted={MailPoet.I18n.t('wooSubscribersImportedTaskDone')}
         link="admin.php?page=mailpoet-woocommerce-setup"
         order={3}
         status={tasksStatus.wooSubscribersImported}
@@ -60,11 +65,33 @@ export function TaskList(): JSX.Element {
     <Task
       key="subscribersAdded"
       title={MailPoet.I18n.t('subscribersAddedTask')}
+      titleCompleted={
+        hasImportedSubscribers
+          ? MailPoet.I18n.t('subscribersAddedTaskDoneByImport')
+          : MailPoet.I18n.t('subscribersAddedTaskDoneByForm')
+      }
       link="admin.php?page=mailpoet-import"
       order={canImportWooCommerceSubscribers ? 4 : 3}
       status={tasksStatus.subscribersAdded}
       isActive={currentTask === 'subscribersAdded'}
-    />,
+    >
+      {!tasksStatus.subscribersAdded ? (
+        <p>
+          {MailPoet.I18n.t('noSubscribersQuestion')}{' '}
+          <a href="admin.php?page=mailpoet-form-editor-template-selection">
+            {MailPoet.I18n.t('setUpForm')}
+          </a>
+        </p>
+      ) : null}
+      {tasksStatus.subscribersAdded && !hasImportedSubscribers ? (
+        <p>
+          {MailPoet.I18n.t('haveSubscribersQuestion')}{' '}
+          <a href="admin.php?page=mailpoet-import">
+            {MailPoet.I18n.t('import')}
+          </a>
+        </p>
+      ) : null}
+    </Task>,
   );
 
   return isTaskListHidden ? null : (

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -33,7 +33,7 @@ export function TaskList(): JSX.Element {
       titleCompleted={MailPoet.I18n.t('senderSetTaskDone')}
       link="admin.php?page=mailpoet-settings#/basics"
       order={1}
-      status={tasksStatus.senderSet}
+      isCompleted={tasksStatus.senderSet}
       isActive={currentTask === 'senderSet'}
     />,
   );
@@ -44,7 +44,7 @@ export function TaskList(): JSX.Element {
       titleCompleted={MailPoet.I18n.t('mssConnectedTaskDone')}
       link="admin.php?page=mailpoet-settings#/premium"
       order={2}
-      status={tasksStatus.mssConnected}
+      isCompleted={tasksStatus.mssConnected}
       isActive={currentTask === 'mssConnected'}
     />,
   );
@@ -56,7 +56,7 @@ export function TaskList(): JSX.Element {
         titleCompleted={MailPoet.I18n.t('wooSubscribersImportedTaskDone')}
         link="admin.php?page=mailpoet-woocommerce-setup"
         order={3}
-        status={tasksStatus.wooSubscribersImported}
+        isCompleted={tasksStatus.wooSubscribersImported}
         isActive={currentTask === 'wooSubscribersImported'}
       />,
     );
@@ -72,7 +72,7 @@ export function TaskList(): JSX.Element {
       }
       link="admin.php?page=mailpoet-import"
       order={canImportWooCommerceSubscribers ? 4 : 3}
-      status={tasksStatus.subscribersAdded}
+      isCompleted={tasksStatus.subscribersAdded}
       isActive={currentTask === 'subscribersAdded'}
     >
       {!tasksStatus.subscribersAdded ? (

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -1,10 +1,23 @@
 import { MailPoet } from 'mailpoet';
+import { DropdownMenu } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 
 export function TaskList(): JSX.Element {
   return (
     <>
       <h1>{MailPoet.I18n.t('welcomeToMailPoet')}</h1>
       <h2>{MailPoet.I18n.t('beginByCompletingSetup')}</h2>
+      <DropdownMenu
+        label={MailPoet.I18n.t('hideList')}
+        icon={moreVertical}
+        controls={[
+          {
+            title: MailPoet.I18n.t('hideList'),
+            onClick: () => {},
+            icon: null,
+          },
+        ]}
+      />
     </>
   );
 }

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -1,0 +1,10 @@
+import { MailPoet } from 'mailpoet';
+
+export function TaskList(): JSX.Element {
+  return (
+    <>
+      <h1>{MailPoet.I18n.t('welcomeToMailPoet')}</h1>
+      <h2>{MailPoet.I18n.t('beginByCompletingSetup')}</h2>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -69,19 +69,21 @@ export function TaskList(): JSX.Element {
 
   return isTaskListHidden ? null : (
     <>
-      <h1>{MailPoet.I18n.t('welcomeToMailPoet')}</h1>
-      <h2>{MailPoet.I18n.t('beginByCompletingSetup')}</h2>
-      <DropdownMenu
-        label={MailPoet.I18n.t('hideList')}
-        icon={moreVertical}
-        controls={[
-          {
-            title: MailPoet.I18n.t('hideList'),
-            onClick: hideTaskList,
-            icon: null,
-          },
-        ]}
-      />
+      <div className="mailpoet-task-list__heading">
+        <h1>{MailPoet.I18n.t('welcomeToMailPoet')}</h1>
+        <p>{MailPoet.I18n.t('beginByCompletingSetup')}</p>
+        <DropdownMenu
+          label={MailPoet.I18n.t('hideList')}
+          icon={moreVertical}
+          controls={[
+            {
+              title: MailPoet.I18n.t('hideList'),
+              onClick: hideTaskList,
+              icon: null,
+            },
+          ]}
+        />
+      </div>
       <ul>{taskListItems.map((item) => item)}</ul>
     </>
   );

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -3,6 +3,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { DropdownMenu } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { storeName } from 'homepage/store/store';
+import { Task } from './task';
 
 export function TaskList(): JSX.Element {
   const { isTaskListHidden, tasksStatus } = useSelect(
@@ -16,30 +17,42 @@ export function TaskList(): JSX.Element {
 
   const taskListItems = [];
   taskListItems.push(
-    <div key="senderSet">
-      {MailPoet.I18n.t('senderSetTask')}{' '}
-      {tasksStatus.senderSet ? '[done]' : '[not_done]'}
-    </div>,
+    <Task
+      key="senderSet"
+      title={MailPoet.I18n.t('senderSetTask')}
+      link="admin.php?page=mailpoet-settings#/basics"
+      order={1}
+      status={tasksStatus.senderSet}
+    />,
   );
   taskListItems.push(
-    <div key="mssConnected">
-      {MailPoet.I18n.t('mssConnectedTask')}{' '}
-      {tasksStatus.mssConnected ? '[done]' : '[not_done]'}
-    </div>,
+    <Task
+      key="mssConnected"
+      title={MailPoet.I18n.t('mssConnectedTask')}
+      link="admin.php?page=mailpoet-settings#/premium"
+      order={2}
+      status={tasksStatus.mssConnected}
+    />,
   );
   if (MailPoet.isWoocommerceActive) {
     taskListItems.push(
-      <div key="wooSubscribersImported">
-        {MailPoet.I18n.t('wooSubscribersImportedTask')}{' '}
-        {tasksStatus.wooSubscribersImported ? '[done]' : '[not_done]'}
-      </div>,
+      <Task
+        key="wooSubscribersImported"
+        title={MailPoet.I18n.t('wooSubscribersImportedTask')}
+        link="admin.php?page=mailpoet-woocommerce-setup"
+        order={3}
+        status={tasksStatus.wooSubscribersImported}
+      />,
     );
   }
   taskListItems.push(
-    <div key="subscribersAdded">
-      {MailPoet.I18n.t('subscribersAddedTask')}{' '}
-      {tasksStatus.subscribersAdded ? '[done]' : '[not_done]'}
-    </div>,
+    <Task
+      key="subscribersAdded"
+      title={MailPoet.I18n.t('subscribersAddedTask')}
+      link="admin.php?page=mailpoet-import"
+      order={MailPoet.isWoocommerceActive ? 4 : 3}
+      status={tasksStatus.subscribersAdded}
+    />,
   );
 
   return isTaskListHidden ? null : (
@@ -57,7 +70,7 @@ export function TaskList(): JSX.Element {
           },
         ]}
       />
-      {taskListItems.map((item) => item)}
+      <ul>{taskListItems.map((item) => item)}</ul>
     </>
   );
 }

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -5,11 +5,42 @@ import { moreVertical } from '@wordpress/icons';
 import { storeName } from 'homepage/store/store';
 
 export function TaskList(): JSX.Element {
-  const isTaskListHidden = useSelect(
-    (select) => select(storeName).getIsTaskListHidden(),
+  const { isTaskListHidden, tasksStatus } = useSelect(
+    (select) => ({
+      isTaskListHidden: select(storeName).getIsTaskListHidden(),
+      tasksStatus: select(storeName).getTasksStatus(),
+    }),
     [],
   );
   const { hideTaskList } = useDispatch(storeName);
+
+  const taskListItems = [];
+  taskListItems.push(
+    <div key="senderSet">
+      {MailPoet.I18n.t('senderSetTask')}{' '}
+      {tasksStatus.senderSet ? '[done]' : '[not_done]'}
+    </div>,
+  );
+  taskListItems.push(
+    <div key="mssConnected">
+      {MailPoet.I18n.t('mssConnectedTask')}{' '}
+      {tasksStatus.mssConnected ? '[done]' : '[not_done]'}
+    </div>,
+  );
+  if (MailPoet.isWoocommerceActive) {
+    taskListItems.push(
+      <div key="wooSubscribersImported">
+        {MailPoet.I18n.t('wooSubscribersImportedTask')}{' '}
+        {tasksStatus.wooSubscribersImported ? '[done]' : '[not_done]'}
+      </div>,
+    );
+  }
+  taskListItems.push(
+    <div key="subscribersAdded">
+      {MailPoet.I18n.t('subscribersAddedTask')}{' '}
+      {tasksStatus.subscribersAdded ? '[done]' : '[not_done]'}
+    </div>,
+  );
 
   return isTaskListHidden ? null : (
     <>
@@ -26,6 +57,7 @@ export function TaskList(): JSX.Element {
           },
         ]}
       />
+      {taskListItems.map((item) => item)}
     </>
   );
 }

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -6,10 +6,11 @@ import { storeName } from 'homepage/store/store';
 import { Task } from './task';
 
 export function TaskList(): JSX.Element {
-  const { isTaskListHidden, tasksStatus } = useSelect(
+  const { isTaskListHidden, tasksStatus, currentTask } = useSelect(
     (select) => ({
       isTaskListHidden: select(storeName).getIsTaskListHidden(),
       tasksStatus: select(storeName).getTasksStatus(),
+      currentTask: select(storeName).getCurrentTask(),
     }),
     [],
   );
@@ -23,6 +24,7 @@ export function TaskList(): JSX.Element {
       link="admin.php?page=mailpoet-settings#/basics"
       order={1}
       status={tasksStatus.senderSet}
+      isActive={currentTask === 'senderSet'}
     />,
   );
   taskListItems.push(
@@ -32,6 +34,7 @@ export function TaskList(): JSX.Element {
       link="admin.php?page=mailpoet-settings#/premium"
       order={2}
       status={tasksStatus.mssConnected}
+      isActive={currentTask === 'mssConnected'}
     />,
   );
   if (MailPoet.isWoocommerceActive) {
@@ -42,6 +45,7 @@ export function TaskList(): JSX.Element {
         link="admin.php?page=mailpoet-woocommerce-setup"
         order={3}
         status={tasksStatus.wooSubscribersImported}
+        isActive={currentTask === 'wooSubscribersImported'}
       />,
     );
   }
@@ -52,6 +56,7 @@ export function TaskList(): JSX.Element {
       link="admin.php?page=mailpoet-import"
       order={MailPoet.isWoocommerceActive ? 4 : 3}
       status={tasksStatus.subscribersAdded}
+      isActive={currentTask === 'subscribersAdded'}
     />,
   );
 

--- a/mailpoet/assets/js/src/homepage/components/task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task.tsx
@@ -4,18 +4,22 @@ import classnames from 'classnames';
 
 type Props = {
   title: string;
+  titleCompleted?: string;
   link: string;
   order: number;
   status: boolean;
   isActive: boolean;
+  children?: React.ReactNode;
 };
 
 export function Task({
   title,
+  titleCompleted = '',
   link,
   order,
   status,
   isActive,
+  children = null,
 }: Props): JSX.Element {
   const className = classnames('mailpoet-task-list__task', {
     'mailpoet-task-list__task--completed': status,
@@ -37,7 +41,12 @@ export function Task({
           {status ? <Icon icon={check} /> : order}
         </div>
       </div>
-      <div className="mailpoet-task-list__task-title">{title}</div>
+      <div className="mailpoet-task-list__task-content">
+        <div className="mailpoet-task-list__task-title">
+          {status && titleCompleted ? titleCompleted : title}
+        </div>
+        {children}
+      </div>
     </li>
   );
 }

--- a/mailpoet/assets/js/src/homepage/components/task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task.tsx
@@ -1,0 +1,35 @@
+import { Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+import classnames from 'classnames';
+
+type Props = {
+  title: string;
+  link: string;
+  order: number;
+  status: boolean;
+};
+
+export function Task({ title, link, order, status }: Props): JSX.Element {
+  const className = classnames('mailpoet-task-list__task', {
+    'mailpoet-task-list__task--completed': status,
+  });
+  const handleTaskClick = () => {
+    window.location.href = link;
+  };
+  return (
+    <li
+      className={className}
+      role="row"
+      onClick={handleTaskClick}
+      tabIndex={0}
+      onKeyDown={(e) => e.key === 'Enter' && handleTaskClick()}
+    >
+      <div className="mailpoet-task-list__task-before">
+        <div className="mailpoet-task-list__task-icon">
+          {status ? <Icon icon={check} /> : order}
+        </div>
+      </div>
+      <div className="mailpoet-task-list__task-title">{title}</div>
+    </li>
+  );
+}

--- a/mailpoet/assets/js/src/homepage/components/task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task.tsx
@@ -7,7 +7,7 @@ type Props = {
   titleCompleted?: string;
   link: string;
   order: number;
-  status: boolean;
+  isCompleted: boolean;
   isActive: boolean;
   children?: React.ReactNode;
 };
@@ -17,12 +17,12 @@ export function Task({
   titleCompleted = '',
   link,
   order,
-  status,
+  isCompleted,
   isActive,
   children = null,
 }: Props): JSX.Element {
   const className = classnames('mailpoet-task-list__task', {
-    'mailpoet-task-list__task--completed': status,
+    'mailpoet-task-list__task--completed': isCompleted,
     'mailpoet-task-list__task--active': isActive,
   });
   const handleTaskClick = () => {
@@ -38,12 +38,12 @@ export function Task({
     >
       <div className="mailpoet-task-list__task-before">
         <div className="mailpoet-task-list__task-icon">
-          {status ? <Icon icon={check} /> : order}
+          {isCompleted ? <Icon icon={check} /> : order}
         </div>
       </div>
       <div className="mailpoet-task-list__task-content">
         <div className="mailpoet-task-list__task-title">
-          {status && titleCompleted ? titleCompleted : title}
+          {isCompleted && titleCompleted ? titleCompleted : title}
         </div>
         {children}
       </div>

--- a/mailpoet/assets/js/src/homepage/components/task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task.tsx
@@ -7,11 +7,19 @@ type Props = {
   link: string;
   order: number;
   status: boolean;
+  isActive: boolean;
 };
 
-export function Task({ title, link, order, status }: Props): JSX.Element {
+export function Task({
+  title,
+  link,
+  order,
+  status,
+  isActive,
+}: Props): JSX.Element {
   const className = classnames('mailpoet-task-list__task', {
     'mailpoet-task-list__task--completed': status,
+    'mailpoet-task-list__task--active': isActive,
   });
   const handleTaskClick = () => {
     window.location.href = link;

--- a/mailpoet/assets/js/src/homepage/components/task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task.tsx
@@ -32,9 +32,11 @@ export function Task({
     <li
       className={className}
       role="row"
-      onClick={handleTaskClick}
-      tabIndex={0}
-      onKeyDown={(e) => e.key === 'Enter' && handleTaskClick()}
+      onClick={isCompleted ? undefined : handleTaskClick}
+      tabIndex={isCompleted ? undefined : 0}
+      onKeyDown={
+        isCompleted ? undefined : (e) => e.key === 'Enter' && handleTaskClick()
+      }
     >
       <div className="mailpoet-task-list__task-before">
         <div className="mailpoet-task-list__task-icon">

--- a/mailpoet/assets/js/src/homepage/homepage.tsx
+++ b/mailpoet/assets/js/src/homepage/homepage.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom';
 import { useEffect, useState } from 'react';
+import { ErrorBoundary } from 'common';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { HomepageNotices } from 'homepage/notices';
@@ -19,7 +20,9 @@ function App(): JSX.Element {
       <HomepageNotices />
       {isStoreInitialized ? (
         <Layout>
-          <TaskList />
+          <ErrorBoundary>
+            <TaskList />
+          </ErrorBoundary>
         </Layout>
       ) : null}
     </GlobalContext.Provider>
@@ -28,5 +31,10 @@ function App(): JSX.Element {
 
 const container = document.getElementById('mailpoet_homepage_container');
 if (container) {
-  ReactDOM.render(<App />, container);
+  ReactDOM.render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>,
+    container,
+  );
 }

--- a/mailpoet/assets/js/src/homepage/homepage.tsx
+++ b/mailpoet/assets/js/src/homepage/homepage.tsx
@@ -1,10 +1,15 @@
 import ReactDOM from 'react-dom';
+import { useEffect } from 'react';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { HomepageNotices } from 'homepage/notices';
 import { TaskList } from './components/task-list';
+import { createStore } from './store/store';
 
 function App(): JSX.Element {
+  useEffect(() => {
+    createStore();
+  }, []);
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <TopBarWithBeamer />

--- a/mailpoet/assets/js/src/homepage/homepage.tsx
+++ b/mailpoet/assets/js/src/homepage/homepage.tsx
@@ -2,12 +2,14 @@ import ReactDOM from 'react-dom';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { HomepageNotices } from 'homepage/notices';
+import { TaskList } from './components/task-list';
 
 function App(): JSX.Element {
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <TopBarWithBeamer />
       <HomepageNotices />
+      <TaskList />
     </GlobalContext.Provider>
   );
 }

--- a/mailpoet/assets/js/src/homepage/homepage.tsx
+++ b/mailpoet/assets/js/src/homepage/homepage.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { HomepageNotices } from 'homepage/notices';
@@ -7,20 +7,21 @@ import { TaskList } from './components/task-list';
 import { createStore } from './store/store';
 
 function App(): JSX.Element {
+  const [isStoreInitialized, setIsStoreInitialized] = useState(false);
   useEffect(() => {
     createStore();
+    setIsStoreInitialized(true);
   }, []);
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <TopBarWithBeamer />
       <HomepageNotices />
-      <TaskList />
+      {isStoreInitialized ? <TaskList /> : null}
     </GlobalContext.Provider>
   );
 }
 
 const container = document.getElementById('mailpoet_homepage_container');
-
 if (container) {
   ReactDOM.render(<App />, container);
 }

--- a/mailpoet/assets/js/src/homepage/homepage.tsx
+++ b/mailpoet/assets/js/src/homepage/homepage.tsx
@@ -4,6 +4,7 @@ import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { HomepageNotices } from 'homepage/notices';
 import { TaskList } from './components/task-list';
+import { Layout } from './components/layout';
 import { createStore } from './store/store';
 
 function App(): JSX.Element {
@@ -16,7 +17,11 @@ function App(): JSX.Element {
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <TopBarWithBeamer />
       <HomepageNotices />
-      {isStoreInitialized ? <TaskList /> : null}
+      {isStoreInitialized ? (
+        <Layout>
+          <TaskList />
+        </Layout>
+      ) : null}
     </GlobalContext.Provider>
   );
 }

--- a/mailpoet/assets/js/src/homepage/store/actions.ts
+++ b/mailpoet/assets/js/src/homepage/store/actions.ts
@@ -1,0 +1,3 @@
+export const hideTaskList = () => ({
+  type: 'SET_TASK_LIST_HIDDEN',
+});

--- a/mailpoet/assets/js/src/homepage/store/actions.ts
+++ b/mailpoet/assets/js/src/homepage/store/actions.ts
@@ -1,3 +1,6 @@
-export const hideTaskList = () => ({
-  type: 'SET_TASK_LIST_HIDDEN',
-});
+import { saveTaskListDismissed } from 'homepage/store/controls';
+
+export function* hideTaskList() {
+  yield saveTaskListDismissed();
+  return { type: 'SET_TASK_LIST_HIDDEN' };
+}

--- a/mailpoet/assets/js/src/homepage/store/controls.ts
+++ b/mailpoet/assets/js/src/homepage/store/controls.ts
@@ -1,0 +1,12 @@
+import { callApi } from 'common/controls/call_api';
+
+export function saveTaskListDismissed() {
+  return callApi({
+    endpoint: 'settings',
+    action: 'set',
+    method: 'POST',
+    data: {
+      'homepage.task_list_dismissed': true,
+    },
+  });
+}

--- a/mailpoet/assets/js/src/homepage/store/initial-state.ts
+++ b/mailpoet/assets/js/src/homepage/store/initial-state.ts
@@ -5,6 +5,8 @@ export function getInitialState(): State {
     taskList: {
       isTaskListHidden: window.mailpoet_homepage_data.task_list_dismissed,
       tasksStatus: window.mailpoet_homepage_data.task_list_status,
+      canImportWooCommerceSubscribers:
+        window.mailpoet_homepage_data.woo_customers_count > 0,
     },
   };
 }

--- a/mailpoet/assets/js/src/homepage/store/initial-state.ts
+++ b/mailpoet/assets/js/src/homepage/store/initial-state.ts
@@ -1,0 +1,9 @@
+import { State } from './types';
+
+export function getInitialState(): State {
+  return {
+    taskList: {
+      isTaskListHidden: false,
+    },
+  };
+}

--- a/mailpoet/assets/js/src/homepage/store/initial-state.ts
+++ b/mailpoet/assets/js/src/homepage/store/initial-state.ts
@@ -4,6 +4,7 @@ export function getInitialState(): State {
   return {
     taskList: {
       isTaskListHidden: window.mailpoet_homepage_data.task_list_dismissed,
+      tasksStatus: window.mailpoet_homepage_data.task_list_status,
     },
   };
 }

--- a/mailpoet/assets/js/src/homepage/store/initial-state.ts
+++ b/mailpoet/assets/js/src/homepage/store/initial-state.ts
@@ -7,6 +7,8 @@ export function getInitialState(): State {
       tasksStatus: window.mailpoet_homepage_data.task_list_status,
       canImportWooCommerceSubscribers:
         window.mailpoet_homepage_data.woo_customers_count > 0,
+      hasImportedSubscribers:
+        window.mailpoet_homepage_data.subscribers_count > 10,
     },
   };
 }

--- a/mailpoet/assets/js/src/homepage/store/initial-state.ts
+++ b/mailpoet/assets/js/src/homepage/store/initial-state.ts
@@ -3,7 +3,7 @@ import { State } from './types';
 export function getInitialState(): State {
   return {
     taskList: {
-      isTaskListHidden: false,
+      isTaskListHidden: window.mailpoet_homepage_data.task_list_dismissed,
     },
   };
 }

--- a/mailpoet/assets/js/src/homepage/store/reducer.ts
+++ b/mailpoet/assets/js/src/homepage/store/reducer.ts
@@ -1,0 +1,17 @@
+import { Action } from '@wordpress/data';
+import { State } from './types';
+
+export function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SET_TASK_LIST_HIDDEN':
+      return {
+        ...state,
+        taskList: {
+          ...state.taskList,
+          isTaskListHidden: true,
+        },
+      };
+    default:
+      return state;
+  }
+}

--- a/mailpoet/assets/js/src/homepage/store/selectors.ts
+++ b/mailpoet/assets/js/src/homepage/store/selectors.ts
@@ -1,4 +1,3 @@
-import { MailPoet } from 'mailpoet';
 import { State, TaskListTasksStatus, TaskType } from './types';
 
 export function getIsTaskListHidden(state: State): boolean {
@@ -9,12 +8,16 @@ export function getTasksStatus(state: State): TaskListTasksStatus {
   return state.taskList.tasksStatus;
 }
 
+export function getCanImportWooCommerceSubscribers(state: State): boolean {
+  return state.taskList.canImportWooCommerceSubscribers;
+}
+
 export function getCurrentTask(state: State): TaskType | null {
   if (!state.taskList.tasksStatus.senderSet) return 'senderSet';
   if (!state.taskList.tasksStatus.mssConnected) return 'mssConnected';
   if (
     !state.taskList.tasksStatus.wooSubscribersImported &&
-    MailPoet.isWoocommerceActive
+    state.taskList.canImportWooCommerceSubscribers
   )
     return 'wooSubscribersImported';
   if (!state.taskList.tasksStatus.subscribersAdded) return 'subscribersAdded';

--- a/mailpoet/assets/js/src/homepage/store/selectors.ts
+++ b/mailpoet/assets/js/src/homepage/store/selectors.ts
@@ -1,0 +1,5 @@
+import { State } from './types';
+
+export function getIsTaskListHidden(state: State): boolean {
+  return state.taskList.isTaskListHidden;
+}

--- a/mailpoet/assets/js/src/homepage/store/selectors.ts
+++ b/mailpoet/assets/js/src/homepage/store/selectors.ts
@@ -1,5 +1,9 @@
-import { State } from './types';
+import { State, TaskListTasksStatus } from './types';
 
 export function getIsTaskListHidden(state: State): boolean {
   return state.taskList.isTaskListHidden;
+}
+
+export function getTasksStatus(state: State): TaskListTasksStatus {
+  return state.taskList.tasksStatus;
 }

--- a/mailpoet/assets/js/src/homepage/store/selectors.ts
+++ b/mailpoet/assets/js/src/homepage/store/selectors.ts
@@ -1,4 +1,5 @@
-import { State, TaskListTasksStatus } from './types';
+import { MailPoet } from 'mailpoet';
+import { State, TaskListTasksStatus, TaskType } from './types';
 
 export function getIsTaskListHidden(state: State): boolean {
   return state.taskList.isTaskListHidden;
@@ -6,4 +7,16 @@ export function getIsTaskListHidden(state: State): boolean {
 
 export function getTasksStatus(state: State): TaskListTasksStatus {
   return state.taskList.tasksStatus;
+}
+
+export function getCurrentTask(state: State): TaskType | null {
+  if (!state.taskList.tasksStatus.senderSet) return 'senderSet';
+  if (!state.taskList.tasksStatus.mssConnected) return 'mssConnected';
+  if (
+    !state.taskList.tasksStatus.wooSubscribersImported &&
+    MailPoet.isWoocommerceActive
+  )
+    return 'wooSubscribersImported';
+  if (!state.taskList.tasksStatus.subscribersAdded) return 'subscribersAdded';
+  return null;
 }

--- a/mailpoet/assets/js/src/homepage/store/selectors.ts
+++ b/mailpoet/assets/js/src/homepage/store/selectors.ts
@@ -12,6 +12,10 @@ export function getCanImportWooCommerceSubscribers(state: State): boolean {
   return state.taskList.canImportWooCommerceSubscribers;
 }
 
+export function getHasImportedSubscribers(state: State): boolean {
+  return state.taskList.hasImportedSubscribers;
+}
+
 export function getCurrentTask(state: State): TaskType | null {
   if (!state.taskList.tasksStatus.senderSet) return 'senderSet';
   if (!state.taskList.tasksStatus.mssConnected) return 'mssConnected';

--- a/mailpoet/assets/js/src/homepage/store/store.ts
+++ b/mailpoet/assets/js/src/homepage/store/store.ts
@@ -5,31 +5,27 @@ import {
   StoreDescriptor,
 } from '@wordpress/data';
 import { OmitFirstArgs } from 'types';
+import { getInitialState } from './initial-state';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import { reducer } from './reducer';
+import { State } from './types';
 
-const storeName = 'mailpoet/homepage';
-const actions = {};
-const selectors = {};
+export const storeName = 'mailpoet/homepage';
 const controls = {};
-const reducer = (state) => state;
-const initialState = {};
 
 type StoreType = Omit<StoreDescriptor, 'name'> & {
   name: typeof storeName;
 };
-type State = {
-  [K in string]: never;
-};
 type EditorStoreConfigType = StoreConfig<State>;
-
 export const createStore = (): StoreType => {
   const storeConfig = {
     actions,
     controls,
     selectors,
     reducer,
-    initialState,
+    initialState: getInitialState(),
   } as EditorStoreConfigType;
-
   const store = createReduxStore<State>(storeName, storeConfig) as StoreType;
   register(store);
   return store;

--- a/mailpoet/assets/js/src/homepage/store/store.ts
+++ b/mailpoet/assets/js/src/homepage/store/store.ts
@@ -1,0 +1,43 @@
+import {
+  createReduxStore,
+  register,
+  StoreConfig,
+  StoreDescriptor,
+} from '@wordpress/data';
+import { OmitFirstArgs } from 'types';
+
+const storeName = 'mailpoet/homepage';
+const actions = {};
+const selectors = {};
+const controls = {};
+const reducer = (state) => state;
+const initialState = {};
+
+type StoreType = Omit<StoreDescriptor, 'name'> & {
+  name: typeof storeName;
+};
+type State = {
+  [K in string]: never;
+};
+type EditorStoreConfigType = StoreConfig<State>;
+
+export const createStore = (): StoreType => {
+  const storeConfig = {
+    actions,
+    controls,
+    selectors,
+    reducer,
+    initialState,
+  } as EditorStoreConfigType;
+
+  const store = createReduxStore<State>(storeName, storeConfig) as StoreType;
+  register(store);
+  return store;
+};
+
+export type StoreKey = typeof storeName | StoreType;
+
+declare module '@wordpress/data' {
+  function select(key: StoreKey): OmitFirstArgs<typeof selectors>;
+  function dispatch(key: StoreKey): typeof actions;
+}

--- a/mailpoet/assets/js/src/homepage/store/types.ts
+++ b/mailpoet/assets/js/src/homepage/store/types.ts
@@ -1,6 +1,7 @@
 export type TaskListState = {
   isTaskListHidden: boolean;
   tasksStatus: TaskListTasksStatus;
+  canImportWooCommerceSubscribers: boolean;
 };
 
 export type TaskListTasksStatus = {

--- a/mailpoet/assets/js/src/homepage/store/types.ts
+++ b/mailpoet/assets/js/src/homepage/store/types.ts
@@ -10,6 +10,8 @@ export type TaskListTasksStatus = {
   wooSubscribersImported: boolean;
 };
 
+export type TaskType = keyof TaskListTasksStatus;
+
 export type State = {
   taskList: TaskListState;
 };

--- a/mailpoet/assets/js/src/homepage/store/types.ts
+++ b/mailpoet/assets/js/src/homepage/store/types.ts
@@ -2,6 +2,7 @@ export type TaskListState = {
   isTaskListHidden: boolean;
   tasksStatus: TaskListTasksStatus;
   canImportWooCommerceSubscribers: boolean;
+  hasImportedSubscribers: boolean;
 };
 
 export type TaskListTasksStatus = {

--- a/mailpoet/assets/js/src/homepage/store/types.ts
+++ b/mailpoet/assets/js/src/homepage/store/types.ts
@@ -1,0 +1,7 @@
+export type TaskListState = {
+  isTaskListHidden: boolean;
+};
+
+export type State = {
+  taskList: TaskListState;
+};

--- a/mailpoet/assets/js/src/homepage/store/types.ts
+++ b/mailpoet/assets/js/src/homepage/store/types.ts
@@ -1,5 +1,13 @@
 export type TaskListState = {
   isTaskListHidden: boolean;
+  tasksStatus: TaskListTasksStatus;
+};
+
+export type TaskListTasksStatus = {
+  senderSet: boolean;
+  mssConnected: boolean;
+  subscribersAdded: boolean;
+  wooSubscribersImported: boolean;
 };
 
 export type State = {

--- a/mailpoet/lib/AdminPages/Pages/Homepage.php
+++ b/mailpoet/lib/AdminPages/Pages/Homepage.php
@@ -23,6 +23,9 @@ class Homepage {
   public function render() {
     $data = [
       'mta_log' => $this->settingsController->get('mta_log'),
+      'homepage' => [
+        'task_list_dismissed' => (bool)$this->settingsController->get('homepage.task_list_dismissed', false),
+      ],
     ];
     $this->pageRenderer->displayPage('homepage.html', $data);
   }

--- a/mailpoet/lib/AdminPages/Pages/Homepage.php
+++ b/mailpoet/lib/AdminPages/Pages/Homepage.php
@@ -7,6 +7,7 @@ use MailPoet\Form\FormsRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 
 class Homepage {
   /** @var PageRenderer */
@@ -21,16 +22,21 @@ class Homepage {
   /** @var FormsRepository */
   private $formsRepository;
 
+  /** @var WooCommerceHelper */
+  private $wooCommerceHelper;
+
   public function __construct(
     PageRenderer $pageRenderer,
     SettingsController $settingsController,
     SubscribersRepository $subscribersRepository,
-    FormsRepository $formsRepository
+    FormsRepository $formsRepository,
+    WooCommerceHelper $wooCommerceHelper
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->settingsController = $settingsController;
     $this->subscribersRepository = $subscribersRepository;
     $this->formsRepository = $formsRepository;
+    $this->wooCommerceHelper = $wooCommerceHelper;
   }
 
   public function render() {
@@ -39,6 +45,7 @@ class Homepage {
       'homepage' => [
         'task_list_dismissed' => (bool)$this->settingsController->get('homepage.task_list_dismissed', false),
         'task_list_status' => $this->getTaskListStatus(),
+        'woo_customers_count' => $this->wooCommerceHelper->getCustomersCount(),
       ],
     ];
     $this->pageRenderer->displayPage('homepage.html', $data);

--- a/mailpoet/lib/AdminPages/Pages/Homepage.php
+++ b/mailpoet/lib/AdminPages/Pages/Homepage.php
@@ -46,6 +46,7 @@ class Homepage {
         'task_list_dismissed' => (bool)$this->settingsController->get('homepage.task_list_dismissed', false),
         'task_list_status' => $this->getTaskListStatus(),
         'woo_customers_count' => $this->wooCommerceHelper->getCustomersCount(),
+        'subscribers_count' => $this->subscribersRepository->getTotalSubscribers(),
       ],
     ];
     $this->pageRenderer->displayPage('homepage.html', $data);

--- a/mailpoet/tests/acceptance/Homepage/HomepageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageBasicsCest.php
@@ -31,4 +31,18 @@ class HomepageBasicsCest {
     $i->waitForText('Sending has been resumed');
     $i->dontSee('Sending is broken!');
   }
+
+  public function homepageTaskListRenders(\AcceptanceTester $i) {
+    $i->wantTo('Check homepage renders task list');
+    $i->login();
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText('Welcome to MailPoet');
+    $i->see('Begin by completing your setup');
+    $i->see('Sender information added');
+    $i->see('Connect MailPoet sending service');
+    $i->click('button', '.mailpoet-task-list__heading');
+    $i->waitForText('Hide setup list', 5, '.mailpoet-task-list__heading .components-popover__content');
+    $i->click('.components-popover__content button', '.mailpoet-task-list__heading');
+    $i->dontSee('Begin by completing your setup');
+  }
 }

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -23,11 +23,20 @@
     'beginByCompletingSetup': __('Begin by completing your setup'),
     'hideList': __('Hide setup list'),
     'senderSetTask': _x('Add your sender information', 'Link in a task list'),
+    'senderSetTaskDone': _x('Sender information added!', 'Link in a task list'),
     'mssConnectedTask': _x('Connect MailPoet sending service', 'Link in a task list'),
+    'mssConnectedTaskDone': _x('MailPoet sending service activated!', 'Link in a task list'),
     'wooSubscribersImportedTask': _x('Import WooCommerce subscribers', 'Link in a task list'),
+    'wooSubscribersImportedTaskDone': _x('WooCommerce subscribers imported!', 'Link in a task list'),
     'subscribersAddedTask': _x('Import existing subscribers', 'Link in a task list'),
+    'subscribersAddedTaskDoneByImport': _x('Subscribers imported!', 'Link in a task list'),
+    'subscribersAddedTaskDoneByForm': _x('Subscription form created!', 'Link in a task list'),
     'youAreSet': _x('You’re all set!', 'Part of string "You’re all set! Dismiss setup list"'),
     'dismissList': _x('Dismiss setup list', 'Part of string "You’re all set! Dismiss setup list"'),
+    'noSubscribersQuestion': _x('No subscribers yet?', 'Part of string "No subscribers yet? Set up a subscription form"'),
+    'setUpForm': _x('Set up a subscription form', 'Part of string "No subscribers yet? Set up a subscription form"'),
+    'haveSubscribersQuestion': _x('Have existing subscribers?', 'Part of string "Have existing subscribers? Import"'),
+    'import': _x('Import', 'Part of string "Have existing subscribers? Import"'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -16,6 +16,7 @@
   <%= localize({
     'welcomeToMailPoet': __('Welcome to MailPoet 🎉'),
     'beginByCompletingSetup': __('Begin by completing your setup'),
+    'hideList': __('Hide setup list'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -7,6 +7,7 @@
 <script>
   <% autoescape 'js' %>
     var mailpoet_mta_log = <%= json_encode(mta_log) %>;
+    var mailpoet_homepage_data = <%= json_encode(homepage) %>;
   <% endautoescape %>
 </script>
 

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -18,6 +18,10 @@
     'welcomeToMailPoet': __('Welcome to MailPoet 🎉'),
     'beginByCompletingSetup': __('Begin by completing your setup'),
     'hideList': __('Hide setup list'),
+    'senderSetTask': _x('Add your sender information', 'Link in a task list'),
+    'mssConnectedTask': _x('Connect MailPoet sending service', 'Link in a task list'),
+    'wooSubscribersImportedTask': _x('Import WooCommerce subscribers', 'Link in a task list'),
+    'subscribersAddedTask': _x('Import existing subscribers', 'Link in a task list'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -26,6 +26,8 @@
     'mssConnectedTask': _x('Connect MailPoet sending service', 'Link in a task list'),
     'wooSubscribersImportedTask': _x('Import WooCommerce subscribers', 'Link in a task list'),
     'subscribersAddedTask': _x('Import existing subscribers', 'Link in a task list'),
+    'youAreSet': _x('You’re all set!', 'Part of string "You’re all set! Dismiss setup list"'),
+    'dismissList': _x('Dismiss setup list', 'Part of string "You’re all set! Dismiss setup list"'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -11,3 +11,13 @@
 </script>
 
 <% endblock %>
+
+<% block translations %>
+  <%= localize({
+    'welcomeToMailPoet': __('Welcome to MailPoet 🎉'),
+    'beginByCompletingSetup': __('Begin by completing your setup'),
+  }) %>
+<% endblock %>
+
+
+

--- a/mailpoet/views/homepage.html
+++ b/mailpoet/views/homepage.html
@@ -13,6 +13,10 @@
 
 <% endblock %>
 
+<% block after_css %>
+<%= stylesheet('mailpoet-homepage.css') %>
+<% endblock %>
+
 <% block translations %>
   <%= localize({
     'welcomeToMailPoet': __('Welcome to MailPoet 🎉'),


### PR DESCRIPTION
## Description

This PR adds the onboarding task list for the new homepage.
![Screenshot 2023-01-02 at 15 58 30](https://user-images.githubusercontent.com/1082140/210341232-5ff49e35-fdb4-493f-be85-d3df32b5a16a.png)


## Code review notes

The PR is a bit bigger because it also adds the store for the homepage app. I recommend reviewing commit by commit.

## QA notes

You need to activate the homepage feature on `/wp-admin/admin.php?page=mailpoet-experimental`
The logic for the steps is described in the ticket.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4826]

## After-merge notes

_N/A_


[MAILPOET-4826]: https://mailpoet.atlassian.net/browse/MAILPOET-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ