### PR TITLE
Improve logging errors for JSON API [MAILPOET-4104]

### DIFF
--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -283,7 +283,7 @@ class API {
     // logging to the php log
     error_log((string)$e); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
     // logging to the MailPoet table
-    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_API)->error($e->getMessage(), [
+    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_API)->warning($e->getMessage(), [
       'requestMethod' => $this->requestMethod,
       'requestData' => $this->requestData,
       'requestEndpoint' => $this->requestEndpoint,

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -285,7 +285,6 @@ class API {
     // logging to the MailPoet table
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_API)->warning($e->getMessage(), [
       'requestMethod' => $this->requestMethod,
-      'requestData' => $this->requestData,
       'requestEndpoint' => $this->requestEndpoint,
       'exceptionMessage' => $e->getMessage(),
       'exceptionTrace' => $e->getTrace(),

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -280,6 +280,9 @@ class API {
   }
 
   private function logError(Throwable $e): void {
+    // logging to the php log
+    error_log((string)$e); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+    // logging to the MailPoet table
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_API)->error($e->getMessage(), [
       'requestMethod' => $this->requestMethod,
       'requestData' => $this->requestData,

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -307,7 +307,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Listing\Handler::class)->setPublic(true);
     $container->autowire(\MailPoet\Listing\PageLimit::class)->setPublic(true);
     // Logging
-    $container->autowire(\MailPoet\Logging\LoggerFactory::class);
+    $container->autowire(\MailPoet\Logging\LoggerFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Logging\LogRepository::class)->setPublic(true);
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -32,6 +32,7 @@ class LoggerFactory {
   const TOPIC_BRIDGE = 'bridge-api';
   const TOPIC_SENDING = 'sending';
   const TOPIC_CRON = 'cron';
+  const TOPIC_API = 'api';
 
   /** @var LoggerFactory */
   private static $instance;

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -229,8 +229,14 @@ class SubscriberSaveController {
     // wipe any unconfirmed data at this point
     $subscriber->setUnconfirmedData(null);
 
-    $this->subscribersRepository->persist($subscriber);
-    $this->subscribersRepository->flush();
+    try {
+      $this->subscribersRepository->persist($subscriber);
+      $this->subscribersRepository->flush();
+    } catch (ValidationException $exception) {
+      // detach invalid entity because it can block another work with doctrine
+      $this->subscribersRepository->detach($subscriber);
+      throw $exception;
+    }
 
     return $subscriber;
   }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -16,6 +16,7 @@ use MailPoet\Config\AccessControl;
 use MailPoet\DI\ContainerConfigurator;
 use MailPoet\DI\ContainerFactory;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Container;
@@ -38,6 +39,9 @@ class APITest extends \MailPoetTest {
   /** @var SettingsController */
   private $settings;
 
+  /** @var LoggerFactory */
+  private $loggerFactory;
+
   public function _before() {
     parent::_before();
     // create WP user
@@ -56,11 +60,13 @@ class APITest extends \MailPoetTest {
     $this->container->compile();
     $this->errorHandler = $this->container->get(ErrorHandler::class);
     $this->settings = $this->container->get(SettingsController::class);
+    $this->loggerFactory = $this->container->get(LoggerFactory::class);
     $this->api = new JSONAPI(
       $this->container,
       $this->container->get(AccessControl::class),
       $this->errorHandler,
       $this->settings,
+      $this->loggerFactory,
       new WPFunctions
     );
   }
@@ -242,7 +248,7 @@ class APITest extends \MailPoetTest {
       ['validatePermission' => false]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, $this->loggerFactory, new WPFunctions);
     $api->addEndpointNamespace($namespace['name'], $namespace['version']);
     $api->setRequestData($data, Endpoint::TYPE_POST);
     $response = $api->processRoute();
@@ -264,7 +270,7 @@ class APITest extends \MailPoetTest {
       ]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, $this->loggerFactory, new WPFunctions);
     expect($api->validatePermissions(null, $permissions))->false();
 
     $accessControl = Stub::make(
@@ -276,7 +282,7 @@ class APITest extends \MailPoetTest {
         }),
       ]
     );
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, $this->loggerFactory, new WPFunctions);
     expect($api->validatePermissions(null, $permissions))->true();
   }
 
@@ -298,7 +304,7 @@ class APITest extends \MailPoetTest {
       ]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, $this->loggerFactory, new WPFunctions);
     expect($api->validatePermissions('test', $permissions))->false();
 
     $accessControl = Stub::make(
@@ -311,7 +317,7 @@ class APITest extends \MailPoetTest {
       ]
     );
 
-    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, new WPFunctions);
+    $api = new JSONAPI($this->container, $accessControl, $this->errorHandler, $this->settings, $this->loggerFactory, new WPFunctions);
     expect($api->validatePermissions('test', $permissions))->true();
   }
 

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -62,7 +62,7 @@ class APITest extends \MailPoetTest {
     $this->container->compile();
     $this->errorHandler = $this->container->get(ErrorHandler::class);
     $this->settings = $this->container->get(SettingsController::class);
-    $this->loggerFactory = $this->diContainer->get(LoggerFactory::class);
+    $this->loggerFactory = $this->container->get(LoggerFactory::class);
     $this->api = new JSONAPI(
       $this->container,
       $this->container->get(AccessControl::class),
@@ -343,6 +343,7 @@ class APITest extends \MailPoetTest {
   }
 
   public function testItLogsExceptionToLogTable() {
+    $this->settings->set('logging', 'everything');
     $namespace = [
       'name' => 'MailPoet\API\JSON\v1',
       'version' => 'v1',
@@ -367,6 +368,7 @@ class APITest extends \MailPoetTest {
     expect($log->getMessage())->stringContainsString('Some Error');
     expect($log->getName())->equals(LoggerFactory::TOPIC_API);
     expect($response->errors)->equals([['error' => 'bad_request', 'message' => 'Some Error']]);
+    $this->diContainer->get(SettingsController::class)->set('logging', 'errors');
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV1.php
+++ b/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV1.php
@@ -26,4 +26,8 @@ class APITestNamespacedEndpointStubV1 extends APIEndpoint {
   public function restricted($data) {
     return $this->successResponse($data);
   }
+
+  public function testError($data) {
+    throw new \Exception('Some Error');
+  }
 }

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -8,6 +8,7 @@ use MailPoet\API\JSON\ErrorResponse;
 use MailPoet\API\JSON\Response;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
+use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
@@ -150,6 +151,7 @@ class FormTest extends \MailPoetTest {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(FormEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(LogEntity::class);
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -8,7 +8,6 @@ use MailPoet\API\JSON\ErrorResponse;
 use MailPoet\API\JSON\Response;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
-use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
@@ -151,7 +150,6 @@ class FormTest extends \MailPoetTest {
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(FormEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(LogEntity::class);
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }


### PR DESCRIPTION
## Description

Because sometimes can be hard to debug our plugin, we want to improve API logs. Those changes store an error stack in our log table and the PHP error log.

## Linked tickets

[MAILPOET-4104]


[MAILPOET-4104]: https://mailpoet.atlassian.net/browse/MAILPOET-4104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ