### PR TITLE
Use translate function on errors from bridge [MAILPOET-4639]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -348,7 +348,7 @@ class Settings extends APIEndpoint {
     if (!$response['ok']) {
       // sender domain verification error. probably an improper setup
       return $this->badRequest([
-        APIError::BAD_REQUEST => $response['error'] ?? __('Sender domain verification failed.', 'mailpoet'),
+        APIError::BAD_REQUEST => $response['message'] ?? __('Sender domain verification failed.', 'mailpoet'),
       ], $response);
     }
 

--- a/mailpoet/lib/Mailer/MailerError.php
+++ b/mailpoet/lib/Mailer/MailerError.php
@@ -13,12 +13,6 @@ class MailerError {
   const LEVEL_HARD = 'hard';
   const LEVEL_SOFT = 'soft';
 
-  const MESSAGE_EMAIL_FORBIDDEN_ACTION = 'Key is valid, but the action is forbidden';
-  const MESSAGE_EMAIL_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges';
-  const MESSAGE_EMAIL_NOT_AUTHORIZED = 'The email address is not authorized';
-  const MESSAGE_EMAIL_VOLUME_LIMIT_REACHED = 'Email volume limit reached';
-  const MESSAGE_PENDING_APPROVAL = 'Key is valid, but not approved yet; you can send only to authorized email addresses at the moment';
-
   /** @var string */
   private $operation;
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -76,7 +76,7 @@ class MailPoetMapper {
         $resultParsed = json_decode($result['message'], true);
         $message = __('Error while sending.', 'mailpoet');
         if (!is_array($resultParsed)) {
-          if ($result['error'] === API::ERROR_MESSAGE_DMRAC) {
+          if (isset($result['error']) && $result['error'] === API::ERROR_MESSAGE_DMRAC) {
             $message .= $this->getDmarcMessage($result, $sender);
           } else {
             $message .= ' ' . $result['message'];

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -4,7 +4,6 @@ namespace MailPoet\Mailer\Methods;
 
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Mailer\Mailer;
-use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Services\AuthorizedEmailsController;
@@ -83,7 +82,7 @@ class MailPoet implements MailerMethod {
     } elseif (
       !empty($result['code'])
       && $result['code'] === API::RESPONSE_CODE_CAN_NOT_SEND
-      && $result['message'] === MailerError::MESSAGE_EMAIL_NOT_AUTHORIZED
+      && $result['error'] === API::ERROR_MESSAGE_INVALID_FROM
     ) {
       $this->authorizedEmailsController->checkAuthorizedEmailAddresses();
     }

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -70,7 +70,7 @@ class MailPoet implements MailerMethod {
       case API::SENDING_STATUS_SEND_ERROR:
         $error = $this->processSendError($result, $subscriber, $newsletter);
         return Mailer::formatMailerErrorResult($error);
-      case API::SENDING_STATUS_OK:
+      case API::RESPONSE_STATUS_OK:
       default:
         return Mailer::formatMailerSendSuccessResult();
     }

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -96,7 +96,7 @@ class AuthorizedEmailsController {
     }
 
     $response = $this->bridge->createAuthorizedEmailAddress($email);
-    if ($response['status'] === API::AUTHORIZED_EMAIL_STATUS_ERROR) {
+    if ($response['status'] === API::RESPONSE_STATUS_ERROR) {
       throw new \InvalidArgumentException($response['message']);
     }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -7,7 +7,7 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\NewslettersRepository;
-use MailPoet\Services\AuthorizedSenderDomainController;
+use MailPoet\Services\Bridge\API;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Helpers;
 
@@ -95,13 +95,12 @@ class AuthorizedEmailsController {
       throw new \InvalidArgumentException(self::AUTHORIZED_EMAIL_ERROR_PENDING_CONFIRMATION);
     }
 
-    $finalData = $this->bridge->createAuthorizedEmailAddress($email);
-
-    if ($finalData && isset($finalData['error'])) {
-      throw new \InvalidArgumentException($finalData['error']);
+    $response = $this->bridge->createAuthorizedEmailAddress($email);
+    if ($response['status'] === API::AUTHORIZED_EMAIL_STATUS_ERROR) {
+      throw new \InvalidArgumentException($response['message']);
     }
 
-    return $finalData;
+    return $response;
   }
 
   public function isEmailAddressAuthorized(string $email): bool {

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -85,16 +85,16 @@ class AuthorizedSenderDomainController {
       throw new \InvalidArgumentException(self::AUTHORIZED_SENDER_DOMAIN_ERROR_ALREADY_CREATED);
     }
 
-    $finalData = $this->bridge->createAuthorizedSenderDomain($domain);
+    $response = $this->bridge->createAuthorizedSenderDomain($domain);
 
-    if ($finalData && isset($finalData['error'])) {
-      throw new \InvalidArgumentException($finalData['error']);
+    if ($response['status'] === API::AUTHORIZED_DOMAIN_STATUS_ERROR) {
+      throw new \InvalidArgumentException($response['message']);
     }
 
     // Reset cached value since a new domain was added
     $this->currentRecords = null;
 
-    return $finalData;
+    return $response;
   }
 
   /**

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -87,7 +87,7 @@ class AuthorizedSenderDomainController {
 
     $response = $this->bridge->createAuthorizedSenderDomain($domain);
 
-    if ($response['status'] === API::AUTHORIZED_DOMAIN_STATUS_ERROR) {
+    if ($response['status'] === API::RESPONSE_STATUS_ERROR) {
       throw new \InvalidArgumentException($response['message']);
     }
 
@@ -129,7 +129,7 @@ class AuthorizedSenderDomainController {
     $response = $this->bridge->verifyAuthorizedSenderDomain($domain);
 
     // API response contains status, but we need to check that dns array is not included
-    if ($response['status'] === API::AUTHORIZED_DOMAIN_STATUS_ERROR && !isset($response['dns'])) {
+    if ($response['status'] === API::RESPONSE_STATUS_ERROR && !isset($response['dns'])) {
       throw new \InvalidArgumentException($response['message']);
     }
 

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -189,11 +189,9 @@ class Bridge {
    * @see https://github.com/mailpoet/services-bridge#verify-a-sender-domain
    */
   public function verifyAuthorizedSenderDomain(string $domain): array {
-    $data = $this
-    ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
-    ->verifyAuthorizedSenderDomain($domain);
-
-    return $data;
+    return $this
+      ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
+      ->verifyAuthorizedSenderDomain($domain);
   }
 
   public function checkMSSKey($apiKey) {

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -134,12 +134,10 @@ class Bridge {
   /**
    * Create Authorized Email Address
    */
-  public function createAuthorizedEmailAddress(string $emailAdress) {
-    $data = $this
+  public function createAuthorizedEmailAddress(string $emailAddress) {
+    return $this
       ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
-      ->createAuthorizedEmailAddress($emailAdress);
-
-    return $data;
+      ->createAuthorizedEmailAddress($emailAddress);
   }
 
   /**
@@ -179,8 +177,8 @@ class Bridge {
    */
   public function createAuthorizedSenderDomain(string $domain): array {
     $data = $this
-    ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
-    ->createAuthorizedSenderDomain($domain);
+      ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
+      ->createAuthorizedSenderDomain($domain);
 
     return $data['dns'] ?? $data;
   }

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -7,11 +7,8 @@ use MailPoet\WP\Functions as WPFunctions;
 use WP_Error;
 
 class API {
-  const AUTHORIZED_EMAIL_STATUS_OK = 'ok';
-  const AUTHORIZED_EMAIL_STATUS_ERROR = 'authorized_email_error';
-  const AUTHORIZED_DOMAIN_STATUS_OK = 'ok';
-  const AUTHORIZED_DOMAIN_STATUS_ERROR = 'authorized_domain_error';
-  const SENDING_STATUS_OK = 'ok';
+  const RESPONSE_STATUS_OK = 'ok';
+  const RESPONSE_STATUS_ERROR = 'error';
   const SENDING_STATUS_CONNECTION_ERROR = 'connection_error';
   const SENDING_STATUS_SEND_ERROR = 'send_error';
 
@@ -162,7 +159,7 @@ class API {
         'code' => $responseCode,
       ];
     }
-    return ['status' => self::SENDING_STATUS_OK];
+    return ['status' => self::RESPONSE_STATUS_OK];
   }
 
   public function checkBounces(array $emails) {
@@ -235,14 +232,14 @@ class API {
       $fallbackError = sprintf(__('An error has happened while performing a request, the server has responded with response code %d', 'mailpoet'), $responseCode);
 
       return [
-        'status' => self::AUTHORIZED_EMAIL_STATUS_ERROR,
+        'status' => self::RESPONSE_STATUS_ERROR,
         'code' => $responseCode,
         'error' => is_array($errorResponseData) && isset($errorResponseData['error']) ? $errorResponseData['error'] : $fallbackError,
         'message' => is_array($errorResponseData) && isset($errorResponseData['error']) ? $this->getTranslatedErrorMessage($errorResponseData['error']) : $fallbackError,
       ];
     }
 
-    return ['status' => self::AUTHORIZED_EMAIL_STATUS_OK];
+    return ['status' => self::RESPONSE_STATUS_OK];
   }
 
   /**
@@ -296,7 +293,7 @@ class API {
       $fallbackError = sprintf(__('An error has happened while performing a request, the server has responded with response code %d', 'mailpoet'), $responseCode);
 
       return [
-        'status' => self::AUTHORIZED_DOMAIN_STATUS_ERROR,
+        'status' => self::RESPONSE_STATUS_ERROR,
         'code' => $responseCode,
         'error' => is_array($responseBody) && isset($responseBody['error']) ? $responseBody['error'] : $fallbackError,
         'message' => is_array($responseBody) && isset($responseBody['error']) ? $this->getTranslatedErrorMessage($responseBody['error']) : $fallbackError,
@@ -308,7 +305,7 @@ class API {
       return [];
     }
 
-    $responseBody['status'] = self::AUTHORIZED_DOMAIN_STATUS_OK;
+    $responseBody['status'] = self::RESPONSE_STATUS_OK;
     return $responseBody;
   }
 
@@ -332,7 +329,7 @@ class API {
       if ($responseCode === 400) {
         // we need to return the body as it is, but for consistency we add status and translated error message
         $response = is_array($responseBody) ? $responseBody : [];
-        $response['status'] = self::AUTHORIZED_DOMAIN_STATUS_ERROR;
+        $response['status'] = self::RESPONSE_STATUS_ERROR;
         $response['message'] = $this->getTranslatedErrorMessage($response['error']);
         return $response;
       }
@@ -346,7 +343,7 @@ class API {
       $fallbackError = sprintf(__('An error has happened while performing a request, the server has responded with response code %d', 'mailpoet'), $responseCode);
 
       return [
-        'status' => self::AUTHORIZED_DOMAIN_STATUS_ERROR,
+        'status' => self::RESPONSE_STATUS_ERROR,
         'code' => $responseCode,
         'error' => is_array($responseBody) && isset($responseBody['error']) ? $responseBody['error'] : $fallbackError,
         'message' => is_array($responseBody) && isset($responseBody['error']) ? $this->getTranslatedErrorMessage($responseBody['error']) : $fallbackError,
@@ -358,7 +355,7 @@ class API {
       return [];
     }
 
-    $responseBody['status'] = self::AUTHORIZED_DOMAIN_STATUS_OK;
+    $responseBody['status'] = self::RESPONSE_STATUS_OK;
     return $responseBody;
   }
 

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -25,6 +25,16 @@ class API {
   const RESPONSE_CODE_PAYLOAD_ERROR = 400;
   const RESPONSE_CODE_CAN_NOT_SEND = 403;
 
+  // Bridge messages from https://github.com/mailpoet/services-bridge/blob/master/api/messages.rb
+  public const ERROR_MESSAGE_BANNED = 'Key is valid, but the action is forbidden';
+  public const ERROR_MESSAGE_INVALID_FROM = 'The email address is not authorized';
+  public const ERROR_MESSAGE_PENDING_APPROVAL = 'Key is valid, but not approved yet; you can send only to authorized email addresses at the moment';
+  public const ERROR_MESSAGE_DMRAC = "Email violates Sender Domain's DMARC policy. Please set up sender authentication.";
+  // Bridge message from https://github.com/mailpoet/services-bridge/blob/master/extensions/authentication/basic_strategy.rb
+  public const ERROR_MESSAGE_UNAUTHORIZED = 'No valid API key provided';
+  public const ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges';
+  public const ERROR_MESSAGE_EMAIL_VOLUME_LIMIT_REACHED = 'Email volume limit reached';
+
   private $apiKey;
   private $wp;
   /** @var LoggerFactory */
@@ -133,7 +143,8 @@ class API {
         $this->wp->wpRemoteRetrieveResponseMessage($result);
       return [
         'status' => self::SENDING_STATUS_SEND_ERROR,
-        'message' => $response,
+        'error' => $response,
+        'message' => $this->getTranslatedErrorMessage($response),
         'code' => $responseCode,
       ];
     }
@@ -331,6 +342,28 @@ class API {
 
   public function getKey() {
     return $this->apiKey;
+  }
+
+  public function getTranslatedErrorMessage(string $errorMessage): string {
+    switch ($errorMessage) {
+      case self::ERROR_MESSAGE_BANNED:
+        return __('Key is valid, but the action is forbidden.', 'mailpoet');
+      case self::ERROR_MESSAGE_INVALID_FROM:
+        return __('The email address is not authorized.', 'mailpoet');
+      case self::ERROR_MESSAGE_PENDING_APPROVAL:
+        return __('Key is valid, but not approved yet; you can send only to authorized email addresses at the moment.', 'mailpoet');
+      case self::ERROR_MESSAGE_DMRAC:
+        return __("Email violates Sender Domain's DMARC policy. Please set up sender authentication.", 'mailpoet');
+      case self::ERROR_MESSAGE_UNAUTHORIZED:
+        return __('No valid API key provided.', 'mailpoet');
+      case self::ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES:
+        return __('Insufficient privileges.', 'mailpoet');
+      case self::ERROR_MESSAGE_EMAIL_VOLUME_LIMIT_REACHED:
+        return __('Email volume limit reached.', 'mailpoet');
+      // when we don't match translation we return the origin
+      default:
+        return $errorMessage;
+    }
   }
 
   private function auth() {

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -153,7 +153,7 @@ class MailPoetAPITest extends \MailPoetTest {
       $url = $hasHttps ? $extraParams['one_click_unsubscribe'][$i] : $extraParams['unsubscribe_url'][$i];
       expect($body[$i]['unsubscribe'])->equals(['url' => $url, 'post' => $hasHttps]);
     }
-    
+
     expect($body[0]['meta'])->equals($extraParams['meta'][0]);
     expect($body[9]['meta'])->equals($extraParams['meta'][9]);
   }
@@ -304,7 +304,8 @@ class MailPoetAPITest extends \MailPoetTest {
       ['sendMessages' => [
         'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
         'status' => API::SENDING_STATUS_SEND_ERROR,
-        'message' => MailerError::MESSAGE_EMAIL_NOT_AUTHORIZED,
+        'message' => API::ERROR_MESSAGE_INVALID_FROM,
+        'error' => API::ERROR_MESSAGE_INVALID_FROM,
       ]]
     );
     $mailer->send([$this->newsletter], [$this->subscriber]);

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -354,7 +354,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
       'createAuthorizedEmailAddress' => Expected::once([
         'error' => $errorMessage,
         'message' => $errorMessage,
-        'status' => Bridge\API::AUTHORIZED_EMAIL_STATUS_ERROR,
+        'status' => Bridge\API::RESPONSE_STATUS_ERROR,
       ]),
     ]);
     $mocks = [

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -351,7 +351,11 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
 
     $bridgeMock = $this->make(Bridge::class, [
       'getAuthorizedEmailAddresses' => Expected::once([]),
-      'createAuthorizedEmailAddress' => Expected::once(['error' => $errorMessage]),
+      'createAuthorizedEmailAddress' => Expected::once([
+        'error' => $errorMessage,
+        'message' => $errorMessage,
+        'status' => Bridge\API::AUTHORIZED_EMAIL_STATUS_ERROR,
+      ]),
     ]);
     $mocks = [
       'Bridge' => $bridgeMock,

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -153,7 +153,11 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     $domains = ['testdomain.com' => []];
     $getSenderDomainsExpectation = Expected::once($domains);
-    $verifySenderDomainsExpectation = Expected::once(['error' => $errorMessage, 'status' => false]);
+    $verifySenderDomainsExpectation = Expected::once([
+      'error' => $errorMessage,
+      'message' => $errorMessage,
+      'status' => API::AUTHORIZED_DOMAIN_STATUS_ERROR,
+    ]);
 
     $bridgeMock = $this->make(Bridge::class, [
       'getAuthorizedSenderDomains' => $getSenderDomainsExpectation,

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -156,7 +156,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
     $verifySenderDomainsExpectation = Expected::once([
       'error' => $errorMessage,
       'message' => $errorMessage,
-      'status' => API::AUTHORIZED_DOMAIN_STATUS_ERROR,
+      'status' => API::RESPONSE_STATUS_ERROR,
     ]);
 
     $bridgeMock = $this->make(Bridge::class, [

--- a/mailpoet/tests/integration/Services/BridgeApiTest.php
+++ b/mailpoet/tests/integration/Services/BridgeApiTest.php
@@ -183,7 +183,7 @@ class BridgeApiTest extends \MailPoetTest {
       ->method('wpRemoteRetrieveBody')
       ->willReturn(json_encode(['error' => 'This domain was already added to the list.']));
     $result = $this->api->createAuthorizedSenderDomain('existing.com');
-    expect($result['status'])->equals(false);
+    expect($result['status'])->equals(API::AUTHORIZED_DOMAIN_STATUS_ERROR);
     expect($result['error'])->equals('This domain was already added to the list.');
   }
 

--- a/mailpoet/tests/integration/Services/BridgeApiTest.php
+++ b/mailpoet/tests/integration/Services/BridgeApiTest.php
@@ -183,7 +183,7 @@ class BridgeApiTest extends \MailPoetTest {
       ->method('wpRemoteRetrieveBody')
       ->willReturn(json_encode(['error' => 'This domain was already added to the list.']));
     $result = $this->api->createAuthorizedSenderDomain('existing.com');
-    expect($result['status'])->equals(API::AUTHORIZED_DOMAIN_STATUS_ERROR);
+    expect($result['status'])->equals(API::RESPONSE_STATUS_ERROR);
     expect($result['error'])->equals('This domain was already added to the list.');
   }
 

--- a/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
+++ b/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
@@ -30,7 +30,7 @@ class BridgeTestMockAPI extends API {
         'message' => '',
       ],
     ],
-    'status' => API::AUTHORIZED_DOMAIN_STATUS_OK,
+    'status' => API::RESPONSE_STATUS_OK,
   ];
 
   public $apiKey;

--- a/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
+++ b/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
@@ -6,29 +6,31 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class BridgeTestMockAPI extends API {
-  const VERIFIED_DOMAIN_RESPONSE = [ 'dns' => [
-    [
-      'host' => 'mailpoet1._domainkey.example.com',
-      'value' => 'dkim1.sendingservice.net',
-      'type' => 'CNAME',
-      'status' => 'valid',
-      'message' => '',
+  const VERIFIED_DOMAIN_RESPONSE = [
+    'dns' => [
+      [
+        'host' => 'mailpoet1._domainkey.example.com',
+        'value' => 'dkim1.sendingservice.net',
+        'type' => 'CNAME',
+        'status' => 'valid',
+        'message' => '',
+      ],
+      [
+        'host' => 'mailpoet2._domainkey.example.com',
+        'value' => 'dkim2.sendingservice.net',
+        'type' => 'CNAME',
+        'status' => 'valid',
+        'message' => '',
+      ],
+      [
+        'host' => '_mailpoet.example.com',
+        'value' => '34567abc876556abc8754',
+        'type' => 'TXT',
+        'status' => 'valid',
+        'message' => '',
+      ],
     ],
-    [
-      'host' => 'mailpoet2._domainkey.example.com',
-      'value' => 'dkim2.sendingservice.net',
-      'type' => 'CNAME',
-      'status' => 'valid',
-      'message' => '',
-    ],
-    [
-      'host' => '_mailpoet.example.com',
-      'value' => '34567abc876556abc8754',
-      'type' => 'TXT',
-      'status' => 'valid',
-      'message' => '',
-    ],
-  ],
+    'status' => API::AUTHORIZED_DOMAIN_STATUS_OK,
   ];
 
   public $apiKey;

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -74,7 +74,8 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     $apiResult = [
       'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
       'status' => API::SENDING_STATUS_SEND_ERROR,
-      'message' => MailerError::MESSAGE_EMAIL_FORBIDDEN_ACTION,
+      'message' => API::ERROR_MESSAGE_BANNED,
+      'error' => API::ERROR_MESSAGE_BANNED,
     ];
     $error = $this->mapper->getErrorForResult($apiResult, $this->subscribers);
 
@@ -88,7 +89,8 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     $apiResult = [
       'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
       'status' => API::SENDING_STATUS_SEND_ERROR,
-      'message' => MailerError::MESSAGE_EMAIL_INSUFFICIENT_PRIVILEGES,
+      'message' => API::ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES,
+      'error' => API::ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES,
     ];
     $error = $this->mapper->getErrorForResult($apiResult, $this->subscribers);
 
@@ -102,7 +104,8 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     $apiResult = [
       'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
       'status' => API::SENDING_STATUS_SEND_ERROR,
-      'message' => MailerError::MESSAGE_EMAIL_NOT_AUTHORIZED,
+      'message' => API::ERROR_MESSAGE_INVALID_FROM,
+      'error' => API::ERROR_MESSAGE_INVALID_FROM,
     ];
     $error = $this->mapper->getErrorForResult($apiResult, $this->subscribers);
 
@@ -174,7 +177,8 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     $apiResult = [
       'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
       'status' => API::SENDING_STATUS_SEND_ERROR,
-      'message' => MailerError::MESSAGE_PENDING_APPROVAL,
+      'message' => API::ERROR_MESSAGE_PENDING_APPROVAL,
+      'error' => API::ERROR_MESSAGE_PENDING_APPROVAL,
     ];
     $error = $this->mapper->getErrorForResult($apiResult, $this->subscribers);
     expect($error)->isInstanceOf(MailerError::class);


### PR DESCRIPTION
## Description

This PR uses the WP translate function on errors from the bridge. It should explain to our users, who use a different language, where is the exact issue with sending.

## Code review notes

I tried to find all possible MSS errors that can be rendered in messages, but if I missed something, please let me know.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4639]

## After-merge notes

_N/A_


[MAILPOET-4639]: https://mailpoet.atlassian.net/browse/MAILPOET-4639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ