### PR TITLE
Prevent reseting sending errors in confirmation mailer [MAILPOET-4940]

### DIFF
--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Mailer;
 
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Settings\SettingsController;
 
 /**
@@ -173,6 +174,13 @@ class MailerLog {
     $mailerLog = self::setError($mailerLog, $operation, $errorMessage, $errorCode);
     self::updateMailerLog($mailerLog);
     if ($pauseSending) {
+      LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_SENDING)->error(
+        'Email sending was paused due an error',
+        [
+          'error_message' => $errorMessage,
+          'error_code' => $errorCode,
+        ]
+      );
       self::pauseSending($mailerLog);
     }
     self::enforceExecutionRequirements();
@@ -202,6 +210,13 @@ class MailerLog {
     $mailerLog['transactional_email_error_count'] = ($mailerLog['transactional_email_error_count'] ?? 0) + 1;
     self::updateMailerLog($mailerLog);
     if ($mailerLog['transactional_email_error_count'] >= self::RETRY_ATTEMPTS_LIMIT) {
+      LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_SENDING)->error(
+        'Email sending was paused due a transactional email error',
+        [
+          'error_message' => $errorMessage,
+          'error_code' => $errorCode,
+        ]
+      );
       self::pauseSending($mailerLog);
     }
   }

--- a/mailpoet/lib/Migrations/Migration_20230109_144830.php
+++ b/mailpoet/lib/Migrations/Migration_20230109_144830.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Mailer\MailerLog;
+use MailPoet\Migrator\Migration;
+
+class Migration_20230109_144830 extends Migration {
+  /**
+   * Due to a bug https://mailpoet.atlassian.net/browse/MAILPOET-4940 some users may have
+   * paused sending without having the error message and they have no way to resume sending.
+   * This migration will unpause sending for all users who have paused sending and have no error message.
+   */
+  public function run(): void {
+    $mailerLog = MailerLog::getMailerLog();
+    if (isset($mailerLog['status']) && $mailerLog['status'] === MailerLog::STATUS_PAUSED && !isset($mailerLog['error'])) {
+      $mailerLog['status'] = null;
+      MailerLog::updateMailerLog($mailerLog);
+    }
+  }
+}

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Mailer;
 
+use MailPoet\Entities\LogEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
@@ -265,6 +266,9 @@ class MailerLogTest extends \MailPoetTest {
         'error_message' => $error,
       ]
     );
+    $logs = $this->entityManager->getRepository(LogEntity::class)->findAll();
+    $this->assertInstanceOf(LogEntity::class, $logs[0]);
+    expect($logs[0]->getMessage())->stringContainsString('Email sending was paused due an error');
   }
 
   public function testItProcessesTransactionalEmailSendingError() {
@@ -318,6 +322,9 @@ class MailerLogTest extends \MailPoetTest {
     expect($mailerLog['transactional_email_last_error_at'])->null();
     expect($mailerLog['transactional_email_error_count'])->null();
     expect(MailerLog::isSendingPaused())->true();
+    $logs = $this->entityManager->getRepository(LogEntity::class)->findAll();
+    $this->assertInstanceOf(LogEntity::class, $logs[0]);
+    expect($logs[0]->getMessage())->stringContainsString('Email sending was paused due a transactional email error');
   }
 
   public function testItEnforcesSendingLimit() {
@@ -448,5 +455,6 @@ class MailerLogTest extends \MailPoetTest {
 
   public function _after() {
     $this->diContainer->get(SettingsRepository::class)->truncate();
+    $this->truncateEntity(LogEntity::class);
   }
 }


### PR DESCRIPTION
## Description
In a [recently merged PR](https://github.com/mailpoet/mailpoet/pull/4601), we introduced catching errors in confirmation emails.
After release, we discovered an issue. When a confirmation email is successfully sent, it also [increases the sent email count and resets the error message](https://github.com/mailpoet/mailpoet/pull/4601/commits/710050b27e729e401467978dcc26567eda529dc7#diff-deb9a568f8e7cd3a24f1da13dfec4c6daca71aa8500a9e4ddd05cbeccb9f8e80R151-R152). 

The problem is that the increaseSentCount method resets the error, but it doesn't reset the `paused` status. This results in a state where there is not any error message in the admin that would allow the admin to `resume sending` so the user ends up stuck with paused sending.

One possible solution could be that we unpause sending each time when a confirmation email is successfully sent. But this may be problematic because we have some states (pending approval) where we allow sending only to some email addresses (so that users may send themselves a preview email etc.) and resuming sending may hide an important error from MSS. It is rather an edge case but still may happen.

So as a fix, I chose an option where I prevent sending confirmation emails when sending is paused and display the same error as if the sending failed without even trying. When the sending is paused, it is usually due to an error or a ban, etc. so the confirmation email would probably fail anyway.

I also added a migration that detects and fixes the inconsistent state in MailerLog, which might be caused by this issue. And I also added logging of errors when pausing sending. The error is currently reset when sending was resumed and we lost info about it. With the logs, we will be able to see the history of issues that caused paused sending, which might be helpful for debugging issues.

## Code review notes

_N/A_

## QA notes

#### Replication 

1.  Misconfigure sending (e.g. use SMTP with incorrect port)
2. Try to send a newsletter campaign and wait until you see an error in the admin
3. Fix sending configuration, but do not click the resume sending button in the error!
4. Subscribe via a subscription form
5. The successful sending of a confirmation email will reset the sending error but will not unpause sending in the mta_log and since the error message is gone user can’t resume sending.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4940]

## After-merge notes

_N/A_


[MAILPOET-4940]: https://mailpoet.atlassian.net/browse/MAILPOET-4940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ