### PR TITLE
Add deactivation survey [MAILPOET-4686]

### DIFF
--- a/mailpoet/lib/Config/DeactivationPoll.php
+++ b/mailpoet/lib/Config/DeactivationPoll.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class DeactivationPoll {
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var Renderer */
+  private $renderer;
+
+  public function __construct(
+    WPFunctions $wp,
+    Renderer $renderer
+  ) {
+    $this->wp = $wp;
+    $this->renderer = $renderer;
+  }
+
+  public function init() {
+    $this->wp->addAction('admin_print_scripts', [$this, 'css']);
+    $this->wp->addAction('admin_footer', [$this, 'modal']);
+  }
+
+  private function shouldShow(): bool {
+    if (!function_exists('get_current_screen')) {
+      return false;
+    }
+    $screen = $this->wp->getCurrentScreen();
+    if (is_null($screen)) {
+      return false;
+    }
+    return in_array($screen->id, ['plugins', 'plugins-network'], true);
+  }
+
+  public function css(): void {
+    if (!$this->shouldShow()) {
+      return;
+    }
+    $this->render('deactivationPoll/css.html');
+  }
+
+  public function modal(): void {
+    if (!$this->shouldShow()) {
+      return;
+    }
+    $this->render('deactivationPoll/index.html');
+  }
+
+  private function render($template): void {
+    try {
+      // phpcs:disable -- because we use echo here, WordPress sniffs reported a warning
+      echo $this->renderer->render($template);
+      // phpcs:enable
+    } catch (\Exception $e) {
+      // if the website fails to render we have other places to catch and display the error
+    }
+  }
+}

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -313,6 +313,7 @@ class Initializer {
       $this->setupPermanentNotices();
       $this->setupAutomaticEmails();
       $this->setupWoocommerceBlocksIntegration();
+      $this->setupDeactivationPoll();
       $this->subscriberActivityTracker->trackActivity();
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();
@@ -497,5 +498,10 @@ class Initializer {
     if ($wcEnabled && $wcBlocksEnabled) {
       $this->woocommerceBlocksIntegration->init();
     }
+  }
+
+  private function setupDeactivationPoll(): void {
+    $deactivationPoll = new DeactivationPoll($this->wpFunctions, $this->renderer);
+    $deactivationPoll->init();
   }
 }

--- a/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Test\DataFactories\Settings;
 
 class LandingpageBasicsCest {
@@ -30,6 +31,8 @@ class LandingpageBasicsCest {
     $settings->withWelcomeWizard();
 
     $i->click('#deactivate-mailpoet');
+    $i->wantTo('Close the poll about MailPoet deactivation.');
+    $i->pressKey('body', WebDriverKeys::ESCAPE);
     $i->waitForText('Plugin deactivated.');
     $i->click('#activate-mailpoet');
     $i->waitForText('Better email — without leaving WordPress');

--- a/mailpoet/views/deactivationPoll/css.html
+++ b/mailpoet/views/deactivationPoll/css.html
@@ -1,0 +1,40 @@
+<style type="text/css">
+  .mailpoet-deactivate-survey-modal {
+    display: none;
+    table-layout: fixed;
+    position: fixed;
+    z-index: 9999;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    font-size: 14px;
+    top: 0;
+    left: 0;
+    background: rgba(0,0,0,0.8);
+  }
+  .mailpoet-deactivate-survey-wrap {
+    display: table-cell;
+    vertical-align: middle;
+  }
+
+  .mailpoet-deactivate-survey {
+    background-color: #fff;
+    border: 0 solid #ccc;
+    border-radius: 3px;
+    margin: 0 auto;
+    padding: 12px;
+    width: 520px;
+    direction: ltr;
+  }
+
+  .mailpoet-deactivate-survey a.button {
+    white-space: normal;
+    height: auto;
+  }
+
+  .pds-box .pds-vote {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/mailpoet/views/deactivationPoll/index.html
+++ b/mailpoet/views/deactivationPoll/index.html
@@ -9,7 +9,6 @@
           var formOpen = false;
 
           if (!deactivateLink || !overlay || !closeButton) {
-            console.log('early return');
             return;
           }
 

--- a/mailpoet/views/deactivationPoll/index.html
+++ b/mailpoet/views/deactivationPoll/index.html
@@ -1,13 +1,17 @@
-<div class="mailpoet-deactivate-survey-modal" id="mailpoet-deactivate-survey">
+<div class="mailpoet-deactivate-survey-modal" id="mailpoet-deactivate-survey-modal">
   <div class="mailpoet-deactivate-survey-wrap">
     <div class="mailpoet-deactivate-survey">
-
       <script type="text/javascript">
-        window.addEventListener('load', function(event) {
+        window.addEventListener('load', function() {
           var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
-          var overlay = document.querySelector('#mailpoet-deactivate-survey');
+          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
           var closeButton = document.querySelector('#mailpoet-deactivate-survey-close');
           var formOpen = false;
+
+          if (!deactivateLink || !overlay || !closeButton) {
+            console.log('early return');
+            return;
+          }
 
           deactivateLink.addEventListener('click', function (event) {
             event.preventDefault();
@@ -33,8 +37,7 @@
         var pd_callback = function(json) {
           var obj = JSON.parse(json);
           var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
-          var overlay = document.querySelector('#mailpoet-deactivate-survey');
-
+          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
           if (obj.result === 'already-registered' || obj.result === 'registered') {
             overlay.style.display = 'none';
             location.href = deactivateLink.getAttribute('href');

--- a/mailpoet/views/deactivationPoll/index.html
+++ b/mailpoet/views/deactivationPoll/index.html
@@ -1,0 +1,51 @@
+<div class="mailpoet-deactivate-survey-modal" id="mailpoet-deactivate-survey">
+  <div class="mailpoet-deactivate-survey-wrap">
+    <div class="mailpoet-deactivate-survey">
+
+      <script type="text/javascript">
+        window.addEventListener('load', function(event) {
+          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
+          var overlay = document.querySelector('#mailpoet-deactivate-survey');
+          var closeButton = document.querySelector('#mailpoet-deactivate-survey-close');
+          var formOpen = false;
+
+          deactivateLink.addEventListener('click', function (event) {
+            event.preventDefault();
+            overlay.style.display = 'table';
+            formOpen = true;
+          });
+
+          closeButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            overlay.style.display = 'none';
+            formOpen = false;
+            location.href = deactivateLink.getAttribute('href');
+          });
+
+          document.addEventListener('keyup', function (event) {
+            if ((event.keyCode === 27) && formOpen) {
+              location.href = deactivateLink.getAttribute('href');
+            }
+          });
+        });
+
+        // This callback is by docs, and guarantees that the modal window is closed and deactivated only after the vote has been submitted
+        var pd_callback = function(json) {
+          var obj = JSON.parse(json);
+          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
+          var overlay = document.querySelector('#mailpoet-deactivate-survey');
+
+          if (obj.result === 'already-registered' || obj.result === 'registered') {
+            overlay.style.display = 'none';
+            location.href = deactivateLink.getAttribute('href');
+          }
+        };
+      </script>
+      <script type="text/javascript" charset="utf-8" src="https://secure.polldaddy.com/p/11161195.js"></script>
+
+      <noscript><a href="https://poll.fm/11161195">We're sorry to see you leave. Could you tell us more why are you deactivating MailPoet?</a></noscript>
+
+      <a class="button" id="mailpoet-deactivate-survey-close"><%= __('Skip survey and deactivate MailPoet') %> &rarr;</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Description

This PR adds a modal with a survey when a user deactivates our plugin.

I tried to unify a design with our plugin, but there are some restrictions because it's a 3rd party survey.
![Here is the current state](https://d.pr/i/SvWvW8+)

## Code review notes

_N/A_

## QA notes

 1. Deactivate the plugin and check the modal with the survey
   a. Reply to the survey and check your answer in the result (the link is in the Jira ticket)
   b. Skip the survey and check that plugin is deactivated

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4686]

## After-merge notes

Delete results from the poll.


[MAILPOET-4686]: https://mailpoet.atlassian.net/browse/MAILPOET-4686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ