### PR TITLE
Automation: Set isBusy state for create buttons [MAILPOET-4918]

### DIFF
--- a/mailpoet/assets/css/src/components-automation/_option-button.scss
+++ b/mailpoet/assets/css/src/components-automation/_option-button.scss
@@ -23,3 +23,11 @@
   transform: scale(-1, -1);
   transform-origin: center 12.5px;
 }
+
+.mailpoet-option-button-opener.is-busy {
+  animation: components-button__busy-animation 2500ms infinite linear;
+  background-color: var(--wp-admin-theme-color);
+  background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
+  background-size: 100px 100%;
+  border-color: var(--wp-admin-theme-color);
+}

--- a/mailpoet/assets/js/src/automation/components/option-button/index.tsx
+++ b/mailpoet/assets/js/src/automation/components/option-button/index.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction, useState } from 'react';
 import { Button, DropdownMenu } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -8,7 +9,7 @@ type OptionButtonPropType = {
   variant: Button.ButtonVariant;
   controls: StepMoreControlsType;
   title: string;
-  onClick: () => void;
+  onClick: (setIsBusy: Dispatch<SetStateAction<boolean>>) => void;
 };
 export function OptionButton({
   controls,
@@ -16,13 +17,22 @@ export function OptionButton({
   onClick,
   variant,
 }: OptionButtonPropType): JSX.Element {
+  const [isBusy, setIsBusy] = useState(false);
   const slots = Object.values(controls).filter((item) => item.slot);
+  const dropDownMenuClassNames = isBusy
+    ? `mailpoet-option-button-opener is-busy`
+    : `mailpoet-option-button-opener`;
   return (
     <div className="mailpoet-option-button">
       <Button
+        isBusy={isBusy}
+        disabled={isBusy}
         variant={variant}
         className="mailpoet-option-button-main"
-        onClick={onClick}
+        onClick={() => {
+          setIsBusy(true);
+          onClick(setIsBusy);
+        }}
       >
         {title}
       </Button>
@@ -32,10 +42,20 @@ export function OptionButton({
         ))}
       {Object.values(controls).length > 0 && (
         <DropdownMenu
-          className="mailpoet-option-button-opener"
+          className={dropDownMenuClassNames}
           label={__('More', 'mailpoet')}
           icon={chevronDown}
-          controls={Object.values(controls).map((item) => item.control)}
+          controls={Object.values(controls).map((item) => {
+            const control = {
+              ...item.control,
+              onClick: () => {
+                setIsBusy(true);
+                item.control.onClick(setIsBusy);
+              },
+            };
+
+            return control;
+          })}
           popoverProps={{ position: 'bottom left' }}
         />
       )}

--- a/mailpoet/assets/js/src/automation/templates/components/from-scratch.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/from-scratch.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import { Dispatch, useCallback, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Hooks } from 'wp-js-hooks';
@@ -9,21 +9,19 @@ import { FromScratchHookType } from '../../types/filters';
 
 type FromScratchPremiumModalProps = {
   showModal: boolean;
-  setShowModal: Dispatch<SetStateAction<boolean>>;
+  onClose: () => void;
 };
 
 function FromScratchPremiumModal({
   showModal,
-  setShowModal,
+  onClose,
 }: FromScratchPremiumModalProps): JSX.Element | null {
   if (!showModal) {
     return null;
   }
   return (
     <PremiumModal
-      onRequestClose={() => {
-        setShowModal(false);
-      }}
+      onRequestClose={onClose}
       tracking={{
         utm_medium: 'upsell_modal',
         utm_campaign: 'create_automation_from_scratch',
@@ -47,11 +45,17 @@ function fromScratchHook(callback: () => void, errorHandler: Dispatch<string>) {
 export function FromScratchButton(): JSX.Element {
   const [showModal, setShowModal] = useState(false);
   const [error, errorHandler] = useState(null);
+  const [isBusy, setIsBusy] = useState(false);
   const onClickScratchButton = useCallback(() => {
     fromScratchHook(() => {
       setShowModal(true);
     }, errorHandler);
   }, []);
+
+  const premiumClose = () => {
+    setShowModal(false);
+    setIsBusy(false);
+  };
   return (
     <>
       {error && (
@@ -59,25 +63,37 @@ export function FromScratchButton(): JSX.Element {
           <p>{error}</p>
         </Notice>
       )}
-      <Button variant="secondary" onClick={() => onClickScratchButton()}>
+      <Button
+        variant="secondary"
+        isBusy={isBusy}
+        disabled={isBusy}
+        onClick={() => {
+          setIsBusy(true);
+          onClickScratchButton();
+        }}
+      >
         {__('From scratch', 'mailpoet')}
       </Button>
-      <FromScratchPremiumModal
-        showModal={showModal}
-        setShowModal={setShowModal}
-      />
+      <FromScratchPremiumModal showModal={showModal} onClose={premiumClose} />
     </>
   );
 }
 
 export function FromScratchListItem(): JSX.Element {
   const [showModal, setShowModal] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
   const [error, errorHandler] = useState(null);
   const onClickScratchButton = useCallback(() => {
     fromScratchHook(() => {
       setShowModal(true);
     }, errorHandler);
   }, []);
+
+  const premiumClose = () => {
+    setShowModal(false);
+    setIsBusy(false);
+  };
+
   return (
     <li className="mailpoet-automation-template-list-item mailpoet-automation-from-scratch">
       {error && (
@@ -85,14 +101,18 @@ export function FromScratchListItem(): JSX.Element {
           <p>{error}</p>
         </Notice>
       )}
-      <Button onClick={() => onClickScratchButton()}>
+      <Button
+        isBusy={isBusy}
+        disabled={isBusy}
+        onClick={() => {
+          setIsBusy(true);
+          onClickScratchButton();
+        }}
+      >
         <Icon width="50px" height="50px" icon={plusCircleFilled} />
         {__('Create from scratch', 'mailpoet')}
       </Button>
-      <FromScratchPremiumModal
-        showModal={showModal}
-        setShowModal={setShowModal}
-      />
+      <FromScratchPremiumModal showModal={showModal} onClose={premiumClose} />
     </li>
   );
 }

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -3,16 +3,19 @@
  * filters.
  */
 
-import { Dispatch } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { DropdownMenu } from '@wordpress/components';
 import { StoreConfig } from '@wordpress/data';
 import { Item } from '../editor/components/inserter/item';
 import { Step } from '../editor/components/automation/types';
 import { State } from '../editor/store/types';
 
+interface ControlWithSetIsBusy extends Omit<DropdownMenu.Control, 'onClick'> {
+  onClick: (setIsBusy?: Dispatch<SetStateAction<boolean>>) => void;
+}
 export type MoreControlType = {
   key: string;
-  control: DropdownMenu.Control;
+  control: ControlWithSetIsBusy;
   slot: () => JSX.Element | undefined;
 };
 


### PR DESCRIPTION
## Description
Sets the state of the "Create from scratch" button (templates view) and the option button (Start with a template, create new) from the onboarding page to isBusy.

## Code review notes
CSS: I had to add the isBusy styles for the DropDown component of the OptionButton myself. It follows the styles of the general is-busy state.

Filter: The OptionButton is filterable, so 3rd parties can extend the options. The `setIsBusy()` method is now passed down to the `onClick` methods of the controls, so that the control itself can set this state to `false` again. `true` is default after clicking.

## Linked tickets
[MAILPOET-4918]


[MAILPOET-4918]: https://mailpoet.atlassian.net/browse/MAILPOET-4918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ