### PR TITLE
Rename migrations using Migration::columnExists() [MAILPOET-4962]

### DIFF
--- a/mailpoet/lib/Migrations/Migration_20230111_120000.php
+++ b/mailpoet/lib/Migrations/Migration_20230111_120000.php
@@ -7,7 +7,7 @@ use MailPoet\Migrator\Migration;
 use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 
-class Migration_20221124_131445 extends Migration {
+class Migration_20230111_120000 extends Migration {
   public function run(): void {
     $segmentsTable = $this->getTableName(SegmentEntity::class);
     $columnName = 'display_in_manage_subscription_page';

--- a/mailpoet/lib/Migrations/Migration_20230111_130000.php
+++ b/mailpoet/lib/Migrations/Migration_20230111_130000.php
@@ -5,7 +5,7 @@ namespace MailPoet\Migrations;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Migrator\Migration;
 
-class Migration_20221124_160356 extends Migration {
+class Migration_20230111_130000 extends Migration {
   public function run(): void {
     $tableName = $this->getTableName(StatisticsUnsubscribeEntity::class);
     if (!$this->columnExists($tableName, 'method')) {


### PR DESCRIPTION
Because we expect that our plugin can recover from an invalid DB state, we rename old migrations that ensure both migrations are executed again.

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

You can simulate the issue mentioned in the ticket's slack thread and verify that those changes solve the problem.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4962]

## After-merge notes

_N/A_


[MAILPOET-4962]: https://mailpoet.atlassian.net/browse/MAILPOET-4962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ