### PR TITLE
Enable visual confirmation emails by default [MAILPOET-4931]

### DIFF
--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -66,6 +66,7 @@ class SettingsController {
         ],
         'signup_confirmation' => [
           'enabled' => true,
+          'use_mailpoet_editor' => true,
           'subject' => __('Confirm your subscription to [site:title]', 'mailpoet'),
           'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_link]\">[site:title]</a>", 'mailpoet'),
         ],

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -72,6 +72,11 @@ class Settings {
     return $this;
   }
 
+  public function withConfirmationVisualEditorDisabled() {
+    $this->settings->set('signup_confirmation.use_mailpoet_editor', false);
+    return $this;
+  }
+
   public function withTrackingDisabled() {
     $this->settings->set('tracking.level', 'basic');
     return $this;

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -42,7 +42,7 @@ class CreateNewWordPressUserCest {
     $i->checkEmailWasReceived($emailTitle);
     $i->click(Locator::contains('span.subject', $emailTitle));
     $i->switchToIframe('#preview-html');
-    $i->click('Click here to confirm your subscription.');
+    $i->click('Click here to confirm your subscription');
     $i->switchToNextTab();
     $i->see('You have subscribed to');
     $i->seeNoJSErrors();

--- a/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
+++ b/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
@@ -13,6 +13,7 @@ class EditSignUpConfirmationEmailCest {
     $settings = new Settings();
     $settings->withSender('Confirmation Test From', 'from-confirmation-test@example.com');
     $settings->withConfirmationEmailEnabled();
+    $settings->withConfirmationVisualEditorDisabled();
     $forms = new Form();
     $forms->withDefaultSuccessMessage();
     $confirmationEmailSubject = 'Confirmation email subject';

--- a/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
@@ -75,7 +75,7 @@ class SubscribeOnRegistrationPageCest {
     $i->checkEmailWasReceived('Confirm your subscription');
     $i->click(Locator::contains('span.subject', 'Confirm your subscription'));
     $i->switchToIframe('#preview-html');
-    $i->click('Click here to confirm your subscription.');
+    $i->click('Click here to confirm your subscription');
     $i->switchToNextTab();
     $i->see('You have subscribed');
     $i->seeNoJSErrors();

--- a/mailpoet/views/newsletter/templates/components/save.hbs
+++ b/mailpoet/views/newsletter/templates/components/save.hbs
@@ -23,6 +23,7 @@
 {{else if isConfirmationEmailTemplate}}
   <div class="mailpoet_editor_confirmation_email_section">
     <div class="mailpoet_save_button_group">
+      <input type="button" name="preview" value="<%= __('Preview') %>" class="button mailpoet_show_preview" />
       <input type="button" name="save" value="<%= __('Save') %>" class="button button-primary mailpoet_save_button" />
     </div>
     <div class="clearfix"></div>


### PR DESCRIPTION
## Description

This PR enables the email editor for confirmation emails by default. The existing installations should use their current configuration.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4931]

## After-merge notes

_N/A_


[MAILPOET-4931]: https://mailpoet.atlassian.net/browse/MAILPOET-4931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ