### PR TITLE
Remove the feature flag from Landing page - MAILPOET-4803

### DIFF
--- a/mailpoet/lib/Config/Changelog.php
+++ b/mailpoet/lib/Config/Changelog.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Config;
 
-use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Util\Url;
@@ -25,23 +24,18 @@ class Changelog {
   /** @var TrackingConfig */
   private $trackingConfig;
 
-  /** @var FeaturesController */
-  private $featuresController;
-
   public function __construct(
     SettingsController $settings,
     WPFunctions $wp,
     Helper $wooCommerceHelper,
     Url $urlHelper,
-    TrackingConfig $trackingConfig,
-    FeaturesController $featuresController
+    TrackingConfig $trackingConfig
   ) {
     $this->wooCommerceHelper = $wooCommerceHelper;
     $this->settings = $settings;
     $this->wp = $wp;
     $this->urlHelper = $urlHelper;
     $this->trackingConfig = $trackingConfig;
-    $this->featuresController = $featuresController;
   }
 
   public function init() {
@@ -88,7 +82,7 @@ class Changelog {
   }
 
   public function shouldShowLandingPage(): bool {
-    return $this->shouldShowWelcomeWizard() && $this->featuresController->isSupported(FeaturesController::FEATURE_LANDINGPAGE);
+    return $this->shouldShowWelcomeWizard();
   }
 
   public function shouldShowWooCommerceListImportPage() {
@@ -121,26 +115,11 @@ class Changelog {
   public function maybeRedirectToLandingPage() {
     if ($this->isWelcomeWizardPage()) return; // do not redirect when on welcome wizard page
 
-    if ($this->shouldShowLandingPage()) {
-      $this->redirectToLandingPage();
-      return;
-    }
-
-    $this->maybeRedirectToWelcomeWizard(); //TODO: Remove when landing page is out of experimental
+    $this->redirectToLandingPage();
   }
 
   private function setupNewInstallation() {
     $this->settings->set('show_congratulate_after_first_newsletter', true);
-  }
-
-  private function maybeRedirectToWelcomeWizard() {
-    if ($this->shouldShowWelcomeWizard() && !$this->isWelcomeWizardPage()) {
-      if ($this->isLandingPage()) return; // do not redirect when on landing page
-
-      $this->urlHelper->redirectWithReferer(
-        $this->wp->adminUrl('admin.php?page=mailpoet-welcome-wizard')
-      );
-    }
   }
 
   private function isWelcomeWizardPage() {

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -206,19 +206,17 @@ class Menu {
     );
 
     // Landingpage
-    if ($this->featuresController->isSupported(FeaturesController::FEATURE_LANDINGPAGE)) {
-      $this->wp->addSubmenuPage(
-        true,
-        $this->setPageTitle(__('MailPoet', 'mailpoet')),
-        esc_html__('MailPoet', 'mailpoet'),
-        AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-        self::LANDINGPAGE_PAGE_SLUG,
-        [
-          $this,
-          'landingPage',
-        ]
-      );
-    }
+    $this->wp->addSubmenuPage(
+      true,
+      $this->setPageTitle(__('MailPoet', 'mailpoet')),
+      esc_html__('MailPoet', 'mailpoet'),
+      AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
+      self::LANDINGPAGE_PAGE_SLUG,
+      [
+        $this,
+        'landingPage',
+      ]
+    );
 
     // Hide sub-menu entries if the user still needs to complete the Welcome Wizard
     if (!$this->changelog->shouldShowWelcomeWizard()) {

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -7,15 +7,12 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 class FeaturesController {
   const FEATURE_HOMEPAGE = 'homepage';
 
-  const FEATURE_LANDINGPAGE = 'landingpage';
-
   const FEATURE_COUPON_BLOCK = 'Coupon block';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_HOMEPAGE => false,
-    self::FEATURE_LANDINGPAGE => false,
     self::FEATURE_COUPON_BLOCK => false,
   ];
 

--- a/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Settings;
 
 class LandingpageBasicsCest {
@@ -12,7 +10,6 @@ class LandingpageBasicsCest {
     $i->login();
 
     // show welcome wizard & landing page
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_LANDINGPAGE);
     $settings = new Settings();
     $settings->withWelcomeWizard();
 
@@ -21,7 +18,7 @@ class LandingpageBasicsCest {
     $i->waitForText('Better email — without leaving WordPress');
   }
 
-  public function homepageRendersAfterActivation(\AcceptanceTester $i) {
+  public function landingpageRendersAfterActivation(\AcceptanceTester $i) {
     $i->wantTo('Check landingpage renders after plugin activation for new users');
     $i->login();
 
@@ -29,7 +26,6 @@ class LandingpageBasicsCest {
     $i->waitForText('Create and send newsletters, post notifications and welcome emails from your WordPress.');
 
     // show welcome wizard & landing page
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_LANDINGPAGE);
     $settings = new Settings();
     $settings->withWelcomeWizard();
 
@@ -37,5 +33,20 @@ class LandingpageBasicsCest {
     $i->waitForText('Plugin deactivated.');
     $i->click('#activate-mailpoet');
     $i->waitForText('Better email — without leaving WordPress');
+  }
+
+  public function landingpageRedirectsToWelcomeWizard(\AcceptanceTester $i) {
+    $i->wantTo('Check landingpage redirect to welcome wizard when button is clicked');
+    $i->login();
+
+    // show welcome wizard & landing page
+    $settings = new Settings();
+    $settings->withWelcomeWizard();
+
+    $i->amOnMailpoetPage('Emails');
+    $i->waitForText('Better email — without leaving WordPress');
+    $i->click('Begin setup');
+
+    $i->waitForText('Start by configuring your sender information');
   }
 }

--- a/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
+++ b/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
@@ -35,7 +35,7 @@ class ReinstallFromScratchCest {
     $i->waitForElement('[data-automation-id="reinstall-button"]');
     $i->click('Reinstall now...');
     $i->acceptPopup();
-    $i->waitForText('Start by configuring your sender information'); //TODO: Update when landing page is out of experimental
+    $i->waitForText('Better email — without leaving WordPress');
 
     // Step 3 - skip all tutorials, which could interfere with other tests
     $settings = new Settings();


### PR DESCRIPTION


## Description
In this PR, we remove the landing page from experimental features.


## QA notes

You can access the page here: `wp-admin/admin.php?page=mailpoet-landingpage`

Please merge after https://github.com/mailpoet/mailpoet/pull/4651

## Linked PRs

Related to: https://github.com/mailpoet/mailpoet/pull/4651

## Linked tickets

[MAILPOET-4803](https://mailpoet.atlassian.net/browse/MAILPOET-4803)




[MAILPOET-4803]: https://mailpoet.atlassian.net/browse/MAILPOET-4803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ