### PR TITLE
Display the PHP outdated version warning for sites running PHP <= 7.3

### DIFF
--- a/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
+++ b/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
@@ -23,7 +23,7 @@ class PHPVersionWarnings {
 
   public function display($phpVersion) {
     // translators: %s is the PHP version
-    $errorString = __('Your website is running on PHP %s which MailPoet does not officially support. Read our [link]simple PHP upgrade guide.[/link]', 'mailpoet');
+    $errorString = __('Your website is running an outdated version of PHP (%s), on which MailPoet might stop working in the future. We recommend upgrading to 7.4 or greater. Read our [link]simple PHP upgrade guide.[/link]', 'mailpoet');
     $errorString = sprintf($errorString, $phpVersion);
     $error = Helpers::replaceLinkTags($errorString, 'https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version', [
       'target' => '_blank',

--- a/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
+++ b/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
@@ -18,7 +18,7 @@ class PHPVersionWarnings {
   }
 
   public function isOutdatedPHPVersion($phpVersion) {
-    return version_compare($phpVersion, '7.3', '<') && !get_transient(self::OPTION_NAME);
+    return version_compare($phpVersion, '7.4', '<') && !get_transient(self::OPTION_NAME);
   }
 
   public function display($phpVersion) {

--- a/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
@@ -29,8 +29,8 @@ class PHPVersionWarningsTest extends \MailPoetTest {
     expect($this->phpVersionWarning->isOutdatedPHPVersion('7.2'))->true();
   }
 
-  public function testPHP73IsNotOutdated() {
-    expect($this->phpVersionWarning->isOutdatedPHPVersion('7.3'))->false();
+  public function testPHP73IsOutdated() {
+    expect($this->phpVersionWarning->isOutdatedPHPVersion('7.3'))->true();
   }
 
   public function testPHP74IsNotOutdated() {
@@ -49,9 +49,10 @@ class PHPVersionWarningsTest extends \MailPoetTest {
     expect($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
   }
 
-  public function testItPrintsNoWarningFor73() {
-    $warning = $this->phpVersionWarning->init('7.3', true);
-    expect($warning)->null();
+  public function testItPrintsWarningFor73() {
+    $warning = $this->phpVersionWarning->init('7.3.0', true);
+    expect($warning->getMessage())->stringContainsString('Your website is running on PHP 7.3.0');
+    expect($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
   }
 
   public function testItPrintsNoWarningWhenDisabled() {

--- a/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
@@ -39,19 +39,19 @@ class PHPVersionWarningsTest extends \MailPoetTest {
 
   public function testItPrintsWarningFor71() {
     $warning = $this->phpVersionWarning->init('7.1.0', true);
-    expect($warning->getMessage())->stringContainsString('Your website is running on PHP 7.1.0');
+    expect($warning->getMessage())->stringContainsString('Your website is running an outdated version of PHP (7.1.0)');
     expect($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
   }
 
   public function testItPrintsWarningFor72() {
     $warning = $this->phpVersionWarning->init('7.2.0', true);
-    expect($warning->getMessage())->stringContainsString('Your website is running on PHP 7.2.0');
+    expect($warning->getMessage())->stringContainsString('Your website is running an outdated version of PHP (7.2.0)');
     expect($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
   }
 
   public function testItPrintsWarningFor73() {
     $warning = $this->phpVersionWarning->init('7.3.0', true);
-    expect($warning->getMessage())->stringContainsString('Your website is running on PHP 7.3.0');
+    expect($warning->getMessage())->stringContainsString('Your website is running an outdated version of PHP (7.3.0)');
     expect($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
   }
 


### PR DESCRIPTION
## Description

@NeosinneR, I assigned this PR to you as the code changes are fairly straightforward and the main question that I have is related to the specs of this ticket. I wonder if we want to update the message that is displayed in the notice for users running PHP 7.3 or if we are fine with it? The message currently says "Your website is running on PHP 7.3.0 which MailPoet does not officially support".

Please correct me if I'm wrong, but my understanding is that we still support PHP 7.3, but don't recommend that sites run it. Let me know if it is fine to proceed with this PR the way it is or if I should change the message to something else.

## Code review notes

_N/A_

## QA notes

- Check you can see a PHP outdated version warning in all MailPoet versions when the site is running PHP <= 7.3 and that the same warning is not displayed for sites running PHP >= 7.4.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4933]

## After-merge notes

_N/A_


[MAILPOET-4933]: https://mailpoet.atlassian.net/browse/MAILPOET-4933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ