### PR TITLE
Attempt to prevent 429 errors in Switch Languages test [MAILPOET-4969]

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -28,6 +28,8 @@ class SwitchingLanguagesCest {
         $i->wait($attemtps);
         $i->amOnAdminPage('update-core.php');
         $i->waitForText('WordPress-Aktualisierungen');
+        // Wait before clicking the update button to prevent triggering too many requests too translate.wordpress.com within one second
+        $i->wait(1);
         $i->click('Übersetzungen aktualisieren');
         $i->waitForText('Weiter zur WordPress-Aktualisierungs-Seite');
         break;
@@ -37,6 +39,8 @@ class SwitchingLanguagesCest {
     }
 
     $i->wantTo('Check menu strings (translated in PHP)');
+    // The page load after updating languages also triggers a WP check that calls translate.wordpress.com so we wait a bit to prevent triggering too many requests error
+    $i->wait(1);
     $i->amOnMailpoetPage('newsletters');
     $i->waitForText('E-Mails');
     $i->waitForText('Automatisierungen');


### PR DESCRIPTION
## Description
I added a couple of waits so that we don't call the API a couple of times within a second.

## Code review notes

_N/A_

## QA notes

No changes in the plugin code so this doesn't need QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4969]

## After-merge notes

_N/A_


[MAILPOET-4969]: https://mailpoet.atlassian.net/browse/MAILPOET-4969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ