### PR TITLE
Add an option to use an existing coupon in the email editor coupon block [MAILPOET-4761]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -240,6 +240,7 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         'select2:select': function (event) {
           const coupon = event.params.data.text;
           model.set('existingCoupon', coupon);
+          model.set('code', coupon);
         },
       })
       .trigger('change');
@@ -255,12 +256,21 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
       this.$('.mailpoet_field_coupon_source_create_new').removeClass(
         'mailpoet_hidden',
       );
+      // reset code placeholder
+      this.model.set('code', App.getConfig().get('coupon.code_placeholder'));
     } else if (value === 'useExisting') {
       this.$('.mailpoet_field_coupon_source_create_new').addClass(
         'mailpoet_hidden',
       );
       this.$('.mailpoet_field_coupon_source_use_existing').removeClass(
         'mailpoet_hidden',
+      );
+      // set selected code from available
+      this.model.set(
+        'code',
+        this.$('.mailpoet_field_coupon_existing_coupon')
+          .find(':selected')
+          .val(),
       );
     }
   },

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -8,7 +8,6 @@ import _ from 'underscore';
 import jQuery from 'jquery';
 import 'backbone.marionette';
 import { MailPoet } from '../../mailpoet';
-import 'select2';
 
 export const FEATURE_COUPON_BLOCK = 'Coupon block';
 
@@ -274,7 +273,7 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         'code',
         this.$('.mailpoet_field_coupon_existing_coupon')
           .find(':selected')
-          .html(),
+          .text(),
       );
       this.model.set(
         'couponId',

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -56,6 +56,7 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
   events() {
     return {
       'input .mailpoet_field_coupon_code': _.partial(this.changeField, 'code'),
+      'change .mailpoet_field_coupon_source': 'changeSource',
       'change .mailpoet_field_coupon_discount_type': 'changeDiscountType',
       'input .mailpoet_field_coupon_amount': _.partial(
         this.changeField,
@@ -226,6 +227,20 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
           instance.validate();
         }
       });
+  },
+  changeSource(event) {
+    const value = jQuery(event.target).val();
+    this.model.set('source', value);
+
+    if (value === 'createNew') {
+      this.$('.mailpoet_field_coupon_source_create_new').removeClass(
+        'mailpoet_hidden',
+      );
+    } else if (value === 'useExisting') {
+      this.$('.mailpoet_field_coupon_source_create_new').addClass(
+        'mailpoet_hidden',
+      );
+    }
   },
 });
 

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -8,6 +8,7 @@ import _ from 'underscore';
 import jQuery from 'jquery';
 import 'backbone.marionette';
 import { MailPoet } from '../../mailpoet';
+import 'select2';
 
 export const FEATURE_COUPON_BLOCK = 'Coupon block';
 
@@ -176,6 +177,7 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         availableDiscountTypes: App.getConfig()
           .get('coupon.discount_types')
           .toJSON(),
+        availableCoupons: App.getConfig().get('coupon.available_coupons'),
       },
     );
   },
@@ -227,17 +229,37 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
           instance.validate();
         }
       });
+
+    const model = this.model;
+    this.$('.mailpoet_field_coupon_existing_coupon')
+      .select2({
+        multiple: false,
+        allowClear: false,
+      })
+      .on({
+        'select2:select': function (event) {
+          const coupon = event.params.data.text;
+          model.set('existingCoupon', coupon);
+        },
+      })
+      .trigger('change');
   },
   changeSource(event) {
     const value = jQuery(event.target).val();
     this.model.set('source', value);
 
     if (value === 'createNew') {
+      this.$('.mailpoet_field_coupon_source_use_existing').addClass(
+        'mailpoet_hidden',
+      );
       this.$('.mailpoet_field_coupon_source_create_new').removeClass(
         'mailpoet_hidden',
       );
     } else if (value === 'useExisting') {
       this.$('.mailpoet_field_coupon_source_create_new').addClass(
+        'mailpoet_hidden',
+      );
+      this.$('.mailpoet_field_coupon_source_use_existing').removeClass(
         'mailpoet_hidden',
       );
     }

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -177,7 +177,9 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         availableDiscountTypes: App.getConfig()
           .get('coupon.discount_types')
           .toJSON(),
-        availableCoupons: App.getConfig().get('coupon.available_coupons'),
+        availableCoupons: App.getConfig()
+          .get('coupon.available_coupons')
+          .toJSON(),
       },
     );
   },
@@ -238,9 +240,10 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
       })
       .on({
         'select2:select': function (event) {
-          const coupon = event.params.data.text;
-          model.set('existingCoupon', coupon);
-          model.set('code', coupon);
+          const couponId = event.params.data.id;
+          const couponCode = event.params.data.text;
+          model.set('couponId', couponId);
+          model.set('code', couponCode);
         },
       })
       .trigger('change');
@@ -258,6 +261,7 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
       );
       // reset code placeholder
       this.model.set('code', App.getConfig().get('coupon.code_placeholder'));
+      this.model.set('couponId', null);
     } else if (value === 'useExisting') {
       this.$('.mailpoet_field_coupon_source_create_new').addClass(
         'mailpoet_hidden',
@@ -268,6 +272,12 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
       // set selected code from available
       this.model.set(
         'code',
+        this.$('.mailpoet_field_coupon_existing_coupon')
+          .find(':selected')
+          .html(),
+      );
+      this.model.set(
+        'couponId',
         this.$('.mailpoet_field_coupon_existing_coupon')
           .find(':selected')
           .val(),

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -110,6 +110,7 @@ class NewsletterEditor {
           'config' => [
             'discount_types' => $discountTypes,
             'available_coupons' => $this->woocommerceHelper->getCouponList(),
+            'code_placeholder' => Coupon::CODE_PLACEHOLDER,
           ],
           'defaults' => [
             'code' => Coupon::CODE_PLACEHOLDER,

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -109,6 +109,7 @@ class NewsletterEditor {
         'coupon' => [
           'config' => [
             'discount_types' => $discountTypes,
+            'available_coupons' => $this->woocommerceHelper->getCouponList(),
           ],
           'defaults' => [
             'code' => Coupon::CODE_PLACEHOLDER,

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -39,7 +39,7 @@ class FirstPurchase {
     WCHelper $helper = null
   ) {
     if ($helper === null) {
-      $helper = new WCHelper();
+      $helper = ContainerWrapper::getInstance()->get(WCHelper::class);
     }
     $this->helper = $helper;
     $this->scheduler = ContainerWrapper::getInstance()->get(AutomaticEmailScheduler::class);

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -37,7 +37,7 @@ class PurchasedInCategory {
     WCHelper $woocommerceHelper = null
   ) {
     if ($woocommerceHelper === null) {
-      $woocommerceHelper = new WCHelper();
+      $woocommerceHelper = ContainerWrapper::getInstance()->get(WCHelper::class);
     }
     $this->woocommerceHelper = $woocommerceHelper;
     $this->scheduler = ContainerWrapper::getInstance()->get(AutomaticEmailScheduler::class);

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -38,7 +38,7 @@ class PurchasedProduct {
     WCHelper $helper = null
   ) {
     if ($helper === null) {
-      $helper = new WCHelper();
+      $helper = ContainerWrapper::getInstance()->get(WCHelper::class);
     }
     $this->helper = $helper;
     $this->scheduler = ContainerWrapper::getInstance()->get(AutomaticEmailScheduler::class);

--- a/mailpoet/lib/Config/PrivacyPolicy.php
+++ b/mailpoet/lib/Config/PrivacyPolicy.php
@@ -38,7 +38,7 @@ class PrivacyPolicy {
         __('No identifiable information is otherwise tracked outside this website except for the email address.', 'mailpoet') .
       '</p>'
     );
-    $helper = new WooCommerceHelper();
+    $helper = new WooCommerceHelper(WPFunctions::get());
     if ($helper->isWooCommerceActive()) {
       $content .= (
         '<p> ' .

--- a/mailpoet/lib/Models/Segment.php
+++ b/mailpoet/lib/Models/Segment.php
@@ -4,6 +4,7 @@ namespace MailPoet\Models;
 
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\WooCommerce\Helper as WCHelper;
+use MailPoet\WP\Functions;
 
 /**
  * @property array $subscribersCount
@@ -170,7 +171,7 @@ class Segment extends Model {
    * @deprecated Use the non static implementation in \MailPoet\Segments\WooCommerce::shouldShowWooCommerceSegment instead
    */
   public static function shouldShowWooCommerceSegment() {
-    $woocommerceHelper = new WCHelper();
+    $woocommerceHelper = new WCHelper(Functions::get());
     $isWoocommerceActive = $woocommerceHelper->isWooCommerceActive();
     $woocommerceUserExists = Segment::tableAlias('segment')
       ->where('segment.type', Segment::TYPE_WC_USERS)

--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -22,7 +22,7 @@ class PostContentManager {
   ) {
     $this->wp = new WPFunctions;
     $this->maxExcerptLength = $this->wp->applyFilters('mailpoet_newsletter_post_excerpt_length', $this->maxExcerptLength);
-    $this->woocommerceHelper = $woocommerceHelper ?: new WooCommerceHelper();
+    $this->woocommerceHelper = $woocommerceHelper ?: new WooCommerceHelper($this->wp);
   }
 
   public function getContent($post, $displayType) {

--- a/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -21,7 +21,7 @@ class PostTransformerContentsExtractor {
   ) {
     $this->args = $args;
     $this->wp = new WPFunctions();
-    $this->woocommerceHelper = new WooCommerceHelper();
+    $this->woocommerceHelper = new WooCommerceHelper($this->wp);
   }
 
   public function getContent($post, $withPostClass, $displayType) {

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Coupon.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Coupon.php
@@ -23,7 +23,7 @@ class Coupon {
   public function render($element, $columnBaseWidth) {
     $couponCode = self::CODE_PLACEHOLDER;
     if (!empty($element['couponId'])) {
-      $couponCode = $this->helper->wcGetCouponCodeById($element['couponId']);
+      $couponCode = $this->helper->wcGetCouponCodeById((int)$element['couponId']);
     }
     $element['styles']['block']['width'] = $this->calculateWidth($element, $columnBaseWidth);
     $styles = 'display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;' . StylesHelper::getBlockStyles($element, $exclude = ['textAlign']);

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -27,7 +27,7 @@ class Functions extends AbstractExtension {
 
   private function getWooCommerceHelper(): WooCommerceHelper {
     if ($this->woocommerceHelper === null) {
-      $this->woocommerceHelper = new WooCommerceHelper();
+      $this->woocommerceHelper = new WooCommerceHelper($this->getWp());
     }
     return $this->woocommerceHelper;
   }

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -9,6 +9,9 @@ use MailPoet\WP\DateTime;
 
 class CouponPreProcessor {
 
+  /** @var bool */
+  private $generated = false;
+
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
@@ -49,7 +52,6 @@ class CouponPreProcessor {
 
   private function ensureCouponForBlocks(array &$blocks, NewsletterEntity $newsletter): bool {
 
-    static $generated = false;
     foreach ($blocks as &$innerBlock) {
       if (isset($innerBlock['blocks']) && !empty($innerBlock['blocks'])) {
         $this->ensureCouponForBlocks($innerBlock['blocks'], $newsletter);
@@ -57,12 +59,12 @@ class CouponPreProcessor {
       if (isset($innerBlock['type']) && $innerBlock['type'] === Coupon::TYPE) {
         if ($this->shouldGenerateCoupon($innerBlock)) {
           $innerBlock['couponId'] = $this->addOrUpdateCoupon($innerBlock, $newsletter);
-          $generated = true;
+          $this->generated = true;
         }
       }
     }
 
-    return $generated;
+    return $this->generated;
   }
 
   private function addOrUpdateCoupon(array $couponBlock, NewsletterEntity $newsletter): int {

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -55,8 +55,10 @@ class CouponPreProcessor {
         $this->ensureCouponForBlocks($innerBlock['blocks'], $newsletter);
       }
       if (isset($innerBlock['type']) && $innerBlock['type'] === Coupon::TYPE) {
-        $generated = $this->shouldGenerateCoupon($innerBlock);
-        $innerBlock['couponId'] = $this->addOrUpdateCoupon($innerBlock, $newsletter);
+        if ($this->shouldGenerateCoupon($innerBlock)) {
+          $innerBlock['couponId'] = $this->addOrUpdateCoupon($innerBlock, $newsletter);
+          $generated = true;
+        }
       }
     }
 
@@ -102,7 +104,7 @@ class CouponPreProcessor {
   private function shouldGenerateCoupon(array $block): bool {
     return empty($block['couponId']);
   }
-  
+
   /**
    * For some renders/send outs the coupon id shouldn't be persisted along the coupon block
    * This is a placeholder method and should be augmented with more newsletter types that should dynamically get coupons

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -8,6 +8,15 @@ use MailPoet\RuntimeException;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Helper {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
   public function isWooCommerceActive() {
     return class_exists('WooCommerce');
   }
@@ -168,5 +177,19 @@ class Helper {
    */
   public function createWcCoupon($data) {
     return new \WC_Coupon($data);
+  }
+
+  public function getCouponList(): array {
+    $couponPosts = $this->wp->getPosts([
+      'posts_per_page' => -1,
+      'orderby' => 'name',
+      'order' => 'asc',
+      'post_type' => 'shop_coupon',
+      'post_status' => 'publish',
+    ]);
+
+    return array_map(function(\WP_Post $post): string {
+      return $post->post_title; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }, $couponPosts);
   }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -188,8 +188,11 @@ class Helper {
       'post_status' => 'publish',
     ]);
 
-    return array_map(function(\WP_Post $post): string {
-      return $post->post_title; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    return array_map(function(\WP_Post $post): array {
+      return [
+        'id' => $post->ID,
+        'text' => $post->post_title, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      ];
     }, $couponPosts);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/AutomaticEmailsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomaticEmailsTest.php
@@ -20,7 +20,7 @@ class AutomaticEmailsTest extends \MailPoetTest {
 
     $wooCommerceEventFactory = $this->diContainer->get(WooCommerceEventFactory::class);
     $automaticEmailFactory = $this->makeEmpty(AutomaticEmailFactory::class, [
-      'createWooCommerceEmail' => new WooCommerce($this->wp, new Helper(), $wooCommerceEventFactory),
+      'createWooCommerceEmail' => new WooCommerce($this->wp, new Helper($this->wp), $wooCommerceEventFactory),
     ]);
     $this->api = new AutomaticEmails(new AutomaticEmailsController($this->wp, $automaticEmailFactory), $this->wp);
   }

--- a/mailpoet/tests/integration/AutomaticEmails/AutomaticEmailsTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/AutomaticEmailsTest.php
@@ -21,7 +21,7 @@ class AutomaticEmailsTest extends \MailPoetTest {
     $this->wp = new WPFunctions();
     $this->wooCommerceEventFactory = $this->diContainer->get(WooCommerceEventFactory::class);
     $this->automaticEmailFactory = $this->makeEmpty(AutomaticEmailFactory::class, [
-      'createWooCommerceEmail' => new WooCommerce($this->wp, new Helper(), $this->wooCommerceEventFactory),
+      'createWooCommerceEmail' => new WooCommerce($this->wp, new Helper($this->wp), $this->wooCommerceEventFactory),
     ]);
     $this->AM = new AutomaticEmails($this->wp, $this->automaticEmailFactory);
   }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -114,7 +114,7 @@ class AbandonedCartTest extends \MailPoetTest {
   public function testItGetsEventDetails() {
     $settings = $this->diContainer->get(SettingsController::class);
     $wp = new WPFunctions();
-    $wcHelper = new WooCommerceHelper();
+    $wcHelper = new WooCommerceHelper($wp);
     $cookies = new Cookies();
     $subscriberCookie = new SubscriberCookie($cookies, new TrackingConfig($settings));
     $event = new AbandonedCart(

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceTest.php
@@ -22,9 +22,10 @@ class WooCommerceTest extends \MailPoetTest {
   private $automaticEmailFactory;
 
   public function _before() {
+    $wp = new WPFunctions();
     $this->wooCommerceEventFactory = $this->diContainer->get(WooCommerceEventFactory::class);
     $this->automaticEmailFactory = $this->makeEmpty(AutomaticEmailFactory::class, [
-      'createWooCommerceEmail' => new WooCommerce(new WPFunctions(), new Helper(), $this->wooCommerceEventFactory),
+      'createWooCommerceEmail' => new WooCommerce($wp, new Helper($wp), $this->wooCommerceEventFactory),
     ]);
   }
 
@@ -109,8 +110,9 @@ class WooCommerceTest extends \MailPoetTest {
   }
 
   private function createWooCommerceEmailMock(bool $isWoocommerceEnabled = true): WooCommerce {
+    $wp = new WPFunctions();
     $mock = $this->make(WooCommerce::class, ['isWoocommerceEnabled' => $isWoocommerceEnabled]);
-    $mock->__construct(new WPFunctions(), new Helper(), $this->wooCommerceEventFactory);
+    $mock->__construct($wp, new Helper($wp), $this->wooCommerceEventFactory);
     return $mock;
   }
 }

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -45,6 +45,17 @@
     </label>
 </div>
 
+<div class="mailpoet_form_field mailpoet_field_coupon_source_use_existing {{#ifCond model.source '!==' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
+  <div class="mailpoet_form_field_type"><%= __('Existing coupon') %></div>
+  <div class="mailpoet_form_field_select_option mailpoet_form_field_input_nowrap">
+    <select name="existing_coupon" class="mailpoet_select mailpoet_select_large mailpoet_field_coupon_existing_coupon">
+      {{#each availableCoupons}}
+        <option value="{{ this }}" {{#ifCond ../model.existingCoupon '==' this}}selected="selected"{{/ifCond}}>{{ this }}</option>
+      {{/each}}
+    </select>
+  </div>
+</div>
+
 <hr />
 <div class="mailpoet_form_field">
     <div class="mailpoet_form_field_title"><%= __('Alignment') %></div>

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -1,5 +1,20 @@
 <h3><%= __('Coupon') %></h3>
 <div class="mailpoet_form_field">
+  <div class="mailpoet_form_field_radio_option">
+    <label>
+      <input type="radio" name="source" class="mailpoet_field_coupon_source" value="createNew" {{#ifCond model.source '!==' 'useExisting'}}CHECKED{{/ifCond}}/>
+      <%= _x('Create new') %>
+    </label>
+  </div>
+  <div class="mailpoet_form_field_radio_option">
+    <label>
+      <input type="radio" name="source" class="mailpoet_field_coupon_source" value="useExisting" {{#ifCond model.source '===' 'useExisting'}}CHECKED{{/ifCond}}/>
+      <%= _x('Use existing') %>
+    </label>
+  </div>
+</div>
+
+<div class="mailpoet_form_field mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
     <div class="mailpoet_form_field_type"><%= __('Discount type') %></div>
     <div class="mailpoet_form_field_input_option mailpoet_form_field_input_nowrap">
         <select id="mailpoet_field_coupon_discount_type" name="discount-type" class="mailpoet_select mailpoet_select_full mailpoet_field_coupon_discount_type">
@@ -9,7 +24,7 @@
         </select>
     </div>
 </div>
-<div class="mailpoet_form_field">
+<div class="mailpoet_form_field mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
     <label>
         <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon amount') %></div>
         <div class="coupon_amount_wrapper">
@@ -20,8 +35,7 @@
         </div>
     </label>
 </div>
-
-<div class="mailpoet_form_field">
+<div class="mailpoet_form_field mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
     <label>
         <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon expiry days') %></div>
         <div class="mailpoet_form_field_input_option">
@@ -30,6 +44,7 @@
         </div>
     </label>
 </div>
+
 <hr />
 <div class="mailpoet_form_field">
     <div class="mailpoet_form_field_title"><%= __('Alignment') %></div>

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -50,7 +50,7 @@
   <div class="mailpoet_form_field_select_option mailpoet_form_field_input_nowrap">
     <select name="existing_coupon" class="mailpoet_select mailpoet_select_large mailpoet_field_coupon_existing_coupon">
       {{#each availableCoupons}}
-        <option value="{{ this }}" {{#ifCond ../model.existingCoupon '==' this}}selected="selected"{{/ifCond}}>{{ this }}</option>
+        <option value="{{ id }}" {{#ifCond ../model.couponId '==' id}}selected="selected"{{/ifCond}}>{{ text }}</option>
       {{/each}}
     </select>
   </div>

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -14,35 +14,37 @@
   </div>
 </div>
 
-<div class="mailpoet_form_field mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
-    <div class="mailpoet_form_field_type"><%= __('Discount type') %></div>
-    <div class="mailpoet_form_field_input_option mailpoet_form_field_input_nowrap">
-        <select id="mailpoet_field_coupon_discount_type" name="discount-type" class="mailpoet_select mailpoet_select_full mailpoet_field_coupon_discount_type">
-        {{#each availableDiscountTypes}}
-            <option value="{{@key}}" {{#ifCond @key '==' ../model.discountType}}SELECTED{{/ifCond}}>{{ this }}</option>
-        {{/each}}
-        </select>
-    </div>
-</div>
-<div class="mailpoet_form_field mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
-    <label>
-        <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon amount') %></div>
-        <div class="coupon_amount_wrapper">
-            {{#ifCond model.amountMax '===' 100}}
-                <span class="amount_percentage_sign">%</span>
-            {{/ifCond}}
-            <input type="text" name="amount"  data-parsley-validate data-parsley-validation-threshold="0" data-parsley-required data-parsley-trigger="input"  data-parsley-type="digits" {{#ifCond model.amountMax '!==' null }} data-parsley-maxlength="{{ model.amountMax }}" max="{{ model.amountMax }}" {{/ifCond}}   class="mailpoet_input mailpoet_field_coupon_amount mailpoet_input_medium" value="{{ model.amount }}" min="0" />
-        </div>
-    </label>
-</div>
-<div class="mailpoet_form_field mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
-    <label>
-        <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon expiry days') %></div>
-        <div class="mailpoet_form_field_input_option">
-            <input type="text" data-parsley-validate data-parsley-required data-parsley-validation-threshold="0"  name="expiry-day" data-parsley-trigger="input"  data-parsley-type="digits" class="mailpoet_input mailpoet_input_small mailpoet_field_coupon_expiry_day" value="{{ model.expiryDay }}" />
-            <p class='description'><%= __('Number of days the coupon is valid after the email is sent') %></p>
-        </div>
-    </label>
+<div class="mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
+  <div class="mailpoet_form_field">
+      <div class="mailpoet_form_field_type"><%= __('Discount type') %></div>
+      <div class="mailpoet_form_field_input_option mailpoet_form_field_input_nowrap">
+          <select id="mailpoet_field_coupon_discount_type" name="discount-type" class="mailpoet_select mailpoet_select_full mailpoet_field_coupon_discount_type">
+          {{#each availableDiscountTypes}}
+              <option value="{{@key}}" {{#ifCond @key '==' ../model.discountType}}SELECTED{{/ifCond}}>{{ this }}</option>
+          {{/each}}
+          </select>
+      </div>
+  </div>
+  <div class="mailpoet_form_field">
+      <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon amount') %></div>
+          <div class="coupon_amount_wrapper">
+              {{#ifCond model.amountMax '===' 100}}
+                  <span class="amount_percentage_sign">%</span>
+              {{/ifCond}}
+              <input type="text" name="amount"  data-parsley-validate data-parsley-validation-threshold="0" data-parsley-required data-parsley-trigger="input"  data-parsley-type="digits" {{#ifCond model.amountMax '!==' null }} data-parsley-maxlength="{{ model.amountMax }}" max="{{ model.amountMax }}" {{/ifCond}}   class="mailpoet_input mailpoet_field_coupon_amount mailpoet_input_medium" value="{{ model.amount }}" min="0" />
+          </div>
+      </label>
+  </div>
+  <div class="mailpoet_form_field">
+      <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon expiry days') %></div>
+          <div class="mailpoet_form_field_input_option">
+              <input type="text" data-parsley-validate data-parsley-required data-parsley-validation-threshold="0"  name="expiry-day" data-parsley-trigger="input"  data-parsley-type="digits" class="mailpoet_input mailpoet_input_small mailpoet_field_coupon_expiry_day" value="{{ model.expiryDay }}" />
+              <p class='description'><%= __('Number of days the coupon is valid after the email is sent') %></p>
+          </div>
+      </label>
+  </div>
 </div>
 
 <div class="mailpoet_form_field mailpoet_field_coupon_source_use_existing {{#ifCond model.source '!==' 'useExisting'}}mailpoet_hidden{{/ifCond}}">


### PR DESCRIPTION
## Description

Add an option to use an existing coupon in the email editor coupon block.

## Code review notes

_N/A_

## QA notes

This functionality is behind a feature flag.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4761]

## After-merge notes

_N/A_


[MAILPOET-4761]: https://mailpoet.atlassian.net/browse/MAILPOET-4761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ