### PR TITLE
Add a new item to the WooCommerce Task List with a link to the MP wizard [MAILPOET-4814]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -90,6 +90,8 @@ interface Window {
   mailpoet_premium_version: string;
   mailpoet_premium_link: string;
   mailpoet_woocommerce_active: boolean;
+  mailpoet_woocommerce_version: string;
+  mailpoet_track_wizard_loaded_via_woocommerce: boolean;
   mailpoet_premium_active: boolean;
   mailpoet_subscribers_limit: number;
   mailpoet_subscribers_limit_reached: boolean;

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -187,25 +187,6 @@ class NewsletterListStandardComponent extends Component {
     };
   }
 
-  componentDidMount() {
-    // Send event that the MP wizard was loaded via the WooCommerce home page to Mixpanel and delete the corresponding setting.
-    // We need to do this after the user completes the wizard, since before that tracking is not enabled.
-    if (window.mailpoet_track_wizard_loaded_via_woocommerce) {
-      MailPoet.trackEvent(
-        'User opened the MailPoet setup task in WooCommerce > Home',
-        {
-          'WooCommerce version': MailPoet.woocommerceVersion,
-        },
-      );
-      MailPoet.Ajax.post({
-        api_version: window.mailpoet_api_version,
-        endpoint: 'settings',
-        action: 'delete',
-        data: 'send_event_that_wizard_was_loaded_via_woocommerce',
-      });
-    }
-  }
-
   renderItem = (newsletter, actions, meta) => {
     const rowClasses = classnames(
       'manage-column',

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -200,8 +200,8 @@ class NewsletterListStandardComponent extends Component {
       MailPoet.Ajax.post({
         api_version: window.mailpoet_api_version,
         endpoint: 'settings',
-        action: 'set',
-        data: { send_event_that_wizard_was_loaded_via_woocommerce: 0 },
+        action: 'delete',
+        data: 'send_event_that_wizard_was_loaded_via_woocommerce',
       });
     }
   }

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -187,6 +187,25 @@ class NewsletterListStandardComponent extends Component {
     };
   }
 
+  componentDidMount() {
+    // Send event that the MP wizard was loaded via the WooCommerce home page to Mixpanel and delete the corresponding setting.
+    // We need to do this after the user completes the wizard, since before that tracking is not enabled.
+    if (window.mailpoet_track_wizard_loaded_via_woocommerce) {
+      MailPoet.trackEvent(
+        'User opened the MailPoet setup task in WooCommerce > Home',
+        {
+          'WooCommerce version': MailPoet.woocommerceVersion,
+        },
+      );
+      MailPoet.Ajax.post({
+        api_version: window.mailpoet_api_version,
+        endpoint: 'settings',
+        action: 'set',
+        data: { send_event_that_wizard_was_loaded_via_woocommerce: 0 },
+      });
+    }
+  }
+
   renderItem = (newsletter, actions, meta) => {
     const rowClasses = classnames(
       'manage-column',

--- a/mailpoet/assets/js/src/webpack_admin_index.tsx
+++ b/mailpoet/assets/js/src/webpack_admin_index.tsx
@@ -19,3 +19,4 @@ import 'sending-paused-notices-fix-button.tsx'; // side effect - renders ReactDO
 import 'sending-paused-notices-resume-button.ts'; // side effect - executes on doc ready, adds events
 import 'sending-paused-notices-authorize-email.tsx'; // side effect - renders ReactDOM to document
 import 'landingpage/landingpage'; // side effect - renders ReactDOM to document
+import 'wizard/track_wizard_loaded_via_woocommerce.tsx';

--- a/mailpoet/assets/js/src/wizard/track_wizard_loaded_via_woocommerce.tsx
+++ b/mailpoet/assets/js/src/wizard/track_wizard_loaded_via_woocommerce.tsx
@@ -1,0 +1,20 @@
+function trackWizardLoadedViaWooCommerce() {
+  // Send event that the MP wizard was loaded via the WooCommerce home page to Mixpanel and delete the corresponding setting.
+  // We need to do this after the user completes the wizard, since before that tracking is not enabled.
+  if (window.mailpoet_track_wizard_loaded_via_woocommerce) {
+    window.MailPoet.trackEvent(
+      'User opened the MailPoet setup task in WooCommerce > Home',
+      {
+        'WooCommerce version': window.mailpoet_woocommerce_version,
+      },
+    );
+    void window.MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'settings',
+      action: 'delete',
+      data: 'send_event_that_wizard_was_loaded_via_woocommerce',
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', trackWizardLoadedViaWooCommerce);

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -4,6 +4,7 @@ namespace MailPoet\API\JSON\v1;
 
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
+use MailPoet\API\JSON\Response;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\Workers\SubscribersEngagementScore;
@@ -167,6 +168,32 @@ class Settings extends APIEndpoint {
 
       return $this->successResponse($this->settings->getAll(), $meta);
     }
+  }
+
+  public function delete(string $settingName): Response {
+    if (empty($settingName)) {
+      return $this->badRequest(
+        [
+          APIError::BAD_REQUEST =>
+            __('You have not specified any setting to be deleted.', 'mailpoet'),
+        ]
+      );
+    }
+
+    $setting = $this->settings->get($settingName);
+
+    if (is_null($setting)) {
+      return $this->badRequest(
+        [
+          APIError::BAD_REQUEST =>
+            __('Setting doesn\'t exist.', 'mailpoet'),
+        ]
+      );
+    }
+
+    $this->settings->delete($settingName);
+
+    return $this->successResponse();
   }
 
   public function recalculateSubscribersScore() {

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\AdminPages;
 
+use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Config\Installer;
 use MailPoet\Config\Menu;
@@ -140,6 +141,7 @@ class PageRenderer {
       'deactivate_subscriber_after_inactive_days' => $this->settings->get('deactivate_subscriber_after_inactive_days'),
       'send_transactional_emails' => (bool)$this->settings->get('send_transactional_emails'),
       'transactional_emails_opt_in_notice_dismissed' => (bool)$this->userFlags->get('transactional_emails_opt_in_notice_dismissed'),
+      'track_wizard_loaded_via_woocommerce' => (bool)$this->settings->get(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME),
 
       // Premium & plan upgrade info
       'current_wp_user_email' => $this->wp->wpGetCurrentUser()->user_email,

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -9,6 +9,8 @@ use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
 class WelcomeWizard {
+  const TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME = 'send_event_that_wizard_was_loaded_via_woocommerce';
+
   /** @var PageRenderer */
   private $pageRenderer;
 
@@ -35,6 +37,14 @@ class WelcomeWizard {
 
   public function render() {
     if ((bool)(defined('DOING_AJAX') && DOING_AJAX)) return;
+
+    $loadedViaWooCommerce = $this->settings->get(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME, false);
+
+    if (!$loadedViaWooCommerce && isset($_GET['mailpoet_wizard_loaded_via_woocommerce'])) {
+      // This setting is used to send an event to Mixpanel in another request as, before completing the wizard, Mixpanel is not enabled.
+      $this->settings->set(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME, 1);
+    }
+
     $data = [
       'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::$mainPageSlug),
       'sender' => $this->settings->get('sender'),

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -318,6 +318,11 @@ class Hooks {
       $this->hooksWooCommerce,
       'declareHposCompatibility',
     ]);
+
+    $this->wp->addAction('init', [
+      $this->hooksWooCommerce,
+      'addMailPoetTaskToWooHomePage',
+    ]);
   }
 
   public function setupWooCommerceUsers() {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -2,10 +2,13 @@
 
 namespace MailPoet\Config;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\Statistics\Track\WooCommercePurchases;
 use MailPoet\Subscription\Registration;
+use MailPoet\WooCommerce\MailPoetTask;
 use MailPoet\WooCommerce\Settings as WooCommerceSettings;
 use MailPoet\WooCommerce\SubscriberEngagement;
 use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
@@ -154,6 +157,16 @@ class HooksWooCommerce {
       return $data;
     }
     return $this->tracker->addTrackingData($data);
+  }
+
+  public function addMailPoetTaskToWooHomePage() {
+    try {
+      if (class_exists(TaskLists::class) && class_exists(Task::class)) {
+        TaskLists::add_task('extended', new MailPoetTask());
+      }
+    } catch (\Throwable $e) {
+      $this->logError($e, 'Unable to add MailPoet task to WooCommerce homepage');
+    }
   }
 
   private function logError(\Throwable $e, $name) {

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -151,6 +151,11 @@ class Functions extends AbstractExtension {
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
+        'get_woocommerce_version',
+        [$this, 'getWooCommerceVersion'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
         'wp_start_of_week',
         [$this, 'getWPStartOfWeek'],
         ['is_safe' => ['all']]
@@ -277,6 +282,10 @@ class Functions extends AbstractExtension {
 
   public function isWoocommerceActive() {
     return $this->getWooCommerceHelper()->isWooCommerceActive();
+  }
+
+  public function getWooCommerceVersion() {
+    return $this->getWooCommerceHelper()->getWooCommerceVersion();
   }
 
   public function statsColor($percentage) {

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -21,6 +21,10 @@ class Helper {
     return class_exists('WooCommerce');
   }
 
+  public function getWooCommerceVersion() {
+    return $this->isWooCommerceActive() ? get_plugin_data(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'] : null;
+  }
+
   public function isWooCommerceBlocksActive($min_version = '') {
     if (!class_exists('\Automattic\WooCommerce\Blocks\Package')) {
       return false;

--- a/mailpoet/lib/WooCommerce/MailPoetTask.php
+++ b/mailpoet/lib/WooCommerce/MailPoetTask.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use MailPoet\Config\Menu;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Settings\SettingsController;
+
+/**
+ * MailPoet task that is added to the WooCommerce homepage.
+ */
+class MailPoetTask extends Task {
+  /**
+   * @return string
+   */
+  public function get_id() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return 'mailpoet_task';
+  }
+
+  /**
+   * @return string
+   */
+  public function get_title() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->is_complete()) {
+      return esc_html__( 'MailPoet setup completed', 'mailpoet' );
+    }
+
+    return esc_html__( 'Setup MailPoet', 'mailpoet' );
+  }
+
+  /**
+   * @return string
+   */
+  public function get_content() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '';
+  }
+
+  /**
+   * String that is displayed below the title of the task indicating the estimated completion time.
+   *
+   * @return string
+   */
+  public function get_time() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '';
+  }
+
+  /**
+   * Link used when the user clicks on the title of the task.
+   *
+   * @return string
+   */
+  public function get_action_url() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->is_complete()) {
+      return admin_url('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
+    }
+
+    return admin_url('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG);
+  }
+
+  /**
+   * Whether the task is completed.
+   * If the setting 'version' is not null it means the welcome wizard
+   * was already completed so we mark this task as completed as well.
+   *
+   * @return bool
+   */
+  public function is_complete() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    $settings = ContainerWrapper::getInstance()->get(SettingsController::class);
+    $version = $settings->get('version');
+
+    return $version !== null;
+  }
+}

--- a/mailpoet/lib/WooCommerce/MailPoetTask.php
+++ b/mailpoet/lib/WooCommerce/MailPoetTask.php
@@ -55,7 +55,7 @@ class MailPoetTask extends Task {
       return admin_url('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
     }
 
-    return admin_url('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG);
+    return admin_url('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG . '&mailpoet_wizard_loaded_via_woocommerce');
   }
 
   /**

--- a/mailpoet/lib/WooCommerce/MailPoetTask.php
+++ b/mailpoet/lib/WooCommerce/MailPoetTask.php
@@ -11,17 +11,11 @@ use MailPoet\Settings\SettingsController;
  * MailPoet task that is added to the WooCommerce homepage.
  */
 class MailPoetTask extends Task {
-  /**
-   * @return string
-   */
-  public function get_id() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function get_id(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return 'mailpoet_task';
   }
 
-  /**
-   * @return string
-   */
-  public function get_title() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->is_complete()) {
       return esc_html__( 'MailPoet setup completed', 'mailpoet' );
     }
@@ -29,28 +23,21 @@ class MailPoetTask extends Task {
     return esc_html__( 'Setup MailPoet', 'mailpoet' );
   }
 
-  /**
-   * @return string
-   */
-  public function get_content() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '';
   }
 
   /**
    * String that is displayed below the title of the task indicating the estimated completion time.
-   *
-   * @return string
    */
-  public function get_time() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function get_time(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '';
   }
 
   /**
    * Link used when the user clicks on the title of the task.
-   *
-   * @return string
    */
-  public function get_action_url() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function get_action_url(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->is_complete()) {
       return admin_url('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
     }
@@ -62,10 +49,8 @@ class MailPoetTask extends Task {
    * Whether the task is completed.
    * If the setting 'version' is not null it means the welcome wizard
    * was already completed so we mark this task as completed as well.
-   *
-   * @return bool
    */
-  public function is_complete() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function is_complete(): bool { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     $settings = ContainerWrapper::getInstance()->get(SettingsController::class);
     $version = $settings->get('version');
 

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -84,6 +84,11 @@ parameters:
     - message: '/Return type \(array\) of method MailPoet\\Logging\\PluginVersionProcessor::__invoke\(\) should be compatible with return type \(MailPoetVendor\\Monolog\\Processor\\Record\) of method MailPoetVendor\\Monolog\\Processor\\ProcessorInterface::__invoke\(\)/'
       count: 1
       path: ../../lib/Logging/PluginVersionProcessor.php
+    - # Can be removed once https://github.com/woocommerce/woocommerce/pull/36104 is merged. WooCommerce docblock for this method is outdated.
+      message: '/^Parameter #2 \$args of static method Automattic\\WooCommerce\\Admin\\Features\\OnboardingTasks\\TaskLists::add_task\(\) expects array, MailPoet\\WooCommerce\\MailPoetTask given.$/'
+      count: 1
+      path: ../../lib/Config/HooksWooCommerce.php
+
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:
     - MAILPOET_PREMIUM_INITIALIZED

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -5,7 +5,9 @@ namespace MailPoet\Test\API\JSON\v1;
 use Codeception\Stub\Expected;
 use Codeception\Util\Fixtures;
 use MailPoet\API\JSON\Error as APIError;
+use MailPoet\API\JSON\ErrorResponse;
 use MailPoet\API\JSON\Response as APIResponse;
+use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\API\JSON\v1\Settings;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\Workers\InactiveSubscribers;
@@ -294,6 +296,21 @@ class SettingsTest extends \MailPoetTest {
     expect($response->meta['showNotice'])->equals(false);
     $response = $this->endpoint->set(['tracking' => ['level' => TrackingConfig::LEVEL_BASIC]]);
     expect($response->meta['showNotice'])->equals(false);
+  }
+
+  public function testItCanDeleteSetting() {
+    $this->settings->set('setting_to_be_deleted', true);
+    $response = $this->endpoint->delete('setting_to_be_deleted');
+    expect($response)->isInstanceOf(SuccessResponse::class);
+    expect($this->settings->get('setting_to_be_deleted'))->null();
+  }
+
+  public function testDeleteReturnErrorForEmptySettingName() {
+    expect($this->endpoint->delete(''))->isInstanceOf(ErrorResponse::class);
+  }
+
+  public function testDeleteReturnErrorIfSettingDoesntExist() {
+    expect($this->endpoint->delete('unexistent_setting'))->isInstanceOf(ErrorResponse::class);
   }
 
   private function createNewsletter(string $type, string $status = NewsletterEntity::STATUS_DRAFT, $parent = null): NewsletterEntity {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -79,6 +79,8 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   var mailpoet_send_transactional_emails = <%= json_encode(send_transactional_emails) %>;
   var mailpoet_transactional_emails_opt_in_notice_dismissed = <%= json_encode(transactional_emails_opt_in_notice_dismissed) %>;
   var mailpoet_deactivate_subscriber_after_inactive_days = <%= json_encode(deactivate_subscriber_after_inactive_days) %>;
+  var mailpoet_woocommerce_version = <%= json_encode(get_woocommerce_version()) %>;
+  var mailpoet_track_wizard_loaded_via_woocommerce = <%= json_encode(track_wizard_loaded_via_woocommerce) %>;
 
   var mailpoet_site_name = '<%= site_name %>';
   var mailpoet_site_url = "<%= site_url %>";


### PR DESCRIPTION
## Description

This PR adds a new item to the WooCommerce Task List with a link to the MP wizard (see ticket description for more details). It also adds a new Mixpanel event to track when the user arrives to the MP wizard via the WooCommerce task list item.

## Code review notes

- To check that Mixpanel tracking is working you can add `debug: true` to [/mailpoet/assets/js/lib/analytics.js#L9](https://github.com/mailpoet/mailpoet/blob/c368b130b84ca66dcee6b91bd99eb754de8cd330/mailpoet/assets/js/lib/analytics.js#L9) (see https://developer.mixpanel.com/docs/javascript#debug-mode).
- Since Mixpanel is not enabled before the user finishes the wizard, I had to store the information that we want to send an event to Mixpanel in a setting and use it later in a different request. I have some doubts about this implementation, and I left a few questions in inline comments.

## QA notes

- Go to /wp-admin/admin.php?page=wc-admin
- If the user never completed the MP Welcome Wizard, check that there is a link under `Things to do next` pointing the user to the MP wizard. If the user completed the wizard, the same link should point to the newsletters page. In the future, we will update this to point to the MP homepage (https://mailpoet.atlassian.net/browse/MAILPOET-4926).
- Check that the MP Welcome Wizard still works as expected.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4814]

## After-merge notes

_N/A_


[MAILPOET-4814]: https://mailpoet.atlassian.net/browse/MAILPOET-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ