### PR TITLE
Add more options for the WooCommerce coupon block in the email editor - MAILPOET-4762

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -70,6 +70,35 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         this.changeBoolCheckboxField,
         'freeShipping',
       ),
+      'input .mailpoet_field_coupon_minimum_amount': _.partial(
+        this.changeField,
+        'minimumAmount',
+      ),
+      'input .mailpoet_field_coupon_maximum_amount': _.partial(
+        this.changeField,
+        'maximumAmount',
+      ),
+      'change .mailpoet_field_coupon_individual_use': _.partial(
+        this.changeBoolCheckboxField,
+        'individualUse',
+      ),
+      'change .mailpoet_field_coupon_exclude_sale_items': _.partial(
+        this.changeBoolCheckboxField,
+        'excludeSaleItems',
+      ),
+      // more items here
+      'input .mailpoet_field_coupon_email_restrictions': _.partial(
+        this.changeField,
+        'emailRestrictions',
+      ),
+      'input .mailpoet_field_coupon_usage_limit': _.partial(
+        this.changeField,
+        'usageLimit',
+      ),
+      'input .mailpoet_field_coupon_usage_limit_per_user': _.partial(
+        this.changeField,
+        'usageLimitPerUser',
+      ),
       'change .mailpoet_field_coupon_alignment': _.partial(
         this.changeField,
         'styles.block.textAlign',

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -66,6 +66,10 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         this.changeField,
         'expiryDay',
       ),
+      'change .mailpoet_field_coupon_free_shipping': _.partial(
+        this.changeBoolCheckboxField,
+        'freeShipping',
+      ),
       'change .mailpoet_field_coupon_alignment': _.partial(
         this.changeField,
         'styles.block.textAlign',

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -81,11 +81,11 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         'freeShipping',
       ),
       'input .mailpoet_field_coupon_minimum_amount': _.partial(
-        this.changeField,
+        this.validateMinAndMaxAmountFields,
         'minimumAmount',
       ),
       'input .mailpoet_field_coupon_maximum_amount': _.partial(
-        this.changeField,
+        this.validateMinAndMaxAmountFields,
         'maximumAmount',
       ),
       'change .mailpoet_field_coupon_individual_use': _.partial(
@@ -97,7 +97,7 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         'excludeSaleItems',
       ),
       'input .mailpoet_field_coupon_email_restrictions': _.partial(
-        this.changeField,
+        this.validateEmailRestrictionsField,
         'emailRestrictions',
       ),
       'input .mailpoet_field_coupon_usage_limit': _.partial(
@@ -465,6 +465,49 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         this.model.set(fieldName, modelItem.toJSON());
       },
     };
+  },
+  validateMinAndMaxAmountFields(field, event) {
+    const element = event.target;
+    const errorElem = element.nextElementSibling;
+
+    const value = element.value
+      ? Number.parseFloat(String(element.value))
+      : element.value;
+
+    if (Number.isNaN(value)) {
+      if (errorElem && errorElem.classList.contains('mailpoet_hidden')) {
+        errorElem.classList.remove('mailpoet_hidden'); // show error message
+      }
+      return;
+    }
+
+    if (errorElem && !errorElem.classList.contains('mailpoet_hidden')) {
+      errorElem.classList.add('mailpoet_hidden'); // hide error message
+    }
+
+    this.model.set(field, value);
+  },
+  validateEmailRestrictionsField(field, event) {
+    const element = event.target;
+    const errorElem = element.nextElementSibling;
+
+    const isValid = element.checkValidity();
+
+    if (!isValid) {
+      errorElem.textContent = element.validationMessage;
+
+      if (errorElem.classList.contains('mailpoet_hidden')) {
+        errorElem.classList.remove('mailpoet_hidden');
+      }
+
+      return;
+    }
+
+    if (errorElem && !errorElem.classList.contains('mailpoet_hidden')) {
+      errorElem.classList.add('mailpoet_hidden');
+    }
+
+    this.model.set(field, element.value);
   },
 });
 

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -24,7 +24,6 @@ Module.CouponBlockModel = base.BlockModel.extend({
         excludedProductIds: [],
         productCategories: [], // selected categories id
         excludedProductCategories: [],
-        emailRestrictions: [],
       },
       App.getConfig().get('blockDefaults.coupon'),
     );

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.ts
@@ -68,11 +68,11 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
       'change .mailpoet_field_coupon_source': 'changeSource',
       'change .mailpoet_field_coupon_discount_type': 'changeDiscountType',
       'input .mailpoet_field_coupon_amount': _.partial(
-        this.changeField,
+        this.validateChangeField,
         'amount',
       ),
       'input .mailpoet_field_coupon_expiry_day': _.partial(
-        this.changeField,
+        this.validateChangeField,
         'expiryDay',
       ),
       'change .mailpoet_field_coupon_free_shipping': _.partial(
@@ -268,6 +268,16 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
 
     // It's a new element after the re-render
     this.$('.mailpoet_field_coupon_amount').parsley().validate();
+  },
+  validateChangeField(field, event) {
+    const element = this.$(event.target);
+    const value = element.val();
+
+    if (!element.parsley().isValid()) {
+      return; // input invalid. not saving
+    }
+
+    this.model.set(field, value);
   },
   onRender() {
     this.$('[data-parsley-validate]')

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -111,6 +111,7 @@ class NewsletterEditor {
             'discount_types' => $discountTypes,
             'available_coupons' => $this->woocommerceHelper->getCouponList(),
             'code_placeholder' => Coupon::CODE_PLACEHOLDER,
+            'price_decimal_separator' => $this->woocommerceHelper->wcGetPriceDecimalSeparator(),
           ],
           'defaults' => [
             'code' => Coupon::CODE_PLACEHOLDER,

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -85,29 +85,46 @@ class CouponPreProcessor {
 
     // general
     $coupon->set_discount_type($couponBlock['discountType']);
-    $coupon->set_amount($couponBlock['amount']);
+
+    if (isset($couponBlock['amount'])) {
+      $coupon->set_amount($couponBlock['amount']);
+    }
+
     if (isset($couponBlock['expiryDay'])) {
       $expiration = (new DateTime())->getCurrentDateTime()->modify("+{$couponBlock['expiryDay']} day")->getTimestamp();
       $coupon->set_date_expires($expiration);
     }
-    $coupon->set_free_shipping($couponBlock['freeShipping'] ?: false);
+
+    $coupon->set_free_shipping($couponBlock['freeShipping'] ?? false);
 
     // usage restriction
-    $coupon->set_minimum_amount($couponBlock['minimumAmount'] ?: '');
-    $coupon->set_maximum_amount($couponBlock['maximumAmount'] ?: '');
-    $coupon->set_individual_use($couponBlock['individualUse'] ?: false);
-    $coupon->set_exclude_sale_items($couponBlock['excludeSaleItems'] ?: false);
-    $coupon->set_product_ids($couponBlock['productIds'] ?: []);
-    $coupon->set_excluded_product_ids($couponBlock['excludedProductIds'] ?: []);
-    $coupon->set_product_categories($couponBlock['productCategories'] ?: []);
-    $coupon->set_excluded_product_categories($couponBlock['excludedProductCategories'] ?: []);
-    $coupon->set_email_restrictions($couponBlock['emailRestrictions'] ?: []);
+    $coupon->set_minimum_amount($couponBlock['minimumAmount'] ?? '');
+    $coupon->set_maximum_amount($couponBlock['maximumAmount'] ?? '');
+    $coupon->set_individual_use($couponBlock['individualUse'] ?? false);
+    $coupon->set_exclude_sale_items($couponBlock['excludeSaleItems'] ?? false);
+    $coupon->set_product_ids($couponBlock['productIds'] ?? []);
+    $coupon->set_excluded_product_ids($couponBlock['excludedProductIds'] ?? []);
+
+    $coupon->set_product_categories($this->getCategoryItemIds($couponBlock['productCategories']));
+    $coupon->set_excluded_product_categories($this->getCategoryItemIds($couponBlock['excludedProductCategories']));
+
+    $coupon->set_email_restrictions(explode(',', $couponBlock['emailRestrictions']));
 
     // usage limit
-    $coupon->set_usage_limit($couponBlock['usageLimit'] ?: 0);
-    $coupon->set_usage_limit_per_user($couponBlock['usageLimitPerUser'] ?: 0);
+    $coupon->set_usage_limit($couponBlock['usageLimit'] ?? 0);
+    $coupon->set_usage_limit_per_user($couponBlock['usageLimitPerUser'] ?? 0);
 
     return $coupon->save();
+  }
+
+  private function getCategoryItemIds(array $items): array {
+    if (empty($items)) {
+      return [];
+    }
+
+    return array_map(function ($item){
+      return $item['term_id'];
+    }, $items);
   }
 
   /**

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -103,13 +103,13 @@ class CouponPreProcessor {
     $coupon->set_individual_use($couponBlock['individualUse'] ?? false);
     $coupon->set_exclude_sale_items($couponBlock['excludeSaleItems'] ?? false);
 
-    $coupon->set_product_ids($this->getProductIds($couponBlock['productIds']));
-    $coupon->set_excluded_product_ids($this->getProductIds($couponBlock['excludedProductIds']));
+    $coupon->set_product_ids($this->getProductIds($couponBlock['productIds'] ?? []));
+    $coupon->set_excluded_product_ids($this->getProductIds($couponBlock['excludedProductIds'] ?? []));
 
-    $coupon->set_product_categories($this->getCategoryItemIds($couponBlock['productCategories']));
-    $coupon->set_excluded_product_categories($this->getCategoryItemIds($couponBlock['excludedProductCategories']));
+    $coupon->set_product_categories($this->getCategoryItemIds($couponBlock['productCategories'] ?? []));
+    $coupon->set_excluded_product_categories($this->getCategoryItemIds($couponBlock['excludedProductCategories'] ?? []));
 
-    $coupon->set_email_restrictions(explode(',', $couponBlock['emailRestrictions']));
+    $coupon->set_email_restrictions(explode(',', $couponBlock['emailRestrictions'] ?? ''));
 
     // usage limit
     $coupon->set_usage_limit($couponBlock['usageLimit'] ?? 0);

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -73,10 +73,7 @@ class CouponPreProcessor {
       $code = isset($couponBlock['code']) && $couponBlock['code'] !== Coupon::CODE_PLACEHOLDER ? $couponBlock['code'] : $this->generateRandomCode();
       $coupon->set_code($code);
     }
-    $coupon->set_discount_type($couponBlock['discountType']);
-    $coupon->set_amount($couponBlock['amount']);
-    $expiration = (new DateTime())->getCurrentDateTime()->modify("+{$couponBlock['expiryDay']} day")->getTimestamp();
-    $coupon->set_date_expires($expiration);
+
     $coupon->set_description(
       sprintf(
       // translators: %1$s is newsletter id and %2$s is the subject.
@@ -85,6 +82,30 @@ class CouponPreProcessor {
         $newsletter->getSubject()
       )
     );
+
+    // general
+    $coupon->set_discount_type($couponBlock['discountType']);
+    $coupon->set_amount($couponBlock['amount']);
+    if (isset($couponBlock['expiryDay'])) {
+      $expiration = (new DateTime())->getCurrentDateTime()->modify("+{$couponBlock['expiryDay']} day")->getTimestamp();
+      $coupon->set_date_expires($expiration);
+    }
+    $coupon->set_free_shipping($couponBlock['freeShipping'] ?: false);
+
+    // usage restriction
+    $coupon->set_minimum_amount($couponBlock['minimumAmount'] ?: '');
+    $coupon->set_maximum_amount($couponBlock['maximumAmount'] ?: '');
+    $coupon->set_individual_use($couponBlock['individualUse'] ?: false);
+    $coupon->set_exclude_sale_items($couponBlock['excludeSaleItems'] ?: false);
+    $coupon->set_product_ids($couponBlock['productIds'] ?: []);
+    $coupon->set_excluded_product_ids($couponBlock['excludedProductIds'] ?: []);
+    $coupon->set_product_categories($couponBlock['productCategories'] ?: []);
+    $coupon->set_excluded_product_categories($couponBlock['excludedProductCategories'] ?: []);
+    $coupon->set_email_restrictions($couponBlock['emailRestrictions'] ?: []);
+
+    // usage limit
+    $coupon->set_usage_limit($couponBlock['usageLimit'] ?: 0);
+    $coupon->set_usage_limit_per_user($couponBlock['usageLimitPerUser'] ?: 0);
 
     return $coupon->save();
   }

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -102,8 +102,9 @@ class CouponPreProcessor {
     $coupon->set_maximum_amount($couponBlock['maximumAmount'] ?? '');
     $coupon->set_individual_use($couponBlock['individualUse'] ?? false);
     $coupon->set_exclude_sale_items($couponBlock['excludeSaleItems'] ?? false);
-    $coupon->set_product_ids($couponBlock['productIds'] ?? []);
-    $coupon->set_excluded_product_ids($couponBlock['excludedProductIds'] ?? []);
+
+    $coupon->set_product_ids($this->getProductIds($couponBlock['productIds']));
+    $coupon->set_excluded_product_ids($this->getProductIds($couponBlock['excludedProductIds']));
 
     $coupon->set_product_categories($this->getCategoryItemIds($couponBlock['productCategories']));
     $coupon->set_excluded_product_categories($this->getCategoryItemIds($couponBlock['excludedProductCategories']));
@@ -118,12 +119,20 @@ class CouponPreProcessor {
   }
 
   private function getCategoryItemIds(array $items): array {
+    return $this->getItemIds($items, 'term_id');
+  }
+
+  private function getProductIds(array $items): array {
+    return $this->getItemIds($items, 'ID');
+  }
+
+  private function getItemIds(array $items, $field = ''): array {
     if (empty($items)) {
       return [];
     }
 
-    return array_map(function ($item){
-      return $item['term_id'];
+    return array_map(function ($item) use ($field) {
+      return $item[$field];
     }, $items);
   }
 

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -195,4 +195,8 @@ class Helper {
       ];
     }, $couponPosts);
   }
+
+  public function wcGetPriceDecimalSeparator() {
+    return wc_get_price_decimal_separator();
+  }
 }

--- a/mailpoet/tests/unit/WooCommerce/CouponPreProcessorTest.php
+++ b/mailpoet/tests/unit/WooCommerce/CouponPreProcessorTest.php
@@ -164,7 +164,26 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
   private function createCouponMock() {
     /* @phpstan-ignore-next-line ignoring usage of string instead of class-string */
     return $this->getMockBuilder('MaybeMissingWC_Coupon')
-      ->setMethods(['set_code', 'set_discount_type', 'set_amount', 'set_description', 'set_date_expires', 'save'])
+      ->setMethods([
+        'set_code',
+        'set_discount_type',
+        'set_amount',
+        'set_description',
+        'set_date_expires',
+        'set_free_shipping',
+        'set_minimum_amount',
+        'set_maximum_amount',
+        'set_individual_use',
+        'set_exclude_sale_items',
+        'set_product_ids',
+        'set_excluded_product_ids',
+        'set_product_categories',
+        'set_excluded_product_categories',
+        'set_email_restrictions',
+        'set_usage_limit',
+        'set_usage_limit_per_user',
+        'save',
+      ])
       ->getMock();
   }
 }

--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -438,6 +438,7 @@
     'canNotUndo': _x('No actions available to undo.', "A button title when user can't undo the change in editor", 'mailpoet'),
     'canRedo': _x('Redo', 'A button title when user can redo the change in editor', 'mailpoet'),
     'canNotRedo': _x('No actions available to redo.', "A button title when user can't redo the change in editor", 'mailpoet'),
+    'couponMinAndMaxAmountFieldsErrorMessage': __('Please enter a value with one monetary decimal point (%s) without thousand separators and currency symbols.'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -15,36 +15,76 @@
 </div>
 
 <div class="mailpoet_field_coupon_source_create_new {{#ifCond model.source '===' 'useExisting'}}mailpoet_hidden{{/ifCond}}">
-  <div class="mailpoet_form_field">
-      <div class="mailpoet_form_field_type"><%= __('Discount type') %></div>
-      <div class="mailpoet_form_field_input_option mailpoet_form_field_input_nowrap">
+  <details open>
+    <summary>
+      <strong> <%= __('General') %> </strong>
+    </summary>
+    <div className="content">
+      <div class="mailpoet_form_field">
+        <div class="mailpoet_form_field_type"><%= __('Discount type') %></div>
+        <div class="mailpoet_form_field_input_option mailpoet_form_field_input_nowrap">
           <select id="mailpoet_field_coupon_discount_type" name="discount-type" class="mailpoet_select mailpoet_select_full mailpoet_field_coupon_discount_type">
-          {{#each availableDiscountTypes}}
+            {{#each availableDiscountTypes}}
               <option value="{{@key}}" {{#ifCond @key '==' ../model.discountType}}SELECTED{{/ifCond}}>{{ this }}</option>
-          {{/each}}
+            {{/each}}
           </select>
+        </div>
       </div>
-  </div>
-  <div class="mailpoet_form_field">
-      <label>
+
+      <div class="mailpoet_form_field">
+        <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon amount') %></div>
           <div class="coupon_amount_wrapper">
-              {{#ifCond model.amountMax '===' 100}}
-                  <span class="amount_percentage_sign">%</span>
-              {{/ifCond}}
-              <input type="text" name="amount"  data-parsley-validate data-parsley-validation-threshold="0" data-parsley-required data-parsley-trigger="input"  data-parsley-type="digits" {{#ifCond model.amountMax '!==' null }} data-parsley-maxlength="{{ model.amountMax }}" max="{{ model.amountMax }}" {{/ifCond}}   class="mailpoet_input mailpoet_field_coupon_amount mailpoet_input_medium" value="{{ model.amount }}" min="0" />
+            {{#ifCond model.amountMax '===' 100}}
+              <span class="amount_percentage_sign">%</span>
+            {{/ifCond}}
+            <input type="text" name="amount"  data-parsley-validate data-parsley-validation-threshold="0" data-parsley-required data-parsley-trigger="input"  data-parsley-type="digits" {{#ifCond model.amountMax '!==' null }} data-parsley-maxlength="{{ model.amountMax }}" max="{{ model.amountMax }}" {{/ifCond}}   class="mailpoet_input mailpoet_field_coupon_amount mailpoet_input_medium" value="{{ model.amount }}" min="0" />
           </div>
-      </label>
-  </div>
-  <div class="mailpoet_form_field">
-      <label>
+        </label>
+      </div>
+
+      <div class="mailpoet_form_field">
+        <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Coupon expiry days') %></div>
           <div class="mailpoet_form_field_input_option">
-              <input type="text" data-parsley-validate data-parsley-required data-parsley-validation-threshold="0"  name="expiry-day" data-parsley-trigger="input"  data-parsley-type="digits" class="mailpoet_input mailpoet_input_small mailpoet_field_coupon_expiry_day" value="{{ model.expiryDay }}" />
-              <p class='description'><%= __('Number of days the coupon is valid after the email is sent') %></p>
+            <input type="text" data-parsley-validate data-parsley-required data-parsley-validation-threshold="0"  name="expiry-day" data-parsley-trigger="input"  data-parsley-type="digits" class="mailpoet_input mailpoet_input_small mailpoet_field_coupon_expiry_day" value="{{ model.expiryDay }}" />
+            <p class='description'><%= __('Number of days the coupon is valid after the email is sent') %></p>
           </div>
-      </label>
-  </div>
+        </label>
+      </div>
+
+      <div class="mailpoet_form_field">
+        <div class="mailpoet_form_field_checkbox_option">
+          <label>
+            <input type="checkbox" name="free-shipping" class="mailpoet_field_coupon_free_shipping"  {{#ifCond model.freeShipping '===' true }}CHECKED{{/ifCond}}/>
+            <%= __('Allow free shipping') %>
+          </label>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>
+      <strong> <%= __('Usage restriction') %> </strong>
+    </summary>
+    <div className="content">
+
+      Content here
+
+    </div>
+  </details>
+
+  <details>
+    <summary>
+      <strong> <%= __('Usage limits') %> </strong>
+    </summary>
+    <div className="content">
+
+      Content here
+
+    </div>
+  </details>
 </div>
 
 <div class="mailpoet_form_field mailpoet_field_coupon_source_use_existing {{#ifCond model.source '!==' 'useExisting'}}mailpoet_hidden{{/ifCond}}">

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -70,7 +70,53 @@
     </summary>
     <div className="content">
 
-      Content here
+      <div class="mailpoet_form_field">
+        <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Minimum spend') %></div>
+          <div class="mailpoet_form_field_input_option">
+            <input type="text" name="minimum-amount" class="mailpoet_input mailpoet_field_coupon_minimum_amount" value="{{ model.minimumAmount }}" placeholder="<%= __('No minimum')%>" />
+          </div>
+        </label>
+      </div>
+
+      <div class="mailpoet_form_field">
+        <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Maximum spend') %></div>
+          <div class="mailpoet_form_field_input_option">
+            <input type="text" name="maximum-amount" class="mailpoet_input mailpoet_field_coupon_maximum_amount" value="{{ model.maximumAmount }}" placeholder="<%= __('No Maximum')%>" />
+          </div>
+        </label>
+      </div>
+
+      <div class="mailpoet_form_field">
+        <div class="mailpoet_form_field_checkbox_option">
+          <label>
+            <input type="checkbox" name="individual-use" class="mailpoet_field_coupon_individual_use"  {{#ifCond model.individualUse '===' true }}CHECKED{{/ifCond}}/>
+            <%= __('Individual use only') %>
+          </label>
+        </div>
+      </div>
+
+      <div class="mailpoet_form_field">
+        <div class="mailpoet_form_field_checkbox_option">
+          <label>
+            <input type="checkbox" name="exclude-sale-items" class="mailpoet_field_coupon_exclude_sale_items"  {{#ifCond model.excludeSaleItems '===' true }}CHECKED{{/ifCond}}/>
+            <%= __('Exclude sale items') %>
+          </label>
+        </div>
+      </div>
+
+      <!--  More items here    -->
+
+      <hr />
+      <div class="mailpoet_form_field">
+        <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Allowed emails') %></div>
+          <div class="mailpoet_form_field_input_option">
+            <input type="email" name="email-restrictions" class="mailpoet_input mailpoet_field_coupon_email_restrictions" value="{{ model.emailRestrictions }}" placeholder="<%= __('No restrictions')%>" multiple="multiple" />
+          </div>
+        </label>
+      </div>
 
     </div>
   </details>
@@ -81,7 +127,23 @@
     </summary>
     <div className="content">
 
-      Content here
+      <div class="mailpoet_form_field">
+        <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Usage limit per coupon') %></div>
+          <div class="mailpoet_form_field_input_option">
+            <input type="number" name="usage-limit" class="mailpoet_input mailpoet_field_coupon_usage_limit" value="{{ model.usageLimit }}" placeholder="<%= __('Unlimited usage')%>" step="1" min="0" />
+          </div>
+        </label>
+      </div>
+
+      <div class="mailpoet_form_field">
+        <label>
+          <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Usage limit per user') %></div>
+          <div class="mailpoet_form_field_input_option">
+            <input type="number" name="usage-limit-per-user" class="mailpoet_input mailpoet_field_coupon_usage_limit_per_user" value="{{ model.usageLimitPerUser }}" placeholder="<%= __('Unlimited usage')%>" step="1" min="0" />
+          </div>
+        </label>
+      </div>
 
     </div>
   </details>

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -106,7 +106,29 @@
         </div>
       </div>
 
-      <!--  More items here    -->
+      <hr />
+      <div class="mailpoet_product_selection_filter_row">
+        <label for="mailpoet_field_coupon_product_ids">
+          <%= __('Products') %>
+        </label>
+        <select id="mailpoet_field_coupon_product_ids" class="mailpoet_select" data-placeholder="<%= __('Search for a product…')%>" multiple="multiple">
+          {{#each model.productIds}}
+            <option value="{{ id }}" selected="selected">{{ text }}</option>
+          {{/each}}
+        </select>
+      </div>
+
+      <div class="mailpoet_product_selection_filter_row">
+        <label for="mailpoet_field_coupon_excluded_product_ids">
+          <%= __('Exclude products') %>
+        </label>
+        <select id="mailpoet_field_coupon_excluded_product_ids" class="mailpoet_select" data-placeholder="<%= __('Search for a product…')%>" multiple="multiple">
+          {{#each model.excludedProductIds}}
+            <option value="{{ id }}" selected="selected">{{ text }}</option>
+          {{/each}}
+        </select>
+      </div>
+
       <hr />
       <div class="mailpoet_product_selection_filter_row">
         <label for="mailpoet_field_coupon_product_categories">

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -107,6 +107,28 @@
       </div>
 
       <!--  More items here    -->
+      <hr />
+      <div class="mailpoet_product_selection_filter_row">
+        <label for="mailpoet_field_coupon_product_categories">
+          <%= __('Product categories') %>
+        </label>
+        <select id="mailpoet_field_coupon_product_categories" class="mailpoet_select" data-placeholder="<%= __('Any category')%>" multiple="multiple">
+          {{#each model.productCategories}}
+            <option value="{{ id }}" selected="selected">{{ text }}</option>
+          {{/each}}
+        </select>
+      </div>
+
+      <div class="mailpoet_product_selection_filter_row">
+        <label for="mailpoet_field_coupon_excluded_product_categories">
+          <%= __('Exclude categories') %>
+        </label>
+        <select id="mailpoet_field_coupon_excluded_product_categories" class="mailpoet_select" data-placeholder="<%= __('No categories')%>" multiple="multiple">
+          {{#each model.excludedProductCategories}}
+            <option value="{{ id }}" selected="selected">{{ text }}</option>
+          {{/each}}
+        </select>
+      </div>
 
       <hr />
       <div class="mailpoet_form_field">

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -75,7 +75,7 @@
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Minimum spend') %></div>
           <div class="mailpoet_form_field_input_option">
             <input type="text" name="minimum-amount" class="mailpoet_input mailpoet_field_coupon_minimum_amount" value="{{ model.minimumAmount }}" placeholder="<%= __('No minimum')%>" />
-            <span class="mailpoet_error mailpoet_hidden"> <%= __('Please enter with one monetary decimal point (.) without thousand separators and currency symbols.') %> </span>
+            <span class="mailpoet_error mailpoet_hidden"> {{ minAndMaxAmountFieldsErrorMessage }} </span>
           </div>
         </label>
       </div>
@@ -85,7 +85,7 @@
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Maximum spend') %></div>
           <div class="mailpoet_form_field_input_option">
             <input type="text" name="maximum-amount" class="mailpoet_input mailpoet_field_coupon_maximum_amount" value="{{ model.maximumAmount }}" placeholder="<%= __('No Maximum')%>" />
-            <span class="mailpoet_error mailpoet_hidden"> <%= __('Please enter with one monetary decimal point (.) without thousand separators and currency symbols.') %> </span>
+            <span class="mailpoet_error mailpoet_hidden"> {{ minAndMaxAmountFieldsErrorMessage }} </span>
           </div>
         </label>
       </div>

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -74,7 +74,7 @@
         <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Minimum spend') %></div>
           <div class="mailpoet_form_field_input_option">
-            <input type="text" name="minimum-amount" class="mailpoet_input mailpoet_field_coupon_minimum_amount" value="{{ model.minimumAmount }}" placeholder="<%= __('No minimum')%>" />
+            <input type="text" name="minimum-amount" class="mailpoet_input mailpoet_field_coupon_minimum_amount" value="{{ model.minimumAmount }}" placeholder="<%= __('No minimum') | escape('html_attr') %>" />
             <span class="mailpoet_error mailpoet_hidden"> {{ minAndMaxAmountFieldsErrorMessage }} </span>
           </div>
         </label>
@@ -84,7 +84,7 @@
         <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Maximum spend') %></div>
           <div class="mailpoet_form_field_input_option">
-            <input type="text" name="maximum-amount" class="mailpoet_input mailpoet_field_coupon_maximum_amount" value="{{ model.maximumAmount }}" placeholder="<%= __('No Maximum')%>" />
+            <input type="text" name="maximum-amount" class="mailpoet_input mailpoet_field_coupon_maximum_amount" value="{{ model.maximumAmount }}" placeholder="<%= __('No Maximum') | escape('html_attr') %>" />
             <span class="mailpoet_error mailpoet_hidden"> {{ minAndMaxAmountFieldsErrorMessage }} </span>
           </div>
         </label>
@@ -113,7 +113,7 @@
         <label for="mailpoet_field_coupon_product_ids">
           <%= __('Products') %>
         </label>
-        <select id="mailpoet_field_coupon_product_ids" class="mailpoet_select" data-placeholder="<%= __('Search for a product…')%>" multiple="multiple">
+        <select id="mailpoet_field_coupon_product_ids" class="mailpoet_select" data-placeholder="<%= __('Search for a product…') | escape('html_attr') %>" multiple="multiple">
           {{#each model.productIds}}
             <option value="{{ id }}" selected="selected">{{ text }}</option>
           {{/each}}
@@ -124,7 +124,7 @@
         <label for="mailpoet_field_coupon_excluded_product_ids">
           <%= __('Exclude products') %>
         </label>
-        <select id="mailpoet_field_coupon_excluded_product_ids" class="mailpoet_select" data-placeholder="<%= __('Search for a product…')%>" multiple="multiple">
+        <select id="mailpoet_field_coupon_excluded_product_ids" class="mailpoet_select" data-placeholder="<%= __('Search for a product…') | escape('html_attr') %>" multiple="multiple">
           {{#each model.excludedProductIds}}
             <option value="{{ id }}" selected="selected">{{ text }}</option>
           {{/each}}
@@ -136,7 +136,7 @@
         <label for="mailpoet_field_coupon_product_categories">
           <%= __('Product categories') %>
         </label>
-        <select id="mailpoet_field_coupon_product_categories" class="mailpoet_select" data-placeholder="<%= __('Any category')%>" multiple="multiple">
+        <select id="mailpoet_field_coupon_product_categories" class="mailpoet_select" data-placeholder="<%= __('Any category') | escape('html_attr') %>" multiple="multiple">
           {{#each model.productCategories}}
             <option value="{{ id }}" selected="selected">{{ text }}</option>
           {{/each}}
@@ -147,7 +147,7 @@
         <label for="mailpoet_field_coupon_excluded_product_categories">
           <%= __('Exclude categories') %>
         </label>
-        <select id="mailpoet_field_coupon_excluded_product_categories" class="mailpoet_select" data-placeholder="<%= __('No categories')%>" multiple="multiple">
+        <select id="mailpoet_field_coupon_excluded_product_categories" class="mailpoet_select" data-placeholder="<%= __('No categories') | escape('html_attr') %>" multiple="multiple">
           {{#each model.excludedProductCategories}}
             <option value="{{ id }}" selected="selected">{{ text }}</option>
           {{/each}}
@@ -159,7 +159,7 @@
         <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Allowed emails') %></div>
           <div class="mailpoet_form_field_input_option">
-            <input type="email" name="email-restrictions" class="mailpoet_input mailpoet_field_coupon_email_restrictions" value="{{ model.emailRestrictions }}" placeholder="<%= __('No restrictions')%>" multiple="multiple" />
+            <input type="email" name="email-restrictions" class="mailpoet_input mailpoet_field_coupon_email_restrictions" value="{{ model.emailRestrictions }}" placeholder="<%= __('No restrictions') | escape('html_attr') %>" multiple="multiple" />
             <span class="mailpoet_error mailpoet_hidden"> </span>
           </div>
         </label>
@@ -178,7 +178,7 @@
         <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Usage limit per coupon') %></div>
           <div class="mailpoet_form_field_input_option">
-            <input type="number" name="usage-limit" class="mailpoet_input mailpoet_field_coupon_usage_limit" value="{{ model.usageLimit }}" placeholder="<%= __('Unlimited usage')%>" step="1" min="0" />
+            <input type="number" name="usage-limit" class="mailpoet_input mailpoet_field_coupon_usage_limit" value="{{ model.usageLimit }}" placeholder="<%= __('Unlimited usage') | escape('html_attr') %>" step="1" min="0" />
           </div>
         </label>
       </div>
@@ -187,7 +187,7 @@
         <label>
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Usage limit per user') %></div>
           <div class="mailpoet_form_field_input_option">
-            <input type="number" name="usage-limit-per-user" class="mailpoet_input mailpoet_field_coupon_usage_limit_per_user" value="{{ model.usageLimitPerUser }}" placeholder="<%= __('Unlimited usage')%>" step="1" min="0" />
+            <input type="number" name="usage-limit-per-user" class="mailpoet_input mailpoet_field_coupon_usage_limit_per_user" value="{{ model.usageLimitPerUser }}" placeholder="<%= __('Unlimited usage') | escape('html_attr') %>" step="1" min="0" />
           </div>
         </label>
       </div>

--- a/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/coupon/settings.hbs
@@ -75,6 +75,7 @@
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Minimum spend') %></div>
           <div class="mailpoet_form_field_input_option">
             <input type="text" name="minimum-amount" class="mailpoet_input mailpoet_field_coupon_minimum_amount" value="{{ model.minimumAmount }}" placeholder="<%= __('No minimum')%>" />
+            <span class="mailpoet_error mailpoet_hidden"> <%= __('Please enter with one monetary decimal point (.) without thousand separators and currency symbols.') %> </span>
           </div>
         </label>
       </div>
@@ -84,6 +85,7 @@
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Maximum spend') %></div>
           <div class="mailpoet_form_field_input_option">
             <input type="text" name="maximum-amount" class="mailpoet_input mailpoet_field_coupon_maximum_amount" value="{{ model.maximumAmount }}" placeholder="<%= __('No Maximum')%>" />
+            <span class="mailpoet_error mailpoet_hidden"> <%= __('Please enter with one monetary decimal point (.) without thousand separators and currency symbols.') %> </span>
           </div>
         </label>
       </div>
@@ -158,6 +160,7 @@
           <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Allowed emails') %></div>
           <div class="mailpoet_form_field_input_option">
             <input type="email" name="email-restrictions" class="mailpoet_input mailpoet_field_coupon_email_restrictions" value="{{ model.emailRestrictions }}" placeholder="<%= __('No restrictions')%>" multiple="multiple" />
+            <span class="mailpoet_error mailpoet_hidden"> </span>
           </div>
         </label>
       </div>


### PR DESCRIPTION
## Description

Add coupon settings to the Email editor WooCommerce coupon block.

## Code review notes

Please start reviewing from https://github.com/mailpoet/mailpoet/commit/92b9d11fe952abd76f8d90d780464a9325948f36

## QA notes

You need to enable Coupon block experimental features here: `/wp-admin/admin.php?page=mailpoet-experimental`

* On the email editor
* Select the coupon block
* Click on the Usage restriction or Usage limits
* Add some options
* Send the newsletter
* Your newsletter should have the new coupon code. 
* You may verify the coupon options at `/wp-admin/edit.php?post_type=shop_coupon`, select the coupon code found in the newsletter

## Linked PRs

Dependent on https://github.com/mailpoet/mailpoet/pull/4636

## Linked tickets

[MAILPOET-4762](https://mailpoet.atlassian.net/browse/MAILPOET-4762)




[MAILPOET-4762]: https://mailpoet.atlassian.net/browse/MAILPOET-4762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ