### PR TITLE
Add new shortcode site:homepate_url and change rendering of site:homepage_link [MAILPOET-4936]

### DIFF
--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -35,8 +35,8 @@ class Site implements CategoryInterface {
       case 'homepage_link':
         return sprintf(
           '<a target="_blank" href="%s">%s</a>',
-          $this->wp->getBloginfo('url'),
-          $this->wp->getBloginfo('name')
+          $this->wp->escUrl($this->wp->getBloginfo('url')),
+          $this->wp->escHtml($this->wp->getBloginfo('name'))
         );
 
       default:

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -30,8 +30,14 @@ class Site implements CategoryInterface {
         return $this->wp->getBloginfo('name');
 
       case 'homepage_url':
-      case 'homepage_link':
         return $this->wp->getBloginfo('url');
+
+      case 'homepage_link':
+        return sprintf(
+          '<a target="_blank" href="%s">%s</a>',
+          $this->wp->getBloginfo('url'),
+          $this->wp->getBloginfo('name')
+        );
 
       default:
         return null;

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -29,6 +29,7 @@ class Site implements CategoryInterface {
       case 'title':
         return $this->wp->getBloginfo('name');
 
+      case 'homepage_url':
       case 'homepage_link':
         return $this->wp->getBloginfo('url');
 

--- a/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -124,6 +124,10 @@ class ShortcodesHelper {
             '[site:title]'
           ),
         ],
+        [
+          'text' => __('Homepage URL', 'mailpoet'),
+          'shortcode' => '[site:homepage_url]',
+        ],
       ],
     ];
     $customFields = $this->getCustomFields();

--- a/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -118,7 +118,11 @@ class ShortcodesHelper {
         ],
         [
           'text' => __('Homepage link', 'mailpoet'),
-          'shortcode' => '[site:homepage_link]',
+          'shortcode' => sprintf(
+            '<a target="_blank" href="%s">%s</a>',
+            '[site:homepage_url]',
+            '[site:title]'
+          ),
         ],
       ],
     ];

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -67,7 +67,7 @@ class SettingsController {
         'signup_confirmation' => [
           'enabled' => true,
           'subject' => __('Confirm your subscription to [site:title]', 'mailpoet'),
-          'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_link]\">[site:title]</a>", 'mailpoet'),
+          'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_url]\">[site:title]</a>", 'mailpoet'),
         ],
         'tracking' => [
           'level' => TrackingConfig::LEVEL_FULL,

--- a/mailpoet/lib/Subscribers/ConfirmationEmailTemplate/template-confirmation.json
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailTemplate/template-confirmation.json
@@ -99,7 +99,7 @@
                 },
                 {
                   "type": "text",
-                  "text": "<p><span>Thank you,</span></p>\n<p><span></span></p>\n<p><span>[site:homepage_link]</span></p>\n<p>&nbsp;</p>"
+                  "text": "<p><span>Thank you,</span></p>\n<p><span></span></p>\n<p><span><a href=\"[site:homepage_url]\">[site:title]</a></span></p>\n<p>&nbsp;</p>"
                 },
                 {
                   "type": "footer",

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -426,6 +426,16 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result[0])->equals($siteUrl);
   }
 
+  public function testItCanProcessSiteHomepageUrlShortcode() {
+    $optionName = 'home';
+    $siteUrl = get_option($optionName);
+
+    $shortcode = '[site:homepage_url]';
+    $shortcodesObject = $this->shortcodesObject;
+    $result = $shortcodesObject->process([$shortcode]);
+    expect($result[0])->equals($siteUrl);
+  }
+
   public function _createWPPost() {
     $data = [
       'post_title' => 'Sample Post',

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -417,13 +417,13 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function testItCanProcessSiteHomepageLinkShortcode() {
-    $optionName = 'home';
-    $siteUrl = get_option($optionName);
+    $siteUrl = strval(get_option('home'));
+    $siteName = strval(get_option('blogname'));
 
     $shortcode = '[site:homepage_link]';
     $shortcodesObject = $this->shortcodesObject;
     $result = $shortcodesObject->process([$shortcode]);
-    expect($result[0])->equals($siteUrl);
+    expect($result[0])->equals("<a target=\"_blank\" href=\"{$siteUrl}\">{$siteName}</a>");
   }
 
   public function testItCanProcessSiteHomepageUrlShortcode() {


### PR DESCRIPTION
## Description

This PR changes the behavior of the shortcode `[site:homepage_link]` and unifies it with the other link shortcodes. For this change was created a new shortcode `[site:homepage_url]`.

## Code review notes

_N/A_

## QA notes

When you want to test new settings for confirmation emails, you need to remove the old one from the mailpoet settings table. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4936]

## After-merge notes

_N/A_


[MAILPOET-4936]: https://mailpoet.atlassian.net/browse/MAILPOET-4936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ