### PR TITLE
Fix ManageSegmentsCest:deleteExistingSegment - MAILPOET-4881

### DIFF
--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -172,7 +172,8 @@ class ManageSegmentsCest {
     $i->wantTo('Empty trash from other segments');
     $i->waitForElementClickable('[data-automation-id="empty_trash"]');
     $i->click('[data-automation-id="empty_trash"]');
-    $i->waitForText('1 segment was permanently deleted.');
+    $i->waitForNoticeAndClose('1 segment was permanently deleted.');
+    $i->wait(10); // wait a moment for redirect loading
     $listingAutomationSelector = '[data-automation-id="listing_item_' . $segment1->getId() . '"]';
     $i->dontSeeElement($listingAutomationSelector);
     $i->seeInCurrentURL(urlencode('group[all]'));

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -173,7 +173,7 @@ class ManageSegmentsCest {
     $i->waitForElementClickable('[data-automation-id="empty_trash"]');
     $i->click('[data-automation-id="empty_trash"]');
     $i->waitForNoticeAndClose('1 segment was permanently deleted.');
-    $i->wait(10); // wait a moment for redirect loading
+    $i->wait(2); // wait a moment for redirect loading
     $listingAutomationSelector = '[data-automation-id="listing_item_' . $segment1->getId() . '"]';
     $i->dontSeeElement($listingAutomationSelector);
     $i->seeInCurrentURL(urlencode('group[all]'));


### PR DESCRIPTION


## Description

Fix ManageSegmentsCest:deleteExistingSegment flaky test


## Linked tickets

[MAILPOET-4881](https://mailpoet.atlassian.net/browse/MAILPOET-4881)




[MAILPOET-4881]: https://mailpoet.atlassian.net/browse/MAILPOET-4881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ