### PR TITLE
Make an option to create coupons dynamically [MAILPOET-4763]

### DIFF
--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -38,6 +38,14 @@ class NewsletterEntity {
   const STATUS_SENDING = 'sending';
   const STATUS_SENT = 'sent';
 
+  /**
+   * Newsletters that their body HTML can get re-generated
+   * @see NewsletterSaveController::updateQueue
+   */
+  const TYPES_WITH_RESETTABLE_BODY = [
+    NewsletterEntity::TYPE_STANDARD,
+  ];
+
   // automatic newsletters status
   const STATUS_ACTIVE = 'active';
 

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -104,11 +104,9 @@ class CouponPreProcessor {
   }
   
   /**
-   * For some renders/send outs the coupon id shouldn't be persisted along the coupon block
-   * This is a placeholder method and should be augmented with more newsletter types that should dynamically get coupons
-   * and not have one single coupon saved along with the block's settings
+   * Only emails that can have their body-HTML re-generated should persist the generated couponId
    */
   private function shouldPersist(NewsletterEntity $newsletter): bool {
-    return $newsletter->getType() !== NewsletterEntity::TYPE_AUTOMATIC;
+    return in_array($newsletter->getType(), NewsletterEntity::TYPES_WITH_RESETTABLE_BODY);
   }
 }


### PR DESCRIPTION
## Description

This PR allows generation of coupons dynamically for some newsletter types.

## Code review notes

Please note that the newsletters that get their coupon codes saved, won't get a new coupon code on next renders.

## QA notes

- Add a coupon block to different types of newsletters.
- Verify that only the standard newsletter keeps the same same coupon code, even after pausing and editing the newsletter, and all the automatic newsletters letters, get a new coupon code for each send-out.
- Please merge it to trunk after the [base PR ](https://github.com/mailpoet/mailpoet/pull/4636) is merged to trunk
## Linked PRs

https://github.com/mailpoet/mailpoet/pull/4636

## Linked tickets

[MAILPOET-4763]

## Additional notes:
- Please merge it to trunk after the [base PR ](https://github.com/mailpoet/mailpoet/pull/4636) is merged to trunk

[MAILPOET-4763]: https://mailpoet.atlassian.net/browse/MAILPOET-4763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ