### PR TITLE
WC Tracker - campaign revenue tracking [MAILPOET-5014]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -89,6 +89,7 @@ class Hooks {
     $this->setupWooCommerceUsers();
     $this->setupWooCommercePurchases();
     $this->setupWooCommerceSubscriberEngagement();
+    $this->setupWooCommerceTracking();
     $this->setupImageSize();
     $this->setupListing();
     $this->setupSubscriptionEvents();
@@ -377,6 +378,16 @@ class Hooks {
       [$this->hooksWooCommerce, 'updateSubscriberEngagement'],
       7
     );
+  }
+
+  public function setupWooCommerceTracking() {
+    if ($this->wp->getOption('woocommerce_allow_tracking', 'no') === 'yes') {
+      $this->wp->addFilter(
+        'woocommerce_tracker_data',
+        [$this->hooksWooCommerce, 'addTrackingData'],
+        10
+      );
+    }
   }
 
   public function setupImageSize() {

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -381,13 +381,11 @@ class Hooks {
   }
 
   public function setupWooCommerceTracking() {
-    if ($this->wp->getOption('woocommerce_allow_tracking', 'no') === 'yes') {
-      $this->wp->addFilter(
-        'woocommerce_tracker_data',
-        [$this->hooksWooCommerce, 'addTrackingData'],
-        10
-      );
-    }
+    $this->wp->addFilter(
+      'woocommerce_tracker_data',
+      [$this->hooksWooCommerce, 'addTrackingData'],
+      10
+    );
   }
 
   public function setupImageSize() {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -9,6 +9,7 @@ use MailPoet\Subscription\Registration;
 use MailPoet\WooCommerce\Settings as WooCommerceSettings;
 use MailPoet\WooCommerce\SubscriberEngagement;
 use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
+use MailPoet\WooCommerce\Tracker;
 
 class HooksWooCommerce {
   /** @var WooCommerceSubscription */
@@ -32,6 +33,9 @@ class HooksWooCommerce {
   /** @var SubscriberEngagement */
   private $subscriberEngagement;
 
+  /** @var Tracker */
+  private $tracker;
+
   public function __construct(
     WooCommerceSubscription $woocommerceSubscription,
     WooCommerceSegment $woocommerceSegment,
@@ -39,6 +43,7 @@ class HooksWooCommerce {
     WooCommercePurchases $woocommercePurchases,
     Registration $subscriberRegistration,
     LoggerFactory $loggerFactory,
+    Tracker $tracker,
     SubscriberEngagement $subscriberEngagement
   ) {
     $this->woocommerceSubscription = $woocommerceSubscription;
@@ -47,6 +52,7 @@ class HooksWooCommerce {
     $this->woocommercePurchases = $woocommercePurchases;
     $this->loggerFactory = $loggerFactory;
     $this->subscriberRegistration = $subscriberRegistration;
+    $this->tracker = $tracker;
     $this->subscriberEngagement = $subscriberEngagement;
   }
 
@@ -141,6 +147,10 @@ class HooksWooCommerce {
     } catch (\Throwable $e) {
       $this->logError($e, 'WooCommerce HPOS Compatibility');
     }
+  }
+
+  public function addTrackingData($data) {
+    return $this->tracker->addTrackingData($data);
   }
 
   private function logError(\Throwable $e, $name) {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -150,6 +150,9 @@ class HooksWooCommerce {
   }
 
   public function addTrackingData($data) {
+    if (!is_array($data)) {
+      return $data;
+    }
     return $this->tracker->addTrackingData($data);
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -510,6 +510,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmailHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\Tracker::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\Template::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\Renderer::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor::class)->setPublic(true);

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -33,6 +33,7 @@ class LoggerFactory {
   const TOPIC_SENDING = 'sending';
   const TOPIC_CRON = 'cron';
   const TOPIC_API = 'api';
+  const TOPIC_TRACKING = 'tracking';
 
   /** @var LoggerFactory */
   private static $instance;

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -203,7 +203,11 @@ class NewslettersRepository extends Repository {
       'product_purchased_in_category_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATIC][PurchasedInCategory::SLUG] ?? 0,
       'abandoned_cart_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATIC][AbandonedCart::SLUG] ?? 0,
     ];
-    $data['campaigns_count'] = $data['welcome_newsletters_count'] + $data['notifications_count'] + $data['automatic_emails_count'] + $data['automation_emails_count'] + $data['re-engagement_emails_count'] + $data['sent_newsletters_count'];
+    // Count all campaigns
+    $analyticsMap[NewsletterEntity::TYPE_AUTOMATIC] = array_sum($analyticsMap[NewsletterEntity::TYPE_AUTOMATIC] ?? []);
+    // Post notification history is not a campaign, we count only the parent notification
+    unset($analyticsMap[NewsletterEntity::TYPE_NOTIFICATION_HISTORY]);
+    $data['campaigns_count'] = array_sum($analyticsMap);
     return $data;
   }
 

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -189,10 +189,12 @@ class NewslettersRepository extends Repository {
       }
     }
 
-    return [
+    $data = [
       'welcome_newsletters_count' => $analyticsMap[NewsletterEntity::TYPE_WELCOME] ?? 0,
       'notifications_count' => $analyticsMap[NewsletterEntity::TYPE_NOTIFICATION] ?? 0,
       'automatic_emails_count' => array_sum($analyticsMap[NewsletterEntity::TYPE_AUTOMATIC] ?? []),
+      'automation_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATION] ?? 0,
+      're-engagement_emails_count' => $analyticsMap[NewsletterEntity::TYPE_RE_ENGAGEMENT] ?? 0,
       'sent_newsletters_count' => $analyticsMap[NewsletterEntity::TYPE_STANDARD] ?? 0,
       'sent_newsletters_3_months' => $this->getStandardNewsletterSentCount(Carbon::now()->subMonths(3)),
       'sent_newsletters_30_days' => $this->getStandardNewsletterSentCount(Carbon::now()->subDays(30)),
@@ -201,6 +203,8 @@ class NewslettersRepository extends Repository {
       'product_purchased_in_category_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATIC][PurchasedInCategory::SLUG] ?? 0,
       'abandoned_cart_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATIC][AbandonedCart::SLUG] ?? 0,
     ];
+    $data['campaigns_count'] = $data['welcome_newsletters_count'] + $data['notifications_count'] + $data['automatic_emails_count'] + $data['automation_emails_count'] + $data['re-engagement_emails_count'] + $data['sent_newsletters_count'];
+    return $data;
   }
 
   /**

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -51,7 +51,7 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
     $revenueStatsTable = $this->entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
     $newsletterTable = $this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName();
 
-    return $this->entityManager->getConnection()->executeQuery('
+    $data = $this->entityManager->getConnection()->executeQuery('
       SELECT
         SUM(swp.order_price_total) AS revenue,
         COALESCE(n.parent_id, n.id) AS campaign_id,
@@ -66,5 +66,12 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
       'notification_history_type' => NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
       'notification_type' => NewsletterEntity::TYPE_NOTIFICATION,
     ])->fetchAllAssociative();
+
+    $data = array_map(function($row) {
+      $row['revenue'] = round(floatval($row['revenue']), 2);
+      $row['orders_count'] = intval($row['orders_count']);
+      return $row;
+    }, $data);
+    return $data;
   }
 }

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -51,6 +51,8 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
     $revenueStatsTable = $this->entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
     $newsletterTable = $this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName();
 
+    // The "SELECT MIN(click_id)..." sub-query is used to count each purchase only once.
+    // In the data we track a purchase to multiple newsletters if clicks from multiple newsletters occurred.
     $data = $this->entityManager->getConnection()->executeQuery('
       SELECT
         SUM(swp.order_price_total) AS revenue,

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -47,7 +47,7 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
     $this->flush();
   }
 
-  public function getRevenuesByCampaigns() {
+  public function getRevenuesByCampaigns(): array {
     $revenueStatsTable = $this->entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
     $newsletterTable = $this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName();
 

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -47,7 +47,7 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
     $this->flush();
   }
 
-  public function getRevenuesByCampaigns(): array {
+  public function getRevenuesByCampaigns(string $currency): array {
     $revenueStatsTable = $this->entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
     $newsletterTable = $this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName();
 
@@ -63,10 +63,12 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
         JOIN ' . $newsletterTable . ' n ON
           n.id = swp.newsletter_id
           AND swp.click_id IN (SELECT MIN(click_id) FROM ' . $revenueStatsTable . ' ss GROUP BY order_id)
+      WHERE swp.order_currency = :currency
       GROUP BY campaign_id, n.type;
     ', [
       'notification_history_type' => NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
       'notification_type' => NewsletterEntity::TYPE_NOTIFICATION,
+      'currency' => $currency,
     ])->fetchAllAssociative();
 
     $data = array_map(function($row) {

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -32,14 +32,7 @@ class Tracker {
     $this->loggerFactory = $loggerFactory;
   }
 
-  /**
-   * @param array $data
-   * @return array
-   */
-  public function addTrackingData($data): array {
-    if (!is_array($data)) {
-      return $data;
-    }
+  public function addTrackingData(array $data): array {
     try {
       $analyticsData = $this->newslettersRepository->getAnalytics();
       $data['extensions']['mailpoet'] = [

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -14,16 +14,21 @@ class Tracker {
   /** @var LoggerFactory */
   private $loggerFactory;
 
+  /** @var Helper */
+  private $wooHelper;
+
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
   public function __construct(
     StatisticsWooCommercePurchasesRepository $wooPurchasesRepository,
     NewslettersRepository $newslettersRepository,
+    Helper $wooHelper,
     LoggerFactory $loggerFactory
   ) {
     $this->wooPurchasesRepository = $wooPurchasesRepository;
     $this->newslettersRepository = $newslettersRepository;
+    $this->wooHelper = $wooHelper;
     $this->loggerFactory = $loggerFactory;
   }
 
@@ -39,6 +44,7 @@ class Tracker {
       $analyticsData = $this->newslettersRepository->getAnalytics();
       $data['extensions']['mailpoet'] = [
         'campaigns_count' => $analyticsData['campaigns_count'],
+        'currency' => $this->wooHelper->getWoocommerceCurrency(),
       ];
       $campaignData = $this->wooPurchasesRepository->getRevenuesByCampaigns();
       $data['extensions']['mailpoet']['campaign_revenues'] = $campaignData;

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -2,7 +2,19 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
+
 class Tracker {
+
+  /** @var StatisticsWooCommercePurchasesRepository */
+  private $wooPurchasesRepository;
+
+  public function __construct(
+    StatisticsWooCommercePurchasesRepository $wooPurchasesRepository
+  ) {
+    $this->wooPurchasesRepository = $wooPurchasesRepository;
+  }
+
   /**
    * @param array $data
    * @return array
@@ -11,7 +23,8 @@ class Tracker {
     if (!is_array($data)) {
       return $data;
     }
-    $data['extensions']['mailpoet']['campaign_revenues'] = [];
+    $campaignData = $this->wooPurchasesRepository->getRevenuesByCampaigns();
+    $data['extensions']['mailpoet']['campaign_revenues'] = $campaignData;
     return $data;
   }
 }

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -34,12 +34,13 @@ class Tracker {
 
   public function addTrackingData(array $data): array {
     try {
+      $currency = $this->wooHelper->getWoocommerceCurrency();
       $analyticsData = $this->newslettersRepository->getAnalytics();
       $data['extensions']['mailpoet'] = [
         'campaigns_count' => $analyticsData['campaigns_count'],
-        'currency' => $this->wooHelper->getWoocommerceCurrency(),
+        'currency' => $currency,
       ];
-      $campaignData = $this->formatCampaignsData($this->wooPurchasesRepository->getRevenuesByCampaigns());
+      $campaignData = $this->formatCampaignsData($this->wooPurchasesRepository->getRevenuesByCampaigns($currency));
       $data['extensions']['mailpoet'] = array_merge($data['extensions']['mailpoet'], $campaignData);
     } catch (\Throwable $e) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_TRACKING)->error($e->getMessage());

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+class Tracker {
+  /**
+   * @param array $data
+   * @return array
+   */
+  public function addTrackingData($data): array {
+    if (!is_array($data)) {
+      return $data;
+    }
+    $data['extensions']['mailpoet']['campaign_revenues'] = [];
+    return $data;
+  }
+}

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -3,6 +3,7 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\Logging\LoggerFactory;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
 
 class Tracker {
@@ -13,11 +14,16 @@ class Tracker {
   /** @var LoggerFactory */
   private $loggerFactory;
 
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
   public function __construct(
     StatisticsWooCommercePurchasesRepository $wooPurchasesRepository,
+    NewslettersRepository $newslettersRepository,
     LoggerFactory $loggerFactory
   ) {
     $this->wooPurchasesRepository = $wooPurchasesRepository;
+    $this->newslettersRepository = $newslettersRepository;
     $this->loggerFactory = $loggerFactory;
   }
 
@@ -30,6 +36,10 @@ class Tracker {
       return $data;
     }
     try {
+      $analyticsData = $this->newslettersRepository->getAnalytics();
+      $data['extensions']['mailpoet'] = [
+        'campaigns_count' => $analyticsData['campaigns_count'],
+      ];
       $campaignData = $this->wooPurchasesRepository->getRevenuesByCampaigns();
       $data['extensions']['mailpoet']['campaign_revenues'] = $campaignData;
     } catch (\Throwable $e) {

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -39,6 +39,7 @@ class WooCommercePastRevenues implements Generator {
   const POST_NOTIFICATIONS_HISTORY = 30;
   const STANDARD_NEWSLETTER = 30;
 
+
   /** @var EntityManager */
   private $entityManager;
 

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -237,7 +237,7 @@ class WooCommercePastRevenues implements Generator {
       $openedCount = floor(count($subscriberReceivedEmails) / rand(2, 5));
       $emailsToClick = array_intersect_key(
         $subscriberReceivedEmails,
-        array_flip(array_rand($subscriberReceivedEmails, $openedCount))
+        array_flip(array_rand($subscriberReceivedEmails, intval($openedCount)))
       );
       // Click and open selected emails
       foreach ($emailsToClick as $email) {

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -42,7 +42,6 @@ class TrackerTest extends \MailPoetTest {
     expect($data['extensions']['mailpoet'])->notEmpty();
     expect($data['extensions']['mailpoet']['campaigns_count'])->notNull();
     expect($data['extensions']['mailpoet']['currency'])->notNull();
-    expect($data['extensions']['mailpoet']['campaign_revenues'])->notNull();
   }
 
   public function testItAddsCampaignRevenuesForStandardNewsletters() {
@@ -53,17 +52,15 @@ class TrackerTest extends \MailPoetTest {
     $this->createRevenueRecord($newsletter2, $this->createOrderData(2, 'USD', 20));
 
     $tracker = $this->diContainer->get(Tracker::class);
-    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
-    expect($campaignRevenues)->count(2);
-    expect($campaignRevenues[0]['campaign_id'])->equals($newsletter1->getId());
-    expect($campaignRevenues[0]['revenue'])->equals(30);
-    expect($campaignRevenues[0]['campaign_type'])->equals($newsletter1->getType());
-    expect($campaignRevenues[0]['orders_count'])->equals(2);
+    $mailPoetData = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet'];
 
-    expect($campaignRevenues[1]['campaign_id'])->equals($newsletter2->getId());
-    expect($campaignRevenues[1]['revenue'])->equals(20);
-    expect($campaignRevenues[1]['campaign_type'])->equals($newsletter2->getType());
-    expect($campaignRevenues[1]['orders_count'])->equals(1);
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_revenue'])->equals(30);
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_type'])->equals($newsletter1->getType());
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_orders_count'])->equals(2);
+
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_revenue'])->equals(20);
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_type'])->equals($newsletter2->getType());
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_orders_count'])->equals(1);
   }
 
   public function testItAddsCampaignRevenuesForAutomaticCampaigns() {
@@ -75,19 +72,19 @@ class TrackerTest extends \MailPoetTest {
     $this->createRevenueRecord($newsletter3, $this->createOrderData(3, 'USD', 30));
 
     $tracker = $this->diContainer->get(Tracker::class);
-    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
-    expect($campaignRevenues)->count(3);
-    expect($campaignRevenues[0]['campaign_id'])->equals($newsletter1->getId());
-    expect($campaignRevenues[0]['revenue'])->equals(10);
-    expect($campaignRevenues[0]['campaign_type'])->equals($newsletter1->getType());
+    $mailPoetData = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet'];
 
-    expect($campaignRevenues[1]['campaign_id'])->equals($newsletter2->getId());
-    expect($campaignRevenues[1]['revenue'])->equals(20);
-    expect($campaignRevenues[1]['campaign_type'])->equals($newsletter2->getType());
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_revenue'])->equals(10);
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_type'])->equals($newsletter1->getType());
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_orders_count'])->equals(1);
 
-    expect($campaignRevenues[2]['campaign_id'])->equals($newsletter3->getId());
-    expect($campaignRevenues[2]['revenue'])->equals(30);
-    expect($campaignRevenues[2]['campaign_type'])->equals($newsletter3->getType());
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_revenue'])->equals(20);
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_type'])->equals($newsletter2->getType());
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_orders_count'])->equals(1);
+
+    expect($mailPoetData['campaign_' . $newsletter3->getId() . '_revenue'])->equals(30);
+    expect($mailPoetData['campaign_' . $newsletter3->getId() . '_type'])->equals($newsletter3->getType());
+    expect($mailPoetData['campaign_' . $newsletter3->getId() . '_orders_count'])->equals(1);
   }
 
   public function testItAddsTotalCampaigns() {
@@ -116,11 +113,14 @@ class TrackerTest extends \MailPoetTest {
     $this->createRevenueRecord($notificationHistory2, $this->createOrderData(2, 'USD', 20));
 
     $tracker = $this->diContainer->get(Tracker::class);
-    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
-    expect($campaignRevenues)->count(1);
-    expect($campaignRevenues[0]['campaign_id'])->equals($notificationParent->getId());
-    expect($campaignRevenues[0]['revenue'])->equals(30);
-    expect($campaignRevenues[0]['campaign_type'])->equals($notificationParent->getType());
+    $mailPoetData = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet'];
+
+    expect($mailPoetData['campaign_' . $notificationParent->getId() . '_revenue'])->equals(30);
+    expect($mailPoetData['campaign_' . $notificationParent->getId() . '_type'])->equals($notificationParent->getType());
+    expect($mailPoetData['campaign_' . $notificationParent->getId() . '_orders_count'])->equals(2);
+
+    expect($mailPoetData)->hasNotKey('campaign_' . $notificationHistory1->getId() . '_revenue');
+    expect($mailPoetData)->hasNotKey('campaign_' . $notificationHistory2->getId() . '_revenue');
   }
 
   /**
@@ -137,17 +137,17 @@ class TrackerTest extends \MailPoetTest {
     $this->createRevenueRecord($newsletter3, $this->createOrderData(1, 'USD', 10));
 
     $tracker = $this->diContainer->get(Tracker::class);
-    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
-    expect($campaignRevenues)->count(2);
-    expect($campaignRevenues[0]['campaign_id'])->equals($newsletter1->getId());
-    expect($campaignRevenues[0]['revenue'])->equals(10);
-    expect($campaignRevenues[0]['campaign_type'])->equals($newsletter1->getType());
-    expect($campaignRevenues[0]['orders_count'])->equals(1);
+    $mailPoetData = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet'];
 
-    expect($campaignRevenues[1]['campaign_id'])->equals($newsletter2->getId());
-    expect($campaignRevenues[1]['revenue'])->equals(15);
-    expect($campaignRevenues[1]['campaign_type'])->equals($newsletter2->getType());
-    expect($campaignRevenues[1]['orders_count'])->equals(1);
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_revenue'])->equals(10);
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_type'])->equals($newsletter1->getType());
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_orders_count'])->equals(1);
+
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_revenue'])->equals(15);
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_type'])->equals($newsletter2->getType());
+    expect($mailPoetData['campaign_' . $newsletter2->getId() . '_orders_count'])->equals(1);
+
+    expect($mailPoetData)->hasNotKey('campaign_' . $newsletter3->getId() . '_revenue');
   }
 
   /**

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+class TrackerTest extends \MailPoetTest {
+  public function testItAddsTrackingData() {
+    $tracker = $this->diContainer->get(Tracker::class);
+    $data = $tracker->addTrackingData(['extensions' => []]);
+    expect($data['extensions']['mailpoet'])->notEmpty();
+  }
+}

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -24,7 +24,7 @@ class TrackerTest extends \MailPoetTest {
   /** @var Tracker */
   private $tracker;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->cleanUp();
     $this->subscriber = (new Subscriber())->create();
@@ -37,14 +37,14 @@ class TrackerTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  public function testItAddsTrackingData() {
+  public function testItAddsTrackingData(): void {
     $data = $this->tracker->addTrackingData(['extensions' => []]);
     expect($data['extensions']['mailpoet'])->notEmpty();
     expect($data['extensions']['mailpoet']['campaigns_count'])->notNull();
     expect($data['extensions']['mailpoet']['currency'])->notNull();
   }
 
-  public function testItAddsCampaignRevenuesForStandardNewsletters() {
+  public function testItAddsCampaignRevenuesForStandardNewsletters(): void {
     $newsletter1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_STANDARD)->create();
     $newsletter2 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_STANDARD)->create();
     $this->createRevenueRecord($newsletter1, $this->createOrderData(1, 'USD', 10));
@@ -63,7 +63,7 @@ class TrackerTest extends \MailPoetTest {
     expect($mailPoetData['campaign_' . $newsletter2->getId() . '_orders_count'])->equals(1);
   }
 
-  public function testItAddsCampaignRevenuesForAutomaticCampaigns() {
+  public function testItAddsCampaignRevenuesForAutomaticCampaigns(): void {
     $newsletter1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_WELCOME)->create();
     $newsletter2 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATIC)->create();
     $newsletter3 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATION)->create();
@@ -87,7 +87,7 @@ class TrackerTest extends \MailPoetTest {
     expect($mailPoetData['campaign_' . $newsletter3->getId() . '_orders_count'])->equals(1);
   }
 
-  public function testItAddsTotalCampaigns() {
+  public function testItAddsTotalCampaigns(): void {
     (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_WELCOME)->withStatus(NewsletterEntity::STATUS_ACTIVE)->create();
     (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATIC)->withStatus(NewsletterEntity::STATUS_ACTIVE)->create();
     (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATION)->withStatus(NewsletterEntity::STATUS_ACTIVE)->create();
@@ -103,7 +103,7 @@ class TrackerTest extends \MailPoetTest {
     expect($campaignsCount)->equals(6);
   }
 
-  public function testItAddsCampaignRevenuesPostNotificationsUnderTheParentId() {
+  public function testItAddsCampaignRevenuesPostNotificationsUnderTheParentId(): void {
     $notificationParent = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_NOTIFICATION)->create();
     $notificationHistory1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY)->create();
     $notificationHistory1->setParent($notificationParent);
@@ -126,7 +126,7 @@ class TrackerTest extends \MailPoetTest {
   /**
    * Because we save the revenue for every recent click, we need to make sure we count the order only once (for the first click)
    */
-  public function testItTracksTheRevenueOncePerOrder() {
+  public function testItTracksTheRevenueOncePerOrder(): void {
     $newsletter1 = (new Newsletter())->withSendingQueue()->create();
     $newsletter2 = (new Newsletter())->withSendingQueue()->create();
     $newsletter3 = (new Newsletter())->withSendingQueue()->create();
@@ -167,7 +167,7 @@ class TrackerTest extends \MailPoetTest {
     return (new StatisticsWooCommercePurchases($click, $orderData))->create();
   }
 
-  private function cleanUp() {
+  private function cleanUp(): void {
     $this->truncateEntity(NewsletterLinkEntity::class);
     $this->truncateEntity(NewsletterEntity::class);
     $this->truncateEntity(SubscriberEntity::class);

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -2,10 +2,147 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterLink;
+use MailPoet\Test\DataFactories\StatisticsClicks;
+use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
+use MailPoet\Test\DataFactories\Subscriber;
+
 class TrackerTest extends \MailPoetTest {
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var Tracker */
+  private $tracker;
+
+  public function _before() {
+    parent::_before();
+    $this->cleanUp();
+    $this->subscriber = (new Subscriber())->create();
+    $this->tracker = $this->diContainer->get(Tracker::class);
+  }
+
   public function testItAddsTrackingData() {
-    $tracker = $this->diContainer->get(Tracker::class);
-    $data = $tracker->addTrackingData(['extensions' => []]);
+    $data = $this->tracker->addTrackingData(['extensions' => []]);
     expect($data['extensions']['mailpoet'])->notEmpty();
+  }
+
+  public function testItAddsCampaignRevenuesForStandardNewsletters() {
+    $newsletter1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_STANDARD)->create();
+    $newsletter2 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_STANDARD)->create();
+    $this->createRevenueRecord($newsletter1, $this->createOrderData(1, 'USD', 10));
+    $this->createRevenueRecord($newsletter1, $this->createOrderData(3, 'USD', 20));
+    $this->createRevenueRecord($newsletter2, $this->createOrderData(2, 'USD', 20));
+
+    $tracker = $this->diContainer->get(Tracker::class);
+    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
+    expect($campaignRevenues)->count(2);
+    expect($campaignRevenues[0]['campaign_id'])->equals($newsletter1->getId());
+    expect($campaignRevenues[0]['revenue'])->equals(30);
+    expect($campaignRevenues[0]['campaign_type'])->equals($newsletter1->getType());
+    expect($campaignRevenues[0]['orders_count'])->equals(2);
+
+    expect($campaignRevenues[1]['campaign_id'])->equals($newsletter2->getId());
+    expect($campaignRevenues[1]['revenue'])->equals(20);
+    expect($campaignRevenues[1]['campaign_type'])->equals($newsletter2->getType());
+    expect($campaignRevenues[1]['orders_count'])->equals(1);
+  }
+
+  public function testItAddsCampaignRevenuesForAutomaticCampaigns() {
+    $newsletter1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_WELCOME)->create();
+    $newsletter2 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATIC)->create();
+    $newsletter3 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATION)->create();
+    $this->createRevenueRecord($newsletter1, $this->createOrderData(1, 'USD', 10));
+    $this->createRevenueRecord($newsletter2, $this->createOrderData(2, 'USD', 20));
+    $this->createRevenueRecord($newsletter3, $this->createOrderData(3, 'USD', 30));
+
+    $tracker = $this->diContainer->get(Tracker::class);
+    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
+    expect($campaignRevenues)->count(3);
+    expect($campaignRevenues[0]['campaign_id'])->equals($newsletter1->getId());
+    expect($campaignRevenues[0]['revenue'])->equals(10);
+    expect($campaignRevenues[0]['campaign_type'])->equals($newsletter1->getType());
+
+    expect($campaignRevenues[1]['campaign_id'])->equals($newsletter2->getId());
+    expect($campaignRevenues[1]['revenue'])->equals(20);
+    expect($campaignRevenues[1]['campaign_type'])->equals($newsletter2->getType());
+
+    expect($campaignRevenues[2]['campaign_id'])->equals($newsletter3->getId());
+    expect($campaignRevenues[2]['revenue'])->equals(30);
+    expect($campaignRevenues[2]['campaign_type'])->equals($newsletter3->getType());
+  }
+
+  public function testItAddsCampaignRevenuesPostNotificationsUnderTheParentId() {
+    $notificationParent = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_NOTIFICATION)->create();
+    $notificationHistory1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY)->create();
+    $notificationHistory1->setParent($notificationParent);
+    $notificationHistory2 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY)->create();
+    $notificationHistory2->setParent($notificationParent);
+    $this->createRevenueRecord($notificationHistory1, $this->createOrderData(1, 'USD', 10));
+    $this->createRevenueRecord($notificationHistory2, $this->createOrderData(2, 'USD', 20));
+
+    $tracker = $this->diContainer->get(Tracker::class);
+    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
+    expect($campaignRevenues)->count(1);
+    expect($campaignRevenues[0]['campaign_id'])->equals($notificationParent->getId());
+    expect($campaignRevenues[0]['revenue'])->equals(30);
+    expect($campaignRevenues[0]['campaign_type'])->equals($notificationParent->getType());
+  }
+
+  /**
+   * Because we save the revenue for every recent click, we need to make sure we count the order only once (for the first click)
+   */
+  public function testItTracksTheRevenueOncePerOrder() {
+    $newsletter1 = (new Newsletter())->withSendingQueue()->create();
+    $newsletter2 = (new Newsletter())->withSendingQueue()->create();
+    $newsletter3 = (new Newsletter())->withSendingQueue()->create();
+    $this->createRevenueRecord($newsletter1, $this->createOrderData(1, 'USD', 10));
+    $this->createRevenueRecord($newsletter2, $this->createOrderData(1, 'USD', 10));
+    $this->createRevenueRecord($newsletter2, $this->createOrderData(2, 'USD', 15));
+    // Newsletter 3 has only one order and it is already tracked for newsletter 1 so the newsletter 3 will be skipped
+    $this->createRevenueRecord($newsletter3, $this->createOrderData(1, 'USD', 10));
+
+    $tracker = $this->diContainer->get(Tracker::class);
+    $campaignRevenues = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet']['campaign_revenues'];
+    expect($campaignRevenues)->count(2);
+    expect($campaignRevenues[0]['campaign_id'])->equals($newsletter1->getId());
+    expect($campaignRevenues[0]['revenue'])->equals(10);
+    expect($campaignRevenues[0]['campaign_type'])->equals($newsletter1->getType());
+    expect($campaignRevenues[0]['orders_count'])->equals(1);
+
+    expect($campaignRevenues[1]['campaign_id'])->equals($newsletter2->getId());
+    expect($campaignRevenues[1]['revenue'])->equals(15);
+    expect($campaignRevenues[1]['campaign_type'])->equals($newsletter2->getType());
+    expect($campaignRevenues[1]['orders_count'])->equals(1);
+  }
+
+  /**
+   * @return array{id: int, currency: string, total: float}
+   */
+  private function createOrderData(int $id, string $currency, float $total): array {
+    return [
+      'id' => $id,
+      'currency' => $currency,
+      'total' => $total,
+    ];
+  }
+
+  private function createRevenueRecord(NewsletterEntity $newsletter, array $orderData): StatisticsWooCommercePurchaseEntity {
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $this->subscriber))->create();
+    return (new StatisticsWooCommercePurchases($click, $orderData))->create();
+  }
+
+  private function cleanUp() {
+    $this->truncateEntity(NewsletterLinkEntity::class);
+    $this->truncateEntity(NewsletterEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(StatisticsWooCommercePurchaseEntity::class);
+    $this->truncateEntity(StatisticsClickEntity::class);
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -40,6 +40,9 @@ class TrackerTest extends \MailPoetTest {
   public function testItAddsTrackingData() {
     $data = $this->tracker->addTrackingData(['extensions' => []]);
     expect($data['extensions']['mailpoet'])->notEmpty();
+    expect($data['extensions']['mailpoet']['campaigns_count'])->notNull();
+    expect($data['extensions']['mailpoet']['currency'])->notNull();
+    expect($data['extensions']['mailpoet']['campaign_revenues'])->notNull();
   }
 
   public function testItAddsCampaignRevenuesForStandardNewsletters() {

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -14,6 +14,9 @@ use MailPoet\Test\DataFactories\StatisticsClicks;
 use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
 use MailPoet\Test\DataFactories\Subscriber;
 
+/**
+ * @group woo
+ */
 class TrackerTest extends \MailPoetTest {
   /** @var SubscriberEntity */
   private $subscriber;

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -123,6 +123,19 @@ class TrackerTest extends \MailPoetTest {
     expect($mailPoetData)->hasNotKey('campaign_' . $notificationHistory2->getId() . '_revenue');
   }
 
+  public function testItTracksOnlyTheMainShopCurrency(): void {
+    $newsletter1 = (new Newsletter())->withSendingQueue()->create();
+    $this->createRevenueRecord($newsletter1, $this->createOrderData(1, 'USD', 20));
+    $this->createRevenueRecord($newsletter1, $this->createOrderData(1, 'CZK', 10));
+
+    $tracker = $this->diContainer->get(Tracker::class);
+    $mailPoetData = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet'];
+
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_revenue'])->equals(20);
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_type'])->equals($newsletter1->getType());
+    expect($mailPoetData['campaign_' . $newsletter1->getId() . '_orders_count'])->equals(1);
+  }
+
   /**
    * Because we save the revenue for every recent click, we need to make sure we count the order only once (for the first click)
    */


### PR DESCRIPTION
## Description
We want to find out how MailPoet campaigns help to generate revenue in Woo stores.
In order to do so, we want to use WC Tracker for tracking campaign revenue stats data we already store in the `mailpoet_statistics_woocommerce_purchases` table.

### Tracked data
Here is an example of the data that will be added to the tracker data:
```JSON
{
    "campaigns_count": 476,
    "currency": "CZK",
    "campaign_191_revenue": 1200.5,
    "campaign_191_orders_count": 12,
    "campaign_191_type": "standard",
    "campaign_192_revenue": 600,
    "campaign_192_orders_count": 6,
    "campaign_192_type": "standard",
    "campaign_194_revenue": 500,
    "campaign_194_orders_count": 5,
    "campaign_194_type": "welcome",
    "campaign_195_revenue": 800,
    "campaign_195_orders_count": 8,
    "campaign_195_type": "automation",
    "campaign_196_revenue": 600,
    "campaign_196_orders_count": 6,
    "campaign_196_type": "automatic",
    "campaign_197_revenue": 600.5,
    "campaign_197_orders_count": 6,
    "campaign_197_type": "notification",
    "campaign_201_revenue": 700,
    "campaign_201_orders_count": 7,
    "campaign_201_type": "notification"
}
```

`"campaign_XXX_revenue": 1200.0` - Sum of revenue generated by the campaign
`"campaign_XXX_type": "standard"` - Campaign type
`"campaign_XXX_orders_count": 12` - Number of orders that were created after users visited the site via the campaign

Regarding the format, please see [this comment](https://github.com/mailpoet/mailpoet/pull/4665#issuecomment-1401610401).

#### Notes
1. In the DB table, we save revenue for all clicks a subscriber did a couple of days before making an order. In the tracking data, I take into account only the first click so that every order is included only once.
2. `campaign_revenues` contains only campaigns that generated some orders.
3. We save revenue for post notifications (e.g., weekly post notification) emails separately for each sending. I grouped those data under post-notification parent so that all post notifications emails are under a single campaign.
4. In the future, I would like to extend the campaign data with some additional details (e.g., type of an automatic email, type of dynamic segment used, post notifications frequency, and sent count)

## Code review notes

_N/A_

## QA notes

There are no changes in UI.
In case you want to check what is tracked (you need to have WP CLI):
1) Setup page with Woo and MailPoet
2) Create a subscriber and add to a list
3) Send a newsletter to the list
4) Click on a link from the received email
5) Make an order when being signed in using the subscribers email (or use the email in the order)
6) Go to a command line and use: `wp wc tracker snapshot --format=yaml`
7) You should see the data from above being printed among other tracker data

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5014]

## After-merge notes

We need to update Woo usage tracking page https://href.li/?https://woocommerce.com/usage-tracking/


[MAILPOET-5014]: https://mailpoet.atlassian.net/browse/MAILPOET-5014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ