### PR TITLE
Set reasonable default values until validation is built [MAILPOET-4678]

### DIFF
--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -1567,6 +1567,8 @@
             discountType: <%= json_encode(woocommerce.coupon.defaults.discountType) %>,
             code: <%= json_encode(woocommerce.coupon.defaults.code) %>,
             amountMax: <%= json_encode(woocommerce.coupon.defaults.amountMax) %>,
+            amount: 10,
+            expiryDay: 10,
             styles: {
               block: {
                 backgroundColor: '#ffffff',


### PR DESCRIPTION
## Description

Failing to set default values without validation could stall sending, this issue should be addressed in MAILPOET-4983


## QA notes

This only improves [the PR ](https://github.com/mailpoet/mailpoet/pull/4636)

## Linked tickets

[MAILPOET-4678]

## Linked PRs
[4636](https://github.com/mailpoet/mailpoet/pull/4636)

[MAILPOET-4678]: https://mailpoet.atlassian.net/browse/MAILPOET-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ