### PR TITLE
Fix deprecated callable usage in Sudzy library [MAILPOET-4873]

### DIFF
--- a/mailpoet/lib-3rd-party/Sudzy/Engine.php
+++ b/mailpoet/lib-3rd-party/Sudzy/Engine.php
@@ -34,7 +34,7 @@ class Engine
   }
 
   public function executeOne($check, $val, $params=[]) {
-    $callback = __NAMESPACE__ . '\Engine::' . $check;
+    $callback = [$this, $check];
     if (is_callable($callback)) {
       return call_user_func($callback, $val, $params);
     }


### PR DESCRIPTION
[MAILPOET-4873]

## Description

There was a rare form of a callable used, the only adequate explanation for it I found [here](https://wiki.php.net/rfc/deprecate_partially_supported_callables) (under the "Backward Incompatible Changes" section). Basically, `["Foo", "Bar::method"]` is used to call a parent class method. I have replaced it with a simpler callable which should still do the job because the validation checks aren't overridden, so they can be called on the child class too.

## Code review notes

In the code it looked like a normal callback (e.g. `MailPoetVendor\Sudzy\Engine::required`), but when called, for some reason it was transformed into the deprecated form `["MailPoet\Models\ModelValidator", "MailPoetVendor\Sudzy\Engine::required"]` which generated the error.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4873]

## After-merge notes

_N/A_


[MAILPOET-4873]: https://mailpoet.atlassian.net/browse/MAILPOET-4873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4873]: https://mailpoet.atlassian.net/browse/MAILPOET-4873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ