### PR TITLE
Allow rgb() in the newsletter style attributes [MAILPOET-4981]

### DIFF
--- a/mailpoet/tests/integration/Newsletter/NewsletterHtmlSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterHtmlSanitizerTest.php
@@ -23,6 +23,7 @@ class NewsletterHtmlSanitizerTest extends \MailPoetTest {
     expect($this->sanitizer->sanitize('<table><tr><th>Head</th></tr><tr><td>Cell</td></tr></table>'))->equals('<table><tr><th>Head</th></tr><tr><td>Cell</td></tr></table>');
     expect($this->sanitizer->sanitize('<a href="http://example.com/" target="_blank" class="some-class">link</a>'))->equals('<a href="http://example.com/" target="_blank" class="some-class">link</a>');
     expect($this->sanitizer->sanitize('<a href="[link:subscribe]" target="_blank" style="color: blue;font-size: 12px">Subscribe</a>'))->equals('<a href="[link:subscribe]" target="_blank" style="color: blue;font-size: 12px">Subscribe</a>');
+    expect($this->sanitizer->sanitize('<span style="color:rgb(0,0,0)">Does not sanitize RGB</span>'))->equals('<span style="color:rgb(0,0,0)">Does not sanitize RGB</span>');
   }
 
   public function testItRemovesUnwantedHtml() {


### PR DESCRIPTION
## Description
Fixes the color setting issue in the editor

## Code review notes
Since we updated TinyMCE in #4610, we send now `style=rgb()` instead of hex. At the same time the setting `force_hex_style_colors` with which you were able to force TinyMCE to use hex colors has been deprecated (See [Changelog](https://github.com/tinymce/tinymce/blob/1998c1ea51aaaafbcb09131d74a57c9ad98720b8/modules/tinymce/CHANGELOG.md#600---2022-03-03)).

Using `wp_kses()` does strip `rgb()` from `style` attributes. This happens in `safecss_filter_attr()` here: https://github.com/WordPress/WordPress/blob/215de3c5f31e7cf090c7efaadf1a5e885bf17c7d/wp-includes/kses.php#L2549-L2577

This PR utilizes the filter `safecss_filter_attr_allow_css` to overwrite the decision.


## Linked tickets
[MAILPOET-4981]


[MAILPOET-4981]: https://mailpoet.atlassian.net/browse/MAILPOET-4981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ