### PR TITLE
Improvement to check mail (DisabledMailFunctionNotice) service - MAILPOET-4929

### DIFF
--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -132,6 +132,10 @@ class Activator {
   }
 
   private function checkForDisabledMailFunction() {
+    $version = $this->settings->get('version');
+
+    if (!is_null($version)) return; // not a new user
+
     $sendingMethodSet = $this->settings->get('mta.method', false);
 
     if ($sendingMethodSet === 'PHPMail') {

--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -136,12 +136,8 @@ class Activator {
 
     if (!is_null($version)) return; // not a new user
 
-    $sendingMethodSet = $this->settings->get('mta.method', false);
-
-    if ($sendingMethodSet === 'PHPMail') {
-      // check for valid mail function
-      $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
-    }
+    // check for valid mail function on new installs
+    $this->settings->set(DisabledMailFunctionNotice::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, true);
   }
 
   private function deleteAllMailPoetTablesAndData(): void {

--- a/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
@@ -57,7 +57,7 @@ class DisabledMailFunctionNotice {
       $this->settings->set(self::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, false);
     }
 
-    $sendingMethod = $this->settings->get('mta.method', false);
+    $sendingMethod = $this->settings->get('mta.method', SettingsController::DEFAULT_SENDING_METHOD);
     $isPhpMailSendingMethod = $sendingMethod === Mailer::METHOD_PHPMAIL;
 
     if (!$isPhpMailSendingMethod) {

--- a/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
@@ -85,11 +85,18 @@ class DisabledMailFunctionNotice {
    * disabled_mail_function_check === true
    * or
    * queue_disabled_mail_function_check === true
+   * or
+   * Totally disabled when wp filter `mailpoet_display_disabled_mail_function_notice` === false
    *
    */
   public function shouldCheckMisconfiguredFunction(): bool {
+    $shouldCheck = $this->wp->applyFilters('mailpoet_display_disabled_mail_function_notice', true);
     $this->isInQueueForChecking = $this->settings->get(self::QUEUE_DISABLED_MAIL_FUNCTION_CHECK, false);
-    return $this->settings->get(self::DISABLED_MAIL_FUNCTION_CHECK, false) || $this->isInQueueForChecking;
+
+    return $shouldCheck && (
+      $this->settings->get(self::DISABLED_MAIL_FUNCTION_CHECK, false) ||
+      $this->isInQueueForChecking
+      );
   }
 
   public function isFunctionDisabled(string $function): bool {


### PR DESCRIPTION
## Description

A few improvements to check mail (DisabledMailFunctionNotice) service

## Code review notes

How to disable `mail` function.

The mail function can be disabled from the php.ini file.

On the MailPoet Dev environment, you may do that here: [dev/php.ini](https://github.com/mailpoet/mailpoet/blob/trunk/dev/php.ini#L5)
By setting `disable_functions = 'mail'`

```
upload_max_filesize = 500M
memory_limit = 1024M
post_max_size = 500M
sendmail_path = /usr/bin/msmtp -C /etc/msmtprc -t
sendmail_from = 'wordpress@mp3.localhost'
disable_functions = 'mail'
```

Note: Remember to rebuild your docker image: `docker-compose build wordpress`

## QA notes

> The [site:homepage_link] shortcode should function as in the regular newsletters - and link to the homepage with the anchor label of the site title.

**Note**: Spec item `4b ii` can only be available once this [PR](https://github.com/mailpoet/mailpoet/pull/4662) is merged

**Test case 1**
Test on a site with a restricted `mail` function (e.g., Pressable) and others without restriction (e.g., Jurassic ninja)

* Activate the plugin, and check MailPoet pages.
* Switch the sending method from settings (/wp-admin/admin.php?page=mailpoet-settings#/mta/other)
* Select SMTP, Click on Activate button
* Reload the page. 
* Confirm Notice is not displayed.
* Switch the sending method back to "Your web host/web server", Click on the Activate button
* Reload the page. 

You should receive an email in your `sender.From` address

**Test case 2**
* Deactivate the plugin and reload the page
* Activate the plugin and reload the page
* Check a MailPoet page
* You should not receive any email

Check other information on the ticket.



## Linked tickets

[MAILPOET-4929](https://mailpoet.atlassian.net/browse/MAILPOET-4929)



[MAILPOET-4929]: https://mailpoet.atlassian.net/browse/MAILPOET-4929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ