### PR TITLE
Fix Form Editor scrollbars [MAILPOET-4607]

### DIFF
--- a/mailpoet/assets/css/src/components-form-editor/_block-editor.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_block-editor.scss
@@ -129,3 +129,11 @@ h2 {
     transform: rotate(45deg);
   }
 }
+
+// Hide block selector header with close button on desktops
+
+@include respond-to(not-small-screen) {
+  .edit-post-editor__inserter-panel-header {
+    display: none;
+  }
+}

--- a/mailpoet/assets/css/src/components-form-editor/_block-editor.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_block-editor.scss
@@ -118,3 +118,14 @@ h2 {
 .wp-block-columns.has-background {
   padding: 10px;
 }
+
+// Close button animation
+.edit-post-header-toolbar.edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle {
+  svg {
+    transition: transform cubic-bezier(.165, .84, .44, 1) .2s;
+  }
+
+  &.is-pressed svg {
+    transform: rotate(45deg);
+  }
+}

--- a/mailpoet/assets/css/src/settings/_breakpoints.scss
+++ b/mailpoet/assets/css/src/settings/_breakpoints.scss
@@ -1,3 +1,3 @@
 // WordPress breakpoints
-$mailpoet-breakpoint-small: 782px;
+$mailpoet-breakpoint-small: 781px;
 $mailpoet-breakpoint-medium: 960px;


### PR DESCRIPTION
## Description

Remove the redundant close button in the Form Editor sidebar header, which was causing vertical scrollbars to be present in all areas (sidebar, content and settings). 

Also added animation on the toggle button in the top bar when opening/closing the sidebar.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4607]

## After-merge notes

_N/A_


[MAILPOET-4607]: https://mailpoet.atlassian.net/browse/MAILPOET-4607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ