### PR TITLE
Slightly improved select2 height [MAILPOET-4630]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_common.scss
+++ b/mailpoet/assets/css/src/components-plugin/_common.scss
@@ -56,6 +56,7 @@ p.sender_email_address_warning:first-child {
 // Fix for select 2 placeholder padding rendering issue in Chrome
 .select2-container .select2-search--inline,
 .select2-container .select2-search--inline .select2-search__field {
+  height: 22px;
   max-width: 100%;
 }
 

--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -27,10 +27,6 @@ input.select2-search__field:-ms-input-placeholder {
   color: $color-placeholder-select2;
 }
 
-.select2-container--default.select2-container--focus .select2-selection--multiple {
-  border: 1px solid #aaa; /* default Select2 border for single dropdown */
-}
-
 textarea.regular-text {
   width: 25em !important;
 }

--- a/mailpoet/assets/css/src/generic/_forms-select2.scss
+++ b/mailpoet/assets/css/src/generic/_forms-select2.scss
@@ -50,7 +50,11 @@
     border: 0 !important;
     height: auto !important;
     outline: none;
-    padding: 10px 5px 5px 16px !important;
+    padding: 5px 5px 2px 16px !important;
+
+    &.select2-selection--multiple {
+      padding: 7px 5px 0 16px !important;
+    }
   }
 
   .select2-selection__arrow {
@@ -62,10 +66,6 @@
     line-height: 22px !important;
     padding: 7px 0 9px !important;
     vertical-align: top;
-  }
-
-  .select2-selection--multiple .select2-selection__rendered {
-    padding-bottom: 0 !important;
   }
 
   .select2-selection__choice {

--- a/mailpoet/assets/css/src/generic/_forms-select2.scss
+++ b/mailpoet/assets/css/src/generic/_forms-select2.scss
@@ -98,7 +98,7 @@
 
   .select2-search--inline {
     display: inline-block;
-    margin-bottom: 9px;
+    margin-bottom: 5px;
   }
 
   .select2-search__field {


### PR DESCRIPTION
## Description

This PR:

1. Fixes the cut-off placeholder in multi-value select2 and makes it slightly smaller.

<img width="415" alt="Screenshot 2023-01-25 at 08 21 39" src="https://user-images.githubusercontent.com/470616/214503486-8a2ef4bb-9430-479b-9946-67522d041b42.png">

2. Fixes the height of the single-value select2 component to be the same as regular input. 

<img width="416" alt="Screenshot 2023-01-25 at 08 21 01" src="https://user-images.githubusercontent.com/470616/214503355-46822597-1e33-4c88-bd5b-d11382a91ecf.png">

---

With changes applied:

<img width="429" alt="Screenshot 2023-01-25 at 08 22 33" src="https://user-images.githubusercontent.com/470616/214503548-a112b99c-6b27-4b4b-90f6-356abf0ee522.png">

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4630]

## After-merge notes

_N/A_


[MAILPOET-4630]: https://mailpoet.atlassian.net/browse/MAILPOET-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ