### PR TITLE
Draft products in editor [MAILPOET-4883]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -92,7 +92,7 @@ class AutomatedLatestContent extends APIEndpoint {
   public function getTransformedPosts(array $data = []): SuccessResponse {
     $posts = $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery([
       'args' => $data,
-      // If the request is for Posts block then we are fetching data for a static block
+      // If the request is for Posts or Products block then we are fetching data for a static block
       'dynamic' => !(isset($data['type']) && in_array($data['type'], ["posts", "products"])),
     ]
     )));

--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -93,7 +93,7 @@ class AutomatedLatestContent extends APIEndpoint {
     $posts = $this->getPermittedPosts($this->ALC->getPosts(new BlockPostQuery([
       'args' => $data,
       // If the request is for Posts block then we are fetching data for a static block
-      'dynamic' => !(isset($data['type']) && $data['type'] === "posts"),
+      'dynamic' => !(isset($data['type']) && in_array($data['type'], ["posts", "products"])),
     ]
     )));
     return $this->successResponse(


### PR DESCRIPTION
## Description
Enables to fetch draft products in the newsletter editor using the Products block

## Code review notes
Added also some integration test which covers the case as well as the case for the Posts block

## Linked tickets

[MAILPOET-4883]

[MAILPOET-4883]: https://mailpoet.atlassian.net/browse/MAILPOET-4883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ