### PR TITLE
Dotcom Ecommerce plan UI fixes [MAILPOET-5017]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_menu.scss
+++ b/mailpoet/assets/css/src/components-plugin/_menu.scss
@@ -4,6 +4,6 @@
 }
 
 // Fix for 3rd party plugins icons in menu that might display broken because we block loading 3rd party CSS on mailepoet pages
-#adminmenu .wp-menu-image img {
+#adminmenu :not(.toplevel_page_site-card) .wp-menu-image img {
   max-width: 20px;
 }

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -2,6 +2,7 @@ import ReactDOM from 'react-dom';
 import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { ErrorBoundary } from 'common';
 import { Background } from 'common/background/background';
+import { HideScreenOptions } from 'common/hide_screen_options/hide_screen_options';
 import { Header } from './header';
 import { Footer } from './footer';
 import { Faq } from './faq';
@@ -11,6 +12,8 @@ function Landingpage() {
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <main>
+        <HideScreenOptions />
+
         <Background color="#fff" />
 
         <Header />

--- a/mailpoet/assets/js/src/wizard/welcome_wizard_controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome_wizard_controller.tsx
@@ -18,6 +18,7 @@ import { Steps } from '../common/steps/steps';
 import { StepsContent } from '../common/steps/steps_content';
 import { TopBar } from '../common/top_bar/top_bar';
 import { ErrorBoundary } from '../common';
+import { HideScreenOptions } from '../common/hide_screen_options/hide_screen_options';
 
 type WelcomeWizardStepsControllerPropType = {
   match: { params: { step: string } };
@@ -111,6 +112,7 @@ function WelcomeWizardStepsController({
 
   return (
     <>
+      <HideScreenOptions />
       <TopBar logoWithLink={false}>
         <Steps count={stepsCount} current={step} />
       </TopBar>

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -180,6 +180,11 @@ class Functions extends AbstractExtension {
         [$this, 'libs3rdPartyEnabled'],
         ['is_safe' => ['all']]
       ),
+      new TwigFunction(
+        'is_dotcom_ecommerce_plan',
+        [$this, 'isDotcomEcommercePlan'],
+        ['is_safe' => ['all']]
+      ),
     ];
   }
 
@@ -319,5 +324,12 @@ class Functions extends AbstractExtension {
 
   public function libs3rdPartyEnabled(): bool {
     return $this->getSettings()->get('3rd_party_libs.enabled') === '1';
+  }
+
+  public function isDotcomEcommercePlan(): bool {
+    if (function_exists('wc_calypso_bridge_is_ecommerce_plan')) {
+      return wc_calypso_bridge_is_ecommerce_plan();
+    }
+    return false;
   }
 }

--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -18,11 +18,13 @@ class ConflictResolver {
       'jetpack',
       'query-monitor',
       'wpt-tx-updater-network',
-      // WP.com styles
+      // WP.com
       '^/_static',
       'atomic-plugins/debug-bar/css',
       'woocommerce-payments/',
       'automatewoo/',
+      'full-site-editing',
+      'wpcomsh',
     ],
     'scripts' => [
       'mailpoet',
@@ -35,6 +37,9 @@ class ConflictResolver {
       // third-party
       'query-monitor',
       'wpt-tx-updater-network',
+      // WP.com
+      'full-site-editing',
+      'wpcomsh',
     ],
   ];
 

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -262,7 +262,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'admin.js'
 )%>
 
-<%if is_loading_3rd_party_enabled() %>
+<%if is_loading_3rd_party_enabled() and not is_dotcom_ecommerce_plan() %>
   <%= javascript('lib/analytics.js') %>
 
   <% set helpscout_form_id = '1c666cab-c0f6-4614-bc06-e5d0ad78db2b' %>
@@ -274,8 +274,6 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   <% endif %>
 
   <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script>
-
-  <script type="text/javascript"></script>
 
   <script type="text/javascript">
     if(window['Beacon'] !== undefined && window.hide_mailpoet_beacon !== true) {


### PR DESCRIPTION
## Description

This PR fixes https://github.com/Automattic/wc-calypso-bridge/issues/895

## Code review notes

_N/A_

## QA notes

For these to be verified, the build needs to be used on Ecommerce plan on Hosted Woo. But [Panos already tested them](https://a8c.slack.com/archives/CNA89KY6M/p1674656391925449?thread_ts=1674655299.590169&cid=CNA89KY6M), so maybe we can merge this if no new issues are introduced outside of Dotcom.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5017]

## After-merge notes

_N/A_


[MAILPOET-5017]: https://mailpoet.atlassian.net/browse/MAILPOET-5017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ