### PR TITLE
Do not substitute alt attribute with title attribute in image block [MAILPOET-4932]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/behaviors/MediaManagerBehavior.js
+++ b/mailpoet/assets/js/src/newsletter_editor/behaviors/MediaManagerBehavior.js
@@ -316,10 +316,7 @@ BL.MediaManagerBehavior = Marionette.Behavior.extend({
             width: mainSize.width + 'px',
             src: mainSize.url,
             alt:
-              attachment.get('alt') !== '' &&
-              attachment.get('alt') !== undefined
-                ? attachment.get('alt')
-                : attachment.get('title'),
+              attachment.get('alt') !== undefined ? attachment.get('alt') : '',
           });
         }
       });


### PR DESCRIPTION
## Description
In the image block, we used to substitute the alt attribute with the title attribute when no alternative text was found. This PR changes the behavior and leaves the alt attribute empty, when no alternative text was found.

## QA notes
Use the media manager to upload two images. Add an alternative text to one picture and leave the alternative text empty for the other one. Ensure in both cases the title field is populated.

![image](https://user-images.githubusercontent.com/6458412/214778948-43f3293b-0341-44aa-80e9-b46be6df8cab.png)

In the newsletter editor, use the image block and select the picture with the alt text. This text should show up in the "Alternative Text" input field. Select the picture without the alt text. The "Alternative Text" input field should be empty.

## Linked tickets

[MAILPOET-4932]


[MAILPOET-4932]: https://mailpoet.atlassian.net/browse/MAILPOET-4932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ