### PR TITLE
Allow editor to access automations [MAILPOET-5024]

### DIFF
--- a/mailpoet/lib/Config/AccessControl.php
+++ b/mailpoet/lib/Config/AccessControl.php
@@ -67,6 +67,7 @@ class AccessControl {
         'mailpoet_permission_manage_automations',
         [
           'administrator',
+          'editor',
         ]
       ),
     ];

--- a/mailpoet/tests/integration/REST/Automation/AutomationTest.php
+++ b/mailpoet/tests/integration/REST/Automation/AutomationTest.php
@@ -7,13 +7,26 @@ require_once __DIR__ . '/../Test.php';
 use MailPoet\REST\Test;
 
 abstract class AutomationTest extends Test {
+
+  protected $editorUserId;
+
   public function _before() {
     parent::_before();
     wp_set_current_user(1);
+    $userId = wp_create_user(
+      'editor',
+      'password',
+      'editor@localhost'
+    );
+    $this->assertIsNumeric($userId);
+    $user = new \WP_User($userId);
+    $user->add_role('editor');
+    $this->editorUserId = $userId;
   }
 
   public function _after() {
     parent::_after();
     wp_set_current_user(0);
+    is_multisite() ? wpmu_delete_user($this->editorUserId) : wp_delete_user($this->editorUserId);
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
@@ -31,6 +31,24 @@ class AutomationPutEndpointTest extends AutomationTest {
     $this->assertInstanceOf(Automation::class, $this->automation);
   }
 
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->automation->getId()),
+      [
+        'json' => [
+          'name' => 'Test',
+        ],
+      ]
+    );
+
+    $this->assertSame("Test", $data['data']['name']);
+
+    $automation = $this->automationStorage->getAutomation($this->automation->getId());
+    $this->assertInstanceOf(Automation::class, $automation);
+    $this->assertSame('Test', $automation->getName());
+  }
+
   public function testGuestNotAllowed(): void {
     wp_set_current_user(0);
     $data = $this->put(

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -17,6 +17,13 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $data = $this->get(self::ENDPOINT_PATH, []);
+
+    $this->assertCount(7, $data['data']);
+  }
+
   public function testGuestNotAllowed(): void {
     wp_set_current_user(0);
     $data = $this->get(self::ENDPOINT_PATH, []);

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
@@ -31,6 +31,20 @@ class AutomationsCreateFromTemplateTest extends AutomationTest {
     expect($countAfter)->equals($countBefore + 1);
   }
 
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $countBefore = count($this->automationStorage->getAutomations());
+    $data = $this->post(self::ENDPOINT_PATH, [
+      'json' => [
+        'slug' => 'subscriber-welcome-email',
+      ],
+    ]);
+    $countAfter = count($this->automationStorage->getAutomations());
+    $this->assertEquals($countBefore + 1, $countAfter);
+
+    $this->assertSame("Welcome new subscribers", $data['data']['name']);
+  }
+
   public function testGuestNotAllowed(): void {
     wp_set_current_user(0);
     $countBefore = count($this->automationStorage->getAutomations());

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -33,6 +33,14 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
     $this->automation = $automation;
   }
 
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $data = $this->delete(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));
+
+    $this->assertSame("mailpoet_automation_not_trashed", $data['code']);
+
+  }
+
   public function testGuestNotAllowed(): void {
     wp_set_current_user(0);
     $data = $this->delete(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -36,6 +36,14 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
     $this->automation = $automation;
   }
 
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $data = $this->post(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));
+
+    $this->assertSame('Copy of Testing automation', $data['data']['name']);
+    $this->assertNotNull($this->automationStorage->getAutomation($this->automation->getId() + 1));
+  }
+
   public function testGuestNotAllowed(): void {
     wp_set_current_user(0);
     $data = $this->post(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
@@ -32,6 +32,13 @@ class AutomationsGetTest extends AutomationTest {
     $this->userIds[] = $userId;
   }
 
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $data = $this->get(self::ENDPOINT_PATH);
+
+    $this->assertCount(0, $data['data']);
+  }
+
   public function testGuestNotAllowed(): void {
     wp_set_current_user(0);
     $data = $this->get(self::ENDPOINT_PATH);


### PR DESCRIPTION
## Description
This PR enables editors to use the automation feature.

## QA
When you test this PR, deactivate and activate the plugin, so the capabilities of the editor get updated. Test with the editor role.

## Linked tickets
[MAILPOET-5024]

[MAILPOET-5024]: https://mailpoet.atlassian.net/browse/MAILPOET-5024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## After merge
Deactivate and activate plugin, when you want to reap the benefits immediately.