### PR TITLE
Focusable close buttons on forms [MAILPOET-4877]

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -343,10 +343,12 @@ div.mailpoet_form_popup {
 .mailpoet_form_close_icon {
   cursor: pointer;
   display: block;
+  height: 20px;
   margin: 0 0 0 auto;
   position: absolute;
   right: 10px;
   top: 10px;
+  width: 20px;
   z-index: 100002;
 }
 

--- a/mailpoet/views/form/front_end_form.html
+++ b/mailpoet/views/form/front_end_form.html
@@ -27,15 +27,6 @@
       data-editor-url="<%= editor_url %>"
     <% endif %>
   >
-    <% if form_type == 'popup' or form_type == 'fixed_bar' or form_type == 'slide_in' %>
-      <img
-        class="mailpoet_form_close_icon"
-        alt="close"
-        width=20
-        height=20
-        src='<%= image_url("form_close_icon/" ~ close_button_icon ~ ".svg") %>'
-      >
-    <% endif %>
 
     <style type="text/css">
      <%= styles|raw %>
@@ -76,6 +67,14 @@
         </p>
       </div>
     </form>
+
+    <% if form_type == 'popup' or form_type == 'fixed_bar' or form_type == 'slide_in' %>
+      <input type="image"
+        class="mailpoet_form_close_icon"
+        alt="<%= __('Close') %>"
+        src='<%= image_url("form_close_icon/" ~ close_button_icon ~ ".svg") %>'
+      />
+    <% endif %>
   </div>
 
   <% if(after_widget) %>


### PR DESCRIPTION
## Description

This PR makes the close buttons of forms focusable and interactive via the keyboard (hitting space or enter will activate the button when it's focused). It also moves the close button after the form HTML so it receives focus last.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-4877]

## After-merge notes

_N/A_


[MAILPOET-4877]: https://mailpoet.atlassian.net/browse/MAILPOET-4877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ