### PR TITLE
Validate input fields by type in newsletter [MAILPOET-4905]

### DIFF
--- a/mailpoet/assets/css/src/components-editor/_forms.scss
+++ b/mailpoet/assets/css/src/components-editor/_forms.scss
@@ -27,6 +27,21 @@ select.mailpoet_font-size {
   width: 283px;
 }
 
+input {
+  &.mailpoet_error {
+    border: 1px solid #900;
+
+    ~ .mailpoet_text_on_error {
+      display: block;
+    }
+  }
+}
+
+.mailpoet_text_on_error {
+  color: #900;
+  display: none;
+}
+
 .mailpoet_input_small {
   width: 58px;
 }

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/base.js
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/base.js
@@ -11,6 +11,7 @@ import _ from 'underscore';
 import jQuery from 'jquery';
 import { MailPoet } from 'mailpoet';
 import 'modal';
+import { validateField } from '../utils';
 
 var Module = {};
 var AugmentedView = Marionette.View.extend({});
@@ -306,6 +307,9 @@ Module.BlockSettingsView = Marionette.View.extend({
     this.destroy();
   },
   changeField: function changeField(field, event) {
+    if (!validateField(event.target)) {
+      return;
+    }
     this.model.set(field, jQuery(event.target).val());
   },
   changePixelField: function changePixelField(field, event) {

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/social.js
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/social.js
@@ -9,6 +9,7 @@ import Marionette from 'backbone.marionette';
 import SuperModel from 'backbone.supermodel';
 import _ from 'underscore';
 import jQuery from 'jquery';
+import { validateField } from '../utils';
 
 var Module = {};
 var base = BaseBlock;
@@ -246,14 +247,19 @@ SocialBlockSettingsIconView = Marionette.View.extend({
     this.model.destroy();
   },
   changeLink: function (event) {
+    if (!validateField(event.target)) {
+      return;
+    }
     if (this.model.get('iconType') === 'email') {
       this.model.set('link', 'mailto:' + jQuery(event.target).val());
     } else {
-      return this.changeField('link', event);
+      this.changeField('link', event);
     }
-    return undefined;
   },
   changeField: function (field, event) {
+    if (!validateField(event.target)) {
+      return;
+    }
     this.model.set(field, jQuery(event.target).val());
   },
 });

--- a/mailpoet/assets/js/src/newsletter_editor/utils.js
+++ b/mailpoet/assets/js/src/newsletter_editor/utils.js
@@ -12,3 +12,12 @@ export const isEventInsideElement = (event, $el) => {
   }
   return true;
 };
+
+export const validateField = (element) => {
+  element.classList.remove('mailpoet_error');
+  if (typeof element.validity !== 'object' || element.validity.valid) {
+    return true;
+  }
+  element.classList.add('mailpoet_error');
+  return false;
+};

--- a/mailpoet/views/newsletter/templates/blocks/button/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/button/settings.hbs
@@ -13,7 +13,8 @@
     <label>
         <div class="mailpoet_form_field_title mailpoet_form_field_title_inline"><%= __('Link') %></div>
         <div class="mailpoet_form_field_input_option">
-            <input type="text" name="url" class="mailpoet_input mailpoet_field_button_url" value="{{ model.url }}" placeholder="http://" />
+            <input type="url" name="url" class="mailpoet_input mailpoet_field_button_url" value="{{ model.url }}" placeholder="http://" />
+            <p class="mailpoet_text_on_error"><%= __('This is not a valid URL.') %></p>
         </div>
     </label>
 </div>

--- a/mailpoet/views/newsletter/templates/blocks/image/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/image/settings.hbs
@@ -3,7 +3,8 @@
     <label>
         <div class="mailpoet_form_field_title"><%= __('Link') %> <span class="mailpoet_form_field_optional">(<%= __('Optional') %>)</div>
         <div class="mailpoet_form_field_input_option">
-            <input type="text" name="src" class="mailpoet_input mailpoet_field_image_link" value="{{ model.link }}" placeholder="http://" />
+            <input type="url" name="src" class="mailpoet_input mailpoet_field_image_link" value="{{ model.link }}" placeholder="http://" />
+            <p class="mailpoet_text_on_error"><%= __('This is not a valid URL.') %></p>
         </div>
     </label>
 </div>
@@ -11,7 +12,7 @@
     <label>
         <div class="mailpoet_form_field_title"><%= _x('Image address', 'input field for the image URL') %></div>
         <div class="mailpoet_form_field_input_option">
-            <input type="text" name="src" class="mailpoet_input mailpoet_field_image_address" value="{{ model.src }}" placeholder="http://" /><br />
+            <input type="text" name="url" class="mailpoet_input mailpoet_field_image_address" readonly value="{{ model.src }}" placeholder="http://" />
         </div>
     </label>
 </div>

--- a/mailpoet/views/newsletter/templates/blocks/social/settingsIcon.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/social/settingsIcon.hbs
@@ -40,9 +40,11 @@
         </div>
         <div class="mailpoet_social_icon_settings_form_element">
             {{#ifCond iconType '==' 'email'}}
-            <input type="text" name="link" class="mailpoet_social_icon_field_link" value="{{emailFromMailto model.link }}" placeholder="example@example.org" /><br />
+            <input type="email" name="link" class="mailpoet_social_icon_field_link" value="{{emailFromMailto model.link }}" placeholder="example@example.org" />
+            <p class="mailpoet_text_on_error"><%= __('This is not a valid email.') %></p>
             {{else}}
-            <input type="text" name="link" class="mailpoet_social_icon_field_link" value="{{ model.link }}" placeholder="http://" /><br />
+            <input type="url" name="link" class="mailpoet_social_icon_field_link" value="{{ model.link }}" placeholder="http://" />
+            <p class="mailpoet_text_on_error"><%= __('This is not a valid URL.') %></p>
             {{/ifCond}}
         </div>
         </label>


### PR DESCRIPTION
## Description
Validates url and email input fields in the newsletter editor. The `Image address` field of the image block has been made `readonly` as no update event was associated with it.

## Linked tickets

[MAILPOET-4905]



[MAILPOET-4905]: https://mailpoet.atlassian.net/browse/MAILPOET-4905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ