### PR TITLE
link to the new homepage from the mailpoet task in woocommerce - MAILPOET-4926

### DIFF
--- a/mailpoet/lib/WooCommerce/MailPoetTask.php
+++ b/mailpoet/lib/WooCommerce/MailPoetTask.php
@@ -39,7 +39,7 @@ class MailPoetTask extends Task {
    */
   public function get_action_url(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->is_complete()) {
-      return admin_url('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
+      return admin_url('admin.php?page=' . Menu::$mainPageSlug);
     }
 
     return admin_url('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG . '&mailpoet_wizard_loaded_via_woocommerce');


### PR DESCRIPTION
## Description

Link to the new homepage from the MailPoet task in WooCommerce

## Code review notes

Please start review from https://github.com/mailpoet/mailpoet/pull/4697/commits/324d706105e942be09ff244ade37cc7ab38ec9f4


## QA notes

You can access the WC admin page here: `/wp-admin/admin.php?page=wc-admin`

* Ensure you have completed the welcome wizard 
* Visit the WC admin page
* Click on the "MailPoet setup completed" task list

**Test case 1**
If you have the New homepage feature enabled (`/wp-admin/admin.php?page=mailpoet-experimental`)
* You should be redirected to the Homepage

**Test case 2**
If you don't have the New homepage feature enabled
* You should be redirected to the Newsletter page




## Linked PRs

Dependent on https://github.com/mailpoet/mailpoet/pull/4660

## Linked tickets

[MAILPOET-4926](https://mailpoet.atlassian.net/browse/MAILPOET-4926)



[MAILPOET-4926]: https://mailpoet.atlassian.net/browse/MAILPOET-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ