### PR TITLE
Prevent captcha audio to get out of sync when loaded range wise [MAILPOET-5032]

### DIFF
--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -74,9 +74,9 @@ jQuery(($) => {
     }
     const audioCaptchaSource = audioCaptcha.querySelector('source');
     let captchaSrc = captcha.getAttribute('src');
-    let hashPos = captchaSrc.indexOf('#');
+    let hashPos = captchaSrc.indexOf('&cachebust=');
     let newSrc = hashPos > 0 ? captchaSrc.substring(0, hashPos) : captchaSrc;
-    captcha.setAttribute('src', `${newSrc}#${new Date().getTime()}`);
+    captcha.setAttribute('src', `${newSrc}&cachebust=${new Date().getTime()}`);
 
     captchaSrc = audioCaptchaSource.getAttribute('src');
     hashPos = captchaSrc.indexOf('&cachebust=');

--- a/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
@@ -23,7 +23,7 @@ class CaptchaRenderer {
   public function renderAudio($sessionId, $return = false) {
 
     $audioPath = Env::$assetsPath . '/audio/';
-    $phrase = $this->phrase->getPhraseForType('audio', $sessionId);
+    $phrase = $this->phrase->getPhraseForType($this->determineAudioType(), $sessionId);
     $audio = null;
     foreach (str_split($phrase) as $character) {
       $file = $audioPath . strtolower($character) . '.mp3';
@@ -43,6 +43,14 @@ class CaptchaRenderer {
     //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPressDotOrg.sniffs.OutputEscaping.UnescapedOutputParameter
     echo $audio;
     exit;
+  }
+
+  private function determineAudioType(): string {
+    $type = 'audio';
+    if (isset($_SERVER['HTTP_RANGE'])) {
+      $type .= '-range-' . sanitize_text_field(wp_unslash($_SERVER['HTTP_RANGE']));
+    }
+    return $type;
   }
 
   public function renderImage($width = null, $height = null, $sessionId = null, $return = false) {

--- a/mailpoet/lib/Subscription/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Subscription/CaptchaFormRenderer.php
@@ -123,7 +123,7 @@ class CaptchaFormRenderer {
     $playIcon = Env::$assetsUrl . '/img/icons/controls-volumeon.svg';
     $formHtml .= '<div class="mailpoet_form_hide_on_success">';
     $formHtml .= '<p class="mailpoet_paragraph">';
-    $formHtml .= '<img class="mailpoet_captcha" src="' . $captchaUrl . '" width="' . $width . '" height="' . $height . '" title="' . esc_attr__('Click to refresh the CAPTCHA', 'mailpoet') . '" />';
+    $formHtml .= '<img class="mailpoet_captcha" src="' . $captchaUrl . '" width="' . $width . '" height="' . $height . '" title="' . esc_attr__('CAPTCHA', 'mailpoet') . '" />';
     $formHtml .= '</p>';
     $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_update" title="' . esc_attr(__('Reload CAPTCHA', 'mailpoet')) . '"><img src="' . $reloadIcon . '" alt="" /></button>';
     $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_audio" title="' . esc_attr(__('Play CAPTCHA', 'mailpoet')) . '"><img src="' . $playIcon . '" alt="" /></button>';

--- a/mailpoet/tests/integration/Subscription/Captcha/CaptchaRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/Captcha/CaptchaRendererTest.php
@@ -69,6 +69,22 @@ class CaptchaRendererTest extends \MailPoetTest {
   }
 
   /**
+   * We need to ensure that a new captcha phrase is created when reloading
+   */
+  public function testItDoesNotChangeCaptchaWhenAudioRangeHeaderChanges() {
+    $this->session->init();
+    $sessionId = $this->session->getId();
+    $fistAudio = $this->testee->renderAudio($sessionId, true);
+    $firstCaptcha = $this->session->getCaptchaHash();
+    $_SERVER['HTTP_RANGE'] = 'bytes:0-1';
+    $secondAudio = $this->testee->renderAudio($sessionId, true);
+    $secondCaptcha = $this->session->getCaptchaHash();
+    unset($_SERVER['HTTP_RANGE']);
+    expect($fistAudio)->Equals($secondAudio);
+    expect($firstCaptcha['phrase'])->Equals($secondCaptcha['phrase']);
+  }
+
+  /**
    * We need to make sure that the audio presented to a listener plays the same captcha
    * the image shows.
    */


### PR DESCRIPTION
## Description
In Safari the build in captcha does not always work. The reason is that Safari sends three requests to load the captcha
* 1 normal request for the image
* 1 request where it just requests the first byte of the audio
* 1 request where it requests the whole audio

This broke the logic when to create a new captcha phrase. This PR fixes this issue.

A second issue was discovered where the reload button would not properly work in Safari. This PR fixes also this issue.

## QA notes
I was able to reproduce the issues on Mac Ventura and Safari 16

## Linked tickets

[MAILPOET-5032]

[MAILPOET-5032]: https://mailpoet.atlassian.net/browse/MAILPOET-5032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ