### PR TITLE
Fix flaky MailerLog test [MAILPOET-4866]

### DIFF
--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -109,12 +109,13 @@ class MailerLogTest extends \MailPoetTest {
         'interval' => 1,
       ],
     ];
-    $inCurrenTimeFrame = time() - 60;
-    $outdated = $inCurrenTimeFrame - 1;
+    $currentTimeframeBorder = time() - 60;
+    $outdated = $currentTimeframeBorder - 1;
+    $notOutdated = $currentTimeframeBorder + 1;
     $mailerLog = [
       'sent' => [
         date('Y-m-d H:i:s', $outdated) => 2,
-        date('Y-m-d H:i:s', $inCurrenTimeFrame) => 10,
+        date('Y-m-d H:i:s', $notOutdated) => 10,
       ],
       'started' => $outdated,
       'error' => null,


### PR DESCRIPTION
## Description

The test was setting the tested value to the very edge of the allowed interval. So if the tested method was executed, a second later test failed. I set the tested value a second before the end of the interval, so there should be enough time for the method to run with the expected outcome.

Alternatively, we could mock time, but that would require refactoring the mailer log to use Carbon. So I went with this simple solution.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4866]

## After-merge notes

_N/A_


[MAILPOET-4866]: https://mailpoet.atlassian.net/browse/MAILPOET-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ