### PR TITLE
Create integration docker containers prior running tests [MAILPOET-4947]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,6 +525,12 @@ jobs:
           # Pull docker images with 3 retries
           command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - run:
+          name: Create docker containers for test
+          # We experienced some failures when creating containers so we do it explicitly with one retry
+          command: |
+            cd tests/docker
+            docker-compose create || docker-compose create
+      - run:
           name: 'PHP Integration tests'
           command: |
             mkdir -m 777 -p tests/_output/exceptions


### PR DESCRIPTION
## Description
This fixes the occasional issue with  `Error response from daemon: Conflict. The container name "/wordpress_0".`.
We already use the same workaround in acceptance tests, and it fixed the issue.

## Code review notes

_N/A_

## QA notes

This only relates to tests configuration on Circle CI.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4947]

## After-merge notes

_N/A_


[MAILPOET-4947]: https://mailpoet.atlassian.net/browse/MAILPOET-4947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ