### PR TITLE
Remove currency from the Woo Tracker data [MAILPOET-5037]

### DIFF
--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -38,7 +38,6 @@ class Tracker {
       $analyticsData = $this->newslettersRepository->getAnalytics();
       $data['extensions']['mailpoet'] = [
         'campaigns_count' => $analyticsData['campaigns_count'],
-        'currency' => $currency,
       ];
       $campaignData = $this->formatCampaignsData($this->wooPurchasesRepository->getRevenuesByCampaigns($currency));
       $data['extensions']['mailpoet'] = array_merge($data['extensions']['mailpoet'], $campaignData);

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -41,7 +41,6 @@ class TrackerTest extends \MailPoetTest {
     $data = $this->tracker->addTrackingData(['extensions' => []]);
     expect($data['extensions']['mailpoet'])->notEmpty();
     expect($data['extensions']['mailpoet']['campaigns_count'])->notNull();
-    expect($data['extensions']['mailpoet']['currency'])->notNull();
   }
 
   public function testItAddsCampaignRevenuesForStandardNewsletters(): void {


### PR DESCRIPTION
## Description

In https://github.com/mailpoet/mailpoet/pull/4665 I added revenue data tracking. Later I found that we don't need to track the currency because it is already covered by the basic data tracked by the Woo core. This PR removes the redundant currency data.

## Code review notes

_N/A_

## QA notes

There are no user-facing changes.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/4665

## Linked tickets

[MAILPOET-5037]

## After-merge notes

_N/A_


[MAILPOET-5037]: https://mailpoet.atlassian.net/browse/MAILPOET-5037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ