### PR TITLE
Fix failing test due to a changed DMARC policy [MAILPOET-5038]

### DIFF
--- a/mailpoet/tests/integration/Util/DmarcPolicyCheckerTest.php
+++ b/mailpoet/tests/integration/Util/DmarcPolicyCheckerTest.php
@@ -19,11 +19,6 @@ class DmarcPolicyCheckerTest extends \MailPoetTest {
   }
 
   public function testItReturnsQuarantineStatus() {
-    $domain = 'automattic.com'; // quarantine
-    $result = $this->dmarcPolicyChecker->getDomainDmarcPolicy($domain);
-    expect($result)->equals(DmarcPolicyChecker::POLICY_QUARANTINE);
-
-    // testing with mailpoet.com
     $domain = 'mailpoet.com'; // quarantine
     $result = $this->dmarcPolicyChecker->getDomainDmarcPolicy($domain);
     expect($result)->equals(DmarcPolicyChecker::POLICY_QUARANTINE);
@@ -31,6 +26,10 @@ class DmarcPolicyCheckerTest extends \MailPoetTest {
 
   public function testItReturnsRejectStatus() {
     $domain = 'google.com'; // reject
+    $result = $this->dmarcPolicyChecker->getDomainDmarcPolicy($domain);
+    expect($result)->equals(DmarcPolicyChecker::POLICY_REJECT);
+
+    $domain = 'automattic.com'; // reject
     $result = $this->dmarcPolicyChecker->getDomainDmarcPolicy($domain);
     expect($result)->equals(DmarcPolicyChecker::POLICY_REJECT);
   }


### PR DESCRIPTION
## Description

It seems that the DMARC policy for automattic.com was changed from "quarantine" to "reject". I updated the test to reflect that.

## Code review notes

Fix in tests only; we can skip QA.

## QA notes

Fix in tests only; we can skip QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5038]

## After-merge notes

_N/A_


[MAILPOET-5038]: https://mailpoet.atlassian.net/browse/MAILPOET-5038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ