### PR TITLE
Add new test Settings basics

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import { wpLogin } from './tests/wp-login.js';
 import { newsletterListing } from './tests/newsletter-listing.js';
 import { subscribersListing } from './tests/subscribers-listing.js';
+import { settingsBasic } from './tests/settings-basic.js';
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
@@ -12,12 +12,12 @@ import { scenario } from './config.js';
 export let options = {
   scenarios: {},
   thresholds: {
-    browser_dom_content_loaded: ['p(95) < 1000'],
-    browser_first_contentful_paint: ['max < 1000'],
-    browser_first_meaningful_paint: ['max < 2000'],
-    browser_first_paint: ['max < 1000'],
-    browser_loaded: ['p(95) < 2000'],
-    http_req_duration: ['p(95) < 1500'],
+    browser_dom_content_loaded: ['p(95) < 2000'],
+    browser_first_contentful_paint: ['max < 2000'],
+    browser_first_meaningful_paint: ['max < 3000'],
+    browser_first_paint: ['max < 2000'],
+    browser_loaded: ['p(95) < 3000'],
+    http_req_duration: ['p(95) < 2500'],
     checks: ['rate==1.0'],
   },
   tags: {
@@ -31,7 +31,7 @@ let scenarios = {
     executor: 'per-vu-iterations',
     vus: 1,
     iterations: 1,
-    maxDuration: '1m',
+    maxDuration: '2m',
     exec: 'pullRequests',
   },
   nightlytests: {
@@ -56,13 +56,12 @@ if (scenario) {
 export function pullRequests() {
   newsletterListing();
   subscribersListing();
+  settingsBasic();
 }
 
 // All the tests ran for a nightly testing
 export function nightly() {
-  wpLogin();
-  newsletterListing();
-  subscribersListing();
+  // TBD
 }
 
 // HTML report data saved in performance folder

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
@@ -11,7 +12,7 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
  * Internal dependencies
  */
 import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
-import { login } from '../utils/helpers.js';
+import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function newsletterListing() {
@@ -25,7 +26,7 @@ export function newsletterListing() {
       })
 
       .then(() => {
-        login(page);
+        authenticate(page);
       })
 
       .then(() => {
@@ -51,6 +52,6 @@ export function newsletterListing() {
   sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
 }
 
-export function newsletterListingTest() {
+export default function newsletterListingTest() {
   newsletterListing();
 }

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -15,15 +15,15 @@ import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
-export function subscribersListing() {
+export function settingsBasic() {
   const browser = chromium.launch({ headless: headlessSet });
   const page = browser.newPage();
 
   group(
-    'Subscribers - Load all subscribers',
-    function subscribersLoadAllSusbcribers() {
+    'Settings - Load and save the basics tab',
+    function settingsBasicTabSaving() {
       page
-        .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+        .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-settings#/basics`, {
           waitUntil: 'networkidle',
         })
 
@@ -39,15 +39,24 @@ export function subscribersListing() {
 
         .then(() => {
           check(page, {
-            'subscribers filter is visible': page
-              .locator('[data-automation-id="listing_filter_segment"]')
+            'basics tab is visible': page
+              .locator('[data-automation-id="basic_settings_tab"]')
               .isVisible(),
-            'subscribers tag is visible': page
-              .locator('[data-automation-id="listing_filter_tag"]')
-              .isVisible(),
-            'subscribers listing is visible': page
-              .locator('table.mailpoet-listing-table')
-              .isVisible(),
+          });
+        })
+
+        .then(() => {
+          return Promise.all([
+            page.waitForNavigation(),
+            page
+              .locator('[data-automation-id="settings-submit-button"]')
+              .click(),
+          ]);
+        })
+
+        .then(() => {
+          check(page, {
+            'settings saved is visible': page.locator('div.notice').isVisible(),
           });
         })
 
@@ -61,6 +70,6 @@ export function subscribersListing() {
   sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
 }
 
-export default function subscribersListingTest() {
-  subscribersListing();
+export default function settingsBasicTest() {
+  settingsBasic();
 }

--- a/mailpoet/tests/performance/tests/wp-login.js
+++ b/mailpoet/tests/performance/tests/wp-login.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
@@ -11,7 +12,7 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
  * Internal dependencies
  */
 import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
-import { login } from '../utils/helpers.js';
+import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function wpLogin() {
@@ -23,7 +24,7 @@ export function wpLogin() {
       .goto(`${baseURL}/wp-login.php`, { waitUntil: 'networkidle' })
 
       .then(() => {
-        login(page);
+        authenticate(page);
       })
 
       .then(() => {
@@ -48,6 +49,6 @@ export function wpLogin() {
   sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
 }
 
-export function wpLoginTest() {
+export default function wpLoginTest() {
   wpLogin();
 }

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
 /**
  * Internal dependencies
  */
@@ -7,10 +8,13 @@ import { adminUsername, adminPassword } from '../config.js';
 /* global Promise */
 
 // WordPress login authorization
-export function login(page) {
+export function authenticate(page) {
   // Enter login credentials and login
-  page.locator('input[name="log"]').type(`${adminUsername}`);
-  page.locator('input[name="pwd"]').type(`${adminPassword}`);
+  Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle' }),
+    page.locator('input[name="log"]').type(`${adminUsername}`),
+    page.locator('input[name="pwd"]').type(`${adminPassword}`),
+  ]);
   // Wait for asynchronous operations to complete
   return Promise.all([
     page.waitForNavigation(),

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -10,11 +10,9 @@ import { adminUsername, adminPassword } from '../config.js';
 // WordPress login authorization
 export function authenticate(page) {
   // Enter login credentials and login
-  Promise.all([
-    page.waitForNavigation({ waitUntil: 'networkidle' }),
-    page.locator('input[name="log"]').type(`${adminUsername}`),
-    page.locator('input[name="pwd"]').type(`${adminPassword}`),
-  ]);
+  page.waitForNavigation({ waitUntil: 'networkidle' });
+  page.locator('input[name="log"]').type(`${adminUsername}`);
+  page.locator('input[name="pwd"]').type(`${adminPassword}`);
   // Wait for asynchronous operations to complete
   return Promise.all([
     page.waitForNavigation(),


### PR DESCRIPTION
## Description

Adding a new test for covering Settings - Basics saving only

## Code review notes

Additionally some changes:
- added `default` to tests so they can be run individually.
- renamed `login` to `authenticate`, as this was a more standard name for what the function does.
- deleted tests from the `nightly` scenario, will be `// TBD` for now
- increased timing for the tests, this will be configured at the end of the project, we don't know the exact time wanted atm.

Executing tests locally is not set yet properly (no data to test against). However, executing against `qawp.net` site is possible, so please ping me if you'd like to test that way.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4960](https://mailpoet.atlassian.net/browse/MAILPOET-4960)


[MAILPOET-4960]: https://mailpoet.atlassian.net/browse/MAILPOET-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ