### PR TITLE
Update woocommerce-stubs to version 7.3.0

### DIFF
--- a/mailpoet/tasks/phpstan/composer.json
+++ b/mailpoet/tasks/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php-stubs/woocommerce-stubs": "^7.0",
+    "php-stubs/woocommerce-stubs": "7.3.0",
     "phpstan/phpstan": "1.4.10",
     "phpstan/phpstan-doctrine": "1.2.11",
     "phpstan/phpstan-phpunit": "1.0.0",

--- a/mailpoet/tasks/phpstan/composer.lock
+++ b/mailpoet/tasks/phpstan/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v7.0.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "2bbe0ba67081cfad17d33ac503883fdc6e68a386"
+                "reference": "446c335118632e00854b9ada74319b200e5c78a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/2bbe0ba67081cfad17d33ac503883fdc6e68a386",
-                "reference": "2bbe0ba67081cfad17d33ac503883fdc6e68a386",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/446c335118632e00854b9ada74319b200e5c78a2",
+                "reference": "446c335118632e00854b9ada74319b200e5c78a2",
                 "shasum": ""
             },
             "require": {
@@ -46,9 +46,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.0.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.3.0"
             },
-            "time": "2022-10-12T08:25:57+00:00"
+            "time": "2023-01-13T00:24:42+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",


### PR DESCRIPTION
## Description

This PR simply updates the version of woocommerce-stubs used in MailPoet. The ticket mentions a problem when attempting a previous update, but I believe that was already fixed by @costasovo in cdcdfb135c70522cd2fa4b99105c7a8ddfd7d0fd. The ignored errors were already removed from the phpstan.neon file and the CircleCI build passed. The link to the CircleCI build that failed when the ticket was created is not available anymore so I don't think there is a way for us to know what was the error, but it seems it is not happening anymore.

## Code review notes

IMHO, this PR does not need QA and can be merged directly by the reviewer.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4313]

## After-merge notes

_N/A_


[MAILPOET-4313]: https://mailpoet.atlassian.net/browse/MAILPOET-4313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ