### PR TITLE
Switch languages test fix attempt [MAILPOET-4979]

### DIFF
--- a/mailpoet/lib/Config/TranslationUpdater.php
+++ b/mailpoet/lib/Config/TranslationUpdater.php
@@ -89,8 +89,14 @@ class TranslationUpdater {
     $rawResponse = $this->wpFunctions->getTransient($cacheKey);
     if (!$rawResponse) {
       $rawResponse = $this->fetchApiResponse($requestBody);
-      // Don't continue when API request failed.
       $responseCode = $this->wpFunctions->wpRemoteRetrieveResponseCode($rawResponse);
+      // Wait a couple of seconds and retry when 429 is returned.
+      if ($responseCode === 429) {
+        sleep(2);
+        $rawResponse = $this->fetchApiResponse($requestBody);
+        $responseCode = $this->wpFunctions->wpRemoteRetrieveResponseCode($rawResponse);
+      }
+      // Don't continue when API request failed.
       if ($responseCode !== 200) {
         $this->logError("MailPoet: Failed to fetch translations from WordPress.com API with $responseCode and response message: " . $this->wpFunctions->wpRemoteRetrieveResponseMessage($rawResponse));
         return [];


### PR DESCRIPTION
## Description
In this PR, I refactored caching of responses from the translations API. The response is now cached in the transient, so it will persist for multiple site requests.
I also added a simple retry mechanism in case there is a 429 error.

## Code review notes

_N/A_

## QA notes
Please test translations are downloaded.

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-4979]

## After-merge notes

_N/A_


[MAILPOET-4979]: https://mailpoet.atlassian.net/browse/MAILPOET-4979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ