### PR TITLE
Update form template "Relax" definition to display correctly  [MAILPOET-5047]

### DIFF
--- a/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
@@ -79,74 +79,42 @@ class Template7Popup extends FormTemplate {
         'name' => 'Divider',
       ],
       [
-        'type' => 'columns',
-        'body' => [
-          [
-            'type' => 'column',
-            'params' => [
-              'class_name' => '',
-              'vertical_alignment' => '',
-              'width' => '50',
-            ],
-            'body' => [
-              [
-                'type' => 'text',
-                'params' => [
-                  'label' => _x('Email Address', 'Form label', 'mailpoet'),
-                  'class_name' => '',
-                  'required' => '1',
-                  'label_within' => '1',
-                ],
-                'id' => 'email',
-                'name' => 'Email',
-                'styles' => [
-                  'full_width' => '1',
-                  'bold' => '0',
-                  'background_color' => '#ffffff',
-                  'font_color' => '#abb8c3',
-                  'border_size' => '0',
-                  'border_radius' => '6',
-                ],
-              ],
-            ],
-          ],
-          [
-            'type' => 'column',
-            'params' => [
-              'class_name' => '',
-              'vertical_alignment' => '',
-              'width' => '50',
-            ],
-            'body' => [
-              [
-                'type' => 'submit',
-                'params' => [
-                  'label' => _x('Get the latest deals', 'Form label', 'mailpoet'),
-                  'class_name' => '',
-                ],
-                'id' => 'submit',
-                'name' => 'Submit',
-                'styles' => [
-                  'full_width' => '1',
-                  'bold' => '1',
-                  'gradient' => 'linear-gradient(180deg,rgb(0,159,251) 0%,rgb(29,123,164) 100%)',
-                  'font_size' => '24',
-                  'font_color' => '#ffffff',
-                  'border_size' => '1',
-                  'border_radius' => '6',
-                  'padding' => '12',
-                  'font_family' => 'Cairo',
-                ],
-              ],
-            ],
-          ],
-        ],
+        'type' => 'text',
         'params' => [
-          'vertical_alignment' => '',
+          'label' => _x('Email Address', 'Form label', 'mailpoet'),
           'class_name' => '',
-          'text_color' => '',
-          'background_color' => '',
-          'gradient' => '',
+          'required' => '1',
+          'label_within' => '1',
+        ],
+        'id' => 'email',
+        'name' => 'Email',
+        'styles' => [
+          'full_width' => '1',
+          'bold' => '0',
+          'background_color' => '#ffffff',
+          'font_color' => '#abb8c3',
+          'border_size' => '0',
+          'border_radius' => '6',
+        ],
+      ],
+      [
+        'type' => 'submit',
+        'params' => [
+          'label' => _x('Get the latest deals', 'Form label', 'mailpoet'),
+          'class_name' => '',
+        ],
+        'id' => 'submit',
+        'name' => 'Submit',
+        'styles' => [
+          'full_width' => '1',
+          'bold' => '1',
+          'gradient' => 'linear-gradient(180deg,rgb(0,159,251) 0%,rgb(29,123,164) 100%)',
+          'font_size' => '24',
+          'font_color' => '#ffffff',
+          'border_size' => '1',
+          'border_radius' => '6',
+          'padding' => '12',
+          'font_family' => 'Cairo',
         ],
       ],
       [

--- a/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
@@ -79,74 +79,42 @@ class Template7SlideIn extends FormTemplate {
         'name' => 'Divider',
       ],
       [
-        'type' => 'columns',
-        'body' => [
-          [
-            'type' => 'column',
-            'params' => [
-              'class_name' => '',
-              'vertical_alignment' => '',
-              'width' => '50',
-            ],
-            'body' => [
-              [
-                'type' => 'text',
-                'params' => [
-                  'label' => _x('Email Address', 'Form label', 'mailpoet'),
-                  'class_name' => '',
-                  'required' => '1',
-                  'label_within' => '1',
-                ],
-                'id' => 'email',
-                'name' => 'Email',
-                'styles' => [
-                  'full_width' => '1',
-                  'bold' => '0',
-                  'background_color' => '#ffffff',
-                  'font_color' => '#abb8c3',
-                  'border_size' => '0',
-                  'border_radius' => '6',
-                ],
-              ],
-            ],
-          ],
-          [
-            'type' => 'column',
-            'params' => [
-              'class_name' => '',
-              'vertical_alignment' => '',
-              'width' => '50',
-            ],
-            'body' => [
-              [
-                'type' => 'submit',
-                'params' => [
-                  'label' => _x('Get the latest deals', 'Form label', 'mailpoet'),
-                  'class_name' => '',
-                ],
-                'id' => 'submit',
-                'name' => 'Submit',
-                'styles' => [
-                  'full_width' => '1',
-                  'bold' => '1',
-                  'gradient' => 'linear-gradient(180deg,rgb(0,159,251) 2%,rgb(29,123,164) 100%)',
-                  'font_size' => '24',
-                  'font_color' => '#ffffff',
-                  'border_size' => '1',
-                  'border_radius' => '6',
-                  'padding' => '12',
-                  'font_family' => 'Cairo',
-                ],
-              ],
-            ],
-          ],
-        ],
+        'type' => 'text',
         'params' => [
-          'vertical_alignment' => '',
+          'label' => _x('Email Address', 'Form label', 'mailpoet'),
           'class_name' => '',
-          'text_color' => '',
-          'background_color' => '',
-          'gradient' => '',
+          'required' => '1',
+          'label_within' => '1',
+        ],
+        'id' => 'email',
+        'name' => 'Email',
+        'styles' => [
+          'full_width' => '1',
+          'bold' => '0',
+          'background_color' => '#ffffff',
+          'font_color' => '#abb8c3',
+          'border_size' => '0',
+          'border_radius' => '6',
+        ],
+      ],
+      [
+        'type' => 'submit',
+        'params' => [
+          'label' => _x('Get the latest deals', 'Form label', 'mailpoet'),
+          'class_name' => '',
+        ],
+        'id' => 'submit',
+        'name' => 'Submit',
+        'styles' => [
+          'full_width' => '1',
+          'bold' => '1',
+          'gradient' => 'linear-gradient(180deg,rgb(0,159,251) 2%,rgb(29,123,164) 100%)',
+          'font_size' => '24',
+          'font_color' => '#ffffff',
+          'border_size' => '1',
+          'border_radius' => '6',
+          'padding' => '12',
+          'font_family' => 'Cairo',
         ],
       ],
       [


### PR DESCRIPTION
## Description

This PR updates the form template data for popup and slide-in  "Relax" forms so that they display as advertised on screenshots

## Code review notes

The diff looks a bit strange. I just removed the columns block that was wrapping the input, and the submit button block and moved them to the top level.

## QA notes
You can verify by creating a pop-up form and slide-in form using the "Relax" template.

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-5047]

## After-merge notes

_N/A_


[MAILPOET-5047]: https://mailpoet.atlassian.net/browse/MAILPOET-5047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ