### PR TITLE
Run workflow multiple times per subscriber [MAILPOET-4966]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/edit/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/edit/index.tsx
@@ -1,5 +1,11 @@
 import { ListPanel } from './list_panel';
+import { RunOnlyOncePanel } from '../../../../shared/run-only-once-panel';
 
 export function Edit(): JSX.Element {
-  return <ListPanel />;
+  return (
+    <>
+      <RunOnlyOncePanel />
+      <ListPanel />
+    </>
+  );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/index.tsx
@@ -1,5 +1,11 @@
 import { RolePanel } from './role_panel';
+import { RunOnlyOncePanel } from '../../../../shared/run-only-once-panel';
 
 export function Edit(): JSX.Element {
-  return <RolePanel />;
+  return (
+    <>
+      <RunOnlyOncePanel />
+      <RolePanel />
+    </>
+  );
 }

--- a/mailpoet/assets/js/src/automation/integrations/shared/run-only-once-panel/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/shared/run-only-once-panel/index.tsx
@@ -1,0 +1,35 @@
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { dispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { storeName } from '../../../editor/store';
+import { PlainBodyTitle } from '../../../editor/components';
+
+export function RunOnlyOncePanel(): JSX.Element {
+  const { selectedStep } = useSelect(
+    (select) => ({
+      selectedStep: select(storeName).getSelectedStep(),
+    }),
+    [],
+  );
+  const checked: boolean = selectedStep.args?.run_multiple_times as boolean;
+  return (
+    <PanelBody opened>
+      <PlainBodyTitle title={__('Automation setting', 'mailpoet')} />
+
+      <ToggleControl
+        label={__(
+          'A subscriber can enter this automation multiple times.',
+          'mailpoet',
+        )}
+        checked={checked}
+        onChange={(value) => {
+          dispatch(storeName).updateStepArgs(
+            selectedStep.id,
+            'run_multiple_times',
+            value,
+          );
+        }}
+      />
+    </PanelBody>
+  );
+}

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -61,7 +61,13 @@ class TriggerHandler {
         $entry->getPayload();
       }
 
-      $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);
+      $automationRun = new AutomationRun(
+        $automation->getId(),
+        $automation->getVersionId(),
+        $trigger->getKey(),
+        $subjects,
+        $trigger->getSubjectHash($subjectEntries)
+      );
       if (!$trigger->isTriggeredBy(new StepRunArgs($automation, $automationRun, $step, $subjectEntries))) {
         continue;
       }

--- a/mailpoet/lib/Automation/Engine/Data/AutomationRun.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationRun.php
@@ -35,6 +35,8 @@ class AutomationRun {
   /** @var Subject[] */
   private $subjects;
 
+  private $subjectHash;
+
   /**
    * @param Subject[] $subjects
    */
@@ -43,12 +45,14 @@ class AutomationRun {
     int $versionId,
     string $triggerKey,
     array $subjects,
+    string $subjectHash = '',
     int $id = null
   ) {
     $this->automationId = $automationId;
     $this->versionId = $versionId;
     $this->triggerKey = $triggerKey;
     $this->subjects = $subjects;
+    $this->subjectHash = $subjectHash;
 
     if ($id) {
       $this->id = $id;
@@ -87,6 +91,10 @@ class AutomationRun {
     return $this->updatedAt;
   }
 
+  public function getSubjectHash(): string {
+    return $this->subjectHash;
+  }
+
   /** @return Subject[] */
   public function getSubjects(string $key = null): array {
     if ($key) {
@@ -112,6 +120,7 @@ class AutomationRun {
           return $subject->toArray();
         }, $this->subjects)
       ),
+      'subject_hash' => $this->subjectHash,
     ];
   }
 
@@ -126,6 +135,7 @@ class AutomationRun {
     );
     $automationRun->id = (int)$data['id'];
     $automationRun->status = $data['status'];
+    $automationRun->subjectHash = $data['subject_hash'];
     $automationRun->createdAt = new DateTimeImmutable($data['created_at']);
     $automationRun->updatedAt = new DateTimeImmutable($data['updated_at']);
     return $automationRun;

--- a/mailpoet/lib/Automation/Engine/Integration/Trigger.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Trigger.php
@@ -3,9 +3,16 @@
 namespace MailPoet\Automation\Engine\Integration;
 
 use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 
 interface Trigger extends Step {
   public function registerHooks(): void;
 
   public function isTriggeredBy(StepRunArgs $args): bool;
+
+  /**
+   * @param SubjectEntry<Subject<Payload>>[] $subjectEntries
+   * @return string
+   */
+  public function getSubjectHash(array $subjectEntries): string;
 }

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -28,6 +28,13 @@ class AutomationRunStorage {
     return $this->wpdb->insert_id;
   }
 
+  public function getAutomationRunByAutomationIdAndSubjectHash(int $automationId, string $hash): ?AutomationRun {
+    $table = esc_sql($this->table);
+    $query = (string)$this->wpdb->prepare("SELECT * FROM $table WHERE automation_id = %d AND subject_hash = %s", $automationId, $hash);
+    $result = $this->wpdb->get_row($query, ARRAY_A);
+    return $result ? AutomationRun::fromArray((array)$result) : null;
+  }
+
   public function getAutomationRun(int $id): ?AutomationRun {
     $table = esc_sql($this->table);
     $query = (string)$this->wpdb->prepare("SELECT * FROM $table WHERE id = %d", $id);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -14,7 +14,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\AutomationEmailScheduler;
-use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Validator\Builder;
@@ -30,9 +29,6 @@ class SendEmailAction implements Action {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
-  /** @var ScheduledTasksRepository */
-  private $scheduledTasksRepository;
-
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
@@ -42,13 +38,11 @@ class SendEmailAction implements Action {
   public function __construct(
     SettingsController $settings,
     NewslettersRepository $newslettersRepository,
-    ScheduledTasksRepository $scheduledTasksRepository,
     SubscriberSegmentRepository $subscriberSegmentRepository,
     AutomationEmailScheduler $automationEmailScheduler
   ) {
     $this->settings = $settings;
     $this->newslettersRepository = $newslettersRepository;
-    $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
     $this->automationEmailScheduler = $automationEmailScheduler;
   }
@@ -136,11 +130,6 @@ class SendEmailAction implements Action {
     $subscriberStatus = $subscriber->getStatus();
     if ($subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED) {
       throw InvalidStateException::create()->withMessage(sprintf("Cannot schedule a newsletter for subscriber ID '%s' because their status is '%s'.", $subscriberId, $subscriberStatus));
-    }
-
-    $previouslyScheduledNotification = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($newsletter, $subscriberId);
-    if (!empty($previouslyScheduledNotification)) {
-      throw InvalidStateException::create()->withMessage(sprintf("Subscriber ID '%s' was already scheduled to receive newsletter ID '%s'.", $subscriberId, $newsletter->getId()));
     }
 
     try {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Integration\Trigger;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SegmentPayload;
+use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Entities\SegmentEntity;
@@ -88,5 +89,15 @@ class SomeoneSubscribesTrigger implements Trigger {
     $triggerArgs = $args->getStep()->getArgs();
     $segmentIds = $triggerArgs['segment_ids'] ?? [];
     return !is_array($segmentIds) || !$segmentIds || in_array($segmentId, $segmentIds, true);
+  }
+
+  public function getSubjectHash(array $subjectEntries): string {
+    foreach ($subjectEntries as $entry) {
+      $payload = $entry->getPayload();
+      if ($payload instanceof SubscriberPayload) {
+        return SubscriberSubject::KEY . ':' . $payload->getId();
+      }
+    }
+    return '';
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/UserRegistrationTrigger.php
@@ -98,4 +98,14 @@ class UserRegistrationTrigger implements Trigger {
     $roles = $triggerArgs['roles'] ?? [];
     return !is_array($roles) || !$roles || count(array_intersect($user->roles, $roles)) > 0;
   }
+
+  public function getSubjectHash(array $subjectEntries): string {
+    foreach ($subjectEntries as $entry) {
+      $payload = $entry->getPayload();
+      if ($payload instanceof SubscriberPayload) {
+        return SubscriberSubject::KEY . ':' . $payload->getId();
+      }
+    }
+    return '';
+  }
 }

--- a/mailpoet/lib/Migrations/Migration_20230203_065303.php
+++ b/mailpoet/lib/Migrations/Migration_20230203_065303.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Migrator\Migration;
+
+class Migration_20230203_065303 extends Migration {
+  public function run(): void {
+
+    global $wpdb;
+    $tableName = $wpdb->prefix . 'mailpoet_automation_runs';
+    if ($this->columnExists($tableName, 'subject_hash')) {
+      return;
+    }
+    $this->connection->executeQuery("ALTER TABLE {$tableName} ADD `subject_hash` VARCHAR(191) NOT NULL DEFAULT '' AFTER `next_step_id`, ADD INDEX `subject_hash` (`subject_hash`);");
+  }
+}

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -44,7 +44,7 @@ parameters:
     - '/Call to method getName\(\) on an unknown class _generated\\([a-zA-Z])*Cookie/' # codeception generate incorrect return type in ../../tests/_support/_generated
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 6
+      count: 7
       path: ../../lib/Automation/Engine/Storage/AutomationRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -120,7 +120,7 @@ class IntegrationTester extends \Codeception\Actor {
     expect($date1->getTimestamp())->equals($date2->getTimestamp(), $delta);
   }
 
-  public function createAutomation(string $name, Step ...$steps): ?Automation {
+  public function createAutomation(string $name, Step ...$steps): Automation {
     $automationStorage = ContainerWrapper::getInstance()->get(AutomationStorage::class);
 
     if (!$steps) {
@@ -146,7 +146,12 @@ class IntegrationTester extends \Codeception\Actor {
     }
     $automation = new Automation($name, $stepsWithIds, wp_get_current_user());
     $automation->setStatus(Automation::STATUS_ACTIVE);
-    return $automationStorage->getAutomation($automationStorage->createAutomation($automation));
+    $id = $automationStorage->createAutomation($automation);
+    $automation = $automationStorage->getAutomation($id);
+    if (!$automation instanceof Automation) {
+      throw new \Exception("Automation could not be created.");
+    }
+    return $automation;
   }
 
   public function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -154,7 +154,7 @@ class IntegrationTester extends \Codeception\Actor {
     return $automation;
   }
 
-  public function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
+  public function createAutomationRun(Automation $automation, $subjects = []): AutomationRun {
     $trigger = array_filter($automation->getSteps(), function(Step $step): bool { return $step->getType() === Step::TYPE_TRIGGER;
 
     });
@@ -170,6 +170,11 @@ class IntegrationTester extends \Codeception\Actor {
       $subjects
     );
     $automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
-    return $automationRunStorage->getAutomationRun($automationRunStorage->createAutomationRun($automationRun));
+    $id = $automationRunStorage->createAutomationRun($automationRun);
+    $automationRun = $automationRunStorage->getAutomationRun($id);
+    if (!$automationRun instanceof AutomationRun) {
+      throw new \Exception("Automation run could not be created.");
+    }
+    return $automationRun;
   }
 }

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -2,8 +2,10 @@
 
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore;
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
 use MailPoet\DI\ContainerWrapper;
@@ -145,5 +147,24 @@ class IntegrationTester extends \Codeception\Actor {
     $automation = new Automation($name, $stepsWithIds, wp_get_current_user());
     $automation->setStatus(Automation::STATUS_ACTIVE);
     return $automationStorage->getAutomation($automationStorage->createAutomation($automation));
+  }
+
+  public function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
+    $trigger = array_filter($automation->getSteps(), function(Step $step): bool { return $step->getType() === Step::TYPE_TRIGGER;
+
+    });
+    $triggerKeys = array_map(function(Step $step): string { return $step->getKey();
+
+    }, $trigger);
+    $triggerKey = count($triggerKeys) > 0 ? current($triggerKeys) : '';
+
+    $automationRun = new AutomationRun(
+      $automation->getId(),
+      $automation->getVersionId(),
+      $triggerKey,
+      $subjects
+    );
+    $automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
+    return $automationRunStorage->getAutomationRun($automationRunStorage->createAutomationRun($automationRun));
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -44,7 +44,6 @@ class StepHandlerTest extends \MailPoetTest {
     $automation = $this->createAutomation();
     $steps = $automation->getSteps();
     $automationRun = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $automationRun);
 
     $currentStep = current($steps);
     $this->assertInstanceOf(Step::class, $currentStep);
@@ -79,7 +78,6 @@ class StepHandlerTest extends \MailPoetTest {
       $automation->setStatus($status);
       $this->automationStorage->updateAutomation($automation);
       $automationRun = $this->tester->createAutomationRun($automation);
-      $this->assertInstanceOf(AutomationRun::class, $automationRun);
       $error = null;
       try {
         $this->testee->handle(['automation_run_id' => $automationRun->getId(), 'step_id' => $currentStep->getId()]);
@@ -98,9 +96,7 @@ class StepHandlerTest extends \MailPoetTest {
   public function testAnDeactivatingAutomationBecomesDraftAfterLastRunIsExecuted() {
     $automation = $this->createAutomation();
     $automationRun1 = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $automationRun1);
     $automationRun2 = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $automationRun2);
     $automation->setStatus(Automation::STATUS_DEACTIVATING);
     $this->automationStorage->updateAutomation($automation);
 

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -42,7 +42,6 @@ class StepHandlerTest extends \MailPoetTest {
 
   public function testItDoesOnlyProcessActiveAndDeactivatingAutomations() {
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $steps = $automation->getSteps();
     $automationRun = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun);
@@ -98,7 +97,6 @@ class StepHandlerTest extends \MailPoetTest {
 
   public function testAnDeactivatingAutomationBecomesDraftAfterLastRunIsExecuted() {
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $automationRun1 = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun1);
     $automationRun2 = $this->tester->createAutomationRun($automation);
@@ -129,7 +127,7 @@ class StepHandlerTest extends \MailPoetTest {
     $this->assertSame(AutomationRun::STATUS_COMPLETE, $updatedautomationRun->getStatus());
   }
 
-  private function createAutomation(): ?Automation {
+  private function createAutomation(): Automation {
     $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
     $delay = $this->diContainer->get(DelayAction::class);
     return $this->tester->createAutomation(

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -132,14 +132,11 @@ class StepHandlerTest extends \MailPoetTest {
   private function createAutomation(): ?Automation {
     $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
     $delay = $this->diContainer->get(DelayAction::class);
-    $steps = [
-      'root' => new Step('root', Step::TYPE_ROOT, 'root', [], [new NextStep('someone-subscribes')]),
-      'someone-subscribes' => new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
-      'delay' => new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], []),
-    ];
-    $automation = new Automation('test', $steps, wp_get_current_user());
-    $automation->setStatus(Automation::STATUS_ACTIVE);
-    return $this->automationStorage->getAutomation($this->automationStorage->createAutomation($automation));
+    return $this->tester->createAutomation(
+      'test',
+      new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
+      new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], [])
+    );
   }
 
   private function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -44,7 +44,7 @@ class StepHandlerTest extends \MailPoetTest {
     $automation = $this->createAutomation();
     $this->assertInstanceOf(Automation::class, $automation);
     $steps = $automation->getSteps();
-    $automationRun = $this->createAutomationRun($automation);
+    $automationRun = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun);
 
     $currentStep = current($steps);
@@ -79,7 +79,7 @@ class StepHandlerTest extends \MailPoetTest {
     foreach ($invalidStati as $status) {
       $automation->setStatus($status);
       $this->automationStorage->updateAutomation($automation);
-      $automationRun = $this->createAutomationRun($automation);
+      $automationRun = $this->tester->createAutomationRun($automation);
       $this->assertInstanceOf(AutomationRun::class, $automationRun);
       $error = null;
       try {
@@ -99,9 +99,9 @@ class StepHandlerTest extends \MailPoetTest {
   public function testAnDeactivatingAutomationBecomesDraftAfterLastRunIsExecuted() {
     $automation = $this->createAutomation();
     $this->assertInstanceOf(Automation::class, $automation);
-    $automationRun1 = $this->createAutomationRun($automation);
+    $automationRun1 = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun1);
-    $automationRun2 = $this->createAutomationRun($automation);
+    $automationRun2 = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun2);
     $automation->setStatus(Automation::STATUS_DEACTIVATING);
     $this->automationStorage->updateAutomation($automation);
@@ -137,24 +137,6 @@ class StepHandlerTest extends \MailPoetTest {
       new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
       new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], [])
     );
-  }
-
-  private function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
-    $trigger = array_filter($automation->getSteps(), function(Step $step): bool { return $step->getType() === Step::TYPE_TRIGGER;
-
-    });
-    $triggerKeys = array_map(function(Step $step): string { return $step->getKey();
-
-    }, $trigger);
-    $triggerKey = count($triggerKeys) > 0 ? current($triggerKeys) : '';
-
-    $automationRun = new AutomationRun(
-      $automation->getId(),
-      $automation->getVersionId(),
-      $triggerKey,
-      $subjects
-    );
-    return $this->automationRunStorage->getAutomationRun($this->automationRunStorage->createAutomationRun($automationRun));
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Test\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
-use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
@@ -30,15 +29,9 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
     $this->testee = $this->diContainer->get(AutomationStatisticsStorage::class);
 
     $this->automations = [
-      $this->automationStorage->createAutomation(
-      new Automation('1', ['root' => new Step('root', Step::TYPE_ROOT, 'root', [], [])], new \WP_User(1))
-    ),
-      $this->automationStorage->createAutomation(
-      new Automation('2', ['root' => new Step('root', Step::TYPE_ROOT, 'root', [], [])], new \WP_User(1))
-    ),
-      $this->automationStorage->createAutomation(
-      new Automation('3', ['root' => new Step('root', Step::TYPE_ROOT, 'root', [], [])], new \WP_User(1))
-    ),
+      $this->tester->createAutomation('1')->getId(),
+      $this->tester->createAutomation('2')->getId(),
+      $this->tester->createAutomation('3')->getId(),
     ];
   }
 

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -181,6 +181,7 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
       'version_id' => $automation->getVersionId(),
       'trigger_key' => '',
       'subjects' => "[]",
+      'subject_hash' => 'hash',
       'id' => 0,
       'status' => $status,
       'created_at' => (new \DateTimeImmutable())->format(\DateTimeImmutable::W3C),

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
@@ -114,7 +114,6 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest {
         []
       )
     );
-    $this->assertInstanceOf(Automation::class, $automation);
 
     /** @var SomeoneSubscribesTrigger $testee */
     $testee = $this->diContainer->get(SomeoneSubscribesTrigger::class);

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
@@ -8,20 +8,38 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\SubscribersRepository;
 
 class SomeoneSubscribesTriggerTest extends \MailPoetTest {
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
   /** @var SegmentsRepository */
   private $segmentRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
 
   /** @var SegmentEntity[] */
   private $segments;
 
   public function _before() {
     $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
     $this->segments = [
       'segment_1' => $this->segmentRepository->createOrUpdate('Segment 1'),
       'segment_2' => $this->segmentRepository->createOrUpdate('Segment 2'),
@@ -80,9 +98,55 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest {
     ];
   }
 
+  /**
+   * @dataProvider dataForTestItObeysMultipleRunsSetting
+   */
+  public function testItObeysMultipleRunsSetting(bool $runMultipleTimes, int $expectedRuns) {
+    $automation = $this->tester->createAutomation('test',
+      new Step(
+        'trigger',
+        Step::TYPE_TRIGGER,
+        SomeoneSubscribesTrigger::KEY,
+        [
+          'segment_ids' => [],
+          'run_multiple_times' => $runMultipleTimes,
+        ],
+        []
+      )
+    );
+    $this->assertInstanceOf(Automation::class, $automation);
+
+    /** @var SomeoneSubscribesTrigger $testee */
+    $testee = $this->diContainer->get(SomeoneSubscribesTrigger::class);
+    $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+
+    $subscriber = new SubscriberEntity();
+    $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+    $subscriber->setEmail('test@mailpoet.com');
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+
+    $subscriberSegment1 = new SubscriberSegmentEntity($this->segments['segment_1'], $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
+    $subscriberSegment2 = new SubscriberSegmentEntity($this->segments['segment_2'], $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
+    $testee->handleSubscription($subscriberSegment1);
+    $this->assertCount(1, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+    $testee->handleSubscription($subscriberSegment2);
+    $this->assertCount($expectedRuns, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+  }
+
+  public function dataForTestItObeysMultipleRunsSetting(): array {
+    return [
+      'run_only_once' => [false, 1],
+      'run_more_often' => [true, 2],
+    ];
+  }
+
   public function _after() {
     $segmentIds = $this->getSegmentIds(array_keys($this->segments));
     $this->segmentRepository->bulkDelete($segmentIds);
+    $this->automationStorage->truncate();
+    $this->automationRunStorage->truncate();
+    $this->subscribersRepository->truncate();
   }
 
   private function getSegmentId(string $index): int {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
@@ -37,8 +37,18 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest {
 
     $testee = $this->diContainer->get(SomeoneSubscribesTrigger::class);
     $stepRunArgs = new StepRunArgs(
-      $this->make(Automation::class),
-      $this->make(AutomationRun::class),
+      $this->make(
+        Automation::class,
+        [
+          'getId' => 1,
+        ]
+      ),
+      $this->make(
+        AutomationRun::class,
+        [
+          'getSubjectHash' => 'hash',
+        ]
+      ),
       new Step('test-id', 'trigger', 'test:trigger', ['segment_ids' => $segmentIds], []),
       [
         new SubjectEntry(

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
@@ -177,7 +177,6 @@ class UserRegistrationTriggerTest extends \MailPoetTest {
         ],
         []
       ));
-    $this->assertInstanceOf(Automation::class, $automation);
     $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $this->userId]);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $subscriberSegment = $this->subscriberSegmentRepository->findOneBy(['subscriber' => $subscriber]);

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
@@ -9,6 +9,7 @@ use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\UserRegistrationTrigger;
@@ -63,7 +64,8 @@ class UserRegistrationTriggerTest extends \MailPoetTest {
     $wpMock = $this->createMock(Functions::class);
     $testee = new UserRegistrationTrigger(
       $wpMock,
-      $this->diContainer->get(SubscribersRepository::class)
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(AutomationRunStorage::class)
     );
 
     $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $this->userId]);
@@ -107,8 +109,18 @@ class UserRegistrationTriggerTest extends \MailPoetTest {
     $this->assertInstanceOf(SegmentEntity::class, $segment);
 
     $stepRunArgs = new StepRunArgs(
-      $this->make(Automation::class),
-      $this->make(AutomationRun::class),
+      $this->make(
+        Automation::class,
+        [
+          'getId' => 1,
+        ]
+      ),
+      $this->make(
+        AutomationRun::class,
+        [
+          'getSubjectHash' => 'hash',
+        ]
+      ),
       new Step('test-id', 'trigger', 'test:trigger', ['roles' => $roleSetting], []),
       [
         new SubjectEntry(

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -21,7 +21,6 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
     parent::_before();
     $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
     $automation = $this->tester->createAutomation('Testing automation');
-    $this->assertInstanceOf(Automation::class, $automation);
     $this->automation = $automation;
   }
 

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\REST\Automation\Automations;
 
 use MailPoet\Automation\Engine\Data\Automation;
-use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\REST\Automation\AutomationTest;
 
@@ -21,14 +20,7 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
   public function _before() {
     parent::_before();
     $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
-    $id = $this->automationStorage->createAutomation(
-      new Automation(
-        'Testing automation',
-        ['root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [])],
-        wp_get_current_user()
-      )
-    );
-    $automation = $this->automationStorage->getAutomation($id);
+    $automation = $this->tester->createAutomation('Testing automation');
     $this->assertInstanceOf(Automation::class, $automation);
     $this->automation = $automation;
   }

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepOrderRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepOrderRuleTest.php
@@ -10,8 +10,11 @@ use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\StepValidationArgs;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Integration\Action;
+use MailPoet\Automation\Engine\Integration\Payload;
+use MailPoet\Automation\Engine\Integration\Subject;
 use MailPoet\Automation\Engine\Integration\Trigger;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationWalker;
@@ -142,6 +145,14 @@ class ValidStepOrderRuleTest extends AutomationRuleTest {
 
       public function getArgsSchema(): ObjectSchema {
         return new ObjectSchema();
+      }
+
+      /**
+       * @param SubjectEntry<Subject<Payload>>[] $subjectEntries
+       * @return string
+       */
+      public function getSubjectHash(array $subjectEntries): string {
+        return '';
       }
 
       public function getSubjectKeys(): array {


### PR DESCRIPTION
## Description
Adds a small toggle to our two triggers which enables us to run an automation only once per subscriber:
![image](https://user-images.githubusercontent.com/6458412/216545721-559e4eeb-7211-4b5b-bd58-24b43871f829.png)


## Code review notes
1. I moved some helper functions in the IntegrationTester class. Seemed more appropriate there.
2. Do you think we should just remove the "previouslyScheduled"-check in SendEmail or check if - in case there is are previously scheduled emails if they are all send? I opted for removing it completely, but maybe there is a good reason for not sending the email a 2nd time when we haven't yet send the first one :thinking: 
3. I call the extra db column `subject_hash`but I do not actually hash the value, as I do not see a benefit in doing so. But currently I lack of a better name.

## QA notes

Check if  a subscriber gets an email multiple times when the setting of the trigger is accordingly and vice versa.

## Linked tickets
[MAILPOET-4966]

## After-merge notes

_N/A_


[MAILPOET-4966]: https://mailpoet.atlassian.net/browse/MAILPOET-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ