### PR TITLE
Show the MailPoet logo on the landing page - MAILPOET-5029

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_landingpage.scss
+++ b/mailpoet/assets/css/src/components-plugin/_landingpage.scss
@@ -1,6 +1,7 @@
 #mailpoet_landingpage_container {
   $content-padding: 32px 65px;
   $mobile-content-padding: 25px;
+  $landingpage-max-width: 1460px;
 
   .mailpoet-content-center {
     text-align: center;
@@ -129,6 +130,11 @@
         }
       }
     }
+  }
+
+  main {
+    margin: 0 auto;
+    max-width: $landingpage-max-width;
   }
 }
 

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -3,6 +3,7 @@ import { GlobalContext, useGlobalContextValue } from 'context/index.jsx';
 import { ErrorBoundary } from 'common';
 import { Background } from 'common/background/background';
 import { HideScreenOptions } from 'common/hide_screen_options/hide_screen_options';
+import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { Header } from './header';
 import { Footer } from './footer';
 import { Faq } from './faq';
@@ -13,6 +14,7 @@ function Landingpage() {
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <main>
         <HideScreenOptions />
+        <TopBarWithBeamer />
 
         <Background color="#fff" />
 


### PR DESCRIPTION


## Description

Show the MailPoet logo on the landing page

This will show the topbar (including the MailPoet logo) and set content max-width




## QA notes

You can access the page here: `wp-admin/admin.php?page=mailpoet-landingpage`

Check https://github.com/mailpoet/mailpoet/pull/4620 for more QA information 

## Linked tickets

[MAILPOET-5029](https://mailpoet.atlassian.net/browse/MAILPOET-5029)




[MAILPOET-5029]: https://mailpoet.atlassian.net/browse/MAILPOET-5029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ