### PR TITLE
Fix TinyMCE prefixing

### DIFF
--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -159,6 +159,11 @@ const baseConfig = {
               flags: 'g',
             },
             {
+              search: 'window\\.tinyMCE',
+              replace: 'window.mailpoetTinyMCE',
+              flags: 'g',
+            },
+            {
               search: 'tinymce\\.util',
               replace: 'window.mailpoetTinymce.util',
               flags: 'g',


### PR DESCRIPTION
## Description

TinyMCE is accessible on `window.tinyMCE`. This should be prefixed to `window.mailpoetTinyMCE`.

## Code review notes

_N/A_

## QA notes

Open the email editor, open browser dev console, and type in `window.tinyMCE`. It should be `undefined`.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5052]

## After-merge notes

_N/A_


[MAILPOET-5052]: https://mailpoet.atlassian.net/browse/MAILPOET-5052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ