### PR TITLE
Fix Codeception PHP 8.2 deprecation notices [MAILPOET-4872]

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -78,13 +78,15 @@
       "./tools/vendor/composer.phar --working-dir=tasks/code_sniffer install",
       "./tools/vendor/composer.phar --working-dir=tasks/phpstan install",
       "php ./tasks/fix-guzzle.php",
-      "php ./tasks/fix-php82-deprecations.php"
+      "php ./tasks/fix-php82-deprecations.php",
+      "php ./tasks/fix-php82-codeception.php"
     ],
     "post-install-cmd": [
       "./tools/vendor/composer.phar --working-dir=tasks/code_sniffer install",
       "./tools/vendor/composer.phar --working-dir=tasks/phpstan install",
       "php ./tasks/fix-guzzle.php",
-      "php ./tasks/fix-php82-deprecations.php"
+      "php ./tasks/fix-php82-deprecations.php",
+      "php ./tasks/fix-php82-codeception.php"
     ],
     "pre-autoload-dump": [
       "php ./tasks/fix-codeception-stub.php",

--- a/mailpoet/tasks/fix-php82-codeception.php
+++ b/mailpoet/tasks/fix-php82-codeception.php
@@ -1,0 +1,59 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+// throw exception if anything fails
+set_error_handler(function ($severity, $message, $file, $line) {
+  throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+// Fixes for PHP8.2 Compatibility
+
+$codeceptionStepReplacement = <<<'CODE'
+$parentClass = get_parent_class($argument);
+            $reflection = new \ReflectionClass($argument);
+
+            if ($parentClass !== false) {
+                return $this->formatClassName($parentClass);
+            }
+
+            $interfaces = $reflection->getInterfaceNames();
+            foreach ($interfaces as $interface) {
+                if (str_starts_with($interface, 'PHPUnit\\')) {
+                    continue;
+                }
+                if (str_starts_with($interface, 'Codeception\\')) {
+                    continue;
+                }
+                return $this->formatClassName($interface);
+            }
+CODE;
+
+// Development packages
+$replacements = [
+  [
+    'file' => __DIR__ . '/../vendor/codeception/stub/src/Stub.php',
+    'find' => [
+      '  $mock->__mocked = $reflection->getName();',
+    ],
+    'replace' => [
+      '  //$mock->__mocked = $reflection->getName();',
+    ],
+  ],
+  [
+    'file' => __DIR__ . '/../vendor/codeception/codeception/src/Codeception/Step.php',
+    'find' => [
+      '} elseif ($argument instanceof MockObject && isset($argument->__mocked)) {',
+      'return $this->formatClassName($argument->__mocked);',
+    ],
+    'replace' => [
+      '} elseif ($argument instanceof MockObject) {',
+      $codeceptionStepReplacement,
+    ],
+  ],
+];
+
+// Apply replacements
+foreach ($replacements as $singleFile) {
+  $data = file_get_contents($singleFile['file']);
+  $data = str_replace($singleFile['find'], $singleFile['replace'], $data);
+  file_put_contents($singleFile['file'], $data);
+}

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -98,7 +98,7 @@ class AbandonedCartTest extends \MailPoetTest {
     $this->wp = $wp;
     WPFunctions::set($this->wp);
 
-    $this->automaticEmailScheduler = $this->getServiceWithOverrides(AutomaticEmailScheduler::class, ['wp' => $this->wp]);
+    $this->automaticEmailScheduler = $this->diContainer->get(AutomaticEmailScheduler::class);
 
     $this->wooCommerceCartMock = $this->mockWooCommerceClass(WC_Cart::class, ['is_empty', 'get_cart']);
     $this->cartBackup = $this->wooCommerce->cart;

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -82,6 +82,8 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 
   protected static $savedGlobals;
 
+  protected $tester;
+
   /** @var ContainerWrapper */
   protected $diContainer;
 


### PR DESCRIPTION
## Description

Since we cannot update to the newest version of Codeception due to a need to support legacy PHP versions, I had to backport fixes via a patch. I also fixed a couple things causing Codeception notices in our codebase. [Example test run of this branch on PHP 8.2](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/13134/workflows/e3a9a4a7-4c92-414b-8553-4b2ab0db4900/jobs/223940). Check for absence of Codeception deprecation notices.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4872]

## After-merge notes

_N/A_


[MAILPOET-4872]: https://mailpoet.atlassian.net/browse/MAILPOET-4872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ