### PR TITLE
Migration fixes [MAILPOET-5054]

### DIFF
--- a/mailpoet/lib/Migrator/Cli.php
+++ b/mailpoet/lib/Migrator/Cli.php
@@ -109,6 +109,8 @@ class Cli {
 
       WP_CLI::log("MIGRATIONS:\n");
       $table = array_map(function (array $data): array {
+        $data['name'] .= $data['unknown'] ? ' (unknown)' : '';
+        unset($data['unknown']);
         return array_map(function ($field) {
           return $field === null ? '' : $field;
         }, $data);

--- a/mailpoet/lib/Migrator/Migrator.php
+++ b/mailpoet/lib/Migrator/Migrator.php
@@ -36,7 +36,7 @@ class Migrator {
     }
 
     foreach ($migrations as $migration) {
-      if ($migration['status'] === self::MIGRATION_STATUS_COMPLETED) {
+      if ($migration['unknown'] || $migration['status'] === self::MIGRATION_STATUS_COMPLETED) {
         continue;
       }
 
@@ -56,7 +56,7 @@ class Migrator {
     }
   }
 
-  /** @return array{name: string, status: string, started_at: string|null, completed_at: string|null, retries: int|null, error: string|null}[] */
+  /** @return array{name: string, status: string, started_at: string|null, completed_at: string|null, retries: int|null, error: string|null, unknown: bool}[] */
   public function getStatus(): array {
     $defined = $this->repository->loadAll();
     $processed = $this->store->getAll();
@@ -74,6 +74,7 @@ class Migrator {
         'completed_at' => $data['completed_at'] ?? null,
         'retries' => isset($data['retries']) ? (int)$data['retries'] : null,
         'error' => $data && $data['error'] ? mb_strimwidth($data['error'], 0, 20, '…') : null,
+        'unknown' => !in_array($name, $defined, true),
       ];
     }
     return $status;

--- a/mailpoet/lib/Migrator/Store.php
+++ b/mailpoet/lib/Migrator/Store.php
@@ -54,8 +54,16 @@ class Store {
   }
 
   public function getAll(): array {
+    // Some backup plugins may convert NULL values to empty strings,
+    // in which case we need to cast the error column value to NULL.
     return $this->connection->fetchAllAssociative("
-      SELECT *
+      SELECT
+        id,
+        name,
+        started_at,
+        completed_at,
+        retries,
+        IF(error = '', NULL, error) AS error
       FROM {$this->table}
       ORDER BY id ASC
     ");

--- a/mailpoet/tests/integration/Migrator/StoreTest.php
+++ b/mailpoet/tests/integration/Migrator/StoreTest.php
@@ -112,6 +112,20 @@ class StoreTest extends MailPoetTest {
     $this->assertSame($data['error'], 'test-error');
   }
 
+  /**
+   * Some backup plugins may convert NULL values to empty strings,
+   * in which case we need to cast the error column value to NULL.
+   */
+  public function testItCastsEmptyErrorToNull(): void {
+    $this->store->ensureMigrationsTable();
+    $this->store->startMigration('Failed');
+    $this->connection->executeStatement("UPDATE {$this->table} SET error = '' WHERE name = 'Failed'");
+
+    $migrations = $this->store->getAll();
+    $this->assertCount(1, $migrations);
+    $this->assertNull($migrations[0]['error']);
+  }
+
   public function _after() {
     parent::_after();
     $this->connection->executeStatement("DROP TABLE IF EXISTS {$this->table}");


### PR DESCRIPTION
## Description

Includes two fixes resulting in errors like https://wordpress.org/support/topic/migration-class-mailpoetmigrationsmigration_20221108_140545-not-found/:
1. Always skip unknown migrations, not only when they are completed (e.g. if a migration is marked as failed in the DB but doesn't exist at all, it should not be retried).
2. Cast empty errors to `NULL`. This is a fix for 3rd party plugins corrupting our data: https://wordpress.org/support/topic/null-values-are-exported-as-empty-strings/

## Code review notes

_N/A_

## QA notes

1. Install and activate the plugin.
3. Go to the `<prefix>_mailpoet_migrations` table and change some `error` records from `NULL` to an empty string.
4. Deactivate and activate the plugin. You should see no errors.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5054]

## After-merge notes

_N/A_


[MAILPOET-5054]: https://mailpoet.atlassian.net/browse/MAILPOET-5054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ