### PR TITLE
Update pnpm to the latest version [MAILPOET-5055]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint-staged": "^12.3.7",
     "prettier": "2.6.2"
   },
-  "packageManager": "pnpm@7.25.1",
+  "packageManager": "pnpm@7.27.0",
   "volta": {
     "node": "17.9.1"
   },


### PR DESCRIPTION
## Description
Update PNPM to the latest version. In PNPM v7.26.0 `pnpm dedupe` was added.

## Code review notes
No changes in lockfile, can be merged right away, QA not needed.

## QA notes
No changes in lockfile, can be merged right away, QA not needed.

## Linked PRs
https://github.com/mailpoet/mailpoet-premium/pull/681

## Linked tickets
[MAILPOET-5055]

## After-merge notes
_N/A_

[MAILPOET-5055]: https://mailpoet.atlassian.net/browse/MAILPOET-5055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ