### PR TITLE
Use the new coupon block in the default templates - MAILPOET-4764

### DIFF
--- a/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
@@ -513,16 +513,21 @@ class Avocado {
                                  ],
                               1 =>
                                 [
-                                 'productIds' => [],
-                                 'excludedProductIds' => [],
-                                 'productCategories' => [],
-                                 'excludedProductCategories' => [],
-                                 'type' => 'coupon',
-                                 'amount' => 10,
-                                 'amountMax' => 100,
-                                 'discountType' => 'percent',
-                                 'expiryDay' => 10,
-                                 'styles' => [
+                                  'productIds' => [],
+                                  'excludedProductIds' => [],
+                                  'productCategoryIds' => [],
+                                  'excludedProductCategoryIds' => [],
+                                  'type' => 'coupon',
+                                  'amount' => 10,
+                                  'amountMax' => 100,
+                                  'discountType' => 'percent',
+                                  'expiryDay' => 10,
+                                  'usageLimit' => '',
+                                  'usageLimitPerUser' => '',
+                                  'minimumAmount' => '',
+                                  'maximumAmount' => '',
+                                  'emailRestrictions' => '',
+                                  'styles' => [
                                    'block' => [
                                      'backgroundColor' => '#dbefb4',
                                      'borderColor' => '#3d3d3d',
@@ -537,8 +542,9 @@ class Avocado {
                                      'fontWeight' => 'bold',
                                      'textAlign' => 'center',
                                    ],
-                                 ],
-                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                                  ],
+                                  'source' => 'createNew',
+                                  'code' => 'XXXX-XXXXXXX-XXXX',
                                ],
                               2 =>
                                  [

--- a/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
@@ -512,29 +512,34 @@ class Avocado {
                                   'text' => '<p style="text-align: center;">Send them your exclusive coupon code now and they\'ll receive 50% off their next order, and you\'ll get your next box for free!&nbsp;</p>',
                                  ],
                               1 =>
-                                 [
-                                  'type' => 'button',
-                                  'text' => 'AVOCADOSRULE',
-                                  'url' => '',
-                                  'styles' =>
-                                     [
-                                      'block' =>
-                                         [
-                                          'backgroundColor' => '#dbefb4',
-                                          'borderColor' => '#3d3d3d',
-                                          'borderWidth' => '3px',
-                                          'borderRadius' => '0px',
-                                          'borderStyle' => 'solid',
-                                          'width' => '254px',
-                                          'lineHeight' => '50px',
-                                          'fontColor' => '#3d3d3d',
-                                          'fontFamily' => 'Arial',
-                                          'fontSize' => '26px',
-                                          'fontWeight' => 'bold',
-                                          'textAlign' => 'center',
-                                         ],
-                                     ],
+                                [
+                                 'productIds' => [],
+                                 'excludedProductIds' => [],
+                                 'productCategories' => [],
+                                 'excludedProductCategories' => [],
+                                 'type' => 'coupon',
+                                 'amount' => 10,
+                                 'amountMax' => 100,
+                                 'discountType' => 'percent',
+                                 'expiryDay' => 10,
+                                 'styles' => [
+                                   'block' => [
+                                     'backgroundColor' => '#dbefb4',
+                                     'borderColor' => '#3d3d3d',
+                                     'borderWidth' => '3px',
+                                     'borderRadius' => '0px',
+                                     'borderStyle' => 'solid',
+                                     'width' => '254px',
+                                     'lineHeight' => '50px',
+                                     'fontColor' => '#3d3d3d',
+                                     'fontFamily' => 'Arial',
+                                     'fontSize' => '26px',
+                                     'fontWeight' => 'bold',
+                                     'textAlign' => 'center',
+                                   ],
                                  ],
+                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                               ],
                               2 =>
                                  [
                                   'type' => 'spacer',
@@ -831,30 +836,6 @@ class Avocado {
                  ],
               'backgroundColor' => '#ffffff',
               'backgroundColorAlternate' => '#eeeeee',
-             ],
-          'button' =>
-             [
-              'text' => 'AVOCADOSRULE',
-              'url' => '',
-              'styles' =>
-                 [
-                  'block' =>
-                     [
-                      'backgroundColor' => '#dbefb4',
-                      'borderColor' => '#3d3d3d',
-                      'borderWidth' => '3px',
-                      'borderRadius' => '0px',
-                      'borderStyle' => 'solid',
-                      'width' => '254px',
-                      'lineHeight' => '50px',
-                      'fontColor' => '#3d3d3d',
-                      'fontFamily' => 'Arial',
-                      'fontSize' => '26px',
-                      'fontWeight' => 'bold',
-                      'textAlign' => 'center',
-                     ],
-                 ],
-              'type' => 'button',
              ],
           'divider' =>
              [

--- a/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
@@ -453,13 +453,18 @@ class BookStoreWithCoupon {
                     [
                       'productIds' => [],
                       'excludedProductIds' => [],
-                      'productCategories' => [],
-                      'excludedProductCategories' => [],
+                      'productCategoryIds' => [],
+                      'excludedProductCategoryIds' => [],
                       'type' => 'coupon',
                       'amount' => 10,
                       'amountMax' => 100,
                       'discountType' => 'percent',
                       'expiryDay' => 10,
+                      'usageLimit' => '',
+                      'usageLimitPerUser' => '',
+                      'minimumAmount' => '',
+                      'maximumAmount' => '',
+                      'emailRestrictions' => '',
                       'styles' => [
                         'block' => [
                           'backgroundColor' => '#ffffff',
@@ -476,7 +481,8 @@ class BookStoreWithCoupon {
                           'textAlign' => 'center',
                         ],
                       ],
-                      'code' => 'XXXX-XXXXXXX-XXXX'
+                      'source' => 'createNew',
+                      'code' => 'XXXX-XXXXXXX-XXXX',
                     ],
                   4 =>
                    [

--- a/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
@@ -450,29 +450,34 @@ class BookStoreWithCoupon {
                     'text' => '<h2 style="text-align: center;"><strong>20% off all books</strong></h2>',
                    ],
                   3 =>
-                   [
-                    'type' => 'button',
-                    'text' => 'Coupon_Code',
-                    'url' => '',
-                    'styles' =>
-                     [
-                      'block' =>
-                       [
-                        'backgroundColor' => '#ffffff',
-                        'borderColor' => '#125674',
-                        'borderWidth' => '3px',
-                        'borderRadius' => '40px',
-                        'borderStyle' => 'solid',
-                        'width' => '288px',
-                        'lineHeight' => '50px',
-                        'fontColor' => '#125674',
-                        'fontFamily' => 'Courier New',
-                        'fontSize' => '26px',
-                        'fontWeight' => 'bold',
-                        'textAlign' => 'center',
-                       ],
-                     ],
-                   ],
+                    [
+                      'productIds' => [],
+                      'excludedProductIds' => [],
+                      'productCategories' => [],
+                      'excludedProductCategories' => [],
+                      'type' => 'coupon',
+                      'amount' => 10,
+                      'amountMax' => 100,
+                      'discountType' => 'percent',
+                      'expiryDay' => 10,
+                      'styles' => [
+                        'block' => [
+                          'backgroundColor' => '#ffffff',
+                          'borderColor' => '#125674',
+                          'borderWidth' => '3px',
+                          'borderRadius' => '40px',
+                          'borderStyle' => 'solid',
+                          'width' => '288px',
+                          'lineHeight' => '50px',
+                          'fontColor' => '#125674',
+                          'fontFamily' => 'Courier New',
+                          'fontSize' => '26px',
+                          'fontWeight' => 'bold',
+                          'textAlign' => 'center',
+                        ],
+                      ],
+                      'code' => 'XXXX-XXXXXXX-XXXX'
+                    ],
                   4 =>
                    [
                     'type' => 'image',
@@ -1014,30 +1019,6 @@ class BookStoreWithCoupon {
            ],
           'backgroundColor' => '#ffffff',
           'backgroundColorAlternate' => '#eeeeee',
-         ],
-        'button' =>
-         [
-          'text' => 'Coupon_Code',
-          'url' => '',
-          'styles' =>
-           [
-            'block' =>
-             [
-              'backgroundColor' => '#ffffff',
-              'borderColor' => '#125674',
-              'borderWidth' => '3px',
-              'borderRadius' => '40px',
-              'borderStyle' => 'solid',
-              'width' => '288px',
-              'lineHeight' => '50px',
-              'fontColor' => '#125674',
-              'fontFamily' => 'Courier New',
-              'fontSize' => '26px',
-              'fontWeight' => 'bold',
-              'textAlign' => 'center',
-             ],
-           ],
-          'type' => 'button',
          ],
         'divider' =>
          [

--- a/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
@@ -550,16 +550,21 @@ class Fitness {
                                 ],
                               2 =>
                                 [
-                                 'productIds' => [],
-                                 'excludedProductIds' => [],
-                                 'productCategories' => [],
-                                 'excludedProductCategories' => [],
-                                 'type' => 'coupon',
-                                 'amount' => 10,
-                                 'amountMax' => 100,
-                                 'discountType' => 'percent',
-                                 'expiryDay' => 10,
-                                 'styles' => [
+                                  'productIds' => [],
+                                  'excludedProductIds' => [],
+                                  'productCategoryIds' => [],
+                                  'excludedProductCategoryIds' => [],
+                                  'type' => 'coupon',
+                                  'amount' => 10,
+                                  'amountMax' => 100,
+                                  'discountType' => 'percent',
+                                  'expiryDay' => 10,
+                                  'usageLimit' => '',
+                                  'usageLimitPerUser' => '',
+                                  'minimumAmount' => '',
+                                  'maximumAmount' => '',
+                                  'emailRestrictions' => '',
+                                  'styles' => [
                                    'block' => [
                                      'backgroundColor' => '#afd147',
                                      'borderColor' => '#56741d',
@@ -574,8 +579,9 @@ class Fitness {
                                      'fontWeight' => 'bold',
                                      'textAlign' => 'center',
                                    ],
-                                 ],
-                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                                  ],
+                                  'source' => 'createNew',
+                                  'code' => 'XXXX-XXXXXXX-XXXX',
                                ],
                               3 =>
                                  [

--- a/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
@@ -549,29 +549,34 @@ class Fitness {
 <p style="text-align: center;"><strong>Here\'s 20% off your order if you complete it right now. We\'re nice like that.</strong></p>',
                                 ],
                               2 =>
-                                 [
-                                  'type' => 'button',
-                                  'text' => 'COUPONCODE',
-                                  'url' => '',
-                                  'styles' =>
-                                     [
-                                      'block' =>
-                                         [
-                                          'backgroundColor' => '#afd147',
-                                          'borderColor' => '#56741d',
-                                          'borderWidth' => '3px',
-                                          'borderRadius' => '5px',
-                                          'borderStyle' => 'solid',
-                                          'width' => '219px',
-                                          'lineHeight' => '50px',
-                                          'fontColor' => '#56741d',
-                                          'fontFamily' => 'Courier New',
-                                          'fontSize' => '26px',
-                                          'fontWeight' => 'bold',
-                                          'textAlign' => 'center',
-                                        ],
-                                    ],
-                                ],
+                                [
+                                 'productIds' => [],
+                                 'excludedProductIds' => [],
+                                 'productCategories' => [],
+                                 'excludedProductCategories' => [],
+                                 'type' => 'coupon',
+                                 'amount' => 10,
+                                 'amountMax' => 100,
+                                 'discountType' => 'percent',
+                                 'expiryDay' => 10,
+                                 'styles' => [
+                                   'block' => [
+                                     'backgroundColor' => '#afd147',
+                                     'borderColor' => '#56741d',
+                                     'borderWidth' => '3px',
+                                     'borderRadius' => '5px',
+                                     'borderStyle' => 'solid',
+                                     'width' => '219px',
+                                     'lineHeight' => '50px',
+                                     'fontColor' => '#56741d',
+                                     'fontFamily' => 'Courier New',
+                                     'fontSize' => '26px',
+                                     'fontWeight' => 'bold',
+                                     'textAlign' => 'center',
+                                   ],
+                                 ],
+                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                               ],
                               3 =>
                                  [
                                   'type' => 'spacer',

--- a/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
@@ -366,29 +366,34 @@ class FlowersWithCoupon {
     <p style="text-align: center;"><span style="color: #333333;"><strong>here\'s a little gift from us for your next order.</strong></span></p>',
                    ],
                   1 =>
-                   [
-                    'type' => 'button',
-                    'text' => 'CoUpOn_Code',
-                    'url' => '',
-                    'styles' =>
-                     [
-                      'block' =>
-                       [
-                        'backgroundColor' => '#292929',
-                        'borderColor' => '#0074a2',
-                        'borderWidth' => '0px',
-                        'borderRadius' => '0px',
-                        'borderStyle' => 'solid',
-                        'width' => '288px',
-                        'lineHeight' => '50px',
-                        'fontColor' => '#ffffff',
-                        'fontFamily' => 'Courier New',
-                        'fontSize' => '26px',
-                        'fontWeight' => 'normal',
-                        'textAlign' => 'center',
-                       ],
-                     ],
-                   ],
+                    [
+                      'productIds' => [],
+                      'excludedProductIds' => [],
+                      'productCategories' => [],
+                      'excludedProductCategories' => [],
+                      'type' => 'coupon',
+                      'amount' => 10,
+                      'amountMax' => 100,
+                      'discountType' => 'percent',
+                      'expiryDay' => 10,
+                      'styles' => [
+                        'block' => [
+                          'backgroundColor' => '#292929',
+                          'borderColor' => '#0074a2',
+                          'borderWidth' => '0px',
+                          'borderRadius' => '0px',
+                          'borderStyle' => 'solid',
+                          'width' => '288px',
+                          'lineHeight' => '50px',
+                          'fontColor' => '#ffffff',
+                          'fontFamily' => 'Courier New',
+                          'fontSize' => '26px',
+                          'fontWeight' => 'normal',
+                          'textAlign' => 'center'
+                        ],
+                      ],
+                      'code' => 'XXXX-XXXXXXX-XXXX'
+                    ],
                   2 =>
                    [
                     'type' => 'text',

--- a/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
@@ -369,13 +369,18 @@ class FlowersWithCoupon {
                     [
                       'productIds' => [],
                       'excludedProductIds' => [],
-                      'productCategories' => [],
-                      'excludedProductCategories' => [],
+                      'productCategoryIds' => [],
+                      'excludedProductCategoryIds' => [],
                       'type' => 'coupon',
                       'amount' => 10,
                       'amountMax' => 100,
                       'discountType' => 'percent',
                       'expiryDay' => 10,
+                      'usageLimit' => '',
+                      'usageLimitPerUser' => '',
+                      'minimumAmount' => '',
+                      'maximumAmount' => '',
+                      'emailRestrictions' => '',
                       'styles' => [
                         'block' => [
                           'backgroundColor' => '#292929',
@@ -389,10 +394,11 @@ class FlowersWithCoupon {
                           'fontFamily' => 'Courier New',
                           'fontSize' => '26px',
                           'fontWeight' => 'normal',
-                          'textAlign' => 'center'
+                          'textAlign' => 'center',
                         ],
                       ],
-                      'code' => 'XXXX-XXXXXXX-XXXX'
+                      'source' => 'createNew',
+                      'code' => 'XXXX-XXXXXXX-XXXX',
                     ],
                   2 =>
                    [

--- a/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
@@ -460,29 +460,34 @@ class WineCity {
 <p style="text-align: center;"><span style="color: #6d6d6d;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam a elementum ex. Aliquam mollis metus ac nisl luctus pulvinar. Donec tincidunt pharetra sem, nec eleifend augue.</span></p>',
                                  ],
                               2 =>
-                                 [
-                                  'type' => 'button',
-                                  'text' => 'CoUponCoDE',
-                                  'url' => '',
-                                  'styles' =>
-                                     [
-                                      'block' =>
-                                         [
-                                          'backgroundColor' => '#ffffff',
-                                          'borderColor' => '#6d6d6d',
-                                          'borderWidth' => '2px',
-                                          'borderRadius' => '0px',
-                                          'borderStyle' => 'solid',
-                                          'width' => '219px',
-                                          'lineHeight' => '50px',
-                                          'fontColor' => '#6d6d6d',
-                                          'fontFamily' => 'Courier New',
-                                          'fontSize' => '30px',
-                                          'fontWeight' => 'bold',
-                                          'textAlign' => 'center',
-                                         ],
-                                     ],
+                                [
+                                 'productIds' => [],
+                                 'excludedProductIds' => [],
+                                 'productCategories' => [],
+                                 'excludedProductCategories' => [],
+                                 'type' => 'coupon',
+                                 'amount' => 10,
+                                 'amountMax' => 100,
+                                 'discountType' => 'percent',
+                                 'expiryDay' => 10,
+                                 'styles' => [
+                                   'block' => [
+                                     'backgroundColor' => '#ffffff',
+                                     'borderColor' => '#6d6d6d',
+                                     'borderWidth' => '2px',
+                                     'borderRadius' => '0px',
+                                     'borderStyle' => 'solid',
+                                     'width' => '219px',
+                                     'lineHeight' => '50px',
+                                     'fontColor' => '#6d6d6d',
+                                     'fontFamily' => 'Courier New',
+                                     'fontSize' => '30px',
+                                     'fontWeight' => 'bold',
+                                     'textAlign' => 'center',
+                                   ],
                                  ],
+                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                               ],
                               3 =>
                                  [
                                   'type' => 'divider',
@@ -756,30 +761,6 @@ class WineCity {
                  ],
               'backgroundColor' => '#ffffff',
               'backgroundColorAlternate' => '#eeeeee',
-             ],
-          'button' =>
-             [
-              'text' => 'CoUponCoDE',
-              'url' => '',
-              'styles' =>
-                 [
-                  'block' =>
-                     [
-                      'backgroundColor' => '#ffffff',
-                      'borderColor' => '#6d6d6d',
-                      'borderWidth' => '2px',
-                      'borderRadius' => '0px',
-                      'borderStyle' => 'solid',
-                      'width' => '219px',
-                      'lineHeight' => '50px',
-                      'fontColor' => '#6d6d6d',
-                      'fontFamily' => 'Courier New',
-                      'fontSize' => '30px',
-                      'fontWeight' => 'bold',
-                      'textAlign' => 'center',
-                     ],
-                 ],
-              'type' => 'button',
              ],
           'divider' =>
              [

--- a/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
@@ -461,16 +461,21 @@ class WineCity {
                                  ],
                               2 =>
                                 [
-                                 'productIds' => [],
-                                 'excludedProductIds' => [],
-                                 'productCategories' => [],
-                                 'excludedProductCategories' => [],
-                                 'type' => 'coupon',
-                                 'amount' => 10,
-                                 'amountMax' => 100,
-                                 'discountType' => 'percent',
-                                 'expiryDay' => 10,
-                                 'styles' => [
+                                  'productIds' => [],
+                                  'excludedProductIds' => [],
+                                  'productCategoryIds' => [],
+                                  'excludedProductCategoryIds' => [],
+                                  'type' => 'coupon',
+                                  'amount' => 10,
+                                  'amountMax' => 100,
+                                  'discountType' => 'percent',
+                                  'expiryDay' => 10,
+                                  'usageLimit' => '',
+                                  'usageLimitPerUser' => '',
+                                  'minimumAmount' => '',
+                                  'maximumAmount' => '',
+                                  'emailRestrictions' => '',
+                                  'styles' => [
                                    'block' => [
                                      'backgroundColor' => '#ffffff',
                                      'borderColor' => '#6d6d6d',
@@ -485,8 +490,9 @@ class WineCity {
                                      'fontWeight' => 'bold',
                                      'textAlign' => 'center',
                                    ],
-                                 ],
-                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                                  ],
+                                  'source' => 'createNew',
+                                  'code' => 'XXXX-XXXXXXX-XXXX',
                                ],
                               3 =>
                                  [


### PR DESCRIPTION
## Description

Use the new coupon block in the default templates -


##  Code review notes

Please start reviewing from https://github.com/mailpoet/mailpoet/pull/4723/commits/493fb85b086997e2e2be4e6e9f97b3ed6120d744

## QA

**Testing on new site**
* ~Enable the coupon block experimental feature here: `/wp-admin/admin.php?page=mailpoet-experimental`~
* Create a new Newsletter (standard newsletter)
* Use the following Newsletter templates (template section: WooCommerce Emails): 
  * Flowers (with coupon), 
  * Book store (with coupon), 
  * Avocado, 
  * Abandoned Cart – Fitness, 
  * Wine City (with coupon)
* Observe the Coupon block should be included


**Testing on old/existing site**

1. You need to delete the current templates saved in the DB
<details>
<summary>SQL query</summary>
<p>

```sql

DELETE FROM `wp_mailpoet_newsletter_templates`
WHERE (
(`name` LIKE '%Flowers (with coupon)%') OR 
(`name` LIKE '%Book store (with coupon)%') OR 
(`name` LIKE '%Avocado%') OR 
(`name` LIKE '%Abandoned Cart – Fitness%') OR
(`name` LIKE '%Wine City (with coupon)%')
);

```
</p>
</details>

2. Deactivate and Reactive the MailPoet plugin
3. Complete the remaining steps in **_Testing on new site_** above

## Linked PRs


Based off https://github.com/mailpoet/mailpoet/pull/4742

## Linked tickets

[MAILPOET-4764](https://mailpoet.atlassian.net/browse/MAILPOET-4764)



[MAILPOET-4890]: https://mailpoet.atlassian.net/browse/MAILPOET-4890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-4764]: https://mailpoet.atlassian.net/browse/MAILPOET-4764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ