### PR TITLE
Remove `Export` from Main menu options - MAILPOET-5045

### DIFF
--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -370,7 +370,7 @@ class Menu {
 
     // import
     $this->wp->addSubmenuPage(
-      'admin.php?page=mailpoet-subscribers',
+      self::SUBSCRIBERS_PAGE_SLUG,
       $this->setPageTitle(__('Import', 'mailpoet')),
       esc_html__('Import', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
@@ -383,7 +383,7 @@ class Menu {
 
     // export
     $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      self::SUBSCRIBERS_PAGE_SLUG,
       $this->setPageTitle(__('Export', 'mailpoet')),
       esc_html__('Export', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,


### PR DESCRIPTION


## Description

Remove `Export` from the Main menu options.



## Linked tickets

[MAILPOET-5045](https://mailpoet.atlassian.net/browse/MAILPOET-5045)




[MAILPOET-5045]: https://mailpoet.atlassian.net/browse/MAILPOET-5045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ