### PR TITLE
Prevent crash of form listing when form settings data are missing or are malformed [MAILPOET-5056]

### DIFF
--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import { Component } from 'react';
 import jQuery from 'jquery';
 import PropTypes from 'prop-types';
+import { escapeHTML } from '@wordpress/escape-html';
 
 import { Button } from 'common';
 import { Listing } from 'listing/listing.jsx';
@@ -155,7 +156,10 @@ const itemActions = [
             ? response.data.name
             : MailPoet.I18n.t('noName');
           MailPoet.Notice.success(
-            MailPoet.I18n.t('formDuplicated').replace('%1$s', formName),
+            MailPoet.I18n.t('formDuplicated').replace(
+              '%1$s',
+              escapeHTML(formName),
+            ),
           );
           refresh();
         })
@@ -227,7 +231,7 @@ class FormListComponent extends Component {
     if (form.settings === null) {
       MailPoet.Notice.error(
         MailPoet.I18n.t('formSettingsCorrupted')
-          .replace('%1$s', form.name)
+          .replace('%1$s', escapeHTML(form.name))
           .replace(
             '[link]',
             `<a class="mailpoet-link" href="admin.php?page=mailpoet-form-editor&id=${parseInt(

--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -226,7 +226,16 @@ class FormListComponent extends Component {
   renderItem = (form, actions) => {
     if (form.settings === null) {
       MailPoet.Notice.error(
-        MailPoet.I18n.t('formSettingsCorrupted').replace('%1$s', form.name),
+        MailPoet.I18n.t('formSettingsCorrupted')
+          .replace('%1$s', form.name)
+          .replace(
+            '[link]',
+            `<a class="mailpoet-link" href="admin.php?page=mailpoet-form-editor&id=${parseInt(
+              form.id,
+              10,
+            )}">`,
+          )
+          .replace('[/link]', '</a>'),
       );
     }
     const rowClasses = classnames(

--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -224,6 +224,11 @@ class FormListComponent extends Component {
   }
 
   renderItem = (form, actions) => {
+    if (form.settings === null) {
+      MailPoet.Notice.error(
+        MailPoet.I18n.t('formSettingsCorrupted').replace('%1$s', form.name),
+      );
+    }
     const rowClasses = classnames(
       'manage-column',
       'column-primary',

--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -249,7 +249,7 @@ class FormListComponent extends Component {
         </td>
         <td className="column" data-colname={MailPoet.I18n.t('segments')}>
           <SegmentTags segments={segments} dimension="large">
-            {form.settings.segments_selected_by === 'user' && (
+            {form.settings?.segments_selected_by === 'user' && (
               <span className="mailpoet-tags-prefix">
                 {MailPoet.I18n.t('userChoice')}
               </span>

--- a/mailpoet/views/forms.html
+++ b/mailpoet/views/forms.html
@@ -97,6 +97,7 @@
     'placeSlideInFormOnPages': _x('Slide–in', 'This is a text on a widget that leads to settings for form placement - form type is slide in'),
     'placePopupFormOnPages': _x('Pop-up', 'This is a text on a widget that leads to settings for form placement - form type is pop-up, it will be displayed on page in a small modal window'),
     'placeFormOthers': _x('Others (widget)', 'Placement of the form using theme widget'),
+    'formSettingsCorrupted': __('Form settings of "%1$s" form are corrupted. Please reconfigure the form in the editor.'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/forms.html
+++ b/mailpoet/views/forms.html
@@ -97,7 +97,7 @@
     'placeSlideInFormOnPages': _x('Slide–in', 'This is a text on a widget that leads to settings for form placement - form type is slide in'),
     'placePopupFormOnPages': _x('Pop-up', 'This is a text on a widget that leads to settings for form placement - form type is pop-up, it will be displayed on page in a small modal window'),
     'placeFormOthers': _x('Others (widget)', 'Placement of the form using theme widget'),
-    'formSettingsCorrupted': __('Form settings of "%1$s" form are corrupted. Please reconfigure the form in the editor.'),
+    'formSettingsCorrupted': __('Form settings of "%1$s" form are corrupted. Please [link]reconfigure the form in the editor[/link].'),
   }) %>
 <% endblock %>
 


### PR DESCRIPTION
## Description
This PR adds changes that prevent the form listing page from crashing when the form's settings data are missing or malformed.
It also adds a check for missing data, and in case there are missing data, we show a notice to the user.

## Code review notes

_N/A_

## QA notes

#### Replication
1) Create a form and save it
2) Go to the DB admin and in wp_mailpoet_forms table delete the data in the column `settings`
3) Go to MailPoet > Forms and observe the issue

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5056]

## After-merge notes

_N/A_


[MAILPOET-5056]: https://mailpoet.atlassian.net/browse/MAILPOET-5056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ