### PR TITLE
Bump minimum required WP version to 5.9 [MAILPOET-4893]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -771,7 +771,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-5.8_php7.3_20221104.1
+          wordpress_image_version: wp-5.9_php7.3_20230213.1
           requires:
             - build
       - unit_tests:

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 5.8
+ * Requires at least: 5.9
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -27,6 +27,8 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '5.9';
+
 function mailpoet_deactivate_plugin() {
   deactivate_plugins(plugin_basename(__FILE__));
   if (!empty($_GET['activate'])) {
@@ -35,7 +37,7 @@ function mailpoet_deactivate_plugin() {
 }
 
 // Check for minimum supported WP version
-if (version_compare(get_bloginfo('version'), '5.8', '<')) {
+if (version_compare(get_bloginfo('version'), MAILPOET_MINIMUM_REQUIRED_WP_VERSION, '<')) {
   add_action('admin_notices', 'mailpoet_wp_version_notice');
   // deactivate the plugin
   add_action('admin_init', 'mailpoet_deactivate_plugin');
@@ -55,7 +57,11 @@ function mailpoet_wp_version_notice() {
   $notice = str_replace(
     '[link]',
     '<a href="https://kb.mailpoet.com/article/152-minimum-requirements-for-mailpoet-3#wp_version" target="_blank">',
-    __('MailPoet plugin requires WordPress version 5.8 or newer. Please read our [link]instructions[/link] on how to resolve this issue.', 'mailpoet')
+    sprintf(
+      // translators: %s is the number of minimum WordPress version that MailPoet requires
+      __('MailPoet plugin requires WordPress version %s or newer. Please read our [link]instructions[/link] on how to resolve this issue.', 'mailpoet'),
+      MAILPOET_MINIMUM_REQUIRED_WP_VERSION
+    )
   );
   $notice = str_replace('[/link]', '</a>', $notice);
   printf(

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,7 +1,7 @@
 === MailPoet - emails and newsletters in WordPress ===
 Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
-Requires at least: 5.8
+Requires at least: 5.9
 Tested up to: 6.1
 Stable tag: 4.6.0
 Requires PHP: 7.2


### PR DESCRIPTION
## Description

This PR bumps the minimum required WP version to 5.9 and updates the Docker image used for the oldest acceptance tests to a Docker image that uses WP 5.9 and PHP 7.3.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/wordpress-images/pull/42

## Linked tickets

[MAILPOET-4893]

## After-merge notes

_N/A_


[MAILPOET-4893]: https://mailpoet.atlassian.net/browse/MAILPOET-4893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ