### PR TITLE
Update copy of the MailPoet link added to the WooCommerce task list [MAILPOET-5063]

### DIFF
--- a/mailpoet/lib/WooCommerce/MailPoetTask.php
+++ b/mailpoet/lib/WooCommerce/MailPoetTask.php
@@ -17,10 +17,10 @@ class MailPoetTask extends Task {
 
   public function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->is_complete()) {
-      return esc_html__( 'MailPoet setup completed', 'mailpoet' );
+      return esc_html__( 'MailPoet is ready to send marketing emails from your store', 'mailpoet' );
     }
 
-    return esc_html__( 'Setup MailPoet', 'mailpoet' );
+    return esc_html__( 'Set up email marketing with MailPoet', 'mailpoet' );
   }
 
   public function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps


### PR DESCRIPTION
## Description

This PR updates the copy of the MailPoet link added to the WooCommerce task list.

## Code review notes

_N/A_

## QA notes

To see the changes to the copy done in this PR, on a site with MailPoet and WooCommerce installed, go to `/wp-admin/admin.php?page=wc-admin` and check the links under the "Things to do next" section. One of the changed strings appears if the user has completed the MailPoet onboarding and the other if it has not.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5063]

## After-merge notes

_N/A_


[MAILPOET-5063]: https://mailpoet.atlassian.net/browse/MAILPOET-5063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ