### PR TITLE
Add filter for PHPMailer instance into SMTP mailer method [MAILPOET-5064]

### DIFF
--- a/mailpoet/lib/Mailer/Methods/SMTP.php
+++ b/mailpoet/lib/Mailer/Methods/SMTP.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Mailer\Methods;
 
 use MailPoet\Mailer\Methods\ErrorMappers\SMTPMapper;
+use MailPoet\RuntimeException;
 use MailPoet\WP\Functions as WPFunctions;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -79,6 +80,10 @@ class SMTP extends PHPMailerMethod {
       $mailer->Password = $filterPassword; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
 
+    $mailer = $this->wp->applyFilters('mailpoet_mailer_smtp_instance', $mailer);
+    if (!$mailer instanceof PHPMailer) {
+      throw new RuntimeException(__('Filter "mailpoet_mailer_smtp_instance" must return an instance of PHPMailer.', 'mailpoet'));
+    }
     return $mailer;
   }
 }


### PR DESCRIPTION
## Description

From time to time, users ask for the possibility of adding additional configuration for SMTP. This PR adds a filter that allows them to directly configure PHPMailer instance before sending in the SMPT send method.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5064]

## After-merge notes

_N/A_


[MAILPOET-5064]: https://mailpoet.atlassian.net/browse/MAILPOET-5064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ