### PR TITLE
Fix mixpanel conflict [MAILPOET-5065]

### DIFF
--- a/mailpoet/assets/js/src/analytics_event.js
+++ b/mailpoet/assets/js/src/analytics_event.js
@@ -78,7 +78,7 @@ function cacheEvent(forced, name, data, options, callback) {
   }
 }
 
-function initializeMixpanelWhenLoaded() {
+export function initializeMixpanelWhenLoaded() {
   if (typeof window.mixpanel === 'object') {
     exportMixpanel();
     trackCachedEvents();
@@ -89,5 +89,3 @@ function initializeMixpanelWhenLoaded() {
 
 export const MailPoetTrackEvent = _.partial(cacheEvent, false);
 export const MailPoetForceTrackEvent = _.partial(cacheEvent, true);
-
-initializeMixpanelWhenLoaded();

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -5,8 +5,11 @@ import { MailPoetDate } from './date';
 import { MailPoetAjax } from './ajax';
 import { MailPoetModal } from './modal';
 import { MailPoetNotice } from './notice';
-// side effect - extends MailPoet object in initializeMixpanelWhenLoaded
-import { MailPoetForceTrackEvent, MailPoetTrackEvent } from './analytics_event';
+import {
+  MailPoetForceTrackEvent,
+  MailPoetTrackEvent,
+  initializeMixpanelWhenLoaded,
+} from './analytics_event';
 import { MailPoetNum } from './num';
 import { MailPoetHelpTooltip } from './help-tooltip-helper';
 import { MailPoetIframe } from './iframe';
@@ -82,3 +85,6 @@ declare global {
 
 // Expose MailPoet globally
 window.MailPoet = MailPoet;
+
+// initializeMixpanelWhenLoaded needs to be called after window.MailPoet is defined.
+initializeMixpanelWhenLoaded();


### PR DESCRIPTION
## Description
When another plugin or theme loads mixpanel library it may cause that MailPoet's pages crash with an error.

See details in https://github.com/mailpoet/mailpoet/issues/4712

The initializeMixpanelWhenLoaded expects window.MailPoet to be defined. Instead of calling initializeMixpanelWhenLoaded as a side-effect of the import we can export the function and make sure it is called really after window.MailPoet is defined. 

## Code review notes

_N/A_

## QA notes

Please verify that Mixpanel tracking works. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5065] , Closes https://github.com/mailpoet/mailpoet/issues/4712

## After-merge notes

_N/A_


[MAILPOET-5065]: https://mailpoet.atlassian.net/browse/MAILPOET-5065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ