### PR TITLE
Campaign IDs for emails sent via MSS [MAILPOET-5034]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -301,6 +301,9 @@ class SendingQueue {
     $statistics = [];
     $metas = [];
     $oneClickUnsubscribeUrls = [];
+    $sendingQueueEntity = $queue->getSendingQueueEntity();
+    $sendingQueueMeta = $sendingQueueEntity->getMeta() ?? [];
+    $campaignId = $sendingQueueMeta['campaignId'] ?? null;
 
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
 
@@ -331,7 +334,11 @@ class SendingQueue {
       $unsubscribeUrls[] = $this->links->getUnsubscribeUrl($queue->id, $subscriberEntity);
       $oneClickUnsubscribeUrls[] = $this->links->getOneClickUnsubscribeUrl($queue->id, $subscriberEntity);
 
-      $metas[] = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriberEntity);
+      $metasForSubscriber = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletter, $subscriberEntity);
+      if ($campaignId) {
+        $metasForSubscriber['campaign_id'] = $campaignId;
+      }
+      $metas[] = $metasForSubscriber;
 
       // keep track of values for statistics purposes
       $statistics[] = [
@@ -370,7 +377,11 @@ class SendingQueue {
         $preparedSubscribers,
         $statistics,
         $timer,
-        ['unsubscribe_url' => $unsubscribeUrls, 'meta' => $metas, 'one_click_unsubscribe' => $oneClickUnsubscribeUrls]
+        [
+          'unsubscribe_url' => $unsubscribeUrls,
+          'meta' => $metas,
+          'one_click_unsubscribe' => $oneClickUnsubscribeUrls,
+        ]
       );
     }
     return $queue;

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -20,7 +20,6 @@ use MailPoet\Models\StatisticsNewsletters as StatisticsNewslettersModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -79,9 +78,6 @@ class SendingQueue {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
-  /** @var SendingQueuesRepository */
-  private $sendingQueueRepository;
-
   public function __construct(
     SendingErrorHandler $errorHandler,
     SendingThrottlingHandler $throttlingHandler,
@@ -96,7 +92,6 @@ class SendingQueue {
     ScheduledTasksRepository $scheduledTasksRepository,
     MailerTask $mailerTask,
     SubscribersRepository $subscribersRepository,
-    SendingQueuesRepository $sendingQueuesRepository,
     $newsletterTask = false
   ) {
     $this->errorHandler = $errorHandler;
@@ -114,7 +109,6 @@ class SendingQueue {
     $this->links = $links;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->subscribersRepository = $subscribersRepository;
-    $this->sendingQueueRepository = $sendingQueuesRepository;
   }
 
   public function process($timer = false) {
@@ -166,32 +160,12 @@ class SendingQueue {
       return;
     }
 
-    $campaignId = null;
-
-    $afterPreProcessFilter = function(array $renderedNewsletters, NewsletterEntity $renderedNewsletterEntity) use ($newsletterEntity, &$campaignId) {
-      if ($newsletterEntity !== $renderedNewsletterEntity || !isset($renderedNewsletters['text'])) {
-        return;
-      }
-      $textVersion = $renderedNewsletters['text'];
-      $campaignId = $this->calculateCampaignId($newsletterEntity, $textVersion);
-      return $renderedNewsletters;
-    };
-
-    // This filter fires during preProcessNewsletter, after some initial rendering but before any shortcodes are replaced.
-    $this->wp->addFilter('mailpoet_sending_newsletter_render_after_pre_process', $afterPreProcessFilter, 10, 2);
-
     // pre-process newsletter (render, replace shortcodes/links, etc.)
     $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $queue);
-
-    $this->wp->removeFilter('mailpoet_sending_newsletter_render_after_pre_process', $afterPreProcessFilter);
 
     if (!$newsletterEntity) {
       $this->deleteTask($queue);
       return;
-    }
-
-    if ($campaignId) {
-      $this->sendingQueueRepository->addCampaignId($queue->getSendingQueueEntity(), $campaignId);
     }
 
     $newsletter = Newsletter::findOne($newsletterEntity->getId());
@@ -425,18 +399,6 @@ class SendingQueue {
       $statistics,
       $timer
     );
-  }
-
-  /**
-   * @param NewsletterEntity $newsletter
-   * @param string $textBody - The pre-processed text body of the newsletter, before any shortcodes have been processed.
-   * Leaving the shortcodes unprocessed ensures that we get the same campaignId for different subscribers, as well as
-   * for different sends of the same automatic email when link tracking is enabled.
-   *
-   * @return string
-   */
-  public function calculateCampaignId(NewsletterEntity $newsletter, string $textBody): string {
-    return substr(md5(implode('|', [$newsletter->getId(), $textBody, $newsletter->getSubject()])), 0, 16);
   }
 
   /**

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -427,6 +427,14 @@ class SendingQueue {
     );
   }
 
+  /**
+   * @param NewsletterEntity $newsletter
+   * @param string $textBody - The pre-processed text body of the newsletter, before any shortcodes have been processed.
+   * Leaving the shortcodes unprocessed ensures that we get the same campaignId for different subscribers, as well as
+   * for different sends of the same automatic email when link tracking is enabled.
+   *
+   * @return string
+   */
   public function calculateCampaignId(NewsletterEntity $newsletter, string $textBody): string {
     return substr(md5(implode('|', [$newsletter->getId(), $textBody, $newsletter->getSubject()])), 0, 16);
   }

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -151,7 +151,7 @@ class SendingQueuesRepository extends Repository {
       ->execute();
   }
 
-  public function addCampaignId(SendingQueueEntity $queue, string $campaignId): void {
+  public function saveCampaignId(SendingQueueEntity $queue, string $campaignId): void {
     $meta = $queue->getMeta();
     if (!is_array($meta)) {
       $meta = [];

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -150,4 +150,14 @@ class SendingQueuesRepository extends Repository {
       ->getQuery()
       ->execute();
   }
+
+  public function addCampaignId(SendingQueueEntity $queue, string $campaignId): void {
+    $meta = $queue->getMeta();
+    if (!is_array($meta)) {
+      $meta = [];
+    }
+    $meta['campaignId'] = $campaignId;
+    $queue->setMeta($meta);
+    $this->flush();
+  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -44,6 +44,7 @@ use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
@@ -96,6 +97,8 @@ class SendingQueueTest extends \MailPoetTest {
   private $scheduledTasksRepository;
   /** @var SubscribersRepository */
   private $subscribersRepository;
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
 
   public function _before() {
     parent::_before();
@@ -154,6 +157,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->tasksLinks = $this->diContainer->get(TasksLinks::class);
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->sendingQueueWorker = $this->getSendingQueueWorker();
   }
 
@@ -209,7 +213,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->diContainer->get(MailerTask::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
     try {
       $sendingQueueWorker->process();
@@ -243,7 +248,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => $this->mailerTaskDummyResponse,
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
     $sendingQueueWorker->sendNewsletters(
       $this->queue,
@@ -288,7 +294,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => $this->mailerTaskDummyResponse,
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
     $sendingQueueWorker->sendNewsletters(
       $queue,
@@ -327,7 +334,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->diContainer->get(MailerTask::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
     $sendingQueueWorker->process();
   }
@@ -650,7 +658,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => Stub::consecutive(['response' => false, 'error' => $mailerError], $this->mailerTaskDummyResponse),
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
 
     $sendingQueueWorker->sendNewsletters(
@@ -1049,7 +1058,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => $this->mailerTaskDummyResponse,
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
     try {
       $sendingQueueWorker->sendNewsletters(
@@ -1271,7 +1281,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $mailerMock ?? $this->diContainer->get(MailerTask::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueuesRepository
     );
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -565,6 +565,20 @@ class NewsletterTest extends \MailPoetTest {
     expect($this->newsletterTask->calculateCampaignId($newsletter1, $renderedNewsletters))->notEquals($this->newsletterTask->calculateCampaignId($newsletter2, $renderedNewsletters));
   }
 
+  public function testCampaignIdChangesIfImageChanges() {
+    $newsletter = (new NewsletterFactory())->withSubject('Subject')->create();
+    $renderedNewsletters = [
+      'text' => '[alt text] Text',
+      'html' => '<img src="http://example.com/image.jpg" alt="alt text"><p>Text</p>',
+    ];
+    $originalCampaignId = $this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters);
+    $renderedNewslettersDifferentImageSrc = [
+      'text' => '[alt text] Text',
+      'html' => '<img src="http://example.com/different-image-same-alt.jpg" alt="alt text"><p>Text</p>',
+    ];
+    expect($originalCampaignId)->notEquals($this->newsletterTask->calculateCampaignId($newsletter, $renderedNewslettersDifferentImageSrc));
+  }
+
   public function _after() {
     $this->diContainer->get(SettingsRepository::class)->truncate();
     $this->truncateEntity(SubscriberEntity::class);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -516,6 +516,55 @@ class NewsletterTest extends \MailPoetTest {
     expect($result['body']['text'])->stringContainsString($coupon);
   }
 
+  public function testCampaignIdDoesNotChangeIfContentStaysTheSame() {
+    $newsletter = (new NewsletterFactory())->withSubject('Subject')->create();
+    $renderedNewsletters = [
+      'text' => 'text body',
+    ];
+    $campaignId = $this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters);
+    expect($campaignId)->equals($this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters));
+  }
+
+  public function testCampaignIdChangesIfSubjectChanges() {
+    $newsletter = (new NewsletterFactory())->withSubject('Subject')->create();
+    $renderedNewsletters = [
+      'text' => 'text body',
+    ];
+    $originalCampaignId = $this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters);
+    $newsletter->setSubject('Subject 2');
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    expect($originalCampaignId)->notEquals($this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters));
+  }
+
+  public function testCampaignIdRevertsIfContentReverts() {
+    $newsletter = (new NewsletterFactory())->withSubject('Subject')->create();
+    $renderedNewsletters = [
+      'text' => 'text body',
+    ];
+    $originalCampaignId = $this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters);
+    $newsletter->setSubject('Subject 2');
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    $updatedRenderedNewsletters = [
+      'text' => 'text body updated',
+    ];
+    expect($originalCampaignId)->notEquals($this->newsletterTask->calculateCampaignId($newsletter, $updatedRenderedNewsletters));
+    $newsletter->setSubject('Subject');
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    expect($originalCampaignId)->equals($this->newsletterTask->calculateCampaignId($newsletter, $renderedNewsletters));
+  }
+
+  public function testCampaignIdDependsOnNewsletterId() {
+    $newsletter1 = (new NewsletterFactory())->withSubject('Subject')->create();
+    $newsletter2 = (new NewsletterFactory())->withSubject('Subject')->create();
+    $renderedNewsletters = [
+      'text' => 'text body',
+    ];
+    expect($this->newsletterTask->calculateCampaignId($newsletter1, $renderedNewsletters))->notEquals($this->newsletterTask->calculateCampaignId($newsletter2, $renderedNewsletters));
+  }
+
   public function _after() {
     $this->diContainer->get(SettingsRepository::class)->truncate();
     $this->truncateEntity(SubscriberEntity::class);


### PR DESCRIPTION
## Description

This PR generates campaign IDs for emails, stores them as part of the sending queue, and includes them in the `meta` when performing sends. 

Even though the campaignId is currently only relevant for MSS sends, this PR creates and stores one for all sending queues. This is both for simplicity and because it's theoretically possible to switch from  a non-MSS sending method to MSS in the middle of processing a queue.

## Code review notes

Campaign IDs should be different if the content for the same newsletter changes, so I decided to calculate a hash right after preprocessing the newsletter.

The sending queue seemed like a good place to store the campaignId because we have a very specific version of the rendered email at that point. The campaignId can also change for a specific newsletter ID, so storing the campaignId on the newsletter table seemed like a bad idea because we wouldn't be able to easily determine which newsletter corresponds to an old campaignId if it does change. I also wanted to avoid any database migrations if possible.

This will not add campaign IDs for preview emails.

## QA notes

I think the easiest way to test this will be to send a variety of emails and verify that you see unique campaign IDs stored in the `meta` column of the `mailpoet_sending_queues` table. 

For automatic or automation emails, the campaign ID should stay the same from send to send unless the content changes (see the ticket for exact details). This doesn't really apply to post notification emails since the content changes every time.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5034](https://mailpoet.atlassian.net/browse/MAILPOET-5034)

## After-merge notes

_N/A_

[MAILPOET-5034]: https://mailpoet.atlassian.net/browse/MAILPOET-5034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ