### PR TITLE
Add setting to run a workflow only once. [MAILPOET-4966]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
@@ -32,4 +32,5 @@ export type Automation = {
     };
   };
   steps: Record<string, Step> & { root: Step };
+  meta: Record<string, unknown>;
 };

--- a/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
@@ -7,7 +7,6 @@ export type NextStep = {
 export type Step = {
   id: string;
   type: 'root' | 'trigger' | 'action';
-  subject_keys: string[];
   key: string;
   args: Record<string, unknown>;
   next_steps: NextStep[];

--- a/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
@@ -7,6 +7,7 @@ export type NextStep = {
 export type Step = {
   id: string;
   type: 'root' | 'trigger' | 'action';
+  subject_keys: string[];
   key: string;
   args: Record<string, unknown>;
   next_steps: NextStep[];

--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/automation/index.tsx
@@ -4,6 +4,27 @@ import { __ } from '@wordpress/i18n';
 import { storeName } from '../../../store';
 import { TrashButton } from '../../actions/trash-button';
 import { locale } from '../../../../config';
+import { Hooks } from '../../../../../hooks';
+import { AutomationSettingElements } from '../../../../types/filters';
+
+function AutomationSettings(): JSX.Element {
+  const settings: AutomationSettingElements = Hooks.applyFilters(
+    'mailpoet.automation.settings.render',
+    {},
+  );
+
+  if (Object.keys(settings).length === 0) {
+    return null;
+  }
+
+  return (
+    <PanelBody title={__('Automation settings', 'mailpoet')} initialOpen>
+      {Object.keys(settings).map((key) => (
+        <PanelRow key={key}>{settings[key]}</PanelRow>
+      ))}
+    </PanelBody>
+  );
+}
 
 export function AutomationSidebar(): JSX.Element {
   const { automationData } = useSelect(
@@ -20,37 +41,40 @@ export function AutomationSidebar(): JSX.Element {
   };
 
   return (
-    <PanelBody title={__('Automation details', 'mailpoet')} initialOpen>
-      <PanelRow>
-        <strong>Date added</strong>{' '}
-        {new Date(Date.parse(automationData.created_at)).toLocaleDateString(
-          locale.toString(),
-          dateOptions,
-        )}
-      </PanelRow>
-      <PanelRow>
-        <strong>Activated</strong>{' '}
-        {automationData.status === 'active' &&
-          new Date(Date.parse(automationData.updated_at)).toLocaleDateString(
+    <>
+      <PanelBody title={__('Automation details', 'mailpoet')} initialOpen>
+        <PanelRow>
+          <strong>Date added</strong>{' '}
+          {new Date(Date.parse(automationData.created_at)).toLocaleDateString(
             locale.toString(),
             dateOptions,
           )}
-        {automationData.status !== 'active' &&
-          automationData.activated_at &&
-          new Date(Date.parse(automationData.activated_at)).toLocaleDateString(
-            locale.toString(),
-            dateOptions,
-          )}
-        {automationData.status !== 'active' && !automationData.activated_at && (
-          <span className="mailpoet-deactive">Not activated yet.</span>
-        )}
-      </PanelRow>
-      <PanelRow>
-        <strong>Author</strong> {automationData.author.name}
-      </PanelRow>
-      <PanelRow>
-        <TrashButton />
-      </PanelRow>
-    </PanelBody>
+        </PanelRow>
+        <PanelRow>
+          <strong>Activated</strong>{' '}
+          {automationData.status === 'active' &&
+            new Date(Date.parse(automationData.updated_at)).toLocaleDateString(
+              locale.toString(),
+              dateOptions,
+            )}
+          {automationData.status !== 'active' &&
+            automationData.activated_at &&
+            new Date(
+              Date.parse(automationData.activated_at),
+            ).toLocaleDateString(locale.toString(), dateOptions)}
+          {automationData.status !== 'active' &&
+            !automationData.activated_at && (
+              <span className="mailpoet-deactive">Not activated yet.</span>
+            )}
+        </PanelRow>
+        <PanelRow>
+          <strong>Author</strong> {automationData.author.name}
+        </PanelRow>
+        <PanelRow>
+          <TrashButton />
+        </PanelRow>
+      </PanelBody>
+      <AutomationSettings />
+    </>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -235,6 +235,14 @@ export function updateStepArgs(stepId, name, value) {
   };
 }
 
+export function updateAutomationMeta(key, value) {
+  return {
+    type: 'UPDATE_AUTOMATION_META',
+    key,
+    value,
+  };
+}
+
 export function setErrors(errors) {
   trackErrors(errors);
   return {

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -110,6 +110,18 @@ export function reducer(state: State, action: Action): State {
             : undefined,
       };
     }
+    case 'UPDATE_AUTOMATION_META':
+      return {
+        ...state,
+        automationData: {
+          ...state.automationData,
+          meta: {
+            ...state.automationData.meta,
+            [action.key]: action.value,
+          },
+        },
+        automationSaved: false,
+      };
     case 'SET_ERRORS':
       return {
         ...state,

--- a/mailpoet/assets/js/src/automation/editor/store/selectors.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/selectors.ts
@@ -103,3 +103,9 @@ export function getErrors(state: State): Errors | undefined {
 export function getStepError(state: State, id: string): StepErrors | undefined {
   return state.errors?.steps[id] ?? undefined;
 }
+
+export const getStepSubjectKeys = (state: State, key: string): string[] => {
+  const step = state.registry.steps[key];
+  if (!step) return [];
+  return step.subject_keys;
+};

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -12,6 +12,7 @@ export type Registry = {
     string,
     {
       key: string;
+      subject_keys: string[];
       name: string;
       args_schema: {
         type: 'object';

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/index.tsx
@@ -1,0 +1,14 @@
+import { Hooks } from 'wp-js-hooks';
+import { AutomationSettingElements } from '../../../types/filters';
+import { RunAutomationOnce } from './run_automation_once';
+
+export function registerAutomationSidebar() {
+  Hooks.addFilter(
+    'mailpoet.automation.settings.render',
+    'mailpoet',
+    (elements: AutomationSettingElements): AutomationSettingElements => ({
+      ...elements,
+      run_automation_once: <RunAutomationOnce />,
+    }),
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/index.tsx
@@ -1,14 +1,19 @@
 import { Hooks } from 'wp-js-hooks';
 import { AutomationSettingElements } from '../../../types/filters';
-import { RunAutomationOnce } from './run_automation_once';
+import { RunAutomationOnce, showRunOnlyOnce } from './run_automation_once';
 
 export function registerAutomationSidebar() {
   Hooks.addFilter(
     'mailpoet.automation.settings.render',
     'mailpoet',
-    (elements: AutomationSettingElements): AutomationSettingElements => ({
-      ...elements,
-      run_automation_once: <RunAutomationOnce />,
-    }),
+    (elements: AutomationSettingElements): AutomationSettingElements => {
+      if (!showRunOnlyOnce()) {
+        return elements;
+      }
+      return {
+        ...elements,
+        run_automation_once: <RunAutomationOnce />,
+      };
+    },
   );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
@@ -1,0 +1,24 @@
+import { ToggleControl } from '@wordpress/components';
+import { dispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { storeName } from '../../../editor/store';
+
+export function RunAutomationOnce(): JSX.Element {
+  const { automationData } = useSelect(
+    (select) => ({
+      automationData: select(storeName).getAutomationData(),
+    }),
+    [],
+  );
+  const checked =
+    (automationData.meta?.run_automation_once as boolean) || false;
+  return (
+    <ToggleControl
+      label={__('Run this automation only once per subscriber.', 'mailpoet')}
+      checked={checked}
+      onChange={(value) => {
+        dispatch(storeName).updateAutomationMeta('run_automation_once', value);
+      }}
+    />
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
@@ -13,7 +13,9 @@ export function showRunOnlyOnce(): boolean {
   }
 
   const subscriberTriggers = triggers.filter((trigger) =>
-    trigger.subject_keys.includes('mailpoet:subscriber'),
+    select(storeName)
+      .getStepSubjectKeys(trigger.key)
+      .includes('mailpoet:subscriber'),
   );
   return subscriberTriggers.length > 0;
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
@@ -1,19 +1,36 @@
 import { ToggleControl } from '@wordpress/components';
-import { dispatch, useSelect } from '@wordpress/data';
+import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { storeName } from '../../../editor/store';
 
+export function showRunOnlyOnce(): boolean {
+  const automation = select(storeName).getAutomationData();
+  const triggers = Object.values(automation.steps).filter(
+    (step) => step.type === 'trigger',
+  );
+  if (triggers.length === 0) {
+    return true;
+  }
+
+  const subscriberTriggers = triggers.filter((trigger) =>
+    trigger.subject_keys.includes('mailpoet:subscriber'),
+  );
+  return subscriberTriggers.length > 0;
+}
+
 export function RunAutomationOnce(): JSX.Element {
   const { automationData } = useSelect(
-    (select) => ({
-      automationData: select(storeName).getAutomationData(),
+    (s) => ({
+      automationData: s(storeName).getAutomationData(),
     }),
     [],
   );
+
   const checked =
     (automationData.meta?.run_automation_once as boolean) || false;
   return (
     <ToggleControl
+      className="mailpoet-automation-run-only-once"
       label={__('Run this automation only once per subscriber.', 'mailpoet')}
       checked={checked}
       onChange={(value) => {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run_automation_once.tsx
@@ -27,14 +27,18 @@ export function RunAutomationOnce(): JSX.Element {
   );
 
   const checked =
-    (automationData.meta?.run_automation_once as boolean) || false;
+    (automationData.meta?.['mailpoet:run-once-per-subscriber'] as boolean) ||
+    false;
   return (
     <ToggleControl
       className="mailpoet-automation-run-only-once"
       label={__('Run this automation only once per subscriber.', 'mailpoet')}
       checked={checked}
       onChange={(value) => {
-        dispatch(storeName).updateAutomationMeta('run_automation_once', value);
+        dispatch(storeName).updateAutomationMeta(
+          'mailpoet:run-once-per-subscriber',
+          value,
+        );
       }}
     />
   );

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
@@ -8,6 +8,7 @@ import { step as AddToListStep } from './steps/add_to_list';
 import { step as RemoveFromListStep } from './steps/remove_from_list';
 import { step as UpdateSubscriberStep } from './steps/update-subscriber';
 import { registerStepControls } from './step-controls';
+import { registerAutomationSidebar } from './automation-sidebar';
 
 export const initialize = (): void => {
   registerStepType(SendEmailStep);
@@ -19,4 +20,5 @@ export const initialize = (): void => {
   registerStepType(RemoveFromListStep);
   registerStepType(UpdateSubscriberStep);
   registerStepControls();
+  registerAutomationSidebar();
 };

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -41,3 +41,6 @@ export type EditorStoreConfigType = StoreConfig<State>;
 
 // mailpoet.automation.templates.from_scratch_button
 export type FromScratchHookType = (errorHandler: Dispatch<string>) => void;
+
+// mailpoet.automation.settings.render
+export type AutomationSettingElements = Record<string, JSX.Element>;

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -94,6 +94,7 @@ class AutomationEditor {
       $steps[$key] = [
         'key' => $step->getKey(),
         'name' => $step->getName(),
+        'subject_keys' => $step->getSubjectKeys(),
         'args_schema' => $step->getArgsSchema()->toArray(),
       ];
     }

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -66,7 +66,7 @@ class UpdateAutomationController {
       }
     }
 
-    $automation->deleteMetas();
+    $automation->deleteAllMetas();
     if (array_key_exists('meta', $data)) {
       foreach ($data['meta'] as $key => $value) {
         $automation->setMeta($key, $value);

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -66,8 +66,8 @@ class UpdateAutomationController {
       }
     }
 
-    $automation->deleteAllMetas();
     if (array_key_exists('meta', $data)) {
+      $automation->deleteAllMetas();
       foreach ($data['meta'] as $key => $value) {
         $automation->setMeta($key, $value);
       }

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -66,6 +66,13 @@ class UpdateAutomationController {
       }
     }
 
+    $automation->deleteMetas();
+    if (array_key_exists('meta', $data)) {
+      foreach ($data['meta'] as $key => $value) {
+        $automation->setMeta($key, $value);
+      }
+    }
+
     $this->hooks->doAutomationBeforeSave($automation);
 
     $this->automationValidator->validate($automation);

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -11,6 +11,7 @@ use MailPoet\Automation\Engine\Integration\Trigger;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
+use MailPoet\WP\Functions;
 
 class TriggerHandler {
   /** @var ActionScheduler */
@@ -28,18 +29,22 @@ class TriggerHandler {
   /** @var AutomationRunStorage */
   private $automationRunStorage;
 
+  private $wp;
+
   public function __construct(
     ActionScheduler $actionScheduler,
     SubjectLoader $subjectLoader,
     WordPress $wordPress,
     AutomationStorage $automationStorage,
-    AutomationRunStorage $automationRunStorage
+    AutomationRunStorage $automationRunStorage,
+    Functions $wp
   ) {
     $this->actionScheduler = $actionScheduler;
     $this->wordPress = $wordPress;
     $this->automationStorage = $automationStorage;
     $this->automationRunStorage = $automationRunStorage;
     $this->subjectLoader = $subjectLoader;
+    $this->wp = $wp;
   }
 
   public function initialize(): void {
@@ -62,7 +67,14 @@ class TriggerHandler {
       }
 
       $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);
-      if (!$trigger->isTriggeredBy(new StepRunArgs($automation, $automationRun, $step, $subjectEntries))) {
+      $stepRunArgs = new StepRunArgs($automation, $automationRun, $step, $subjectEntries);
+      $createAutomationRun = $trigger->isTriggeredBy($stepRunArgs);
+      $createAutomationRun = $this->wp->applyFilters(
+        Hooks::AUTOMATION_RUN_CREATE,
+        $createAutomationRun,
+        $stepRunArgs
+      );
+      if (!$createAutomationRun) {
         continue;
       }
 

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -190,7 +190,7 @@ class Automation {
     return $this->meta[$key] ?? null;
   }
 
-  public function getMetas(): array {
+  public function getAllMetas(): array {
     return $this->meta;
   }
 
@@ -209,7 +209,7 @@ class Automation {
     $this->setUpdatedAt();
   }
 
-  public function deleteMetas(): void {
+  public function deleteAllMetas(): void {
     $this->meta = [];
     $this->setUpdatedAt();
   }

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -45,7 +45,7 @@ class Automation {
   /** @var array<string, Step> */
   private $steps;
 
-  /** @var array<string, Mixed> */
+  /** @var array<string, mixed> */
   private $meta = [];
 
   /** @param array<string, Step> $steps */

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -45,6 +45,9 @@ class Automation {
   /** @var array<string, Step> */
   private $steps;
 
+  /** @var array<string, Mixed> */
+  private $meta = [];
+
   /** @param array<string, Step> $steps */
   public function __construct(
     string $name,
@@ -171,11 +174,44 @@ class Automation {
           return $step->toArray();
         }, $this->steps)
       ),
+      'meta' => Json::encode($this->meta),
     ];
   }
 
   private function setUpdatedAt(): void {
     $this->updatedAt = new DateTimeImmutable();
+  }
+
+  /**
+   * @param string $key
+   * @return mixed|null
+   */
+  public function getMeta(string $key) {
+    return $this->meta[$key] ?? null;
+  }
+
+  public function getMetas(): array {
+    return $this->meta;
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $value
+   * @return void
+   */
+  public function setMeta(string $key, $value): void {
+    $this->meta[$key] = $value;
+    $this->setUpdatedAt();
+  }
+
+  public function deleteMeta(string $key): void {
+    unset($this->meta[$key]);
+    $this->setUpdatedAt();
+  }
+
+  public function deleteMetas(): void {
+    $this->meta = [];
+    $this->setUpdatedAt();
   }
 
   public static function fromArray(array $data): self {
@@ -193,6 +229,8 @@ class Automation {
     $automation->createdAt = new DateTimeImmutable($data['created_at']);
     $automation->updatedAt = new DateTimeImmutable($data['updated_at']);
     $automation->activatedAt = $data['activated_at'] !== null ? new DateTimeImmutable($data['activated_at']) : null;
+
+    $automation->meta = $data['meta'] ? Json::decode($data['meta']) : [];
     return $automation;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Data/AutomationRun.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationRun.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Automation\Engine\Data;
 
 use DateTimeImmutable;
-use MailPoet\Automation\Engine\Utils\Json;
 
 class AutomationRun {
   public const STATUS_RUNNING = 'running';
@@ -107,11 +106,9 @@ class AutomationRun {
       'status' => $this->status,
       'created_at' => $this->createdAt->format(DateTimeImmutable::W3C),
       'updated_at' => $this->updatedAt->format(DateTimeImmutable::W3C),
-      'subjects' => Json::encode(
-        array_map(function (Subject $subject): array {
+      'subjects' => array_map(function (Subject $subject): array {
           return $subject->toArray();
-        }, $this->subjects)
-      ),
+      }, $this->subjects),
     ];
   }
 
@@ -122,7 +119,7 @@ class AutomationRun {
       $data['trigger_key'],
       array_map(function (array $subject) {
         return Subject::fromArray($subject);
-      }, Json::decode($data['subjects']))
+      }, $data['subjects'])
     );
     $automationRun->id = (int)$data['id'];
     $automationRun->status = $data['status'];

--- a/mailpoet/lib/Automation/Engine/Data/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Data/Subject.php
@@ -27,10 +27,15 @@ class Subject {
     return $this->args;
   }
 
+  public function hash(): string {
+    return md5($this->getKey() . Json::encode($this->getArgs()));
+  }
+
   public function toArray(): array {
     return [
       'key' => $this->getKey(),
       'args' => Json::encode($this->getArgs()),
+      'hash' => $this->hash(),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Data/Subject.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Automation\Engine\Data;
 
+use MailPoet\Automation\Engine\Utils\Json;
+
 class Subject {
   /** @var string */
   private $key;
@@ -28,11 +30,11 @@ class Subject {
   public function toArray(): array {
     return [
       'key' => $this->getKey(),
-      'args' => $this->getArgs(),
+      'args' => Json::encode($this->getArgs()),
     ];
   }
 
   public static function fromArray(array $data): self {
-    return new self($data['key'], $data['args']);
+    return new self($data['key'], Json::decode($data['args']));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Data/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Data/Subject.php
@@ -27,7 +27,7 @@ class Subject {
     return $this->args;
   }
 
-  public function hash(): string {
+  public function getHash(): string {
     return md5($this->getKey() . serialize($this->getArgs()));
   }
 
@@ -35,7 +35,7 @@ class Subject {
     return [
       'key' => $this->getKey(),
       'args' => Json::encode($this->getArgs()),
-      'hash' => $this->hash(),
+      'hash' => $this->getHash(),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Data/Subject.php
@@ -28,7 +28,7 @@ class Subject {
   }
 
   public function hash(): string {
-    return md5($this->getKey() . Json::encode($this->getArgs()));
+    return md5($this->getKey() . serialize($this->getArgs()));
   }
 
   public function toArray(): array {

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsPutEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsPutEndpoint.php
@@ -37,6 +37,7 @@ class AutomationsPutEndpoint extends Endpoint {
       'name' => Builder::string()->minLength(1),
       'status' => Builder::string(),
       'steps' => AutomationSchema::getStepsSchema(),
+      'meta' => Builder::object(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -29,6 +29,8 @@ class Hooks {
 
   public const AUTOMATION_RUN_LOG_AFTER_STEP_RUN = 'mailpoet/automation/step/after_run';
 
+  public const AUTOMATION_RUN_CREATE = 'mailpoet/automation/run/create';
+
   public const AUTOMATION_TEMPLATES = 'mailpoet/automation/templates';
 
   public function doAutomationBeforeSave(Automation $automation): void {

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -7,19 +7,26 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 
 class AutomationMapper {
   /** @var AutomationStatisticsStorage */
   private $statisticsStorage;
 
+  /** @var Registry */
+  private $registry;
+
   public function __construct(
-    AutomationStatisticsStorage $statisticsStorage
+    AutomationStatisticsStorage $statisticsStorage,
+    Registry $registry
   ) {
     $this->statisticsStorage = $statisticsStorage;
+    $this->registry = $registry;
   }
 
   public function buildAutomation(Automation $automation): array {
+
     return [
       'id' => $automation->getId(),
       'name' => $automation->getName(),
@@ -33,10 +40,12 @@ class AutomationMapper {
       ],
       'stats' => $this->statisticsStorage->getAutomationStats($automation->getId())->toArray(),
       'steps' => array_map(function (Step $step) {
+        $stepDefinition = $this->registry->getStep($step->getKey());
         return [
           'id' => $step->getId(),
           'type' => $step->getType(),
           'key' => $step->getKey(),
+          'subject_keys' => $stepDefinition ? $stepDefinition->getSubjectKeys() : [],
           'args' => $step->getArgs(),
           'next_steps' => array_map(function (NextStep $nextStep) {
             return $nextStep->toArray();

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -7,22 +7,16 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
-use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 
 class AutomationMapper {
   /** @var AutomationStatisticsStorage */
   private $statisticsStorage;
 
-  /** @var Registry */
-  private $registry;
-
   public function __construct(
-    AutomationStatisticsStorage $statisticsStorage,
-    Registry $registry
+    AutomationStatisticsStorage $statisticsStorage
   ) {
     $this->statisticsStorage = $statisticsStorage;
-    $this->registry = $registry;
   }
 
   public function buildAutomation(Automation $automation): array {
@@ -40,12 +34,10 @@ class AutomationMapper {
       ],
       'stats' => $this->statisticsStorage->getAutomationStats($automation->getId())->toArray(),
       'steps' => array_map(function (Step $step) {
-        $stepDefinition = $this->registry->getStep($step->getKey());
         return [
           'id' => $step->getId(),
           'type' => $step->getType(),
           'key' => $step->getKey(),
-          'subject_keys' => $stepDefinition ? $stepDefinition->getSubjectKeys() : [],
           'args' => $step->getArgs(),
           'next_steps' => array_map(function (NextStep $nextStep) {
             return $nextStep->toArray();

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -43,6 +43,7 @@ class AutomationMapper {
           }, $step->getNextSteps()),
         ];
       }, $automation->getSteps()),
+      'meta' => (object)$automation->getMetas(),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -52,7 +52,7 @@ class AutomationMapper {
           }, $step->getNextSteps()),
         ];
       }, $automation->getSteps()),
-      'meta' => (object)$automation->getMetas(),
+      'meta' => (object)$automation->getAllMetas(),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -121,7 +121,7 @@ class AutomationRunStorage {
     $table = esc_sql($this->table);
     $subjectTable = esc_sql($this->subjectTable);
 
-    $sql = "SELECT count(runs.id) as count from $table as runs
+    $sql = "SELECT count(DISTINCT runs.id) as count from $table as runs
       JOIN $subjectTable as subjects on runs.id = subjects.automation_run_id
       WHERE runs.automation_id = %d
       AND subjects.hash = %s";

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -83,9 +83,18 @@ class AutomationRunStorage {
 
     $automationRunIds = array_column($automationRuns, 'id');
 
-    $sql = sprintf("SELECT * FROM $subjectTable WHERE automation_run_id in (%s) order by automation_run_id", implode(',', array_map(function() {return '%d';
-
-    }, $automationRunIds)));
+    $sql = sprintf(
+      "SELECT * FROM $subjectTable WHERE automation_run_id in (%s) order by automation_run_id",
+      implode(
+        ',',
+        array_map(
+          function() {
+            return '%d';
+          },
+          $automationRunIds
+        )
+      )
+    );
 
     $query = (string)$this->wpdb->prepare($sql, ...$automationRunIds);
     $subjects = $this->wpdb->get_results($query, ARRAY_A);

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -39,10 +39,10 @@ class AutomationRunStorage {
       return $automationRunId;
     }
 
-    $sql = 'insert into ' . esc_sql($this->subjectTable) . ' (`automation_run_id`, `key`, `args`) values %s';
+    $sql = 'insert into ' . esc_sql($this->subjectTable) . ' (`automation_run_id`, `key`, `args`, `hash`) values %s';
     $values = [];
     foreach ($subjectTableData as $entry) {
-      $values[] = (string)$this->wpdb->prepare("(%d,%s,%s)", $automationRunId, $entry['key'], $entry['args']);
+      $values[] = (string)$this->wpdb->prepare("(%d,%s,%s,%s)", $automationRunId, $entry['key'], $entry['args'], $entry['hash']);
     }
     $sql = sprintf($sql, implode(',', $values));
     $result = $this->wpdb->query($sql);

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -101,12 +101,12 @@ class AutomationRunStorage {
 
     return array_map(
       function(array $runData) use ($subjects): AutomationRun {
-        $runData['subjects'] = array_filter(
+        $runData['subjects'] = array_values(array_filter(
           is_array($subjects) ? $subjects : [],
           function(array $subjectData) use ($runData): bool {
             return (int)$subjectData['automation_run_id'] === (int)$runData['id'];
           }
-        );
+        ));
         return AutomationRun::fromArray($runData);
       },
       $automationRuns

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Exceptions;
 use wpdb;
 
@@ -106,6 +107,26 @@ class AutomationRunStorage {
       },
       $automationRuns
     );
+  }
+
+  /**
+   * @param Automation $automation
+   * @return int
+   */
+  public function countRunsForAutomationAndSubject(Automation $automation, Subject $subject): int {
+    $table = esc_sql($this->table);
+    $subjectTable = esc_sql($this->subjectTable);
+
+    $sql = "SELECT count(runs.id) as count from $table as runs
+      JOIN $subjectTable as subjects on runs.id = subjects.automation_run_id
+      WHERE runs.automation_id = %d
+      AND subjects.hash = %s";
+
+    $result = $this->wpdb->get_col(
+      (string)$this->wpdb->prepare($sql, $automation->getId(), $subject->hash())
+    );
+
+    return $result ? (int)current($result) : 0;
   }
 
   public function getCountForAutomation(Automation $automation, string ...$status): int {

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -127,7 +127,7 @@ class AutomationRunStorage {
       AND subjects.hash = %s";
 
     $result = $this->wpdb->get_col(
-      (string)$this->wpdb->prepare($sql, $automation->getId(), $subject->hash())
+      (string)$this->wpdb->prepare($sql, $automation->getId(), $subject->getHash())
     );
 
     return $result ? (int)current($result) : 0;

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -84,7 +84,7 @@ class AutomationRunStorage {
     $automationRunIds = array_column($automationRuns, 'id');
 
     $sql = sprintf(
-      "SELECT * FROM $subjectTable WHERE automation_run_id in (%s) order by automation_run_id",
+      "SELECT * FROM $subjectTable WHERE automation_run_id in (%s) order by automation_run_id, id",
       implode(
         ',',
         array_map(

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -81,12 +81,7 @@ class AutomationRunStorage {
       return [];
     }
 
-    $automationRunIds = array_map(
-      function(array $runData): int {
-        return (int)$runData['id'];
-      },
-      $automationRuns
-    );
+    $automationRunIds = array_column($automationRuns, 'id');
 
     $sql = sprintf("SELECT * FROM $subjectTable WHERE automation_run_id in (%s) order by automation_run_id", implode(',', array_map(function() {return '%d';
 

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -117,7 +117,7 @@ class AutomationRunStorage {
    * @param Automation $automation
    * @return int
    */
-  public function countRunsForAutomationAndSubject(Automation $automation, Subject $subject): int {
+  public function getCountByAutomationAndSubject(Automation $automation, Subject $subject): int {
     $table = esc_sql($this->table);
     $subjectTable = esc_sql($this->subjectTable);
 

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -27,13 +27,13 @@ class AutomationRunStorage {
 
   public function createAutomationRun(AutomationRun $automationRun): int {
     $automationTableData = $automationRun->toArray();
+    $subjectTableData = $automationTableData['subjects'];
     unset($automationTableData['subjects']);
     $result = $this->wpdb->insert($this->table, $automationTableData);
     if ($result === false) {
       throw Exceptions::databaseError($this->wpdb->last_error);
     }
     $automationRunId = $this->wpdb->insert_id;
-    $subjectTableData = $automationRun->toArray()['subjects'];
 
     if (!$subjectTableData) {
       //We allow for AutomationRuns with no subjects.

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -79,6 +79,9 @@ class AutomationTemplateStorage {
             'delay_type' => 'MINUTES',
           ],
           [],
+        ],
+        [
+          'run_automation_once' => true,
         ]
       ),
       AutomationTemplate::TYPE_FREE_ONLY
@@ -105,6 +108,9 @@ class AutomationTemplateStorage {
             'delay_type' => 'MINUTES',
           ],
           [],
+        ],
+        [
+          'run_automation_once' => true,
         ]
       ),
       AutomationTemplate::TYPE_FREE_ONLY

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -81,7 +81,7 @@ class AutomationTemplateStorage {
           [],
         ],
         [
-          'run_automation_once' => true,
+          'mailpoet:run-once-per-subscriber' => true,
         ]
       ),
       AutomationTemplate::TYPE_FREE_ONLY
@@ -110,7 +110,7 @@ class AutomationTemplateStorage {
           [],
         ],
         [
-          'run_automation_once' => true,
+          'mailpoet:run-once-per-subscriber' => true,
         ]
       ),
       AutomationTemplate::TYPE_FREE_ONLY

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -14,7 +14,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\AutomationEmailScheduler;
-use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Validator\Builder;
@@ -30,9 +29,6 @@ class SendEmailAction implements Action {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
-  /** @var ScheduledTasksRepository */
-  private $scheduledTasksRepository;
-
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
@@ -42,13 +38,11 @@ class SendEmailAction implements Action {
   public function __construct(
     SettingsController $settings,
     NewslettersRepository $newslettersRepository,
-    ScheduledTasksRepository $scheduledTasksRepository,
     SubscriberSegmentRepository $subscriberSegmentRepository,
     AutomationEmailScheduler $automationEmailScheduler
   ) {
     $this->settings = $settings;
     $this->newslettersRepository = $newslettersRepository;
-    $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
     $this->automationEmailScheduler = $automationEmailScheduler;
   }
@@ -136,11 +130,6 @@ class SendEmailAction implements Action {
     $subscriberStatus = $subscriber->getStatus();
     if ($subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED) {
       throw InvalidStateException::create()->withMessage(sprintf("Cannot schedule a newsletter for subscriber ID '%s' because their status is '%s'.", $subscriberId, $subscriberStatus));
-    }
-
-    $previouslyScheduledNotification = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($newsletter, $subscriberId);
-    if (!empty($previouslyScheduledNotification)) {
-      throw InvalidStateException::create()->withMessage(sprintf("Subscriber ID '%s' was already scheduled to receive newsletter ID '%s'.", $subscriberId, $newsletter->getId()));
     }
 
     try {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
@@ -34,7 +34,7 @@ class CreateAutomationRunHook {
     }
 
     $automation = $args->getAutomation();
-    $runOnlyOnce = $automation->getMeta('run_automation_once');
+    $runOnlyOnce = $automation->getMeta('mailpoet:run-once-per-subscriber');
     if (!$runOnlyOnce) {
       return true;
     }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Hooks;
+
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\WP\Functions;
+
+class CreateAutomationRunHook {
+
+
+  /** @var Functions */
+  private $wp;
+
+  private $automationRunStorage;
+
+  public function __construct(
+    Functions $wp,
+    AutomationRunStorage $automationRunStorage
+  ) {
+    $this->wp = $wp;
+    $this->automationRunStorage = $automationRunStorage;
+  }
+
+  public function init(): void {
+    $this->wp->addAction(Hooks::AUTOMATION_RUN_CREATE, [$this, 'createAutomationRun'], 5, 2);
+  }
+
+  public function createAutomationRun(bool $result, StepRunArgs $args): bool {
+    if (!$result) {
+      return $result;
+    }
+
+    $automation = $args->getAutomation();
+    $runOnlyOnce = $automation->getMeta('run_automation_once');
+    if (!$runOnlyOnce) {
+      return true;
+    }
+
+    $subscriberSubject = $args->getAutomationRun()->getSubjects(SubscriberSubject::KEY);
+    if (!$subscriberSubject) {
+      return true;
+    }
+
+    return $this->automationRunStorage->countRunsForAutomationAndSubject($automation, current($subscriberSubject)) === 0;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
@@ -44,6 +44,6 @@ class CreateAutomationRunHook {
       return true;
     }
 
-    return $this->automationRunStorage->countRunsForAutomationAndSubject($automation, current($subscriberSubject)) === 0;
+    return $this->automationRunStorage->getCountByAutomationAndSubject($automation, current($subscriberSubject)) === 0;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
@@ -6,6 +6,7 @@ use MailPoet\Automation\Engine\Integration;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Automation\Integrations\MailPoet\Hooks\AutomationEditorLoadingHooks;
+use MailPoet\Automation\Integrations\MailPoet\Hooks\CreateAutomationRunHook;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
@@ -30,7 +31,11 @@ class MailPoetIntegration implements Integration {
   /** @var SendEmailAction */
   private $sendEmailAction;
 
+  /** @var AutomationEditorLoadingHooks  */
   private $automationEditorLoadingHooks;
+
+  /** @var CreateAutomationRunHook */
+  private $createAutomationRunHook;
 
   public function __construct(
     ContextFactory $contextFactory,
@@ -39,7 +44,8 @@ class MailPoetIntegration implements Integration {
     SomeoneSubscribesTrigger $someoneSubscribesTrigger,
     UserRegistrationTrigger $userRegistrationTrigger,
     SendEmailAction $sendEmailAction,
-    AutomationEditorLoadingHooks $automationEditorLoadingHooks
+    AutomationEditorLoadingHooks $automationEditorLoadingHooks,
+    CreateAutomationRunHook $createAutomationRunHook
   ) {
     $this->contextFactory = $contextFactory;
     $this->segmentSubject = $segmentSubject;
@@ -48,6 +54,7 @@ class MailPoetIntegration implements Integration {
     $this->userRegistrationTrigger = $userRegistrationTrigger;
     $this->sendEmailAction = $sendEmailAction;
     $this->automationEditorLoadingHooks = $automationEditorLoadingHooks;
+    $this->createAutomationRunHook = $createAutomationRunHook;
   }
 
   public function register(Registry $registry): void {
@@ -68,5 +75,6 @@ class MailPoetIntegration implements Integration {
     );
 
     $this->automationEditorLoadingHooks->init();
+    $this->createAutomationRunHook->init();
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/AutomationBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/AutomationBuilder.php
@@ -21,7 +21,7 @@ class AutomationBuilder {
     $this->registry = $registry;
   }
 
-  public function createFromSequence(string $name, array $sequence, array $sequenceArgs = []): Automation {
+  public function createFromSequence(string $name, array $sequence, array $sequenceArgs = [], array $meta = []): Automation {
     $steps = [];
     $nextSteps = [];
     foreach (array_reverse($sequence) as $index => $stepKey) {
@@ -42,11 +42,15 @@ class AutomationBuilder {
     }
     $steps['root'] = new Step('root', 'root', 'core:root', [], $nextSteps);
     $steps = array_reverse($steps);
-    return new Automation(
+    $automation = new Automation(
       $name,
       $steps,
       wp_get_current_user()
     );
+    foreach ($meta as $key => $value) {
+      $automation->setMeta($key, $value);
+    }
+    return $automation;
   }
 
   private function uniqueId(): string {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -162,6 +162,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\AutomationBuilder::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Hooks\AutomationEditorLoadingHooks::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Hooks\CreateAutomationRunHook::class)->setPublic(true);
     // Config
     $container->autowire(\MailPoet\Config\AccessControl::class)->setPublic(true);
     $container->autowire(\MailPoet\Config\Activator::class)->setPublic(true);

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -18,7 +18,7 @@ class Migration_20230215_050813 extends Migration {
       return;
     }
     $this->connection->executeQuery("ALTER TABLE $tableName ADD COLUMN `meta` LONGTEXT DEFAULT NULL AFTER `status`");
-    $this->connection->executeQuery("UPDATE $tableName SET `meta` = '{\"run_automation_once\":true}'");
+    $this->connection->executeQuery("UPDATE $tableName SET `meta` = '{\"mailpoet:run-once-per-subscriber\":true}'");
   }
 
   private function subjectsMigration(): void {

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -79,11 +79,6 @@ class Migration_20230215_050813 extends Migration {
       return;
     }
 
-    $sql = "SELECT id,subjects FROM $tableName where subjects is not null";
-    $results = $wpdb->get_results($sql, ARRAY_A);
-    if (is_array($results) && $results) {
-      return;
-    }
     $wpdb->query("ALTER TABLE $tableName DROP COLUMN subjects");
   }
 }

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -18,6 +18,7 @@ class Migration_20230215_050813 extends Migration {
       return;
     }
     $this->connection->executeQuery("ALTER TABLE $tableName ADD COLUMN `meta` LONGTEXT DEFAULT NULL AFTER `status`");
+    $this->connection->executeQuery("UPDATE $tableName SET `meta` = '{\"run_automation_once\":true}'");
   }
 
   private function subjectsMigration(): void {

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -23,10 +23,12 @@ class Migration_20230215_050813 extends Migration {
 
   private function subjectsMigration(): void {
     $this->createTable('automation_run_subjects', [
+      '`id` int(11) unsigned NOT NULL AUTO_INCREMENT',
       '`automation_run_id` int(11) unsigned NOT NULL',
       '`key` varchar(191)',
       '`args` longtext',
       '`hash` varchar(191)',
+      'PRIMARY KEY  (id)',
       'index (automation_run_id)',
       'index (hash)',
     ]);

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -25,7 +25,9 @@ class Migration_20230215_050813 extends Migration {
       '`automation_run_id` int(11) unsigned NOT NULL',
       '`key` varchar(191)',
       '`args` longtext',
+      '`hash` varchar(191)',
       'index (automation_run_id)',
+      'index (hash)',
     ]);
     $this->moveSubjectData();
     $this->dropSubjectColumn();

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Migrator\Migration;
+
+class Migration_20230215_050813 extends Migration {
+  public function run(): void {
+    $this->subjectsMigration();
+  }
+
+  private function subjectsMigration(): void {
+    $this->createTable('automation_run_subjects', [
+      '`automation_run_id` int(11) unsigned NOT NULL',
+      '`key` varchar(191)',
+      '`args` longtext',
+      'index (automation_run_id)',
+    ]);
+    $this->moveSubjectData();
+    $this->dropSubjectColumn();
+  }
+
+  private function moveSubjectData(): void {
+    global $wpdb;
+    $runTable = $wpdb->prefix . 'mailpoet_automation_runs';
+    $subjectTable = $wpdb->prefix . 'mailpoet_automation_run_subjects';
+    if (!$this->columnExists($runTable, 'subjects')) {
+      return;
+    }
+    $sql = "SELECT id,subjects FROM $runTable";
+    $results = $wpdb->get_results($sql, ARRAY_A);
+    if (!is_array($results) || !$results) {
+      return;
+    }
+
+    foreach ($results as $result) {
+      $subjects = $result['subjects'];
+      if (!$subjects) {
+        continue;
+      }
+      $subjects = json_decode($subjects, true);
+      if (!is_array($subjects) || !$subjects) {
+        continue;
+      }
+      $values = [];
+      foreach ($subjects as $subject) {
+        $values[] = (string)$wpdb->prepare("(%d,%s,%s)", $result['id'], $subject['key'], json_encode($subject['args']));
+      }
+      $sql = sprintf("INSERT INTO $subjectTable (`automation_run_id`, `key`, `args`) VALUES %s", implode(',', $values));
+      if ($wpdb->query($sql) === false) {
+        continue;
+      }
+
+      $sql = $wpdb->prepare('UPDATE ' . $runTable . ' SET subjects = NULL WHERE id = %d', $result['id']);
+      $wpdb->query($sql);
+    }
+  }
+
+  private function dropSubjectColumn(): void {
+    global $wpdb;
+    $tableName = esc_sql($wpdb->prefix . 'mailpoet_automation_runs');
+    if (!$this->columnExists($tableName, 'subjects')) {
+      return;
+    }
+
+    $sql = "SELECT id,subjects FROM $tableName where subjects is not null";
+    $results = $wpdb->get_results($sql, ARRAY_A);
+    if (is_array($results) && $results) {
+      return;
+    }
+    $wpdb->query("ALTER TABLE $tableName DROP COLUMN subjects");
+  }
+}

--- a/mailpoet/lib/Migrations/Migration_20230215_050813.php
+++ b/mailpoet/lib/Migrations/Migration_20230215_050813.php
@@ -7,6 +7,17 @@ use MailPoet\Migrator\Migration;
 class Migration_20230215_050813 extends Migration {
   public function run(): void {
     $this->subjectsMigration();
+    $this->addMetaColumnToAutomations();
+  }
+
+  private function addMetaColumnToAutomations(): void {
+
+    global $wpdb;
+    $tableName = esc_sql($wpdb->prefix . 'mailpoet_automations');
+    if ($this->columnExists($tableName, 'meta')) {
+      return;
+    }
+    $this->connection->executeQuery("ALTER TABLE $tableName ADD COLUMN `meta` LONGTEXT DEFAULT NULL AFTER `status`");
   }
 
   private function subjectsMigration(): void {

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -44,7 +44,7 @@ parameters:
     - '/Call to method getName\(\) on an unknown class _generated\\([a-zA-Z])*Cookie/' # codeception generate incorrect return type in ../../tests/_support/_generated
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 6
+      count: 9
       path: ../../lib/Automation/Engine/Storage/AutomationRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -44,7 +44,7 @@ parameters:
     - '/Call to method getName\(\) on an unknown class _generated\\([a-zA-Z])*Cookie/' # codeception generate incorrect return type in ../../tests/_support/_generated
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 9
+      count: 10
       path: ../../lib/Automation/Engine/Storage/AutomationRunStorage.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tests/DataFactories/Automation.php
+++ b/mailpoet/tests/DataFactories/Automation.php
@@ -33,7 +33,7 @@ class Automation {
         [],
         []
       ),
-      ], new \WP_User());
+      ], new \WP_User(1));
   }
 
   public function withName($name) {

--- a/mailpoet/tests/DataFactories/Automation.php
+++ b/mailpoet/tests/DataFactories/Automation.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\Automation\Engine\Data\Automation as Entity;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\DI\ContainerWrapper;
+
+class Automation {
+
+
+  /**
+   * @var AutomationStorage
+   */
+  private $storage;
+
+  /**
+   * @var Entity
+   */
+  private $automation;
+
+  public function __construct() {
+    $this->storage = ContainerWrapper::getInstance(WP_DEBUG)->get(AutomationStorage::class);
+    $this->automation = new Entity(
+      '', [
+      'root' => new Step(
+        'root',
+
+        Step::TYPE_ROOT,
+        'core:root',
+        [],
+        []
+      ),
+      ], new \WP_User());
+  }
+
+  public function withName($name) {
+    $this->automation->setName($name);
+    return $this;
+  }
+
+  public function withSteps(Step ...$steps) {
+    $sortedSteps = [];
+    foreach ($steps as $step) {
+      $sortedSteps[$step->getId()] = $step;
+    }
+    $this->automation->setSteps($sortedSteps);
+    return $this;
+  }
+
+  public function addStep(Step $step) {
+    $steps = $this->automation->getSteps();
+    $lastStep = end($steps);
+    if (!$lastStep) {
+      return $this->withSteps($step);
+    }
+    $lastStep->setNextSteps([new NextStep($step->getId())]);
+    $steps[$step->getId()] = $step;
+    return $this->withSteps(...$steps);
+  }
+
+  public function withDelayAction() {
+    $step = new Step(
+      uniqid(),
+      Step::TYPE_ACTION,
+      'core:delay',
+      [
+        'delay_type' => 'MINUTES',
+        'delay' => 1,
+      ],
+      []
+    );
+    return $this->addStep($step);
+  }
+
+  public function withSomeoneSubscribesTrigger() {
+    $step = new Step(
+      uniqid(),
+      Step::TYPE_TRIGGER,
+      'mailpoet:someone-subscribes',
+      [],
+      []
+    );
+    return $this->addStep($step);
+  }
+
+  public function withMeta($key, $value) {
+    $this->automation->setMeta($key, $value);
+    return $this;
+  }
+
+  public function withStatus($status) {
+    $this->automation->setStatus($status);
+    return $this;
+  }
+
+  public function withStatusActive() {
+    $this->automation->setStatus(Entity::STATUS_ACTIVE);
+    return $this;
+  }
+
+  public function create() {
+    $id = $this->storage->createAutomation($this->automation);
+    $automation = $this->storage->getAutomation($id);
+    if (!$automation) {
+      throw new \Exception('Automation not found.');
+    }
+    $this->automation = $automation;
+    return $this->automation;
+  }
+}

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -2,8 +2,10 @@
 
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore;
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
 use MailPoet\DI\ContainerWrapper;
@@ -145,5 +147,24 @@ class IntegrationTester extends \Codeception\Actor {
     $automation = new Automation($name, $stepsWithIds, wp_get_current_user());
     $automation->setStatus(Automation::STATUS_ACTIVE);
     return $automationStorage->getAutomation($automationStorage->createAutomation($automation));
+  }
+
+  public function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
+    $trigger = array_filter($automation->getSteps(), function(Step $step): bool { return $step->getType() === Step::TYPE_TRIGGER;
+
+    });
+    $triggerKeys = array_map(function(Step $step): string { return $step->getKey();
+
+    }, $trigger);
+    $triggerKey = count($triggerKeys) > 0 ? current($triggerKeys) : '';
+
+    $automationRun = new AutomationRun(
+      $automation->getId(),
+      $automation->getVersionId(),
+      $triggerKey,
+      $subjects
+    );
+    $automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
+    return $automationRunStorage->getAutomationRun($automationRunStorage->createAutomationRun($automationRun));
   }
 }

--- a/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
+++ b/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
@@ -44,7 +44,7 @@ class RunAutomationOnlyOnceSettingCest {
       ->withName('runAutomationOnlyOnce Automation')
       ->withSomeoneSubscribesTrigger()
       ->withDelayAction()
-      ->withMeta('run_automation_once', false)
+      ->withMeta('mailpoet:run-once-per-subscriber', false)
       ->withStatusActive()
       ->create();
     $this->segment = (new DataFactories\Segment())->withName('runAutomationOnlyOnce-segment')->create();

--- a/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
+++ b/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Test\DataFactories;
+
+class RunAutomationOnlyOnceSettingCest {
+
+  /** @var DataFactories\Settings */
+  private $settingsFactory;
+
+  /** @var ContainerWrapper */
+  private $container;
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  /** @var AutomationRunLogStorage */
+  private $automationRunLogStorage;
+
+  /** @var Automation */
+  private $automation;
+
+  private $segment;
+
+  public function _before(\AcceptanceTester $i) {
+    $this->container = ContainerWrapper::getInstance();
+    $this->settingsFactory = new DataFactories\Settings();
+    $this->settingsFactory->withCronTriggerMethod('Action Scheduler');
+    $this->automationStorage = $this->container->get(AutomationStorage::class);
+    $this->automationRunStorage = $this->container->get(AutomationRunStorage::class);
+    $this->automationRunLogStorage = $this->container->get(AutomationRunLogStorage::class);
+
+
+    $this->automation = (new DataFactories\Automation())
+      ->withName('runAutomationOnlyOnce Automation')
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withMeta('run_automation_once', false)
+      ->withStatusActive()
+      ->create();
+    $this->segment = (new DataFactories\Segment())->withName('runAutomationOnlyOnce-segment')->create();
+  }
+
+  public function runAutomationOnlyOnce(\AcceptanceTester $i) {
+
+    $subscriberEmail = 'run-automation-only-once-test@mailpoet.com';
+    $i->wantTo('Ensure that a subscriber enters an automation only once when the setting is set');
+    $i->login();
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Edit');
+    $i->dontSee('Entered 1');
+    $i->see('Entered 0'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
+    $i->click($this->automation->getName());
+    $i->waitForText('Automation settings');
+    $i->waitForText('Run this automation only once per subscriber.');
+    $i->click('.mailpoet-automation-run-only-once label');
+
+    $i->click('Trigger');
+    $i->fillField('When someone subscribes to the following lists:', $this->segment->getName());
+    $i->click('Update');
+    $i->waitForText('The automation has been saved.');
+
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/new');
+    $i->fillField('#field_email', $subscriberEmail);
+    $i->fillField('#field_first_name', 'automation-tester-firstname');
+    $i->selectOptionInSelect2($this->segment->getName());
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText($this->automation->getName());
+    $i->see('Entered 1'); //Actually I see "1 Entered", but this CSS switch is not caught by the test
+
+    $i->amOnMailpoetPage('subscribers');
+    $i->searchFor($subscriberEmail);
+    $i->waitForText($subscriberEmail);
+    $i->click($subscriberEmail);
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->click('Remove item'); // Removes the newsletter list from the subscriber
+    $i->click('Save');
+    $i->searchFor($subscriberEmail);
+    $i->waitForText($subscriberEmail);
+    $i->click($subscriberEmail);
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->selectOptionInSelect2($this->segment->getName());
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText($this->automation->getName());
+    // No new run has been created.
+    $i->see('Entered 1');
+    $i->dontSee('Entered 2');
+  }
+
+  public function runAutomationMultipleTimes(\AcceptanceTester $i) {
+
+    $this->automation = (new DataFactories\Automation())
+      ->withName('runAutomationOnlyOnce Automation')
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withMeta('run_only_once', false)
+      ->withStatusActive()
+      ->create();
+
+    $subscriberEmail = 'run-automation-only-once-test@mailpoet.com';
+    $i->wantTo('Ensure that a subscriber enters an automation only once when the setting is set');
+    $i->login();
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Edit');
+    $i->dontSee('Entered 1');
+    $i->dontSee('Entered 2');
+    $i->see('Entered 0'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
+    $i->click($this->automation->getName());
+    $i->waitForText('Run this automation only once per subscriber.');
+    $i->click('.mailpoet-automation-run-only-once'); //yes
+    $i->click('.mailpoet-automation-run-only-once'); //no
+
+    $i->click('Trigger');
+    $i->fillField('When someone subscribes to the following lists:', $this->segment->getName());
+    $i->click('Update');
+    $i->waitForText('The automation has been saved.');
+
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/new');
+    $i->fillField('#field_email', $subscriberEmail);
+    $i->fillField('#field_first_name', 'automation-tester-firstname');
+    $i->selectOptionInSelect2($this->segment->getName());
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText($this->automation->getName());
+    $i->see('Entered 1'); //Actually I see "1 Entered", but this CSS switch is not caught by the test
+    $i->dontSee('Entered 2');
+
+    $i->amOnMailpoetPage('subscribers');
+    $i->searchFor($subscriberEmail);
+    $i->waitForText($subscriberEmail);
+    $i->click($subscriberEmail);
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->click('Remove item'); // Removes the newsletter list from the subscriber
+    $i->click('Save');
+    $i->searchFor($subscriberEmail);
+    $i->waitForText($subscriberEmail);
+    $i->click($subscriberEmail);
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->selectOptionInSelect2($this->segment->getName());
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText($this->automation->getName());
+
+    // A new run has been created.
+    $i->see('Entered 2');
+    $i->dontSee('Entered 1');
+  }
+
+  public function _after(\AcceptanceTester $i) {
+    $this->automationStorage->truncate();
+    $this->automationRunStorage->truncate();
+    $this->automationRunLogStorage->truncate();
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -132,14 +132,11 @@ class StepHandlerTest extends \MailPoetTest {
   private function createAutomation(): ?Automation {
     $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
     $delay = $this->diContainer->get(DelayAction::class);
-    $steps = [
-      'root' => new Step('root', Step::TYPE_ROOT, 'root', [], [new NextStep('someone-subscribes')]),
-      'someone-subscribes' => new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
-      'delay' => new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], []),
-    ];
-    $automation = new Automation('test', $steps, wp_get_current_user());
-    $automation->setStatus(Automation::STATUS_ACTIVE);
-    return $this->automationStorage->getAutomation($this->automationStorage->createAutomation($automation));
+    return $this->tester->createAutomation(
+      'test',
+      new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
+      new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], [])
+    );
   }
 
   private function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -44,7 +44,7 @@ class StepHandlerTest extends \MailPoetTest {
     $automation = $this->createAutomation();
     $this->assertInstanceOf(Automation::class, $automation);
     $steps = $automation->getSteps();
-    $automationRun = $this->createAutomationRun($automation);
+    $automationRun = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun);
 
     $currentStep = current($steps);
@@ -79,7 +79,7 @@ class StepHandlerTest extends \MailPoetTest {
     foreach ($invalidStati as $status) {
       $automation->setStatus($status);
       $this->automationStorage->updateAutomation($automation);
-      $automationRun = $this->createAutomationRun($automation);
+      $automationRun = $this->tester->createAutomationRun($automation);
       $this->assertInstanceOf(AutomationRun::class, $automationRun);
       $error = null;
       try {
@@ -99,9 +99,9 @@ class StepHandlerTest extends \MailPoetTest {
   public function testAnDeactivatingAutomationBecomesDraftAfterLastRunIsExecuted() {
     $automation = $this->createAutomation();
     $this->assertInstanceOf(Automation::class, $automation);
-    $automationRun1 = $this->createAutomationRun($automation);
+    $automationRun1 = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun1);
-    $automationRun2 = $this->createAutomationRun($automation);
+    $automationRun2 = $this->tester->createAutomationRun($automation);
     $this->assertInstanceOf(AutomationRun::class, $automationRun2);
     $automation->setStatus(Automation::STATUS_DEACTIVATING);
     $this->automationStorage->updateAutomation($automation);
@@ -137,24 +137,6 @@ class StepHandlerTest extends \MailPoetTest {
       new Step('someone-subscribes', Step::TYPE_TRIGGER, $trigger->getKey(), [], [new NextStep('a')]),
       new Step('delay', Step::TYPE_ACTION, $delay->getKey(), [], [])
     );
-  }
-
-  private function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
-    $trigger = array_filter($automation->getSteps(), function(Step $step): bool { return $step->getType() === Step::TYPE_TRIGGER;
-
-    });
-    $triggerKeys = array_map(function(Step $step): string { return $step->getKey();
-
-    }, $trigger);
-    $triggerKey = count($triggerKeys) > 0 ? current($triggerKeys) : '';
-
-    $automationRun = new AutomationRun(
-      $automation->getId(),
-      $automation->getVersionId(),
-      $triggerKey,
-      $subjects
-    );
-    return $this->automationRunStorage->getAutomationRun($this->automationRunStorage->createAutomationRun($automationRun));
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -54,6 +54,27 @@ class AutomationTest extends \MailPoetTest {
     $this->assertTrue($automation->equals($automation2));
   }
 
+  /**
+   * @dataProvider dataForTestFullValidationWorks
+   */
+  public function testFullValidationWorks($status, $expected) {
+    $automation = $this->tester->createAutomation('test');
+    $automation->setStatus($status);
+    $this->assertEquals($expected, $automation->needsFullValidation());
+  }
+
+  public function dataForTestFullValidationWorks(): array {
+    return array_map(
+      function(string $status): array {
+        return [
+          'status' => $status,
+          'expected' => in_array($status, [Automation::STATUS_ACTIVE, Automation::STATUS_DEACTIVATING], true),
+        ];
+      },
+      Automation::STATUS_ALL
+    );
+  }
+
   public function _after() {
     $this->storage->truncate();
   }

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -79,6 +79,3 @@ class AutomationTest extends \MailPoetTest {
     $this->storage->truncate();
   }
 }
-{
-
-}

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+
+class AutomationTest extends \MailPoetTest {
+
+  /** @var AutomationStorage $storage */
+  private $storage;
+
+  public function _before() {
+    $this->storage = $this->diContainer->get(AutomationStorage::class);
+  }
+
+  public function testMetaDataIsStored() {
+    $automation = $this->tester->createAutomation('test');
+
+    $automation->setMeta('foo', 'bar');
+    $this->assertEquals('bar', $automation->getMeta('foo'));
+    $this->assertEquals(['foo' => 'bar'], $automation->getMetas());
+    $this->storage->updateAutomation($automation);
+
+    $storedAutomation = $this->storage->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $storedAutomation);
+    $this->assertEquals('bar', $storedAutomation->getMeta('foo'));
+  }
+
+  public function testMetaDataIsDeleted() {
+
+    $automation = $this->tester->createAutomation('test');
+
+    $automation->setMeta('foo', 'bar');
+    $automation->deleteMeta('foo');
+    $this->assertNull($automation->getMeta('foo'));
+    $this->storage->updateAutomation($automation);
+    $storedAutomation = $this->storage->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $storedAutomation);
+    $this->assertNull($storedAutomation->getMeta('foo'));
+
+    $automation->setMeta('foo', 'bar');
+    $automation->setMeta('bar', 'baz');
+    $automation->deleteMetas();
+    $this->assertEmpty($automation->getMetas());
+  }
+
+  public function _after() {
+    $this->storage->truncate();
+  }
+}
+{
+
+}

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -45,6 +45,15 @@ class AutomationTest extends \MailPoetTest {
     $this->assertEmpty($automation->getMetas());
   }
 
+  public function testAutomationComparisonWorks() {
+    $automation = $this->tester->createAutomation('test');
+    $automation2 = clone $automation;
+    $automation2->setMeta('foo', 'bar');
+    $this->assertFalse($automation->equals($automation2));
+    $automation2->deleteMeta('foo');
+    $this->assertTrue($automation->equals($automation2));
+  }
+
   public function _after() {
     $this->storage->truncate();
   }

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -19,7 +19,7 @@ class AutomationTest extends \MailPoetTest {
 
     $automation->setMeta('foo', 'bar');
     $this->assertEquals('bar', $automation->getMeta('foo'));
-    $this->assertEquals(['foo' => 'bar'], $automation->getMetas());
+    $this->assertEquals(['foo' => 'bar'], $automation->getAllMetas());
     $this->storage->updateAutomation($automation);
 
     $storedAutomation = $this->storage->getAutomation($automation->getId());
@@ -41,8 +41,8 @@ class AutomationTest extends \MailPoetTest {
 
     $automation->setMeta('foo', 'bar');
     $automation->setMeta('bar', 'baz');
-    $automation->deleteMetas();
-    $this->assertEmpty($automation->getMetas());
+    $automation->deleteAllMetas();
+    $this->assertEmpty($automation->getAllMetas());
   }
 
   public function testAutomationComparisonWorks() {

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Test\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
-use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
@@ -30,15 +29,9 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
     $this->testee = $this->diContainer->get(AutomationStatisticsStorage::class);
 
     $this->automations = [
-      $this->automationStorage->createAutomation(
-      new Automation('1', ['root' => new Step('root', Step::TYPE_ROOT, 'root', [], [])], new \WP_User(1))
-    ),
-      $this->automationStorage->createAutomation(
-      new Automation('2', ['root' => new Step('root', Step::TYPE_ROOT, 'root', [], [])], new \WP_User(1))
-    ),
-      $this->automationStorage->createAutomation(
-      new Automation('3', ['root' => new Step('root', Step::TYPE_ROOT, 'root', [], [])], new \WP_User(1))
-    ),
+      $this->tester->createAutomation('1')->getId(),
+      $this->tester->createAutomation('2')->getId(),
+      $this->tester->createAutomation('3')->getId(),
     ];
   }
 

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -187,7 +187,7 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
       'automation_id' => $automation->getId(),
       'version_id' => $automation->getVersionId(),
       'trigger_key' => '',
-      'subjects' => "[]",
+      'subjects' => [],
       'id' => 0,
       'status' => $status,
       'created_at' => (new \DateTimeImmutable())->format(\DateTimeImmutable::W3C),

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\REST\Automation\Automations;
 
 use MailPoet\Automation\Engine\Data\Automation;
-use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\REST\Automation\AutomationTest;
 
@@ -21,14 +20,7 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
   public function _before() {
     parent::_before();
     $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
-    $id = $this->automationStorage->createAutomation(
-      new Automation(
-        'Testing automation',
-        ['root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [])],
-        wp_get_current_user()
-      )
-    );
-    $automation = $this->automationStorage->getAutomation($id);
+    $automation = $this->tester->createAutomation('Testing automation');
     $this->assertInstanceOf(Automation::class, $automation);
     $this->automation = $automation;
   }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -60,7 +60,7 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
     $this->assertNull($this->automationStorage->getAutomation($this->automation->getId() + 1));
   }
 
-  public function testItDuplicatesAAutomation(): void {
+  public function testItDuplicatesAnAutomation(): void {
     $data = $this->post(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));
 
     $id = $this->automation->getId() + 1;
@@ -96,10 +96,12 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
           'id' => 'root',
           'type' => 'root',
           'key' => 'core:root',
+          'subject_keys' => [],
           'args' => [],
           'next_steps' => [],
         ],
       ],
+      'meta' => [],
     ];
     $this->assertSame(['data' => $expected], $data);
 

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -96,7 +96,6 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
           'id' => 'root',
           'type' => 'root',
           'key' => 'core:root',
-          'subject_keys' => [],
           'args' => [],
           'next_steps' => [],
         ],


### PR DESCRIPTION
## Description

Solves [MAILPOET-4966]

## Code review notes

As we discussed, for now we show the setting only when a certain circumstances are given: No trigger, or trigger with subscriber subject ([3039181](https://github.com/mailpoet/mailpoet/pull/4737/commits/3039181454210a5245003af35ae0e3a1786c0e62)). I therefore extended the `Step` definition in React: [7fb717f](https://github.com/mailpoet/mailpoet/pull/4737/commits/7fb717f89495b166a88ba0d3e534ae4ad222ad01), which made it necessary to update also the Add Step process in premium, to transfer this information to the automation data.

I moved the subjects of a run to its own data table and I added a `hash`, which is indexed in order to query by hash. The hash is a `md5` hash, which limits the length of the string. I chose to do so as this enables us to use `longtext` for the subject arguments.

As I test whether `Automation::getMeta()` et.al work as expected, I added also some more tests for the `Automation` class.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/683

## Linked tickets

[MAILPOET-4966]


[MAILPOET-4966]: https://mailpoet.atlassian.net/browse/MAILPOET-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4966]: https://mailpoet.atlassian.net/browse/MAILPOET-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ