### PR TITLE
Test mail poet using the latest woo commerce release 7 4 and bump the woo tags [MAILPOET-4783]

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -12,7 +12,7 @@
  * Domain Path: /lang
  *
  * WC requires at least: 6.9.0
- * WC tested up to: 7.1.0
+ * WC tested up to: 7.4.0
  *
  * @package WordPress
  * @author MailPoet

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,7 +11,7 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 6.9.0
+ * WC requires at least: 7.2.0
  * WC tested up to: 7.4.0
  *
  * @package WordPress

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -64,7 +64,7 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->waitForText('Name');
     $i->see('Welcome new subscribers');
     $i->see('Active');
-    $i->see('Entered 0'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
+    $i->see('Entered 0', ['css' => '.mailpoet-automation-stats-item']); //Actually I see "0 Entered", but this CSS switch is not caught by the test
     $i->dontSeeInDatabase('mp_actionscheduler_actions', ['hook' => 'mailpoet/automation/step']);
 
     $i->wantTo('Check a new subscriber gets the automation email.');
@@ -77,8 +77,8 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->amOnMailpoetPage('Automation');
     $i->seeInDatabase('mp_actionscheduler_actions', ['hook' => 'mailpoet/automation/step', 'status' => 'pending']);
     $i->waitForText('Welcome new subscribers');
-    $i->see('Entered 1'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
-    $i->see('Processing 1');
+    $i->see('Entered 1', ['css' => '.mailpoet-automation-stats-item']); //Actually I see "1 Entered", but this CSS switch is not caught by the test
+    $i->see('Processing 1', ['css' => '.mailpoet-automation-stats-item']);
     $i->see('Exited 0');
     $i->amOnMailboxAppPage();
     $i->see('Inbox (0)');
@@ -91,9 +91,9 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->amOnUrl('http://test.local/wp-admin/');
     $i->amOnMailpoetPage('Automation');
     $i->waitForText('Welcome new subscribers');
-    $i->see('Entered 1'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
-    $i->see('Processing 0');
-    $i->see('Exited 1');
+    $i->see('Entered 1', ['css' => '.mailpoet-automation-stats-item']); //Actually I see "1 Entered", but this CSS switch is not caught by the test
+    $i->see('Processing 0', ['css' => '.mailpoet-automation-stats-item']);
+    $i->see('Exited 1', ['css' => '.mailpoet-automation-stats-item']);
     $i->amOnMailboxAppPage();
     $i->see('Inbox (1)');
     $i->see('Automation-Test-Subject');

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
@@ -41,7 +41,7 @@ class DeleteNewsletterCest {
     // click to select all newsletters
     $i->click('[data-automation-id="select_all"]');
     $i->click('Restore');
-    $i->waitForText('2 emails have been restored from the Trash.');
+    $i->waitForText('2 emails have been restored from the Trash.', 20);
     $i->changeGroupInListingFilter('all');
     $i->waitForText($newsletterName);
   }

--- a/mailpoet/tests/acceptance/Newsletters/SendPageSenderDomainCheckCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendPageSenderDomainCheckCest.php
@@ -21,6 +21,7 @@ class SendPageSenderDomainCheckCest {
 
     $dmarcError = 'Email violates Sender Domain’s DMARC policy.';
     $i->cantSee($dmarcError);
+    $i->waitForElement('[id="field_sender_address"]');
     $i->clearField('[id="field_sender_address"]');
     $i->fillField('[id="field_sender_address"]', 'something@automattic.com');
     $i->click('[id="field_sender_name"]'); // Go to different field to trigger blur

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -54,6 +54,7 @@ class CreateNewWordPressUserCest {
     $i->waitForText('Subscribers');
     $i->clickItemRowActionByItemName('newuser@test.com', 'Edit');
     $i->waitForText('Subscribed');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->seeSelectedInSelect2($secondListName);
   }
 }

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -113,9 +113,9 @@ class ManageSubscribersCest {
     $i->waitForText($newSubscriberEmail);
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Delete Permanently');
     $i->waitForText('1 subscriber was permanently deleted.');
+    $i->waitForText($newSubscriberEmail2, 20);
     $i->dontSee($newSubscriberEmail);
 
-    $i->waitForText($newSubscriberEmail2, 20);
     $i->seeNoJSErrors();
   }
 

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -113,6 +113,7 @@ class ManageSubscribersCest {
     $i->waitForText($newSubscriberEmail);
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Delete Permanently');
     $i->waitForText('1 subscriber was permanently deleted.');
+    $i->waitForElementNotVisible('.mailpoet-listing-loading');
     $i->waitForText($newSubscriberEmail2, 20);
     $i->dontSee($newSubscriberEmail);
 
@@ -211,6 +212,7 @@ class ManageSubscribersCest {
     $i->waitForElementVisible('[data-automation-id="listing_item_1"]');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
     $i->waitForText('Subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->seeSelectedInSelect2('Cooking');
     $i->seeSelectedInSelect2('Camping');
     $i->seeOptionIsSelected('[data-automation-id="subscriber-status"]', 'Subscribed');

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -85,7 +85,7 @@ class ManageSubscriptionLinkCest {
     $link = $i->grabTextFrom('//div[@class="row headers"]//th[text()="List-Unsubscribe"]/following-sibling::td');
     $link = trim($link, '<>');
     $i->amOnUrl($link);
-    $i->waitForText('You are now unsubscribed');
+    $i->waitForText('You are now unsubscribed', 15);
     $i->click('Manage your subscription');
     $i->seeOptionIsSelected($formStatusElement, 'Unsubscribed');
 


### PR DESCRIPTION
## Description

 - This PR tests MailPoet against WC 7.4, while running the acceptance tests locally some tests kept failing and for better clarity these are fixed so I could run the tests with WC 7.4
- It updates the WC compatibility tags

## Linked tickets

[MAILPOET-4783]



[MAILPOET-4783]: https://mailpoet.atlassian.net/browse/MAILPOET-4783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ