### PR TITLE
Merge checkout opt-ins from AutomateWoo and MailPoet [MAILPOET-5057]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ jobs:
             ./do download:woo-commerce-subscriptions-zip 4.6.0
             ./do download:woo-commerce-memberships-zip 1.23.1
             ./do download:woo-commerce-blocks-zip 8.8.2
+            ./do download:automate-woo-zip 5.6.8
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |
@@ -344,6 +345,9 @@ jobs:
       woo_blocks_version:
         type: string
         default: ''
+      automate_woo_version:
+        type: string
+        default: ''
       enable_cot:
         type: integer
         default: 0
@@ -397,6 +401,14 @@ jobs:
                 command: |
                   cd tests/docker
                   docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-blocks-zip << parameters.woo_blocks_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+      - when:
+          condition: << parameters.automate_woo_version >>
+          steps:
+            - run:
+                name: Download AutomateWoo
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - run:
           name: Group acceptance tests
           command: |
@@ -759,6 +771,7 @@ workflows:
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           woo_blocks_version: latest
+          automate_woo_version: latest
           requires:
             - build
       - acceptance_tests:
@@ -768,6 +781,7 @@ workflows:
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0
+          automate_woo_version: 5.1.1
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1229,6 +1229,15 @@ class RoboFile extends \Robo\Tasks {
       ->downloadReleaseZip('woocommerce-subscriptions.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
+  public function downloadAutomateWooZip($tag = null) {
+    if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
+      $this->yell("Skipping download of Automate Woo", 40, 'red');
+      exit(0); // Exit with 0 since it is a valid state for some environments
+    }
+    $this->createGithubClient('woocommerce/automatewoo')
+      ->downloadReleaseZip('automatewoo.zip', __DIR__ . '/tests/plugins/', $tag);
+  }
+
   public function downloadWooCommerceZip($tag = null) {
     $this->createWpOrgDownloader('woocommerce')
     ->downloadPluginZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -399,7 +399,7 @@ class Functions {
 
     /**
    * @param string $tag
-   * @param callable $functionToRemove
+   * @param callable|string|array $functionToRemove
    * @param int $priority
    */
   public function removeAction($tag, $functionToRemove, $priority = 10) {

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -51,6 +51,7 @@ class AcceptanceTester extends \Codeception\Actor {
   const WOO_COMMERCE_BLOCKS_PLUGIN = 'woo-gutenberg-products-block';
   const WOO_COMMERCE_MEMBERSHIPS_PLUGIN = 'woocommerce-memberships';
   const WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN = 'woocommerce-subscriptions';
+  const AUTOMATE_WOO_PLUGIN = 'automatewoo';
 
   /**
    * Define custom actions here
@@ -404,6 +405,16 @@ class AcceptanceTester extends \Codeception\Actor {
   public function deactivateWooCommerceSubscriptions() {
     $i = $this;
     $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN]);
+  }
+
+  public function activateAutomateWoo() {
+    $i = $this;
+    $i->cli(['plugin', 'activate', self::AUTOMATE_WOO_PLUGIN]);
+  }
+
+  public function deactivateAutomateWoo() {
+    $i = $this;
+    $i->cli(['plugin', 'deactivate', self::AUTOMATE_WOO_PLUGIN]);
   }
 
   public function checkPluginIsActive(string $plugin): bool {

--- a/mailpoet/tests/_support/PluginsExtension.php
+++ b/mailpoet/tests/_support/PluginsExtension.php
@@ -12,6 +12,7 @@ class PluginsExtension extends Extension {
   ];
 
   public function setupInitialPluginsState() {
+    exec('wp plugin deactivate automatewoo --allow-root');
     exec('wp plugin deactivate woo-gutenberg-products-block --allow-root');
     exec('wp plugin deactivate woocommerce-memberships --allow-root');
     exec('wp plugin deactivate woocommerce-subscriptions --allow-root');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\WooCommerceProduct;
+
+/**
+ * This class contains tests for subscriptions
+ * of customers done via checkout page with
+ * AutomateWoo plugin active which has its own
+ * checkout opt-in functionality
+ * @group woo
+ */
+class WooCheckoutAutomateWooSubscriptionsCest {
+
+  const MAILPOET_OPTIN_ELEMENT = '#mailpoet_woocommerce_checkout_optin';
+  const AUTOMATE_WOO_OPTIN_TEXT = 'I want to receive updates about products and promotions';
+
+  /** @var Settings */
+  private $settingsFactory;
+
+  /** @var array WooCommerce Product data*/
+  private $product;
+
+  public function _before(\AcceptanceTester $i) {
+    $i->activateWooCommerce();
+    $i->activateAutomateWoo();
+    $this->product = (new WooCommerceProduct($i))->create();
+    $this->settingsFactory = new Settings();
+    $this->settingsFactory->withWooCommerceListImportPageDisplayed(true);
+    $this->settingsFactory->withCookieRevenueTrackingDisabled();
+    // Let AutomateWoo settings to be applied
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-settings');
+    $i->seeCheckboxIsChecked('#automatewoo_enable_checkout_optin');
+    $i->logout();
+  }
+
+  public function checkoutOptInDisabled(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
+    $i->dontSeeElement(self::MAILPOET_OPTIN_ELEMENT);
+  }
+
+  public function checkoutOptInEnabled(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForElement(self::MAILPOET_OPTIN_ELEMENT, 10);
+    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
+  }
+
+  public function checkoutOptInUnchecked(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_uncheck@example.com';
+    $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->dontSee($customerEmail, '.automatewoo-content');
+    $i->seeConfirmationEmailWasNotReceived();
+  }
+
+  public function checkoutOptInChecked(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_check@example.com';
+    $i->orderProductWithRegistration($this->product, $customerEmail, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->see($customerEmail, '.automatewoo-content');
+    $i->seeConfirmationEmailWasReceived();
+  }
+}

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -121,6 +121,19 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     unzip -q -o "$WOOCOMMERCE_BLOCKS_ZIP" -d /wp-core/wp-content/plugins/
   fi
 
+  # Install AutomateWoo
+  if [[ ! -d "/wp-core/wp-content/plugins/automatewoo" ]]; then
+    AUTOMATEWOO_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/automatewoo.zip"
+    if [ ! -f "$AUTOMATEWOO_ZIP" ]; then
+      echo "AutomateWoo plugin zip not found. Downloading AutomateWoo plugin latest zip"
+      cd /project
+      ./do download:automate-woo-zip latest
+      cd /wp-core/wp-content/plugins
+    fi
+    echo "Unzip AutomateWoo plugin from $AUTOMATEWOO_ZIP"
+    unzip -q -o "$AUTOMATEWOO_ZIP" -d /wp-core/wp-content/plugins/
+  fi
+
   # Install WooCommerce COT helper plugin
   mkdir -p /wp-core/wp-content/plugins/woo_cot_helper_plugin
   cp /wp-core/wp-content/plugins/mailpoet/tests/_support/woo_cot_helper_plugin.php /wp-core/wp-content/plugins/woo_cot_helper_plugin.php
@@ -138,12 +151,14 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
   wp plugin activate woocommerce-subscriptions --url=$ACTIVATION_CONTEXT
   wp plugin activate woocommerce-memberships --url=$ACTIVATION_CONTEXT
   wp plugin activate woo-gutenberg-products-block --url=$ACTIVATION_CONTEXT
+  wp plugin activate automatewoo --url=$ACTIVATION_CONTEXT
 
   # print info about activated plugins
   wp plugin get woocommerce --url=$ACTIVATION_CONTEXT
   wp plugin get woocommerce-subscriptions --url=$ACTIVATION_CONTEXT
   wp plugin get woocommerce-memberships --url=$ACTIVATION_CONTEXT
   wp plugin get woo-gutenberg-products-block --url=$ACTIVATION_CONTEXT
+  wp plugin get automatewoo --url=$ACTIVATION_CONTEXT
 
    # Activate helper plugin for WooCommerce COT and create tables in DB
    if [[ $ENABLE_COT == "1" ]]; then


### PR DESCRIPTION
## Description

The solution builds on the fact that WooCommerce actions used by MailPoet are run before actions used by AutomateWoo, so MP can reliably control AW's checkout opt-in behavior.

## Code review notes

_N/A_

## QA notes

**Testing instructions:**
1. Install & activate AutomateWoo;
2. Set up WooCommerce checkout opt-ins in both MP and AW settings;
3. Try to order a product on your site, see if there's only one checkbox (MailPoet's) displayed on the checkout page;
4. Check the checkbox and see that opt-in works for both MP and AW (in the Opt-ins submenu).
5. Install the [Plugins Load Order](https://wordpress.org/plugins/plugins-load-order/) plugin, check that the above-mentioned scenario works regardless of what plugin loads first, MP or AW.

Please test other cases in combination:
* AW active/disabled;
* Opt-in checkbox active/disabled (should display AW's checkbox in the latter case);
* Opt-in checkbox checked/unchecked.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5057]

## After-merge notes

_N/A_


[MAILPOET-5057]: https://mailpoet.atlassian.net/browse/MAILPOET-5057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ