### PR TITLE
Feat/remove coupon block feature flag - MAILPOET-4978

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.tsx
@@ -8,10 +8,7 @@ import ReactDOM from 'react-dom';
 import _ from 'underscore';
 import jQuery from 'jquery';
 import 'backbone.marionette';
-import { MailPoet } from 'mailpoet';
 import { Settings } from './coupon/settings';
-
-export const FEATURE_COUPON_BLOCK = 'Coupon block';
 
 const Module: Record<string, (...args: unknown[]) => void> = {};
 const base = BaseBlock;
@@ -286,10 +283,7 @@ Module.CouponWidgetView = base.WidgetView.extend({
 });
 
 App.on('before:start', (BeforeStartApp) => {
-  if (
-    !MailPoet.FeaturesController.isSupported(FEATURE_COUPON_BLOCK) ||
-    !window.MailPoet.isWoocommerceActive
-  ) {
+  if (!window.MailPoet.isWoocommerceActive) {
     return;
   }
   BeforeStartApp.registerBlockType('coupon', {

--- a/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
@@ -513,16 +513,21 @@ class Avocado {
                                  ],
                               1 =>
                                 [
-                                 'productIds' => [],
-                                 'excludedProductIds' => [],
-                                 'productCategories' => [],
-                                 'excludedProductCategories' => [],
-                                 'type' => 'coupon',
-                                 'amount' => 10,
-                                 'amountMax' => 100,
-                                 'discountType' => 'percent',
-                                 'expiryDay' => 10,
-                                 'styles' => [
+                                  'productIds' => [],
+                                  'excludedProductIds' => [],
+                                  'productCategoryIds' => [],
+                                  'excludedProductCategoryIds' => [],
+                                  'type' => 'coupon',
+                                  'amount' => 10,
+                                  'amountMax' => 100,
+                                  'discountType' => 'percent',
+                                  'expiryDay' => 10,
+                                  'usageLimit' => '',
+                                  'usageLimitPerUser' => '',
+                                  'minimumAmount' => '',
+                                  'maximumAmount' => '',
+                                  'emailRestrictions' => '',
+                                  'styles' => [
                                    'block' => [
                                      'backgroundColor' => '#dbefb4',
                                      'borderColor' => '#3d3d3d',
@@ -537,8 +542,9 @@ class Avocado {
                                      'fontWeight' => 'bold',
                                      'textAlign' => 'center',
                                    ],
-                                 ],
-                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                                  ],
+                                  'source' => 'createNew',
+                                  'code' => 'XXXX-XXXXXXX-XXXX',
                                ],
                               2 =>
                                  [

--- a/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Avocado.php
@@ -512,29 +512,34 @@ class Avocado {
                                   'text' => '<p style="text-align: center;">Send them your exclusive coupon code now and they\'ll receive 50% off their next order, and you\'ll get your next box for free!&nbsp;</p>',
                                  ],
                               1 =>
-                                 [
-                                  'type' => 'button',
-                                  'text' => 'AVOCADOSRULE',
-                                  'url' => '',
-                                  'styles' =>
-                                     [
-                                      'block' =>
-                                         [
-                                          'backgroundColor' => '#dbefb4',
-                                          'borderColor' => '#3d3d3d',
-                                          'borderWidth' => '3px',
-                                          'borderRadius' => '0px',
-                                          'borderStyle' => 'solid',
-                                          'width' => '254px',
-                                          'lineHeight' => '50px',
-                                          'fontColor' => '#3d3d3d',
-                                          'fontFamily' => 'Arial',
-                                          'fontSize' => '26px',
-                                          'fontWeight' => 'bold',
-                                          'textAlign' => 'center',
-                                         ],
-                                     ],
+                                [
+                                 'productIds' => [],
+                                 'excludedProductIds' => [],
+                                 'productCategories' => [],
+                                 'excludedProductCategories' => [],
+                                 'type' => 'coupon',
+                                 'amount' => 10,
+                                 'amountMax' => 100,
+                                 'discountType' => 'percent',
+                                 'expiryDay' => 10,
+                                 'styles' => [
+                                   'block' => [
+                                     'backgroundColor' => '#dbefb4',
+                                     'borderColor' => '#3d3d3d',
+                                     'borderWidth' => '3px',
+                                     'borderRadius' => '0px',
+                                     'borderStyle' => 'solid',
+                                     'width' => '254px',
+                                     'lineHeight' => '50px',
+                                     'fontColor' => '#3d3d3d',
+                                     'fontFamily' => 'Arial',
+                                     'fontSize' => '26px',
+                                     'fontWeight' => 'bold',
+                                     'textAlign' => 'center',
+                                   ],
                                  ],
+                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                               ],
                               2 =>
                                  [
                                   'type' => 'spacer',
@@ -831,30 +836,6 @@ class Avocado {
                  ],
               'backgroundColor' => '#ffffff',
               'backgroundColorAlternate' => '#eeeeee',
-             ],
-          'button' =>
-             [
-              'text' => 'AVOCADOSRULE',
-              'url' => '',
-              'styles' =>
-                 [
-                  'block' =>
-                     [
-                      'backgroundColor' => '#dbefb4',
-                      'borderColor' => '#3d3d3d',
-                      'borderWidth' => '3px',
-                      'borderRadius' => '0px',
-                      'borderStyle' => 'solid',
-                      'width' => '254px',
-                      'lineHeight' => '50px',
-                      'fontColor' => '#3d3d3d',
-                      'fontFamily' => 'Arial',
-                      'fontSize' => '26px',
-                      'fontWeight' => 'bold',
-                      'textAlign' => 'center',
-                     ],
-                 ],
-              'type' => 'button',
              ],
           'divider' =>
              [

--- a/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
@@ -453,13 +453,18 @@ class BookStoreWithCoupon {
                     [
                       'productIds' => [],
                       'excludedProductIds' => [],
-                      'productCategories' => [],
-                      'excludedProductCategories' => [],
+                      'productCategoryIds' => [],
+                      'excludedProductCategoryIds' => [],
                       'type' => 'coupon',
                       'amount' => 10,
                       'amountMax' => 100,
                       'discountType' => 'percent',
                       'expiryDay' => 10,
+                      'usageLimit' => '',
+                      'usageLimitPerUser' => '',
+                      'minimumAmount' => '',
+                      'maximumAmount' => '',
+                      'emailRestrictions' => '',
                       'styles' => [
                         'block' => [
                           'backgroundColor' => '#ffffff',
@@ -476,7 +481,8 @@ class BookStoreWithCoupon {
                           'textAlign' => 'center',
                         ],
                       ],
-                      'code' => 'XXXX-XXXXXXX-XXXX'
+                      'source' => 'createNew',
+                      'code' => 'XXXX-XXXXXXX-XXXX',
                     ],
                   4 =>
                    [

--- a/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/BookStoreWithCoupon.php
@@ -450,29 +450,34 @@ class BookStoreWithCoupon {
                     'text' => '<h2 style="text-align: center;"><strong>20% off all books</strong></h2>',
                    ],
                   3 =>
-                   [
-                    'type' => 'button',
-                    'text' => 'Coupon_Code',
-                    'url' => '',
-                    'styles' =>
-                     [
-                      'block' =>
-                       [
-                        'backgroundColor' => '#ffffff',
-                        'borderColor' => '#125674',
-                        'borderWidth' => '3px',
-                        'borderRadius' => '40px',
-                        'borderStyle' => 'solid',
-                        'width' => '288px',
-                        'lineHeight' => '50px',
-                        'fontColor' => '#125674',
-                        'fontFamily' => 'Courier New',
-                        'fontSize' => '26px',
-                        'fontWeight' => 'bold',
-                        'textAlign' => 'center',
-                       ],
-                     ],
-                   ],
+                    [
+                      'productIds' => [],
+                      'excludedProductIds' => [],
+                      'productCategories' => [],
+                      'excludedProductCategories' => [],
+                      'type' => 'coupon',
+                      'amount' => 10,
+                      'amountMax' => 100,
+                      'discountType' => 'percent',
+                      'expiryDay' => 10,
+                      'styles' => [
+                        'block' => [
+                          'backgroundColor' => '#ffffff',
+                          'borderColor' => '#125674',
+                          'borderWidth' => '3px',
+                          'borderRadius' => '40px',
+                          'borderStyle' => 'solid',
+                          'width' => '288px',
+                          'lineHeight' => '50px',
+                          'fontColor' => '#125674',
+                          'fontFamily' => 'Courier New',
+                          'fontSize' => '26px',
+                          'fontWeight' => 'bold',
+                          'textAlign' => 'center',
+                        ],
+                      ],
+                      'code' => 'XXXX-XXXXXXX-XXXX'
+                    ],
                   4 =>
                    [
                     'type' => 'image',
@@ -1014,30 +1019,6 @@ class BookStoreWithCoupon {
            ],
           'backgroundColor' => '#ffffff',
           'backgroundColorAlternate' => '#eeeeee',
-         ],
-        'button' =>
-         [
-          'text' => 'Coupon_Code',
-          'url' => '',
-          'styles' =>
-           [
-            'block' =>
-             [
-              'backgroundColor' => '#ffffff',
-              'borderColor' => '#125674',
-              'borderWidth' => '3px',
-              'borderRadius' => '40px',
-              'borderStyle' => 'solid',
-              'width' => '288px',
-              'lineHeight' => '50px',
-              'fontColor' => '#125674',
-              'fontFamily' => 'Courier New',
-              'fontSize' => '26px',
-              'fontWeight' => 'bold',
-              'textAlign' => 'center',
-             ],
-           ],
-          'type' => 'button',
          ],
         'divider' =>
          [

--- a/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
@@ -550,16 +550,21 @@ class Fitness {
                                 ],
                               2 =>
                                 [
-                                 'productIds' => [],
-                                 'excludedProductIds' => [],
-                                 'productCategories' => [],
-                                 'excludedProductCategories' => [],
-                                 'type' => 'coupon',
-                                 'amount' => 10,
-                                 'amountMax' => 100,
-                                 'discountType' => 'percent',
-                                 'expiryDay' => 10,
-                                 'styles' => [
+                                  'productIds' => [],
+                                  'excludedProductIds' => [],
+                                  'productCategoryIds' => [],
+                                  'excludedProductCategoryIds' => [],
+                                  'type' => 'coupon',
+                                  'amount' => 10,
+                                  'amountMax' => 100,
+                                  'discountType' => 'percent',
+                                  'expiryDay' => 10,
+                                  'usageLimit' => '',
+                                  'usageLimitPerUser' => '',
+                                  'minimumAmount' => '',
+                                  'maximumAmount' => '',
+                                  'emailRestrictions' => '',
+                                  'styles' => [
                                    'block' => [
                                      'backgroundColor' => '#afd147',
                                      'borderColor' => '#56741d',
@@ -574,8 +579,9 @@ class Fitness {
                                      'fontWeight' => 'bold',
                                      'textAlign' => 'center',
                                    ],
-                                 ],
-                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                                  ],
+                                  'source' => 'createNew',
+                                  'code' => 'XXXX-XXXXXXX-XXXX',
                                ],
                               3 =>
                                  [

--- a/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/Fitness.php
@@ -549,29 +549,34 @@ class Fitness {
 <p style="text-align: center;"><strong>Here\'s 20% off your order if you complete it right now. We\'re nice like that.</strong></p>',
                                 ],
                               2 =>
-                                 [
-                                  'type' => 'button',
-                                  'text' => 'COUPONCODE',
-                                  'url' => '',
-                                  'styles' =>
-                                     [
-                                      'block' =>
-                                         [
-                                          'backgroundColor' => '#afd147',
-                                          'borderColor' => '#56741d',
-                                          'borderWidth' => '3px',
-                                          'borderRadius' => '5px',
-                                          'borderStyle' => 'solid',
-                                          'width' => '219px',
-                                          'lineHeight' => '50px',
-                                          'fontColor' => '#56741d',
-                                          'fontFamily' => 'Courier New',
-                                          'fontSize' => '26px',
-                                          'fontWeight' => 'bold',
-                                          'textAlign' => 'center',
-                                        ],
-                                    ],
-                                ],
+                                [
+                                 'productIds' => [],
+                                 'excludedProductIds' => [],
+                                 'productCategories' => [],
+                                 'excludedProductCategories' => [],
+                                 'type' => 'coupon',
+                                 'amount' => 10,
+                                 'amountMax' => 100,
+                                 'discountType' => 'percent',
+                                 'expiryDay' => 10,
+                                 'styles' => [
+                                   'block' => [
+                                     'backgroundColor' => '#afd147',
+                                     'borderColor' => '#56741d',
+                                     'borderWidth' => '3px',
+                                     'borderRadius' => '5px',
+                                     'borderStyle' => 'solid',
+                                     'width' => '219px',
+                                     'lineHeight' => '50px',
+                                     'fontColor' => '#56741d',
+                                     'fontFamily' => 'Courier New',
+                                     'fontSize' => '26px',
+                                     'fontWeight' => 'bold',
+                                     'textAlign' => 'center',
+                                   ],
+                                 ],
+                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                               ],
                               3 =>
                                  [
                                   'type' => 'spacer',

--- a/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
@@ -366,29 +366,34 @@ class FlowersWithCoupon {
     <p style="text-align: center;"><span style="color: #333333;"><strong>here\'s a little gift from us for your next order.</strong></span></p>',
                    ],
                   1 =>
-                   [
-                    'type' => 'button',
-                    'text' => 'CoUpOn_Code',
-                    'url' => '',
-                    'styles' =>
-                     [
-                      'block' =>
-                       [
-                        'backgroundColor' => '#292929',
-                        'borderColor' => '#0074a2',
-                        'borderWidth' => '0px',
-                        'borderRadius' => '0px',
-                        'borderStyle' => 'solid',
-                        'width' => '288px',
-                        'lineHeight' => '50px',
-                        'fontColor' => '#ffffff',
-                        'fontFamily' => 'Courier New',
-                        'fontSize' => '26px',
-                        'fontWeight' => 'normal',
-                        'textAlign' => 'center',
-                       ],
-                     ],
-                   ],
+                    [
+                      'productIds' => [],
+                      'excludedProductIds' => [],
+                      'productCategories' => [],
+                      'excludedProductCategories' => [],
+                      'type' => 'coupon',
+                      'amount' => 10,
+                      'amountMax' => 100,
+                      'discountType' => 'percent',
+                      'expiryDay' => 10,
+                      'styles' => [
+                        'block' => [
+                          'backgroundColor' => '#292929',
+                          'borderColor' => '#0074a2',
+                          'borderWidth' => '0px',
+                          'borderRadius' => '0px',
+                          'borderStyle' => 'solid',
+                          'width' => '288px',
+                          'lineHeight' => '50px',
+                          'fontColor' => '#ffffff',
+                          'fontFamily' => 'Courier New',
+                          'fontSize' => '26px',
+                          'fontWeight' => 'normal',
+                          'textAlign' => 'center'
+                        ],
+                      ],
+                      'code' => 'XXXX-XXXXXXX-XXXX'
+                    ],
                   2 =>
                    [
                     'type' => 'text',

--- a/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/FlowersWithCoupon.php
@@ -369,13 +369,18 @@ class FlowersWithCoupon {
                     [
                       'productIds' => [],
                       'excludedProductIds' => [],
-                      'productCategories' => [],
-                      'excludedProductCategories' => [],
+                      'productCategoryIds' => [],
+                      'excludedProductCategoryIds' => [],
                       'type' => 'coupon',
                       'amount' => 10,
                       'amountMax' => 100,
                       'discountType' => 'percent',
                       'expiryDay' => 10,
+                      'usageLimit' => '',
+                      'usageLimitPerUser' => '',
+                      'minimumAmount' => '',
+                      'maximumAmount' => '',
+                      'emailRestrictions' => '',
                       'styles' => [
                         'block' => [
                           'backgroundColor' => '#292929',
@@ -389,10 +394,11 @@ class FlowersWithCoupon {
                           'fontFamily' => 'Courier New',
                           'fontSize' => '26px',
                           'fontWeight' => 'normal',
-                          'textAlign' => 'center'
+                          'textAlign' => 'center',
                         ],
                       ],
-                      'code' => 'XXXX-XXXXXXX-XXXX'
+                      'source' => 'createNew',
+                      'code' => 'XXXX-XXXXXXX-XXXX',
                     ],
                   2 =>
                    [

--- a/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
@@ -460,29 +460,34 @@ class WineCity {
 <p style="text-align: center;"><span style="color: #6d6d6d;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam a elementum ex. Aliquam mollis metus ac nisl luctus pulvinar. Donec tincidunt pharetra sem, nec eleifend augue.</span></p>',
                                  ],
                               2 =>
-                                 [
-                                  'type' => 'button',
-                                  'text' => 'CoUponCoDE',
-                                  'url' => '',
-                                  'styles' =>
-                                     [
-                                      'block' =>
-                                         [
-                                          'backgroundColor' => '#ffffff',
-                                          'borderColor' => '#6d6d6d',
-                                          'borderWidth' => '2px',
-                                          'borderRadius' => '0px',
-                                          'borderStyle' => 'solid',
-                                          'width' => '219px',
-                                          'lineHeight' => '50px',
-                                          'fontColor' => '#6d6d6d',
-                                          'fontFamily' => 'Courier New',
-                                          'fontSize' => '30px',
-                                          'fontWeight' => 'bold',
-                                          'textAlign' => 'center',
-                                         ],
-                                     ],
+                                [
+                                 'productIds' => [],
+                                 'excludedProductIds' => [],
+                                 'productCategories' => [],
+                                 'excludedProductCategories' => [],
+                                 'type' => 'coupon',
+                                 'amount' => 10,
+                                 'amountMax' => 100,
+                                 'discountType' => 'percent',
+                                 'expiryDay' => 10,
+                                 'styles' => [
+                                   'block' => [
+                                     'backgroundColor' => '#ffffff',
+                                     'borderColor' => '#6d6d6d',
+                                     'borderWidth' => '2px',
+                                     'borderRadius' => '0px',
+                                     'borderStyle' => 'solid',
+                                     'width' => '219px',
+                                     'lineHeight' => '50px',
+                                     'fontColor' => '#6d6d6d',
+                                     'fontFamily' => 'Courier New',
+                                     'fontSize' => '30px',
+                                     'fontWeight' => 'bold',
+                                     'textAlign' => 'center',
+                                   ],
                                  ],
+                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                               ],
                               3 =>
                                  [
                                   'type' => 'divider',
@@ -756,30 +761,6 @@ class WineCity {
                  ],
               'backgroundColor' => '#ffffff',
               'backgroundColorAlternate' => '#eeeeee',
-             ],
-          'button' =>
-             [
-              'text' => 'CoUponCoDE',
-              'url' => '',
-              'styles' =>
-                 [
-                  'block' =>
-                     [
-                      'backgroundColor' => '#ffffff',
-                      'borderColor' => '#6d6d6d',
-                      'borderWidth' => '2px',
-                      'borderRadius' => '0px',
-                      'borderStyle' => 'solid',
-                      'width' => '219px',
-                      'lineHeight' => '50px',
-                      'fontColor' => '#6d6d6d',
-                      'fontFamily' => 'Courier New',
-                      'fontSize' => '30px',
-                      'fontWeight' => 'bold',
-                      'textAlign' => 'center',
-                     ],
-                 ],
-              'type' => 'button',
              ],
           'divider' =>
              [

--- a/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/WineCity.php
@@ -461,16 +461,21 @@ class WineCity {
                                  ],
                               2 =>
                                 [
-                                 'productIds' => [],
-                                 'excludedProductIds' => [],
-                                 'productCategories' => [],
-                                 'excludedProductCategories' => [],
-                                 'type' => 'coupon',
-                                 'amount' => 10,
-                                 'amountMax' => 100,
-                                 'discountType' => 'percent',
-                                 'expiryDay' => 10,
-                                 'styles' => [
+                                  'productIds' => [],
+                                  'excludedProductIds' => [],
+                                  'productCategoryIds' => [],
+                                  'excludedProductCategoryIds' => [],
+                                  'type' => 'coupon',
+                                  'amount' => 10,
+                                  'amountMax' => 100,
+                                  'discountType' => 'percent',
+                                  'expiryDay' => 10,
+                                  'usageLimit' => '',
+                                  'usageLimitPerUser' => '',
+                                  'minimumAmount' => '',
+                                  'maximumAmount' => '',
+                                  'emailRestrictions' => '',
+                                  'styles' => [
                                    'block' => [
                                      'backgroundColor' => '#ffffff',
                                      'borderColor' => '#6d6d6d',
@@ -485,8 +490,9 @@ class WineCity {
                                      'fontWeight' => 'bold',
                                      'textAlign' => 'center',
                                    ],
-                                 ],
-                                 'code' => 'XXXX-XXXXXXX-XXXX'
+                                  ],
+                                  'source' => 'createNew',
+                                  'code' => 'XXXX-XXXXXXX-XXXX',
                                ],
                               3 =>
                                  [

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -6,16 +6,12 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
   const FEATURE_HOMEPAGE = 'homepage';
-
-  const FEATURE_COUPON_BLOCK = 'Coupon block';
-
   const LANDINGPAGE_AB_TEST_DEBUGGER = 'landingpage_ab_test_debugger';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_HOMEPAGE => false,
-    self::FEATURE_COUPON_BLOCK => false,
     self::LANDINGPAGE_AB_TEST_DEBUGGER => false,
   ];
 

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Newsletter\Renderer;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -32,21 +31,16 @@ class Preprocessor {
   /*** @var CouponPreProcessor */
   private $couponPreProcessor;
 
-  /*** @var FeaturesController */
-  private $featuresController;
-
   public function __construct(
     AbandonedCartContent $abandonedCartContent,
     AutomatedLatestContentBlock $automatedLatestContent,
     ContentPreprocessor $wooCommerceContentPreprocessor,
-    CouponPreProcessor $couponPreProcessor,
-    FeaturesController $featuresController
+    CouponPreProcessor $couponPreProcessor
   ) {
     $this->abandonedCartContent = $abandonedCartContent;
     $this->automatedLatestContent = $automatedLatestContent;
     $this->wooCommerceContentPreprocessor = $wooCommerceContentPreprocessor;
     $this->couponPreProcessor = $couponPreProcessor;
-    $this->featuresController = $featuresController;
   }
 
   /**
@@ -60,9 +54,9 @@ class Preprocessor {
     }
     $blocks = [];
     $contentBlocks = $content['blocks'];
-    if ($this->featuresController->isSupported(FeaturesController::FEATURE_COUPON_BLOCK)) {
-      $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview);
-    }
+
+    $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview);
+
     foreach ($contentBlocks as $block) {
       $processedBlock = $this->processBlock($newsletter, $block, $preview, $sendingTask);
       if (!empty($processedBlock)) {

--- a/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
@@ -2,19 +2,13 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
 
 /**
  * @group woo
  */
 class EditorCouponCest {
-  public function _before() {
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_COUPON_BLOCK);
-  }
-
   public function addCoupon(\AcceptanceTester $i) {
     $couponInEditor = '[data-automation-id="coupon_block"]';
     $couponSettingsHeading = '[data-automation-id="coupon_settings_heading"]';

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -16,7 +16,6 @@ use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\NewsletterPostsRepository;
@@ -26,7 +25,6 @@ use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsRepository;
 use MailPoet\Tasks\Sending as SendingTask;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WooCommerce\Helper;
@@ -487,8 +485,6 @@ class NewsletterTest extends \MailPoetTest {
    * @group woo
    */
   public function testItGeneratesWooCommerceCouponForCouponBlock(): void {
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_COUPON_BLOCK);
-
     $newsletter = (new NewsletterFactory())
       ->loadBodyFrom('newsletterWithCoupon.json')
       ->withType(NewsletterEntity::TYPE_STANDARD)

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\WooCommerce\TransactionalEmails;
 use Codeception\Stub;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\Editor\LayoutHelper as L;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -111,8 +110,7 @@ class RendererTest extends \MailPoetTest {
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent::class),
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock::class),
         $wooPreprocessor,
-        $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class),
-        $this->diContainer->get(FeaturesController::class)
+        $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class)
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(ServicesChecker::class),

--- a/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Test\Newsletter;
 
 use Codeception\Stub;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
 use MailPoet\Newsletter\Renderer\Preprocessor;
@@ -23,8 +22,7 @@ class PreprocessorTest extends \MailPoetUnitTest {
       ],
     ]);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor($transactionalEmails);
-    $featuresController = Stub::make(FeaturesController::class);
-    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor, $featuresController);
+    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor);
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceHeading']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',
@@ -52,8 +50,7 @@ class PreprocessorTest extends \MailPoetUnitTest {
     $alc = Stub::make(AutomatedLatestContentBlock::class);
     $couponPreProcessor = Stub::make(CouponPreProcessor::class);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor(Stub::make(TransactionalEmails::class));
-    $featuresController = Stub::make(FeaturesController::class);
-    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor, $featuresController);
+    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor);
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceContent']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',


### PR DESCRIPTION
## Description

Remove the coupon block feature flag.

## Code review notes

Please start reviewing from https://github.com/mailpoet/mailpoet/commit/1ca34fe39d978417e5d1ea30ad6a94769e776e61

## QA notes

You should be able to use the Coupon block without activating it from the experimental page.

## Linked PRs

Based off https://github.com/mailpoet/mailpoet/pull/4733

## Linked tickets

[MAILPOET-4978](https://mailpoet.atlassian.net/browse/MAILPOET-4978)

## After-merge notes

_N/A_


[MAILPOET-4978]: https://mailpoet.atlassian.net/browse/MAILPOET-4978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ