### PR TITLE
Add a new k6 test: Subscribers filtering by status, list and search subscriber

### DIFF
--- a/mailpoet/tests/performance/README.md
+++ b/mailpoet/tests/performance/README.md
@@ -28,7 +28,7 @@ Automated k6 performance tests for MailPoet. To be used for benchmarking perform
 
 ### Installing k6
 
-You don't need to install it - it's Automattic! :)
+You don't need to install it - it's automatic!
 
 To execute the tests, use the following command:
 

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -5,7 +5,7 @@ export const headlessSet = ['true', '1'].includes(
 export const scenario = __ENV.SCENARIO; // eslint-disable-line
 
 export const adminUsername = 'admin';
-export const adminPassword = 'uYNOVMJVd@!';
+export const adminPassword = 'password';
 export const adminEmail = 'test@test.com';
 
 export const thinkTimeMin = '1';

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -1,11 +1,12 @@
-export const baseURL = __ENV.URL || 'http://localhost:9500';
+export const baseURL = __ENV.URL || 'http://localhost:9500'; // eslint-disable-line
 export const headlessSet = ['true', '1'].includes(
-  `${__ENV.HEADLESS || 'true'}`.toLowerCase(),
+  `${__ENV.HEADLESS || 'true'}`.toLowerCase(), // eslint-disable-line
 );
-export const scenario = __ENV.SCENARIO;
+export const scenario = __ENV.SCENARIO; // eslint-disable-line
 
 export const adminUsername = 'admin';
-export const adminPassword = 'password';
+export const adminPassword = 'uYNOVMJVd@!';
+export const adminEmail = 'test@test.com';
 
 export const thinkTimeMin = '1';
 export const thinkTimeMax = '4';

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -3,6 +3,7 @@ export const headlessSet = ['true', '1'].includes(
   `${__ENV.HEADLESS || 'true'}`.toLowerCase(), // eslint-disable-line
 );
 export const scenario = __ENV.SCENARIO; // eslint-disable-line
+export const timeoutSet = '2m';
 
 export const adminUsername = 'admin';
 export const adminPassword = 'password';

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -4,6 +4,7 @@
 import { newsletterListing } from './tests/newsletter-listing.js';
 import { subscribersListing } from './tests/subscribers-listing.js';
 import { settingsBasic } from './tests/settings-basic.js';
+import { subscribersFiltering } from './tests/subscribers-filtering.js';
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
@@ -18,6 +19,7 @@ export let options = {
     browser_first_paint: ['max < 2000'],
     browser_loaded: ['p(95) < 3000'],
     http_req_duration: ['p(95) < 2500'],
+    http_req_receiving: ['p(95) < 2500'],
     checks: ['rate==1.0'],
   },
   tags: {
@@ -57,6 +59,7 @@ export function pullRequests() {
   newsletterListing();
   subscribersListing();
   settingsBasic();
+  subscribersFiltering();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**
@@ -28,7 +27,7 @@ export function newsletterListing() {
   });
   const page = browser.newPage();
 
-  group('Emails - Load all newsletters', function EmailsLoadAllNewsletters() {
+  group('Emails - Load all newsletters', () => {
     page
       .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
         waitUntil: 'networkidle',

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -11,12 +11,21 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 /**
  * Internal dependencies
  */
-import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+} from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function newsletterListing() {
-  const browser = chromium.launch({ headless: headlessSet });
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
   const page = browser.newPage();
 
   group('Emails - Load all newsletters', function EmailsLoadAllNewsletters() {
@@ -49,7 +58,7 @@ export function newsletterListing() {
       });
   });
 
-  sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }
 
 export default function newsletterListingTest() {

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -11,12 +11,21 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 /**
  * Internal dependencies
  */
-import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+} from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function settingsBasic() {
-  const browser = chromium.launch({ headless: headlessSet });
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
   const page = browser.newPage();
 
   group(
@@ -67,7 +76,7 @@ export function settingsBasic() {
     },
   );
 
-  sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }
 
 export default function settingsBasicTest() {

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**
@@ -28,53 +27,48 @@ export function settingsBasic() {
   });
   const page = browser.newPage();
 
-  group(
-    'Settings - Load and save the basics tab',
-    function settingsBasicTabSaving() {
-      page
-        .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-settings#/basics`, {
-          waitUntil: 'networkidle',
-        })
+  group('Settings - Load and save the basics tab', () => {
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-settings#/basics`, {
+        waitUntil: 'networkidle',
+      })
 
-        .then(() => {
-          authenticate(page);
-        })
+      .then(() => {
+        authenticate(page);
+      })
 
-        .then(() => {
-          return Promise.all([
-            page.waitForNavigation({ waitUntil: 'networkidle' }),
-          ]);
-        })
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
 
-        .then(() => {
-          check(page, {
-            'basics tab is visible': page
-              .locator('[data-automation-id="basic_settings_tab"]')
-              .isVisible(),
-          });
-        })
-
-        .then(() => {
-          return Promise.all([
-            page.waitForNavigation(),
-            page
-              .locator('[data-automation-id="settings-submit-button"]')
-              .click(),
-          ]);
-        })
-
-        .then(() => {
-          check(page, {
-            'settings saved is visible': page.locator('div.notice').isVisible(),
-          });
-        })
-
-        .finally(() => {
-          page.close();
-          browser.close();
+      .then(() => {
+        check(page, {
+          'basics tab is visible': page
+            .locator('[data-automation-id="basic_settings_tab"]')
+            .isVisible(),
         });
-    },
-  );
+      })
+
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation(),
+          page.locator('[data-automation-id="settings-submit-button"]').click(),
+        ]);
+      })
+
+      .then(() => {
+        check(page, {
+          'settings saved is visible': page.locator('div.notice').isVisible(),
+        });
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
 
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -42,6 +42,16 @@ export function subscribersFiltering() {
       })
 
       .then(() => {
+        page.locator('[data-automation-id="filters_subscribed"]').click();
+        page.waitForSelector('[data-automation-id="filters_subscribed"]');
+        check(page, {
+          'subscribers filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+        });
+      })
+
+      .then(() => {
         page
           .locator('[data-automation-id="listing_filter_segment"]')
           .selectOption('3');
@@ -56,7 +66,7 @@ export function subscribersFiltering() {
 
       .then(() => {
         page.waitForNavigation({ waitUntil: 'networkidle' });
-        page.locator('#search_input').type(adminEmail);
+        page.locator('#search_input').type(adminEmail, { delay: 50 });
         sleep(2);
         page.waitForSelector('[data-automation-id="filters_subscribed"]');
         check(page, {

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -16,13 +16,17 @@ import {
   thinkTimeMin,
   thinkTimeMax,
   headlessSet,
+  timeoutSet,
   adminEmail,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function subscribersFiltering() {
-  const browser = chromium.launch({ headless: headlessSet });
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
   const page = browser.newPage();
 
   group('Subscribers - Filter subscribers', function subscribersFiltering() {
@@ -55,7 +59,7 @@ export function subscribersFiltering() {
         page
           .locator('[data-automation-id="listing_filter_segment"]')
           .selectOption('3');
-        sleep(2);
+        page.waitForSelector('.mailpoet-listing-no-items');
         page.waitForSelector('[data-automation-id="filters_subscribed"]');
         check(page, {
           'subscribers filter is visible': page
@@ -67,7 +71,7 @@ export function subscribersFiltering() {
       .then(() => {
         page.waitForNavigation({ waitUntil: 'networkidle' });
         page.locator('#search_input').type(adminEmail, { delay: 50 });
-        sleep(2);
+        page.waitForSelector('.mailpoet-listing-no-items');
         page.waitForSelector('[data-automation-id="filters_subscribed"]');
         check(page, {
           'subscribers filter is visible': page
@@ -82,7 +86,7 @@ export function subscribersFiltering() {
       });
   });
 
-  sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }
 
 export default function subscribersFilteringTest() {

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**
@@ -29,7 +28,7 @@ export function subscribersFiltering() {
   });
   const page = browser.newPage();
 
-  group('Subscribers - Filter subscribers', function subscribersFiltering() {
+  group('Subscribers - Filter subscribers', () => {
     page
       .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
         waitUntil: 'networkidle',

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-shadow */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check, group } from 'k6';
+import { chromium } from 'k6/x/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  adminEmail,
+} from '../config.js';
+import { authenticate } from '../utils/helpers.js';
+/* global Promise */
+
+export function subscribersFiltering() {
+  const browser = chromium.launch({ headless: headlessSet });
+  const page = browser.newPage();
+
+  group('Subscribers - Filter subscribers', function subscribersFiltering() {
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+        waitUntil: 'networkidle',
+      })
+
+      .then(() => {
+        authenticate(page);
+      })
+
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
+
+      .then(() => {
+        page
+          .locator('[data-automation-id="listing_filter_segment"]')
+          .selectOption('3');
+        sleep(2);
+        page.waitForSelector('[data-automation-id="filters_subscribed"]');
+        check(page, {
+          'subscribers filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+        });
+      })
+
+      .then(() => {
+        page.waitForNavigation({ waitUntil: 'networkidle' });
+        page.locator('#search_input').type(adminEmail);
+        sleep(2);
+        page.waitForSelector('[data-automation-id="filters_subscribed"]');
+        check(page, {
+          'subscribers filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+        });
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
+
+  sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
+}
+
+export default function subscribersFilteringTest() {
+  subscribersFiltering();
+}

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -11,12 +11,21 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 /**
  * Internal dependencies
  */
-import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+} from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function subscribersListing() {
-  const browser = chromium.launch({ headless: headlessSet });
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
   const page = browser.newPage();
 
   group(
@@ -58,7 +67,7 @@ export function subscribersListing() {
     },
   );
 
-  sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }
 
 export default function subscribersListingTest() {

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**
@@ -28,44 +27,41 @@ export function subscribersListing() {
   });
   const page = browser.newPage();
 
-  group(
-    'Subscribers - Load all subscribers',
-    function subscribersLoadAllSusbcribers() {
-      page
-        .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
-          waitUntil: 'networkidle',
-        })
+  group('Subscribers - Load all subscribers', () => {
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+        waitUntil: 'networkidle',
+      })
 
-        .then(() => {
-          authenticate(page);
-        })
+      .then(() => {
+        authenticate(page);
+      })
 
-        .then(() => {
-          return Promise.all([
-            page.waitForNavigation({ waitUntil: 'networkidle' }),
-          ]);
-        })
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
 
-        .then(() => {
-          check(page, {
-            'subscribers filter is visible': page
-              .locator('[data-automation-id="listing_filter_segment"]')
-              .isVisible(),
-            'subscribers tag is visible': page
-              .locator('[data-automation-id="listing_filter_tag"]')
-              .isVisible(),
-            'subscribers listing is visible': page
-              .locator('table.mailpoet-listing-table')
-              .isVisible(),
-          });
-        })
-
-        .finally(() => {
-          page.close();
-          browser.close();
+      .then(() => {
+        check(page, {
+          'subscribers filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+          'subscribers tag is visible': page
+            .locator('[data-automation-id="listing_filter_tag"]')
+            .isVisible(),
+          'subscribers listing is visible': page
+            .locator('table.mailpoet-listing-table')
+            .isVisible(),
         });
-    },
-  );
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
 
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }

--- a/mailpoet/tests/performance/tests/wp-login.js
+++ b/mailpoet/tests/performance/tests/wp-login.js
@@ -11,12 +11,21 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 /**
  * Internal dependencies
  */
-import { baseURL, thinkTimeMin, thinkTimeMax, headlessSet } from '../config.js';
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+} from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 /* global Promise */
 
 export function wpLogin() {
-  const browser = chromium.launch({ headless: headlessSet });
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
   const page = browser.newPage();
 
   group('Login to WP Admin', function LoginToWPAdmin() {
@@ -46,7 +55,7 @@ export function wpLogin() {
       });
   });
 
-  sleep(randomIntBetween(`${thinkTimeMin}`, `${thinkTimeMax}`));
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 }
 
 export default function wpLoginTest() {

--- a/mailpoet/tests/performance/tests/wp-login.js
+++ b/mailpoet/tests/performance/tests/wp-login.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**
@@ -28,7 +27,7 @@ export function wpLogin() {
   });
   const page = browser.newPage();
 
-  group('Login to WP Admin', function LoginToWPAdmin() {
+  group('Login to WP Admin', () => {
     page
       .goto(`${baseURL}/wp-login.php`, { waitUntil: 'networkidle' })
 

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**


### PR DESCRIPTION
## Description

More details in the linked Jira ticket below.

In this task, I wanted to add a new k6 tests:

- Subscribers filtering by subscribed status
- Subscribers filtering by a list
- Searching for a specific subscriber

Testable against qawp.net site (local site is empty, no testing data)

Additionally, I added a few changes:

- Renamed Automattic to automatic.
- Added adminEmail in config file
- Added eslint ignore for __ENV lines in config.js, we use it currently for running tests but not inside the test files so it triggers error when you want to commit

## Code review notes

After reviewing the code, please try running this individual test locally against qawp.net test site using the following command:

Note: Before running these, make sure to change the admin password in `config.js` from `password` to **reveal the password on the secret store** (search for `qawp`).

- ./do test:performance --url=https://qawp.net tests/performance/tests/subscribers-filtering.js --head
- ./do test:performance --url=https://qawp.net --scenario pullrequests

Expected result when running this test case: https://d.pr/i/kmSawi
Expected result when running scenarios: https://d.pr/i/iJpVqh

## Linked tickets

[MAILPOET-4955](https://mailpoet.atlassian.net/browse/MAILPOET-4955)

[MAILPOET-4955]: https://mailpoet.atlassian.net/browse/MAILPOET-4955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ