### PR TITLE
Auto merge release PRs after a successful release [MAILPOET-3987]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1013,6 +1013,9 @@ class RoboFile extends \Robo\Tasks {
       ->addCode(function () use ($version) {
         return $this->releasePublishSlack($version);
       })
+      ->addCode(function () {
+        return $this->releaseMergePullRequest(\MailPoetTasks\Release\GitHubController::RELEASE_SOURCE_BRANCH);
+      })
       ->run();
   }
 

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1016,6 +1016,17 @@ class RoboFile extends \Robo\Tasks {
       ->run();
   }
 
+  public function releaseMergePullRequest(string $branch) {
+    try {
+      $this->createGitHubController()
+        ->mergePullRequest(\MailPoetTasks\Release\CircleCiController::PROJECT_MAILPOET, $branch);
+    } catch (\Exception $e) {
+      $this->yell($e->getMessage(), 40, 'red');
+      exit(1);
+    }
+    $this->say("Pull request for branch: '{$branch}' was successfully merged");
+  }
+
   /**
    * This command displays how many pull request each person did recently
    */

--- a/mailpoet/tasks/release/GitHubController.php
+++ b/mailpoet/tasks/release/GitHubController.php
@@ -266,7 +266,10 @@ class GitHubController {
 
     $response = $this->httpClient->put(
       "pulls/{$pullRequest['number']}/merge",
-      ['http_errors' => false]
+      [
+        'http_errors' => false,
+        'json' => ['merge_method' => 'rebase'],
+      ]
     );
 
     if ($response->getStatusCode() !== 200) {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I wanted to use [the listing endpoint](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests) to search for a specific PR, but since it doesn't allow it, I decided to use search endpoint.

## QA notes

I guess we can skip QA here.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/685

## Linked tickets

[MAILPOET-3987]

## After-merge notes

Update release documentation


[MAILPOET-3987]: https://mailpoet.atlassian.net/browse/MAILPOET-3987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ