### PR TITLE
Coupon block error handling log errors for the newsletter stop sending for this newsletter [MAILPOET-4983]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -203,11 +203,15 @@ h1.title.mailpoet-newsletter-listing-heading {
 }
 
 .mailpoet-listing-status-corrupt {
-  color: $color-destructive;
+  flex-direction: column;
   padding-left: 0;
 
   .mailpoet-listing-status-label {
     padding-left: 0;
+  }
+
+  .mailpoet-listing-status-message {
+    color: $color-destructive;
   }
 }
 

--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -202,6 +202,15 @@ h1.title.mailpoet-newsletter-listing-heading {
   }
 }
 
+.mailpoet-listing-status-corrupt {
+  color: $color-destructive;
+  padding-left: 0;
+
+  .mailpoet-listing-status-label {
+    padding-left: 0;
+  }
+}
+
 .mailpoet-listing-status-percentage {
   stroke-width: 2px;
 }

--- a/mailpoet/assets/js/src/common/index.ts
+++ b/mailpoet/assets/js/src/common/index.ts
@@ -13,3 +13,4 @@ export * from './functions';
 export * from './utils';
 export * from './thumbnail';
 export * from './controls';
+export * from './confirm_alert';

--- a/mailpoet/assets/js/src/common/listings/_stories/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/_stories/newsletter_status.tsx
@@ -2,6 +2,7 @@ import { addHours, subHours } from 'date-fns';
 import { MailPoet } from 'mailpoet';
 import { NewsletterStatus } from '../newsletter_status';
 import { Heading } from '../../typography/heading/heading';
+import { NewsletterStatus as NewsletterStatusEnum } from '../../../newsletters/models';
 
 MailPoet.I18n.add('notSentYet', 'Not sent yet!');
 MailPoet.I18n.add('sent', 'Sent');
@@ -57,7 +58,7 @@ export function NewsletterStatuses() {
       <div className="mailpoet-gap" />
 
       <Heading level={3}>Sent without queue</Heading>
-      <NewsletterStatus status="sent" />
+      <NewsletterStatus status={NewsletterStatusEnum.Sent} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/common/listings/_stories/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/_stories/newsletter_status.tsx
@@ -1,8 +1,8 @@
 import { addHours, subHours } from 'date-fns';
 import { MailPoet } from 'mailpoet';
-import { NewsletterStatus } from '../newsletter_status';
-import { Heading } from '../../typography/heading/heading';
 import { NewsletterStatus as NewsletterStatusEnum } from 'newsletters/models';
+import { NewsletterStatus } from '../newsletter_status';
+import { Heading } from '../../typography';
 
 MailPoet.I18n.add('notSentYet', 'Not sent yet!');
 MailPoet.I18n.add('sent', 'Sent');

--- a/mailpoet/assets/js/src/common/listings/_stories/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/_stories/newsletter_status.tsx
@@ -2,7 +2,7 @@ import { addHours, subHours } from 'date-fns';
 import { MailPoet } from 'mailpoet';
 import { NewsletterStatus } from '../newsletter_status';
 import { Heading } from '../../typography/heading/heading';
-import { NewsletterStatus as NewsletterStatusEnum } from '../../../newsletters/models';
+import { NewsletterStatus as NewsletterStatusEnum } from 'newsletters/models';
 
 MailPoet.I18n.add('notSentYet', 'Not sent yet!');
 MailPoet.I18n.add('sent', 'Sent');

--- a/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from '../tooltip/tooltip';
 import {
   NewsLetter,
   NewsletterStatus as NewsletterStatusEnum,
-} from '../../newsletters/models';
+} from 'newsletters/models';
 
 type CircularProgressProps = {
   percentage: number;

--- a/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
@@ -2,11 +2,11 @@ import { MailPoet } from 'mailpoet';
 import classnames from 'classnames';
 import { addDays, differenceInMinutes, isFuture, isPast } from 'date-fns';
 import { t } from 'common/functions/t';
-import { Tooltip } from '../tooltip/tooltip';
 import {
   NewsLetter,
   NewsletterStatus as NewsletterStatusEnum,
 } from 'newsletters/models';
+import { Tooltip } from '../tooltip/tooltip';
 
 type CircularProgressProps = {
   percentage: number;

--- a/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
@@ -3,7 +3,10 @@ import classnames from 'classnames';
 import { addDays, differenceInMinutes, isFuture, isPast } from 'date-fns';
 import { t } from 'common/functions/t';
 import { Tooltip } from '../tooltip/tooltip';
-import { NewsletterStatus as NewsletterStatusEnum } from '../../newsletters/models';
+import {
+  NewsLetter,
+  NewsletterStatus as NewsletterStatusEnum,
+} from '../../newsletters/models';
 
 type CircularProgressProps = {
   percentage: number;
@@ -62,6 +65,7 @@ type NewsletterStatusProps = {
   total?: number;
   isPaused?: boolean;
   status?: NewsletterStatusEnum;
+  logs?: NewsLetter['logs'];
 };
 
 function NewsletterStatus({
@@ -70,6 +74,7 @@ function NewsletterStatus({
   total,
   isPaused,
   status,
+  logs = [],
 }: NewsletterStatusProps) {
   const isCorrupt = status === 'corrupt';
   const unknown = !scheduledFor && !processed && !total;
@@ -155,6 +160,9 @@ function NewsletterStatus({
       {scheduled && <ScheduledIcon />}
       {!isCorrupt && <CircularProgress percentage={percentage} />}
       <div className="mailpoet-listing-status-label">{label}</div>
+      {isCorrupt && logs.length > 0 && (
+        <div className="mailpoet-listing-status-message">{logs.join('\n')}</div>
+      )}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter_status.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { addDays, differenceInMinutes, isFuture, isPast } from 'date-fns';
 import { t } from 'common/functions/t';
 import { Tooltip } from '../tooltip/tooltip';
+import { NewsletterStatus as NewsletterStatusEnum } from '../../newsletters/models';
 
 type CircularProgressProps = {
   percentage: number;
@@ -60,7 +61,7 @@ type NewsletterStatusProps = {
   processed?: number;
   total?: number;
   isPaused?: boolean;
-  status?: string;
+  status?: NewsletterStatusEnum;
 };
 
 function NewsletterStatus({
@@ -70,10 +71,11 @@ function NewsletterStatus({
   isPaused,
   status,
 }: NewsletterStatusProps) {
+  const isCorrupt = status === 'corrupt';
   const unknown = !scheduledFor && !processed && !total;
   const scheduled = scheduledFor && isFuture(scheduledFor);
   const inProgress =
-    (!scheduledFor || isPast(scheduledFor)) && processed < total;
+    (!scheduledFor || isPast(scheduledFor)) && processed < total && !isCorrupt;
   const sent = (!scheduledFor || isPast(scheduledFor)) && processed >= total;
   const sentWithoutQueue = status === 'sent' && total === undefined;
   let percentage = 0;
@@ -134,6 +136,11 @@ function NewsletterStatus({
   if (isPaused && !sent && !sentWithoutQueue) {
     label = t('paused');
   }
+
+  if (isCorrupt) {
+    label = t('renderingProblem');
+  }
+
   return (
     <div
       className={classnames({
@@ -142,10 +149,11 @@ function NewsletterStatus({
         'mailpoet-listing-status-scheduled': scheduled,
         'mailpoet-listing-status-in-progress': inProgress,
         'mailpoet-listing-status-sent': sent || sentWithoutQueue,
+        'mailpoet-listing-status-corrupt': isCorrupt,
       })}
     >
       {scheduled && <ScheduledIcon />}
-      <CircularProgress percentage={percentage} />
+      {!isCorrupt && <CircularProgress percentage={percentage} />}
       <div className="mailpoet-listing-status-label">{label}</div>
     </div>
   );

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -230,4 +230,8 @@ interface Window {
       events: string[];
     }
   >;
+  corrupt_newsletters: Array<{
+    id: string;
+    subject: string;
+  }>;
 }

--- a/mailpoet/assets/js/src/help/system_status.jsx
+++ b/mailpoet/assets/js/src/help/system_status.jsx
@@ -1,7 +1,7 @@
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
 import { CronStatus } from './cron_status.jsx';
-import { QueueStatus } from './queue_status.jsx';
+import { QueueStatus } from './queue_status';
 import { ActionSchedulerStatus } from './action_scheduler_status';
 
 function renderStatusMessage(

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -6,9 +6,9 @@ import { MailPoetAjax } from './ajax';
 import { MailPoetModal } from './modal';
 import { MailPoetNotice } from './notice';
 import {
+  initializeMixpanelWhenLoaded,
   MailPoetForceTrackEvent,
   MailPoetTrackEvent,
-  initializeMixpanelWhenLoaded,
 } from './analytics_event';
 import { MailPoetNum } from './num';
 import { MailPoetHelpTooltip } from './help-tooltip-helper';
@@ -75,6 +75,7 @@ export const MailPoet = {
   transactionalEmailsOptInNoticeDismissed:
     window.mailpoet_transactional_emails_opt_in_notice_dismissed,
   mailFunctionEnabled: window.mailpoet_mail_function_enabled,
+  corrupt_newsletters: window.corrupt_newsletters ?? [],
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/newsletters/listings/notification_history.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification_history.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
-import { QueueStatus } from 'newsletters/listings/queue_status.jsx';
+import { QueueStatus } from 'newsletters/listings/queue_status';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
 import {
   addStatsCTAAction,

--- a/mailpoet/assets/js/src/newsletters/listings/queue_status.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue_status.tsx
@@ -4,13 +4,12 @@ import { Link } from 'react-router-dom';
 import parseDate from 'date-fns/parse';
 import { APIErrorsNotice } from 'notices/api_errors_notice';
 import { Button } from 'common/button/button';
-import { NewsletterStatus } from 'common/listings/newsletter_status';
-import { withBoundary } from '../../common';
+import { NewsletterStatus } from 'common/listings';
+import { confirmAlert, withBoundary } from 'common';
 import {
   NewsLetter,
   NewsletterStatus as NewsletterStatusEnum,
 } from '../models';
-import { confirmAlert } from '../../common/confirm_alert';
 
 type QueueSendingProps = {
   newsletter: NewsLetter;

--- a/mailpoet/assets/js/src/newsletters/listings/queue_status.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue_status.tsx
@@ -90,6 +90,7 @@ function QueueStatus({ newsletter, mailerLog }: QueueStatusProps) {
           total={parseInt(newsletter.queue.count_total, 10)}
           isPaused={isMtaPaused}
           status={newsletter.status}
+          logs={newsletter.logs}
         />
       </Link>
       {newsletter.queue.status !== 'completed' && !isMtaPaused && (
@@ -103,6 +104,7 @@ function QueueStatus({ newsletter, mailerLog }: QueueStatusProps) {
       scheduledFor={newsletterDate}
       isPaused={newsletter.queue.status === 'scheduled' && isMtaPaused}
       status={newsletter.status}
+      logs={newsletter.logs}
     />
   );
 

--- a/mailpoet/assets/js/src/newsletters/listings/queue_status.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue_status.tsx
@@ -52,10 +52,9 @@ function QueueSending({ newsletter }: QueueSendingProps) {
   };
 
   const confirmAndResumeSending = async () => {
-    setErrors([]);
     confirmAlert({
       message: MailPoet.I18n.t('confirmResumingCorruptNewsletter'),
-      onConfirm: requestResume,
+      onConfirm: resumeSending,
     });
   };
 

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 import { confirmAlert } from 'common/confirm_alert.jsx';
 import { SegmentTags } from 'common/tag/tags';
 import { Listing } from 'listing/listing.jsx';
-import { QueueStatus } from 'newsletters/listings/queue_status.jsx';
+import { QueueStatus } from 'newsletters/listings/queue_status';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
 import {
   addStatsCTAAction,

--- a/mailpoet/assets/js/src/newsletters/models/newsletter.ts
+++ b/mailpoet/assets/js/src/newsletters/models/newsletter.ts
@@ -15,6 +15,7 @@ export enum NewsletterStatus {
   Sending = 'sending',
   Sent = 'sent',
   Active = 'active',
+  Corrupt = 'corrupt',
 }
 
 export enum NewsletterOptionGroup {
@@ -53,7 +54,11 @@ export type NewsLetter = {
   };
   parent_id: null | string;
   preheader: string;
-  queue: Record<string, unknown>;
+  queue: Record<string, unknown> & {
+    scheduled_at: string;
+    count_processed: string;
+    count_total: string;
+  };
   reply_to_address: string;
   reply_to_name: string;
   segments: Array<{ filters: unknown[] }>;

--- a/mailpoet/assets/js/src/newsletters/models/newsletter.ts
+++ b/mailpoet/assets/js/src/newsletters/models/newsletter.ts
@@ -70,4 +70,5 @@ export type NewsLetter = {
   type: NewsletterType;
   unsubscribe_token: string;
   updated_at: string;
+  logs: string[];
 };

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -39,6 +39,7 @@ import { InvalidMssKeyNotice } from 'notices/invalid_mss_key_notice';
 import { TransactionalEmailsProposeOptInNotice } from 'notices/transactional_emails_propose_opt_in_notice';
 import { EmailVolumeLimitNotice } from 'notices/email_volume_limit_notice';
 import { CampaignStatsPage } from './campaign_stats/page';
+import { CorruptEmailNotice } from '../notices/corrupt_email_notice';
 
 const automaticEmails = window.mailpoet_woocommerce_automatic_emails || [];
 
@@ -52,7 +53,9 @@ const Tabs = withNpsPoll(() => {
       <ListingHeadingDisplay>
         <ListingHeading />
       </ListingHeadingDisplay>
-
+      {MailPoet.corrupt_newsletters.length > 0 && (
+        <CorruptEmailNotice newsletters={MailPoet.corrupt_newsletters} />
+      )}
       <RoutedTabs
         activeKey="standard"
         routerType="switch-only"

--- a/mailpoet/assets/js/src/notices/corrupt_email_notice.tsx
+++ b/mailpoet/assets/js/src/notices/corrupt_email_notice.tsx
@@ -1,0 +1,26 @@
+import { Notice } from './notice';
+import { MailPoet } from '../mailpoet';
+
+type Props = {
+  newsletters: Array<{
+    id: string;
+    subject: string;
+  }>;
+};
+
+function CorruptEmailNotice({ newsletters }: Props) {
+  return (
+    <Notice type="error" timeout={false} closable={false} renderInPlace>
+      <h3>{MailPoet.I18n.t('pausedEmails')}</h3>
+      <p>{MailPoet.I18n.t('problemRenderingNewsletter')}</p>
+      <ul>
+        {newsletters.map(({ id, subject }) => (
+          <li key={id}>{subject}</li>
+        ))}
+      </ul>
+    </Notice>
+  );
+}
+
+CorruptEmailNotice.displayName = 'CorruptEmailNotice';
+export { CorruptEmailNotice };

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -133,6 +133,17 @@ class Newsletters {
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();
     }
 
+    $data['corrupt_newsletters'] = $this->getCorruptNewsletterSubjects();
+
     $this->pageRenderer->displayPage('newsletters.html', $data);
+  }
+
+  private function getCorruptNewsletterSubjects(): array {
+    return array_map(function ($newsletter) {
+      return [
+        'id' => $newsletter->getId(),
+        'subject' => $newsletter->getSubject(),
+      ];
+    }, $this->newslettersRepository->getCorruptNewsletters());
   }
 }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -238,25 +238,32 @@ class SendingQueue {
       // reschedule bounce task to run sooner, if needed
       $this->reScheduleBounceTask();
 
-      $queue = $this->processQueue(
-        $queue,
-        $_newsletter,
-        $foundSubscribers,
-        $timer
-      );
-      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
-        'after queue chunk processing',
-        ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
-      );
-      if ($queue->status === ScheduledTaskEntity::STATUS_COMPLETED) {
+      if ($newsletterEntity->getStatus() !== NewsletterEntity::STATUS_CORRUPT) {
+        $queue = $this->processQueue(
+          $queue,
+          $_newsletter,
+          $foundSubscribers,
+          $timer
+        );
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
-          'completed newsletter sending',
+          'after queue chunk processing',
           ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
         );
-        $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $queue);
-        $this->statsNotificationsScheduler->schedule($newsletterEntity);
+        if ($queue->status === ScheduledTaskEntity::STATUS_COMPLETED) {
+          $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
+            'completed newsletter sending',
+            ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
+          );
+          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $queue);
+          $this->statsNotificationsScheduler->schedule($newsletterEntity);
+        }
+        $this->enforceSendingAndExecutionLimits($timer);
+      } else {
+        $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->error(
+          'Can\'t send corrupt newsletter',
+          ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
+        );
       }
-      $this->enforceSendingAndExecutionLimits($timer);
     }
   }
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -20,6 +20,7 @@ use MailPoet\Models\StatisticsNewsletters as StatisticsNewslettersModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -78,6 +79,9 @@ class SendingQueue {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /*** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
   public function __construct(
     SendingErrorHandler $errorHandler,
     SendingThrottlingHandler $throttlingHandler,
@@ -92,6 +96,7 @@ class SendingQueue {
     ScheduledTasksRepository $scheduledTasksRepository,
     MailerTask $mailerTask,
     SubscribersRepository $subscribersRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
     $newsletterTask = false
   ) {
     $this->errorHandler = $errorHandler;
@@ -109,6 +114,7 @@ class SendingQueue {
     $this->links = $links;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->subscribersRepository = $subscribersRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
   }
 
   public function process($timer = false) {
@@ -259,6 +265,7 @@ class SendingQueue {
         }
         $this->enforceSendingAndExecutionLimits($timer);
       } else {
+        $this->sendingQueuesRepository->pause($queue->getSendingQueueEntity());
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->error(
           'Can\'t send corrupt newsletter',
           ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -94,6 +94,7 @@ class Newsletter {
       is_null($newsletter)
       || $newsletter->getDeletedAt() !== null
       || !in_array($newsletter->getStatus(), [NewsletterEntity::STATUS_ACTIVE, NewsletterEntity::STATUS_SENDING])
+      || $newsletter->getStatus() === NewsletterEntity::STATUS_CORRUPT
     ) {
       return null;
     }

--- a/mailpoet/lib/Entities/LogEntity.php
+++ b/mailpoet/lib/Entities/LogEntity.php
@@ -34,6 +34,19 @@ class LogEntity {
   private $message;
 
   /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $rawMessage;
+
+
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $context;
+
+  /**
    * @return string|null
    */
   public function getName(): ?string {
@@ -54,6 +67,14 @@ class LogEntity {
     return $this->message;
   }
 
+  public function getRawMessage(): ?string {
+    return $this->rawMessage;
+  }
+
+  public function getContext(): ?array {
+    return (array)json_decode($this->context ?? '{}', true);
+  }
+
   public function setName(?string $name): void {
     $this->name = $name;
   }
@@ -68,5 +89,16 @@ class LogEntity {
 
   public function setCreatedAt(DateTimeInterface $createdAt): void {
     $this->createdAt = $createdAt;
+  }
+
+  public function setRawMessage(string $message): void {
+    $this->rawMessage = $message;
+  }
+
+  public function setContext(array $context): void {
+    $str = json_encode($context);
+    if ($str) {
+      $this->context = $str;
+    }
   }
 }

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -37,6 +37,7 @@ class NewsletterEntity {
   const STATUS_SCHEDULED = 'scheduled';
   const STATUS_SENDING = 'sending';
   const STATUS_SENT = 'sent';
+  const STATUS_CORRUPT = 'corrupt';
 
   /**
    * Newsletters that their body HTML can get re-generated

--- a/mailpoet/lib/Logging/LogHandler.php
+++ b/mailpoet/lib/Logging/LogHandler.php
@@ -53,6 +53,8 @@ class LogHandler extends AbstractProcessingHandler {
     $entity->setLevel((int)$record['level']);
     $entity->setMessage($message);
     $entity->setCreatedAt($record['datetime']);
+    $entity->setRawMessage($record['message']);
+    $entity->setContext($record['context']);
 
     if (!$this->entityManager->isOpen()) {
       $this->entityManager = $this->entityManagerFactory->createEntityManager();

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -4,6 +4,7 @@ namespace MailPoet\Logging;
 
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\LogEntity;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -70,5 +71,18 @@ class LogRepository extends Repository {
       ->where('l.createdAt < :days')
       ->setParameter('days', Carbon::now()->subDays($daysToKeepLogs)->toDateTimeString())
       ->getQuery()->execute();
+  }
+
+  public function getRawMessagesForNewsletter(NewsletterEntity $newsletter, string $topic): array {
+    return $this->entityManager->createQueryBuilder()
+      ->select('DISTINCT logs.rawMessage message')
+      ->from(LogEntity::class, 'logs')
+      ->where('logs.name = :topic')
+      ->andWhere('logs.context LIKE :context')
+      ->orderBy('logs.createdAt')
+      ->setParameter('context', json_encode(['newsletter_id' => $newsletter->getId()]))
+      ->setParameter('topic', $topic)
+      ->getQuery()
+      ->getSingleColumnResult();
   }
 }

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -34,6 +34,7 @@ class LoggerFactory {
   const TOPIC_CRON = 'cron';
   const TOPIC_API = 'api';
   const TOPIC_TRACKING = 'tracking';
+  const TOPIC_COUPONS = 'coupons';
 
   /** @var LoggerFactory */
   private static $instance;

--- a/mailpoet/lib/Migrations/Migration_20230221_200520.php
+++ b/mailpoet/lib/Migrations/Migration_20230221_200520.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Migrator\Migration;
+
+class Migration_20230221_200520 extends Migration {
+  public function run(): void {
+    $this->addRawMessagesToLogs();
+    $this->addContextToLogs();
+  }
+
+  private function addRawMessagesToLogs() {
+    $logsTable = $this->getTableName(LogEntity::class);
+    $columnName = 'raw_message';
+
+    if ($this->columnExists($logsTable, $columnName)) {
+      return;
+    }
+
+    $this->connection->executeStatement("
+      ALTER TABLE {$logsTable}
+      ADD {$columnName} longtext DEFAULT NULL
+    ");
+  }
+
+  private function addContextToLogs() {
+    $logsTable = $this->getTableName(LogEntity::class);
+    $columnName = 'context';
+
+    if ($this->columnExists($logsTable, $columnName)) {
+      return;
+    }
+
+    $this->connection->executeStatement("
+      ALTER TABLE {$logsTable}
+      ADD {$columnName} longtext DEFAULT NULL
+    ");
+  }
+}

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -299,6 +299,10 @@ class NewsletterSaveController {
     if (array_key_exists('reply_to_address', $data)) {
       $newsletter->setReplyToAddress($data['reply_to_address'] ?? '');
     }
+
+    if ($newsletter->getStatus() === NewsletterEntity::STATUS_CORRUPT) {
+      $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
+    }
   }
 
   private function updateSegments(NewsletterEntity $newsletter, array $segments) {

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -543,6 +543,12 @@ class NewslettersRepository extends Repository {
     return $this->findBy(['status' => NewsletterEntity::STATUS_CORRUPT, 'deletedAt' => null]);
   }
 
+  public function setAsCorrupt(NewsletterEntity $entity): void {
+    $entity->setStatus(NewsletterEntity::STATUS_CORRUPT);
+    $this->persist($entity);
+    $this->flush();
+  }
+
   private function fetchChildrenIds(array $parentIds) {
     $ids = $this->entityManager->createQueryBuilder()->select('n.id')
       ->from(NewsletterEntity::class, 'n')

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -539,6 +539,10 @@ class NewslettersRepository extends Repository {
     return $newsletters;
   }
 
+  public function getCorruptNewsletters(): array {
+    return $this->findBy(['status' => NewsletterEntity::STATUS_CORRUPT, 'deletedAt' => null]);
+  }
+
   private function fetchChildrenIds(array $parentIds) {
     $ids = $this->entityManager->createQueryBuilder()->select('n.id')
       ->from(NewsletterEntity::class, 'n')

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -7,7 +7,6 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
-use MailPoet\NewsletterProcessingException;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\WooCommerce\CouponPreProcessor;
 use MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor;

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -7,6 +7,7 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
+use MailPoet\NewsletterProcessingException;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\WooCommerce\CouponPreProcessor;
 use MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor;

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -68,8 +68,6 @@ class Preprocessor {
     $blocks = [];
     $contentBlocks = $content['blocks'];
 
-    $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview);
-
     try {
       $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview);
     } catch (NewsletterProcessingException $e) {

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -5,7 +5,10 @@ namespace MailPoet\Newsletter\Renderer;
 use MailPoet\Config\Env;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\EscapeHelper as EHelper;
+use MailPoet\NewsletterProcessingException;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Util\pQuery\DomNode;
 use MailPoet\WP\Functions as WPFunctions;
@@ -32,13 +35,21 @@ class Renderer {
   /** @var WPFunctions */
   private $wp;
 
+  /*** @var LoggerFactory */
+  private $loggerFactory;
+
+  /*** @var NewslettersRepository */
+  private $newslettersRepository;
+
   public function __construct(
     Blocks\Renderer $blocksRenderer,
     Columns\Renderer $columnsRenderer,
     Preprocessor $preprocessor,
     \MailPoetVendor\CSS $cSSInliner,
     ServicesChecker $servicesChecker,
-    WPFunctions $wp
+    WPFunctions $wp,
+    LoggerFactory $loggerFactory,
+    NewslettersRepository $newslettersRepository
   ) {
     $this->blocksRenderer = $blocksRenderer;
     $this->columnsRenderer = $columnsRenderer;
@@ -46,6 +57,8 @@ class Renderer {
     $this->cSSInliner = $cSSInliner;
     $this->servicesChecker = $servicesChecker;
     $this->wp = $wp;
+    $this->loggerFactory = $loggerFactory;
+    $this->newslettersRepository = $newslettersRepository;
   }
 
   public function render(NewsletterEntity $newsletter, SendingTask $sendingTask = null, $type = false) {
@@ -75,8 +88,17 @@ class Renderer {
 
     $language = $this->wp->getBloginfo('language');
     $metaRobots = $preview ? '<meta name="robots" content="noindex, nofollow" />' : '';
-    $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingTask);
-    $renderedBody = $this->renderBody($newsletter, $content);
+    $renderedBody = "";
+    try {
+      $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingTask);
+      $renderedBody = $this->renderBody($newsletter, $content);
+    } catch (NewsletterProcessingException $e) {
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_COUPONS)->error(
+        $e->getMessage(),
+        ['newsletter_id' => $newsletter->getId()]
+      );
+      $this->newslettersRepository->setAsCorrupt($newsletter);
+    }
     $renderedStyles = $this->renderStyles($styles);
     $customFontsLinks = StylesHelper::getCustomFontsLinks($styles);
 

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -40,7 +40,7 @@ class CouponPreProcessor {
 
     if (!$this->wcHelper->isWooCommerceActive()) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_COUPONS)->error(
-        'Woocommerce is not active', ['WC Coupons', 'Process coupons']
+        'Woocommerce is not active', ['WC Coupons', 'Process coupons', 'newsletter_id']
       );
       return $blocks;
     }

--- a/mailpoet/lib/exceptions.php
+++ b/mailpoet/lib/exceptions.php
@@ -113,3 +113,5 @@ class ConflictException extends UnexpectedValueException implements HttpAwareExc
  * API: 500 Server Error (not HTTP-aware)
  */
 class InvalidStateException extends RuntimeException {}
+
+class NewsletterProcessingException extends Exception {}

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\API\JSON\ResponseBuilders;
 use Codeception\Util\Stub;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
@@ -43,7 +44,8 @@ class NewslettersResponseBuilderTest extends \MailPoetTest {
     $newsletterRepository = Stub::make(NewslettersRepository::class);
     $newsletterUrl = $this->diContainer->get(Url::class);
     $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
-    $responseBuilder = new NewslettersResponseBuilder($em, $newsletterRepository, $newsletterStatsRepository, $newsletterUrl, $sendingQueuesRepository);
+    $logRepository = $this->diContainer->get(LogRepository::class);
+    $responseBuilder = new NewslettersResponseBuilder($em, $newsletterRepository, $newsletterStatsRepository, $newsletterUrl, $sendingQueuesRepository, $logRepository);
     $response = $responseBuilder->build($newsletter, [
       NewslettersResponseBuilder::RELATION_CHILDREN_COUNT,
       NewslettersResponseBuilder::RELATION_TOTAL_SENT,

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -19,6 +19,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
 use MailPoet\Newsletter\Preview\SendPreviewException;
@@ -97,7 +98,8 @@ class NewslettersTest extends \MailPoetTest {
             $this->makeEmpty(WCHelper::class)
           ),
           $this->diContainer->get(Url::class),
-          $this->diContainer->get(SendingQueuesRepository::class)
+          $this->diContainer->get(SendingQueuesRepository::class),
+          $this->diContainer->get(LogRepository::class)
         ),
       ]
     );

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -44,6 +44,7 @@ use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
@@ -96,6 +97,9 @@ class SendingQueueTest extends \MailPoetTest {
   private $scheduledTasksRepository;
   /** @var SubscribersRepository */
   private $subscribersRepository;
+
+  /*** @var SendingQueuesRepository */
+  private $sendingQueueRepository;
 
   public function _before() {
     parent::_before();
@@ -154,6 +158,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->tasksLinks = $this->diContainer->get(TasksLinks::class);
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->sendingQueueRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->sendingQueueWorker = $this->getSendingQueueWorker();
   }
 
@@ -209,7 +214,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->diContainer->get(MailerTask::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
     try {
       $sendingQueueWorker->process();
@@ -243,7 +249,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => $this->mailerTaskDummyResponse,
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
     $sendingQueueWorker->sendNewsletters(
       $this->queue,
@@ -288,7 +295,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => $this->mailerTaskDummyResponse,
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
     $sendingQueueWorker->sendNewsletters(
       $queue,
@@ -327,7 +335,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->diContainer->get(MailerTask::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
     $sendingQueueWorker->process();
   }
@@ -650,7 +659,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => Stub::consecutive(['response' => false, 'error' => $mailerError], $this->mailerTaskDummyResponse),
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
 
     $sendingQueueWorker->sendNewsletters(
@@ -1049,7 +1059,8 @@ class SendingQueueTest extends \MailPoetTest {
           'sendBulk' => $this->mailerTaskDummyResponse,
         ]
       ),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
     try {
       $sendingQueueWorker->sendNewsletters(
@@ -1271,7 +1282,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $mailerMock ?? $this->diContainer->get(MailerTask::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->sendingQueueRepository
     );
   }
 }

--- a/mailpoet/tests/integration/Logging/LogHandlerTest.php
+++ b/mailpoet/tests/integration/Logging/LogHandlerTest.php
@@ -34,6 +34,7 @@ class LogHandlerTest extends \MailPoetTest {
       'context' => [],
       'channel' => 'name',
       'datetime' => $time,
+      'message' => 'some log message',
     ]);
 
     $log = $this->repository->findOneBy(['name' => 'name'], ['id' => 'desc']);
@@ -71,6 +72,7 @@ class LogHandlerTest extends \MailPoetTest {
       'context' => [],
       'channel' => 'name',
       'datetime' => new \DateTime(),
+      'message' => 'some log message',
     ]);
 
     $log = $this->repository->findBy(['name' => 'old name']);
@@ -105,6 +107,7 @@ class LogHandlerTest extends \MailPoetTest {
       'context' => [],
       'channel' => 'name',
       'datetime' => new \DateTime(),
+      'message' => 'some log message',
     ]);
 
     $log = $this->repository->findBy(['name' => 'old name keep']);
@@ -130,6 +133,7 @@ class LogHandlerTest extends \MailPoetTest {
         'context' => [],
         'channel' => 'name',
         'datetime' => $time,
+        'message' => 'some log message',
       ]);
     }
 

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -5,6 +5,8 @@ namespace MailPoet\Test\Newsletter;
 use Codeception\Util\Fixtures;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Button;
 use MailPoet\Newsletter\Renderer\Blocks\Divider;
 use MailPoet\Newsletter\Renderer\Blocks\Footer;
@@ -54,7 +56,9 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(Preprocessor::class),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->servicesChecker,
-      $this->diContainer->get(WPFunctions::class)
+      $this->diContainer->get(WPFunctions::class),
+      $this->diContainer->get(LoggerFactory::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
     $this->columnRenderer = new ColumnRenderer();
     $this->dOMParser = new pQuery();

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -18,6 +18,7 @@ use MailPoet\Newsletter\Renderer\Blocks\Text;
 use MailPoet\Newsletter\Renderer\Columns\Renderer as ColumnRenderer;
 use MailPoet\Newsletter\Renderer\Preprocessor;
 use MailPoet\Newsletter\Renderer\Renderer;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Util\pQuery\pQuery;
 use MailPoet\WP\Functions as WPFunctions;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -58,7 +59,8 @@ class RendererTest extends \MailPoetTest {
       $this->servicesChecker,
       $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(LoggerFactory::class),
-      $this->diContainer->get(NewslettersRepository::class)
+      $this->diContainer->get(NewslettersRepository::class),
+      $this->diContainer->get(SendingQueuesRepository::class)
     );
     $this->columnRenderer = new ColumnRenderer();
     $this->dOMParser = new pQuery();

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\WooCommerce\TransactionalEmails;
 use Codeception\Stub;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\Editor\LayoutHelper as L;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -111,7 +112,8 @@ class RendererTest extends \MailPoetTest {
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock::class),
         $wooPreprocessor,
         $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class),
-        $this->diContainer->get(NewslettersRepository::class)
+        $this->diContainer->get(NewslettersRepository::class),
+        $this->diContainer->get(LoggerFactory::class)
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(ServicesChecker::class),

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -112,9 +112,7 @@ class RendererTest extends \MailPoetTest {
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent::class),
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock::class),
         $wooPreprocessor,
-        $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class),
-        $this->diContainer->get(NewslettersRepository::class),
-        $this->diContainer->get(LoggerFactory::class)
+        $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class)
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(ServicesChecker::class),

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -117,7 +117,9 @@ class RendererTest extends \MailPoetTest {
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(ServicesChecker::class),
-      $this->diContainer->get(WPFunctions::class)
+      $this->diContainer->get(WPFunctions::class),
+      $this->diContainer->get(LoggerFactory::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -110,7 +110,8 @@ class RendererTest extends \MailPoetTest {
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent::class),
         $this->diContainer->get(\MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock::class),
         $wooPreprocessor,
-        $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class)
+        $this->diContainer->get(\MailPoet\WooCommerce\CouponPreProcessor::class),
+        $this->diContainer->get(NewslettersRepository::class)
       ),
       $this->diContainer->get(\MailPoetVendor\CSS::class),
       $this->diContainer->get(ServicesChecker::class),

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -11,6 +11,7 @@ use MailPoet\Newsletter\Editor\LayoutHelper as L;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Preprocessor;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\csstidy;
 
@@ -119,7 +120,8 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(ServicesChecker::class),
       $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(LoggerFactory::class),
-      $this->diContainer->get(NewslettersRepository::class)
+      $this->diContainer->get(NewslettersRepository::class),
+      $this->diContainer->get(SendingQueuesRepository::class)
     );
   }
 }

--- a/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
@@ -4,8 +4,6 @@ namespace MailPoet\Test\Newsletter;
 
 use Codeception\Stub;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Logging\LoggerFactory;
-use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
 use MailPoet\Newsletter\Renderer\Preprocessor;
@@ -24,15 +22,11 @@ class PreprocessorTest extends \MailPoetUnitTest {
       ],
     ]);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor($transactionalEmails);
-    $newsletterRepository = Stub::make(NewslettersRepository::class);
-    $loggerFactory = Stub::make(LoggerFactory::class);
     $preprocessor = new Preprocessor(
       $acc,
       $alc,
       $wooPreprocessor,
-      $couponPreProcessor,
-      $newsletterRepository,
-      $loggerFactory
+      $couponPreProcessor
     );
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceHeading']))->equals([[
       'type' => 'container',
@@ -61,15 +55,11 @@ class PreprocessorTest extends \MailPoetUnitTest {
     $alc = Stub::make(AutomatedLatestContentBlock::class);
     $couponPreProcessor = Stub::make(CouponPreProcessor::class);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor(Stub::make(TransactionalEmails::class));
-    $newsletterRepository = Stub::make(NewslettersRepository::class);
-    $loggerFactory = Stub::make(LoggerFactory::class);
     $preprocessor = new Preprocessor(
       $acc,
       $alc,
       $wooPreprocessor,
-      $couponPreProcessor,
-      $newsletterRepository,
-      $loggerFactory
+      $couponPreProcessor
     );
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceContent']))->equals([[
       'type' => 'container',

--- a/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Newsletter;
 
 use Codeception\Stub;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
@@ -24,7 +25,15 @@ class PreprocessorTest extends \MailPoetUnitTest {
     ]);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor($transactionalEmails);
     $newsletterRepository = Stub::make(NewslettersRepository::class);
-    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor, $newsletterRepository);
+    $loggerFactory = Stub::make(LoggerFactory::class);
+    $preprocessor = new Preprocessor(
+      $acc,
+      $alc,
+      $wooPreprocessor,
+      $couponPreProcessor,
+      $newsletterRepository,
+      $loggerFactory
+    );
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceHeading']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',
@@ -53,7 +62,15 @@ class PreprocessorTest extends \MailPoetUnitTest {
     $couponPreProcessor = Stub::make(CouponPreProcessor::class);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor(Stub::make(TransactionalEmails::class));
     $newsletterRepository = Stub::make(NewslettersRepository::class);
-    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor, $newsletterRepository);
+    $loggerFactory = Stub::make(LoggerFactory::class);
+    $preprocessor = new Preprocessor(
+      $acc,
+      $alc,
+      $wooPreprocessor,
+      $couponPreProcessor,
+      $newsletterRepository,
+      $loggerFactory
+    );
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceContent']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',

--- a/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/PreprocessorTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Newsletter;
 
 use Codeception\Stub;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
 use MailPoet\Newsletter\Renderer\Preprocessor;
@@ -22,7 +23,8 @@ class PreprocessorTest extends \MailPoetUnitTest {
       ],
     ]);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor($transactionalEmails);
-    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor);
+    $newsletterRepository = Stub::make(NewslettersRepository::class);
+    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor, $newsletterRepository);
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceHeading']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',
@@ -50,7 +52,8 @@ class PreprocessorTest extends \MailPoetUnitTest {
     $alc = Stub::make(AutomatedLatestContentBlock::class);
     $couponPreProcessor = Stub::make(CouponPreProcessor::class);
     $wooPreprocessor = new TransactionalEmails\ContentPreprocessor(Stub::make(TransactionalEmails::class));
-    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor);
+    $newsletterRepository = Stub::make(NewslettersRepository::class);
+    $preprocessor = new Preprocessor($acc, $alc, $wooPreprocessor, $couponPreProcessor, $newsletterRepository);
     expect($preprocessor->processBlock(new NewsletterEntity(), ['type' => 'woocommerceContent']))->equals([[
       'type' => 'container',
       'orientation' => 'horizontal',

--- a/mailpoet/tests/unit/WooCommerce/CouponPreProcessorTest.php
+++ b/mailpoet/tests/unit/WooCommerce/CouponPreProcessorTest.php
@@ -143,8 +143,6 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => false,
     ]);
 
-    $loggerFactory = $this->getLoggerFactory(Stub\Expected::never());
-
     $processor = new CouponPreProcessor(
       $wcHelper,
       Stub::make(NewslettersRepository::class, [
@@ -153,7 +151,7 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
     );
     $newsletter = (new NewsletterEntity());
 
-    $blocks = ['some' => true, 'random' => false];
+    $blocks = ['blocks' => ['type' => Coupon::TYPE]];
     $this->expectException(NewsletterProcessingException::class);
     $this->expectExceptionMessage('Woocommerce is not active');
     $result = $processor->processCoupons($newsletter, $blocks, false);

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -189,6 +189,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
 
   'sent': __('Sent'),
   'notSentYet': __('Not sent yet!'),
+  'renderingProblem': __('There was a problem with rendering!', 'mailpoet'),
 
   'allSendingPausedHeader': __('All sending is currently paused!'),
   'allSendingPausedBody': __('Your [link]API key[/link] to send with MailPoet is invalid.'),

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -351,6 +351,7 @@
     'confirmLabel': __('Confirm'),
     'cancelLabel': __('Cancel'),
     'confirmAutomaticNewsletterEdit': __('To edit this email, it needs to be deactivated. You can activate it again after you make the changes.'),
+    'confirmResumingCorruptNewsletter': __('The was an issue sending this email before, please confirm the issues are fixed to proceed.'),
 
     'recentlySent': __('Recently sent'),
     'savedTemplates': __('Your saved templates'),

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -59,6 +59,7 @@
     ];
 
     var mailpoet_newsletters_templates_recently_sent_count = <%= json_decode(newsletters_templates_recently_sent_count) %>;
+    var corrupt_newsletters = <%= json_encode(corrupt_newsletters) %>;
 
   </script>
 <% endblock %>
@@ -443,6 +444,8 @@
     'automatedLatestContentMissing': _x('Please add an “Automatic Latest Content” widget to the email from the right sidebar.', '(Please reuse the current translation used for the string “Automatic Latest Content”) This Error message is displayed when a user tries to send a “Post Notification” email without any “Automatic Latest Content” widget inside'),
     'emailAlreadySent': __('This email has already been sent. It can be edited, but not sent again. Duplicate this email if you want to send it again.'),
     'emailCanBeScheduledUpToFiveYears': __('An email can only be scheduled up to 5 years in the future. Please choose a shorter period.'),
+    'problemRenderingNewsletter': __('There was problem sending the following email(s), please fix the issues described for each email and resume.', 'mailpoet'),
+    'pausedEmails': __('Paused emails', 'mailpoet'),
   }) %>
   <% include('mss_pitch_translations.html') %>
 <% endblock %>


### PR DESCRIPTION
## Description

This PR catches issues thrown by the Coupon block in the rendering/processing phase, logs, and notifies the user about it so that they can fix the issue and continue.


## QA notes

You'll need to make a newsletter with a coupon block run into a problem, one way to do this is adding a newsletter with a coupon block, but when on the `Send` page, just before clicking on the `Send` button, go to plugins' page and deactivate WooCommerce, this should prevent the email from being sent and make you end up with a listing like the attached screenshot.
https://d.pr/i/lZf3sV

## Linked tickets
[MAILPOET-4983]


[MAILPOET-4983]: https://mailpoet.atlassian.net/browse/MAILPOET-4983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ