### PR TITLE
Add a new k6 test: Adding a new subscriber

### DIFF
--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -9,5 +9,9 @@ export const adminUsername = 'admin';
 export const adminPassword = 'password';
 export const adminEmail = 'test@test.com';
 
+export const firstName = 'John';
+export const lastName = 'Doe';
+export const defaultListName = 'Newsletter mailing list';
+
 export const thinkTimeMin = '1';
 export const thinkTimeMax = '4';

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -5,6 +5,7 @@ import { newsletterListing } from './tests/newsletter-listing.js';
 import { subscribersListing } from './tests/subscribers-listing.js';
 import { settingsBasic } from './tests/settings-basic.js';
 import { subscribersFiltering } from './tests/subscribers-filtering.js';
+import { subscribersAdding } from './tests/subscribers-adding.js';
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
@@ -60,6 +61,7 @@ export function pullRequests() {
   subscribersListing();
   settingsBasic();
   subscribersFiltering();
+  subscribersAdding();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -34,14 +34,14 @@ let scenarios = {
     executor: 'per-vu-iterations',
     vus: 1,
     iterations: 1,
-    maxDuration: '2m',
+    maxDuration: '5m',
     exec: 'pullRequests',
   },
   nightlytests: {
     executor: 'per-vu-iterations',
     vus: 1,
     iterations: 3,
-    maxDuration: '5m',
+    maxDuration: '15m',
     exec: 'nightly',
   },
 };

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-shadow */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check, group } from 'k6';
+import { chromium } from 'k6/x/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+  firstName,
+  lastName,
+  defaultListName,
+} from '../config.js';
+import { authenticate, selectInSelect2 } from '../utils/helpers.js';
+/* global Promise */
+
+export function subscribersAdding() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  group('Subscribers - Add a new subscriber', function subscribersAdding() {
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+        waitUntil: 'networkidle',
+      })
+
+      .then(() => {
+        authenticate(page);
+      })
+
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
+
+      .then(() => {
+        page
+          .locator('[data-automation-id="add-new-subscribers-button"]')
+          .click();
+        page
+          .locator('input[name="email"]')
+          .type('test+' + Math.floor(Math.random() * 9999 + 1) + '@test.com');
+        page.locator('input[name="first_name"]').type(firstName);
+        page.locator('input[name="last_name"]').type(lastName);
+        selectInSelect2(page, defaultListName);
+        page.locator('button[type="submit"]').click();
+        page.waitForSelector('.mailpoet-listing-no-items');
+        page.waitForSelector('[data-automation-id="filters_subscribed"]');
+        check(page, {
+          'subscribers filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+        });
+      })
+
+      .then(() => {
+        // search for added subscriber
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
+
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+}
+
+export default function subscribersAddingTest() {
+  subscribersAdding();
+}

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
 /**
@@ -31,7 +30,10 @@ export function subscribersAdding() {
   });
   const page = browser.newPage();
 
-  group('Subscribers - Add a new subscriber', function subscribersAdding() {
+  group('Subscribers - Add a new subscriber', () => {
+    let subscriberEmail =
+      'test+' + Math.floor(Math.random() * 9999 + 1) + '@test.com';
+
     page
       .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
         waitUntil: 'networkidle',
@@ -51,9 +53,7 @@ export function subscribersAdding() {
         page
           .locator('[data-automation-id="add-new-subscribers-button"]')
           .click();
-        page
-          .locator('input[name="email"]')
-          .type('test+' + Math.floor(Math.random() * 9999 + 1) + '@test.com');
+        page.locator('input[name="email"]').type(subscriberEmail);
         page.locator('input[name="first_name"]').type(firstName);
         page.locator('input[name="last_name"]').type(lastName);
         selectInSelect2(page, defaultListName);
@@ -68,7 +68,15 @@ export function subscribersAdding() {
       })
 
       .then(() => {
-        // search for added subscriber
+        page.waitForNavigation({ waitUntil: 'networkidle' });
+        page.locator('#search_input').type(subscriberEmail, { delay: 50 });
+        page.waitForSelector('.mailpoet-listing-no-items');
+        page.waitForSelector('[data-automation-id="filters_subscribed"]');
+        check(page, {
+          'newly added subscriber is present in the listing':
+            page.locator('.mailpoet-listing-title').textContent() ===
+            subscriberEmail,
+        });
       })
 
       .finally(() => {

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -18,3 +18,11 @@ export function authenticate(page) {
     page.locator('input[name="wp-submit"]').click(),
   ]);
 }
+
+// Select a segment or a list from a select2 search field
+export function selectInSelect2(page, listName) {
+  // Click and write a list name from a dropdown
+  page.locator('.select2-selection').click();
+  page.locator('.select2-selection').type(listName);
+  page.keyboard.press('Enter');
+}

--- a/mailpoet/tools/xk6browser.php
+++ b/mailpoet/tools/xk6browser.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.7.0';
+$version = 'v0.8.1';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "xk6-browser-$version-$os-$arch";
 $url = "https://github.com/grafana/xk6-browser/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Adding a new k6 performance test for measuring performance while adding a new subscriber.

Additionally,
- updated `xk6-browser` binary version to its latest 8.1 version
- increased max duration time for scenarios
- added a new helper method `selectInSelect2` for react select component

## Code review notes

For executing this test locally, please run the command inside `/mailpoet/` folder:

Note: Since we don't have any data locally yet, please change the password in `config.js` from `password` to the correct one for the site qawp.net (copy/paste the password from the secret store: search for `qawp`)

- ./do test:performance --url=https://qawp.net tests/performance/tests/subscribers-adding.js

The expected result you should see is: [screenshot](https://d.pr/i/wGwhEe).
If you don't see this result at first try, please run it one more time (the test is not flaky, but the server and site qawp.net can sometimes show 502 error on a first page load).

To watch the test run in a real browser add this argument `--head` in the end of the test command above.

## Linked PRs

This branch was created from this pull request #4745

## Linked tickets

[MAILPOET-4956]


[MAILPOET-4956]: https://mailpoet.atlassian.net/browse/MAILPOET-4956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ