### PR TITLE
Improve messages about pending approval review [MAILPOET-4528]

### DIFF
--- a/mailpoet/assets/js/src/common/premium_key/key_messages/key_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/key_messages.tsx
@@ -6,7 +6,7 @@ type KeyValidMessageProps = { canUseSuccessClass: boolean };
 function KeyValidMessage({ canUseSuccessClass }: KeyValidMessageProps) {
   return (
     <div
-      className={classnames('mailpoet_success_item mailpoet_success_item', {
+      className={classnames('mailpoet_success_item', {
         mailpoet_success: canUseSuccessClass,
       })}
     >

--- a/mailpoet/assets/js/src/common/premium_key/key_messages/key_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/key_messages.tsx
@@ -1,9 +1,15 @@
+import classnames from 'classnames';
 import { MailPoet } from 'mailpoet';
 import { useSelector } from 'settings/store/hooks';
 
-function KeyValidMessage() {
+type KeyValidMessageProps = { canUseSuccessClass: boolean };
+function KeyValidMessage({ canUseSuccessClass }: KeyValidMessageProps) {
   return (
-    <div className="mailpoet_success_item mailpoet_success_item mailpoet_success">
+    <div
+      className={classnames('mailpoet_success_item mailpoet_success_item', {
+        mailpoet_success: canUseSuccessClass,
+      })}
+    >
       {MailPoet.I18n.t('premiumTabKeyValidMessage')}
     </div>
   );
@@ -17,7 +23,12 @@ function KeyNotValidMessage() {
   );
 }
 
-export function KeyMessages() {
+type KeyMessagesProps = { canUseSuccessClass: boolean };
+export function KeyMessages({ canUseSuccessClass }: KeyMessagesProps) {
   const { isKeyValid } = useSelector('getKeyActivationState')();
-  return isKeyValid ? <KeyValidMessage /> : <KeyNotValidMessage />;
+  return isKeyValid ? (
+    <KeyValidMessage canUseSuccessClass={canUseSuccessClass} />
+  ) : (
+    <KeyNotValidMessage />
+  );
 }

--- a/mailpoet/assets/js/src/common/premium_key/key_messages/mss_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/mss_messages.tsx
@@ -1,10 +1,16 @@
+import classnames from 'classnames';
 import { MailPoet } from 'mailpoet';
 import { useSelector } from 'settings/store/hooks';
 import { MssStatus } from 'settings/store/types';
 
-function MssActiveMessage() {
+type MssActiveMessageProps = { canUseSuccessClass: boolean };
+function MssActiveMessage({ canUseSuccessClass }: MssActiveMessageProps) {
   return (
-    <div className="mailpoet_success_item mailpoet_success mailpoet_mss_key_valid">
+    <div
+      className={classnames('mailpoet_success_item mailpoet_mss_key_valid', {
+        mailpoet_success: canUseSuccessClass,
+      })}
+    >
       {MailPoet.I18n.t('premiumTabMssActiveMessage')}
     </div>
   );
@@ -41,12 +47,13 @@ function MssNotActiveMessage({ activationCallback }: MssNotActiveMessageProps) {
 type Props = {
   keyMessage?: string;
   activationCallback: () => void;
+  canUseSuccessClass: boolean;
 };
 export function MssMessages(props: Props) {
   const { mssStatus } = useSelector('getKeyActivationState')();
   switch (mssStatus) {
     case MssStatus.VALID_MSS_ACTIVE:
-      return <MssActiveMessage />;
+      return <MssActiveMessage canUseSuccessClass={props.canUseSuccessClass} />;
     case MssStatus.VALID_MSS_NOT_ACTIVE:
       return (
         <MssNotActiveMessage activationCallback={props.activationCallback} />

--- a/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
@@ -1,11 +1,17 @@
+import classnames from 'classnames';
 import { MailPoet } from 'mailpoet';
 import { useSelector } from 'settings/store/hooks';
 import { PremiumStatus } from 'settings/store/types';
 import { Button } from 'common/button/button';
 
-function ActiveMessage() {
+type ActiveMessageProps = { canUseSuccessClass: boolean };
+function ActiveMessage(props: ActiveMessageProps) {
   return (
-    <div className="mailpoet_success_item mailpoet_success">
+    <div
+      className={classnames('mailpoet_success_item', {
+        mailpoet_success: props.canUseSuccessClass,
+      })}
+    >
       {MailPoet.I18n.t('premiumTabPremiumActiveMessage')}
     </div>
   );
@@ -61,6 +67,7 @@ NotValidMessage.defaultProps = {
 
 type Props = {
   keyMessage?: string;
+  canUseSuccessClass: boolean;
 };
 
 export function PremiumMessages(props: Props) {
@@ -72,7 +79,7 @@ export function PremiumMessages(props: Props) {
 
   switch (status) {
     case PremiumStatus.VALID_PREMIUM_PLUGIN_ACTIVE:
-      return <ActiveMessage />;
+      return <ActiveMessage canUseSuccessClass={props.canUseSuccessClass} />;
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_INSTALLED:
       return <PremiumNotInstalledMessage url={downloadUrl} />;
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_ACTIVE:

--- a/mailpoet/assets/js/src/common/premium_key/messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/messages.tsx
@@ -31,11 +31,12 @@ export function Messages(
 
   return (
     <div className="key-activation-messages">
-      <KeyMessages />
+      <KeyMessages canUseSuccessClass={!showPendingApprovalNotice} />
       {state.mssStatus !== null && (
         <MssMessages
           keyMessage={state.mssMessage}
           activationCallback={activationCallback}
+          canUseSuccessClass={!showPendingApprovalNotice}
         />
       )}
       {state.congratulatoryMssEmailSentTo && (
@@ -47,18 +48,21 @@ export function Messages(
         </div>
       )}
       {state.premiumStatus !== null && (
-        <PremiumMessages keyMessage={state.premiumMessage} />
+        <PremiumMessages
+          keyMessage={state.premiumMessage}
+          canUseSuccessClass={!showPendingApprovalNotice}
+        />
       )}
 
       {showPendingApprovalNotice && (
-        <div className="mailpoet_success">
-          <div className="pending_approval_heading">
+        <div>
+          <div className="pending_approval_heading mailpoet_error">
             {MailPoet.I18n.t('premiumTabPendingApprovalHeading')}
           </div>
-          <div>
-            {MailPoet.I18n.t('premiumTabPendingApprovalMessage')}{' '}
-            {showRefreshMessage &&
-              ReactStringReplace(
+          <div>{MailPoet.I18n.t('premiumTabPendingApprovalMessage')}</div>
+          {showRefreshMessage ? (
+            <div>
+              {ReactStringReplace(
                 MailPoet.I18n.t('premiumTabPendingApprovalMessageRefresh'),
                 getLinkRegex(),
                 (match) => (
@@ -67,7 +71,8 @@ export function Messages(
                   </a>
                 ),
               )}
-          </div>
+            </div>
+          ) : null}
         </div>
       )}
 

--- a/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key_activation/key_activation.tsx
@@ -16,6 +16,7 @@ const premiumTabDescription = ReactStringReplace(
   /\[link\](.*?)\[\/link\]/g,
   (text) => (
     <a
+      key="premium-tab-description"
       href="https://account.mailpoet.com/account?utm_source=plugin&utm_medium=settings&utm_campaign=activate-existing-plan&ref=settings-key-activation"
       target="_blank"
       rel="noopener noreferrer"
@@ -30,6 +31,7 @@ const premiumTabGetKey = ReactStringReplace(
   /\[link\](.*?)\[\/link\]/g,
   (text) => (
     <a
+      key="premium-tab-get-key"
       href="https://account.mailpoet.com/account?utm_source=plugin&utm_medium=settings&utm_campaign=activate-existing-plan&ref=settings-key-activation"
       target="_blank"
       rel="noopener noreferrer"
@@ -77,6 +79,7 @@ export function KeyActivation({ subscribersCount }: Props) {
               /\[link\](.*?)\[\/link\]/g,
               (text) => (
                 <a
+                  key="premium-tab-get-plan"
                   href={`https://account.mailpoet.com/?s=${subscribersCount}&utm_source=plugin&utm_medium=settings&utm_campaign=create-new-plan&ref=settings-key-activation`}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Mailer\Mailer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Notice as WPNotice;
+
+class PendingApprovalNotice {
+
+  const OPTION_NAME = 'dismissed-pending-approval-notice';
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function __construct(
+    SettingsController $settings
+  ) {
+    $this->settings = $settings;
+  }
+
+  public function init($shouldDisplay): ?string {
+    // We should display the notice if the user is using MSS and the subscription is not approved
+    if (
+      $shouldDisplay
+      && $this->settings->get('mta.method') === Mailer::METHOD_MAILPOET
+      && $this->settings->get('mta.mailpoet_api_key_state')
+      && !$this->settings->get('mta.mailpoet_api_key_state.data.is_approved', false)
+    ) {
+      return $this->display();
+    }
+
+    return null;
+  }
+
+  private function display(): string {
+    $message = __('<b>Your subscription is currently [link1]pending approval[/link1]</b>, which means you can only send [link2]email previews[/link2] to your [link3]authorized emails[/link3] at the moment. Please check your mailbox or [link4]contact us[/link4] if you haven’t heard from our team about your subscription status in the past 48 hours.', 'mailpoet');
+    $message = Helpers::replaceLinkTags(
+      $message,
+      'https://kb.mailpoet.com/article/350-pending-approval-subscription',
+      [
+        'target' => '_blank',
+        'data-beacon-article' => '5fbd3942cff47e00160bd248',
+      ],
+      'link1'
+    );
+    $message = Helpers::replaceLinkTags(
+      $message,
+      'https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it',
+      [
+        'target' => '_blank',
+        'data-beacon-article' => '5dadd69b2c7d3a7e9ae2cef2',
+      ],
+      'link2'
+    );
+    $message = Helpers::replaceLinkTags(
+      $message,
+      'https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#authorize',
+      [
+        'target' => '_blank',
+        'data-beacon-article' => '5cd2ca2f04286306738ed760',
+      ],
+      'link3'
+    );
+    $message = Helpers::replaceLinkTags(
+      $message,
+      'https://www.mailpoet.com/support/',
+      [
+        'target' => '_blank',
+      ],
+      'link4'
+    );
+
+    WPNotice::displayError($message, '', self::OPTION_NAME, true, false);
+    return $message;
+  }
+}

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -72,7 +72,7 @@ class PendingApprovalNotice {
       'link4'
     );
 
-    WPNotice::displayError($message, '', self::OPTION_NAME, true, false);
+    WPNotice::displayWarning($message, '', self::OPTION_NAME);
     return $message;
   }
 }

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -9,7 +9,7 @@ use MailPoet\WP\Notice as WPNotice;
 
 class PendingApprovalNotice {
 
-  const OPTION_NAME = 'dismissed-pending-approval-notice';
+  const OPTION_NAME = 'mailpoet-pending-approval-notice';
 
   /** @var SettingsController */
   private $settings;

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -48,6 +48,9 @@ class PermanentNotices {
   /** @var DisabledMailFunctionNotice */
   private $disabledMailFunctionNotice;
 
+  /** @var PendingApprovalNotice */
+  private $pendingApprovalNotice;
+
   public function __construct(
     WPFunctions $wp,
     TrackingConfig $trackingConfig,
@@ -68,6 +71,7 @@ class PermanentNotices {
     $this->changedTrackingNotice = new ChangedTrackingNotice($wp);
     $this->deprecatedFilterNotice = new DeprecatedFilterNotice($wp);
     $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature, $mailerFactory);
+    $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
   }
 
   public function init() {
@@ -113,6 +117,9 @@ class PermanentNotices {
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->disabledMailFunctionNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
+    $this->pendingApprovalNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
   }

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -56,8 +56,8 @@ class AddSendingKeyCest {
     $settings = new Settings();
     $settings->withMssKeyPendingApproval();
     $i->reloadPage();
-    $i->waitForText('Note: your account is pending approval by MailPoet.');
-    $i->waitForText('Rest assured, this only takes just a couple of hours. Until then, you can still send email previews to yourself. Any active automatic emails, like Welcome Emails, will be paused.');
+    $i->waitForText('Note: this subscription is currently pending approval by MailPoet.');
+    $i->waitForText('You should receive an email from us about it within 48h. Sending will be paused in the meantime, but you can still send email previews to yourself and explore the plugin features.');
     $i->dontSee('A test email was sent to');
 
     // try invalid key
@@ -65,8 +65,8 @@ class AddSendingKeyCest {
     $i->click('Verify');
     $i->waitForText('Your key is not valid for the MailPoet Sending Service');
     $i->waitForText('Your key is not valid for MailPoet Premium');
-    $i->dontSee('Note: your account is pending approval by MailPoet.');
-    $i->dontSee('Rest assured, this only takes just a couple of hours. Until then, you can still send email previews to yourself. Any active automatic emails, like Welcome Emails, will be paused.');
+    $i->dontSee('Note: this subscription is currently pending approval by MailPoet.');
+    $i->dontSee('You should receive an email from us about it within 48h. Sending will be paused in the meantime, but you can still send email previews to yourself and explore the plugin features.');
     $i->dontSee('A test email was sent to');
   }
 

--- a/mailpoet/tests/integration/Util/Notices/PendingApprovalNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PendingApprovalNoticeTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Mailer\Mailer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\SettingsRepository;
+
+class PendingApprovalNoticeTest extends \MailPoetTest {
+  /** @var PendingApprovalNotice */
+  private $notice;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function _before() {
+    parent::_before();
+    $this->settings = SettingsController::getInstance();
+    $this->notice = new PendingApprovalNotice($this->settings);
+  }
+
+  public function testItDisplays(): void {
+    $this->settings->set('mta.mailpoet_api_key_state.data.is_approved', false);
+    $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
+
+    $result = $this->notice->init(true);
+    // check that the notice is displayed. We cannot check the whole string because it contains HTML tags
+    expect($result)->stringContainsString('Your subscription is currently');
+    expect($result)->stringContainsString('if you haven’t heard from our team about your subscription status in the past 48 hours.');
+  }
+
+  public function testItDoesNotDisplayWhenDisabled(): void {
+    $this->settings->set('mta.mailpoet_api_key_state.data.is_approved', false);
+    $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
+
+    $result = $this->notice->init(false);
+    expect($result)->null();
+  }
+
+  public function testItDoesNotDisplayWhenNotUsingMailPoet(): void {
+    $this->settings->set('mta.mailpoet_api_key_state.data.is_approved', false);
+    $this->settings->set('mta.method', Mailer::METHOD_PHPMAIL);
+
+    $result = $this->notice->init(true);
+    expect($result)->null();
+  }
+
+  public function testItDoesNotDisplayWhenApproved(): void {
+    $this->settings->set('mta.mailpoet_api_key_state.data.is_approved', true);
+    $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
+
+    $result = $this->notice->init(true);
+    expect($result)->null();
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->cleanup();
+  }
+
+  private function cleanup() {
+    $this->diContainer->get(SettingsRepository::class)->truncate();
+  }
+}

--- a/mailpoet/views/premium_key_validation_strings.html
+++ b/mailpoet/views/premium_key_validation_strings.html
@@ -17,8 +17,8 @@
   'premiumTabMssNotActiveMessage': __('MailPoet Sending Service is not active.', 'mailpoet'),
   'premiumTabMssActivateMessage': __('Activate MailPoet Sending Service', 'mailpoet'),
   'premiumTabMssKeyNotValidMessage': __('Your key is not valid for the MailPoet Sending Service', 'mailpoet'),
-  'premiumTabPendingApprovalHeading': __('Note: your account is pending approval by MailPoet.', 'mailpoet'),
-  'premiumTabPendingApprovalMessage': __('Rest assured, this only takes just a couple of hours. Until then, you can still send email previews to yourself. Any active automatic emails, like Welcome Emails, will be paused.', 'mailpoet'),
+  'premiumTabPendingApprovalHeading': __('Note: this subscription is currently pending approval by MailPoet.', 'mailpoet'),
+  'premiumTabPendingApprovalMessage': __('You should receive an email from us about it within 48h. Sending will be paused in the meantime, but you can still send email previews to yourself and explore the plugin features.', 'mailpoet'),
   'premiumTabCongratulatoryMssEmailSent': __('A test email was sent to [email_address]', 'mailpoet'),
   'premiumTabPendingApprovalMessageRefresh': __('If you have already received approval email, click [link]here[/link] to update the status.', 'mailpoet'),
 }) %>


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I added a new parameter for the messages component if the success class can be used. Maybe there is a better approach, but I did not realize it. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4528]

## After-merge notes

_N/A_


[MAILPOET-4528]: https://mailpoet.atlassian.net/browse/MAILPOET-4528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ