### PR TITLE
Update shop links on the Upgrade page [MAILPOET-5081]

### DIFF
--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -16,9 +16,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' |  escape('html_attr') %>"
           <% endif %>
           class="mailpoet-button button-primary"
         >
@@ -178,7 +178,7 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
           <% else %>
             href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
           <% endif %>
@@ -218,7 +218,7 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
           <% else %>
             href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
           <% endif %>
@@ -267,7 +267,7 @@
       <a
         target="_blank"
         <% if (has_valid_api_key) %>
-          href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+          href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
         <% else %>
           href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
         <% endif %>
@@ -295,7 +295,7 @@
     <a
       target="_blank"
       <% if (has_valid_api_key) %>
-        href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+        href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
       <% else %>
         href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
       <% endif %>

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -16,9 +16,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' |  escape('html_attr') %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
           <% endif %>
           class="mailpoet-button button-primary"
         >
@@ -178,9 +178,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
           <% endif %>
         class="mailpoet-button button-primary"
         >
@@ -218,9 +218,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
           <% endif %>
           class="mailpoet-button button-primary"
         >
@@ -267,9 +267,9 @@
       <a
         target="_blank"
         <% if (has_valid_api_key) %>
-          href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
+          href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
         <% else %>
-          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
         <% endif %>
         class="mailpoet-button button-primary"
       >
@@ -295,9 +295,9 @@
     <a
       target="_blank"
       <% if (has_valid_api_key) %>
-        href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' | escape('html_attr') %>"
+        href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
       <% else %>
-        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
       <% endif %>
       class="mailpoet-button button-primary"
     >

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -15,9 +15,14 @@
       <div class="mailpoet-premium-page-intro-link-wrap">
         <a
           target="_blank"
-          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+          <% if (has_valid_api_key) %>
+            href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+          <% else %>
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+          <% endif %>
           class="mailpoet-button button-primary"
         >
+
           <%= _x('Upgrade', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
         </a>
       </div>
@@ -172,8 +177,12 @@
         </ul>
         <a
           target="_blank"
-          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
-          class="mailpoet-button button-primary"
+          <% if (has_valid_api_key) %>
+            href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+          <% else %>
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+          <% endif %>
+        class="mailpoet-button button-primary"
         >
           <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
         </a>
@@ -208,7 +217,11 @@
         <div class="mailpoet-premium-page-options-divider"></div>
         <a
           target="_blank"
-          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+          <% if (has_valid_api_key) %>
+            href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+          <% else %>
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+          <% endif %>
           class="mailpoet-button button-primary"
         >
           <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -253,7 +266,11 @@
       </ul>
       <a
         target="_blank"
-        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+        <% if (has_valid_api_key) %>
+          href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+        <% else %>
+          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+        <% endif %>
         class="mailpoet-button button-primary"
       >
         <%= _x('Buy Now', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -277,7 +294,11 @@
     </p>
     <a
       target="_blank"
-      href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+      <% if (has_valid_api_key) %>
+        href="https://account.mailpoet.com/upgrade?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade"
+      <% else %>
+        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+      <% endif %>
       class="mailpoet-button button-primary"
     >
       <%= _x('Upgrade now', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -15,7 +15,7 @@
       <div class="mailpoet-premium-page-intro-link-wrap">
         <a
           target="_blank"
-          href="<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase') | escape('html_attr') %>"
+          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
           class="mailpoet-button button-primary"
         >
           <%= _x('Upgrade', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -41,7 +41,7 @@
     </p>
     <a
       target="_blank"
-      href="<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=starter&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase') | escape('html_attr') %>"
+      href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=starter&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
       class="mailpoet-button button-primary"
     >
       <%= _x('Sign up for free', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -172,7 +172,7 @@
         </ul>
         <a
           target="_blank"
-          href="<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase') | escape('html_attr') %>"
+          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
           class="mailpoet-button button-primary"
         >
           <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -208,7 +208,7 @@
         <div class="mailpoet-premium-page-options-divider"></div>
         <a
           target="_blank"
-          href="<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase') | escape('html_attr') %>"
+          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
           class="mailpoet-button button-primary"
         >
           <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -253,7 +253,7 @@
       </ul>
       <a
         target="_blank"
-        href="<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase') | escape('html_attr') %>"
+        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
         class="mailpoet-button button-primary"
       >
         <%= _x('Buy Now', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -277,7 +277,7 @@
     </p>
     <a
       target="_blank"
-      href="<%= add_referral_id("https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase') | escape('html_attr') %>"
+      href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
       class="mailpoet-button button-primary"
     >
       <%= _x('Upgrade now', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -31,7 +31,7 @@
 
   <hr>
 
-  <% if (subscriber_count < 1000 ) %>
+  <% if (subscriber_count < 1000 and not has_valid_api_key) %>
   <div class="mailpoet-premium-page-section mailpoet-premium-page-section-narrow mailpoet-premium-page-text-center">
     <h1 class="mailpoet-h0">
       <%= _x('MailPoet Starter plan is actually yours for free', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

Note: While working on the PR, I noticed that the logic for displaying the upgrade page in the sidebar menu is dependent if the premium plugin is installed. The starter plan doesn't have access to the premium plugin, so it makes sense and I kept it that way. I added the note because you may have the premium plugin installed e.g., from the previous testing.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5081]

## After-merge notes

_N/A_


[MAILPOET-5081]: https://mailpoet.atlassian.net/browse/MAILPOET-5081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ