### PR TITLE
Add a new k6 test: Adding a new form

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -6,6 +6,7 @@ import { subscribersListing } from './tests/subscribers-listing.js';
 import { settingsBasic } from './tests/settings-basic.js';
 import { subscribersFiltering } from './tests/subscribers-filtering.js';
 import { subscribersAdding } from './tests/subscribers-adding.js';
+import { formsAdding } from './tests/forms-adding.js';
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
@@ -62,6 +63,7 @@ export function pullRequests() {
   settingsBasic();
   subscribersFiltering();
   subscribersAdding();
+  formsAdding();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { sleep, check, group } from 'k6';
-import { chromium } from 'k6/x/browser';
+import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 
 /**

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -33,7 +33,6 @@ export function formsAdding() {
   const page = browser.newPage();
 
   group('Forms - Add a new form', () => {
-    let formName = 'Test Form';
     page
       .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-forms`, {
         waitUntil: 'networkidle',
@@ -52,12 +51,13 @@ export function formsAdding() {
       .then(() => {
         waitAndClick(page, '[data-automation-id="create_new_form"]');
         sleep(1);
-        waitAndClick(page, '[data-automation-id="create_blank_form"]');
+        page.waitForLoadState('networkidle');
+        waitAndClick(
+          page,
+          '[data-automation-id="select_template_template_1_popup"]',
+        );
         sleep(1);
         page.waitForSelector('[data-automation-id="form_title_input"]');
-        page
-          .locator('[data-automation-id="form_title_input"]')
-          .type(formName, { delay: 50 });
         selectInSelect2(page, defaultListName);
         page.waitForSelector('[data-automation-id="form_save_button"]');
         page.locator('[data-automation-id="form_save_button"]').click();

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -1,0 +1,83 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check, group } from 'k6';
+import { chromium } from 'k6/x/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+  defaultListName,
+} from '../config.js';
+import {
+  authenticate,
+  selectInSelect2,
+  waitAndClick,
+} from '../utils/helpers.js';
+/* global Promise */
+
+export function formsAdding() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  group('Forms - Add a new form', () => {
+    let formName = 'Test Form';
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-forms`, {
+        waitUntil: 'networkidle',
+      })
+
+      .then(() => {
+        authenticate(page);
+      })
+
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
+
+      .then(() => {
+        waitAndClick(page, '[data-automation-id="create_new_form"]');
+        sleep(1);
+        waitAndClick(page, '[data-automation-id="create_blank_form"]');
+        sleep(1);
+        page.waitForSelector('[data-automation-id="form_title_input"]');
+        page
+          .locator('[data-automation-id="form_title_input"]')
+          .type(formName, { delay: 50 });
+        selectInSelect2(page, defaultListName);
+        page.waitForSelector('[data-automation-id="form_save_button"]');
+        page.locator('[data-automation-id="form_save_button"]').click();
+        page.waitForSelector('.components-notice');
+        check(page, {
+          'form has been saved notice is visible': page
+            .locator('.components-notice__content')
+            .isVisible(),
+        });
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
+
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+}
+
+export default function formsAddingTest() {
+  formsAdding();
+}

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -25,3 +25,10 @@ export function selectInSelect2(page, listName) {
   page.locator('.select2-selection').type(listName);
   page.keyboard.press('Enter');
 }
+
+// Wait and click the element with waiting for navigation
+export function waitAndClick(page, elementName) {
+  page.waitForSelector(elementName);
+  page.locator(elementName).click();
+  page.waitForNavigation({ waitUntil: 'networkidle' });
+}


### PR DESCRIPTION
## Description

Adding a new form as a merchant.

Additionally added:

- added a new helper method `waitAndClick`

## Code review notes

Feel free to test it locally by executing the following command:

- `./do test:performance --url=https://qawp.net tests/performance/tests/forms-adding.js`

Adding `--head` to the end of the above command will run the test in head mode (opposite to headless).

## Linked PRs

Branch made from this pr #4750

## Linked tickets

[MAILPOET-4959]


[MAILPOET-4959]: https://mailpoet.atlassian.net/browse/MAILPOET-4959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ