### PR TITLE
HPOS - Update WooCommerceSubscriptions segment filter [MAILPOET-4568]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,10 +179,10 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 7.1.0
-            ./do download:woo-commerce-subscriptions-zip 4.6.0
-            ./do download:woo-commerce-memberships-zip 1.23.1
-            ./do download:woo-commerce-blocks-zip 8.8.2
+            ./do download:woo-commerce-zip 7.4.0
+            ./do download:woo-commerce-subscriptions-zip 4.9.1
+            ./do download:woo-commerce-memberships-zip 1.24.0
+            ./do download:woo-commerce-blocks-zip 9.6.2
             ./do download:automate-woo-zip 5.6.8
       - run:
           name: Dump tests ENV variables for acceptance tests

--- a/mailpoet/tests/DataFactories/WooCommerceSubscription.php
+++ b/mailpoet/tests/DataFactories/WooCommerceSubscription.php
@@ -5,7 +5,7 @@ namespace MailPoet\Test\DataFactories;
 class WooCommerceSubscription {
   public function createSubscription(int $userId, int $subscriptionProductId, string $status = 'active'): \WC_Subscription {
     $args = [
-      'status' => 'active',
+      'status' => $status,
       'customer_id' => $userId,
       'billing_period' => 'month',
       'billing_interval' => 1,

--- a/mailpoet/tests/DataFactories/WooCommerceSubscription.php
+++ b/mailpoet/tests/DataFactories/WooCommerceSubscription.php
@@ -3,7 +3,7 @@
 namespace MailPoet\Test\DataFactories;
 
 class WooCommerceSubscription {
-  public function createSubscription(int $userId, int $subscriptionProductId): \WC_Subscription {
+  public function createSubscription(int $userId, int $subscriptionProductId, string $status = 'active'): \WC_Subscription {
     $args = [
       'status' => 'active',
       'customer_id' => $userId,

--- a/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -15,9 +15,6 @@ class WooCommerceSubscriptionsSegmentCest {
     if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN)) {
       $scenario->skip('Can‘t test without woocommerce-subscriptions');
     }
-    if ($i->isWooCustomOrdersTableEnabled()) {
-      $scenario->skip('Can‘t test when WooCommerce Custom Orders Table is enabled.');
-    }
     (new Settings())->withWooCommerceListImportPageDisplayed(true);
     (new Settings())->withCookieRevenueTrackingDisabled();
     $i->activateWooCommerce();

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -8,7 +8,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\WooCommerceSubscription as WooCommerceSubscriptionFactory;
-use MailPoet\WooCommerce\Helper;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\ForwardCompatibility\DriverStatement;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -38,11 +38,14 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   private $subscriptionsFactory;
 
   public function _before(): void {
-    $wooCommerceHelper = $this->diContainer->get(Helper::class);
-
-    if ($wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled()) {
-      $this->markTestSkipped('WooCommerce Subscriptions does not work with WooCommerce Custom Orders Table.');
-    }
+    // Temporarily disable the check for incompatible plugins and features in Woo
+    // because WooSubscriptions is still officially not compatible with Woo HPOS
+    $this->diContainer->get(WPFunctions::class)->addAction('woocommerce_init', function () {
+      if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::allow_enabling_features_with_incompatible_plugins();
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::allow_activating_plugins_with_incompatible_features();
+      }
+    });
 
     $this->cleanup();
     $productId = $this->createProduct('Premium Newsletter');

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -8,7 +8,6 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\WooCommerceSubscription as WooCommerceSubscriptionFactory;
-use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\ForwardCompatibility\DriverStatement;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -38,15 +37,6 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   private $subscriptionsFactory;
 
   public function _before(): void {
-    // Temporarily disable the check for incompatible plugins and features in Woo
-    // because WooSubscriptions is still officially not compatible with Woo HPOS
-    $this->diContainer->get(WPFunctions::class)->addAction('woocommerce_init', function () {
-      if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
-        \Automattic\WooCommerce\Utilities\FeaturesUtil::allow_enabling_features_with_incompatible_plugins();
-        \Automattic\WooCommerce\Utilities\FeaturesUtil::allow_activating_plugins_with_incompatible_features();
-      }
-    });
-
     $this->cleanup();
     $productId = $this->createProduct('Premium Newsletter');
     $this->subscriptionsFactory = new WooCommerceSubscriptionFactory();

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -44,7 +44,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
       $userId = $this->tester->createWordPressUser($email, 'subscriber');
 
       $status = explode('_', $email)[0];
-      $this->subscriptionsFactory ->createSubscription($userId, $productId, $status);
+      $this->subscriptionsFactory->createSubscription($userId, $productId, $status);
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds support for HPOS to the WooCommerce Subscriptions dynamic segment filter.

## Code review notes
I tried to explain the changes in commit messages.

## QA notes
1) Install Woo and WooCommerce Subscriptions.
2) Create a subscription product (Hint: you can set price 0 and then subscribe without configuring payments)
3) Subscribe to the subscription product and also confirm the subscription to MailPoet emails (you need a subscribed subscriber)
4) Create a dynamic segment for the subscription product
5) You should see one subscriber
6) Enable HPOS on Woo (Settings > Advanced > Features) and wait for orders to migrate (threre is info about migration status in settings).
7) Check that the dynamic segment still contains the subscriber.

You can also switch to HPOS immediately after installing Woo. So you don't need to wait for migration.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4568]

## After-merge notes

_N/A_


[MAILPOET-4568]: https://mailpoet.atlassian.net/browse/MAILPOET-4568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ