### PR TITLE
Remove Sending factory usage from tests [MAILPOET-4369]

### DIFF
--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -10,6 +10,7 @@ use MailPoet\Doctrine\EntityTraits\SafeToOneAssociationLoadTrait;
 use MailPoet\Doctrine\EntityTraits\UpdatedAtTrait;
 use MailPoetVendor\Doctrine\Common\Collections\ArrayCollection;
 use MailPoetVendor\Doctrine\Common\Collections\Collection;
+use MailPoetVendor\Doctrine\Common\Collections\Criteria;
 use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -209,6 +210,19 @@ class ScheduledTaskEntity {
    */
   public function getSubscribers(): Collection {
     return $this->subscribers;
+  }
+
+  /**
+   * @param int $processed ScheduledTaskSubscriberEntity::PROCESSED_* constant
+   * @return SubscriberEntity[]
+   */
+  public function getSubscribersByProcessed(int $processed): array {
+    $criteria = Criteria::create()
+      ->where(Criteria::expr()->eq('processed', $processed));
+    $subscribers = $this->subscribers->matching($criteria)->map(function (ScheduledTaskSubscriberEntity $taskSubscriber): ?SubscriberEntity {
+      return $taskSubscriber->getSubscriber();
+    });
+    return array_filter($subscribers->toArray());
   }
 
   public function getSendingQueue(): ?SendingQueueEntity {

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
+use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 /**
@@ -84,6 +85,33 @@ class ScheduledTaskSubscribersRepository extends Repository {
       ->setParameter('task', $scheduledTask)
       ->getQuery()
       ->execute();
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   */
+  public function updateProcessedSubscribers(ScheduledTaskEntity $task, array $subscriberIds): void {
+    if ($subscriberIds) {
+      $this->entityManager->createQueryBuilder()
+        ->update(ScheduledTaskSubscriberEntity::class, 'sts')
+        ->set('sts.processed', ScheduledTaskSubscriberEntity::STATUS_PROCESSED)
+        ->where('sts.subscriber IN (:subscriberIds)')
+        ->andWhere('sts.task = :task')
+        ->setParameter('subscriberIds', $subscriberIds, Connection::PARAM_INT_ARRAY)
+        ->setParameter('task', $task)
+        ->getQuery()
+        ->execute();
+    }
+
+    $this->checkCompleted($task);
+  }
+
+  private function checkCompleted(ScheduledTaskEntity $task): void {
+    $count = $this->countBy(['task' => $task, 'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED]);
+    if ($count === 0) {
+      $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+      $this->entityManager->flush();
+    }
   }
 
   private function getBaseSubscribersIdsBatchForTaskQuery(int $taskId, int $lastProcessedSubscriberId): QueryBuilder {

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -64,6 +64,18 @@ class ScheduledTasksRepository extends Repository {
     return ($scheduledTask instanceof ScheduledTaskEntity) ? $scheduledTask : null;
   }
 
+  public function findOneBySendingQueue(SendingQueueEntity $sendingQueue): ?ScheduledTaskEntity {
+    $scheduledTask = $this->doctrineRepository->createQueryBuilder('st')
+      ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
+      ->andWhere('sq.id = :sendingQueue')
+      ->setMaxResults(1)
+      ->setParameter('sendingQueue', $sendingQueue)
+      ->getQuery()
+      ->getOneOrNullResult();
+    // for phpstan because it detects mixed instead of entity
+    return ($scheduledTask instanceof ScheduledTaskEntity) ? $scheduledTask : null;
+  }
+
   /**
    * @param NewsletterEntity $newsletter
    * @return ScheduledTaskEntity[]


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

This PR should remove usages `Sending::createFromScheduledTask()` and `Sending::createFromQueue()` from integration tests. Unfortunately, I didn't remove them from `AbandonedCartContentTest` because it would need to change the implementation in the class `AbandonedCartContent`, which is not a part of this task.

## QA notes

I guess we can skip QA here because those changes are only integration tests.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4369]

## After-merge notes

_N/A_


[MAILPOET-4369]: https://mailpoet.atlassian.net/browse/MAILPOET-4369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ