### PR TITLE
Fix InactiveSubscribers cron worker [MAILPOET-5084]

### DIFF
--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -372,7 +372,7 @@ class SubscribersRepository extends Repository {
       ->getQuery()
       ->getSingleScalarResult();
 
-    return is_int($maxSubscriberId) ? $maxSubscriberId : 0;
+    return intval($maxSubscriberId);
   }
 
   /**

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -305,6 +305,15 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     expect($this->repository->findOneById($subscriberId))->notNull();
   }
 
+  public function testItGetsMaxSubscriberId(): void {
+    // check if equals to zero when no subscribers
+    expect($this->repository->getMaxSubscriberId())->equals(0);
+    // check if equals to max subscriber id
+    $this->createSubscriber('sub1@test.com');
+    $subscriberTwo = $this->createSubscriber('sub2@test.com');
+    expect($this->repository->getMaxSubscriberId())->equals($subscriberTwo->getId());
+  }
+
   private function createSubscriber(string $email, ?DateTimeImmutable $deletedAt = null): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Doctrine returns a string from the query when `getSingleScalarResult ()` is used, and usage of [is_int](https://www.php.net/manual/en/function.is-int.php) always returned `false` on a string. This caused our method in the repository always returned zero.
This behavior was the reason why the InactiveSubscribers worker was marked as `completed` during the first iteration.
## QA notes

1. More than 1000 subscribers are needed
2. Change the value of settings `Stop sending to inactive subscribers` (Settings > Advanced). This schedule the cron worker immediately.
3. Verify that the last worker-run with the type `inactive_subscribers` contains a different value from `{"last_subscriber_id":1000}` in the meta column. This can be done in MySQL(Adminer etc.).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5084]

## After-merge notes

_N/A_


[MAILPOET-5084]: https://mailpoet.atlassian.net/browse/MAILPOET-5084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ