### PR TITLE
Add purchase date dynamic filter [MAILPOET-4986]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
@@ -11,7 +11,7 @@ import { Input } from 'common/form/input/input';
 import { DateFormItem } from '../types';
 import { storeName } from '../store';
 
-export enum SubscribedDateOperator {
+export enum DateOperator {
   BEFORE = 'before',
   AFTER = 'after',
   ON = 'on',
@@ -21,12 +21,12 @@ export enum SubscribedDateOperator {
 }
 
 const availableOperators = [
-  SubscribedDateOperator.BEFORE,
-  SubscribedDateOperator.AFTER,
-  SubscribedDateOperator.ON,
-  SubscribedDateOperator.NOT_ON,
-  SubscribedDateOperator.IN_THE_LAST,
-  SubscribedDateOperator.NOT_IN_THE_LAST,
+  DateOperator.BEFORE,
+  DateOperator.AFTER,
+  DateOperator.ON,
+  DateOperator.NOT_ON,
+  DateOperator.IN_THE_LAST,
+  DateOperator.NOT_IN_THE_LAST,
 ];
 
 const convertDateToString = (
@@ -53,7 +53,7 @@ type Props = {
   filterIndex: number;
 };
 
-export function SubscribedDateFields({ filterIndex }: Props): JSX.Element {
+export function DateFields({ filterIndex }: Props): JSX.Element {
   const segment: DateFormItem = useSelect(
     (select) =>
       select(storeName).getSegmentFilter(filterIndex),
@@ -64,19 +64,14 @@ export function SubscribedDateFields({ filterIndex }: Props): JSX.Element {
     useDispatch(storeName);
 
   useEffect(() => {
-    if (
-      !availableOperators.includes(segment.operator as SubscribedDateOperator)
-    ) {
-      void updateSegmentFilter(
-        { operator: SubscribedDateOperator.BEFORE },
-        filterIndex,
-      );
+    if (!availableOperators.includes(segment.operator as DateOperator)) {
+      void updateSegmentFilter({ operator: DateOperator.BEFORE }, filterIndex);
     }
     if (
-      (segment.operator === SubscribedDateOperator.BEFORE ||
-        segment.operator === SubscribedDateOperator.AFTER ||
-        segment.operator === SubscribedDateOperator.ON ||
-        segment.operator === SubscribedDateOperator.NOT_ON) &&
+      (segment.operator === DateOperator.BEFORE ||
+        segment.operator === DateOperator.AFTER ||
+        segment.operator === DateOperator.ON ||
+        segment.operator === DateOperator.NOT_ON) &&
       (parseDate(segment.value) === undefined ||
         !/^\d+-\d+-\d+$/.test(segment.value))
     ) {
@@ -86,8 +81,8 @@ export function SubscribedDateFields({ filterIndex }: Props): JSX.Element {
       );
     }
     if (
-      (segment.operator === SubscribedDateOperator.IN_THE_LAST ||
-        segment.operator === SubscribedDateOperator.NOT_IN_THE_LAST) &&
+      (segment.operator === DateOperator.IN_THE_LAST ||
+        segment.operator === DateOperator.NOT_IN_THE_LAST) &&
       typeof segment.value === 'string' &&
       !/^\d*$/.exec(segment.value)
     ) {
@@ -104,29 +99,21 @@ export function SubscribedDateFields({ filterIndex }: Props): JSX.Element {
           void updateSegmentFilterFromEvent('operator', filterIndex, e);
         }}
       >
-        <option value={SubscribedDateOperator.BEFORE}>
-          {MailPoet.I18n.t('before')}
-        </option>
-        <option value={SubscribedDateOperator.AFTER}>
-          {MailPoet.I18n.t('after')}
-        </option>
-        <option value={SubscribedDateOperator.ON}>
-          {MailPoet.I18n.t('on')}
-        </option>
-        <option value={SubscribedDateOperator.NOT_ON}>
-          {MailPoet.I18n.t('notOn')}
-        </option>
-        <option value={SubscribedDateOperator.IN_THE_LAST}>
+        <option value={DateOperator.BEFORE}>{MailPoet.I18n.t('before')}</option>
+        <option value={DateOperator.AFTER}>{MailPoet.I18n.t('after')}</option>
+        <option value={DateOperator.ON}>{MailPoet.I18n.t('on')}</option>
+        <option value={DateOperator.NOT_ON}>{MailPoet.I18n.t('notOn')}</option>
+        <option value={DateOperator.IN_THE_LAST}>
           {MailPoet.I18n.t('inTheLast')}
         </option>
-        <option value={SubscribedDateOperator.NOT_IN_THE_LAST}>
+        <option value={DateOperator.NOT_IN_THE_LAST}>
           {MailPoet.I18n.t('notInTheLast')}
         </option>
       </Select>
-      {(segment.operator === SubscribedDateOperator.BEFORE ||
-        segment.operator === SubscribedDateOperator.AFTER ||
-        segment.operator === SubscribedDateOperator.ON ||
-        segment.operator === SubscribedDateOperator.NOT_ON) && (
+      {(segment.operator === DateOperator.BEFORE ||
+        segment.operator === DateOperator.AFTER ||
+        segment.operator === DateOperator.ON ||
+        segment.operator === DateOperator.NOT_ON) && (
         <Datepicker
           dateFormat="MMM d, yyyy"
           onChange={(value): void => {
@@ -138,8 +125,8 @@ export function SubscribedDateFields({ filterIndex }: Props): JSX.Element {
           selected={segment.value ? parseDate(segment.value) : undefined}
         />
       )}
-      {(segment.operator === SubscribedDateOperator.IN_THE_LAST ||
-        segment.operator === SubscribedDateOperator.NOT_IN_THE_LAST) && (
+      {(segment.operator === DateOperator.IN_THE_LAST ||
+        segment.operator === DateOperator.NOT_IN_THE_LAST) && (
         <>
           <Input
             key="input"

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { isValid, parseISO } from 'date-fns';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 import { MailPoet } from 'mailpoet';
 import { Select } from 'common/form/select/select';
@@ -55,8 +55,7 @@ type Props = {
 
 export function DateFields({ filterIndex }: Props): JSX.Element {
   const segment: DateFormItem = useSelect(
-    (select) =>
-      select(storeName).getSegmentFilter(filterIndex),
+    (select) => select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],
   );
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
@@ -143,3 +143,32 @@ export function DateFields({ filterIndex }: Props): JSX.Element {
     </Grid.CenteredRow>
   );
 }
+
+export function dateFieldValidator(formItems: DateFormItem): boolean {
+  if (!formItems.operator || !formItems.value) {
+    return false;
+  }
+
+  if (
+    [
+      DateOperator.BEFORE,
+      DateOperator.AFTER,
+      DateOperator.ON,
+      DateOperator.NOT_ON,
+    ].includes(formItems.operator as DateOperator)
+  ) {
+    const re = /^\d+-\d+-\d+$/;
+    return re.test(formItems.value);
+  }
+
+  if (
+    [DateOperator.IN_THE_LAST, DateOperator.NOT_IN_THE_LAST].includes(
+      formItems.operator as DateOperator,
+    )
+  ) {
+    const re = /^\d+$/;
+    return re.test(formItems.value) && Number(formItems.value) > 0;
+  }
+
+  return false;
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -7,10 +7,7 @@ import {
   SubscriberScoreFields,
   validateSubscriberScore,
 } from './subscriber_score';
-import {
-  SubscribedDateFields,
-  SubscribedDateOperator,
-} from './subscriber_subscribed_date';
+import { DateFields, DateOperator } from './date_fields';
 import {
   MailPoetCustomFields,
   validateMailPoetCustomField,
@@ -47,17 +44,17 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
     return false;
   }
   if (
-    formItems.operator === SubscribedDateOperator.BEFORE ||
-    formItems.operator === SubscribedDateOperator.AFTER ||
-    formItems.operator === SubscribedDateOperator.ON ||
-    formItems.operator === SubscribedDateOperator.NOT_ON
+    formItems.operator === DateOperator.BEFORE ||
+    formItems.operator === DateOperator.AFTER ||
+    formItems.operator === DateOperator.ON ||
+    formItems.operator === DateOperator.NOT_ON
   ) {
     const re = /^\d+-\d+-\d+$/;
     return re.test(formItems.value);
   }
   if (
-    formItems.operator === SubscribedDateOperator.IN_THE_LAST ||
-    formItems.operator === SubscribedDateOperator.NOT_IN_THE_LAST
+    formItems.operator === DateOperator.IN_THE_LAST ||
+    formItems.operator === DateOperator.NOT_IN_THE_LAST
   ) {
     const re = /^\d+$/;
     return re.test(formItems.value) && Number(formItems.value) > 0;
@@ -68,7 +65,7 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
 const componentsMap = {
   [SubscriberActionTypes.WORDPRESS_ROLE]: WordpressRoleFields,
   [SubscriberActionTypes.SUBSCRIBER_SCORE]: SubscriberScoreFields,
-  [SubscriberActionTypes.SUBSCRIBED_DATE]: SubscribedDateFields,
+  [SubscriberActionTypes.SUBSCRIBED_DATE]: DateFields,
   [SubscriberActionTypes.MAILPOET_CUSTOM_FIELD]: MailPoetCustomFields,
   [SubscriberActionTypes.SUBSCRIBED_TO_LIST]: SubscribedToList,
   [SubscriberActionTypes.SUBSCRIBER_TAG]: SubscriberTag,

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -1,13 +1,13 @@
 import { useSelect } from '@wordpress/data';
 
-import { WordpressRoleFormItem, SubscriberActionTypes } from '../types';
+import { SubscriberActionTypes, WordpressRoleFormItem } from '../types';
 import { storeName } from '../store';
 import { WordpressRoleFields } from './subscriber_wordpress_role';
 import {
   SubscriberScoreFields,
   validateSubscriberScore,
 } from './subscriber_score';
-import { DateFields, DateOperator } from './date_fields';
+import { DateFields, dateFieldValidator, DateOperator } from './date_fields';
 import {
   MailPoetCustomFields,
   validateMailPoetCustomField,
@@ -44,20 +44,9 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
     return false;
   }
   if (
-    formItems.operator === DateOperator.BEFORE ||
-    formItems.operator === DateOperator.AFTER ||
-    formItems.operator === DateOperator.ON ||
-    formItems.operator === DateOperator.NOT_ON
+    Object.values(DateOperator).includes(formItems.operator as DateOperator)
   ) {
-    const re = /^\d+-\d+-\d+$/;
-    return re.test(formItems.value);
-  }
-  if (
-    formItems.operator === DateOperator.IN_THE_LAST ||
-    formItems.operator === DateOperator.NOT_IN_THE_LAST
-  ) {
-    const re = /^\d+$/;
-    return re.test(formItems.value) && Number(formItems.value) > 0;
+    return dateFieldValidator(formItems);
   }
   return false;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_subscribed_date.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_subscribed_date.tsx
@@ -8,7 +8,7 @@ import { Datepicker } from 'common/datepicker/datepicker';
 import { Grid } from 'common/grid';
 import { Input } from 'common/form/input/input';
 
-import { WordpressRoleFormItem } from '../types';
+import { DateFormItem } from '../types';
 import { storeName } from '../store';
 
 export enum SubscribedDateOperator {
@@ -54,8 +54,9 @@ type Props = {
 };
 
 export function SubscribedDateFields({ filterIndex }: Props): JSX.Element {
-  const segment: WordpressRoleFormItem = useSelect(
-    (select) => select(storeName).getSegmentFilter(filterIndex),
+  const segment: DateFormItem = useSelect(
+    (select) =>
+      select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],
   );
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -15,6 +15,7 @@ import {
   WindowWooCommerceCountries,
   WooCommerceFormItem,
 } from '../types';
+import { SubscribedDateFields } from './subscriber_subscribed_date';
 import { storeName } from '../store';
 import {
   WooCommerceActionTypes,
@@ -284,6 +285,8 @@ export const WooCommerceFields: FunctionComponent<Props> = ({
         </Grid.CenteredRow>
       </>
     );
+  } else if (segment.action === WooCommerceActionTypes.PURCHASE_DATE) {
+    optionFields = SubscribedDateFields({ filterIndex });
   } else if (segment.action === WooCommerceActionTypes.NUMBER_OF_ORDERS) {
     optionFields = (
       <>

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -15,7 +15,7 @@ import {
   WindowWooCommerceCountries,
   WooCommerceFormItem,
 } from '../types';
-import { SubscribedDateFields } from './subscriber_subscribed_date';
+import { DateFields } from './date_fields';
 import { storeName } from '../store';
 import {
   WooCommerceActionTypes,
@@ -286,7 +286,7 @@ export const WooCommerceFields: FunctionComponent<Props> = ({
       </>
     );
   } else if (segment.action === WooCommerceActionTypes.PURCHASE_DATE) {
-    optionFields = SubscribedDateFields({ filterIndex });
+    optionFields = DateFields({ filterIndex });
   } else if (segment.action === WooCommerceActionTypes.NUMBER_OF_ORDERS) {
     optionFields = (
       <>

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -3,7 +3,7 @@ import { MailPoet } from 'mailpoet';
 import { filter } from 'lodash/fp';
 import { ReactSelect } from 'common/form/react_select/react_select';
 import { Select } from 'common/form/select/select';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 import { Grid } from 'common/grid';
 import { Input } from 'common/form/input/input';
@@ -15,11 +15,11 @@ import {
   WindowWooCommerceCountries,
   WooCommerceFormItem,
 } from '../types';
-import { DateFields } from './date_fields';
+import { DateFields, dateFieldValidator, DateOperator } from './date_fields';
 import { storeName } from '../store';
 import {
-  WooCommerceActionTypes,
   actionTypesWithDefaultTypeAny,
+  WooCommerceActionTypes,
 } from './woocommerce_options';
 
 export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
@@ -73,6 +73,11 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
       !formItems.total_spent_type)
   ) {
     return false;
+  }
+  if (
+    Object.values(DateOperator).includes(formItems.operator as DateOperator)
+  ) {
+    return dateFieldValidator(formItems);
   }
   if (
     formItems.action === WooCommerceActionTypes.SINGLE_ORDER_VALUE &&

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
@@ -5,6 +5,7 @@ import { SegmentTypes } from '../types';
 export enum WooCommerceActionTypes {
   NUMBER_OF_ORDERS = 'numberOfOrders',
   PURCHASED_CATEGORY = 'purchasedCategory',
+  PURCHASE_DATE = 'purchaseDate',
   PURCHASED_PRODUCT = 'purchasedProduct',
   TOTAL_SPENT = 'totalSpent',
   CUSTOMER_IN_COUNTRY = 'customerInCountry',
@@ -25,6 +26,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.PURCHASED_CATEGORY,
     label: MailPoet.I18n.t('wooPurchasedCategory'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.PURCHASE_DATE,
+    label: MailPoet.I18n.t('wooPurchaseDate'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -61,6 +61,11 @@ export interface FormItem {
   action?: string;
 }
 
+export interface DateFormItem extends FormItem {
+  operator: string;
+  value: string;
+}
+
 export interface WordpressRoleFormItem extends FormItem {
   wordpressRole?: string[];
   operator?: string;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -62,8 +62,8 @@ export interface FormItem {
 }
 
 export interface DateFormItem extends FormItem {
-  operator: string;
-  value: string;
+  operator?: string;
+  value?: string;
 }
 
 export interface WordpressRoleFormItem extends FormItem {
@@ -121,6 +121,7 @@ export type Segment = {
 };
 
 export type AnyFormItem =
+  | DateFormItem
   | WordpressRoleFormItem
   | WooCommerceFormItem
   | WooCommerceSubscriptionFormItem

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -384,6 +384,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\DateFilterHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -388,6 +388,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\FilterHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberScore::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate::class)->setPublic(true);
@@ -403,6 +404,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooFilterHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\SegmentSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterDataMapper::class)->setPublic(true);
     // Services

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -398,6 +398,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -4,6 +4,7 @@ namespace MailPoet\Segments\DynamicSegments;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Segments\DynamicSegments\Filters\DateFilterHelper;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
 use MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny;
 use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
@@ -92,7 +93,7 @@ class FilterDataMapper {
       if (empty($data['value'])) throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'value' => $data['value'],
-        'operator' => $data['operator'] ?? SubscriberSubscribedDate::BEFORE,
+        'operator' => $data['operator'] ?? DateFilterHelper::BEFORE,
         'connect' => $data['connect'],
       ]);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -17,6 +17,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
@@ -262,6 +263,9 @@ class FilterDataMapper {
       $filterData['single_order_value_type'] = $data['single_order_value_type'];
       $filterData['single_order_value_amount'] = $data['single_order_value_amount'];
       $filterData['single_order_value_days'] = $data['single_order_value_days'];
+    } elseif ($data['action'] === WooCommercePurchaseDate::ACTION) {
+      $filterData['operator'] = $data['operator'];
+      $filterData['value'] = $data['value'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -20,6 +20,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
@@ -42,6 +43,9 @@ class FilterFactory {
 
   /** @var WooCommerceNumberOfOrders */
   private $wooCommerceNumberOfOrders;
+
+  /** @var WooCommercePurchaseDate */
+  private $wooCommercePurchaseDate;
 
   /** @var WooCommerceSingleOrderValue */
   private $wooCommerceSingleOrderValue;
@@ -88,6 +92,7 @@ class FilterFactory {
     WooCommerceNumberOfOrders $wooCommerceNumberOfOrders,
     WooCommerceTotalSpent $wooCommerceTotalSpent,
     WooCommerceMembership $wooCommerceMembership,
+    WooCommercePurchaseDate $wooCommercePurchaseDate,
     WooCommerceSubscription $wooCommerceSubscription,
     SubscriberSubscribedDate $subscriberSubscribedDate,
     SubscriberScore $subscriberScore,
@@ -102,6 +107,7 @@ class FilterFactory {
     $this->wooCommerceCountry = $wooCommerceCountry;
     $this->wooCommerceNumberOfOrders = $wooCommerceNumberOfOrders;
     $this->wooCommerceMembership = $wooCommerceMembership;
+    $this->wooCommercePurchaseDate = $wooCommercePurchaseDate;
     $this->wooCommerceSubscription = $wooCommerceSubscription;
     $this->emailOpensAbsoluteCount = $emailOpensAbsoluteCount;
     $this->wooCommerceTotalSpent = $wooCommerceTotalSpent;
@@ -190,6 +196,8 @@ class FilterFactory {
       return $this->wooCommerceCountry;
     } elseif ($action === WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE) {
       return $this->wooCommerceSingleOrderValue;
+    } elseif ($action === WooCommercePurchaseDate::ACTION) {
+      return $this->wooCommercePurchaseDate;
     }
     return $this->wooCommerceCategory;
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilter.php
@@ -8,7 +8,6 @@ use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 abstract class DateFilter implements Filter {
-
   const BEFORE = 'before';
   const AFTER = 'after';
   const ON = 'on';
@@ -19,34 +18,30 @@ abstract class DateFilter implements Filter {
   abstract public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder;
 
   protected function getValidOperators(): array {
+    return array_merge(
+      $this->getAbsoluteDateOperators(),
+      $this->getRelativeDateOperators()
+    );
+  }
+
+  protected function getAbsoluteDateOperators(): array {
     return [
       self::BEFORE,
       self::AFTER,
       self::ON,
       self::NOT_ON,
-      self::IN_THE_LAST,
-      self::NOT_IN_THE_LAST,
     ];
   }
 
-  protected function getDateOperators() {
-    return [
-      self::BEFORE,
-      self::AFTER,
-      self::ON,
-      self::NOT_ON,
-    ];
-  }
-
-  protected function getRelativeDateOperators() {
+  protected function getRelativeDateOperators(): array {
     return [
       self::IN_THE_LAST,
       self::NOT_IN_THE_LAST,
     ];
   }
 
-  protected function getDateForOperator(string $operator, string $value): string {
-    if (in_array($operator, $this->getDateOperators())) {
+  protected function getDateStringForOperator(string $operator, string $value): string {
+    if (in_array($operator, $this->getAbsoluteDateOperators())) {
       $carbon = CarbonImmutable::createFromFormat('Y-m-d', $value);
       if (!$carbon instanceof CarbonImmutable) {
         throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilter.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoetVendor\Carbon\CarbonImmutable;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+abstract class DateFilter implements Filter {
+
+  const BEFORE = 'before';
+  const AFTER = 'after';
+  const ON = 'on';
+  const NOT_ON = 'notOn';
+  const IN_THE_LAST = 'inTheLast';
+  const NOT_IN_THE_LAST = 'notInTheLast';
+
+  abstract public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder;
+
+  protected function getValidOperators(): array {
+    return [
+      self::BEFORE,
+      self::AFTER,
+      self::ON,
+      self::NOT_ON,
+      self::IN_THE_LAST,
+      self::NOT_IN_THE_LAST,
+    ];
+  }
+
+  protected function getDateOperators() {
+    return [
+      self::BEFORE,
+      self::AFTER,
+      self::ON,
+      self::NOT_ON,
+    ];
+  }
+
+  protected function getRelativeDateOperators() {
+    return [
+      self::IN_THE_LAST,
+      self::NOT_IN_THE_LAST,
+    ];
+  }
+
+  protected function getDateForOperator(string $operator, string $value): string {
+    if (in_array($operator, $this->getDateOperators())) {
+      $carbon = CarbonImmutable::createFromFormat('Y-m-d', $value);
+      if (!$carbon instanceof CarbonImmutable) {
+        throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+      }
+    } else if (in_array($operator, $this->getRelativeDateOperators())) {
+      $carbon = CarbonImmutable::now()->subDays(intval($value));
+    } else {
+      throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
+    }
+
+    return $carbon->toDateString();
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilter.php
@@ -52,11 +52,29 @@ abstract class DateFilter implements Filter {
         throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
       }
     } else if (in_array($operator, $this->getRelativeDateOperators())) {
-      $carbon = CarbonImmutable::now()->subDays(intval($value));
+      $carbon = CarbonImmutable::now()->subDays(intval($value) - 1);
     } else {
       throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }
 
     return $carbon->toDateString();
+  }
+
+  protected function getDateValueFromFilter(DynamicSegmentFilterEntity $filter): string {
+    $filterData = $filter->getFilterData();
+    $dateValue = $filterData->getParam('value');
+    if (!is_string($dateValue)) {
+      throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
+    }
+    return $dateValue;
+  }
+
+  protected function getOperatorFromFilter(DynamicSegmentFilterEntity $filter): string {
+    $filterData = $filter->getFilterData();
+    $operator = $filterData->getParam('operator');
+    if (!is_string($operator) || !in_array($operator, $this->getValidOperators())) {
+      throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
+    }
+    return $operator;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
@@ -5,9 +5,8 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoetVendor\Carbon\CarbonImmutable;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
-abstract class DateFilter implements Filter {
+class DateFilterHelper {
   const BEFORE = 'before';
   const AFTER = 'after';
   const ON = 'on';
@@ -15,16 +14,14 @@ abstract class DateFilter implements Filter {
   const IN_THE_LAST = 'inTheLast';
   const NOT_IN_THE_LAST = 'notInTheLast';
 
-  abstract public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder;
-
-  protected function getValidOperators(): array {
+  public function getValidOperators(): array {
     return array_merge(
       $this->getAbsoluteDateOperators(),
       $this->getRelativeDateOperators()
     );
   }
 
-  protected function getAbsoluteDateOperators(): array {
+  public function getAbsoluteDateOperators(): array {
     return [
       self::BEFORE,
       self::AFTER,
@@ -33,14 +30,14 @@ abstract class DateFilter implements Filter {
     ];
   }
 
-  protected function getRelativeDateOperators(): array {
+  public function getRelativeDateOperators(): array {
     return [
       self::IN_THE_LAST,
       self::NOT_IN_THE_LAST,
     ];
   }
 
-  protected function getDateStringForOperator(string $operator, string $value): string {
+  public function getDateStringForOperator(string $operator, string $value): string {
     if (in_array($operator, $this->getAbsoluteDateOperators())) {
       $carbon = CarbonImmutable::createFromFormat('Y-m-d', $value);
       if (!$carbon instanceof CarbonImmutable) {
@@ -55,7 +52,7 @@ abstract class DateFilter implements Filter {
     return $carbon->toDateString();
   }
 
-  protected function getDateValueFromFilter(DynamicSegmentFilterEntity $filter): string {
+  public function getDateValueFromFilter(DynamicSegmentFilterEntity $filter): string {
     $filterData = $filter->getFilterData();
     $dateValue = $filterData->getParam('value');
     if (!is_string($dateValue)) {
@@ -64,7 +61,7 @@ abstract class DateFilter implements Filter {
     return $dateValue;
   }
 
-  protected function getOperatorFromFilter(DynamicSegmentFilterEntity $filter): string {
+  public function getOperatorFromFilter(DynamicSegmentFilterEntity $filter): string {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('operator');
     if (!is_string($operator) || !in_array($operator, $this->getValidOperators())) {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -16,7 +16,7 @@ class FilterHelper {
     $this->entityManager = $entityManager;
   }
 
-  public function prefixedTable(string $table): string {
+  public function getPrefixedTable(string $table): string {
     global $wpdb;
     return sprintf('%s%s', $wpdb->prefix, $table);
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Util\Security;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -33,5 +34,28 @@ class FilterHelper {
     return $this->entityManager
       ->getClassMetadata(SubscriberEntity::class)
       ->getTableName();
+  }
+
+  public function getInterpolatedSQL(QueryBuilder $query): string {
+    $sql = $query->getSQL();
+    $params = $query->getParameters();
+    $search = array_map(function($key) {
+      return ":$key";
+    }, array_keys($params));
+    $replace = array_map(function($value) use ($query) {
+      if (is_array($value)) {
+        $quotedValues = array_map(function($arrayValue) use ($query) {
+          return $query->expr()->literal($arrayValue);
+        }, $value);
+        return implode(',', $quotedValues);
+      }
+      return $query->expr()->literal($value);
+    }, array_values($params));
+    return str_replace($search, $replace, $sql);
+  }
+
+  public function getUniqueParameterName(string $parameter): string {
+    $suffix = Security::generateRandomString();
+    return sprintf("%s_%s", $parameter, $suffix);
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class FilterHelper {
+    /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    $this->entityManager = $entityManager;
+  }
+
+  public function prefixedTable(string $table): string {
+    global $wpdb;
+    return sprintf('%s%s', $wpdb->prefix, $table);
+  }
+
+  public function getNewSubscribersQueryBuilder(): QueryBuilder {
+    return $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select('id')
+      ->from($this->getSubscribersTable());
+  }
+
+  public function getSubscribersTable(): string {
+    return $this->entityManager
+      ->getClassMetadata(SubscriberEntity::class)
+      ->getTableName();
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -15,7 +15,7 @@ class SubscriberSubscribedDate extends DateFilter {
     $value = $this->getDateValueFromFilter($filter);
     $parameterSuffix = $filter->getId() ?: Security::generateRandomString();
     $parameter = 'date' . $parameterSuffix;
-    $date = $this->getDateForOperator($operator, $value);
+    $date = $this->getDateStringForOperator($operator, $value);
 
     if ($operator === self::BEFORE) {
       $queryBuilder->andWhere("DATE(last_subscribed_at) < :$parameter");

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -5,62 +5,35 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\Security;
-use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberSubscribedDate extends DateFilter {
   const TYPE = 'subscribedDate';
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
-    $filterData = $filter->getFilterData();
-    $value = $filterData->getParam('value');
-    $operator = $filterData->getParam('operator');
+    $operator = $this->getOperatorFromFilter($filter);
+    $value = $this->getDateValueFromFilter($filter);
     $parameterSuffix = $filter->getId() ?: Security::generateRandomString();
     $parameter = 'date' . $parameterSuffix;
-    $date = $this->getDate($operator, $value);
+    $date = $this->getDateForOperator($operator, $value);
 
     if ($operator === self::BEFORE) {
-      $queryBuilder->andWhere("last_subscribed_at < :$parameter");
+      $queryBuilder->andWhere("DATE(last_subscribed_at) < :$parameter");
     } elseif ($operator === self::AFTER) {
-      $queryBuilder->andWhere("last_subscribed_at >= :$parameter");
+      $queryBuilder->andWhere("DATE(last_subscribed_at) > :$parameter");
     } elseif ($operator === self::ON) {
       $queryBuilder->andWhere("DATE(last_subscribed_at) = :$parameter");
-      $date = $date->toDateString();
     } elseif ($operator === self::NOT_ON) {
       $queryBuilder->andWhere("DATE(last_subscribed_at) != :$parameter");
-      $date = $date->toDateString();
     } elseif ($operator === self::IN_THE_LAST) {
-      $queryBuilder->andWhere("last_subscribed_at >= :$parameter");
+      $queryBuilder->andWhere("DATE(last_subscribed_at) >= :$parameter");
     } elseif ($operator === self::NOT_IN_THE_LAST) {
-      $queryBuilder->andWhere("last_subscribed_at < :$parameter");
+      $queryBuilder->andWhere("DATE(last_subscribed_at) < :$parameter");
     } else {
       throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }
     $queryBuilder->setParameter($parameter, $date);
 
     return $queryBuilder;
-  }
-
-  private function getDate(string $operator, string $value): CarbonImmutable {
-    $dateFields = [self::BEFORE, self::AFTER, self::ON, self::NOT_ON];
-
-    if (in_array($operator, $dateFields)) {
-      $carbon = CarbonImmutable::createFromFormat('Y-m-d', $value);
-      if (!$carbon instanceof CarbonImmutable) {
-        throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
-      }
-      if ($operator === self::BEFORE) {
-        return $carbon->startOfDay();
-      }
-      if ($operator === self::AFTER) {
-        return $carbon->endOfDay();
-      }
-      if ($operator === self::ON || $operator === self::NOT_ON) {
-        return $carbon;
-      }
-    }
-
-    $carbon = CarbonImmutable::now();
-    return $carbon->subDays(intval($value) - 1)->startOfDay();
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
@@ -8,15 +8,8 @@ use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
-class SubscriberSubscribedDate implements Filter {
+class SubscriberSubscribedDate extends DateFilter {
   const TYPE = 'subscribedDate';
-
-  const BEFORE = 'before';
-  const AFTER = 'after';
-  const ON = 'on';
-  const NOT_ON = 'notOn';
-  const IN_THE_LAST = 'inTheLast';
-  const NOT_IN_THE_LAST = 'notInTheLast';
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $filterData = $filter->getFilterData();

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Util\DBCollationChecker;
+use MailPoet\Util\Security;
+use MailPoetVendor\Carbon\CarbonImmutable;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class WooCommercePurchaseDate implements Filter {
+  const ACTION = 'purchaseDate';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var DBCollationChecker */
+  private $collationChecker;
+
+  const BEFORE = 'before';
+  const AFTER = 'after';
+  const ON = 'on';
+  const NOT_ON = 'notOn';
+  const IN_THE_LAST = 'inTheLast';
+  const NOT_IN_THE_LAST = 'notInTheLast';
+
+  public function __construct(
+    EntityManager $entityManager,
+    DBCollationChecker $collationChecker
+  ) {
+    $this->entityManager = $entityManager;
+    $this->collationChecker = $collationChecker;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $operator = $filterData->getParam('operator');
+
+    if (!is_string($operator) || !in_array($operator, $this->getValidOperators())) {
+      throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
+    }
+
+    $rawDate = $filterData->getParam('value');
+    if (!is_string($rawDate)) {
+      throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
+    }
+    $date = $this->getDate($operator, $rawDate);
+    $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
+    $dateParameter = sprintf('date_%s', $parameterSuffix);
+
+    $subQuery = $this->getSubQuery($operator, $dateParameter);
+
+    $isNegatedOperator = in_array($operator, [self::NOT_ON, self::NOT_IN_THE_LAST]);
+    $subQueryOperator = $isNegatedOperator ? 'NOT IN' : 'IN';
+
+    $queryBuilder->andWhere("{$this->getSubscribersTable()}.id {$subQueryOperator} ({$subQuery->getSQL()})");
+    $queryBuilder->setParameter($dateParameter, $date);
+
+    return $queryBuilder;
+  }
+
+  private function getDate(string $operator, string $value): string {
+    if (in_array($operator, $this->getDateOperators())) {
+      $carbon = CarbonImmutable::createFromFormat('Y-m-d', $value);
+      if (!$carbon instanceof CarbonImmutable) {
+        throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+      }
+    } else if (in_array($operator, $this->getRelativeDateOperators())) {
+      $carbon = CarbonImmutable::now()->subDays(intval($value));
+    } else {
+      throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
+    }
+
+    return $carbon->toDateString();
+  }
+
+  private function getValidOperators(): array {
+    return [
+      self::BEFORE,
+      self::AFTER,
+      self::ON,
+      self::NOT_ON,
+      self::IN_THE_LAST,
+      self::NOT_IN_THE_LAST,
+    ];
+  }
+
+  private function getDateOperators() {
+    return [
+      self::BEFORE,
+      self::AFTER,
+      self::ON,
+      self::NOT_ON,
+    ];
+  }
+
+  private function getRelativeDateOperators() {
+    return [
+      self::IN_THE_LAST,
+      self::NOT_IN_THE_LAST,
+    ];
+  }
+
+  private function getSubQuery(string $operator, string $dateParameter): QueryBuilder {
+    $queryBuilder = $this->getNewSubscribersQueryBuilder();
+    $this->applyCustomerLookupJoin($queryBuilder);
+    $this->applyCustomerOrderJoin($queryBuilder);
+    $this->applyOrderStatusFilter($queryBuilder, ['wc-processing', 'wc-completed']);
+
+    switch ($operator) {
+      case self::BEFORE:
+        $queryBuilder->andWhere("DATE(orderStats.date_created) < :$dateParameter");
+        break;
+      case self::AFTER:
+        $queryBuilder->andWhere("DATE(orderStats.date_created) > :$dateParameter");
+        break;
+      case self::IN_THE_LAST:
+      case self::NOT_IN_THE_LAST:
+        $queryBuilder->andWhere("DATE(orderStats.date_created) >= :$dateParameter");
+        break;
+      case self::ON:
+      case self::NOT_ON:
+        $queryBuilder->andWhere("DATE(orderStats.date_created) = :$dateParameter");
+        break;
+      default:
+        throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
+    }
+
+    return $queryBuilder;
+  }
+
+  private function applyOrderStatusFilter(QueryBuilder $queryBuilder, array $allowedStatuses, string $orderStatsAlias = 'orderStats') {
+    $quotedStatus = array_map([$queryBuilder->expr(), 'literal'], $allowedStatuses);
+    $queryBuilder->andWhere($queryBuilder->expr()->in("$orderStatsAlias.status", $quotedStatus));
+  }
+
+  private function applyCustomerOrderJoin(QueryBuilder $queryBuilder, $fromAlias = 'customer', $toAlias = 'orderStats'): QueryBuilder {
+    global $wpdb;
+    $queryBuilder->innerJoin(
+      $fromAlias,
+      $wpdb->prefix . 'wc_order_stats',
+      $toAlias,
+      "$fromAlias.customer_id = $toAlias.customer_id");
+
+    return $queryBuilder;
+  }
+
+  private function applyCustomerLookupJoin(QueryBuilder $queryBuilder, string $alias = 'customer'): QueryBuilder {
+    global $wpdb;
+    $subscribersTable = $this->getSubscribersTable();
+
+    $collation = $this->collationChecker->getCollateIfNeeded(
+      $subscribersTable,
+      'email',
+      $wpdb->prefix . 'wc_customer_lookup',
+      'email'
+    );
+
+    $queryBuilder->innerJoin(
+      $subscribersTable,
+      $wpdb->prefix . 'wc_customer_lookup',
+      $alias,
+      "$subscribersTable.email = $alias.email $collation"
+    );
+
+    return $queryBuilder;
+  }
+
+  private function getNewSubscribersQueryBuilder(): QueryBuilder {
+    return $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select('id')
+      ->from($this->getSubscribersTable());
+  }
+
+  private function getSubscribersTable(): string {
+    return $this->entityManager
+      ->getClassMetadata(SubscriberEntity::class)
+      ->getTableName();
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -29,7 +29,7 @@ class WooCommercePurchaseDate extends DateFilter {
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $operator = $this->getOperatorFromFilter($filter);
     $dateValue = $this->getDateValueFromFilter($filter);
-    $date = $this->getDateForOperator($operator, $dateValue);
+    $date = $this->getDateStringForOperator($operator, $dateValue);
     $subQuery = $this->getSubQuery($operator, $date);
 
     if (in_array($operator, [self::NOT_ON, self::NOT_IN_THE_LAST])) {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -28,17 +28,8 @@ class WooCommercePurchaseDate extends DateFilter {
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
-    $filterData = $filter->getFilterData();
-    $operator = $filterData->getParam('operator');
-
-    if (!is_string($operator) || !in_array($operator, $this->getValidOperators())) {
-      throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
-    }
-
-    $dateValue = $filterData->getParam('value');
-    if (!is_string($dateValue)) {
-      throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
-    }
+    $operator = $this->getOperatorFromFilter($filter);
+    $dateValue = $this->getDateValueFromFilter($filter);
     $date = $this->getDateForOperator($operator, $dateValue);
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $dateParameter = sprintf('date_%s', $parameterSuffix);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -3,32 +3,29 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
-use MailPoet\Util\DBCollationChecker;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class WooCommercePurchaseDate implements Filter {
   const ACTION = 'purchaseDate';
 
-  /** @var EntityManager */
-  private $entityManager;
-
-  /** @var DBCollationChecker */
-  private $collationChecker;
-
   /** @var DateFilterHelper */
   private $dateFilterHelper;
 
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
   public function __construct(
-    EntityManager $entityManager,
-    DBCollationChecker $collationChecker,
-    DateFilterHelper $dateFilterHelper
+    DateFilterHelper $dateFilterHelper,
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper
   ) {
-    $this->entityManager = $entityManager;
-    $this->collationChecker = $collationChecker;
     $this->dateFilterHelper = $dateFilterHelper;
+    $this->filterHelper = $filterHelper;
+    $this->wooFilterHelper = $wooFilterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -36,93 +33,41 @@ class WooCommercePurchaseDate implements Filter {
     $dateValue = $this->dateFilterHelper->getDateValueFromFilter($filter);
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $dateValue);
     $subQuery = $this->getSubQuery($operator, $date);
+    $subscribersTable = $this->filterHelper->getSubscribersTable();
 
     if (in_array($operator, [DateFilterHelper::NOT_ON, DateFilterHelper::NOT_IN_THE_LAST])) {
-      $queryBuilder->andWhere($queryBuilder->expr()->notIn("{$this->getSubscribersTable()}.id", $subQuery->getSQL()));
+      $queryBuilder->andWhere($queryBuilder->expr()->notIn("{$subscribersTable}.id", $subQuery->getSQL()));
     } else {
-      $queryBuilder->andWhere($queryBuilder->expr()->in("{$this->getSubscribersTable()}.id", $subQuery->getSQL()));
+      $queryBuilder->andWhere($queryBuilder->expr()->in("{$subscribersTable}.id", $subQuery->getSQL()));
     }
 
     return $queryBuilder;
   }
 
   private function getSubQuery(string $operator, string $date): QueryBuilder {
-    $queryBuilder = $this->getNewSubscribersQueryBuilder();
-    $this->applyCustomerLookupJoin($queryBuilder);
-    $this->applyCustomerOrderJoin($queryBuilder);
-    $this->applyOrderStatusFilter($queryBuilder, ['wc-processing', 'wc-completed']);
+    $queryBuilder = $this->filterHelper->getNewSubscribersQueryBuilder();
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
     $quotedDate = $queryBuilder->expr()->literal($date);
 
     switch ($operator) {
       case DateFilterHelper::BEFORE:
-        $queryBuilder->andWhere("DATE(orderStats.date_created) < $quotedDate");
+        $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) < $quotedDate");
         break;
       case DateFilterHelper::AFTER:
-        $queryBuilder->andWhere("DATE(orderStats.date_created) > $quotedDate");
+        $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) > $quotedDate");
         break;
       case DateFilterHelper::IN_THE_LAST:
       case DateFilterHelper::NOT_IN_THE_LAST:
-        $queryBuilder->andWhere("DATE(orderStats.date_created) >= $quotedDate");
+        $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) >= $quotedDate");
         break;
       case DateFilterHelper::ON:
       case DateFilterHelper::NOT_ON:
-        $queryBuilder->andWhere("DATE(orderStats.date_created) = $quotedDate");
+        $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) = $quotedDate");
         break;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }
 
     return $queryBuilder;
-  }
-
-  private function applyOrderStatusFilter(QueryBuilder $queryBuilder, array $allowedStatuses, string $orderStatsAlias = 'orderStats') {
-    $quotedStatus = array_map([$queryBuilder->expr(), 'literal'], $allowedStatuses);
-    $queryBuilder->andWhere($queryBuilder->expr()->in("$orderStatsAlias.status", $quotedStatus));
-  }
-
-  private function applyCustomerOrderJoin(QueryBuilder $queryBuilder, $fromAlias = 'customer', $toAlias = 'orderStats'): QueryBuilder {
-    global $wpdb;
-    $queryBuilder->innerJoin(
-      $fromAlias,
-      $wpdb->prefix . 'wc_order_stats',
-      $toAlias,
-      "$fromAlias.customer_id = $toAlias.customer_id");
-
-    return $queryBuilder;
-  }
-
-  private function applyCustomerLookupJoin(QueryBuilder $queryBuilder, string $alias = 'customer'): QueryBuilder {
-    global $wpdb;
-    $subscribersTable = $this->getSubscribersTable();
-
-    $collation = $this->collationChecker->getCollateIfNeeded(
-      $subscribersTable,
-      'email',
-      $wpdb->prefix . 'wc_customer_lookup',
-      'email'
-    );
-
-    $queryBuilder->innerJoin(
-      $subscribersTable,
-      $wpdb->prefix . 'wc_customer_lookup',
-      $alias,
-      "$subscribersTable.email = $alias.email $collation"
-    );
-
-    return $queryBuilder;
-  }
-
-  private function getNewSubscribersQueryBuilder(): QueryBuilder {
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select('id')
-      ->from($this->getSubscribersTable());
-  }
-
-  private function getSubscribersTable(): string {
-    return $this->entityManager
-      ->getClassMetadata(SubscriberEntity::class)
-      ->getTableName();
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -32,20 +32,20 @@ class WooCommercePurchaseDate implements Filter {
     $operator = $this->dateFilterHelper->getOperatorFromFilter($filter);
     $dateValue = $this->dateFilterHelper->getDateValueFromFilter($filter);
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $dateValue);
-    $subQuery = $this->getSubQuery($operator, $date);
     $subscribersTable = $this->filterHelper->getSubscribersTable();
 
     if (in_array($operator, [DateFilterHelper::NOT_ON, DateFilterHelper::NOT_IN_THE_LAST])) {
+      $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+      $this->applyConditionsToQueryBuilder($operator, $date, $subQuery);
       $queryBuilder->andWhere($queryBuilder->expr()->notIn("{$subscribersTable}.id", $subQuery->getSQL()));
     } else {
-      $queryBuilder->andWhere($queryBuilder->expr()->in("{$subscribersTable}.id", $subQuery->getSQL()));
+      $this->applyConditionsToQueryBuilder($operator, $date, $queryBuilder);
     }
 
     return $queryBuilder;
   }
 
-  private function getSubQuery(string $operator, string $date): QueryBuilder {
-    $queryBuilder = $this->filterHelper->getNewSubscribersQueryBuilder();
+  private function applyConditionsToQueryBuilder(string $operator, string $date, QueryBuilder $queryBuilder): QueryBuilder {
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
     $quotedDate = $queryBuilder->expr()->literal($date);
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
@@ -84,10 +84,10 @@ class WooFilterHelper {
   }
 
   private function customerLookupTable(): string {
-    return $this->filterHelper->prefixedTable('wc_customer_lookup');
+    return $this->filterHelper->getPrefixedTable('wc_customer_lookup');
   }
 
   private function orderStatsTable(): string {
-    return $this->filterHelper->prefixedTable('wc_order_stats');
+    return $this->filterHelper->getPrefixedTable('wc_order_stats');
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Util\DBCollationChecker;
+use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class WooFilterHelper {
@@ -76,10 +77,10 @@ class WooFilterHelper {
       $allowedStatuses = $this->defaultIncludedStatuses();
     }
 
+    $statusParam = $this->filterHelper->getUniqueParameterName('status');
     $orderStatsAlias = $this->applyCustomerOrderJoin($queryBuilder);
-    $quotedStatus = array_map([$queryBuilder->expr(), 'literal'], $allowedStatuses);
-    $queryBuilder->andWhere($queryBuilder->expr()->in("$orderStatsAlias.status", $quotedStatus));
-
+    $queryBuilder->andWhere("$orderStatsAlias.status IN (:$statusParam)");
+    $queryBuilder->setParameter($statusParam, $allowedStatuses, Connection::PARAM_STR_ARRAY);
     return $orderStatsAlias;
   }
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Util\DBCollationChecker;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooFilterHelper {
+  /** @var DBCollationChecker */
+  private $collationChecker;
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  public function __construct(
+    DBCollationChecker $collationChecker,
+    FilterHelper $filterHelper
+  ) {
+    $this->collationChecker = $collationChecker;
+    $this->filterHelper = $filterHelper;
+  }
+
+  public function defaultIncludedStatuses(): array {
+    return ['wc-processing', 'wc-completed'];
+  }
+
+  /**
+   * @param QueryBuilder $queryBuilder
+   * @param string $customerAlias
+   * @return string - The alias of the joined customer lookup table
+   */
+  public function applyCustomerLookupJoin(QueryBuilder $queryBuilder, string $customerAlias = 'customer'): string {
+    $subscribersTable = $this->filterHelper->getSubscribersTable();
+
+    $collation = $this->collationChecker->getCollateIfNeeded(
+      $subscribersTable,
+      'email',
+      $this->customerLookupTable(),
+      'email'
+    );
+
+    $queryBuilder->innerJoin(
+      $subscribersTable,
+      $this->customerLookupTable(),
+      $customerAlias,
+      "$subscribersTable.email = $customerAlias.email $collation"
+    );
+
+    return $customerAlias;
+  }
+
+  /**
+   * @param QueryBuilder $queryBuilder
+   * @param string $orderStatsAlias
+   * @return string - The alias of the joined order stats table
+   */
+  public function applyCustomerOrderJoin(QueryBuilder $queryBuilder, string $orderStatsAlias = 'orderStats'): string {
+    $customerAlias = $this->applyCustomerLookupJoin($queryBuilder);
+
+    $queryBuilder->innerJoin(
+      $customerAlias,
+      $this->orderStatsTable(),
+      $orderStatsAlias,
+      "$customerAlias.customer_id = $orderStatsAlias.customer_id");
+
+    return $orderStatsAlias;
+  }
+
+  /**
+   * @param QueryBuilder $queryBuilder
+   * @param array|null $allowedStatuses
+   * @return string - The alias of the joined order stats table
+   */
+  public function applyOrderStatusFilter(QueryBuilder $queryBuilder, array $allowedStatuses = null): string {
+    if (is_null($allowedStatuses)) {
+      $allowedStatuses = $this->defaultIncludedStatuses();
+    }
+
+    $orderStatsAlias = $this->applyCustomerOrderJoin($queryBuilder);
+    $quotedStatus = array_map([$queryBuilder->expr(), 'literal'], $allowedStatuses);
+    $queryBuilder->andWhere($queryBuilder->expr()->in("$orderStatsAlias.status", $quotedStatus));
+
+    return $orderStatsAlias;
+  }
+
+  private function customerLookupTable(): string {
+    return $this->filterHelper->prefixedTable('wc_customer_lookup');
+  }
+
+  private function orderStatsTable(): string {
+    return $this->filterHelper->prefixedTable('wc_order_stats');
+  }
+}

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -576,16 +576,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
 
 		-
-			message: "#^Parameter \\#1 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
-
-		-
 			message: "#^Parameter \\#2 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\UserRole\\:\\:createCondition\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/UserRole.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -576,16 +576,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
 
 		-
-			message: "#^Parameter \\#1 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
-
-		-
 			message: "#^Parameter \\#2 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\UserRole\\:\\:createCondition\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/UserRole.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -575,16 +575,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
 
 		-
-			message: "#^Parameter \\#1 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\SubscriberSubscribedDate\\:\\:getDate\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
-
-		-
 			message: "#^Parameter \\#2 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\UserRole\\:\\:createCondition\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/UserRole.php

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/FilterHelperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/FilterHelperTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class FilterHelperTest extends \MailPoetTest {
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  /** @var string */
+  private $subscribersTable;
+
+  public function _before() {
+    parent::_before();
+    $this->filterHelper = $this->diContainer->get(FilterHelper::class);
+    $this->subscribersTable = $this->entityManager
+      ->getClassMetadata(SubscriberEntity::class)
+      ->getTableName();
+  }
+
+  public function testItCanReturnSQLThatDoesNotIncludeParams(): void {
+    $queryBuilder = $this->getSubscribersQueryBuilder();
+    $defaultResult = $queryBuilder->getSQL();
+    expect($defaultResult)->equals("SELECT id FROM $this->subscribersTable");
+    expect($this->filterHelper->getInterpolatedSQL($queryBuilder))->equals($defaultResult);
+  }
+
+  public function testItCanReturnInterpolatedSQL(): void {
+    $queryBuilder = $this->getSubscribersQueryBuilder();
+    $queryBuilder->where("$this->subscribersTable.created_at < :date");
+    $queryBuilder->setParameter('date', '2023-03-09');
+    expect($this->filterHelper->getInterpolatedSQL($queryBuilder))->equals("SELECT id FROM $this->subscribersTable WHERE $this->subscribersTable.created_at < '2023-03-09'");
+  }
+
+  public function testItProperlyInterpolatesArrayValues(): void {
+    $queryBuilder = $this->getSubscribersQueryBuilder();
+    $queryBuilder->where("$this->subscribersTable.status IN (:statuses)");
+    $queryBuilder->setParameter('statuses', ['subscribed', 'inactive']);
+    expect($this->filterHelper->getInterpolatedSQL($queryBuilder))->equals("SELECT id FROM $this->subscribersTable WHERE $this->subscribersTable.status IN ('subscribed','inactive')");
+  }
+
+  private function getSubscribersQueryBuilder(): QueryBuilder {
+    return $this->entityManager->getConnection()->createQueryBuilder()->select('id')->from($this->subscribersTable);
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -47,7 +47,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetBefore(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::BEFORE, CarbonImmutable::now()->subDays(3)->format('Y-m-d'));
+    $segmentFilter = $this->getSegmentFilter('before', CarbonImmutable::now()->subDays(3)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
       ->execute();
@@ -61,7 +61,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetAfter(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::AFTER, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $segmentFilter = $this->getSegmentFilter('after', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
       ->execute();
@@ -81,7 +81,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetOn(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::ON, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $segmentFilter = $this->getSegmentFilter('on', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
       ->execute();
@@ -97,7 +97,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetNotOn(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::NOT_ON, CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $segmentFilter = $this->getSegmentFilter('notOn', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
       ->execute();
@@ -128,7 +128,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetInTheLast(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::IN_THE_LAST, '2');
+    $segmentFilter = $this->getSegmentFilter('inTheLast', '2');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
       ->execute();
@@ -148,7 +148,7 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetNotInTheLast(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberSubscribedDate::NOT_IN_THE_LAST, '3');
+    $segmentFilter = $this->getSegmentFilter('notInTheLast', '3');
     $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
       ->orderBy('email')
       ->execute();

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -1,0 +1,218 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * @group woo
+ */
+class WooCommercePurchaseDateTest extends \MailPoetTest {
+
+  /** @var WooCommercePurchaseDate */
+  private $wooCommercePurchaseDate;
+
+  private $createdCustomerEmails = [];
+
+  public function _before(): void {
+    parent::_before();
+    $this->wooCommercePurchaseDate = $this->diContainer->get(WooCommercePurchaseDate::class);
+  }
+
+  public function testGetSubscribersWithOrderBeforeDate(): void {
+    $customerId1 = $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-02-20'));
+    $this->createOrder($customerId2, new Carbon('2023-02-22'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('before', '2023-02-21');
+    expect(count($emails))->equals(1);
+    expect($emails)->equals(['c1@example.com']);
+  }
+
+  public function testGetSubscribersWithOrderAfterDate(): void {
+    $customerId1 = $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $customerId3 = $this->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-02-02'));
+    $this->createOrder($customerId2, new Carbon('2023-02-01'));
+    $this->createOrder($customerId3, new Carbon('1993-01-01'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('after', '2023-02-01');
+    expect($emails)->count(1);
+    expect($emails)->equals(['c1@example.com']);
+  }
+
+  public function testInTheLast(): void {
+    $customerId1 = $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $customerId3 = $this->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, Carbon::now()->subDays(4));
+    $this->createOrder($customerId2, Carbon::now()->subDays(5));
+    $this->createOrder($customerId3, Carbon::now()->subDays(6));
+    $emails = $this->getSubscriberEmailsMatchingFilter('inTheLast', '5');
+    expect(count($emails))->equals(2);
+    $this->assertEqualsCanonicalizing(['c1@example.com', 'c2@example.com'], $emails);
+  }
+
+  public function testNotInTheLast(): void {
+    $customerId1 = $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $customerId3 = $this->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, Carbon::now()->subDays(4));
+    $this->createOrder($customerId2, Carbon::now()->subDays(5));
+    $this->createOrder($customerId3, Carbon::now()->subDays(6));
+    $emails = $this->getSubscriberEmailsMatchingFilter('notInTheLast', '5');
+    expect(count($emails))->equals(1);
+    expect($emails)->equals(['c3@example.com']);
+  }
+
+  public function testNotInTheLastIncludesNonCustomers(): void {
+    $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $subscriber = (new Subscriber())->create();
+    $this->createOrder($customerId2, (new Carbon())->subDays(3));
+    $emails = $this->getSubscriberEmailsMatchingFilter('notInTheLast', '4');
+    $this->assertEqualsCanonicalizing([$subscriber->getEmail(), 'c1@example.com'], $emails);
+  }
+
+  public function testOnDate(): void {
+    $customerId1 = $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $customerId3 = $this->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-01-01'));
+    $this->createOrder($customerId2, new Carbon('2023-01-02'));
+    $this->createOrder($customerId3, new Carbon('2023-01-03'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('on', '2023-01-02');
+    expect(count($emails))->equals(1);
+    expect($emails)->equals(['c2@example.com']);
+  }
+
+  public function testNotOn(): void {
+    $customerId1 = $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $customerId3 = $this->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-01-01'));
+    $this->createOrder($customerId2, new Carbon('2023-01-02'));
+    $this->createOrder($customerId3, new Carbon('2023-01-03'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('notOn', '2023-01-02');
+    expect(count($emails))->equals(2);
+    $this->assertEqualsCanonicalizing(['c1@example.com', 'c3@example.com'], $emails);
+  }
+
+  public function testNotOnReturnsNonCustomersToo() {
+    $this->createCustomer('c1@example.com');
+    $customerId2 = $this->createCustomer('c2@example.com');
+    $subscriber = (new Subscriber())->create();
+    $this->createOrder($customerId2, new Carbon('2023-02-22'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('notOn', '2023-02-22');
+    $this->assertEqualsCanonicalizing([$subscriber->getEmail(), 'c1@example.com'], $emails);
+  }
+
+  public function testItOnlyIncludesCompletedAndProcessingOrders(): void {
+    $validStatuses = ['wc-processing', 'wc-completed'];
+    $invalidstatuses = ['wc-pending', 'wc-refunded', 'wc-on-hold', 'wc-cancelled', 'wc-failed', 'any-custom-status'];
+    $date = '2023-02-24';
+    foreach ($validStatuses as $validStatus) {
+      $customerId = $this->createCustomer("$validStatus@example.com");
+      $this->createOrder($customerId, new Carbon($date), $validStatus);
+    }
+    foreach ($invalidstatuses as $invalidStatus) {
+      $customerId = $this->createCustomer("$invalidStatus@example.com");
+      $this->createOrder($customerId, new Carbon($date), $invalidStatus);
+    }
+    $emails = $this->getSubscriberEmailsMatchingFilter('on', $date);
+    expect($emails)->count(2);
+    $this->assertEqualsCanonicalizing(['wc-processing@example.com', 'wc-completed@example.com'], $emails);
+  }
+
+  private function getSubscriberEmailsMatchingFilter(string $operator, string $value): array {
+    $data = new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommercePurchaseDate::ACTION,
+      [
+        'operator' => $operator,
+        'value' => $value,
+      ]
+    );
+    $segment = new SegmentEntity('temporary segment', SegmentEntity::TYPE_DYNAMIC, 'description');
+    $this->entityManager->persist($segment);
+    $filter = new DynamicSegmentFilterEntity($segment, $data);
+    $this->entityManager->persist($filter);
+    $segment->addDynamicFilter($filter);
+
+    $queryBuilder = $this->wooCommercePurchaseDate->apply($this->getQueryBuilder(), $filter);
+    $statement = $queryBuilder->execute();
+    $results = $statement instanceof Statement ? $statement->fetchAllAssociative() : [];
+    $emails = array_map(function($row) {
+      $subscriber = $this->entityManager->find(SubscriberEntity::class, $row['id']);
+      if (!$subscriber instanceof SubscriberEntity) {
+        throw new \Exception('this is for PhpStan');
+      }
+      return $subscriber->getEmail();
+    }, $results);
+
+
+    return $emails;
+  }
+
+  private function getQueryBuilder(): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select("$subscribersTable.id")
+      ->from($subscribersTable);
+  }
+
+  private function createCustomer(string $email): int {
+    global $wpdb;
+    $userId = $this->tester->createWordPressUser($email, 'customer');
+    $this->connection->executeQuery("
+      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
+      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
+    ");
+    $this->createdCustomerEmails[] = $email;
+    return $userId;
+  }
+
+  private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_date_created($createdAt->toDateTimeString());
+    $order->set_status($status);
+    $order->save();
+    $this->tester->updateWooOrderStats($order->get_id());
+
+    return $order->get_id();
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->cleanUp();
+  }
+
+  private function cleanUp(): void {
+    global $wpdb;
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SegmentEntity::class);
+    $this->truncateEntity(DynamicSegmentFilterEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+
+    foreach ($this->createdCustomerEmails as $email) {
+      $this->tester->deleteWordPressUser($email);
+    }
+
+    $this->tester->deleteTestWooOrders();
+
+    $this->createdCustomerEmails = [];
+
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -52,9 +52,9 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
     $customerId1 = $this->createCustomer('c1@example.com');
     $customerId2 = $this->createCustomer('c2@example.com');
     $customerId3 = $this->createCustomer('c3@example.com');
-    $this->createOrder($customerId1, Carbon::now()->subDays(4));
-    $this->createOrder($customerId2, Carbon::now()->subDays(5));
-    $this->createOrder($customerId3, Carbon::now()->subDays(6));
+    $this->createOrder($customerId1, Carbon::now()->subDays(3));
+    $this->createOrder($customerId2, Carbon::now()->subDays(4));
+    $this->createOrder($customerId3, Carbon::now()->subDays(5));
     $emails = $this->getSubscriberEmailsMatchingFilter('inTheLast', '5');
     expect(count($emails))->equals(2);
     $this->assertEqualsCanonicalizing(['c1@example.com', 'c2@example.com'], $emails);
@@ -64,9 +64,9 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
     $customerId1 = $this->createCustomer('c1@example.com');
     $customerId2 = $this->createCustomer('c2@example.com');
     $customerId3 = $this->createCustomer('c3@example.com');
-    $this->createOrder($customerId1, Carbon::now()->subDays(4));
-    $this->createOrder($customerId2, Carbon::now()->subDays(5));
-    $this->createOrder($customerId3, Carbon::now()->subDays(6));
+    $this->createOrder($customerId1, Carbon::now()->subDays(3));
+    $this->createOrder($customerId2, Carbon::now()->subDays(4));
+    $this->createOrder($customerId3, Carbon::now()->subDays(5));
     $emails = $this->getSubscriberEmailsMatchingFilter('notInTheLast', '5');
     expect(count($emails))->equals(1);
     expect($emails)->equals(['c3@example.com']);

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -212,7 +212,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
       'action' => SubscriberSubscribedDate::TYPE,
       'value' => 2,
-      'operator' => SubscriberSubscribedDate::AFTER,
+      'operator' => 'after',
     ]]]);
     expect($filters)->array();
     expect($filters)->count(1);
@@ -223,7 +223,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getAction())->equals(SubscriberSubscribedDate::TYPE);
     expect($filter->getData())->equals([
       'value' => 2,
-      'operator' => SubscriberSubscribedDate::AFTER,
+      'operator' => 'after',
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -212,6 +212,7 @@
     'inTheLast': _x('in the last', 'Appears together with `days` when creating a new WooCommerce segment based on the number of orders.'),
     'wooNumberOfOrdersOrders': __('orders'),
     'wooPurchasedCategory': __('purchased in category'),
+    'wooPurchaseDate': __('purchase date'),
     'wooPurchasedProduct': __('purchased product'),
     'wooTotalSpent': __('total spent'),
     'wooCustomerInCountry': __('is in country'),


### PR DESCRIPTION
## Description

This PR implements a Purchase Date dynamic segment for MAILPOET-4986

## Code review notes

Sorry the commits aren't as cohesive as I'd like.

~I really like the simplicity of using a subquery for everything, but I know conventional wisdom is that joins are more likely to perform better. Does the subquery approach seem problematic for performance reasons?~

~Edit: the queries seem to be performing slowly locally, but I haven't done a comparison with joins. I'm assuming I'll need to update to use joins other than in the negated cases.~

Edit2: I updated the code to use standard joins for all but the negated cases, where I think we will need a subquery (correct me if I'm wrong).

~I think it was probably a mistake to make an abstract class for shared functionality. It would probably be better to have some kind of date field helper that we inject instead. Does that seem like a good idea or is there a better approach?~

Edit: I've updated the code to use DI and more helpers instead. I may have made it more confusing by trying to add too many helpers.

I think the refactoring I did for the subscribed date filter was true refactoring and shouldn't have changed any functionality, but I'd appreciate if you could take a close look to verify.

## QA notes

Please be sure to test the Subscribed Date filter as well because I refactored much of its code.

## Linked PRs

A change is required in premium due to some refactoring: https://github.com/mailpoet/mailpoet-premium/pull/688

## Linked tickets

[MAILPOET-4986](https://mailpoet.atlassian.net/browse/MAILPOET-4986)

## After-merge notes

_N/A_


[MAILPOET-4986]: https://mailpoet.atlassian.net/browse/MAILPOET-4986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ