### PR TITLE
Add a new k6 test: View subscribers of a list

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -12,6 +12,7 @@ import { subscribersAdding } from './tests/subscribers-adding.js';
 import { formsAdding } from './tests/forms-adding.js';
 import { newsletterSearching } from './tests/newsletter-searching.js';
 import { newsletterSending } from './tests/newsletter-sending.js';
+import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -68,6 +69,7 @@ export function pullRequests() {
   formsAdding();
   newsletterSearching();
   newsletterSending();
+  listsViewSubscribers();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { sleep, check, group } from 'k6';
-import { chromium } from 'k6/x/browser';
+import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 
 /**

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -1,0 +1,88 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check, group } from 'k6';
+import { chromium } from 'k6/x/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+  defaultListName,
+} from '../config.js';
+import { authenticate } from '../utils/helpers.js';
+/* global Promise */
+
+export function listsViewSubscribers() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  group('Subscribers - Filter subscribers', () => {
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/lists`, {
+        waitUntil: 'networkidle',
+      })
+
+      .then(() => {
+        authenticate(page);
+      })
+
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
+
+      .then(() => {
+        page.waitForSelector('[data-automation-id="dynamic-segments-tab"]');
+        check(page, {
+          'segments tab is visible': page
+            .locator('[data-automation-id="dynamic-segments-tab"]')
+            .isVisible(),
+        });
+      })
+
+      .then(() => {
+        page
+          .locator(
+            '[data-automation-id="segment_name_' + defaultListName + '"]',
+          )
+          .hover();
+        page
+          .locator(
+            '[data-automation-id="view_subscribers_' + defaultListName + '"]',
+          )
+          .click();
+        page.waitForSelector('.mailpoet-listing-no-items');
+        page.waitForSelector('[data-automation-id="filters_subscribed"]');
+        check(page, {
+          'subscribers filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+        });
+        page.waitForLoadState('networkidle');
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
+
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+}
+
+export default function listsViewSubscribersTest() {
+  listsViewSubscribers();
+}

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -28,7 +28,7 @@ export function listsViewSubscribers() {
   });
   const page = browser.newPage();
 
-  group('Subscribers - Filter subscribers', () => {
+  group('Lists - View subscribers of a list', () => {
     page
       .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/lists`, {
         waitUntil: 'networkidle',


### PR DESCRIPTION
## Description

Adding a new k6 test of viewing subscribers of the default list Newsletter Mailing List.

## Code review notes

Feel free to run the test locally with this command:

`./do test:performance --url=https://qawp.net tests/performance/tests/lists-view-subscribers.js`

if you want to see it in action, add `--head` to the end of the command above

## Linked tickets

[MAILPOET-4957]


[MAILPOET-4957]: https://mailpoet.atlassian.net/browse/MAILPOET-4957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ