### PR TITLE
Fix ordering by subscriber on the Sending status page [MAILPOET-4660]

### DIFF
--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
@@ -94,9 +94,13 @@ class ScheduledTaskSubscribersListingRepository extends ListingRepository {
     // ScheduledTaskSubscriber doesn't have id column so the default fallback value 'id'
     // generated in MailPoet\Listing\Handler needs to be changed to something else
     if ($sortBy === 'id') {
-      $sortBy = 'subscriber';
+      $sortBy = 'sts.subscriber';
+    } elseif ($sortBy === 'subscriberId') { // Ordering by subscriberId is mapped to email for consistency with Subscriber listing
+      $sortBy = 's.email';
+    } else {
+      $sortBy = "sts.{$sortBy}";
     }
-    $queryBuilder->addOrderBy("sts.$sortBy", $sortOrder);
+    $queryBuilder->addOrderBy($sortBy, $sortOrder);
   }
 
   protected function applySearch(QueryBuilder $queryBuilder, string $search) {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I tried to maintain backward compatibility and didn't remove a condition for column `id`. Nevertheless, I think it's redundant.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4660]

## After-merge notes

_N/A_


[MAILPOET-4660]: https://mailpoet.atlassian.net/browse/MAILPOET-4660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ