### PR TITLE
Extend tests for the coupon block feature [MAILPOET-5040]

### DIFF
--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -136,6 +136,10 @@ class SendingQueuesRepository extends Repository {
     } else {
       $newsletter = $queue->getNewsletter();
       if (!$newsletter instanceof NewsletterEntity) return;
+      if ($newsletter->getStatus() === NewsletterEntity::STATUS_CORRUPT) { // force a re-render
+        $queue->setNewsletterRenderedBody(null);
+        $this->persist($queue);
+      }
       $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
       $task->setStatus(null);
       $this->flush();

--- a/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
@@ -2,24 +2,39 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Codeception\Util\Locator;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
 use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Settings;
 
 /**
  * @group woo
  */
 class EditorCouponCest {
+
+
+  /** @var Settings */
+  private $settings;
+
+  public function _before() {
+    $this->settings = new Settings();
+  }
+
   public function addCoupon(\AcceptanceTester $i) {
     $couponInEditor = '[data-automation-id="coupon_block"]';
     $couponSettingsHeading = '[data-automation-id="coupon_settings_heading"]';
     $couponSettingsDone = '[data-automation-id="coupon_done_button"]';
     $footer = '[data-automation-id="footer"]';
+    $sendFormElement = '[data-automation-id="newsletter_send_form"]';
+    $emailSubject = 'Newsletter with Coupon';
+    $this->settings->withCronTriggerMethod('Action Scheduler');
 
     $i->activateWooCommerce();
 
     $i->wantTo('Add coupon block to newsletter');
     $newsletter = (new Newsletter())
       ->loadBodyFrom('newsletterWithText.json')
+      ->withSubject($emailSubject)
       ->create();
     $i->login();
     $i->amEditingNewsletter($newsletter->getId());
@@ -36,5 +51,23 @@ class EditorCouponCest {
     $i->wantTo('Close coupon settings panel');
     $i->click($couponSettingsDone);
     $i->seeNoJSErrors();
+
+    $i->wantTo('Send the email with coupon');
+    $i->click('Next');
+    $segmentName = $i->createListWithSubscriber();
+
+    $i->wantTo('Choose list and send');
+    $i->waitForElement($sendFormElement);
+    $i->selectOptionInSelect2($segmentName);
+    $i->click('Send');
+    $i->waitForEmailSendingOrSent();
+    $i->triggerMailPoetActionScheduler();
+
+    $i->wantTo('Verify newsletter with generated coupon is received');
+    $i->checkEmailWasReceived($emailSubject);
+    $i->click('.msglist-message');
+    $i->switchToIFrame("#preview-html");
+    $i->waitForElementVisible('.mailpoet_coupon');
+    $i->dontSee(Locator::contains('.mailpoet_coupon', Coupon::CODE_PLACEHOLDER));
   }
 }

--- a/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
@@ -136,7 +136,7 @@ class EditorCouponCest {
     $i->see($couponCode);
   }
 
-  public function seeNoticeWhenCouponCantGenerate(\AcceptanceTester $i) {
+  public function seeNoticeWhenCouponCantGenerateAndResumeSending(\AcceptanceTester $i) {
     $couponInEditor = '[data-automation-id="coupon_block"]';
     $sendFormElement = '[data-automation-id="newsletter_send_form"]';
     $emailSubject = 'Newsletter with Coupon';
@@ -157,6 +157,7 @@ class EditorCouponCest {
 
     $i->wantTo('Send the email with coupon');
     $i->click('Next');
+
     $segmentName = $i->createListWithSubscriber();
 
     $i->wantTo('Choose list and send');
@@ -166,11 +167,25 @@ class EditorCouponCest {
     $i->click('Send');
     $i->waitForEmailSendingOrSent();
     $i->triggerMailPoetActionScheduler();
-    $i->waitForText('Woocommerce is not active');
+    $i->waitForText('WooCommerce is not active');
     $i->canSee('Resume', 'button');
     $i->reloadPage();
     $i->waitForListingItemsToLoad();
     $i->waitForText($emailSubject, 10, '.mailpoet-listing-title');
     $i->canSee($emailSubject, '.notice.error.notice-error');
+
+
+    $i->wantTo('Resume sending and verify coupon is sent');
+    $i->activateWooCommerce();
+    $i->click(Locator::contains('button', 'Resume'));
+    $i->waitForText('Confirm to proceed');
+    $i->click('#mailpoet_alert_confirm');
+    $i->triggerMailPoetActionScheduler();
+    $i->wantTo('Verify newsletter with generated coupon is received');
+    $i->checkEmailWasReceived($emailSubject);
+    $i->click(Locator::contains('.msglist-message', $emailSubject));
+    $i->switchToIFrame("#preview-html");
+    $i->waitForElementVisible('.mailpoet_coupon');
+    $i->dontSee(Locator::contains('.mailpoet_coupon', Coupon::CODE_PLACEHOLDER));
   }
 }


### PR DESCRIPTION
## Description
This PR adds more acceptance tests for newsletters Coupon block feature

## Linked PRs

[4771](https://github.com/mailpoet/mailpoet/pull/4771)
Please change the base to trunk when 4771 is merged

## Linked tickets
[MAILPOET-5040] 

[MAILPOET-5040]: https://mailpoet.atlassian.net/browse/MAILPOET-5040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ