### PR TITLE
Add default value for the coupon code [MAILPOET-5096]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.tsx
@@ -49,6 +49,7 @@ Module.CouponBlockModel = base.BlockModel.extend({
           },
         },
         source: 'createNew',
+        code: App.getConfig().get('coupon.code_placeholder'),
       },
       App.getConfig().get('blockDefaults.coupon'),
     );


### PR DESCRIPTION
## Description

Our new coupon block has a problem with the code placeholder when this block is used in an existing newsletter. This PR should solve this issue.

## Code review notes

For some reason, the block default values are different when you use them in an existing newsletter. I solved it by extending those default values in JavaScript code.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5096]

## After-merge notes

_N/A_


[MAILPOET-5096]: https://mailpoet.atlassian.net/browse/MAILPOET-5096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ