### PR TITLE
Add a new k6 test: Newsletter searching and filtering by a list

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -10,6 +10,7 @@ import { formsAdding } from './tests/forms-adding.js';
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
+import { newsletterSearching } from './tests/newsletter-searching.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -64,6 +65,7 @@ export function pullRequests() {
   subscribersFiltering();
   subscribersAdding();
   formsAdding();
+  newsletterSearching();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -1,0 +1,69 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check, group } from 'k6';
+import { chromium } from 'k6/x/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+} from '../config.js';
+import { authenticate } from '../utils/helpers.js';
+/* global Promise */
+
+export function newsletterSearching() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  group('Emails - Search for a newsletter', () => {
+    page
+      .goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+        waitUntil: 'networkidle',
+      })
+
+      .then(() => {
+        authenticate(page);
+      })
+
+      .then(() => {
+        return Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle' }),
+        ]);
+      })
+
+      .then(() => {
+        page.locator('#search_input').type('Newsletter 1st', { delay: 50 });
+        page.waitForSelector('.mailpoet-listing-no-items');
+        page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+        page.waitForLoadState('networkidle');
+        check(page, {
+          'newsletter is found': page
+            .locator('.mailpoet-listing-title')
+            .innerText('Newsletter 1st'),
+        });
+      })
+
+      .finally(() => {
+        page.close();
+        browser.close();
+      });
+  });
+
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+}
+
+export default function newsletterSearchingTest() {
+  newsletterSearching();
+}

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { sleep, check, group } from 'k6';
-import { chromium } from 'k6/x/browser';
+import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 
 /**

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -55,6 +55,20 @@ export function newsletterSearching() {
         });
       })
 
+      .then(() => {
+        page
+          .locator('[data-automation-id="listing_filter_segment"]')
+          .selectOption('3');
+        page.waitForSelector('.mailpoet-listing-no-items');
+        page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+        page.waitForLoadState('networkidle');
+        check(page, {
+          'lists filter is visible': page
+            .locator('[data-automation-id="listing_filter_segment"]')
+            .isVisible(),
+        });
+      })
+
       .finally(() => {
         page.close();
         browser.close();


### PR DESCRIPTION
## Description

I will add 2 tests in a single PR because they are very related and to speed up the test execution.

## Code review notes

If you'd like to test it locally, this is the command:

cd to `/mailpoet/` first
- `./do test:performance --url=https://qawp.net tests/performance/tests/newsletter-searching.js`

add `--head` to the end of the command above if you want to see it visually and not in headless mode.

In case it fails at first try, run it once again. Logging to WP admin may not work 100%, or the server where qawp.net is hosted can show 502 error sometimes.

## Linked tickets

[MAILPOET-4952] & [MAILPOET-4953]


[MAILPOET-4952]: https://mailpoet.atlassian.net/browse/MAILPOET-4952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4953]: https://mailpoet.atlassian.net/browse/MAILPOET-4953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ