### PR TITLE
Failing automation tests [MAILPOET-5097]

### DIFF
--- a/mailpoet/tests/DataFactories/Automation.php
+++ b/mailpoet/tests/DataFactories/Automation.php
@@ -58,7 +58,7 @@ class Automation {
     }
     $lastStep->setNextSteps([new NextStep($step->getId())]);
     $steps[$step->getId()] = $step;
-    return $this->withSteps(...$steps);
+    return $this->withSteps(...array_values($steps));
   }
 
   public function withDelayAction() {

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -75,7 +75,7 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->click('Save');
 
     $i->amOnMailpoetPage('Automation');
-    $i->seeInDatabase('mp_actionscheduler_actions', ['hook' => 'mailpoet/automation/step', 'status' => 'pending']);
+    $i->seeInDatabase('mp_actionscheduler_actions', ['hook' => 'mailpoet/automation/step']);
     $i->waitForText('Welcome new subscribers');
     $i->see('Entered 1', ['css' => '.mailpoet-automation-stats-item']); //Actually I see "1 Entered", but this CSS switch is not caught by the test
     $i->see('Processing 1', ['css' => '.mailpoet-automation-stats-item']);


### PR DESCRIPTION
## Description
* f23bec04f05990306f338f81ca1414ea0a8c52b2 In PHP 7.2 you can't unpack associative arrays. So the test failed. See https://3v4l.org/rdCL4#v7.2.0
* 5852263409a2200622b72b3490dd7277539e00d3 I assume this test was flaky as the scheduler might already have run and the task is no longer `pending`

## QA notes

Only test changes. Can be merged without QA

## Linked tickets

[MAILPOET-5097]


[MAILPOET-5097]: https://mailpoet.atlassian.net/browse/MAILPOET-5097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ