### PR TITLE
Homepage - Remove feature switch [MAILPOET-4831]

### DIFF
--- a/mailpoet/assets/js/src/homepage/components/discovery-task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/discovery-task.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@wordpress/components';
 import { check } from '@wordpress/icons';
-import { MailPoet } from 'mailpoet';
 import classnames from 'classnames';
+import { trackCtaAndRedirect } from 'homepage/tracking';
 
 type Props = {
   title: string;
@@ -23,16 +23,7 @@ export function DiscoveryTask({
   isDone,
 }: Props): JSX.Element {
   const handleTaskClick = () => {
-    MailPoet.trackEvent(
-      'Home Page Task',
-      {
-        ctaLabel: slug,
-      },
-      { send_immediately: true },
-      () => {
-        window.location.href = link;
-      },
-    );
+    trackCtaAndRedirect('Home Page Task', slug, link);
   };
   return (
     <li

--- a/mailpoet/assets/js/src/homepage/components/discovery-task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/discovery-task.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 
 type Props = {
   title: string;
+  slug: string;
   link: string;
   imgSrc: string;
   isDone: boolean;
@@ -14,6 +15,7 @@ type Props = {
 
 export function DiscoveryTask({
   title,
+  slug,
   link,
   description,
   doneMessage,
@@ -24,7 +26,7 @@ export function DiscoveryTask({
     MailPoet.trackEvent(
       'Home Page Task',
       {
-        ctaLabel: title,
+        ctaLabel: slug,
       },
       { send_immediately: true },
       () => {

--- a/mailpoet/assets/js/src/homepage/components/product-discovery.tsx
+++ b/mailpoet/assets/js/src/homepage/components/product-discovery.tsx
@@ -23,6 +23,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
   tasks.push(
     <DiscoveryTask
       key="setUpWelcomeCampaign"
+      slug="set up welcome campaign"
       title={MailPoet.I18n.t('setUpWelcomeCampaign')}
       description={MailPoet.I18n.t('setUpWelcomeCampaignDesc')}
       link="admin.php?page=mailpoet-automation-templates"
@@ -32,6 +33,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
     />,
     <DiscoveryTask
       key="addSubscriptionForm"
+      slug="add subscription form"
       title={MailPoet.I18n.t('addSubscriptionForm')}
       description={MailPoet.I18n.t('addSubscriptionFormDesc')}
       link="admin.php?page=mailpoet-form-editor-template-selection"
@@ -44,6 +46,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
     tasks.push(
       <DiscoveryTask
         key="sendFirstNewsletter"
+        slug="send first newsletter"
         title={MailPoet.I18n.t('sendFirstNewsletter')}
         description={MailPoet.I18n.t('sendFirstNewsletterDesc')}
         link="admin.php?page=mailpoet-newsletters#/new"
@@ -56,6 +59,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
     tasks.push(
       <DiscoveryTask
         key="setUpAbandonedCartEmail"
+        slug="set up abandoned cart email"
         title={MailPoet.I18n.t('setUpAbandonedCartEmail')}
         description={MailPoet.I18n.t('setUpAbandonedCartEmailDesc')}
         link="admin.php?page=mailpoet-newsletters#/new/woocommerce/woocommerce_abandoned_shopping_cart/conditions"
@@ -65,6 +69,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
       />,
       <DiscoveryTask
         key="brandWooEmails"
+        slug="brand woocommerce emails"
         title={MailPoet.I18n.t('brandWooEmails')}
         description={MailPoet.I18n.t('brandWooEmailsDesc')}
         link="admin.php?page=mailpoet-settings#/woocommerce"

--- a/mailpoet/assets/js/src/homepage/components/subscribers-stats.tsx
+++ b/mailpoet/assets/js/src/homepage/components/subscribers-stats.tsx
@@ -5,21 +5,13 @@ import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import { MailPoet } from 'mailpoet';
 import { storeName } from 'homepage/store/store';
+import { trackCtaAndRedirect } from 'homepage/tracking';
 import { ListingsEngagementScore } from 'subscribers/listings_engagement_score';
 import { ContentSection } from './content-section';
 
 const handleCtaClick = (event: MouseEvent, cta: string, link: string) => {
   event.preventDefault();
-  MailPoet.trackEvent(
-    'Home Page Statistics Click',
-    {
-      ctaLabel: cta,
-    },
-    { send_immediately: true },
-    () => {
-      window.location.href = link;
-    },
-  );
+  trackCtaAndRedirect('Home Page Statistics Click', cta, link);
 };
 
 export function SubscribersStats(): JSX.Element {

--- a/mailpoet/assets/js/src/homepage/components/task-list.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task-list.tsx
@@ -30,6 +30,7 @@ export function TaskList({ onHide }: Props): JSX.Element {
   taskListItems.push(
     <Task
       key="senderSet"
+      slug="set sender"
       title={MailPoet.I18n.t('senderSetTask')}
       titleCompleted={MailPoet.I18n.t('senderSetTaskDone')}
       link="admin.php?page=mailpoet-settings#/basics"
@@ -41,6 +42,7 @@ export function TaskList({ onHide }: Props): JSX.Element {
   taskListItems.push(
     <Task
       key="mssConnected"
+      slug="connect mss"
       title={MailPoet.I18n.t('mssConnectedTask')}
       titleCompleted={MailPoet.I18n.t('mssConnectedTaskDone')}
       link="admin.php?page=mailpoet-settings#/premium"
@@ -53,6 +55,7 @@ export function TaskList({ onHide }: Props): JSX.Element {
     taskListItems.push(
       <Task
         key="wooSubscribersImported"
+        slug="import woocommerce subscribers"
         title={MailPoet.I18n.t('wooSubscribersImportedTask')}
         titleCompleted={MailPoet.I18n.t('wooSubscribersImportedTaskDone')}
         link="admin.php?page=mailpoet-woocommerce-setup"
@@ -65,6 +68,7 @@ export function TaskList({ onHide }: Props): JSX.Element {
   taskListItems.push(
     <Task
       key="subscribersAdded"
+      slug="add subscribers"
       title={MailPoet.I18n.t('subscribersAddedTask')}
       titleCompleted={
         hasImportedSubscribers

--- a/mailpoet/assets/js/src/homepage/components/task.tsx
+++ b/mailpoet/assets/js/src/homepage/components/task.tsx
@@ -1,10 +1,12 @@
 import { Icon } from '@wordpress/components';
 import { check } from '@wordpress/icons';
 import classnames from 'classnames';
+import { trackCtaAndRedirect } from 'homepage/tracking';
 
 type Props = {
   title: string;
   titleCompleted?: string;
+  slug: string;
   link: string;
   order: number;
   isCompleted: boolean;
@@ -15,6 +17,7 @@ type Props = {
 export function Task({
   title,
   titleCompleted = '',
+  slug,
   link,
   order,
   isCompleted,
@@ -26,7 +29,7 @@ export function Task({
     'mailpoet-task-list__task--active': isActive,
   });
   const handleTaskClick = () => {
-    window.location.href = link;
+    trackCtaAndRedirect('Home Page Task', slug, link);
   };
   return (
     <li

--- a/mailpoet/assets/js/src/homepage/tracking.ts
+++ b/mailpoet/assets/js/src/homepage/tracking.ts
@@ -1,0 +1,14 @@
+import { MailPoet } from 'mailpoet';
+
+export function trackCtaAndRedirect(event: string, cta: string, link: string) {
+  MailPoet.trackEvent(
+    event,
+    {
+      ctaLabel: cta,
+    },
+    { send_immediately: true },
+    () => {
+      window.location.href = link;
+    },
+  );
+}

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -124,7 +124,7 @@ class PageRenderer {
     $defaults = [
       'current_page' => sanitize_text_field(wp_unslash($_GET['page'] ?? '')),
       'site_name' => $this->wp->wpSpecialcharsDecode($this->wp->getOption('blogname'), ENT_QUOTES),
-      'main_page' => Menu::$mainPageSlug,
+      'main_page' => Menu::MAIN_PAGE_SLUG,
       'site_url' => $this->wp->siteUrl(),
       'site_address' => $this->wp->wpParseUrl($this->wp->homeUrl(), PHP_URL_HOST),
       'feature_flags' => $this->featuresController->getAllFlags(),

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -57,7 +57,7 @@ class WelcomeWizard {
     $mpApiKeyValid = $this->servicesChecker->isMailPoetAPIKeyValid(false, true);
 
     $data = [
-      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::$mainPageSlug),
+      'finish_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::MAIN_PAGE_SLUG),
       'admin_email' => $this->wp->getOption('admin_email'),
       'current_wp_user' => $this->wp->wpGetCurrentUser()->to_array(),
       'show_customers_import' => $this->wooCommerceHelper->getCustomersCount() > 0,

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -23,7 +23,6 @@ use MailPoet\AdminPages\Pages\Upgrade;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceSetup;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
@@ -78,9 +77,6 @@ class Menu {
   /** @var CustomFonts  */
   private $customFonts;
 
-  /** @var FeaturesController */
-  private $featuresController;
-
   /** @var Changelog */
   private $changelog;
 
@@ -91,7 +87,6 @@ class Menu {
     ContainerWrapper $container,
     Router $router,
     CustomFonts $customFonts,
-    FeaturesController $featuresController,
     Changelog $changelog
   ) {
     $this->accessControl = $accessControl;
@@ -100,14 +95,11 @@ class Menu {
     $this->container = $container;
     $this->router = $router;
     $this->customFonts = $customFonts;
-    $this->featuresController = $featuresController;
     $this->changelog = $changelog;
   }
 
   public function init() {
-    if ($this->featuresController->isSupported(FeaturesController::FEATURE_HOMEPAGE)) {
-      self::$mainPageSlug = self::HOMEPAGE_PAGE_SLUG;
-    }
+    self::$mainPageSlug = self::HOMEPAGE_PAGE_SLUG;
     $this->checkPremiumKey();
 
     $this->wp->addAction(
@@ -223,19 +215,17 @@ class Menu {
 
   private function registerMailPoetSubMenuEntries(bool $showEntries) {
     // Homepage
-    if ($this->featuresController->isSupported(FeaturesController::FEATURE_HOMEPAGE)) {
-      $this->wp->addSubmenuPage(
-        $showEntries ? self::$mainPageSlug : true,
-        $this->setPageTitle(__('Home', 'mailpoet')),
-        esc_html__('Home', 'mailpoet'),
-        AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-        self::HOMEPAGE_PAGE_SLUG,
-        [
-          $this,
-          'homepage',
-        ]
-      );
-    }
+    $this->wp->addSubmenuPage(
+      $showEntries ? self::$mainPageSlug : true,
+      $this->setPageTitle(__('Home', 'mailpoet')),
+      esc_html__('Home', 'mailpoet'),
+      AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
+      self::HOMEPAGE_PAGE_SLUG,
+      [
+        $this,
+        'homepage',
+      ]
+    );
 
     // Emails page
     $newslettersPage = $this->wp->addSubmenuPage(

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -28,8 +28,7 @@ use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Menu {
-  const MAIN_PAGE_SLUG = 'mailpoet-newsletters';
-  public static $mainPageSlug = 'mailpoet-newsletters';
+  const MAIN_PAGE_SLUG = self::HOMEPAGE_PAGE_SLUG;
 
   const EMAILS_PAGE_SLUG = 'mailpoet-newsletters';
   const FORMS_PAGE_SLUG = 'mailpoet-forms';
@@ -99,7 +98,6 @@ class Menu {
   }
 
   public function init() {
-    self::$mainPageSlug = self::HOMEPAGE_PAGE_SLUG;
     $this->checkPremiumKey();
 
     $this->wp->addAction(
@@ -178,7 +176,7 @@ class Menu {
       'MailPoet',
       'MailPoet',
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
-      self::$mainPageSlug,
+      self::MAIN_PAGE_SLUG,
       null,
       self::ICON_BASE64_SVG,
       30
@@ -216,7 +214,7 @@ class Menu {
   private function registerMailPoetSubMenuEntries(bool $showEntries) {
     // Homepage
     $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Home', 'mailpoet')),
       esc_html__('Home', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -229,7 +227,7 @@ class Menu {
 
     // Emails page
     $newslettersPage = $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Emails', 'mailpoet')),
       esc_html__('Emails', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_EMAILS,
@@ -269,7 +267,7 @@ class Menu {
 
     // Forms page
     $formsPage = $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Forms', 'mailpoet')),
       esc_html__('Forms', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_FORMS,
@@ -335,7 +333,7 @@ class Menu {
 
     // Subscribers page
     $subscribersPage = $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Subscribers', 'mailpoet')),
       esc_html__('Subscribers', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
@@ -386,7 +384,7 @@ class Menu {
 
     // Segments page
     $segmentsPage = $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Lists', 'mailpoet')),
       esc_html__('Lists', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SEGMENTS,
@@ -411,7 +409,7 @@ class Menu {
 
     // Settings page
     $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Settings', 'mailpoet')),
       esc_html__('Settings', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_SETTINGS,
@@ -424,7 +422,7 @@ class Menu {
 
     // Help page
     $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Help', 'mailpoet')),
       esc_html__('Help', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -438,7 +436,7 @@ class Menu {
     // Upgrade page
     // Only show this page in menu if the Premium plugin is not activated
     $this->wp->addSubmenuPage(
-      License::getLicense() || !$showEntries ? true : self::$mainPageSlug,
+      License::getLicense() || !$showEntries ? true : self::MAIN_PAGE_SLUG,
       $this->setPageTitle(__('Upgrade', 'mailpoet')),
       esc_html__('Upgrade', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -485,7 +483,7 @@ class Menu {
 
   private function registerAutomationMenu(bool $showEntries) {
     $automationPage = $this->wp->addSubmenuPage(
-      $showEntries ? self::$mainPageSlug : true,
+      $showEntries ? self::MAIN_PAGE_SLUG : true,
       $this->setPageTitle(__('Automations', 'mailpoet')),
       // @ToDo Remove Beta once Automation is no longer beta.
       '<span>' . esc_html__('Automations', 'mailpoet') . '</span><span class="mailpoet-beta-badge">Beta</span>',
@@ -668,7 +666,7 @@ class Menu {
     // Check if page already exists
     if (
       get_plugin_page_hook($page, '')
-      || WPFunctions::get()->getPluginPageHook($page, self::$mainPageSlug)
+      || WPFunctions::get()->getPluginPageHook($page, self::MAIN_PAGE_SLUG)
     ) {
       return false;
     }

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -119,7 +119,7 @@ class Menu {
     // @ToDo Remove Beta once Automation is no longer beta.
     $this->wp->addAction('admin_head', function () {
       echo '<style>
-#adminmenu .toplevel_page_mailpoet-newsletters a[href="admin.php?page=mailpoet-automation"] {
+#adminmenu .toplevel_page_mailpoet-homepage a[href="admin.php?page=mailpoet-automation"] {
   white-space: nowrap;
 }
 .mailpoet-beta-badge {

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -5,13 +5,11 @@ namespace MailPoet\Features;
 use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
-  const FEATURE_HOMEPAGE = 'homepage';
   const LANDINGPAGE_AB_TEST_DEBUGGER = 'landingpage_ab_test_debugger';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
-    self::FEATURE_HOMEPAGE => false,
     self::LANDINGPAGE_AB_TEST_DEBUGGER => false,
   ];
 

--- a/mailpoet/lib/Migrations/Migration_20230131_121621.php
+++ b/mailpoet/lib/Migrations/Migration_20230131_121621.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Homepage\HomepageDataController;
+use MailPoet\Migrator\Migration;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WooCommerce\Helper;
+
+class Migration_20230131_121621 extends Migration {
+  /**
+   * This migration detect whether we should display Task List and Product Discovery sections
+   * on the homepage for the old users.
+   */
+  public function run(): void {
+    // Hide task list for users who installed the plugin more than 2 weeks ago
+    $settings = $this->container->get(SettingsController::class);
+    $installedAt = strtotime($settings->get('installed_at', date('Y-m-d H:i:s')));
+    $twoWeeksAgo = strtotime('-2 weeks');
+    if ($installedAt < $twoWeeksAgo) {
+      $settings->set('homepage.task_list_dismissed', true);
+    }
+
+    // Hide product discovery for users who completed all tasks
+    $homepageDataController = $this->container->get(HomepageDataController::class);
+    $wooCommerceHelper = $this->container->get(Helper::class);
+    $homepageData = $homepageDataController->getPageData();
+    $productDiscoveryStatus = $homepageData['productDiscoveryStatus'];
+    if ($wooCommerceHelper->isWooCommerceActive()) {
+      $productDiscoveryIsComplete = $productDiscoveryStatus['addSubscriptionForm'] &&
+        $productDiscoveryStatus['setUpWelcomeCampaign'] &&
+        $productDiscoveryStatus['setUpAbandonedCartEmail'] &&
+        $productDiscoveryStatus['brandWooEmails'];
+    } else {
+      $productDiscoveryIsComplete = $productDiscoveryStatus['addSubscriptionForm'] &&
+        $productDiscoveryStatus['setUpWelcomeCampaign'] &&
+        $productDiscoveryStatus['sendFirstNewsletter'];
+    }
+    $settings->set('homepage.product_discovery_dismissed', $productDiscoveryIsComplete);
+  }
+}

--- a/mailpoet/lib/WooCommerce/MailPoetTask.php
+++ b/mailpoet/lib/WooCommerce/MailPoetTask.php
@@ -39,7 +39,7 @@ class MailPoetTask extends Task {
    */
   public function get_action_url(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->is_complete()) {
-      return admin_url('admin.php?page=' . Menu::$mainPageSlug);
+      return admin_url('admin.php?page=' . Menu::MAIN_PAGE_SLUG);
     }
 
     return admin_url('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG . '&mailpoet_wizard_loaded_via_woocommerce');

--- a/mailpoet/tests/acceptance/Homepage/HomepageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageBasicsCest.php
@@ -3,17 +3,11 @@
 namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Features\FeaturesController;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\Subscriber;
 
 class HomepageBasicsCest {
-  public function _before() {
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_HOMEPAGE);
-  }
-
   public function homepageRenders(\AcceptanceTester $i) {
     $i->wantTo('Check homepage renders and is present in menu');
     $i->login();

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
@@ -48,7 +48,7 @@ class WooCommerceSetupPageCest {
     $i->clickToggleYes($trackingToggle);
     $i->click($submitButton);
     $i->seeNoJSErrors();
-    $i->waitForElement('[data-automation-id="create_standard"]');
+    $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
     $i->amOnMailpoetPage('Lists');
     $i->waitForText('WooCommerce Customers');
     $i->moveMouseOver('[data-automation-id="segment_name_WooCommerce Customers"]');
@@ -116,7 +116,7 @@ class WooCommerceSetupPageCest {
     $i->click($submitButton);
     $i->dontSeeElement($errorClass);
     $i->seeNoJSErrors();
-    $i->waitForElement('[data-automation-id="create_standard"]');
+    $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
   }
 
   /**

--- a/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
+++ b/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
@@ -66,8 +66,8 @@ class WelcomeWizardCest {
     $i->waitForText('MailPoet account connected', 20);
     $i->click('.mailpoet-wizard-continue-button');
 
-    // wizard finished and the user was redirect to the newsletter page
-    $i->waitForElement('#newsletters_container');
+    // wizard finished and the user was redirect to the home page
+    $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
 
     Assert::assertSame($senderName, $this->settingsRepository->findOneByName('sender')->getValue()['name']);
     Assert::assertSame($senderAddress, $this->settingsRepository->findOneByName('sender')->getValue()['address']);


### PR DESCRIPTION
## Description

Draft because it waits for https://github.com/mailpoet/mailpoet/pull/4701 to get merged.

This PR:
1) Removes the feature switch and makes the homepage available as the default main page in the plugin.
2) Adds migrations for older users (set states for the task list and the engagement section)
3) Add tracking of clicks in the tasks list

## Code review notes

_N/A_

## QA notes
Please test that the behavior for existing users is correct. See details in [MAILPOET-4831]

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4831]

## After-merge notes

_N/A_


[MAILPOET-4831]: https://mailpoet.atlassian.net/browse/MAILPOET-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4831]: https://mailpoet.atlassian.net/browse/MAILPOET-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ