### PR TITLE
Force a re-render when resuming a corrupt newsletter [MAILPOET-5104]

### DIFF
--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -136,6 +136,10 @@ class SendingQueuesRepository extends Repository {
     } else {
       $newsletter = $queue->getNewsletter();
       if (!$newsletter instanceof NewsletterEntity) return;
+      if ($newsletter->getStatus() === NewsletterEntity::STATUS_CORRUPT) { // force a re-render
+        $queue->setNewsletterRenderedBody(null);
+        $this->persist($queue);
+      }
       $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
       $task->setStatus(null);
       $this->flush();


### PR DESCRIPTION
## Description

This PR makes sure resuming a corrupt newsletter actually removes the rendered body from the queue to force re-rendering in the next run.

## QA notes

This is an issue that shouldn't happen in normal scenarios, but in case some factors prevent the normal flow that catches the exception of the corrupt newsletter, this can happen.
To test, make sure a newsletter with a coupon block which has been paused because of an issue with generating a coupon ( WC was not active when sending for instance ), can be resumed and the email with coupon is sent.

## Linked tickets

[MAILPOET-5104]

[MAILPOET-5104]: https://mailpoet.atlassian.net/browse/MAILPOET-5104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ