### PR TITLE
Add a new k6 test: Newsletter sending

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -1,16 +1,17 @@
 /**
  * Internal dependencies
  */
+import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { scenario } from './config.js';
 import { newsletterListing } from './tests/newsletter-listing.js';
 import { subscribersListing } from './tests/subscribers-listing.js';
 import { settingsBasic } from './tests/settings-basic.js';
 import { subscribersFiltering } from './tests/subscribers-filtering.js';
 import { subscribersAdding } from './tests/subscribers-adding.js';
 import { formsAdding } from './tests/forms-adding.js';
-import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
-import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
-import { scenario } from './config.js';
 import { newsletterSearching } from './tests/newsletter-searching.js';
+import { newsletterSending } from './tests/newsletter-sending.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -66,6 +67,7 @@ export function pullRequests() {
   subscribersAdding();
   formsAdding();
   newsletterSearching();
+  newsletterSending();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -63,9 +63,9 @@ export function formsAdding() {
         page.locator('[data-automation-id="form_save_button"]').click();
         page.waitForSelector('.components-notice');
         check(page, {
-          'form has been saved notice is visible': page
-            .locator('.components-notice__content')
-            .isVisible(),
+          'form has been saved notice is present':
+            page.locator('.components-notice__content').textContent() ===
+            'Form saved. Cookies reset — you will see all your dismissed popup forms again.',
         });
       })
 

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -58,31 +58,31 @@ export async function newsletterSending() {
     page.waitForLoadState('networkidle');
 
     // Click to proceed to the next step (the last one)
-    page.locator('//input[text()="Next"]').click();
-    page.waitForSelector('.mailpoet_loading');
+    await Promise.all([
+      page.waitForNavigation(),
+      page
+        .locator('#mailpoet_editor_top > div > div > .mailpoet_save_next')
+        .click(),
+    ]);
     page.waitForSelector('[data-automation-id="newsletter_send_heading"]');
     page.waitForLoadState('networkidle');
 
     // Select the default list and send the newsletter
-    selectInSelect2(defaultListName);
-    page.locator('[data-automation-id="email-submit"]').click();
-    page.waitForSelector('.mailpoet_loading');
-    page.waitForSelector('.mailpoet-h0');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'title congratulations is present':
-        page.locator('h1').textContent() === 'Congratulations!',
-    });
+    selectInSelect2(page, defaultListName);
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('[data-automation-id="email-submit"]').click(),
+    ]);
+    sleep(1);
 
-    // Click close button to get back to Emails page
-    page.locator('button[type="button"]').click();
-    page.waitForSelector('[data-automation-id="tab-Newsletters"]');
-    page.waitForLoadState('networkidle');
+    // Wait for the success notice message and confirm it
+    page.waitForSelector('#mailpoet_notices');
     check(page, {
-      'newsletter filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
+      'newsletter is being sent notice has shown up':
+        page.locator('div > .notice-success > p').textContent() ===
+        'The newsletter is being sent...',
     });
+    page.waitForLoadState('networkidle');
   } finally {
     page.close();
     browser.close();

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -1,0 +1,96 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check } from 'k6';
+import { chromium } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+  defaultListName,
+} from '../config.js';
+import { authenticate, selectInSelect2 } from '../utils/helpers.js';
+/* global Promise */
+
+export async function newsletterSending() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  try {
+    // Go to the page
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+      waitUntil: 'networkidle',
+    });
+
+    // Log in to WP Admin
+    authenticate(page);
+
+    // Wait for async actions
+    await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' })]);
+
+    // Click to add a new standard newsletter
+    page.locator('[data-automation-id="new_email"]').click();
+    page.locator('[data-automation-id="create_standard"]').click();
+    page.waitForSelector('.mailpoet_loading');
+    page.waitForSelector('[data-automation-id="templates-standard"]');
+    page.waitForLoadState('networkidle');
+
+    // Switch to a Standard templates tab and select the 2nd template
+    page.locator('[data-automation-id="templates-standard"]').click();
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('[data-automation-id="select_template_1"]').click(),
+    ]);
+    page.waitForSelector('.mailpoet_loading');
+    page.waitForSelector('[data-automation-id="newsletter_title"]');
+    page.waitForLoadState('networkidle');
+
+    // Click to proceed to the next step (the last one)
+    page.locator('//input[text()="Next"]').click();
+    page.waitForSelector('.mailpoet_loading');
+    page.waitForSelector('[data-automation-id="newsletter_send_heading"]');
+    page.waitForLoadState('networkidle');
+
+    // Select the default list and send the newsletter
+    selectInSelect2(defaultListName);
+    page.locator('[data-automation-id="email-submit"]').click();
+    page.waitForSelector('.mailpoet_loading');
+    page.waitForSelector('.mailpoet-h0');
+    page.waitForLoadState('networkidle');
+    check(page, {
+      'title congratulations is present':
+        page.locator('h1').textContent() === 'Congratulations!',
+    });
+
+    // Click close button to get back to Emails page
+    page.locator('button[type="button"]').click();
+    page.waitForSelector('[data-automation-id="tab-Newsletters"]');
+    page.waitForLoadState('networkidle');
+    check(page, {
+      'newsletter filter is visible': page
+        .locator('[data-automation-id="listing_filter_segment"]')
+        .isVisible(),
+    });
+  } finally {
+    page.close();
+    browser.close();
+  }
+
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+}
+
+export default function newsletterSendingTest() {
+  newsletterSending();
+}


### PR DESCRIPTION
## Description

In this PR, added a new k6 test: Newsletter sending

Additionally, updated notice verification in `formsAdding.js` test.

## Code review notes

Feel free to run the test locally with:

`./do test:performance --url=https://qawp.net tests/performance/tests/newsletter-sending.js`

If you see a checkmark in the console at the end for the notice-success message, then it worked.

## Linked tickets

[MAILPOET-4951]


[MAILPOET-4951]: https://mailpoet.atlassian.net/browse/MAILPOET-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ