### PR TITLE
Add translating validation error messages for custom fields[MAILPOET-4901]

### DIFF
--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -68,6 +68,7 @@ class BlockRendererHelper {
         $rules['error-message'] = __('Please specify a valid phone number.', 'mailpoet');
       } else {
         $rules['type'] = $this->wp->escAttr($block['params']['validate']);
+        $rules['error-message'] = $this->translateValidationErrorMessage($block['params']['validate']);
       }
     }
 
@@ -255,5 +256,24 @@ class BlockRendererHelper {
       $modifiers[] = 'disabled';
     }
     return join(' ', $modifiers);
+  }
+
+  private function translateValidationErrorMessage(string $validate): string {
+    switch ($validate) {
+      case 'email':
+        return __('This value should be a valid email.', 'mailpoet');
+      case 'url':
+        return __('This value should be a valid url.', 'mailpoet');
+      case 'number':
+        return __('This value should be a valid number.', 'mailpoet');
+      case 'integer':
+        return __('This value should be a valid integer.', 'mailpoet');
+      case 'digits':
+        return __('This value should be digits.', 'mailpoet');
+      case 'alphanum':
+        return __('This value should be alphanumeric.', 'mailpoet');
+      default:
+        return __('This value seems to be invalid.', 'mailpoet');
+    }
   }
 }


### PR DESCRIPTION
## Code review notes

I reused messages that we use in [laytout.html](https://github.com/mailpoet/mailpoet/blob/fe93b1a1503ad7d8f391029f1cf1c44ab82abc85/mailpoet/views/layout.html#L314-L319) for our admin pages.
I consider extending our renderer to be an easy way. If you know about a better option, please let me know.

## Linked tickets

[MAILPOET-4901]



[MAILPOET-4901]: https://mailpoet.atlassian.net/browse/MAILPOET-4901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ