### PR TITLE
Enforce minimum WooCommerce version

### DIFF
--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -51,6 +51,9 @@ class PermanentNotices {
   /** @var PendingApprovalNotice */
   private $pendingApprovalNotice;
 
+  /** @var WooCommerceVersionWarning */
+  private $woocommerceVersionWarning;
+
   public function __construct(
     WPFunctions $wp,
     TrackingConfig $trackingConfig,
@@ -72,6 +75,7 @@ class PermanentNotices {
     $this->deprecatedFilterNotice = new DeprecatedFilterNotice($wp);
     $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature, $mailerFactory);
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
+    $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
   }
 
   public function init() {
@@ -122,6 +126,9 @@ class PermanentNotices {
     $this->pendingApprovalNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
+    $this->woocommerceVersionWarning->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
   }
 
   public function ajaxDismissNoticeHandler() {
@@ -150,6 +157,9 @@ class PermanentNotices {
         break;
       case (DeprecatedFilterNotice::OPTION_NAME):
         $this->deprecatedFilterNotice->disable();
+        break;
+      case (WooCommerceVersionWarning::OPTION_NAME):
+        $this->woocommerceVersionWarning->disable();
         break;
     }
   }

--- a/mailpoet/lib/Util/Notices/WooCommerceVersionWarning.php
+++ b/mailpoet/lib/Util/Notices/WooCommerceVersionWarning.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Config\Env;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class WooCommerceVersionWarning {
+  const OPTION_NAME = 'dismissed-woo-version-outdated-notice';
+  const DISMISS_NOTICE_TIMEOUT_SECONDS = 2592000; // 30 days
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function init($shouldDisplay) {
+    if (!is_plugin_active('woocommerce/woocommerce.php')) {
+      return;
+    }
+    $woocommerceVersion = get_plugin_data(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'];
+    $requiredWooCommerceVersion = $this->getRequiredWooCommerceVersion();
+    if ($shouldDisplay && $this->isOutdatedWooCommerceVersion($woocommerceVersion, $requiredWooCommerceVersion)) {
+      $this->display($requiredWooCommerceVersion);
+    }
+  }
+
+  public function isOutdatedWooCommerceVersion($woocommerceVersion, $requiredWooCommerceVersion): bool {
+    return version_compare($woocommerceVersion, $requiredWooCommerceVersion, '<') && !get_transient(self::OPTION_NAME);
+  }
+
+  private function display($requiredWooCommerceVersion) {
+    // translators: %s is the PHP version
+    $errorString = __('MailPoet plugin requires WooCommerce version %s or newer. Please update your WooCommerce plugin version, or read our [link]instructions[/link] for additional options on how to resolve this issue. ', 'mailpoet');
+    $errorString = sprintf($errorString, $requiredWooCommerceVersion);
+    $error = Helpers::replaceLinkTags($errorString, 'https://kb.mailpoet.com/article/152-minimum-requirements-for-mailpoet-3#woocommerce-version', [
+      'target' => '_blank',
+    ]);
+
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+
+    Notice::displayWarning($error, $extraClasses, self::OPTION_NAME);
+  }
+
+  public function disable() {
+    $this->wp->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+  }
+
+  private function getRequiredWooCommerceVersion(): string {
+    $pluginData = $this->wp->getFileData(
+      Env::$file,
+      [
+        'RequiredWCVersion' => 'WC requires at least',
+      ]
+    );
+    return $pluginData['RequiredWCVersion'] ?? '100.0.0';
+  }
+}

--- a/mailpoet/lib/Util/Notices/WooCommerceVersionWarning.php
+++ b/mailpoet/lib/Util/Notices/WooCommerceVersionWarning.php
@@ -8,7 +8,7 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice;
 
 class WooCommerceVersionWarning {
-  const OPTION_NAME = 'dismissed-woo-version-outdated-notice';
+  const OPTION_NAME = 'mailpoet-dismissed-woo-version-outdated-notice';
   const DISMISS_NOTICE_TIMEOUT_SECONDS = 2592000; // 30 days
 
   /** @var WPFunctions */
@@ -32,7 +32,7 @@ class WooCommerceVersionWarning {
   }
 
   public function isOutdatedWooCommerceVersion($woocommerceVersion, $requiredWooCommerceVersion): bool {
-    return version_compare($woocommerceVersion, $requiredWooCommerceVersion, '<') && !get_transient(self::OPTION_NAME);
+    return version_compare($woocommerceVersion, $requiredWooCommerceVersion, '<') && !$this->wp->getTransient($this->getTransientKey());
   }
 
   private function display($requiredWooCommerceVersion) {
@@ -49,7 +49,12 @@ class WooCommerceVersionWarning {
   }
 
   public function disable() {
-    $this->wp->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+    $this->wp->setTransient($this->getTransientKey(), true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+  }
+
+  private function getTransientKey() {
+    $woocommerceVersion = $this->wp->getPluginData(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'];
+    return self::OPTION_NAME . '_' . $this->getRequiredWooCommerceVersion() . '_' . $woocommerceVersion;
   }
 
   private function getRequiredWooCommerceVersion(): string {

--- a/mailpoet/lib/Util/Notices/WooCommerceVersionWarning.php
+++ b/mailpoet/lib/Util/Notices/WooCommerceVersionWarning.php
@@ -24,7 +24,7 @@ class WooCommerceVersionWarning {
     if (!is_plugin_active('woocommerce/woocommerce.php')) {
       return;
     }
-    $woocommerceVersion = get_plugin_data(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'];
+    $woocommerceVersion = $this->wp->getPluginData(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'];
     $requiredWooCommerceVersion = $this->getRequiredWooCommerceVersion();
     if ($shouldDisplay && $this->isOutdatedWooCommerceVersion($woocommerceVersion, $requiredWooCommerceVersion)) {
       $this->display($requiredWooCommerceVersion);

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -867,4 +867,8 @@ class Functions {
   public function getPostMeta(int $postId, string $key, bool $single = false) {
     return get_post_meta($postId, $key, $single);
   }
+
+  public function getFileData(string $file, array $default_headers, string $context = 'plugin'): array {
+    return get_file_data($file, $default_headers, $context);
+  }
 }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -871,4 +871,8 @@ class Functions {
   public function getFileData(string $file, array $default_headers, string $context = 'plugin'): array {
     return get_file_data($file, $default_headers, $context);
   }
+
+  public function getPluginData(string $plugin_file, bool $markup = true, bool $translate = true): array {
+    return get_plugin_data($plugin_file, $markup, $translate);
+  }
 }

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -54,7 +54,10 @@ if (version_compare(phpversion(), '7.2.0', '<')) {
 }
 
 // Check for minimum supported WooCommerce version
-if (function_exists('is_plugin_active') && is_plugin_active('woocommerce/woocommerce.php')) {
+if (!function_exists('is_plugin_active')) {
+  require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+if (is_plugin_active('woocommerce/woocommerce.php')) {
   $woocommerceVersion = get_plugin_data(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'];
   if (version_compare($woocommerceVersion, MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION, '<')) {
     add_action('admin_notices', 'mailpoet_woocommerce_version_notice');


### PR DESCRIPTION
## Description

After an issue on support where a user had an outdated WooCommerce version, a fatal PHP error on the site led to the site crashing. Now we will not allow installing MailPoet if WC is ancient (< 6.4), and we will display a warning for outdated version (< 7.2)

## Linked tickets

[MAILPOET-5085]


[MAILPOET-5085]: https://mailpoet.atlassian.net/browse/MAILPOET-5085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ