### PR TITLE
Exempt <hr> from being stripped when display type is full [MAILPOET-5114]

### DIFF
--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -63,7 +63,7 @@ class PostContentManager {
       '<a>', '<ul>', '<ol>', '<li>', '<br>', '<blockquote>',
     ];
     if ($displayType === 'full') {
-      $tagsNotBeingStripped = array_merge($tagsNotBeingStripped, ['<figure>', '<img>', '<h1>', '<h2>', '<h3>']);
+      $tagsNotBeingStripped = array_merge($tagsNotBeingStripped, ['<figure>', '<img>', '<h1>', '<h2>', '<h3>', '<hr>']);
     }
 
     if (is_array($content)) {

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
@@ -99,7 +99,6 @@ class PostContentManagerTest extends \MailPoetTest {
       '<iframe src="#" />',
       '<form></form>',
       '<input type="text" />',
-      '<hr />',
       '<script></script>',
       '<style></style>',
       '<table></table>',


### PR DESCRIPTION
## Description
When you use the automated posts block and choose the display type full, this PR allows `<hr>` in the post_content and the emails which are send out.

## QA notes

Before: When you use a `<hr>` tag in the post content, this html element would not be visible in the post notifications email
Now: The `<hr>` element is visible in the email.

## Linked tickets

[MAILPOET-5114]


[MAILPOET-5114]: https://mailpoet.atlassian.net/browse/MAILPOET-5114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ