### PR TITLE
Add an action to display pull request stats

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,16 @@
+name: Pull Request Stats
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pull request stats
+        uses: flowwer-dev/pull-request-stats@master
+        with:
+          period: 90
+          charts: true
+          sort-by: 'TIME'


### PR DESCRIPTION
## Description

This adds a new action that will display statistics about pull requests. Related [P2](https://mailpoetdev.wordpress.com/2023/03/08/rfc-methods-against-a-high-workload/).

This is here in this state for now, for a test. If we [like this tool](https://github.com/marketplace/actions/pull-request-stats) we can improve it and add stats from other repositories. If we don't like it, we can remove it and find a replacement.
