### PR TITLE
Add email scheduling with minute resolution [MAILPOET-4602]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_newsletter-types.scss
+++ b/mailpoet/assets/css/src/components-plugin/_newsletter-types.scss
@@ -90,7 +90,7 @@
 }
 
 .mailpoet-re-engagement-scheduling .mailpoet-form-input-small {
-  width: 100px;
+  width: 150px;
 }
 
 [data-type='re_engagement'] .mailpoet-newsletter-type-image {

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/events/event_scheduling.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/events/event_scheduling.jsx
@@ -109,6 +109,7 @@ class EventScheduling extends Component {
       field: {
         id: 'scheduling_time_duration',
         name: 'scheduling_time_duration',
+        className: 'mailpoet-form-input-small',
         defaultValue: afterTimeNumber ? afterTimeNumber.toString() : '',
         size: afterTimeNumberSize,
         validation: {

--- a/mailpoet/assets/js/src/newsletters/scheduling/common.jsx
+++ b/mailpoet/assets/js/src/newsletters/scheduling/common.jsx
@@ -23,7 +23,7 @@ const intervalValues = {
 
 // notification emails
 const SECONDS_IN_DAY = 86400;
-const TIME_STEP_SECONDS = 3600;
+const TIME_STEP_SECONDS = 900; // 15 minutes
 const numberOfTimeSteps = SECONDS_IN_DAY / TIME_STEP_SECONDS;
 
 const timeOfDayValues = _.object(

--- a/mailpoet/assets/js/src/newsletters/scheduling/common.jsx
+++ b/mailpoet/assets/js/src/newsletters/scheduling/common.jsx
@@ -7,6 +7,7 @@ const timeFormat = window.mailpoet_time_format || 'H:i';
 // welcome emails
 const timeDelayValues = {
   immediate: __('immediately', 'mailpoet'),
+  minutes: __('minute(s) later', 'mailpoet'),
   hours: __('hour(s) later', 'mailpoet'),
   days: __('day(s) later', 'mailpoet'),
   weeks: __('week(s) later', 'mailpoet'),

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -102,8 +102,8 @@ class Newsletters {
     $data['current_date_time'] = $dateTime->getCurrentDateTime()->format(DateTime::DEFAULT_DATE_TIME_FORMAT);
     $data['schedule_time_of_day'] = $dateTime->getTimeInterval(
       '00:00:00',
-      '+1 hour',
-      24
+      '+15 minutes',
+      96
     );
     $data['mailpoet_emails_page'] = $this->wp->adminUrl('admin.php?page=' . Menu::EMAILS_PAGE_SLUG);
     $data['show_congratulate_after_first_newsletter'] = isset($data['settings']['show_congratulate_after_first_newsletter']) ? $data['settings']['show_congratulate_after_first_newsletter'] : 'false';

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
@@ -62,7 +62,7 @@ class AbandonedCart {
       ],
       'timeDelayValues' => [
         'minutes' => [
-          'text' => __('minutes(s)', 'mailpoet'),
+          'text' => __('minute(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,
         ],
         'hours' => [

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
@@ -62,8 +62,8 @@ class AbandonedCart {
       ],
       'timeDelayValues' => [
         'minutes' => [
-          'text' => _x('30 minutes', 'This is a trigger setting. It means that we will send an automatic email to a visitor 30 minutes after this visitor had left the website.', 'mailpoet'),
-          'displayAfterTimeNumberField' => false,
+          'text' => __('minutes(s)', 'mailpoet'),
+          'displayAfterTimeNumberField' => true,
         ],
         'hours' => [
           'text' => __('hour(s)', 'mailpoet'),

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -85,6 +85,10 @@ class FirstPurchase {
           'text' => __('immediately', 'mailpoet'),
           'displayAfterTimeNumberField' => false,
         ],
+        'minutes' => [
+          'text' => __('minutes(s)', 'mailpoet'),
+          'displayAfterTimeNumberField' => true,
+        ],
         'hours' => [
           'text' => __('hour(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -86,7 +86,7 @@ class FirstPurchase {
           'displayAfterTimeNumberField' => false,
         ],
         'minutes' => [
-          'text' => __('minutes(s)', 'mailpoet'),
+          'text' => __('minute(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,
         ],
         'hours' => [

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -62,7 +62,7 @@ class PurchasedInCategory {
           'displayAfterTimeNumberField' => false,
         ],
         'minutes' => [
-          'text' => __('minutes(s)', 'mailpoet'),
+          'text' => __('minute(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,
         ],
         'hours' => [

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -61,6 +61,10 @@ class PurchasedInCategory {
           'text' => __('immediately', 'mailpoet'),
           'displayAfterTimeNumberField' => false,
         ],
+        'minutes' => [
+          'text' => __('minutes(s)', 'mailpoet'),
+          'displayAfterTimeNumberField' => true,
+        ],
         'hours' => [
           'text' => __('hour(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -82,6 +82,10 @@ class PurchasedProduct {
           'text' => __('immediately', 'mailpoet'),
           'displayAfterTimeNumberField' => false,
         ],
+        'minutes' => [
+          'text' => __('minutes(s)', 'mailpoet'),
+          'displayAfterTimeNumberField' => true,
+        ],
         'hours' => [
           'text' => __('hour(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -83,7 +83,7 @@ class PurchasedProduct {
           'displayAfterTimeNumberField' => false,
         ],
         'minutes' => [
-          'text' => __('minutes(s)', 'mailpoet'),
+          'text' => __('minute(s)', 'mailpoet'),
           'displayAfterTimeNumberField' => true,
         ],
         'hours' => [


### PR DESCRIPTION
## Description

This PR extends scheduling all email types with minute resolution.
In the scheduling for the abandoned cart, the item with `30 minutes` was removed, although according to the specification, it should have been retained. The reason was that the item in the selection had the same value.

## Code review notes

I was unsure if some acceptance tests should be added, but because there are only new items in the selections, I decided to skip this step.

## Linked tickets

[MAILPOET-4602]



[MAILPOET-4602]: https://mailpoet.atlassian.net/browse/MAILPOET-4602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ