### PR TITLE
Fix possible horizontal scrollbar in forms [MAILPOET-5116]

### DIFF
--- a/mailpoet/lib/Form/BlockStylesRenderer.php
+++ b/mailpoet/lib/Form/BlockStylesRenderer.php
@@ -18,6 +18,7 @@ class BlockStylesRenderer {
     $rules = [];
     if (isset($styles['full_width']) && intval($styles['full_width'])) {
       $rules[] = 'width:100%;';
+      $rules[] = 'box-sizing:border-box;'; // to avoid a larger width increased by padding
     }
     if (isset($styles['background_color']) && empty($styles['gradient'])) {
       $rules[] = "background-color:{$styles['background_color']};";


### PR DESCRIPTION
## Description

Full-width inputs could be displayed improperly because padding made the input's width larger.
Additional style should fix this issue.

## QA notes

1. Create a form with higher input padding than form padding and use full-with for an input.
2. Check that the x-scrollbar is visible in the popup form on the trunk branch.
3. Verify that the fix works

## Linked tickets

[MAILPOET-5116]


[MAILPOET-5116]: https://mailpoet.atlassian.net/browse/MAILPOET-5116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ