### PR TITLE
Ensure users know they're deactivating email [MAILPOET-4397]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -91,6 +91,16 @@ const initializeEditor = (config) => {
         newsletter.queue &&
         newsletter.queue.status === null
       ) {
+        // Users can confirm before visiting the page
+        let pauseConfirmed = getUrlParam('pauseConfirmed') === 'yes';
+        if (!pauseConfirmed) {
+          // eslint-disable-next-line no-alert
+          pauseConfirmed = window.confirm(MailPoet.I18n.t('confirmEdit'));
+        }
+        if (!pauseConfirmed) {
+          window.location = `admin.php?page=mailpoet-newsletters#/${newsletter.type}`;
+          return;
+        }
         MailPoet.Ajax.post({
           api_version: window.mailpoet_api_version,
           endpoint: 'sending_queue',
@@ -116,7 +126,7 @@ const initializeEditor = (config) => {
         newsletterTypesWithActivation.includes(newsletter.type) &&
         newsletter.status === 'active'
       ) {
-        // Users can confirm deactivation before visiting the page
+        // Users can confirm before visiting the page
         let deactivationConfirmed =
           getUrlParam('deactivationConfirmed') === 'yes';
         if (!deactivationConfirmed) {

--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -95,7 +95,12 @@ const initializeEditor = (config) => {
         let pauseConfirmed = getUrlParam('pauseConfirmed') === 'yes';
         if (!pauseConfirmed) {
           // eslint-disable-next-line no-alert
-          pauseConfirmed = window.confirm(MailPoet.I18n.t('confirmEdit'));
+          pauseConfirmed = window.confirm(
+            __(
+              'Sending is in progress. Do you want to pause sending and edit the newsletter?',
+              'mailpoet',
+            ),
+          );
         }
         if (!pauseConfirmed) {
           window.location = `admin.php?page=mailpoet-newsletters#/${newsletter.type}`;
@@ -132,7 +137,10 @@ const initializeEditor = (config) => {
         if (!deactivationConfirmed) {
           // eslint-disable-next-line no-alert
           deactivationConfirmed = window.confirm(
-            MailPoet.I18n.t('confirmAutomaticNewsletterEdit'),
+            __(
+              'To edit this email, it needs to be deactivated. You can activate it again after you make the changes.',
+              'mailpoet',
+            ),
           );
         }
         if (!deactivationConfirmed) {

--- a/mailpoet/assets/js/src/newsletters/automatic_emails/listings.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic_emails/listings.jsx
@@ -350,6 +350,10 @@ class ListingsComponent extends Component {
           <a
             className="mailpoet-listing-title"
             href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}
+            onClick={(event) => {
+              event.preventDefault();
+              confirmEdit(newsletter);
+            }}
           >
             {newsletter.subject}
           </a>

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -334,6 +334,10 @@ class NewsletterListNotificationComponent extends Component {
           <a
             className="mailpoet-listing-title"
             href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}
+            onClick={(event) => {
+              event.preventDefault();
+              confirmEdit(newsletter);
+            }}
           >
             {newsletter.subject}
           </a>

--- a/mailpoet/assets/js/src/newsletters/listings/re_engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re_engagement.jsx
@@ -317,6 +317,10 @@ class NewsletterListReEngagementComponent extends Component {
           <a
             className="mailpoet-listing-title"
             href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}
+            onClick={(event) => {
+              event.preventDefault();
+              confirmEdit(newsletter);
+            }}
           >
             {newsletter.subject}
           </a>

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -108,22 +108,23 @@ const bulkActions = [
 ];
 
 const confirmEdit = (newsletter) => {
-  const redirectToEditing = () => {
-    window.location.href = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  };
+  const editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
+
   if (
     !newsletter.queue ||
     newsletter.status !== 'sending' ||
     newsletter.queue.status !== null
   ) {
-    redirectToEditing();
+    window.location.href = editorHref;
   } else {
     confirmAlert({
       message: __(
         'Sending is in progress. Do you want to pause sending and edit the newsletter?',
         'mailpoet',
       ),
-      onConfirm: redirectToEditing,
+      onConfirm: () => {
+        window.location.href = `${editorHref}&pauseConfirmed=yes`;
+      },
     });
   }
 };

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -100,9 +100,7 @@ export const newsletterTypesWithActivation = [
 ];
 
 export const confirmEdit = (newsletter) => {
-  const redirectToEditing = () => {
-    window.location.href = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  };
+  const editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
 
   if (
     newsletterTypesWithActivation.includes(newsletter.type) &&
@@ -113,9 +111,11 @@ export const confirmEdit = (newsletter) => {
         'To edit this email, it needs to be deactivated. You can activate it again after you make the changes.',
         'mailpoet',
       ),
-      onConfirm: redirectToEditing,
+      onConfirm: () => {
+        window.location.href = `${editorHref}&deactivationConfirmed=yes`;
+      },
     });
   } else {
-    redirectToEditing();
+    window.location.href = editorHref;
   }
 };

--- a/mailpoet/assets/js/src/newsletters/listings/welcome.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/welcome.jsx
@@ -374,6 +374,10 @@ class NewsletterListWelcomeComponent extends Component {
           <a
             className="mailpoet-listing-title"
             href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}
+            onClick={(event) => {
+              event.preventDefault();
+              confirmEdit(newsletter);
+            }}
           >
             {newsletter.subject}
           </a>

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -134,7 +134,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'senderEmailAddressWarning3': _x('Read more.'),
   'mailerSendingNotResumedUnauthorized': __('Failed to resume sending because the email address is unauthorized. Please authorize it and try again.'),
   'dismissNotice': __('Dismiss this notice.'),
-
+  'confirmAutomaticNewsletterEdit': __('To edit this email, it needs to be deactivated. You can activate it again after you make the changes.'),
   'subscribersLimitNoticeTitle': __('Congratulations, you now have more than [subscribersLimit] subscribers!'),
   'freeVersionLimit': __('Our free version is limited to [subscribersLimit] subscribers.'),
   'yourPlanLimit': __('Your plan is limited to [subscribersLimit] subscribers.'),

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -134,6 +134,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'senderEmailAddressWarning3': _x('Read more.'),
   'mailerSendingNotResumedUnauthorized': __('Failed to resume sending because the email address is unauthorized. Please authorize it and try again.'),
   'dismissNotice': __('Dismiss this notice.'),
+  'confirmEdit': __('Sending is in progress. Do you want to pause sending and edit the newsletter?'),
   'confirmAutomaticNewsletterEdit': __('To edit this email, it needs to be deactivated. You can activate it again after you make the changes.'),
   'subscribersLimitNoticeTitle': __('Congratulations, you now have more than [subscribersLimit] subscribers!'),
   'freeVersionLimit': __('Our free version is limited to [subscribersLimit] subscribers.'),


### PR DESCRIPTION
## Description

This PR aims to decrease the likelihood that users will accidentally deactivate an automated email without realizing it.

- The confirmation shown on the listing page is now triggered when clicking on the subject line of the email in addition to when a user clicks "Edit"
- There is a confirmation when entering the editor itself, which uses the same string as the confirmation modal. If the user hits cancel, they're returned to the listing page for the type of email they were trying to edit. This is useful for the following situations:
  - A user visits the editor from a bookmark
  - A user opens the editor in a new tab
  -  A user activates an inactive email using the toggle on the listing page and then clicks either the edit button or the subject line to enter the editor
- The notice stating that the email was deactivated now uses the warning style instead of success, and it does not dismiss itself automatically.   

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4397](https://mailpoet.atlassian.net/browse/MAILPOET-4397)

## After-merge notes

_N/A_


[MAILPOET-4397]: https://mailpoet.atlassian.net/browse/MAILPOET-4397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ