### PR TITLE
Add new k6 test Newsletter Statistics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,6 +476,15 @@ jobs:
       wordpress_image_version:
         type: string
         default: ''
+      url:
+        type: string
+        default: 'http://localhost:9500'
+      pw:
+        type: string
+        default: 'password'
+      scenario:
+        type: string
+        default: 'pullrequests'
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -498,7 +507,7 @@ jobs:
           name: Run performance tests
           command: |
             mkdir -p tests/performance/_output
-            ./do test:performance --url=https://qawp.net --scenario pullrequests
+            ./do test:performance --url=<< parameters.url >> --pw=<< parameters.pw >> --scenario=<< parameters.scenario >>
       - run:
           name: Check exceptions
           command: |
@@ -849,6 +858,9 @@ workflows:
       - performance_tests:
           <<: *slack-fail-post-step
           name: performance_latest
+          url: https://qawp.net
+          pw: $WP_TEST_PERFORMANCE_PW
+          scenario: nightlytests
           requires:
             - build
       - unit_tests:

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -300,7 +300,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->runTestsInContainer($opts);
   }
 
-  public function testPerformance($path = null, $opts = ['url' => null, 'head' => false, 'scenario' => null]) {
+  public function testPerformance($path = null, $opts = ['url' => null, 'pw' => null, 'head' => false, 'scenario' => null]) {
     // run WordPress setup
     $this->taskExec('COMPOSE_HTTP_TIMEOUT=200 docker-compose run --rm -it setup')
       ->dir(__DIR__ . '/tests/performance')
@@ -312,6 +312,7 @@ class RoboFile extends \Robo\Tasks {
       ->arg('run')
       ->option('env', 'K6_BROWSER_ENABLED=1')
       ->option('env', 'URL=' . $opts['url'])
+      ->option('env', 'PW=' . $opts['pw'])
       ->option('env', 'HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
       ->option('env', 'SCENARIO=' . $opts['scenario'])
       ->arg($path ?? "$dir/tests/performance/scenarios.js")

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
@@ -142,7 +142,11 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
             newsletter,
           )}
 
-          <Tab key="engagement" title={__('Subscriber Engagement', 'mailpoet')}>
+          <Tab
+            key="engagement"
+            title={__('Subscriber Engagement', 'mailpoet')}
+            automationId="engagement-tab"
+          >
             {Hooks.applyFilters(
               'mailpoet_newsletters_subscriber_engagement',
               <PremiumBanner />,

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -6,7 +6,7 @@ export const scenario = __ENV.SCENARIO; // eslint-disable-line
 export const timeoutSet = '2m';
 
 export const adminUsername = 'admin';
-export const adminPassword = 'password';
+export const adminPassword = __ENV.PW || 'password'; // eslint-disable-line
 export const adminEmail = 'test@test.com';
 
 export const firstName = 'John';

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -13,8 +13,6 @@ import { formsAdding } from './tests/forms-adding.js';
 import { newsletterSearching } from './tests/newsletter-searching.js';
 import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
-import { listsComplexSegment } from './tests/lists-complex-segment.js';
-import { newsletterStatistics } from './tests/newsletter-statistics.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -72,8 +70,6 @@ export async function pullRequests() {
   await newsletterSearching();
   await newsletterSending();
   await listsViewSubscribers();
-  await listsComplexSegment();
-  await newsletterStatistics();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -14,6 +14,7 @@ import { newsletterSearching } from './tests/newsletter-searching.js';
 import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
 import { listsComplexSegment } from './tests/lists-complex-segment.js';
+import { newsletterStatistics } from './tests/newsletter-statistics.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -72,6 +73,7 @@ export async function pullRequests() {
   await newsletterSending();
   await listsViewSubscribers();
   await listsComplexSegment();
+  await newsletterStatistics();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -13,6 +13,8 @@ import { formsAdding } from './tests/forms-adding.js';
 import { newsletterSearching } from './tests/newsletter-searching.js';
 import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
+import { listsComplexSegment } from './tests/lists-complex-segment.js';
+import { newsletterStatistics } from './tests/newsletter-statistics.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -59,7 +61,7 @@ if (scenario) {
   options.scenarios = scenarios;
 }
 
-// All the tests ran for pull requests
+// Run those tests against a pull request build
 export async function pullRequests() {
   await newsletterListing();
   await subscribersListing();
@@ -72,9 +74,19 @@ export async function pullRequests() {
   await listsViewSubscribers();
 }
 
-// All the tests ran for a nightly testing
+// Run those tests against trunk in a nightly build
 export async function nightly() {
-  // TBD
+  await newsletterListing();
+  await subscribersListing();
+  await settingsBasic();
+  await subscribersFiltering();
+  await subscribersAdding();
+  await formsAdding();
+  await newsletterSearching();
+  await newsletterSending();
+  await listsViewSubscribers();
+  await listsComplexSegment();
+  await newsletterStatistics();
 }
 
 // HTML report data saved in performance folder

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -13,6 +13,7 @@ import { formsAdding } from './tests/forms-adding.js';
 import { newsletterSearching } from './tests/newsletter-searching.js';
 import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
+import { listsComplexSegment } from './tests/lists-complex-segment.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -70,6 +71,7 @@ export async function pullRequests() {
   await newsletterSearching();
   await newsletterSending();
   await listsViewSubscribers();
+  await listsComplexSegment();
 }
 
 // All the tests ran for a nightly testing

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -1,0 +1,85 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep, check } from 'k6';
+import { chromium } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+} from '../config.js';
+import { authenticate, waitForSelectorToBeVisible } from '../utils/helpers.js';
+
+export async function newsletterStatistics() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  try {
+    // Go to the page
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+      waitUntil: 'networkidle',
+    });
+
+    // Log in to WP Admin
+    authenticate(page);
+
+    // Wait for async actions and open newsletter statistics
+    await page.waitForNavigation({ waitUntil: 'networkidle' });
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters#/stats/1`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    // Wait for the page to load and click sold tab
+    page.waitForSelector('.mailpoet-listing-table');
+    page.waitForSelector('[data-automation-id="products-sold-tab"]');
+    page.waitForLoadState('networkidle');
+    page.locator('[data-automation-id="products-sold-tab"]').click();
+    page.waitForLoadState('networkidle');
+    await waitForSelectorToBeVisible(
+      page,
+      '.mailpoet-tab-content > p:nth-child(1)',
+    );
+    check(page, {
+      'no products present as sold text is present':
+        page.locator('.mailpoet-tab-content > p:nth-child(1)').textContent() ===
+        'Unfortunately, no products were sold as a result of this email!',
+    });
+
+    // Click the subscribers engagement tab
+    page.locator('[data-automation-id="engagement-tab"]');
+    page.waitForSelector('.mailpoet-listing-table');
+    waitForSelectorToBeVisible(
+      page,
+      '[data-automation-id="filters_all_engaged"]',
+    );
+    page.waitForLoadState('networkidle');
+    check(page, {
+      'link clicked filter is visible': page
+        .locator('[data-automation-id="filters_all_engaged"]')
+        .isVisible(),
+    });
+  } finally {
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    page.close();
+    browser.close();
+  }
+}
+
+export default async function newsletterStatisticsTest() {
+  await newsletterStatistics();
+}

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -41,3 +41,8 @@ export function waitAndClick(page, elementName) {
   page.locator(elementName).click();
   page.waitForNavigation({ waitUntil: 'networkidle' });
 }
+
+// Wait for selector to be visible
+export async function waitForSelectorToBeVisible(page, element) {
+  await page.locator(element).waitFor({ state: 'visible' });
+}


### PR DESCRIPTION
## Description

Adding a new k6 test Newsletter Statistics
Added also new helper method `waitForSelectorToBeVisible`
Added new selector `data-automation-id="engagement-tab"`

## Code review notes

This test requires Premium plugin active, but since we don't have it in the free plugin, I would like to keep this test in the suite base and run it later against an online site with active Premium plugin and in nightly tests.

## Linked PRs

Wait for #4791 to be merged first

## Linked tickets

[MAILPOET-4954]

[MAILPOET-4954]: https://mailpoet.atlassian.net/browse/MAILPOET-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ