### PR TITLE
Sending gets stuck if after scheduling the susbcribers unsubscribe or get deleted [MAILPOET-5134]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -200,6 +200,17 @@ class SendingQueue {
 
     // get subscribers
     $subscriberBatches = new BatchIterator($queue->taskId, $this->getBatchSize());
+    if ($subscriberBatches->count() === 0) {
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
+        'no subscribers to process',
+        ['task_id' => $queue->taskId]
+      );
+      $task = $queue->getSendingQueueEntity()->getTask();
+      if ($task) {
+        $this->scheduledTasksRepository->invalidateTask($task);
+      }
+      return;
+    }
     /** @var int[] $subscribersToProcessIds - it's required for PHPStan */
     foreach ($subscriberBatches as $subscribersToProcessIds) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -309,6 +309,12 @@ class ScheduledTasksRepository extends Repository {
       ->getResult();
   }
 
+  public function invalidateTask(ScheduledTaskEntity $task): void {
+    $task->setStatus( ScheduledTaskEntity::STATUS_INVALID);
+    $this->persist($task);
+    $this->flush();
+  }
+
   protected function findByTypeAndStatus($type, $status, $limit = null, $future = false) {
     $queryBuilder = $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')


### PR DESCRIPTION
## Description

This PR invalidates scheduled tasks when in sending time determines they have no more subscriptions.

## QA notes

- Schedule a newsletter with one subscriber
- Unsubscribe the subscribers of the list selected in previous step
- (optional) Change the schedule time via in DB to reduce waiting
- Verify this task is not in `Running tasks` table under Help > System Status.


## Linked tickets

 [MAILPOET-5134]


[MAILPOET-5134]: https://mailpoet.atlassian.net/browse/MAILPOET-5134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ