### PR TITLE
Filter for license provisioning

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -283,6 +283,11 @@ class Services extends APIEndpoint {
     return $this->checkMSSKey(['key' => $key]);
   }
 
+  public function refreshPremiumKeyStatus() {
+    $key = $this->settings->get('premium.premium_key');
+    return $this->checkPremiumKey(['key' => $key]);
+  }
+
   private function isItemInArray($item, $array): bool {
     return in_array($item, $array, true);
   }

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -4,7 +4,9 @@ namespace MailPoet\API\JSON\v1;
 
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
+use MailPoet\API\JSON\ErrorResponse;
 use MailPoet\API\JSON\Response;
+use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\Workers\SubscribersEngagementScore;
@@ -492,5 +494,25 @@ class Settings extends APIEndpoint {
       'showNotice' => !!$draftReEngagementEmails,
       'action' => 'reactivate',
     ];
+  }
+
+  /**
+   * Prepares the settings to set up MSS with the given key and calls the set method.
+   *
+   * @param string $apiKey
+   * @return ErrorResponse|SuccessResponse
+   */
+  public function setupMSS(string $apiKey) {
+    $new_settings = [
+      'mta_group' => 'mailpoet',
+      'mta' => [
+        'method' => 'MailPoet',
+        'mailpoet_api_key' => $apiKey,
+      ],
+      'signup_confirmation' => [
+        'enabled' => '1',
+      ],
+    ];
+    return $this->set($new_settings);
   }
 }

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -13,6 +13,7 @@ use MailPoet\Cron\Workers\SubscribersEngagementScore;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Form\FormMessageController;
+use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
@@ -502,11 +503,11 @@ class Settings extends APIEndpoint {
    * @param string $apiKey
    * @return ErrorResponse|SuccessResponse
    */
-  public function setupMSS(string $apiKey) {
+  public function setKeyAndSetupMss(string $apiKey) {
     $new_settings = [
       'mta_group' => 'mailpoet',
       'mta' => [
-        'method' => 'MailPoet',
+        'method' => Mailer::METHOD_MAILPOET,
         'mailpoet_api_key' => $apiKey,
       ],
       'signup_confirmation' => [

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -512,6 +512,7 @@ class Settings extends APIEndpoint {
       'signup_confirmation' => [
         'enabled' => '1',
       ],
+      'premium.premium_key' => $apiKey,
     ];
     return $this->set($new_settings);
   }

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -13,6 +13,7 @@ use MailPoet\Subscription\Form;
 use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomLicenseProvisioner;
 
 class Hooks {
   /** @var Form */
@@ -54,6 +55,9 @@ class Hooks {
   /** @var SubscriberChangesNotifier */
   private $subscriberChangesNotifier;
 
+  /** @var DotcomLicenseProvisioner */
+  private $dotcomLicenseProvisioner;
+
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -67,7 +71,8 @@ class Hooks {
     HooksWooCommerce $hooksWooCommerce,
     SubscriberHandler $subscriberHandler,
     SubscriberChangesNotifier $subscriberChangesNotifier,
-    WP $wpSegment
+    WP $wpSegment,
+    DotcomLicenseProvisioner $dotcomLicenseProvisioner
   ) {
     $this->subscriptionForm = $subscriptionForm;
     $this->subscriptionComment = $subscriptionComment;
@@ -82,6 +87,7 @@ class Hooks {
     $this->subscriberHandler = $subscriberHandler;
     $this->hooksWooCommerce = $hooksWooCommerce;
     $this->subscriberChangesNotifier = $subscriberChangesNotifier;
+    $this->dotcomLicenseProvisioner = $dotcomLicenseProvisioner;
   }
 
   public function init() {
@@ -99,6 +105,7 @@ class Hooks {
     $this->setupFooter();
     $this->setupSettingsLinkInPluginPage();
     $this->setupChangeNotifications();
+    $this->setupLicenseProvisioning();
   }
 
   public function initEarlyHooks() {
@@ -473,6 +480,15 @@ class Hooks {
     $this->wp->addAction(
       'shutdown',
       [$this->subscriberChangesNotifier, 'notify']
+    );
+  }
+
+  public function setupLicenseProvisioning(): void {
+    $this->wp->addFilter(
+      'wpcom_marketplace_webhook_response_mailpoet-business',
+      [$this->dotcomLicenseProvisioner, 'provisionLicense'],
+      10,
+      3
     );
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -520,6 +520,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WP\Emoji::class)->setPublic(true);
     $container->autowire(\MailPoet\WP\Functions::class)->setPublic(true);
     $container->autowire(\MailPoet\WP\AutocompletePostListLoader::class)->setPublic(true);
+    // WordPress.com
+    $container->autowire(\MailPoet\WPCOM\DotcomLicenseProvisioner::class)->setPublic(true);
     // Third party classes
     $container->autowire(\MailPoetVendor\CSS::class)->setClass(\MailPoetVendor\CSS::class)->setPublic(true);
     $container->autowire(\MailPoetVendor\csstidy::class)->setClass(\MailPoetVendor\csstidy::class);

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -35,6 +35,7 @@ class LoggerFactory {
   const TOPIC_API = 'api';
   const TOPIC_TRACKING = 'tracking';
   const TOPIC_COUPONS = 'coupons';
+  const TOPIC_PROVISIONING = 'provisioning';
 
   /** @var LoggerFactory */
   private static $instance;

--- a/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
+++ b/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
@@ -38,7 +38,7 @@ class DotcomLicenseProvisioner {
    *
    * @return bool
    */
-  private function isAtomicPlatform(): bool {
+  public function isAtomicPlatform(): bool {
     return defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
   }
 
@@ -83,7 +83,7 @@ class DotcomLicenseProvisioner {
    * @param string $apiKey
    * @return true|WP_Error
    */
-  private function activateMSS(string $apiKey) {
+  public function activateMSS(string $apiKey) {
     $response = $this->settings->setupMSS($apiKey);
     if ($response instanceof ErrorResponse) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->error(

--- a/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
+++ b/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WPCOM;
+
+use MailPoet\API\JSON\ErrorResponse;
+use MailPoet\API\JSON\v1\Services;
+use MailPoet\API\JSON\v1\Settings;
+use MailPoet\Logging\LoggerFactory;
+use WP_Error;
+
+/**
+ * This class is responsible for receiving and activating the license purchased from WP.com Marketplace.
+ */
+class DotcomLicenseProvisioner {
+  const EVENT_TYPE_PROVISION_LICENSE = 'provision_license';
+
+  /** @var LoggerFactory */
+  private $loggerFactory;
+
+  /** @var Settings */
+  private $settings;
+
+  /** @var Services */
+  private $services;
+
+  public function __construct(
+    LoggerFactory $loggerFactory,
+    Settings $settings,
+    Services $services
+  ) {
+    $this->loggerFactory = $loggerFactory;
+    $this->settings = $settings;
+    $this->services = $services;
+  }
+
+  /**
+   * Returns true if in the context of WordPress.com Atomic platform.
+   *
+   * @return bool
+   */
+  private function isAtomicPlatform(): bool {
+    return defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
+  }
+
+  /**
+   * Activates MSS and adds API key for subscriptions purchased from WP.com Marketplace.
+   *
+   * @param bool $result
+   * @param array $licensePayload
+   * @param string $eventType
+   * @return bool|WP_Error
+   */
+  public function provisionLicense(bool $result, array $licensePayload, string $eventType) {
+    if (!$this->isAtomicPlatform() || $eventType !== self::EVENT_TYPE_PROVISION_LICENSE) {
+      return $result;
+    }
+
+    $apiKey = $this->getKeyFromPayload($licensePayload);
+    if (is_wp_error($apiKey)) {
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->error(
+        'key was not found in license payload');
+      return $apiKey;
+    }
+
+    return $this->activateMSS($apiKey);
+  }
+
+  /**
+   * Returns API key from license payload.
+   * @param array $licensePayload
+   * @return string|WP_Error
+   */
+  private function getKeyFromPayload(array $licensePayload) {
+    if (isset($licensePayload['apiKey']) && is_string($licensePayload['apiKey'])) {
+      return $licensePayload['apiKey'];
+    }
+
+    return new WP_Error('invalid_license_payload', 'Invalid license payload: Missing API key.');
+  }
+
+  /**
+   * Saves the API key and activates MSS.
+   * @param string $apiKey
+   * @return true|WP_Error
+   */
+  private function activateMSS(string $apiKey) {
+    $response = $this->settings->setupMSS($apiKey);
+    if ($response instanceof ErrorResponse) {
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->error(
+        'Setting sending method and key failed',
+        ['$response' => $response]
+      );
+      return new WP_Error('Provisioning failed setting the data', $this->concatMessages($response));
+    }
+
+    // This is necessary if the key changed but the sending method was already set to MailPoet
+    $response = $this->services->refreshMSSKeyStatus();
+    if ($response instanceof ErrorResponse) {
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->error(
+        'Refreshing the key failed',
+        ['$response' => $response]
+      );
+      return new WP_Error('Provisioning failed activating the data', $this->concatMessages($response));
+    }
+
+
+    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->info(
+      'License was provisioned'
+    );
+    return true;
+  }
+
+  private function concatMessages(ErrorResponse $response): string {
+    $data = $response->getData();
+    $result = '';
+
+    if (empty($data) || !isset($data['errors'])) {
+      return $result;
+    }
+
+    foreach ($data['errors'] as $error) {
+      $result .= $error['message'] . " ";
+    }
+    return $result;
+  }
+}

--- a/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
+++ b/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
@@ -39,6 +39,7 @@ class DotcomLicenseProvisioner {
    * @return bool
    */
   public function isAtomicPlatform(): bool {
+    // ATOMIC_CLIENT_ID === '2' corresponds to WordPress.com client on the Atomic platform
     return defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
   }
 
@@ -84,7 +85,7 @@ class DotcomLicenseProvisioner {
    * @return true|WP_Error
    */
   public function activateMSS(string $apiKey) {
-    $response = $this->settings->setupMSS($apiKey);
+    $response = $this->settings->setKeyAndSetupMss($apiKey);
     if ($response instanceof ErrorResponse) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->error(
         'Setting sending method and key failed',
@@ -109,7 +110,7 @@ class DotcomLicenseProvisioner {
         'Refreshing Premium key failed',
         ['$response' => $response]
       );
-      return new WP_Error('Provisioning failed activating the data', $this->concatMessages($response));
+      return new WP_Error('Provisioning failed to verify api key access for MSS/premium', $this->concatMessages($response));
     }
 
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->info(

--- a/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
+++ b/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
@@ -103,6 +103,14 @@ class DotcomLicenseProvisioner {
       return new WP_Error('Provisioning failed activating the data', $this->concatMessages($response));
     }
 
+    $response = $this->services->refreshPremiumKeyStatus();
+    if ($response instanceof ErrorResponse) {
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->error(
+        'Refreshing Premium key failed',
+        ['$response' => $response]
+      );
+      return new WP_Error('Provisioning failed activating the data', $this->concatMessages($response));
+    }
 
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_PROVISIONING)->info(
       'License was provisioned'

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -335,11 +335,12 @@ class SettingsTest extends \MailPoetTest {
       $this->diContainer->get(ConfirmationEmailCustomizer::class)
     );
 
-    expect($this->endpoint->setupMSS($newKey))->isInstanceOf(SuccessResponse::class);
+    expect($this->endpoint->setKeyAndSetupMss($newKey))->isInstanceOf(SuccessResponse::class);
     expect($this->settings->get('mta.mailpoet_api_key'))->equals($newKey);
     expect($this->settings->get('mta_group'))->equals('mailpoet');
     expect($this->settings->get('mta.method'))->equals('MailPoet');
     expect($this->settings->get('signup_confirmation.enabled'))->equals(1);
+    expect($this->settings->get('premium.premium_key'))->equals($newKey);
   }
 
   private function createNewsletter(string $type, string $status = NewsletterEntity::STATUS_DRAFT, $parent = null): NewsletterEntity {

--- a/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
+++ b/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
@@ -64,7 +64,7 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
       DotcomLicenseProvisioner::class,
       [
         $this->diContainer->get(LoggerFactory::class),
-        $this->make(Settings::class, ['setupMSS' => new ErrorResponse(['error' => 'some-error'])]),
+        $this->make(Settings::class, ['setKeyAndSetupMss' => new ErrorResponse(['error' => 'some-error'])]),
         $this->make(Services::class, ['refreshMSSKeyStatus' => new SuccessResponse()]),
       ],
       ['isAtomicPlatform' => true]);
@@ -81,7 +81,7 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
       DotcomLicenseProvisioner::class,
       [
         $this->diContainer->get(LoggerFactory::class),
-        $this->make(Settings::class, ['setupMSS' => new SuccessResponse()]),
+        $this->make(Settings::class, ['setKeyAndSetupMss' => new SuccessResponse()]),
         $this->make(Services::class, ['refreshMSSKeyStatus' => new ErrorResponse(['error' => 'some-error'])]),
       ],
       ['isAtomicPlatform' => true]);
@@ -98,7 +98,7 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
       DotcomLicenseProvisioner::class,
       [
         $this->diContainer->get(LoggerFactory::class),
-        $this->make(Settings::class, ['setupMSS' => new SuccessResponse()]),
+        $this->make(Settings::class, ['setKeyAndSetupMss' => new SuccessResponse()]),
         $this->make(Services::class,
           [
             'refreshMSSKeyStatus' => new SuccessResponse(),
@@ -119,7 +119,7 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
       DotcomLicenseProvisioner::class,
       [
         $this->diContainer->get(LoggerFactory::class),
-        $this->make(Settings::class, ['setupMSS' => new SuccessResponse()]),
+        $this->make(Settings::class, ['setKeyAndSetupMss' => new SuccessResponse()]),
         $this->make(Services::class,
           [
             'refreshMSSKeyStatus' => new SuccessResponse(),

--- a/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
+++ b/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WPCOM;
+
+use MailPoet\API\JSON\ErrorResponse;
+use MailPoet\API\JSON\SuccessResponse;
+use MailPoet\API\JSON\v1\Services;
+use MailPoet\API\JSON\v1\Settings;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Logging\LogRepository;
+use MailPoet\Settings\SettingsRepository;
+
+class DotcomLicenseProvisionerTest extends \MailPoetTest {
+  /** @var DotcomLicenseProvisioner */
+  private $provisioner;
+
+  public function _before() {
+    parent::_before();
+    $this->provisioner = $this->construct(
+      DotcomLicenseProvisioner::class,
+      [
+        $this->diContainer->get(LoggerFactory::class),
+        $this->make(Settings::class),
+        $this->make(Services::class),
+      ],
+      ['isAtomicPlatform' => true]);
+  }
+
+  public function testItReturnsResultIfNotAtomic() {
+    $result = false;
+    $payload = ['apiKey' => 'some-key'];
+    $provisioner = $this->construct(
+      DotcomLicenseProvisioner::class,
+      [
+        $this->make(LoggerFactory::class),
+        $this->make(Settings::class),
+        $this->make(Services::class),
+      ],
+      ['isAtomicPlatform' => false]);
+    expect($provisioner->provisionLicense($result, $payload, DotcomLicenseProvisioner::EVENT_TYPE_PROVISION_LICENSE))->equals($result);
+  }
+
+  public function testItReturnsResultIfWrongEvent() {
+    $result = false;
+    $payload = ['apiKey' => 'some-key'];
+    $eventType = 'wrong-event';
+    expect($this->provisioner->provisionLicense($result, $payload, $eventType))->equals($result);
+  }
+
+  public function testItReturnsWPErrorIfMissingKey() {
+    $result = false;
+    $payload = [];
+    $eventType = DotcomLicenseProvisioner::EVENT_TYPE_PROVISION_LICENSE;
+    $error = $this->provisioner->provisionLicense($result, $payload, $eventType);
+    $this->assertInstanceOf(\WP_Error::class, $error);
+    expect($error->get_error_message())->equals('Invalid license payload: Missing API key.');
+  }
+
+  public function testItReturnsWPErrorIfErrorOnSettingUpMSS() {
+    $result = false;
+    $payload = ['apiKey' => 'some-key'];
+    $eventType = DotcomLicenseProvisioner::EVENT_TYPE_PROVISION_LICENSE;
+    $provisioner = $this->construct(
+      DotcomLicenseProvisioner::class,
+      [
+        $this->diContainer->get(LoggerFactory::class),
+        $this->make(Settings::class, ['setupMSS' => new ErrorResponse(['error' => 'some-error'])]),
+        $this->make(Services::class, ['refreshMSSKeyStatus' => new SuccessResponse()]),
+      ],
+      ['isAtomicPlatform' => true]);
+    $error = $provisioner->provisionLicense($result, $payload, $eventType);
+    $this->assertInstanceOf(\WP_Error::class, $error);
+    expect($error->get_error_message())->equals('some-error ');
+  }
+
+  public function testItReturnsTrueIfCouldNotRefreshKey() {
+    $result = false;
+    $payload = ['apiKey' => 'some-key'];
+    $eventType = DotcomLicenseProvisioner::EVENT_TYPE_PROVISION_LICENSE;
+    $provisioner = $this->construct(
+      DotcomLicenseProvisioner::class,
+      [
+        $this->diContainer->get(LoggerFactory::class),
+        $this->make(Settings::class, ['setupMSS' => new SuccessResponse()]),
+        $this->make(Services::class, ['refreshMSSKeyStatus' => new ErrorResponse(['error' => 'some-error'])]),
+      ],
+      ['isAtomicPlatform' => true]);
+    $error = $provisioner->provisionLicense($result, $payload, $eventType);
+    $this->assertInstanceOf(\WP_Error::class, $error);
+    expect($error->get_error_message())->equals('some-error ');
+  }
+
+  public function testItReturnsTrueIfKeyProvidedMSSActivatedAndRefreshed() {
+    $result = false;
+    $payload = ['apiKey' => 'some-key'];
+    $eventType = DotcomLicenseProvisioner::EVENT_TYPE_PROVISION_LICENSE;
+    $provisioner = $this->construct(
+      DotcomLicenseProvisioner::class,
+      [
+        $this->diContainer->get(LoggerFactory::class),
+        $this->make(Settings::class, ['setupMSS' => new SuccessResponse()]),
+        $this->make(Services::class, ['refreshMSSKeyStatus' => new SuccessResponse()]),
+      ],
+      ['isAtomicPlatform' => true]);
+    $result = $provisioner->provisionLicense($result, $payload, $eventType);
+    expect($result)->equals(true);
+  }
+
+  public function _after() {
+    $this->diContainer->get(SettingsRepository::class)->truncate();
+    $this->diContainer->get(LogRepository::class)->truncate();
+  }
+}


### PR DESCRIPTION
This commit adds a filter that will provision the API key on WordPress.com

## Description

To test the filter you need:
- A site that can connect to the Bridge (not localhost) and that has wp-cli
- A valid API key for a production subscription that belongs to you
- MailPoet installed and active
- Better if you taste with a fresh site (or click on reinstall from scratch)
- To run the filter: you can unzip the file attached, insert a good key, place the file where you can access it with `wp-cli` 
- run:`wp eval-file runProvisioningFilter.php` (or copy paste line by line inside of `wp shell`)
- Check that MSS is set up, the key added and verified.
- With a bad key, missing key or missing payload it should return a WP_Error.
- If it can't activate set the settings or refresh the key it should return a WP_Error

[runProvisioningFilter.php.zip](https://github.com/mailpoet/mailpoet/files/11007330/runProvisioningFilter.php.zip)

## Code review notes

Please check carefully and verify that I haven't missed anything to activate the MSS and validate the key. 
It's been a while since I haven't worked in the plugin. Please nitpick :)

## QA notes

_N/A_

## Linked PRs

[MAILPOET-5131]

## Linked tickets

_N/A_

## After-merge notes

_N/A_


[MAILPOET-5131]: https://mailpoet.atlassian.net/browse/MAILPOET-5131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ