### PR TITLE
Remove MSS pitch if already active

### DIFF
--- a/mailpoet/assets/js/src/wizard/steps/pitch_mss_step/first_part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch_mss_step/first_part.tsx
@@ -1,9 +1,11 @@
+import { useEffect } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { external, Icon } from '@wordpress/icons';
 import { Heading } from 'common/typography/heading/heading';
 import { MailPoet } from 'mailpoet';
 import { Button, List } from 'common';
 import { OwnEmailServiceNote } from './own_email_service_note';
+import { useSelector } from '../../../settings/store/hooks';
 
 const mailpoetAccountUrl =
   'https://account.mailpoet.com/?ref=plugin-wizard&utm_source=plugin&utm_medium=onboarding&utm_campaign=purchase';
@@ -17,6 +19,13 @@ function openMailPoetShopAndGoToTheNextPart(event, history, step: string) {
 function MSSStepFirstPart(): JSX.Element {
   const history = useHistory();
   const { step } = useParams<{ step: string }>();
+  const state = useSelector('getKeyActivationState')();
+
+  useEffect(() => {
+    if (state.isKeyValid === true) {
+      history.push(`/steps/${step}/part/3`);
+    }
+  }, [state.isKeyValid, history, step]);
 
   return (
     <>

--- a/mailpoet/assets/js/src/wizard/steps/pitch_mss_step/first_part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch_mss_step/first_part.tsx
@@ -23,7 +23,7 @@ function MSSStepFirstPart(): JSX.Element {
 
   useEffect(() => {
     if (state.isKeyValid === true) {
-      history.push(`/steps/${step}/part/3`);
+      history.replace(`/steps/${step}/part/3`);
     }
   }, [state.isKeyValid, history, step]);
 


### PR DESCRIPTION
## Description

This is a small change that extends what was done [here](https://github.com/mailpoet/mailpoet/commit/dd2f100acd3d8920106263c332fd80e875d82a7a) and skips also the MSS pitch on the onboarding wizard if the key is already set up.


## Code review notes

_N/A_

## QA notes
- Start on a fresh site
- Complete all the steps of the onboarding except for clicking on 'Start using MailPoet' (You need to add the MSS key).
- Start the wizard again by clicking on MailPoet menu
- Complete the steps (sender and cookies/tracking consent)
- Check that you don't see the step to connect your MailPoet account or to add the key
- Check you are taken to the last step to start using MailPoet

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5140]

## After-merge notes

_N/A_


[MAILPOET-5140]: https://mailpoet.atlassian.net/browse/MAILPOET-5140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ