### PR TITLE
Update TypeScript to version 5 [MAILPOET-5015]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/form-token-field/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/form-token-field/index.tsx
@@ -26,9 +26,6 @@ export function FormTokenField({
 }: FormTokenFieldProps): JSX.Element {
   return (
     <WpFormTokenField
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      // The following error seems to be a mismatch. It claims the 'label' prop does not exist, but it does.
       label={label}
       value={value.map((item) => item.name)}
       suggestions={suggestions.map((item) => item.name)}

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -50,9 +50,6 @@ function ActivateButton({ label }): JSX.Element {
   if (isDeactivating) {
     return (
       <Tooltip
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // The following error seems to be a mismatch. It claims the 'delay' prop does not exist, but it does.
         delay={0}
         text={__(
           'Editing an active automation is temporarily unavailable. We are working on introducing this functionality.',
@@ -90,9 +87,6 @@ function UpdateButton(): JSX.Element {
   }
   return (
     <Tooltip
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      // The following error seems to be a mismatch. It claims the 'delay' prop does not exist, but it does.
       delay={0}
       text={__(
         'Editing an active automation is temporarily unavailable. We are working on introducing this functionality.',

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
@@ -5,7 +5,7 @@ import { MoreControlType, StepMoreControlsType } from '../../../types/filters';
 import { Step } from '../../../editor/components/automation/types';
 
 const emailStatisticsControl = (step: Step): MoreControlType => {
-  const hasEmail = step.args?.email_id > 0;
+  const hasEmail = (step.args?.email_id as number) > 0;
   return {
     key: 'statistics',
     control: {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
@@ -15,7 +15,7 @@ const emailStatisticsControl = (step: Step): MoreControlType => {
       onClick: () => {
         window.open(
           `admin.php?page=mailpoet-newsletters#/stats/${
-            step.args.email_id as string
+            step.args.email_id as number
           }`,
           '_blank',
         );

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/step-controls/index.tsx
@@ -5,7 +5,7 @@ import { MoreControlType, StepMoreControlsType } from '../../../types/filters';
 import { Step } from '../../../editor/components/automation/types';
 
 const emailStatisticsControl = (step: Step): MoreControlType => {
-  const hasEmail = (step.args?.email_id as number) > 0;
+  const hasEmail = Number.isInteger(step.args?.email_id);
   return {
     key: 'statistics',
     control: {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role_panel.tsx
@@ -48,9 +48,6 @@ export function RolePanel(): JSX.Element {
       <PlainBodyTitle title={__('Trigger settings', 'mailpoet')} />
       <SettingsInfoText />
       <FormTokenField
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // The following error seems to be a mismatch. It claims the 'label' prop does not exist, but it does.
         label={__('When WordPress user role is:', 'mailpoet')}
         value={selected}
         suggestions={userRoles}

--- a/mailpoet/assets/js/src/common/categories/categories_item.tsx
+++ b/mailpoet/assets/js/src/common/categories/categories_item.tsx
@@ -36,7 +36,7 @@ export function CategoriesItem({
       <span className="mailpoet-categories-title" data-title={label}>
         {label}
       </span>
-      {count > 0 && (
+      {Number(count) > 0 && (
         <span className="mailpoet-categories-count">
           {parseInt(count.toString(), 10).toLocaleString()}
         </span>

--- a/mailpoet/assets/js/src/common/error_boundary/with_boundary.tsx
+++ b/mailpoet/assets/js/src/common/error_boundary/with_boundary.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, JSXElementConstructor } from 'react';
 import { ErrorBoundary, ErrorBoundaryProps } from './error_boundary';
 
-export const withBoundary = <P extends Record<string, unknown> | unknown>(
+export const withBoundary = <P extends Record<string, unknown> | object>(
   Bound: JSXElementConstructor<P>,
   props?: ErrorBoundaryProps,
 ): ComponentType<P> =>

--- a/mailpoet/assets/js/src/types/index.ts
+++ b/mailpoet/assets/js/src/types/index.ts
@@ -65,6 +65,14 @@ declare module '@wordpress/components' {
     export interface Props extends FormTokenFieldProps {}
   }
 
+  // Property "delay" is missing in Tooltip props
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace Tooltip {
+    export interface Props {
+      delay?: number;
+    }
+  }
+
   export const __experimentalText: any;
   export const __unstableComposite: typeof Composite;
   export const __unstableCompositeGroup: typeof CompositeGroup;

--- a/mailpoet/assets/js/src/webpack_admin_index.tsx
+++ b/mailpoet/assets/js/src/webpack_admin_index.tsx
@@ -4,19 +4,19 @@
 // This is to avoid undefined import order & messy WebPack config.
 // Code can be gradually refactored to avoid side effects completely.
 
-import 'homepage/homepage.tsx'; // side effect - renders ReactDOM to document
+import 'homepage/homepage'; // side effect - renders ReactDOM to document
 import 'subscribers/subscribers.jsx'; // side effect - renders ReactDOM to document
 import 'newsletters/newsletters.jsx'; // side effect - renders ReactDOM to window
 import 'segments/segments.jsx'; // side effect - renders ReactDOM to document
 import 'forms/forms.jsx'; // side effect - renders ReactDOM to document
 import 'help/help.jsx'; // side effect - renders ReactDOM to document
 import 'subscribers/importExport/import.jsx'; // side effect - executes on doc ready, adds events
-import 'subscribers/importExport/export.ts'; // side effect - executes on doc ready
-import 'wizard/wizard.tsx'; // side effect - renders ReactDOM to document
+import 'subscribers/importExport/export'; // side effect - executes on doc ready
+import 'wizard/wizard'; // side effect - renders ReactDOM to document
 import 'experimental_features/experimental_features.jsx'; // side effect - renders ReactDOM to document
 import 'logs/logs'; // side effect - renders ReactDOM to document
-import 'sending-paused-notices-fix-button.tsx'; // side effect - renders ReactDOM to document
-import 'sending-paused-notices-resume-button.ts'; // side effect - executes on doc ready, adds events
-import 'sending-paused-notices-authorize-email.tsx'; // side effect - renders ReactDOM to document
+import 'sending-paused-notices-fix-button'; // side effect - renders ReactDOM to document
+import 'sending-paused-notices-resume-button'; // side effect - executes on doc ready, adds events
+import 'sending-paused-notices-authorize-email'; // side effect - renders ReactDOM to document
 import 'landingpage/landingpage'; // side effect - renders ReactDOM to document
-import 'wizard/track_wizard_loaded_via_woocommerce.tsx';
+import 'wizard/track_wizard_loaded_via_woocommerce';

--- a/mailpoet/tests/javascript/form_editor/store/mocks/partialMocks.ts
+++ b/mailpoet/tests/javascript/form_editor/store/mocks/partialMocks.ts
@@ -11,7 +11,7 @@ export const createStateMock = (data: Partial<State>): State => data as State;
 export const createBlockMock = (
   data: Partial<BlockInstance>,
 ): BlockInstance => {
-  if (!data.innerBlocks || data.innerBlocks === []) {
+  if (!data.innerBlocks || data.innerBlocks.length === 0) {
     return data as BlockInstance;
   }
   const innerBlocks = data.innerBlocks.map((block) => createBlockMock(block));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@wordpress/scripts": "^25.5.1",
     "lint-staged": "^12.3.7",
     "prettier": "2.6.2",
-    "typescript": "^4.6.3"
+    "typescript": "^5.0.2"
   },
   "packageManager": "pnpm@7.27.0",
   "volta": {
@@ -29,7 +29,8 @@
       "react": "18.2.0",
       "react-dom": "18.2.0",
       "@types/react": "18.0.28",
-      "@types/react-dom": "18.0.11"
+      "@types/react-dom": "18.0.11",
+      "typescript": "$typescript"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,17 +5,18 @@ overrides:
   react-dom: 18.2.0
   '@types/react': 18.0.28
   '@types/react-dom': 18.0.11
+  typescript: ^5.0.2
 
 patchedDependencies:
-  '@woocommerce/components@10.0.0':
-    hash: prtmohnt73dk73q3vnzuiaioji
-    path: patches/@woocommerce__components@10.0.0.patch
-  backbone.supermodel@1.2.0:
-    hash: hhsvgimsfhfs4itf7ipk47fane
-    path: patches/backbone.supermodel@1.2.0.patch
   spectrum-colorpicker@1.8.1:
     hash: km5kmldrym63lx54pzrt7a3qq4
     path: patches/spectrum-colorpicker@1.8.1.patch
+  backbone.supermodel@1.2.0:
+    hash: hhsvgimsfhfs4itf7ipk47fane
+    path: patches/backbone.supermodel@1.2.0.patch
+  '@woocommerce/components@10.0.0':
+    hash: prtmohnt73dk73q3vnzuiaioji
+    path: patches/@woocommerce__components@10.0.0.patch
   parsleyjs@2.9.2:
     hash: omwuxp36airmeyyvhh2whskxvm
     path: patches/parsleyjs@2.9.2.patch
@@ -27,12 +28,12 @@ importers:
       '@wordpress/scripts': ^25.5.1
       lint-staged: ^12.3.7
       prettier: 2.6.2
-      typescript: ^4.6.3
+      typescript: ^5.0.2
     devDependencies:
-      '@wordpress/scripts': 25.5.1_typescript@4.6.3
+      '@wordpress/scripts': 25.5.1_typescript@5.0.2
       lint-staged: 12.3.7
       prettier: 2.6.2
-      typescript: 4.6.3
+      typescript: 5.0.2
 
   mailpoet:
     specifiers:
@@ -296,9 +297,9 @@ importers:
       '@storybook/addon-links': 6.4.19_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-storysource': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
       '@storybook/addons': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
-      '@storybook/manager-webpack5': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
-      '@storybook/react': 6.4.19_54jadd67wjss4dfciknlxwitkq
+      '@storybook/builder-webpack5': 6.4.19_twhz3rgxmaplephi66dld6ypzq
+      '@storybook/manager-webpack5': 6.4.19_twhz3rgxmaplephi66dld6ypzq
+      '@storybook/react': 6.4.19_5kah2t7sgnkntpxitbzmff476y
       '@types/grecaptcha': 3.0.4
       '@types/history': 4.7.11
       '@types/jquery': 3.5.14
@@ -335,7 +336,7 @@ importers:
       cross-env: 7.0.3
       exports-loader: 3.1.0_webpack@5.74.0
       expose-loader: 3.1.0_webpack@5.74.0
-      fork-ts-checker-webpack-plugin: 7.2.1_xjnbks7tshgiwpviuok4cpy6s4
+      fork-ts-checker-webpack-plugin: 7.2.1_volkrzkp4rd5jtlgqecukc4zl4
       grunt-cli: 1.4.3
       husky: 7.0.4
       imports-loader: 3.1.1_webpack@5.74.0
@@ -358,7 +359,7 @@ importers:
       stylelint-order: 5.0.0_stylelint@14.9.1
       stylelint-scss: 4.2.0_stylelint@14.9.1
       terser-webpack-plugin: 5.3.1_webpack@5.74.0
-      ts-loader: 9.2.8_xjnbks7tshgiwpviuok4cpy6s4
+      ts-loader: 9.2.8_volkrzkp4rd5jtlgqecukc4zl4
       url: 0.11.0
       webpack: 5.74.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_webpack@5.74.0
@@ -375,7 +376,7 @@ importers:
     devDependencies:
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
-      fork-ts-checker-webpack-plugin: 7.2.1_typescript@4.6.3
+      fork-ts-checker-webpack-plugin: 7.2.1_typescript@5.0.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
@@ -396,8 +397,8 @@ importers:
       eslint-plugin-react-hooks: ^4.3.0
     devDependencies:
       '@babel/eslint-parser': 7.17.0_eslint@8.9.0
-      '@typescript-eslint/eslint-plugin': 5.12.0_446ivzuj5bvqx4dxcjarndtt54
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/eslint-plugin': 5.12.0_2s6vkmrwcj3xjopjo467tfqwhi
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       eslint: 8.9.0
       eslint-config-airbnb: 19.0.4_zxwye2lau2r5do5c44wxpwjray
       eslint-config-airbnb-typescript: 16.1.2_7gymjgxtcadsxppomu2tie7wr4
@@ -6011,7 +6012,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.4.19_5k73t4ydwjqulcs6yp7u762boa:
+  /@storybook/builder-webpack4/6.4.19_twhz3rgxmaplephi66dld6ypzq:
     resolution: {integrity: sha512-wxA6SMH11duc9D53aeVVBwrVRemFIoxHp/dOugkkg6ZZFAb4ZmWzf/ENc3vQIZdZpfNRi7IZIZEOfoHc994cmw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6049,7 +6050,7 @@ packages:
       '@storybook/client-api': 6.4.19_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.4.19
       '@storybook/components': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
-      '@storybook/core-common': 6.4.19_vvglyd4lzd44cy3asg6vy4rqji
+      '@storybook/core-common': 6.4.19_cde4yvu2dh6hq757j347ezydfq
       '@storybook/core-events': 6.4.19
       '@storybook/node-logger': 6.4.19
       '@storybook/preview-web': 6.4.19_biqbaboplfbrettd7655fr4n2y
@@ -6069,12 +6070,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_nsxf7ncibhkvddkocuxjl34lwu
+      fork-ts-checker-webpack-plugin: 4.1.6_ikqt5m4x57vlca6bzw57fnhhpq
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.6.3
+      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -6085,7 +6086,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
@@ -6103,7 +6104,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/builder-webpack5/6.4.19_5k73t4ydwjqulcs6yp7u762boa:
+  /@storybook/builder-webpack5/6.4.19_twhz3rgxmaplephi66dld6ypzq:
     resolution: {integrity: sha512-AWM4YMN1gPaf7jfntqZTCGpIQ1tF6YRU1JtczPG4ox28rTaO6NMfOBi9aRhBre/59pPOh9bF6u2gu/MIHmRW+w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6140,7 +6141,7 @@ packages:
       '@storybook/client-api': 6.4.19_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.4.19
       '@storybook/components': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
-      '@storybook/core-common': 6.4.19_vvglyd4lzd44cy3asg6vy4rqji
+      '@storybook/core-common': 6.4.19_cde4yvu2dh6hq757j347ezydfq
       '@storybook/core-events': 6.4.19
       '@storybook/node-logger': 6.4.19
       '@storybook/preview-web': 6.4.19_biqbaboplfbrettd7655fr4n2y
@@ -6155,7 +6156,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.21.1
       css-loader: 5.2.7_webpack@5.74.0
-      fork-ts-checker-webpack-plugin: 6.5.0_xjnbks7tshgiwpviuok4cpy6s4
+      fork-ts-checker-webpack-plugin: 6.5.0_volkrzkp4rd5jtlgqecukc4zl4
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       html-webpack-plugin: 5.3.2_webpack@5.74.0
@@ -6167,7 +6168,7 @@ packages:
       style-loader: 2.0.0_webpack@5.74.0
       terser-webpack-plugin: 5.3.1_webpack@5.74.0
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 5.74.0_webpack-cli@4.9.2
       webpack-dev-middleware: 4.3.0_webpack@5.74.0
@@ -6288,7 +6289,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-client/6.4.19_4izzhvmerl7xvkvv5o77yw5afy:
+  /@storybook/core-client/6.4.19_dcyyrkt7nhril45btslnde2jma:
     resolution: {integrity: sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6319,46 +6320,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       regenerator-runtime: 0.13.7
       ts-dedent: 2.2.0
-      typescript: 4.6.3
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-      webpack: 5.74.0_webpack-cli@4.9.2
-    transitivePeerDependencies:
-      - '@types/react'
-    dev: true
-
-  /@storybook/core-client/6.4.19_tytm5unem5wnt4gfntznvxrwy4:
-    resolution: {integrity: sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/channel-postmessage': 6.4.19
-      '@storybook/channel-websocket': 6.4.19
-      '@storybook/client-api': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.4.19
-      '@storybook/core-events': 6.4.19
-      '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/preview-web': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/store': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.21.1
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.10.3
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.7
-      ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
@@ -6366,7 +6328,46 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-common/6.4.19_vvglyd4lzd44cy3asg6vy4rqji:
+  /@storybook/core-client/6.4.19_prea2oy5vwbtqkrduobvlvntey:
+    resolution: {integrity: sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.4.19_biqbaboplfbrettd7655fr4n2y
+      '@storybook/channel-postmessage': 6.4.19
+      '@storybook/channel-websocket': 6.4.19
+      '@storybook/client-api': 6.4.19_biqbaboplfbrettd7655fr4n2y
+      '@storybook/client-logger': 6.4.19
+      '@storybook/core-events': 6.4.19
+      '@storybook/csf': 0.0.2--canary.87bc651.0
+      '@storybook/preview-web': 6.4.19_biqbaboplfbrettd7655fr4n2y
+      '@storybook/store': 6.4.19_biqbaboplfbrettd7655fr4n2y
+      '@storybook/ui': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.21.1
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.10.3
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      regenerator-runtime: 0.13.7
+      ts-dedent: 2.2.0
+      typescript: 5.0.2
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+      webpack: 5.74.0_webpack-cli@4.9.2
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: true
+
+  /@storybook/core-common/6.4.19_cde4yvu2dh6hq757j347ezydfq:
     resolution: {integrity: sha512-X1pJJkO48DFxl6iyEemIKqRkJ7j9/cBh3BRBUr+xZHXBvnD0GKDXIocwh0PjSxSC6XSu3UCQnqtKi3PbjRl8Dg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6409,7 +6410,7 @@ packages:
       express: 4.17.1
       file-system-cache: 1.0.5
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.0_nsxf7ncibhkvddkocuxjl34lwu
+      fork-ts-checker-webpack-plugin: 6.5.0_ikqt5m4x57vlca6bzw57fnhhpq
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -6425,7 +6426,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
     transitivePeerDependencies:
@@ -6442,7 +6443,7 @@ packages:
       core-js: 3.21.1
     dev: true
 
-  /@storybook/core-server/6.4.19_alrpmqodswfra2bqgsy5yc53lq:
+  /@storybook/core-server/6.4.19_ukhnx2fmggjwzt4jo74y6pv52e:
     resolution: {integrity: sha512-bKsUB9f7hl5ya2JXxpIrErmbDQjoH39FVbzYZWjMo4t/b7+Xyi6vYadwyWcqlpUQmis09ZaSMv8L/Tw0TuwLAA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.19
@@ -6459,15 +6460,15 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.3
-      '@storybook/builder-webpack4': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
-      '@storybook/builder-webpack5': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
-      '@storybook/core-client': 6.4.19_tytm5unem5wnt4gfntznvxrwy4
-      '@storybook/core-common': 6.4.19_vvglyd4lzd44cy3asg6vy4rqji
+      '@storybook/builder-webpack4': 6.4.19_twhz3rgxmaplephi66dld6ypzq
+      '@storybook/builder-webpack5': 6.4.19_twhz3rgxmaplephi66dld6ypzq
+      '@storybook/core-client': 6.4.19_dcyyrkt7nhril45btslnde2jma
+      '@storybook/core-common': 6.4.19_cde4yvu2dh6hq757j347ezydfq
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.19
-      '@storybook/manager-webpack4': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
-      '@storybook/manager-webpack5': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
+      '@storybook/manager-webpack4': 6.4.19_twhz3rgxmaplephi66dld6ypzq
+      '@storybook/manager-webpack5': 6.4.19_twhz3rgxmaplephi66dld6ypzq
       '@storybook/node-logger': 6.4.19
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.19_biqbaboplfbrettd7655fr4n2y
@@ -6500,7 +6501,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.46.0_webpack-cli@4.9.2
@@ -6518,7 +6519,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.4.19_blps5h5ybqhyujwvt32ds3r6sa:
+  /@storybook/core/6.4.19_ctp7biftlqn6elt73ljtnlw2fa:
     resolution: {integrity: sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.19
@@ -6532,12 +6533,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.4.19_5k73t4ydwjqulcs6yp7u762boa
-      '@storybook/core-client': 6.4.19_tytm5unem5wnt4gfntznvxrwy4
-      '@storybook/core-server': 6.4.19_alrpmqodswfra2bqgsy5yc53lq
+      '@storybook/builder-webpack5': 6.4.19_twhz3rgxmaplephi66dld6ypzq
+      '@storybook/core-client': 6.4.19_dcyyrkt7nhril45btslnde2jma
+      '@storybook/core-server': 6.4.19_ukhnx2fmggjwzt4jo74y6pv52e
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
@@ -6583,7 +6584,7 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/manager-webpack4/6.4.19_5k73t4ydwjqulcs6yp7u762boa:
+  /@storybook/manager-webpack4/6.4.19_twhz3rgxmaplephi66dld6ypzq:
     resolution: {integrity: sha512-R8ugZjTYqXvlc6gDOcw909L65sIleOmIJLZR+N6/H85MivGXHu39jOwONqB7tVACufRty4FNecn8tEiQL2SAKA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6597,8 +6598,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.9
       '@babel/preset-react': 7.18.6_@babel+core@7.18.9
       '@storybook/addons': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.4.19_tytm5unem5wnt4gfntznvxrwy4
-      '@storybook/core-common': 6.4.19_vvglyd4lzd44cy3asg6vy4rqji
+      '@storybook/core-client': 6.4.19_dcyyrkt7nhril45btslnde2jma
+      '@storybook/core-common': 6.4.19_cde4yvu2dh6hq757j347ezydfq
       '@storybook/node-logger': 6.4.19
       '@storybook/theming': 6.4.19_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
@@ -6616,7 +6617,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.6.3
+      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       read-pkg-up: 7.0.1
@@ -6626,7 +6627,7 @@ packages:
       telejson: 5.3.3
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
@@ -6643,7 +6644,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack5/6.4.19_5k73t4ydwjqulcs6yp7u762boa:
+  /@storybook/manager-webpack5/6.4.19_twhz3rgxmaplephi66dld6ypzq:
     resolution: {integrity: sha512-hVjWhWAOgWaymBy0HeRskN+MfKLpqLP4Txfw+3Xqg1qplgexV0w2O4BQrS/SNEH4V/1qF9h8XTsk3L3oQIj3Mg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6657,8 +6658,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
       '@babel/preset-react': 7.16.7_@babel+core@7.17.8
       '@storybook/addons': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.4.19_4izzhvmerl7xvkvv5o77yw5afy
-      '@storybook/core-common': 6.4.19_vvglyd4lzd44cy3asg6vy4rqji
+      '@storybook/core-client': 6.4.19_prea2oy5vwbtqkrduobvlvntey
+      '@storybook/core-common': 6.4.19_cde4yvu2dh6hq757j347ezydfq
       '@storybook/node-logger': 6.4.19
       '@storybook/theming': 6.4.19_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.4.19_zula6vjvt3wdocc4mwcxqa6nzi
@@ -6684,7 +6685,7 @@ packages:
       telejson: 5.3.3
       terser-webpack-plugin: 5.3.1_webpack@5.74.0
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 5.74.0_webpack-cli@4.9.2
       webpack-dev-middleware: 4.3.0_webpack@5.74.0
@@ -6738,7 +6739,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.253f8c1.0_nsxf7ncibhkvddkocuxjl34lwu:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.253f8c1.0_ikqt5m4x57vlca6bzw57fnhhpq:
     resolution: {integrity: sha512-mmoRG/rNzAiTbh+vGP8d57dfcR2aP+5/Ll03KKFyfy5FqWFm/Gh7u27ikx1I3LmVMI8n6jh5SdWMkMKon7/tDw==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -6749,15 +6750,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.1.0_typescript@4.6.3
+      react-docgen-typescript: 2.1.0_typescript@5.0.2
       tslib: 2.3.1
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.4.19_54jadd67wjss4dfciknlxwitkq:
+  /@storybook/react/6.4.19_5kah2t7sgnkntpxitbzmff476y:
     resolution: {integrity: sha512-5b3i8jkVrjQGmcxxxXwCduHPIh+cluWkfeweKeQOe+lW4BR8fuUICo3AMLrYPAtB/UcaJyYkIYmTvF2mkfepFA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -6777,11 +6778,11 @@ packages:
       '@babel/preset-react': 7.16.7_@babel+core@7.17.8
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4_a3gyllrqvxpec3fpybsrposvju
       '@storybook/addons': 6.4.19_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core': 6.4.19_blps5h5ybqhyujwvt32ds3r6sa
-      '@storybook/core-common': 6.4.19_vvglyd4lzd44cy3asg6vy4rqji
+      '@storybook/core': 6.4.19_ctp7biftlqn6elt73ljtnlw2fa
+      '@storybook/core-common': 6.4.19_cde4yvu2dh6hq757j347ezydfq
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.19
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0_nsxf7ncibhkvddkocuxjl34lwu
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0_ikqt5m4x57vlca6bzw57fnhhpq
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.19_biqbaboplfbrettd7655fr4n2y
       '@types/webpack-env': 1.16.2
@@ -6798,7 +6799,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.7
       ts-dedent: 2.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -7732,7 +7733,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.12.0_446ivzuj5bvqx4dxcjarndtt54:
+  /@typescript-eslint/eslint-plugin/5.12.0_2s6vkmrwcj3xjopjo467tfqwhi:
     resolution: {integrity: sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7743,23 +7744,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       '@typescript-eslint/scope-manager': 5.12.0
-      '@typescript-eslint/type-utils': 5.12.0_cp5evksq3ntdn5fsp5euezguey
-      '@typescript-eslint/utils': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/type-utils': 5.12.0_l4rz7ussvdrlh7evejee5now5a
+      '@typescript-eslint/utils': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       debug: 4.3.4
       eslint: 8.9.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.12.0_cp5evksq3ntdn5fsp5euezguey:
+  /@typescript-eslint/parser/5.12.0_l4rz7ussvdrlh7evejee5now5a:
     resolution: {integrity: sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7771,10 +7772,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.12.0
       '@typescript-eslint/types': 5.12.0
-      '@typescript-eslint/typescript-estree': 5.12.0_typescript@4.6.3
+      '@typescript-eslint/typescript-estree': 5.12.0_typescript@5.0.2
       debug: 4.3.4
       eslint: 8.9.0
-      typescript: 4.6.3
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7787,7 +7788,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.12.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.12.0_cp5evksq3ntdn5fsp5euezguey:
+  /@typescript-eslint/type-utils/5.12.0_l4rz7ussvdrlh7evejee5now5a:
     resolution: {integrity: sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7797,11 +7798,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/utils': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       debug: 4.3.4
       eslint: 8.9.0
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7811,7 +7812,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.12.0_typescript@4.6.3:
+  /@typescript-eslint/typescript-estree/5.12.0_typescript@5.0.2:
     resolution: {integrity: sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7826,13 +7827,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.12.0_cp5evksq3ntdn5fsp5euezguey:
+  /@typescript-eslint/utils/5.12.0_l4rz7ussvdrlh7evejee5now5a:
     resolution: {integrity: sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7841,7 +7842,7 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.12.0
       '@typescript-eslint/types': 5.12.0
-      '@typescript-eslint/typescript-estree': 5.12.0_typescript@4.6.3
+      '@typescript-eslint/typescript-estree': 5.12.0_typescript@5.0.2
       eslint: 8.9.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.9.0
@@ -9057,7 +9058,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
 
-  /@wordpress/eslint-plugin/14.1.0_tna3sd4mxt6szqk2dcspkvuicq:
+  /@wordpress/eslint-plugin/14.1.0_resmp3scu6xyvoobsgansdmgmq:
     resolution: {integrity: sha512-9RLpGuYNWPrSq+56bJ95KTCSJF8FBhCtbQRcAys36NOIKY9yE3q5YlqEjTPme8HNEXphLJcHKutNTDSThbTitQ==}
     engines: {node: '>=14', npm: '>=6.14.4'}
     peerDependencies:
@@ -9073,15 +9074,15 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@babel/eslint-parser': 7.17.0_4q54xt7k7airumpn3hnvxfsifa
-      '@typescript-eslint/eslint-plugin': 5.12.0_446ivzuj5bvqx4dxcjarndtt54
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/eslint-plugin': 5.12.0_2s6vkmrwcj3xjopjo467tfqwhi
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       '@wordpress/babel-preset-default': 7.12.0
       '@wordpress/prettier-config': 2.11.0_wp-prettier@2.6.2
       cosmiconfig: 7.0.1
       eslint: 8.9.0
       eslint-config-prettier: 8.5.0_eslint@8.9.0
       eslint-plugin-import: 2.25.4_ejxzxsyv2dsrkmg64kmojwaw7u
-      eslint-plugin-jest: 27.2.1_47tlwguymqrkbwficbpl25yaci
+      eslint-plugin-jest: 27.2.1_juyd2qgd7chtaaebw66clytpim
       eslint-plugin-jsdoc: 39.9.1_eslint@8.9.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.9.0
       eslint-plugin-prettier: 3.4.1_l7bzc2ruwlcmq4k5vb5czm47wu
@@ -9090,7 +9091,7 @@ packages:
       globals: 13.16.0
       prettier: /wp-prettier/2.6.2
       requireindex: 1.2.0
-      typescript: 4.6.3
+      typescript: 5.0.2
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9479,7 +9480,7 @@ packages:
       rememo: 4.0.2
     dev: false
 
-  /@wordpress/scripts/25.5.1_typescript@4.6.3:
+  /@wordpress/scripts/25.5.1_typescript@5.0.2:
     resolution: {integrity: sha512-tQiOokRzjZnBE5TIsl5LVJGtsRFHS0IiT54+ERJaF7TZcAlCZhF5pI+sSMPpJunbtwzI2n02iq7I/uaDS5BiFQ==}
     engines: {node: '>=14', npm: '>=6.14.4'}
     hasBin: true
@@ -9493,7 +9494,7 @@ packages:
       '@wordpress/babel-preset-default': 7.12.0
       '@wordpress/browserslist-config': 5.11.0
       '@wordpress/dependency-extraction-webpack-plugin': 4.11.0_webpack@5.74.0
-      '@wordpress/eslint-plugin': 14.1.0_tna3sd4mxt6szqk2dcspkvuicq
+      '@wordpress/eslint-plugin': 14.1.0_resmp3scu6xyvoobsgansdmgmq
       '@wordpress/jest-preset-default': 10.9.0_dad3stj4k4grimnro7sru7dscy
       '@wordpress/npm-package-json-lint-config': 4.13.0_ngbyqqcq5j4itme2ewj5k5pf2y
       '@wordpress/postcss-plugins-preset': 4.12.0_postcss@8.4.21
@@ -13386,8 +13387,8 @@ packages:
       eslint: ^7.32.0 || ^8.2.0
       eslint-plugin-import: ^2.25.3
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.12.0_446ivzuj5bvqx4dxcjarndtt54
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/eslint-plugin': 5.12.0_2s6vkmrwcj3xjopjo467tfqwhi
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       eslint: 8.9.0
       eslint-config-airbnb-base: 15.0.0_cmtdok55f7srt3k3ux6kqq5jcq
       eslint-plugin-import: 2.25.4_mk4otwdr6g4gqnmmc77es7tuli
@@ -13472,7 +13473,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-webpack: 0.13.2_t6pef3jrjg2rjejjp7kevcbc34
@@ -13499,7 +13500,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -13517,7 +13518,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       array-includes: 3.1.5
       array.prototype.flat: 1.2.5
       debug: 2.6.9
@@ -13548,7 +13549,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/parser': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       array-includes: 3.1.5
       array.prototype.flat: 1.2.5
       debug: 2.6.9
@@ -13569,7 +13570,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/27.2.1_47tlwguymqrkbwficbpl25yaci:
+  /eslint-plugin-jest/27.2.1_juyd2qgd7chtaaebw66clytpim:
     resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -13582,8 +13583,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.12.0_446ivzuj5bvqx4dxcjarndtt54
-      '@typescript-eslint/utils': 5.12.0_cp5evksq3ntdn5fsp5euezguey
+      '@typescript-eslint/eslint-plugin': 5.12.0_2s6vkmrwcj3xjopjo467tfqwhi
+      '@typescript-eslint/utils': 5.12.0_l4rz7ussvdrlh7evejee5now5a
       eslint: 8.9.0
       jest: 27.5.1
     transitivePeerDependencies:
@@ -14454,7 +14455,7 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6_nsxf7ncibhkvddkocuxjl34lwu:
+  /fork-ts-checker-webpack-plugin/4.1.6_ikqt5m4x57vlca6bzw57fnhhpq:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14474,14 +14475,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.0_nsxf7ncibhkvddkocuxjl34lwu:
+  /fork-ts-checker-webpack-plugin/6.5.0_ikqt5m4x57vlca6bzw57fnhhpq:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14508,11 +14509,11 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.0_xjnbks7tshgiwpviuok4cpy6s4:
+  /fork-ts-checker-webpack-plugin/6.5.0_volkrzkp4rd5jtlgqecukc4zl4:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14539,11 +14540,11 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 5.74.0_webpack-cli@4.9.2
     dev: true
 
-  /fork-ts-checker-webpack-plugin/7.2.1_typescript@4.6.3:
+  /fork-ts-checker-webpack-plugin/7.2.1_typescript@5.0.2:
     resolution: {integrity: sha512-uOfQdg/iQ8iokQ64qcbu8iZb114rOmaKLQFu7hU14/eJaKgsP91cQ7ts7v2iiDld6TzDe84Meksha8/MkWiCyw==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14565,10 +14566,10 @@ packages:
       schema-utils: 4.0.0
       semver: 7.3.7
       tapable: 2.2.1
-      typescript: 4.6.3
+      typescript: 5.0.2
     dev: true
 
-  /fork-ts-checker-webpack-plugin/7.2.1_xjnbks7tshgiwpviuok4cpy6s4:
+  /fork-ts-checker-webpack-plugin/7.2.1_volkrzkp4rd5jtlgqecukc4zl4:
     resolution: {integrity: sha512-uOfQdg/iQ8iokQ64qcbu8iZb114rOmaKLQFu7hU14/eJaKgsP91cQ7ts7v2iiDld6TzDe84Meksha8/MkWiCyw==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14590,7 +14591,7 @@ packages:
       schema-utils: 4.0.0
       semver: 7.3.7
       tapable: 2.2.1
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 5.74.0_webpack-cli@4.9.2
     dev: true
 
@@ -19124,11 +19125,11 @@ packages:
       irregular-plurals: 3.4.1
     dev: true
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.6.3:
+  /pnp-webpack-plugin/1.6.4_typescript@5.0.2:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.6.3
+      ts-pnp: 1.2.0_typescript@5.0.2
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -20210,12 +20211,12 @@ packages:
       react-with-styles-interface-css: 6.0.0_q4az5ymyhkt62qwqwsxp67ltfe
     dev: false
 
-  /react-docgen-typescript/2.1.0_typescript@4.6.3:
+  /react-docgen-typescript/2.1.0_typescript@5.0.2:
     resolution: {integrity: sha512-7kpzLsYzVxff//HUVz1sPWLCdoSNvHD3M8b/iQLdF8fgf7zp26eVysRrAUSxiAT4yQv2zl09zHjJEYSYNxQ8Jw==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.6.3
+      typescript: 5.0.2
     dev: true
 
   /react-docgen/5.4.0:
@@ -22775,7 +22776,7 @@ packages:
     resolution: {integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==}
     dev: true
 
-  /ts-loader/9.2.8_xjnbks7tshgiwpviuok4cpy6s4:
+  /ts-loader/9.2.8_volkrzkp4rd5jtlgqecukc4zl4:
     resolution: {integrity: sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -22786,11 +22787,11 @@ packages:
       enhanced-resolve: 5.10.0
       micromatch: 4.0.5
       semver: 7.3.7
-      typescript: 4.6.3
+      typescript: 5.0.2
       webpack: 5.74.0_webpack-cli@4.9.2
     dev: true
 
-  /ts-pnp/1.2.0_typescript@4.6.3:
+  /ts-pnp/1.2.0_typescript@5.0.2:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -22799,7 +22800,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.6.3
+      typescript: 5.0.2
     dev: true
 
   /tsconfig-paths/3.14.1:
@@ -22830,14 +22831,14 @@ packages:
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
-  /tsutils/3.21.0_typescript@4.6.3:
+  /tsutils/3.21.0_typescript@5.0.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.6.3
+      typescript: 5.0.2
     dev: true
 
   /tty-browserify/0.0.0:
@@ -22922,9 +22923,9 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript/4.6.3:
-    resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 
@@ -24030,7 +24031,7 @@ packages:
   /wp-types/3.59.1:
     resolution: {integrity: sha512-CLiNEjIuB7vJFHd+028HxNq7acTgeTtgNClbUXRlUA04DPZ2j3xP6WIGelnVD1nNVytZ96RpmOoWh5IMieau3Q==}
     dependencies:
-      typescript: 4.6.3
+      typescript: 5.0.2
     dev: true
 
   /wrap-ansi/5.1.0:


### PR DESCRIPTION
## Description

This PR updates TypeScript to version 5, enforces only that version using PNPM overrides, and fixes some reported issues.

## Code review notes

We can merge this when approved. QA can be skipped as TypeScript is only static type analysis.

## QA notes

QA can be skipped as TypeScript is only static type analysis.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/697

## Linked tickets

[MAILPOET-5015]

[MAILPOET-5015]: https://mailpoet.atlassian.net/browse/MAILPOET-5015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ