### PR TITLE
Fix font sizes settings in the form editor [MAILPOET-5139]

### DIFF
--- a/mailpoet/assets/js/src/form_editor/store/map_form_data_after_loading.jsx
+++ b/mailpoet/assets/js/src/form_editor/store/map_form_data_after_loading.jsx
@@ -179,7 +179,7 @@ export function mapFormDataAfterLoading(data) {
           : defaults.formStyles.inputPadding,
       borderColor: data.settings.border_color,
       fontFamily: data.settings.font_family,
-      fontSize: data.settings.fontSize && asNum(data.settings.fontSize),
+      fontSize: data.settings.fontSize,
       successValidationColor: data.settings.success_validation_color,
       errorValidationColor: data.settings.error_validation_color,
       backgroundImageUrl: data.settings.background_image_url,

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -188,8 +188,8 @@ class BlockRendererHelper {
   public function renderFontStyle(array $formSettings, array $styles = []) {
     $rules = [];
     if (isset($formSettings['fontSize'])) {
-      $rules[] = 'font-size: ' . trim($formSettings['fontSize']) . 'px;';
-      $rules[] = 'line-height: ' . (float)trim($formSettings['fontSize']) * 1.2 . 'px";';
+      $rules[] = 'font-size: ' . $formSettings['fontSize'] . (is_numeric($formSettings['fontSize']) ? "px;" : ";");
+      $rules[] = 'line-height: 1.2;';
     }
     if (isset($styles['bold'])) {
       $rules[] = 'font-weight: bold;';

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -191,7 +191,7 @@ class BlockRendererHelper {
       $rules[] = 'font-size: ' . $formSettings['fontSize'] . (is_numeric($formSettings['fontSize']) ? "px;" : ";");
       $rules[] = 'line-height: 1.2;';
     }
-    if (isset($styles['bold'])) {
+    if (isset($styles['bold']) && $styles['bold']) {
       $rules[] = 'font-weight: bold;';
     }
     return $rules ? 'style="' . $this->wp->escAttr(implode("", $rules)) . '"' : '';

--- a/mailpoet/lib/Form/Block/Heading.php
+++ b/mailpoet/lib/Form/Block/Heading.php
@@ -93,7 +93,7 @@ class Heading {
       $styles[] = 'color: ' . $block['params']['text_color'];
     }
     if (!empty($block['params']['font_size'])) {
-      $styles[] = 'font-size: ' . $block['params']['font_size'] . 'px';
+      $styles[] = 'font-size: ' . $block['params']['font_size'] . (is_numeric($block['params']['font_size']) ? 'px' : '');
     }
     if (!empty($block['params']['line_height'])) {
       $styles[] = 'line-height: ' . $block['params']['line_height'];

--- a/mailpoet/lib/Form/Block/Paragraph.php
+++ b/mailpoet/lib/Form/Block/Paragraph.php
@@ -78,7 +78,7 @@ class Paragraph {
       $styles[] = 'color: ' . $block['params']['text_color'];
     }
     if (!empty($block['params']['font_size'])) {
-      $styles[] = 'font-size: ' . $block['params']['font_size'] . 'px';
+      $styles[] = 'font-size: ' . $block['params']['font_size'] . (is_numeric($block['params']['font_size']) ? 'px' : '');
     }
     if (!empty($block['params']['line_height'])) {
       $styles[] = 'line-height: ' . $block['params']['line_height'];

--- a/mailpoet/lib/Form/BlockStylesRenderer.php
+++ b/mailpoet/lib/Form/BlockStylesRenderer.php
@@ -48,10 +48,10 @@ class BlockStylesRenderer {
       $rules[] = "font-family:'{$formSettings['font_family']}';" ;
     }
     if (isset($styles['font_size'])) {
-      $rules[] = "font-size:" . intval($styles['font_size']) . "px;";
+      $rules[] = "font-size:" . $styles['font_size'] . (is_numeric($styles['font_size']) ? "px;" : ";");
     }
     if (isset($formSettings['fontSize']) && !isset($styles['font_size'])) {
-      $rules[] = "font-size:" . intval($formSettings['fontSize']) . "px;";
+      $rules[] = "font-size:" . $formSettings['fontSize'] . (is_numeric($formSettings['fontSize']) ? "px;" : ";");
     }
     if (isset($formSettings['fontSize']) || isset($styles['font_size'])) {
       $rules[] = "line-height:1.5;";

--- a/mailpoet/tests/javascript/form_editor/store/map_form_data_after_loading.spec.ts
+++ b/mailpoet/tests/javascript/form_editor/store/map_form_data_after_loading.spec.ts
@@ -207,7 +207,7 @@ describe('Form Data Load Mapper', () => {
       );
     });
 
-    it('It ensures fontSize is an integer', () => {
+    it('It maps font size', () => {
       const mapData = {
         ...data,
         settings: {
@@ -215,7 +215,7 @@ describe('Form Data Load Mapper', () => {
           fontSize: '23',
         },
       };
-      expect(map(mapData).settings.fontSize).to.equal(23);
+      expect(map(mapData).settings.fontSize).to.equal('23');
 
       const mapData2 = {
         ...data,
@@ -239,13 +239,10 @@ describe('Form Data Load Mapper', () => {
         ...data,
         settings: {
           ...data.settings,
-          fontSize: 13.5,
+          fontSize: '1.3em',
         },
       };
-      expect(map(mapData4).settings.fontSize).to.equal(13);
-
-      mapData.settings.fontSize = 'hello';
-      expect(map(mapData).settings.fontSize).to.be.equal(undefined);
+      expect(map(mapData4).settings.fontSize).to.equal('1.3em');
     });
   });
 });

--- a/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -58,6 +58,12 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
     $block['params']['hide_label'] = '1';
     $label = $this->rendererHelper->renderLabel($block, []);
     expect($label)->equals('');
+
+    $label = $this->rendererHelper->renderLabel($this->block, ['fontSize' => 10]);
+    expect($label)->stringContainsString('style="font-size: 10px;');
+
+    $label = $this->rendererHelper->renderLabel($this->block, ['fontSize' => '1.2em']);
+    expect($label)->stringContainsString('style="font-size: 1.2em;');
   }
 
   public function testItShouldRenderLegend() {

--- a/mailpoet/tests/unit/Form/Block/HeadingTest.php
+++ b/mailpoet/tests/unit/Form/Block/HeadingTest.php
@@ -105,6 +105,16 @@ class HeadingTest extends \MailPoetUnitTest {
     expect($html)->equals('<h2 class="mailpoet-heading mailpoet-has-font-size" style="font-size: 33px">Header</h2>');
   }
 
+  public function testItShouldRenderFontSizeWithUnit() {
+    $html = $this->heading->render([
+      'params' => [
+        'content' => 'Header',
+        'font_size' => '2.2em',
+      ],
+    ]);
+    expect($html)->equals('<h2 class="mailpoet-heading mailpoet-has-font-size" style="font-size: 2.2em">Header</h2>');
+  }
+
   public function testItShouldRenderLineHeight() {
     $html = $this->heading->render([
       'params' => [

--- a/mailpoet/tests/unit/Form/Block/ParagraphTest.php
+++ b/mailpoet/tests/unit/Form/Block/ParagraphTest.php
@@ -80,6 +80,16 @@ class ParagraphTest extends \MailPoetUnitTest {
     expect($html)->equals('<p class="mailpoet_form_paragraph mailpoet-has-font-size" style="font-size: 33px">Paragraph</p>');
   }
 
+  public function testItShouldRenderFontSizeWithUnit() {
+    $html = $this->paragraph->render([
+      'params' => [
+        'content' => 'Paragraph',
+        'font_size' => '2.3em',
+      ],
+    ]);
+    expect($html)->equals('<p class="mailpoet_form_paragraph mailpoet-has-font-size" style="font-size: 2.3em">Paragraph</p>');
+  }
+
   public function testItShouldRenderLineHeight() {
     $html = $this->paragraph->render([
       'params' => [

--- a/mailpoet/tests/unit/Form/BlockStylesRendererTest.php
+++ b/mailpoet/tests/unit/Form/BlockStylesRendererTest.php
@@ -123,4 +123,23 @@ class BlockStylesRendererTest extends \MailPoetUnitTest {
     $result = $this->renderer->renderForButton(['font_family' => 'font2'], $settings);
     expect($result)->stringContainsString("font-family:'font2'");
   }
+
+  public function testItShouldSupportFontSizesWithUnits() {
+    $settings = [
+      'input_padding' => '40',
+      'fontSize' => '1.5rem',
+    ];
+    $result = $this->renderer->renderForButton([], $settings);
+    expect($result)->stringContainsString('font-size:1.5rem;');
+    $styles = [
+      'font_size' => '2.4em',
+    ];
+    $result = $this->renderer->renderForButton($styles, $settings);
+    expect($result)->stringContainsString('font-size:2.4em;');
+    $styles = [
+      'font_size' => '23',
+    ];
+    $result = $this->renderer->renderForButton($styles, $settings);
+    expect($result)->stringContainsString('font-size:23px;');
+  }
 }


### PR DESCRIPTION
## Description

After upgrading the Gutenberg JS packages, the font size pickers started to support also unit selection. During the upgrade, we forgot to add support for other units to the front-end renderer, so all font-sizes rendered in the front end are still in pixels no matter what unit was saved in the editor.


## Code review notes

_N/A_

## QA notes

### Replication
1) Create a form and add a paragraph, and set font size using em or rem unit
2) Go to form preview and check the value of the paragraph.

Note: The issue can also be replicated for global form styles. You can replicate/check it by setting the global font size and checking a label or text input font-size value using dev tools.

Note 2: When using relative units `em` or `rem` the font size might differ in the form editor in admin and on the front end. This is expected since a theme may set a different base size.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5139]

## After-merge notes

_N/A_


[MAILPOET-5139]: https://mailpoet.atlassian.net/browse/MAILPOET-5139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ