### PR TITLE
Test MailPoet with WordPress 6.2 RC [MAILPOET-5073]

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -19,6 +19,7 @@ class SwitchingLanguagesCest {
     $i->amOnAdminPage('/options-general.php');
     $i->selectOption('WPLANG', ['value' => 'de_DE']);
     $i->click('[name="submit"]');
+    $i->waitForText('Die Einstellungen wurden gespeichert.');
 
     $i->wantTo('Update translations to make sure strings are downloaded');
 
@@ -66,6 +67,7 @@ class SwitchingLanguagesCest {
   public function _after(AcceptanceTester $i) {
     try {
       $i->cli(['language', 'core', 'uninstall', 'de_DE']);
+      $i->cli(['language', 'plugin', 'uninstall', 'mailpoet', 'de_DE']);
     } catch (Throwable $e) {
       // language already uninstalled
     }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -213,7 +213,8 @@ class WooCheckoutBlocksCest {
     $this->closeDialog($i);
     $i->click('button[aria-label="Toggle block inserter"]');
     $i->fillField('[placeholder="Search"]', 'Checkout');
-    $i->click('Checkout');
+    $i->waitForElement(Locator::contains('button', 'Checkout'));
+    $i->click(Locator::contains('button', 'Checkout')); // Select Checkout block
     // Close dialog with Compatibility notice
     $this->closeDialog($i);
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -226,6 +226,9 @@ class WooCheckoutBlocksCest {
       $i->click(Locator::contains('label', 'Allow shoppers to sign up for a user account during checkout'));
     }
 
+    // Close dialog if any
+    $this->closeDialog($i);
+
     $i->click('Update');
     $i->waitForText('Page updated.');
     $i->logOut();
@@ -236,9 +239,18 @@ class WooCheckoutBlocksCest {
    * Close dialog when is visible.
    */
   private function closeDialog(\AcceptanceTester $i): void {
-    $closeButton = $i->executeJS('return document.querySelectorAll("button[aria-label=\'Close dialog\']");');
+    // Todo: [MAILPOET-5164] Remove when testing with WC 6.2
+    $oldCloseButton = $i->executeJS('return document.querySelectorAll("button[aria-label=\'Close dialog\']");');
+    $closeButton = $i->executeJS('return document.querySelectorAll("button[aria-label=\'Close\']");');
+
     if ($closeButton) {
+      $i->click('button[aria-label="Close"]');
+      $i->waitForElementNotVisible('button[aria-label="Close"]');
+    }
+    // Todo: [MAILPOET-5164] Remove when testing with WC 6.2 MAILPOET-5164
+    if ($oldCloseButton) {
       $i->click('button[aria-label="Close dialog"]');
+      $i->waitForElementNotVisible('button[aria-label="Close dialog"]');
     }
   }
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -212,6 +212,12 @@ if [[ $CIRCLE_JOB == *"_with_premium_"* ]]; then
   wp plugin activate mailpoet-premium || { echo "MailPoet Premium plugin activation failed!" ; exit 1; }
 fi
 
+# WP installs translations into the `lang` folder, and it should be writable, this change has been added in WP 6.2
+chmod -R 755 wp-content/plugins/mailpoet/lang
+chmod -R 755 wp-content/plugins/mailpoet-premium/lang
+chmod -R 755 wp-content/languages
+chmod -R 755 wp-content/upgrade
+
 echo "MySQL Configuration";
 # print sql_mode
 mysql -u wordpress -pwordpress wordpress -h mysql -e "SELECT @@global.sql_mode"


### PR DESCRIPTION
## Description

This PR tests the plugin against WP v6.2-RC2 and updates some failing tests to work with the new version.

## Code review notes

Please remove (ask @samnajian to do so) the commit that changes the WP version before merging.

## QA notes

Please do a UI general check


## Linked tickets

[MAILPOET-5073]

[MAILPOET-5073]: https://mailpoet.atlassian.net/browse/MAILPOET-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ