### PR TITLE
Execute mailpoet_scripts_admin_before hook

### DIFF
--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -192,6 +192,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'admin_vendor.js'
 )%>
 
+<%= do_action('mailpoet_scripts_admin_before') %>
 
 <%if is_loading_3rd_party_enabled() and not is_dotcom_ecommerce_plan() %>
   <%= javascript('lib/analytics.js') %>
@@ -234,6 +235,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
     }
   </script>
 <% endif %>
+
 <script>
   Parsley.addMessages('mailpoet', {
     defaultMessage: '<%= __("This value seems to be invalid.") %>',


### PR DESCRIPTION
[PREMIUM-229]

## Description

The `mailpoet_scripts_admin_before` was missing and thus the premium JavaScript got not loaded. This PR adds the hook again

## Code review notes

_N/A_

## QA notes

Check this build together with the current premium trunk.
Before: You would not see the premium functionality, e.g. in Newsletter statistics or in the automation.
After: They should all be back again.


## Linked PRs

_N/A_

## Linked tickets

[PREMIUM-229]

## After-merge notes

_N/A_


[PREMIUM-229]: https://mailpoet.atlassian.net/browse/PREMIUM-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PREMIUM-229]: https://mailpoet.atlassian.net/browse/PREMIUM-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ