### PR TITLE
Process Shortcodes in WooCommerce custom templates - MAILPOET-5110

### DIFF
--- a/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\WooCommerce\TransactionalEmails;
 
+use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
 use MailPoetVendor\csstidy;
@@ -33,8 +34,11 @@ class Renderer {
   }
 
   public function render(NewsletterEntity $newsletter, ?string $subject = null) {
-    $renderedHtml = $this->renderer->renderAsPreview($newsletter, 'html', $subject);
+    $renderedNewsletter = $this->renderer->renderAsPreview($newsletter, 'html', $subject);
     $headingText = $subject ?? '';
+
+    $renderedHtml = Shortcodes::process($renderedNewsletter, null, $newsletter, null, null);
+
     $renderedHtml = str_replace(ContentPreprocessor::WC_HEADING_PLACEHOLDER, $headingText, $renderedHtml);
     $html = explode(ContentPreprocessor::WC_CONTENT_PLACEHOLDER, $renderedHtml);
     $this->htmlBeforeContent = $html[0];

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -12,6 +12,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Preprocessor;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Shortcodes\Shortcodes as NewsletterShortcodes;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\csstidy;
 
@@ -44,7 +45,7 @@ class RendererTest extends \MailPoetTest {
   }
 
   public function testGetHTMLBeforeContent() {
-    $renderer = new Renderer(new csstidy, $this->getNewsletterRenderer());
+    $renderer = $this->getRenderer();
     $renderer->render($this->newsletter, 'Heading Text');
     $html = $renderer->getHTMLBeforeContent();
     expect($html)->stringContainsString('Some text before heading');
@@ -54,7 +55,7 @@ class RendererTest extends \MailPoetTest {
   }
 
   public function testGetHTMLAfterContent() {
-    $renderer = new Renderer(new csstidy, $this->getNewsletterRenderer());
+    $renderer = $this->getRenderer();
     $renderer->render($this->newsletter, 'Heading Text');
     $html = $renderer->getHTMLAfterContent();
     expect($html)->stringNotContainsString('Some text before heading');
@@ -74,7 +75,7 @@ class RendererTest extends \MailPoetTest {
       ]),
     ]);
     $this->newslettersRepository->persist($this->newsletter);
-    $renderer = new Renderer(new csstidy, $this->getNewsletterRenderer());
+    $renderer = $this->getRenderer();
     $renderer->render($this->newsletter, 'Heading Text');
     $html = $renderer->getHTMLAfterContent();
     expect($html)->stringContainsString('Heading Text');
@@ -82,7 +83,7 @@ class RendererTest extends \MailPoetTest {
   }
 
   public function testPrefixCss() {
-    $renderer = new Renderer(new csstidy, $this->diContainer->get(NewsletterRenderer::class));
+    $renderer = $this->getRenderer(true);
     $css = $renderer->prefixCss('
       #some_id {color: black}
       .some-class {height: 50px; width: 30px}
@@ -112,7 +113,7 @@ class RendererTest extends \MailPoetTest {
       ]),
     ]);
     $this->newslettersRepository->persist($this->newsletter);
-    $renderer = new Renderer(new csstidy, $this->getNewsletterRenderer());
+    $renderer = $this->getRenderer();
     $renderer->render($this->newsletter, 'Heading Text');
     $html = $renderer->getHTMLAfterContent();
 
@@ -151,6 +152,15 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(LoggerFactory::class),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class)
+    );
+  }
+
+  private function getRenderer($useNewsletterDI = false) {
+    $newsletterRenderer = $useNewsletterDI ? $this->diContainer->get(NewsletterRenderer::class) : $this->getNewsletterRenderer();
+    return new Renderer(
+      new csstidy,
+      $newsletterRenderer,
+      $this->diContainer->get(NewsletterShortcodes::class)
     );
   }
 }


### PR DESCRIPTION


## Description

 Process Shortcodes in WooCommerce custom templates 

## Code review notes

_N/A_

## QA notes

You can test with the Date or Site shortcodes.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5110](https://mailpoet.atlassian.net/browse/MAILPOET-5110)

## After-merge notes

_N/A_


[MAILPOET-5110]: https://mailpoet.atlassian.net/browse/MAILPOET-5110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ