### PR TITLE
Add missing CSS for the form editor [MAILPOET-5146]

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-form-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-form-editor.scss
@@ -20,6 +20,7 @@
 @import '../../../node_modules/@wordpress/edit-post/build-style/style';
 @import '../../../node_modules/@wordpress/edit-post/build-style/classic';
 @import '../../../node_modules/@wordpress/block-editor/build-style/style';
+@import '../../../node_modules/@wordpress/block-editor/build-style/content';
 @import '../../../node_modules/@wordpress/block-library/build-style/style';
 @import '../../../node_modules/@wordpress/block-library/build-style/theme';
 @import '../../../node_modules/@wordpress/block-library/build-style/editor';


### PR DESCRIPTION
## Description

This PR fixes two visual issues with block placeholders and column selection found in the form editor after we updated WordPress dependencies. 

I found that some CSS was extracted into an extra file that we needed to include.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5146]

## After-merge notes

_N/A_


[MAILPOET-5146]: https://mailpoet.atlassian.net/browse/MAILPOET-5146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ