### PR TITLE
Refactor k6 tests and include chai.js

### DIFF
--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -15,3 +15,10 @@ export const defaultListName = 'Newsletter mailing list';
 
 export const thinkTimeMin = '1';
 export const thinkTimeMax = '3';
+
+export const emailsPageTitle = 'Emails Page';
+export const automationsPageTitle = 'Automations Page';
+export const formsPageTitle = 'Forms Page';
+export const subscribersPageTitle = 'Subscribers Page';
+export const listsPageTitle = 'Lists Page';
+export const settingsPageTitle = 'Settings Page';

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -4,8 +4,8 @@
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
-import { newsletterListing } from './tests/newsletter-listing.js';
-import { subscribersListing } from './tests/subscribers-listing.js';
+// import { newsletterListing } from './tests/newsletter-listing.js';
+// import { subscribersListing } from './tests/subscribers-listing.js';
 import { settingsBasic } from './tests/settings-basic.js';
 import { subscribersFiltering } from './tests/subscribers-filtering.js';
 import { subscribersAdding } from './tests/subscribers-adding.js';
@@ -63,15 +63,15 @@ if (scenario) {
 
 // Run those tests against a pull request build
 export async function pullRequests() {
-  await newsletterListing();
-  await subscribersListing();
+  // await newsletterListing();
+  // await subscribersListing();
   await settingsBasic();
   await subscribersFiltering();
-  await subscribersAdding();
-  await formsAdding();
-  await newsletterSearching();
-  await newsletterSending();
-  await listsViewSubscribers();
+  // await subscribersAdding();
+  // await formsAdding();
+  // await newsletterSearching();
+  // await newsletterSending();
+  // await listsViewSubscribers();
 }
 
 // Run those tests against trunk in a nightly build

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -4,8 +4,8 @@
 import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { scenario } from './config.js';
-// import { newsletterListing } from './tests/newsletter-listing.js';
-// import { subscribersListing } from './tests/subscribers-listing.js';
+import { newsletterListing } from './tests/newsletter-listing.js';
+import { subscribersListing } from './tests/subscribers-listing.js';
 import { settingsBasic } from './tests/settings-basic.js';
 import { subscribersFiltering } from './tests/subscribers-filtering.js';
 import { subscribersAdding } from './tests/subscribers-adding.js';
@@ -63,15 +63,15 @@ if (scenario) {
 
 // Run those tests against a pull request build
 export async function pullRequests() {
-  // await newsletterListing();
-  // await subscribersListing();
+  await newsletterListing();
+  await subscribersListing();
   await settingsBasic();
   await subscribersFiltering();
-  // await subscribersAdding();
-  // await formsAdding();
-  // await newsletterSearching();
-  // await newsletterSending();
-  // await listsViewSubscribers();
+  await subscribersAdding();
+  await formsAdding();
+  await newsletterSearching();
+  await newsletterSending();
+  await listsViewSubscribers();
 }
 
 // Run those tests against trunk in a nightly build

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -3,9 +3,13 @@
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -17,6 +21,7 @@ import {
   headlessSet,
   timeoutSet,
   defaultListName,
+  formsPageTitle,
 } from '../config.js';
 import {
   authenticate,
@@ -31,46 +36,46 @@ export async function formsAdding() {
   });
   const page = browser.newPage();
 
-  try {
-    // Go to the page
-    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-forms`, {
-      waitUntil: 'networkidle',
-    });
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-forms`, {
+    waitUntil: 'networkidle',
+  });
 
-    // Log in to WP Admin
-    authenticate(page);
+  // Log in to WP Admin
+  authenticate(page);
 
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
 
-    // Wait and click the Add New Form button
-    waitAndClick(page, '[data-automation-id="create_new_form"]');
-    sleep(1);
-    page.waitForLoadState('networkidle');
+  // Wait and click the Add New Form button
+  waitAndClick(page, '[data-automation-id="create_new_form"]');
+  sleep(1);
+  page.waitForLoadState('networkidle');
 
-    // Choose the form template
-    waitAndClick(
-      page,
-      '[data-automation-id="select_template_template_1_popup"]',
-    );
-    sleep(1);
+  // Choose the form template
+  waitAndClick(page, '[data-automation-id="select_template_template_1_popup"]');
+  sleep(1);
 
-    // Select the list and save the form
-    page.waitForSelector('[data-automation-id="form_title_input"]');
-    selectInSelect2(page, defaultListName);
-    page.waitForSelector('[data-automation-id="form_save_button"]');
-    page.locator('[data-automation-id="form_save_button"]').click();
-    page.waitForSelector('.components-notice');
-    check(page, {
-      'form has been saved notice is present':
-        page.locator('.components-notice__content').textContent() ===
+  // Select the list and save the form
+  page.waitForSelector('[data-automation-id="form_title_input"]');
+  selectInSelect2(page, defaultListName);
+  page.waitForSelector('[data-automation-id="form_save_button"]');
+  page.locator('[data-automation-id="form_save_button"]').click();
+  page.waitForSelector('.components-notice');
+  describe(formsPageTitle, () => {
+    describe('should be able to see Forms Saved message', () => {
+      expect(
+        page.locator('.components-notice__content').innerText(),
+      ).to.contain(
         'Form saved. Cookies reset — you will see all your dismissed popup forms again.',
+      );
     });
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  });
+
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default function formsAddingTest() {

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -3,9 +3,13 @@
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -17,6 +21,7 @@ import {
   headlessSet,
   timeoutSet,
   defaultListName,
+  listsPageTitle,
 } from '../config.js';
 import { authenticate, selectInReact } from '../utils/helpers.js';
 
@@ -27,100 +32,108 @@ export async function listsComplexSegment() {
   });
   const page = browser.newPage();
 
-  try {
-    const complexSegmentName =
-      'Complex Segment ' + Math.floor(Math.random() * 9999 + 1);
+  const complexSegmentName =
+    'Complex Segment ' + Math.floor(Math.random() * 9999 + 1);
 
-    // Go to the page
-    await page.goto(
-      `${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/lists`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+  // Go to the page
+  await page.goto(
+    `${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/lists`,
+    {
+      waitUntil: 'networkidle',
+    },
+  );
 
-    // Log in to WP Admin
-    authenticate(page);
+  // Log in to WP Admin
+  authenticate(page);
 
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
 
-    // Click to add a new segment
-    page.waitForSelector('[data-automation-id="new-segment"]');
-    page.locator('[data-automation-id="new-segment"]').click();
-    page
-      .locator('[data-automation-id="input-name"]')
-      .type(complexSegmentName, { delay: 25 });
+  // Click to add a new segment
+  page.waitForSelector('[data-automation-id="new-segment"]');
+  page.locator('[data-automation-id="new-segment"]').click();
+  page
+    .locator('[data-automation-id="input-name"]')
+    .type(complexSegmentName, { delay: 25 });
 
-    // Select "Subscribed to a list" action
-    selectInReact(page, '#react-select-2-input', 'subscribed to list');
-    selectInReact(page, '#react-select-4-input', defaultListName);
-    page.waitForSelector('.mailpoet-form-notice-message');
-    page.waitForLoadState('networkidle');
-
-    // Click to add a new segment action
-    page
-      .locator(
-        '#segments_container > form > div > div.mailpoet-segments-segments-section > button',
-      )
-      .click();
-
-    // Select "Subscribed date" action
-    selectInReact(page, '#react-select-5-input', 'subscribed date');
-
-    // Click to add a new segment action
-    page
-      .locator(
-        '#segments_container > form > div > div.mailpoet-segments-segments-section > button',
-      )
-      .click();
-
-    // WordPress user role action has been automatically added
-    // Select a WP user role
-    selectInReact(page, '#react-select-8-input', 'Administrator');
-    page.waitForSelector('.mailpoet-form-notice-message');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'confirmation message is visible for segment calculation': page
-        .locator('.mailpoet-form-notice-message')
-        .isVisible(),
+  // Select "Subscribed to a list" action
+  selectInReact(page, '#react-select-2-input', 'subscribed to list');
+  selectInReact(page, '#react-select-4-input', defaultListName);
+  page.waitForSelector('.mailpoet-form-notice-message');
+  describe(listsPageTitle, () => {
+    describe('should be able to see calculating message', () => {
+      expect(
+        page.locator('.mailpoet-form-notice-message').innerText(),
+      ).to.contain('Calculating segment size…');
     });
-    page
-      .locator('[data-automation-id="dynamic-segment-condition-type-or"]')
-      .click();
-    page.waitForSelector('.mailpoet-form-notice-message');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'confirmation message is visible for segment calculation': page
-        .locator('.mailpoet-form-notice-message')
-        .isVisible(),
-    });
+  });
+  page.waitForLoadState('networkidle');
 
-    // Save the segment
-    await page
-      .locator(
-        '#segments_container > form > div > div.mailpoet-form-actions > button > span',
-      )
-      .click();
-    page.waitForSelector('[data-automation-id="filters_all"]', {
-      state: 'visible',
+  // Click to add a new segment action
+  page
+    .locator(
+      '#segments_container > form > div > div.mailpoet-segments-segments-section > button',
+    )
+    .click();
+
+  // Select "Subscribed date" action
+  selectInReact(page, '#react-select-5-input', 'subscribed date');
+  page.waitForSelector('.mailpoet-form-notice-message');
+  describe(listsPageTitle, () => {
+    describe('should be able to see calculating message', () => {
+      expect(
+        page.locator('.mailpoet-form-notice-message').innerText(),
+      ).to.contain('Calculating segment size…');
     });
-    check(page, {
-      'segments tab is visible': page
-        .locator('[data-automation-id="dynamic-segments-tab"]')
-        .isVisible(),
+  });
+
+  // Click to add a new segment action
+  page
+    .locator(
+      '#segments_container > form > div > div.mailpoet-segments-segments-section > button',
+    )
+    .click();
+
+  // WordPress user role action has been automatically added
+  // Select a WP user role
+  selectInReact(page, '#react-select-8-input', 'Administrator');
+  page.waitForSelector('.mailpoet-form-notice-message');
+  page.waitForLoadState('networkidle');
+  describe(listsPageTitle, () => {
+    describe('should be able to see Calculating message', () => {
+      expect(
+        page.locator('.mailpoet-form-notice-message').innerText(),
+      ).to.contain('Calculating segment size…');
     });
-    check(page, {
-      'segment is saved successfully': page
-        .locator('.notice-success')
-        .textContent('Segment successfully updated!'),
+  });
+  page
+    .locator('[data-automation-id="dynamic-segment-condition-type-or"]')
+    .click();
+  page.waitForSelector('.mailpoet-form-notice-message');
+  page.waitForLoadState('networkidle');
+
+  // Save the segment
+  await page
+    .locator(
+      '#segments_container > form > div > div.mailpoet-form-actions > button > span',
+    )
+    .click();
+  page.waitForSelector('[data-automation-id="filters_all"]', {
+    state: 'visible',
+  });
+  describe(listsPageTitle, () => {
+    describe('should be able to see Segment Updated message', () => {
+      expect(page.locator('div.notice').innerText()).to.contain(
+        'Segment successfully updated!',
+      );
     });
-    await page.waitForLoadState('networkidle');
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  });
+  await page.waitForLoadState('networkidle');
+
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function listsComplexSegmentTest() {

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
+/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -17,6 +22,7 @@ import {
   headlessSet,
   timeoutSet,
   defaultListName,
+  listsPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -27,51 +33,50 @@ export async function listsViewSubscribers() {
   });
   const page = browser.newPage();
 
-  try {
-    // Go to the page
-    await page.goto(
-      `${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/lists`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+  // Go to the page
+  await page.goto(
+    `${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/lists`,
+    {
+      waitUntil: 'networkidle',
+    },
+  );
 
-    // Log in to WP Admin
-    authenticate(page);
+  // Log in to WP Admin
+  authenticate(page);
 
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
 
-    // Click to view subscribers of the default list "Newsletter mailing list"
-    page.waitForSelector('[data-automation-id="dynamic-segments-tab"]');
-    check(page, {
-      'segments tab is visible': page
-        .locator('[data-automation-id="dynamic-segments-tab"]')
-        .isVisible(),
+  // Click to view subscribers of the default list "Newsletter mailing list"
+  page.waitForSelector('[data-automation-id="dynamic-segments-tab"]');
+  describe(listsPageTitle, () => {
+    describe('should be able to see Segments tab', () => {
+      expect(page.locator('[data-automation-id="dynamic-segments-tab"]')).to
+        .exist;
     });
-    page
-      .locator('[data-automation-id="segment_name_' + defaultListName + '"]')
-      .hover();
-    page
-      .locator(
-        '[data-automation-id="view_subscribers_' + defaultListName + '"]',
-      )
-      .click();
+  });
+  page
+    .locator('[data-automation-id="segment_name_' + defaultListName + '"]')
+    .hover();
+  page
+    .locator('[data-automation-id="view_subscribers_' + defaultListName + '"]')
+    .click();
 
-    // Wait for the page to load
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="filters_subscribed"]');
-    check(page, {
-      'subscribers filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
+  // Wait for the page to load
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  describe(listsPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
-    page.waitForLoadState('networkidle');
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  });
+  page.waitForLoadState('networkidle');
+
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function listsViewSubscribersTest() {

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
+/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -16,6 +21,7 @@ import {
   thinkTimeMax,
   headlessSet,
   timeoutSet,
+  emailsPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -26,31 +32,31 @@ export async function newsletterListing() {
   });
   const page = browser.newPage();
 
-  try {
-    // Go to the page
-    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
-      waitUntil: 'networkidle',
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Log in to WP Admin
+  authenticate(page);
+
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  // Check if there is element present and visible
+  page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+  page.waitForLoadState('networkidle');
+  describe(emailsPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
+  });
 
-    // Log in to WP Admin
-    authenticate(page);
-
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
-
-    // Check if there is element present and visible
-    page.waitForSelector('[data-automation-id="listing_filter_segment"]');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'newsletter filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
-    });
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function newsletterListingTest() {

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
+/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -16,6 +21,7 @@ import {
   thinkTimeMax,
   headlessSet,
   timeoutSet,
+  emailsPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -26,46 +32,48 @@ export async function newsletterSearching() {
   });
   const page = browser.newPage();
 
-  try {
-    // Go to the page
-    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
-      waitUntil: 'networkidle',
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Log in to WP Admin
+  authenticate(page);
+
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  // Search for a newsletter
+  page.locator('#search_input').type('Newsletter 1st', { delay: 50 });
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+  page.waitForLoadState('networkidle');
+  describe(emailsPageTitle, () => {
+    describe('should be able to search for Newsletter 1st', () => {
+      expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
+        'Newsletter 1st',
+      );
     });
+  });
 
-    // Log in to WP Admin
-    authenticate(page);
-
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
-
-    // Search for a newsletter
-    page.locator('#search_input').type('Newsletter 1st', { delay: 50 });
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="listing_filter_segment"]');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'newsletter is found': page
-        .locator('.mailpoet-listing-title')
-        .innerText('Newsletter 1st'),
+  // Filter newsletter results by a default list "Newsletter mailing list"
+  page
+    .locator('[data-automation-id="listing_filter_segment"]')
+    .selectOption('3');
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+  page.waitForLoadState('networkidle');
+  describe(emailsPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
+  });
 
-    // Filter newsletter results by a default list "Newsletter mailing list"
-    page
-      .locator('[data-automation-id="listing_filter_segment"]')
-      .selectOption('3');
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="listing_filter_segment"]');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'lists filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
-    });
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function newsletterSearchingTest() {

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -3,13 +3,13 @@
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
-// import {
-//   describe,
-//   expect,
-// } from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ import {
   thinkTimeMax,
   headlessSet,
   timeoutSet,
+  settingsPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -29,6 +30,7 @@ export async function settingsBasic() {
     timeout: timeoutSet,
   });
   const page = browser.newPage();
+
   // Go to the page
   await page.goto(
     `${baseURL}/wp-admin/admin.php?page=mailpoet-settings#/basics`,
@@ -49,23 +51,15 @@ export async function settingsBasic() {
   page.waitForLoadState('networkidle');
 
   // Check if there's notice about saved settings
-  // describe('Settings Page - should be able to see the settings saved success notice', () => {
-  //   expect(page.locator('div.notice').innerText()).to.contain(
-  //     'Settings saved2',
-  //   );
-  // });
-
-  check(page, {
-    'Settings saved notice has been present':
-      page.locator('div.notice').textContent() === 'Settings saved2',
+  describe(settingsPageTitle, () => {
+    describe('should be able to see Settings Saved message', () => {
+      expect(page.locator('div.notice').innerText()).to.contain(
+        'Settings saved',
+      );
+    });
   });
 
-  // Click to save the settings
-  page.locator('[data-automation-id="settings-submit-button"]').click();
-  page.waitForSelector('div.notice');
-  page.waitForLoadState('networkidle');
-
-  // Wait for a bit before closing
+  // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   page.close();
   browser.close();

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
+/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -19,6 +24,7 @@ import {
   firstName,
   lastName,
   defaultListName,
+  subscribersPageTitle,
 } from '../config.js';
 import { authenticate, selectInSelect2 } from '../utils/helpers.js';
 
@@ -29,54 +35,64 @@ export async function subscribersAdding() {
   });
   const page = browser.newPage();
 
-  try {
-    let subscriberEmail =
-      'test+' + Math.floor(Math.random() * 9999 + 1) + '@test.com';
+  let subscriberEmail =
+    'test+' + Math.floor(Math.random() * 9999 + 1) + '@test.com';
 
-    // Go to the page
-    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
-      waitUntil: 'networkidle',
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Log in to WP Admin
+  authenticate(page);
+
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  // Add a new subscriber
+  page.locator('[data-automation-id="add-new-subscribers-button"]').click();
+  page.locator('input[name="email"]').type(subscriberEmail);
+  page.locator('input[name="first_name"]').type(firstName);
+  page.locator('input[name="last_name"]').type(lastName);
+  selectInSelect2(page, defaultListName);
+  page.locator('button[type="submit"]').click();
+
+  // Verify you see the success message and the filter is visible
+  page.waitForSelector('div.notice');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Subscriber Added message', () => {
+      expect(page.locator('div.notice').innerText()).to.contain(
+        'Subscriber was added successfully!',
+      );
     });
-
-    // Log in to WP Admin
-    authenticate(page);
-
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
-
-    // Add a new subscriber
-    page.locator('[data-automation-id="add-new-subscribers-button"]').click();
-    page.locator('input[name="email"]').type(subscriberEmail);
-    page.locator('input[name="first_name"]').type(firstName);
-    page.locator('input[name="last_name"]').type(lastName);
-    selectInSelect2(page, defaultListName);
-    page.locator('button[type="submit"]').click();
-
-    // Wait for subscribers listing and verify the filter is visible
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="filters_subscribed"]');
-    check(page, {
-      'subscribers filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
+  });
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
-    page.waitForLoadState('networkidle');
+  });
+  page.waitForLoadState('networkidle');
 
-    // Search for a newly added subscriber and verify
-    page.locator('#search_input').type(subscriberEmail, { delay: 50 });
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="filters_subscribed"]');
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'newly added subscriber is present in the listing':
-        page.locator('.mailpoet-listing-title').textContent() ===
+  // Search for a newly added subscriber and verify
+  page.locator('#search_input').type(subscriberEmail, { delay: 50 });
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  page.waitForLoadState('networkidle');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to search for Newly Added Subscriber', () => {
+      expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
         subscriberEmail,
+      );
     });
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  });
+
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function subscribersAddingTest() {

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
+/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -17,6 +22,7 @@ import {
   headlessSet,
   timeoutSet,
   adminEmail,
+  subscribersPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -27,54 +33,56 @@ export async function subscribersFiltering() {
   });
   const page = browser.newPage();
 
-  try {
-    // Go to the page
-    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
-      waitUntil: 'networkidle',
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Log in to WP Admin
+  authenticate(page);
+
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  // Check the subscribers filter is present
+  page.locator('[data-automation-id="filters_subscribed"]').click();
+  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
+  });
 
-    // Log in to WP Admin
-    authenticate(page);
-
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
-
-    // Check the subscribers filter is present
-    page.locator('[data-automation-id="filters_subscribed"]').click();
-    page.waitForSelector('[data-automation-id="filters_subscribed"]');
-    check(page, {
-      'subscribers filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
+  // Select option "Newsletter mailing list" in the subscribers filter
+  page
+    .locator('[data-automation-id="listing_filter_segment"]')
+    .selectOption('3');
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
+  });
+  page.waitForNavigation({ waitUntil: 'networkidle' });
 
-    // Select option "Newsletter mailing list" in the subscribers filter
-    page
-      .locator('[data-automation-id="listing_filter_segment"]')
-      .selectOption('3');
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="filters_subscribed"]');
-    check(page, {
-      'subscribers filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
+  // Search for a subscriber in a filtered list
+  page.locator('#search_input').type(adminEmail, { delay: 50 });
+  page.waitForSelector('.mailpoet-listing-no-items');
+  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
     });
-    page.waitForNavigation({ waitUntil: 'networkidle' });
+  });
 
-    // Search for a subscriber in a filtered list
-    page.locator('#search_input').type(adminEmail, { delay: 50 });
-    page.waitForSelector('.mailpoet-listing-no-items');
-    page.waitForSelector('[data-automation-id="filters_subscribed"]');
-    check(page, {
-      'subscribers filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
-    });
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function subscribersFilteringTest() {

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-default-export */
+/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -16,6 +21,7 @@ import {
   thinkTimeMax,
   headlessSet,
   timeoutSet,
+  subscribersPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -26,36 +32,30 @@ export async function subscribersListing() {
   });
   const page = browser.newPage();
 
-  try {
-    // Go to the page
-    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
-      waitUntil: 'networkidle',
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Log in to WP Admin
+  authenticate(page);
+
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  // Verify filter, tag and listing are loaded and visible
+  page.waitForLoadState('networkidle');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Tags Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_tag"]')).to
+        .exist;
     });
+  });
 
-    // Log in to WP Admin
-    authenticate(page);
-
-    // Wait for async actions
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
-
-    // Verify filter, tag and listing are loaded and visible
-    page.waitForLoadState('networkidle');
-    check(page, {
-      'subscribers filter is visible': page
-        .locator('[data-automation-id="listing_filter_segment"]')
-        .isVisible(),
-      'subscribers tag is visible': page
-        .locator('[data-automation-id="listing_filter_tag"]')
-        .isVisible(),
-      'subscribers listing is visible': page
-        .locator('table.mailpoet-listing-table')
-        .isVisible(),
-    });
-  } finally {
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    page.close();
-    browser.close();
-  }
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function subscribersListingTest() {


### PR DESCRIPTION
## Description

Now with chai.js library, we could use `expect` and `describe` in tests which will make our tests more stable and reliable. This can be seen also in the output of the test result, here is how it looks now when executed scenario.js:

https://d.pr/i/iUJZZP - The parent page - should do something - expect pass or fail

I removed `try` `finally` from tests so we can see when the test failed in execution (like E2E tests) and if it fails the performance testing is not reliable. Before, even if the E2E test has failed, the performance test will continue in execution and measuring, but then we wouldn't know what we're measuring with perf tests.

## Code review notes

This is about refactoring existing tests so the change is almost the same across all tests.

## Linked PRs

Wait for #4795 before merging

## Linked tickets

[MAILPOET-5156]


[MAILPOET-5156]: https://mailpoet.atlassian.net/browse/MAILPOET-5156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ