### PR TITLE
Fix strange 0 rendered in Subcriber stats on the homepage [MAILPOET-5150]

### DIFF
--- a/mailpoet/assets/js/src/homepage/components/subscribers-stats.tsx
+++ b/mailpoet/assets/js/src/homepage/components/subscribers-stats.tsx
@@ -103,7 +103,7 @@ export function SubscribersStats(): JSX.Element {
               <span>{globalChange.unsubscribed}</span>
             </div>
           </div>
-          {listsChange.length && (
+          {!!listsChange.length && (
             <table className="mailpoet-subscribers-stats-list-change-table">
               <thead>
                 <tr>


### PR DESCRIPTION
## Description
This PR fixes 👇 

<img width="751" alt="Screenshot 2023-03-23 at 15 59 05" src="https://user-images.githubusercontent.com/1082140/227553296-79135966-e08c-4e9e-9331-2972742ca0cf.png">


## Code review notes

_N/A_

## QA notes

#### Replication

1.  Install MailPoet plugin on a fresh site
3. Add one subscriber as subscribed but don’t add them to any list.
5. Observe the issue

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5150]

## After-merge notes

_N/A_


[MAILPOET-5150]: https://mailpoet.atlassian.net/browse/MAILPOET-5150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ