### PR TITLE
Add Unsubscribe API method [MAILPOET-5152]

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -37,6 +37,7 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 - [Is Setup Complete (isSetupComplete)](api_methods/IsSetupComplete.md)
 - [Subscribe to List (subscribeToList)](api_methods/SubscribeToList.md)
 - [Subscribe to Lists (subscribeToLists)](api_methods/SubscribeToLists.md)
+- [Unsubscribe globally](api_methods/UnsubscribeGlobally.md)
 - [Unsubscribe from List (unsubscribeFromList)](api_methods/UnsubscribeFromList.md)
 - [Unsubscribe from Lists (unsubscribeFromLists)](api_methods/UnsubscribeFromLists.md)
 - [Update List (updateList)](api_methods/UpdateList.md)

--- a/doc/api_methods/UnsubscribeGlobally.md
+++ b/doc/api_methods/UnsubscribeGlobally.md
@@ -1,0 +1,29 @@
+[back to list](../Readme.md)
+
+# Unsubscribe from all lists and change subscriber status
+
+## `array unsubscribe(string $subscriber_id)`
+
+This method removes a subscriber from all lists and updates its status to 'unsubscribed'.
+
+It returns a subscriber. See [Get Subscriber](GetSubscriber.md) for returned data structure.
+
+## Arguments
+
+### string `$subscriber_id` (required)
+
+An id or email of an existing subscriber. An `\Exception` is thrown when an id or email doesn't match any subscriber.
+
+## Error handling
+
+All expected errors from the API are exceptions of class `\MailPoet\API\MP\v1\APIException`.
+Code of the exception is populated to distinguish between different errors.
+
+An exception of base class `\Exception` can be thrown when something unexpected happens.
+
+Codes description:
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 4    | Invalid subscriber that does not exist       |
+| 24   | Subscriber already has 'unsubscribed' status |

--- a/mailpoet/assets/js/src/subscribers/form.jsx
+++ b/mailpoet/assets/js/src/subscribers/form.jsx
@@ -213,6 +213,8 @@ function afterFormContent(values) {
               </a>
             ),
           );
+        } else if (unsubscribe.source === 'mp_api') {
+          message = MailPoet.I18n.t('unsubscribedMpApi').replace('%1$d', date);
         } else {
           message = MailPoet.I18n.t('unsubscribedUnknown').replace(
             '%1$d',

--- a/mailpoet/lib/API/MP/v1/API.php
+++ b/mailpoet/lib/API/MP/v1/API.php
@@ -68,6 +68,10 @@ class API {
     return $this->subscribers->unsubscribeFromLists($subscriberId, $listIds);
   }
 
+  public function unsubscribe($subscriberIdOrEmail) {
+    return $this->subscribers->unsubscribe($subscriberIdOrEmail);
+  }
+
   public function getLists(): array {
     return $this->segments->getAll();
   }

--- a/mailpoet/lib/API/MP/v1/APIException.php
+++ b/mailpoet/lib/API/MP/v1/APIException.php
@@ -24,4 +24,5 @@ class APIException extends \Exception {
   const LIST_USED_IN_FORM = 21;
   const FAILED_TO_DELETE_LIST = 22;
   const LIST_TYPE_IS_NOT_SUPPORTED = 23;
+  const SUBSCRIBER_ALREADY_UNSUBSCRIBED = 24;
 }

--- a/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
+++ b/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
@@ -21,6 +21,7 @@ class StatisticsUnsubscribeEntity {
   const SOURCE_ADMINISTRATOR = 'admin';
   const SOURCE_ORDER_CHECKOUT = 'order_checkout';
   const SOURCE_AUTOMATION = 'automation';
+  const SOURCE_MP_API = 'mp_api';
 
   const METHOD_LINK = 'link';
   const METHOD_ONE_CLICK = 'one_click';

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -24,14 +24,12 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\RequiredCustomFieldValidator;
-use MailPoet\Subscribers\SubscriberListingRepository;
 use MailPoet\Subscribers\SubscriberSaveController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
-use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class SubscribersTest extends \MailPoetTest {
@@ -56,19 +54,13 @@ class SubscribersTest extends \MailPoetTest {
   }
 
   private function getSubscribers() {
-    return new Subscribers(
-      Stub::makeEmpty(ConfirmationEmailMailer::class, ['sendConfirmationEmail']),
-      Stub::makeEmpty(NewSubscriberNotificationMailer::class, ['send']),
-      $this->diContainer->get(SegmentsRepository::class),
-      SettingsController::getInstance(),
-      $this->diContainer->get(SubscriberSegmentRepository::class),
-      $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(SubscriberSaveController::class),
-      $this->diContainer->get(SubscribersResponseBuilder::class),
-      Stub::makeEmpty(WelcomeScheduler::class),
-      $this->diContainer->get(RequiredCustomFieldValidator::class),
-      $this->diContainer->get(SubscriberListingRepository::class),
-      $this->diContainer->get(WPFunctions::class)
+    return $this->getServiceWithOverrides(
+      Subscribers::class,
+      [
+        'confirmationEmailMailer' => Stub::makeEmpty(ConfirmationEmailMailer::class, ['sendConfirmationEmail']),
+        'newSubscriberNotificationMailer' => Stub::makeEmpty(NewSubscriberNotificationMailer::class, ['send']),
+        'welcomeScheduler' => Stub::makeEmpty(WelcomeScheduler::class),
+      ]
     );
   }
 

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -79,6 +79,7 @@
     'unsubscribedNewsletter': __('Unsubscribed at %1$d, from newsletter [link].'),
     'unsubscribedManage': __('Unsubscribed at %1$d, using the “Manage my Subscription” page.'),
     'unsubscribedAdmin': __('Unsubscribed at %1$d, by admin "%2$d".'),
+    'unsubscribedMpApi': __('Unsubscribed at %1$d, via the MP API.'),
     'unsubscribedUnknown': __('Unsubscribed at %1$d, for an unknown reason.'),
 
     'subscriber': __('Subscriber'),


### PR DESCRIPTION
## Description

This PR adds an unsubscribe method to the MP API. It also updates the documentation to include the new method.

## Code review notes

_N/A_

## QA notes

To test the code added in this PR you can add the following snippet to mailpoet.php and then load the wp-admin passing the unsubscribe param (`/wp-admin/?unsubscribe`):

```
add_action('admin_init', function() {
  if (isset($_REQUEST['unsubscribe'])) {
    $subscriberId = 7;
    $mailpoet_api = \MailPoet\API\API::MP('v1');
    $mailpoet_api->unsubscribe($subscriberId);
  }
});
```

Make sure to change the value of `$subscriberId` to an ID that matches a given subscriber on your site. You can then check in the admin interface that the subscriber was removed from all its lists and its status changed to `unsubscribed`.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5152]

## After-merge notes

_N/A_


[MAILPOET-5152]: https://mailpoet.atlassian.net/browse/MAILPOET-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ