### PR TITLE
MAILPOET-5145 Simplify integration test cleanup && MAILPOET-5185

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -221,7 +221,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->_exec($command);
   }
 
-  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false, 'enable-cot-sync' => false]) {
+  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'enable-cot' => false, 'enable-cot-sync' => false, 'stop-on-fail' => false]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 
@@ -1445,7 +1445,8 @@ class RoboFile extends \Robo\Tasks {
       (isset($opts['xml']) && $opts['xml'] ? '--xml ' : '') .
       (isset($opts['group']) && $opts['group'] ? '--group ' . $opts['group'] . ' ' : '') .
       (isset($opts['skip-group']) && $opts['skip-group'] ? '--skip-group ' . $opts['skip-group'] . ' ' : '') .
-      '-f ' . (isset($opts['file']) && $opts['file'] ? $opts['file'] : '')
+      (isset($opts['stop-on-fail']) && $opts['stop-on-fail'] ? '-f ' : '') .
+      (isset($opts['file']) && $opts['file'] ? $opts['file'] : '')
     )->dir(__DIR__ . '/tests/docker')->run();
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -436,7 +436,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscription\Captcha\CaptchaConstants::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\CaptchaFormRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Captcha\CaptchaSession::class);
-    $container->autowire(\MailPoet\Subscription\Captcha\CaptchaRenderer::class);
+    $container->autowire(\MailPoet\Subscription\Captcha\CaptchaRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Captcha\CaptchaPhrase::class);
     $container->autowire(\MailPoet\Subscription\Captcha\Validator\BuiltInCaptchaValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscription\Captcha\Validator\RecaptchaValidator::class)->setPublic(true);

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Subscribers\ImportExport\PersonalDataExporters;
 
 use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -94,11 +95,16 @@ class SubscriberExporter {
         : '',
     ];
 
-    foreach ($subscriber->getSubscriberCustomFields() as $field) {
-      if (isset($this->getCustomFields()[$field->getId()])) {
+    foreach ($subscriber->getSubscriberCustomFields() as $subscriberCustomField) {
+      $customField = $subscriberCustomField->getCustomField();
+      if (!$customField instanceof CustomFieldEntity) {
+        continue;
+      }
+      $customFieldId = $customField->getId();
+      if (isset($this->getCustomFields()[$customFieldId])) {
         $result[] = [
-          'name' => $customFields[$field->getId()],
-          'value' => $field->getValue(),
+          'name' => $customFields[$customFieldId],
+          'value' => $subscriberCustomField->getValue(),
         ];
       }
     }

--- a/mailpoet/tests/_support/IntegrationCleanupExtension.php
+++ b/mailpoet/tests/_support/IntegrationCleanupExtension.php
@@ -24,9 +24,26 @@ class IntegrationCleanupExtension extends Extension {
   private $deleteStatement;
 
   public function beforeSuite(SuiteEvent $event) {
+    global $wpdb;
+
     $this->entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
 
     $this->deleteStatement = 'SET FOREIGN_KEY_CHECKS=0;';
+
+    $automationTables = [
+      'mailpoet_automation_run_logs',
+      'mailpoet_automation_run_subjects',
+      'mailpoet_automation_runs',
+      'mailpoet_automation_triggers',
+      'mailpoet_automation_versions',
+      'mailpoet_automations',
+    ];
+
+    foreach ($automationTables as $automationTable) {
+      $fullTable = sprintf('%s%s', $wpdb->prefix, $automationTable);
+      $this->deleteStatement .= "DELETE FROM $fullTable;";
+    }
+
     foreach ($this->entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
       $class = $metadata->getName();
       $table = $metadata->getTableName();

--- a/mailpoet/tests/_support/IntegrationCleanupExtension.php
+++ b/mailpoet/tests/_support/IntegrationCleanupExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\TestsSupport;
+
+use Codeception\Event\SuiteEvent;
+use Codeception\Event\TestEvent;
+use Codeception\Events;
+use Codeception\Extension;
+use MailPoet\Config\Env;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\SettingEntity;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class IntegrationCleanupExtension extends Extension {
+  /** @var EntityManager */
+  private $entityManager;
+
+  public static $events = [
+    Events::TEST_BEFORE => 'beforeTest',
+    Events::SUITE_BEFORE => 'beforeSuite',
+  ];
+
+  /** @var string */
+  private $deleteStatement;
+
+  public function beforeSuite(SuiteEvent $event) {
+    $this->entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+
+    $this->deleteStatement = 'SET FOREIGN_KEY_CHECKS=0;';
+    foreach ($this->entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
+      $class = $metadata->getName();
+      $table = $metadata->getTableName();
+      $this->deleteStatement .= "DELETE FROM $table;";
+
+      // save plugin version to avoid triggering migrator and populator
+      if ($class === SettingEntity::class) {
+        $dbVersion = Env::$version;
+        $this->deleteStatement .= "
+          INSERT INTO $table (name, value, created_at, updated_at)
+          VALUES ('db_version', '$dbVersion', NOW(), NOW());
+        ";
+      }
+    }
+    $this->deleteStatement .= 'SET FOREIGN_KEY_CHECKS=1';
+  }
+
+  public function beforeTest(TestEvent $event) {
+    $this->entityManager->getConnection()->executeStatement($this->deleteStatement);
+  }
+}

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types = 1);
 
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore;
-use Codeception\Scenario;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
@@ -12,7 +11,6 @@ use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Util\Security;
 use MailPoet\WooCommerce\Helper;
-use MailPoetVendor\Doctrine\DBAL\Connection;
 
 require_once(ABSPATH . 'wp-admin/includes/user.php');
 require_once(ABSPATH . 'wp-admin/includes/ms.php');
@@ -40,16 +38,6 @@ class IntegrationTester extends \Codeception\Actor {
 
   private $createdUsers = [];
 
-  /** @var Connection */
-  private $connection;
-
-  public function __construct(
-    Scenario $scenario
-  ) {
-    parent::__construct($scenario);
-    $this->connection = ContainerWrapper::getInstance()->get(Connection::class);
-  }
-
   public function createWordPressUser(string $email, string $role) {
     $userId = wp_insert_user([
       'user_login' => explode('@', $email)[0],
@@ -68,13 +56,7 @@ class IntegrationTester extends \Codeception\Actor {
   }
 
   public function createCustomer(string $email, string $role = 'customer'): int {
-    global $wpdb;
-    $userId = $this->createWordPressUser($email, $role);
-    $this->connection->executeQuery("
-      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
-      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
-    ");
-    return $userId;
+    return $this->createWordPressUser($email, $role);
   }
 
   public function deleteCreatedUsers() {

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -112,6 +112,8 @@ services:
       MYSQL_PASSWORD: wordpress
     volumes:
       - /dev/shm:/dev/shm
+    tmpfs:
+      - /var/lib/mysql:rw
     ports:
       - 4401:3306
     healthcheck:

--- a/mailpoet/tests/integration.suite.yml
+++ b/mailpoet/tests/integration.suite.yml
@@ -13,3 +13,4 @@ error_level: E_ALL
 extensions:
   enabled:
     - CheckSkippedTestsExtension
+    - MailPoet\TestsSupport\IntegrationCleanupExtension

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -16,7 +16,6 @@ use MailPoet\Config\AccessControl;
 use MailPoet\DI\ContainerConfigurator;
 use MailPoet\DI\ContainerFactory;
 use MailPoet\Entities\LogEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Settings\SettingsController;
@@ -373,8 +372,5 @@ class APITest extends \MailPoetTest {
 
   public function _after() {
     wp_delete_user($this->wpUserId);
-    // we need to trucate wp_mailpoet_subscriber_segment manually while https://mailpoet.atlassian.net/browse/MAILPOET-4580 is not fixed.
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(LogEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -371,6 +371,7 @@ class APITest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     wp_delete_user($this->wpUserId);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilderTest.php
@@ -6,15 +6,9 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 
 class DynamicSegmentsResponseBuilderTest extends \MailPoetTest {
-  public function _before() {
-    parent::_before();
-    $this->cleanup();
-  }
-
   public function testItBuildsGetResponse() {
     $name = 'Response Listings Builder Test';
     $description = 'Testing description';
@@ -117,17 +111,5 @@ class DynamicSegmentsResponseBuilderTest extends \MailPoetTest {
     $segment->getDynamicFilters()->add($dynamicFilter);
     $this->entityManager->persist($dynamicFilter);
     return $segment;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/FormsResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/FormsResponseBuilderTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\API\JSON\ResponseBuilders;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
-use MailPoet\Entities\StatisticsFormEntity;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class FormsResponseBuilderTest extends \MailPoetTest {
@@ -52,11 +51,6 @@ class FormsResponseBuilderTest extends \MailPoetTest {
     expect($response)->count(2);
     expect($response[0]['signups'])->equals(0);
     expect($response[0]['segments'])->equals($this->formSettings['segments']);
-  }
-
-  public function _after() {
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(StatisticsFormEntity::class);
   }
 
   private function createForm($name) {

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
@@ -4,9 +4,6 @@ namespace MailPoet\API\JSON\ResponseBuilders;
 
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
-use MailPoet\Entities\SubscriberTagEntity;
-use MailPoet\Entities\TagEntity;
 use MailPoet\Subscribers\Source;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -139,13 +136,5 @@ class SubscribersResponseBuilderTest extends \MailPoetTest {
     $this->assertEquals($this->tag->getName(), $tag['name']);
     $this->assertArrayHasKey('created_at', $tag);
     $this->assertArrayHasKey('updated_at', $tag);
-  }
-
-  protected function _after() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(TagEntity::class);
-    $this->truncateEntity(SubscriberTagEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/CustomFieldsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/CustomFieldsTest.php
@@ -62,7 +62,6 @@ class CustomFieldsTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->repository = ContainerWrapper::getInstance(WP_DEBUG)->get(CustomFieldsRepository::class);
-    $this->repository->truncate();
     foreach ($this->customFields as $customField) {
       $this->repository->createOrUpdate($customField);
     }

--- a/mailpoet/tests/integration/API/JSON/v1/DynamicSegmentsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/DynamicSegmentsTest.php
@@ -225,12 +225,4 @@ class DynamicSegmentsTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $segment;
   }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/FeatureFlagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/FeatureFlagsTest.php
@@ -6,7 +6,6 @@ use Codeception\Stub;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\FeatureFlags;
-use MailPoet\Entities\FeatureFlagEntity;
 use MailPoet\Features\FeatureFlagsController;
 use MailPoet\Features\FeatureFlagsRepository;
 use MailPoet\Features\FeaturesController;
@@ -19,8 +18,6 @@ class FeatureFlagsTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->repository = $this->diContainer->get(FeatureFlagsRepository::class);
-    $tableName = $this->entityManager->getClassMetadata(FeatureFlagEntity::class)->getTableName();
-    $this->entityManager->getConnection()->executeStatement("TRUNCATE $tableName");
   }
 
   public function testItReturnsDefaults() {

--- a/mailpoet/tests/integration/API/JSON/v1/FormsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/FormsTest.php
@@ -351,9 +351,4 @@ class FormsTest extends \MailPoetTest {
     $this->assertInstanceOf(FormEntity::class, $reloaded);
     return $reloaded;
   }
-
-  public function _after() {
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/NewsletterTemplatesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewsletterTemplatesTest.php
@@ -14,8 +14,6 @@ class NewsletterTemplatesTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterTemplateEntity::class);
     $this->newsletterTemplatesRepository = $this->diContainer->get(NewsletterTemplatesRepository::class);
 
     $template1 = new NewsletterTemplateEntity('Template #1');
@@ -133,10 +131,5 @@ class NewsletterTemplatesTest extends \MailPoetTest {
 
     $deletedTemplate = $this->newsletterTemplatesRepository->findOneById($templateId);
     expect($deletedTemplate)->null();
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterTemplateEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -11,14 +11,10 @@ use MailPoet\API\JSON\v1\Newsletters;
 use MailPoet\Cron\CronHelper;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
@@ -663,18 +659,6 @@ class NewslettersTest extends \MailPoetTest {
     expect($previewLinkData['subscriber_id'])->false();
     expect($previewLinkData['subscriber_token'])->false();
     expect((boolean)$previewLinkData['preview'])->true();
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 
   private function createNewsletterSegment(

--- a/mailpoet/tests/integration/API/JSON/v1/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SegmentsTest.php
@@ -272,13 +272,4 @@ class SegmentsTest extends \MailPoetTest {
     $this->subscriberRepository->flush();
     return $subscriber;
   }
-
-  public function _after() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(FormEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -6,14 +6,10 @@ use Codeception\Util\Stub;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\SendingQueue as SendingQueueAPI;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOption;
@@ -28,7 +24,6 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->clean();
     $this->newsletterOptionsFactory = new NewsletterOption();
 
     $this->newsletter = (new Newsletter())
@@ -124,14 +119,5 @@ class SendingQueueTest extends \MailPoetTest {
     expect($response['errors'][0])->array();
     expect($response['errors'][0]['message'])->stringContainsString('some error');
     expect($response['errors'][0]['error'])->stringContainsString('bad_request');
-  }
-
-  public function clean() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingTaskSubscribersTest.php
@@ -9,7 +9,6 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as TaskSubscriberFactory;
@@ -210,13 +209,5 @@ class SendingTaskSubscribersTest extends \MailPoetTest {
 
     $this->entityManager->refresh($this->newsletter);
     expect($this->newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
-  }
-
-  public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -588,6 +588,7 @@ class ServicesTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -16,7 +16,6 @@ use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\CongratulatoryMssEmailController;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class ServicesTest extends \MailPoetTest {
@@ -589,7 +588,6 @@ class ServicesTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 
   public function testItRespondsWithCorrectMessageIfKeyDoesntSupportMSS() {

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -586,10 +586,6 @@ class ServicesTest extends \MailPoetTest {
     expect($response->errors[0]['message'])->equals('Sending of congratulatory email failed.');
   }
 
-  public function _after() {
-    parent::_after();
-  }
-
   public function testItRespondsWithCorrectMessageIfKeyDoesntSupportMSS() {
     $bridge = $this->make(
       new Bridge(),

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -354,10 +354,4 @@ class SettingsTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $newsletter;
   }
-
-  public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -12,7 +12,6 @@ use MailPoet\Cron\ActionScheduler\ActionScheduler;
 use MailPoet\Migrator\Migrator;
 use MailPoet\Referrals\ReferralDetector;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Subscription\Captcha\CaptchaRenderer;
 use MailPoet\WP\Functions as WPFunctions;
@@ -58,6 +57,5 @@ class SetupTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -57,6 +57,7 @@ class SetupTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -54,8 +54,4 @@ class SetupTest extends \MailPoetTest {
     $hookName = 'mailpoet_setup_reset';
     expect(WPHooksHelper::isActionDone($hookName))->true();
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -11,23 +11,15 @@ use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\API\JSON\v1\Subscribers;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\CustomFieldEntity;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\FormEntity;
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberIPEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Listing\Handler;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberListingRepository;
@@ -85,7 +77,6 @@ class SubscribersTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $container = ContainerWrapper::getInstance();
     $wp = $container->get(Functions::class);
     $this->captchaSession = new CaptchaSession($container->get(Functions::class));
@@ -1029,24 +1020,5 @@ class SubscribersTest extends \MailPoetTest {
       ->withActiveStatus()
       ->withWelcomeTypeForSegment($this->segment1->getId())
       ->create();
-  }
-
-  public function _after() {
-    $this->cleanup();
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(SubscriberIPEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/TagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/TagsTest.php
@@ -52,6 +52,5 @@ class TagsTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->repository->truncate();
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/TagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/TagsTest.php
@@ -49,8 +49,4 @@ class TagsTest extends \MailPoetTest {
     $result = $this->testee->create([]);
     $this->assertEquals(400, $result->status);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/UserFlagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/UserFlagsTest.php
@@ -6,7 +6,6 @@ use Codeception\Stub;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\UserFlags;
-use MailPoet\Entities\UserFlagEntity;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\Settings\UserFlagsRepository;
 
@@ -19,7 +18,6 @@ class UserFlagsTest extends \MailPoetTest {
   private $userFlags;
 
   public function _before() {
-    $this->cleanup();
     $this->userFlags = Stub::make(UserFlagsController::class, [
       'userFlagsRepository' => $this->diContainer->get(UserFlagsRepository::class),
       'defaults' => [
@@ -54,15 +52,5 @@ class UserFlagsTest extends \MailPoetTest {
       'flag_2' => 'default_value_2',
       'flag_3' => 'new_value_3',
     ]);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
-  }
-
-  private function cleanup() {
-    $tableName = $this->entityManager->getClassMetadata(UserFlagEntity::class)->getTableName();
-    $this->entityManager->getConnection()->executeStatement("TRUNCATE $tableName");
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/UserFlagsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/UserFlagsTest.php
@@ -57,6 +57,7 @@ class UserFlagsTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->cleanup();
   }
 

--- a/mailpoet/tests/integration/API/MP/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/MP/SegmentsTest.php
@@ -8,11 +8,7 @@ use MailPoet\API\MP\v1\CustomFields;
 use MailPoet\API\MP\v1\Segments;
 use MailPoet\API\MP\v1\Subscribers;
 use MailPoet\Config\Changelog;
-use MailPoet\Entities\FormEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Test\DataFactories\Form;
@@ -280,14 +276,5 @@ class SegmentsTest extends \MailPoetTest {
       ->withType($type)
       ->withDescription($description)
       ->create();
-  }
-
-  public function _after() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -14,9 +14,7 @@ use MailPoet\Config\Changelog;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
@@ -1028,13 +1026,5 @@ class SubscribersTest extends \MailPoetTest {
       'status' => SubscriberEntity::STATUS_UNSUBSCRIBED,
     ]);
     $this->assertEquals(1, $count);
-  }
-
-  public function _after() {
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/AdminPages/HelpTest.php
+++ b/mailpoet/tests/integration/AdminPages/HelpTest.php
@@ -57,10 +57,10 @@ class HelpTest extends \MailPoetTest {
     $newsletter = (new Newsletter())
       ->withSubject('Rendered Subject')
       ->create();
-    $this->createNewSendingQueue($task, $newsletter);
+    $queue = $this->createNewSendingQueue($task, $newsletter);
     $data = $this->helpPage->buildTaskData($task);
-    expect($data['newsletter']['newsletter_id'])->equals(1);
-    expect($data['newsletter']['queue_id'])->equals(1);
+    expect($data['newsletter']['newsletter_id'])->equals($newsletter->getId());
+    expect($data['newsletter']['queue_id'])->equals($queue->getId());
     expect($data['newsletter']['subject'])->equals('Rendered Subject');
     expect($data['newsletter']['preview_url'])->notEmpty();
   }
@@ -78,7 +78,7 @@ class HelpTest extends \MailPoetTest {
     expect($data['newsletter']['preview_url'])->equals(null);
   }
 
-  private function createNewSendingQueue(?ScheduledTaskEntity $task, ?NewsletterEntity $newsletter, $renderedSubject = null) {
+  private function createNewSendingQueue(?ScheduledTaskEntity $task, ?NewsletterEntity $newsletter, $renderedSubject = null): SendingQueueEntity {
     $queue = new SendingQueueEntity();
     if ($newsletter instanceof NewsletterEntity) {
       $queue->setNewsletter($newsletter);
@@ -91,6 +91,7 @@ class HelpTest extends \MailPoetTest {
     $queue->setNewsletterRenderedSubject($renderedSubject);
     $this->entityManager->persist($queue);
     $this->entityManager->flush();
+    return $queue;
   }
 
   private function cleanup() {

--- a/mailpoet/tests/integration/AdminPages/HelpTest.php
+++ b/mailpoet/tests/integration/AdminPages/HelpTest.php
@@ -33,7 +33,6 @@ class HelpTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->scheduledTaskFactory = new ScheduledTaskFactory();
     $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
 
@@ -92,16 +91,5 @@ class HelpTest extends \MailPoetTest {
     $this->entityManager->persist($queue);
     $this->entityManager->flush();
     return $queue;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-  }
-
-  protected function _after() {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Analytics/UnsubscribeAnalyticsTest.php
+++ b/mailpoet/tests/integration/Analytics/UnsubscribeAnalyticsTest.php
@@ -57,9 +57,4 @@ class UnsubscribeAnalyticsTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $entity;
   }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -4,8 +4,6 @@ namespace MailPoet\AutomaticEmails\WooCommerce\Events;
 
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce as WooCommerceEmail;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -72,8 +70,6 @@ class AbandonedCartTest extends \MailPoetTest {
   private $cartBackup;
 
   public function _before() {
-    $this->cleanup();
-
     global $woocommerce;
     $this->wooCommerce = $woocommerce;
 
@@ -389,21 +385,10 @@ class AbandonedCartTest extends \MailPoetTest {
       ->getMock();
   }
 
-  private function cleanup() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-  }
-
   public function _after() {
     WPFunctions::set(new WPFunctions());
     Carbon::setTestNow();
     // Restore original cart object
     $this->wooCommerce->cart = $this->cartBackup;
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -386,6 +386,7 @@ class AbandonedCartTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions());
     Carbon::setTestNow();
     // Restore original cart object

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -387,7 +387,6 @@ class AbandonedCartTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    Carbon::setTestNow();
     // Restore original cart object
     $this->wooCommerce->cart = $this->cartBackup;
   }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -387,7 +387,6 @@ class AbandonedCartTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    WPFunctions::set(new WPFunctions());
     Carbon::setTestNow();
     // Restore original cart object
     $this->wooCommerce->cart = $this->cartBackup;

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
@@ -7,10 +7,7 @@ use Codeception\Stub\Expected;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerceStubs\OrderDetails;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -365,14 +362,6 @@ class FirstPurchaseTest extends \MailPoetTest {
 
   public function _after() {
     $this->tester->deleteTestWooOrders();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
@@ -361,7 +361,7 @@ class FirstPurchaseTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->tester->deleteTestWooOrders();
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
@@ -359,9 +359,4 @@ class FirstPurchaseTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $sendingQueue;
   }
-
-  public function _after() {
-    parent::_after();
-    WPFunctions::set(new WPFunctions);
-  }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
@@ -6,8 +6,6 @@ use MailPoet\AutomaticEmails\WooCommerce\WooCommerce;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -38,14 +36,6 @@ class PurchasedInCategoryTest extends \MailPoetTest {
   private $segmentsRepository;
 
   public function _before() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
     WPFunctions::set(new WPFunctions);
     WPFunctions::get()->removeAllFilters('woocommerce_payment_complete');
     $this->woocommerceHelper = $this->createMock(WCHelper::class);

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedInCategoryTest.php
@@ -36,7 +36,6 @@ class PurchasedInCategoryTest extends \MailPoetTest {
   private $segmentsRepository;
 
   public function _before() {
-    WPFunctions::set(new WPFunctions);
     WPFunctions::get()->removeAllFilters('woocommerce_payment_complete');
     $this->woocommerceHelper = $this->createMock(WCHelper::class);
     $this->event = new PurchasedInCategory($this->woocommerceHelper);

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
@@ -10,8 +10,6 @@ use MailPoet\AutomaticEmails\WooCommerce\WooCommerceStubs\OrderDetails;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -284,14 +282,6 @@ class PurchasedProductTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
@@ -282,6 +282,7 @@ class PurchasedProductTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/PurchasedProductTest.php
@@ -280,9 +280,4 @@ class PurchasedProductTest extends \MailPoetTest {
 
     return $subscriber;
   }
-
-  public function _after() {
-    parent::_after();
-    WPFunctions::set(new WPFunctions);
-  }
 }

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/WooCommerceTest.php
@@ -102,6 +102,7 @@ class WooCommerceTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $wp = new WPFunctions;
     $wp->removeAllFilters('mailpoet_newsletter_shortcode');
     $wp->removeAllFilters('woocommerce_payment_complete');

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -140,6 +140,7 @@ class StepHandlerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->automationStorage->truncate();
     $this->automationRunStorage->truncate();
     $this->automationRunLogStorage->truncate();

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -9,7 +9,6 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
-use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
@@ -23,9 +22,6 @@ class StepHandlerTest extends \MailPoetTest {
   /** @var AutomationRunStorage */
   private $automationRunStorage;
 
-  /** @var AutomationRunLogStorage */
-  private $automationRunLogStorage;
-
   /** @var StepHandler */
   private $testee;
 
@@ -36,7 +32,6 @@ class StepHandlerTest extends \MailPoetTest {
     $this->testee = $this->diContainer->get(StepHandler::class);
     $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
     $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
-    $this->automationRunLogStorage = $this->diContainer->get(AutomationRunLogStorage::class);
     $this->originalRunners = $this->testee->getStepRunners();
   }
 
@@ -141,9 +136,6 @@ class StepHandlerTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
-    $this->automationRunStorage->truncate();
-    $this->automationRunLogStorage->truncate();
     $this->testee->setStepRunners($this->originalRunners);
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -162,6 +162,7 @@ class TriggerHandlerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->automationRunStorage->truncate();
     $this->automationStorage->truncate();
     $this->segmentRepository->truncate();

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -155,8 +155,4 @@ class TriggerHandlerTest extends \MailPoetTest {
     $this->testee->processTrigger($trigger, [$segmentSubject]);
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation1));
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -7,7 +7,6 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
-use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\UserRegistrationTrigger;
@@ -20,9 +19,6 @@ class TriggerHandlerTest extends \MailPoetTest {
   /** @var TriggerHandler */
   private $testee;
 
-  /** @var AutomationStorage */
-  private $automationStorage;
-
   /** @var AutomationRunStorage */
   private $automationRunStorage;
 
@@ -34,7 +30,6 @@ class TriggerHandlerTest extends \MailPoetTest {
 
   public function _before() {
     $this->testee = $this->diContainer->get(TriggerHandler::class);
-    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
     $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
 
     $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
@@ -163,8 +158,5 @@ class TriggerHandlerTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->automationRunStorage->truncate();
-    $this->automationStorage->truncate();
-    $this->segmentRepository->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationRunLogTest.php
@@ -221,6 +221,7 @@ class AutomationRunLogTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->automationStorage->truncate();
     $this->automationRunStorage->truncate();
     $this->automationRunLogStorage->truncate();

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationRunLogTest.php
@@ -222,9 +222,6 @@ class AutomationRunLogTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
-    $this->automationRunStorage->truncate();
-    $this->automationRunLogStorage->truncate();
   }
 
   private function getLogsForAction($callback = null) {

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationRunLogTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationRunLogTest.php
@@ -220,10 +220,6 @@ class AutomationRunLogTest extends \MailPoetTest {
     expect(count($error['trace']))->greaterThan(0);
   }
 
-  public function _after() {
-    parent::_after();
-  }
-
   private function getLogsForAction($callback = null) {
     if ($callback === null) {
       $callback = function() {

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -76,6 +76,7 @@ class AutomationTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->storage->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -77,6 +77,5 @@ class AutomationTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->storage->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -74,8 +74,4 @@ class AutomationTest extends \MailPoetTest {
       Automation::STATUS_ALL
     );
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
@@ -44,6 +44,7 @@ class AutomationRunLogStorageTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->storage->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
@@ -45,6 +45,5 @@ class AutomationRunLogStorageTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->storage->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunLogStorageTest.php
@@ -42,8 +42,4 @@ class AutomationRunLogStorageTest extends \MailPoetTest {
     expect($errors['trace'])->array();
     expect(count($errors['trace']))->greaterThan(0);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -171,6 +171,7 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->automationStorage->truncate();
     $this->automationRunStorage->truncate();
   }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -170,10 +170,6 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
     $this->assertEquals(1, $stats->getEntered());
   }
 
-  public function _after() {
-    parent::_after();
-  }
-
   private function createRun(Automation $automation, string $status) {
     $run = AutomationRun::fromArray([
       'automation_id' => $automation->getId(),

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -172,8 +172,6 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
-    $this->automationRunStorage->truncate();
   }
 
   private function createRun(Automation $automation, string $status) {

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
@@ -175,6 +175,7 @@ class AutomationStorageTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(AutomationStorage::class)->truncate();
     $this->diContainer->get(AutomationRunStorage::class)->truncate();
     $this->diContainer->get(AutomationRunLogStorage::class)->truncate();

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
@@ -173,8 +173,4 @@ class AutomationStorageTest extends \MailPoetTest {
     }
     return $automation;
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
@@ -176,8 +176,5 @@ class AutomationStorageTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(AutomationStorage::class)->truncate();
-    $this->diContainer->get(AutomationRunStorage::class)->truncate();
-    $this->diContainer->get(AutomationRunLogStorage::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -14,13 +14,8 @@ use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Exception;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Segments\SegmentsRepository;
@@ -54,7 +49,6 @@ class SendEmailActionTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
 
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
@@ -267,20 +261,5 @@ class SendEmailActionTest extends \MailPoetTest {
       new SubjectEntry($this->segmentSubject, reset($segmentData)),
       new SubjectEntry($this->subscriberSubject, reset($subscriberData)),
     ];
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -17,7 +17,6 @@ use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\OrderStatusChangedTrigger;
-use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\Automation\Stubs\TestAction;
 
 require_once __DIR__ . '/../../../Stubs/TestAction.php';
@@ -26,9 +25,6 @@ require_once __DIR__ . '/../../../Stubs/TestAction.php';
  * @group woo
  */
 class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
-
-  /** @var SubscribersRepository */
-  private $subscribersRepository;
 
   /** @var AutomationStorage */
   private $automationStorage;
@@ -52,7 +48,6 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
   private $expectedSubscriberSubjectEntry = null;
 
   public function _before() {
-    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
     $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
     $this->automationRunLogStorage = $this->diContainer->get(AutomationRunLogStorage::class);
@@ -124,7 +119,6 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
   public function _after() {
     parent::_after();
     $this->expectedSubscriberSubjectEntry = null;
-    $this->subscribersRepository->truncate();
     $this->automationStorage->truncate();
     $this->automationRunStorage->truncate();
     $this->automationRunLogStorage->truncate();

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -122,6 +122,7 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->expectedSubscriberSubjectEntry = null;
     $this->subscribersRepository->truncate();
     $this->automationStorage->truncate();

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -11,9 +11,7 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Registry;
-use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
-use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\OrderStatusChangedTrigger;
@@ -26,14 +24,8 @@ require_once __DIR__ . '/../../../Stubs/TestAction.php';
  */
 class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
 
-  /** @var AutomationStorage */
-  private $automationStorage;
-
   /** @var AutomationRunStorage */
   private $automationRunStorage;
-
-  /** @var AutomationRunLogStorage */
-  private $automationRunLogStorage;
 
   /** @var Registry */
   private $registry;
@@ -49,8 +41,6 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
 
   public function _before() {
     $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
-    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
-    $this->automationRunLogStorage = $this->diContainer->get(AutomationRunLogStorage::class);
     $this->registry = $this->diContainer->get(Registry::class);
     $this->stepHandler = $this->diContainer->get(StepHandler::class);
     $this->triggerHandler = $this->diContainer->get(TriggerHandler::class);
@@ -119,8 +109,5 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
   public function _after() {
     parent::_after();
     $this->expectedSubscriberSubjectEntry = null;
-    $this->automationStorage->truncate();
-    $this->automationRunStorage->truncate();
-    $this->automationRunLogStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
@@ -71,6 +71,7 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $segmentIds = $this->getSegmentIds(array_keys($this->segments));
     $this->segmentRepository->bulkDelete($segmentIds);
   }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTriggerTest.php
@@ -70,12 +70,6 @@ class SomeoneSubscribesTriggerTest extends \MailPoetTest {
     ];
   }
 
-  public function _after() {
-    parent::_after();
-    $segmentIds = $this->getSegmentIds(array_keys($this->segments));
-    $this->segmentRepository->bulkDelete($segmentIds);
-  }
-
   private function getSegmentId(string $index): int {
     return (int)$this->segments[$index]->getId();
   }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
@@ -148,7 +148,5 @@ class UserRegistrationTriggerTest extends \MailPoetTest {
     }
     is_multisite() ? wpmu_delete_user($this->userId) : wp_delete_user($this->userId);
     $this->userId = null;
-    $this->wpSegment->synchronizeUsers();
-    $this->subscriberSegmentRepository->truncate();
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Triggers/UserRegistrationTriggerTest.php
@@ -142,6 +142,7 @@ class UserRegistrationTriggerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     if (!$this->userId) {
       return;
     }

--- a/mailpoet/tests/integration/Config/AccessControlTest.php
+++ b/mailpoet/tests/integration/Config/AccessControlTest.php
@@ -114,6 +114,7 @@ class AccessControlTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/Config/AccessControlTest.php
+++ b/mailpoet/tests/integration/Config/AccessControlTest.php
@@ -112,9 +112,4 @@ class AccessControlTest extends \MailPoetTest {
 
     expect($accessControl->validatePermission($capability))->true();
   }
-
-  public function _after() {
-    parent::_after();
-    WPFunctions::set(new WPFunctions);
-  }
 }

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -89,6 +89,7 @@ class EnvTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     // Restore the original environment
     Env::init($this->file, $this->version, DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
   }

--- a/mailpoet/tests/integration/Config/RendererTest.php
+++ b/mailpoet/tests/integration/Config/RendererTest.php
@@ -104,6 +104,7 @@ class RendererTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->_removeAssetsManifests();
   }
 

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -5,9 +5,7 @@ namespace MailPoet\Config;
 use Helper\WordPress;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Url;
 use MailPoet\Router\Router;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -230,12 +228,5 @@ class ShortcodesTest extends \MailPoetTest {
     $shortcodes->init();
     $result = do_shortcode('[mailpoet_manage]');
     expect($result)->stringContainsString('Link to subscription management page is only available to mailing lists subscribers.');
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
@@ -10,7 +10,6 @@ use MailPoet\Cron\CronTrigger;
 use MailPoet\Cron\Daemon;
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Entities\LogEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Settings\SettingsController;
@@ -127,7 +126,5 @@ class DaemonRunTest extends \MailPoetTest {
     $wpdb->query('TRUNCATE ' . $actionsTable);
     $claimsTable = $wpdb->prefix . 'actionscheduler_claims';
     $wpdb->query('TRUNCATE ' . $claimsTable);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(LogEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonTriggerTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonTriggerTest.php
@@ -93,6 +93,5 @@ class DaemonTriggerTest extends \MailPoetTest {
     $wpdb->query('TRUNCATE ' . $actionsTable);
     $claimsTable = $wpdb->prefix . 'actionscheduler_claims';
     $wpdb->query('TRUNCATE ' . $claimsTable);
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -6,7 +6,6 @@ use Codeception\Stub;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\DaemonHttpRunner;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class CronHelperTest extends \MailPoetTest {
@@ -337,7 +336,6 @@ class CronHelperTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 
   private function getDeamonTestData() {

--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -336,6 +336,7 @@ class CronHelperTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 

--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -334,10 +334,6 @@ class CronHelperTest extends \MailPoetTest {
     expect($this->cronHelper->validatePingResponse('something else'))->false();
   }
 
-  public function _after() {
-    parent::_after();
-  }
-
   private function getDeamonTestData() {
     return [
       'token' => 'some_token',

--- a/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerRunnerTest.php
@@ -242,8 +242,4 @@ class CronWorkerRunnerTest extends \MailPoetTest {
       Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))
     );
   }
-
-  public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
@@ -19,7 +19,6 @@ class CronWorkerSchedulerTest extends \MailPoetTest {
   public function _before() {
     $this->cronWorkerScheduler = $this->diContainer->get(CronWorkerScheduler::class);
     $this->scheduledTaskFactory = new ScheduledTaskFactory();
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 
   public function testItSchedulesTask() {
@@ -105,9 +104,5 @@ class CronWorkerSchedulerTest extends \MailPoetTest {
     $task->setRescheduleCount(123456); // too many
     $timeout = $this->cronWorkerScheduler->rescheduleProgressively($task);
     expect($timeout)->equals(ScheduledTaskEntity::MAX_RESCHEDULE_TIMEOUT);
-  }
-
-  public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
@@ -6,7 +6,6 @@ use MailPoet\Cron\ActionScheduler\Actions\DaemonRun;
 use MailPoet\Cron\ActionScheduler\Actions\DaemonTrigger;
 use MailPoet\Cron\ActionScheduler\ActionScheduler;
 use MailPoet\Cron\ActionScheduler\ActionSchedulerTestHelper;
-use MailPoet\Entities\ScheduledTaskEntity;
 
 require_once __DIR__ . '/ActionScheduler/ActionSchedulerTestHelper.php';
 
@@ -66,6 +65,5 @@ class DaemonActionSchedulerRunnerTest extends \MailPoetTest {
     global $wpdb;
     $actionsTable = $wpdb->prefix . 'actionscheduler_actions';
     $wpdb->query('TRUNCATE ' . $actionsTable);
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -13,7 +13,6 @@ use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Cron\Workers\WorkersFactory;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class DaemonHttpRunnerTest extends \MailPoetTest {
@@ -279,7 +278,6 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 
   private function createWorkersFactoryMock(array $workers = []) {

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -278,6 +278,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -276,10 +276,6 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $daemon->ping();
   }
 
-  public function _after() {
-    parent::_after();
-  }
-
   private function createWorkersFactoryMock(array $workers = []) {
     $worker = $this->makeEmpty(SimpleWorker::class, [
       'process' => null,

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -12,7 +12,6 @@ use MailPoet\Entities\LogEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\WP\Functions as WpFunctions;
 
 class DaemonTest extends \MailPoetTest {
@@ -92,7 +91,6 @@ class DaemonTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 
   private function createWorkersFactoryMock(array $workers = []) {

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -92,7 +92,6 @@ class DaemonTest extends \MailPoetTest {
 
   public function _after() {
     $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(LogEntity::class);
   }
 
   private function createWorkersFactoryMock(array $workers = []) {

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -91,6 +91,7 @@ class DaemonTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -89,10 +89,6 @@ class DaemonTest extends \MailPoetTest {
     $this->wp->removeFilter('mailpoet_cron_get_execution_limit', $limitCallback);
   }
 
-  public function _after() {
-    parent::_after();
-  }
-
   private function createWorkersFactoryMock(array $workers = []) {
     return $this->make(WorkersFactory::class, $workers + [
       'createScheduleWorker' => $this->createSimpleWorkerMock(),

--- a/mailpoet/tests/integration/Cron/SupervisorTest.php
+++ b/mailpoet/tests/integration/Cron/SupervisorTest.php
@@ -6,7 +6,6 @@ use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\Supervisor;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 
 class SupervisorTest extends \MailPoetTest {
   public $supervisor;
@@ -76,6 +75,5 @@ class SupervisorTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Cron/SupervisorTest.php
+++ b/mailpoet/tests/integration/Cron/SupervisorTest.php
@@ -75,6 +75,7 @@ class SupervisorTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Cron/SupervisorTest.php
+++ b/mailpoet/tests/integration/Cron/SupervisorTest.php
@@ -72,8 +72,4 @@ class SupervisorTest extends \MailPoetTest {
     $daemon = $this->supervisor->checkDaemon();
     expect($daemon['status'])->equals(CronHelper::DAEMON_STATUS_ACTIVE);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
+++ b/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
@@ -22,7 +22,6 @@ use MailPoet\Cron\Workers\WooCommercePastOrders;
 use MailPoet\Cron\Workers\WooCommerceSync as WooCommerceSyncWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Services\Bridge;
@@ -342,11 +341,5 @@ class WordPressTest extends \MailPoetTest {
     $task->setScheduledAt($scheduledAt);
     $this->entityManager->persist($task);
     $this->entityManager->flush();
-  }
-
-  public function _after() {
-    $this->truncateEntity(SettingEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/AuthorizedSendingEmailsCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/AuthorizedSendingEmailsCheckTest.php
@@ -8,11 +8,6 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Services\AuthorizedEmailsController;
 
 class AuthorizedSendingEmailsCheckTest extends \MailPoetTest {
-  public function _before() {
-    parent::_before();
-    $this->truncateEntity(ScheduledTaskEntity::class);
-  }
-
   public function testItRunsCheckOnBridge() {
     $bridgeMock = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Stub\Expected::once()]);
     $worker = new AuthorizedSendingEmailsCheck($bridgeMock);

--- a/mailpoet/tests/integration/Cron/Workers/BounceTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTest.php
@@ -107,7 +107,7 @@ class BounceTest extends \MailPoetTest {
     expect($this->scheduledTaskSubscribersRepository->findBy(['task' => $task]))->notEmpty();
 
     // 2nd run - nothing more to process, ScheduledTaskSubscriber will be cleaned up
-    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntityBackup(SubscriberEntity::class);
     $task = $this->createScheduledTask();
     $this->worker->prepareTaskStrategy($task, microtime(true));
     expect($this->scheduledTaskSubscribersRepository->findBy(['task' => $task]))->isEmpty();

--- a/mailpoet/tests/integration/Cron/Workers/InactiveSubscribersTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/InactiveSubscribersTest.php
@@ -25,7 +25,6 @@ class InactiveSubscribersTest extends \MailPoetTest {
   public function _before() {
     $this->settings = SettingsController::getInstance();
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
     $this->cronHelper = ContainerWrapper::getInstance()->get(CronHelper::class);
     parent::_before();

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
@@ -5,9 +5,7 @@ namespace MailPoet\Test\Cron\Workers\KeyCheck;
 use Codeception\Stub;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Cron\Workers\KeyCheck\KeyCheckWorkerMockImplementation as MockKeyCheckWorker;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Services\Bridge;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -118,10 +116,5 @@ class KeyCheckWorkerTest extends \MailPoetTest {
       null,
       $scheduledAt
     );
-  }
-
-  public function _after() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
@@ -7,7 +7,6 @@ use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Cron\Workers\KeyCheck\PremiumKeyCheck;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class PremiumKeyCheckTest extends \MailPoetTest {
@@ -65,6 +64,5 @@ class PremiumKeyCheckTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
@@ -64,6 +64,7 @@ class PremiumKeyCheckTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/PremiumKeyCheckTest.php
@@ -61,8 +61,4 @@ class PremiumKeyCheckTest extends \MailPoetTest {
       $this->premiumKey
     );
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
@@ -117,6 +117,7 @@ class SendingServiceKeyCheckTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
@@ -10,7 +10,6 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -118,6 +117,5 @@ class SendingServiceKeyCheckTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/SendingServiceKeyCheckTest.php
@@ -114,8 +114,4 @@ class SendingServiceKeyCheckTest extends \MailPoetTest {
       ]
     );
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -974,6 +974,7 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     Carbon::setTestNow();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -8,16 +8,9 @@ use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Cron\Workers\Scheduler;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterSegment;
@@ -982,16 +975,5 @@ class SchedulerTest extends \MailPoetTest {
 
   public function _after() {
     Carbon::setTestNow();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SettingEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -427,7 +427,6 @@ class SchedulerTest extends \MailPoetTest {
     $scheduledTask = $this->scheduledTasksRepository->findOneBySendingQueue($sendingQueue);
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
     $this->tester->assertEqualDateTimes($scheduledTask->getScheduledAt(), $currentTime->addMinutes(ScheduledTask::BASIC_RESCHEDULE_TIMEOUT), 1);
-    WPFunctions::set(new WPFunctions());
   }
 
   public function testItDoesntRunQueueDeliveryWhenMailpoetSubscriberHasUnsubscribed() {

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -971,9 +971,4 @@ class SchedulerTest extends \MailPoetTest {
       ['subscribersFinder' => $finder]
     );
   }
-
-  public function _after() {
-    parent::_after();
-    Carbon::setTestNow();
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -957,7 +957,6 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItDoesNotSendToTrashedSubscribers() {
-    $this->markTestSkipped('calls before and after manually');
     $sendingQueueWorker = $this->sendingQueueWorker;
     $sendingQueueWorker->mailerTask = $this->construct(
       MailerTask::class,
@@ -965,17 +964,7 @@ class SendingQueueTest extends \MailPoetTest {
       ['send' => $this->mailerTaskDummyResponse]
     );
 
-    // newsletter is sent to existing subscriber
-    $sendingQueueWorker->process();
-    $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
-    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
-    $this->sendingQueuesRepository->refresh($sendingQueue);
-    expect($sendingQueue->getCountTotal())->equals(1);
-
     // newsletter is not sent to trashed subscriber
-    $this->_after();
-    $this->entityManager->clear();
-    $this->_before();
     $subscriber = $this->subscriber;
     $subscriber->setDeletedAt(Carbon::now());
     $this->entityManager->flush();

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -454,14 +454,14 @@ class SendingQueueTest extends \MailPoetTest {
   public function testItSendCorrectDataToSubscribersOneByOne() {
     $subscribersRepository = ContainerWrapper::getInstance()->get(SubscribersRepository::class);
 
-    $subscriber1 = $subscribersRepository->findOneById(1);
+    $subscriber1 = $this->createSubscriber('1@localhost.com', 'firstName', 'lastName');
     $subscriber1->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
     $subscriber1->setSource('form');
     $subscriber1->setEmail('1@localhost.com');
     $subscribersRepository->persist($subscriber1);
 
 
-    $subscriber2 = $subscribersRepository->findOneById(2);
+    $subscriber2 = $this->createSubscriber('2@lcoalhost.com', 'first', 'last');
     $subscriber2->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
     $subscriber2->setSource('form');
     $subscriber2->setEmail('2@localhost.com');
@@ -500,9 +500,7 @@ class SendingQueueTest extends \MailPoetTest {
           'getProcessingMethod' => 'individual',
           'send' => Expected::exactly(2, function($newsletter, $subscriberEmail, $extraParams) use ($subscribersRepository, $queue) {
 
-            $subscriberId = explode('@', $subscriberEmail);
-            $subscriberId = (int)$subscriberId[0];
-            $subscriber = $subscribersRepository->findOneById($subscriberId);
+            $subscriber = $subscribersRepository->findOneBy(['email' => $subscriberEmail]);
             $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
             $unsubscribeUrl = $subscriptionUrlFactory->getUnsubscribeUrl($subscriber, (int)$queue->id);
             expect($newsletter['subject'])->equals('News for ' . $subscriberEmail);
@@ -964,6 +962,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItDoesNotSendToTrashedSubscribers() {
+    $this->markTestSkipped('calls before and after manually');
     $sendingQueueWorker = $this->sendingQueueWorker;
     $sendingQueueWorker->mailerTask = $this->construct(
       MailerTask::class,

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -17,15 +17,11 @@ use MailPoet\Cron\Workers\StatsNotifications\Scheduler as StatsNotificationsSche
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
-use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerFactory;
@@ -49,7 +45,6 @@ use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -1319,21 +1314,6 @@ class SendingQueueTest extends \MailPoetTest {
 
     expect($task->getStatus())->equals(ScheduledTaskEntity::STATUS_INVALID);
     expect($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
-  }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(StatisticsNewsletterEntity::class);
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 
   private function createNewsletter(string $type, $subject, string $status = NewsletterEntity::STATUS_DRAFT): NewsletterEntity {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -95,10 +95,4 @@ class LinksTest extends \MailPoetTest {
     );
     expect($unsubscribeCount)->equals(1);
   }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -10,8 +10,6 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Models\Subscriber;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
-use MailPoetVendor\Idiorm\ORM;
 
 class MailerTest extends \MailPoetTest {
   /** @var SettingsController */
@@ -130,7 +128,5 @@ class MailerTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -129,6 +129,7 @@ class MailerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
     ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
   }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/MailerTest.php
@@ -125,8 +125,4 @@ class MailerTest extends \MailPoetTest {
     // send method should return true
     expect($mailerTask->send('Newsletter', 'Subscriber'))->equals(['response' => true]);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -13,7 +13,6 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterPostEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
@@ -23,7 +22,6 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Router;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -573,15 +571,5 @@ class NewsletterTest extends \MailPoetTest {
       'html' => '<img src="http://example.com/different-image-same-alt.jpg" alt="alt text"><p>Text</p>',
     ];
     expect($originalCampaignId)->notEquals($this->newsletterTask->calculateCampaignId($newsletter, $renderedNewslettersDifferentImageSrc));
-  }
-
-  public function _after() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(NewsletterPostEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/PostsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/PostsTest.php
@@ -67,8 +67,4 @@ class PostsTest extends \MailPoetTest {
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
     expect($this->postsTask->extractAndSave($renderedNewsletter, $newsletter))->equals(false);
   }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterPostEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/ShortcodesTest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Test\Cron\Workers\SendingQueue\Tasks;
 
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes;
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use WP_Post;
@@ -47,8 +45,6 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
     wp_delete_post($this->wPPost, true);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/ShortcodesTest.php
@@ -45,6 +45,7 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     wp_delete_post($this->wPPost, true);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SimpleWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SimpleWorkerTest.php
@@ -6,8 +6,6 @@ use Codeception\Stub;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\Workers\SimpleWorkerMockImplementation as MockSimpleWorker;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -67,10 +65,5 @@ class SimpleWorkerTest extends \MailPoetTest {
     $difference -= (Carbon::DAYS_PER_WEEK - (int)$currentDate->format('N'));
     expect($difference)->lessOrEquals(7);
     expect($difference)->greaterOrEquals(0);
-  }
-
-  public function _after() {
-    $this->truncateEntity(SettingEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -6,11 +6,6 @@ use Codeception\Stub;
 use MailPoet\Config\Renderer;
 use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsClickEntity;
-use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MetaInfo;
@@ -83,17 +78,6 @@ class AutomatedEmailsTest extends \MailPoetTest {
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
 
     $this->newsletterFactory = new NewsletterFactory();
-  }
-
-  public function _after() {
-    parent::_after();
-
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
   }
 
   public function testItDoesntWorkIfDisabled() {

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -8,8 +8,6 @@ use MailPoet\Cron\CronHelper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsClickEntity;
-use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\StatsNotificationEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -77,7 +75,6 @@ class WorkerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(StatsNotificationsRepository::class);
     $this->newsletterLinkRepository = $this->diContainer->get(NewsletterLinkRepository::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
@@ -288,20 +285,5 @@ class WorkerTest extends \MailPoetTest {
     if (isset($data['created_at'])) $entity->setCreatedAt(new Carbon($data['created_at']));
     $this->entityManager->flush();
     return $entity;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -79,7 +79,6 @@ class WorkerTest extends \MailPoetTest {
     $this->newsletterLinkRepository = $this->diContainer->get(NewsletterLinkRepository::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
-    $this->repository->truncate();
     $this->mailer = $this->createMock(Mailer::class);
     $this->renderer = $this->createMock(Renderer::class);
     $this->settings = SettingsController::getInstance();

--- a/mailpoet/tests/integration/Cron/Workers/SubscriberLinkTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscriberLinkTokensTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Cron\Workers;
 
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
 class SubscriberLinkTokensTest extends \MailPoetTest {
@@ -33,9 +32,5 @@ class SubscriberLinkTokensTest extends \MailPoetTest {
     $this->assertSame($linkToken, $subscriberWithLinkToken->getLinkToken());
     $this->assertIsString($subscriberWithoutLinkToken1->getLinkToken());
     $this->assertIsString($subscriberWithoutLinkToken2->getLinkToken());
-  }
-
-  public function _after(): void {
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLastEngagementTest.php
@@ -171,13 +171,4 @@ class SubscribersLastEngagementTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $newsletter;
   }
-
-  public function _after(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
@@ -84,7 +84,7 @@ class SubscribersLifetimeEmailCountTest extends \MailPoetTest {
     $this->createCompletedSendingTasksForSubscriber($subscriber2, 8, 80);
 
     $task = new ScheduledTaskEntity();
-    $meta = ['highest_subscriber_id' => 2, 'last_subscriber_id' => 2];
+    $meta = ['highest_subscriber_id' => $subscriber2->getId(), 'last_subscriber_id' => $subscriber2->getId()];
     $task->setMeta($meta);
     $this->worker->processTaskStrategy($task, microtime(true));
 
@@ -105,7 +105,7 @@ class SubscribersLifetimeEmailCountTest extends \MailPoetTest {
     $this->createCompletedSendingTasksForSubscriber($subscriber2, 8, 80);
 
     $task = new ScheduledTaskEntity();
-    $meta = ['highest_subscriber_id' => 2, 'last_subscriber_id' => "2"];
+    $meta = ['highest_subscriber_id' => $subscriber2->getId(), 'last_subscriber_id' => $subscriber2->getId()];
     $task->setMeta($meta);
     $this->worker->processTaskStrategy($task, microtime(true));
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
@@ -39,11 +39,6 @@ class SubscribersLifetimeEmailCountTest extends \MailPoetTest {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->scheduledTaskFactory = new ScheduledTaskFactory();
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
     $this->newsletter = new NewsletterEntity();
     $this->newsletter->setSubject('Subject');
     $this->newsletter->setType(NewsletterEntity::TYPE_STANDARD);
@@ -216,13 +211,5 @@ class SubscribersLifetimeEmailCountTest extends \MailPoetTest {
     $this->entityManager->persist($taskSubscriber);
     $this->entityManager->flush();
     return $taskSubscriber;
-  }
-
-  public function _after(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
@@ -7,7 +7,6 @@ use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\Subscriber;
-use MailPoetVendor\Idiorm\ORM;
 
 class UnsubscribeTokensTest extends \MailPoetTest {
 
@@ -17,9 +16,6 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   private $newsletterWithoutToken;
 
   public function _before() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
     parent::_before();
     $this->subscriberWithToken = Subscriber::createOrUpdate(['email' => 'subscriber1@test.com']);
     $this->subscriberWithToken->set('unsubscribe_token', 'aaabbbcccdddeee');
@@ -64,11 +60,5 @@ class UnsubscribeTokensTest extends \MailPoetTest {
     $this->assertInstanceOf(Newsletter::class, $this->newsletterWithoutToken);
     expect($this->newsletterWithToken->unsubscribeToken)->equals('aaabbbcccdddeee');
     expect(strlen($this->newsletterWithoutToken->unsubscribeToken))->equals(15);
-  }
-
-  public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
@@ -39,7 +39,6 @@ class WooCommerceOrdersTest extends \MailPoetTest {
   private $cronWorkerRunner;
 
   public function _before() {
-    $this->cleanup();
     $this->woocommerceHelper = $this->createMock(WooCommerceHelper::class);
     $this->woocommercePurchases = $this->createMock(WooCommercePurchases::class);
 
@@ -181,14 +180,5 @@ class WooCommerceOrdersTest extends \MailPoetTest {
     $click->setCreatedAt($timestamp);
     $click->setUpdatedAt($timestamp);
     $this->entityManager->flush();
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -56,6 +56,6 @@ class WooCommerceSyncTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->tester->deleteTestWooOrders();
+    parent::_after();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\Cron\Workers;
 
 use MailPoet\Cron\Workers\WooCommerceSync;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
@@ -57,7 +56,6 @@ class WooCommerceSyncTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
     $this->tester->deleteTestWooOrders();
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceSyncTest.php
@@ -54,8 +54,4 @@ class WooCommerceSyncTest extends \MailPoetTest {
     );
     expect($worker->processTaskStrategy($task, microtime(true)))->equals(true);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/EmojiEncodingListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/EmojiEncodingListenerTest.php
@@ -42,9 +42,4 @@ class EmojiEncodingListenerTest extends \MailPoetTest {
       $replacement
     );
   }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(FormEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/LastSubscribedAtTest.php
@@ -107,9 +107,4 @@ class LastSubscribedAtTest extends EventListenersBaseTest {
 
     $this->assertEquals($this->now, $entity2->getLastSubscribedAt());
   }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(SubscriberEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
@@ -6,7 +6,6 @@ use Codeception\Stub\Expected;
 use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -66,6 +65,5 @@ class SubscriberListenerTest extends EventListenersBaseTest {
     parent::_after();
     $originalListener = $this->diContainer->get(TimestampListener::class);
     $this->replaceEntityListener($originalListener);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -16,7 +16,6 @@ class NewsletterEntityTest extends \MailPoetTest {
   private $segmentRepository;
 
   public function _before() {
-    $this->cleanup();
     $this->newsletterRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
   }
@@ -181,10 +180,6 @@ class NewsletterEntityTest extends \MailPoetTest {
     $this->assertSame($processedAt, $newsletter->getProcessedAt());
   }
 
-  public function _after() {
-    $this->cleanup();
-  }
-
   private function createNewsletter(): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
@@ -199,15 +194,5 @@ class NewsletterEntityTest extends \MailPoetTest {
     $newsletterOptionField->setNewsletterType(NewsletterEntity::TYPE_STANDARD);
     $this->entityManager->persist($newsletterOptionField);
     return $newsletterOptionField;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Entities/SubscriberEntityIntegrationTest.php
+++ b/mailpoet/tests/integration/Entities/SubscriberEntityIntegrationTest.php
@@ -20,9 +20,6 @@ class SubscriberEntityIntegrationTest extends \MailPoetTest {
   protected function _before() {
     parent::_before();
 
-    // Calling cleanup() here as some tests from other classes don't remove all SubscriberSegmentEntities causing issues here.
-    $this->cleanup();
-
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
 
     $segment1 = (new SegmentFactory())->create();
@@ -46,16 +43,5 @@ class SubscriberEntityIntegrationTest extends \MailPoetTest {
     $subscriberSegment2 = $this->subscriberSegmentRepository->findOneBy(['segment' => $this->segment2, 'subscriber' => $this->subscriber]);
 
     $this->assertSame([1 => $subscriberSegment2], $this->subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED)->toArray());
-  }
-
-  protected function _after() {
-    parent::_after();
-    $this->cleanup();
-  }
-
-  protected function cleanup() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Form/FormMessageControllerTest.php
+++ b/mailpoet/tests/integration/Form/FormMessageControllerTest.php
@@ -52,12 +52,4 @@ class FormMessageControllerTest extends \MailPoetTest {
       expect($form->getSettings()['success_message'] ?? null)->equals(__('Check your inbox or spam folder to confirm your subscription.', 'mailpoet'));
     }
   }
-
-  private function clear() {
-    $this->truncateEntity(FormEntity::class);
-  }
-
-  public function _after() {
-    $this->clear();
-  }
 }

--- a/mailpoet/tests/integration/Form/FormSaveControllerTest.php
+++ b/mailpoet/tests/integration/Form/FormSaveControllerTest.php
@@ -23,19 +23,11 @@ class FormSaveControllerTest extends \MailPoetTest {
     expect($duplicate->getStatus())->equals($form->getStatus());
   }
 
-  public function _after() {
-    $this->cleanup();
-  }
-
   private function createForm(): FormEntity {
     $form = new FormEntity('My Form');
     $form->setBody(Fixtures::get('form_body_template'));
     $this->entityManager->persist($form);
     $this->entityManager->flush();
     return $form;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(FormEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Form/FormsRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/FormsRepositoryTest.php
@@ -35,10 +35,6 @@ class FormsRepositoryTest extends \MailPoetTest {
     expect($form->getDeletedAt())->null();
   }
 
-  public function _after() {
-    $this->truncateEntity(FormEntity::class);
-  }
-
   private function createForm(string $name): FormEntity {
     $form = new FormEntity($name);
     $this->repository->persist($form);

--- a/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
@@ -94,8 +94,4 @@ class FormListingRepositoryTest extends \MailPoetTest {
     ]));
     expect($forms)->count(0);
   }
-
-  public function _after() {
-    $this->truncateEntity(FormEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Test\Helpscout;
 
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Helpscout\Beacon;
 use MailPoet\Services\Bridge;
@@ -16,7 +15,6 @@ class BeaconTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     // create 4 users (1 confirmed, 1 subscribed, 1 unsubscribed, 1 bounced)
     $subscriberFactory = new SubscriberFactory();
     $subscriberFactory
@@ -179,10 +177,5 @@ class BeaconTest extends \MailPoetTest {
     $beaconData = $this->diContainer->get(Beacon::class)->getData(true);
 
     $this->assertSame($expectedResult, $beaconData['MailPoet Premium/MSS key']);
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SettingEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Homepage/HomepageDataControllerTest.php
+++ b/mailpoet/tests/integration/Homepage/HomepageDataControllerTest.php
@@ -2,12 +2,7 @@
 
 namespace MailPoet\Homepage;
 
-use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -24,7 +19,6 @@ class HomepageDataControllerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->homepageDataController = $this->diContainer->get(HomepageDataController::class);
   }
 
@@ -256,14 +250,14 @@ class HomepageDataControllerTest extends \MailPoetTest {
       $this->entityManager->flush();
     }
     $subscribersStats = $this->homepageDataController->getPageData()['subscribersStats'];
-    expect($subscribersStats['global']['changePercent'])->equals( 0);
+    expect($subscribersStats['global']['changePercent'])->equals(0);
 
     // 10 New Subscribers + 6 Old Subscribers + 11 New Unsubscribed
     $unsubscribed = (new Subscriber())->withLastSubscribedAt($thirtyOneDaysAgo)->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)->create();
     $this->entityManager->persist(new StatisticsUnsubscribeEntity(null, null, $unsubscribed));
     $this->entityManager->flush();
     $subscribersStats = $this->homepageDataController->getPageData()['subscribersStats'];
-    expect($subscribersStats['global']['changePercent'])->equals( -5.9);
+    expect($subscribersStats['global']['changePercent'])->equals(-5.9);
   }
 
   public function testItFetchesCorrectListLevelSubscribedStats(): void {
@@ -329,17 +323,5 @@ class HomepageDataControllerTest extends \MailPoetTest {
     expect($subscribersStats['lists'][0]['name'])->equals($segment->getName());
     expect($subscribersStats['lists'][0]['unsubscribed'])->equals(1);
     expect($subscribersStats['lists'][0]['subscribed'])->equals(0);
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SettingEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Logging/LogHandlerTest.php
+++ b/mailpoet/tests/integration/Logging/LogHandlerTest.php
@@ -16,7 +16,6 @@ class LogHandlerTest extends \MailPoetTest {
   private $entityManagerFactory;
 
   public function _before() {
-    $this->truncateEntity(LogEntity::class);
     $this->repository = $this->diContainer->get(LogRepository::class);
     $this->entityManagerFactory = $this->diContainer->get(EntityManagerFactory::class);
   }
@@ -142,14 +141,6 @@ class LogHandlerTest extends \MailPoetTest {
     $createdAt = $log->getCreatedAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
     expect($createdAt->format('Y-m-d H:i:s'))->equals($time->format('Y-m-d H:i:s'));
-  }
-
-  public function _after() {
-    $this->cleanup();
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SubscriberEntity::class);
   }
 
   /**

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -7,7 +7,6 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 
 class MailerLogTest extends \MailPoetTest {
 
@@ -452,10 +451,5 @@ class MailerLogTest extends \MailPoetTest {
     } catch (\Exception $e) {
       expect($e->getMessage())->equals('Sending has been paused.');
     }
-  }
-
-  public function _after() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(LogEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Mailer/MetaInfoTest.php
+++ b/mailpoet/tests/integration/Mailer/MetaInfoTest.php
@@ -201,8 +201,4 @@ class MetaInfoTest extends \MailPoetTest {
       'subscriber_source' => 'form',
     ]);
   }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
+++ b/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
@@ -19,7 +19,6 @@ class WordpressMailerTest extends \MailPoetTest {
 
   public function _before() {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
-    $this->subscribersRepository->truncate();
   }
 
   public function testItDoesNotSendWhenPreSendCheckFails() {
@@ -343,7 +342,6 @@ class WordpressMailerTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->subscribersRepository->truncate();
   }
 }
 // phpcs:enable

--- a/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
+++ b/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
@@ -195,7 +195,7 @@ class WordpressMailerTest extends \MailPoetTest {
         'subscribersRepository' => $this->subscribersRepository,
       ],
       [
-        'postSend' => function() { throw new \Exception('Some strange error in mailer'); 
+        'postSend' => function() { throw new \Exception('Some strange error in mailer');
         },
       ]
     );
@@ -342,6 +342,7 @@ class WordpressMailerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->subscribersRepository->truncate();
   }
 }

--- a/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
+++ b/mailpoet/tests/integration/Mailer/WordPress/WordpressMailerTest.php
@@ -339,9 +339,5 @@ class WordpressMailerTest extends \MailPoetTest {
     $mock->method('buildMailer')->willReturn($mailerMock);
     return $mock;
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }
 // phpcs:enable

--- a/mailpoet/tests/integration/Migrations/Migration_20221028_105818_Test.php
+++ b/mailpoet/tests/integration/Migrations/Migration_20221028_105818_Test.php
@@ -28,7 +28,6 @@ class Migration_20221028_105818_Test extends \MailPoetTest {
     parent::_before();
     $this->migration = new Migration_20221028_105818($this->diContainer);
     $this->settings = $this->diContainer->get(SettingsController::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 
   public function testItMigratesEmailMachineOpensFiltersCorrectly() {
@@ -254,9 +253,5 @@ class Migration_20221028_105818_Test extends \MailPoetTest {
       ]
     );
     return (int)$this->entityManager->getConnection()->lastInsertId();
-  }
-
-  public function _after() {
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Models/CustomFieldTest.php
+++ b/mailpoet/tests/integration/Models/CustomFieldTest.php
@@ -145,6 +145,7 @@ class CustomFieldTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     CustomField::deleteMany();
     Subscriber::deleteMany();
     SubscriberCustomField::deleteMany();

--- a/mailpoet/tests/integration/Models/CustomFieldTest.php
+++ b/mailpoet/tests/integration/Models/CustomFieldTest.php
@@ -143,11 +143,4 @@ class CustomFieldTest extends \MailPoetTest {
     $subscriber = $customField->subscribers()->findOne();
     expect($subscriber->value)->equals($association->value);
   }
-
-  public function _after() {
-    parent::_after();
-    CustomField::deleteMany();
-    Subscriber::deleteMany();
-    SubscriberCustomField::deleteMany();
-  }
 }

--- a/mailpoet/tests/integration/Models/ModelTest.php
+++ b/mailpoet/tests/integration/Models/ModelTest.php
@@ -85,6 +85,7 @@ class ModelTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     ORM::setDb($this->connection->getWrappedConnection());
   }
 }

--- a/mailpoet/tests/integration/Models/NewsletterTest.php
+++ b/mailpoet/tests/integration/Models/NewsletterTest.php
@@ -3,15 +3,6 @@
 namespace MailPoet\Test\Models;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\NewsletterSegmentEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsClickEntity;
-use MailPoet\Entities\StatisticsOpenEntity;
-use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterSegment;
 use MailPoet\Models\ScheduledTask;
@@ -512,18 +503,5 @@ class NewsletterTest extends \MailPoetTest {
     $newsletter = Newsletter::findOne($newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $newsletter);
     return $newsletter;
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Models/ScheduledTaskSubscriberTest.php
+++ b/mailpoet/tests/integration/Models/ScheduledTaskSubscriberTest.php
@@ -6,7 +6,6 @@ use Codeception\Util\Fixtures;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\Subscriber;
-use MailPoetVendor\Idiorm\ORM;
 
 class ScheduledTaskSubscriberTest extends \MailPoetTest {
   public $subscribersCounter;
@@ -77,12 +76,5 @@ class ScheduledTaskSubscriberTest extends \MailPoetTest {
     $this->taskSubscriber->save();
     $count = ScheduledTaskSubscriber::getProcessedCount($this->task->id);
     expect($count)->equals(1);
-  }
-
-  public function _after() {
-    parent::_after();
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
-    ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
   }
 }

--- a/mailpoet/tests/integration/Models/ScheduledTaskSubscriberTest.php
+++ b/mailpoet/tests/integration/Models/ScheduledTaskSubscriberTest.php
@@ -80,6 +80,7 @@ class ScheduledTaskSubscriberTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
     ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
     ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);

--- a/mailpoet/tests/integration/Models/ScheduledTaskTest.php
+++ b/mailpoet/tests/integration/Models/ScheduledTaskTest.php
@@ -9,7 +9,6 @@ use MailPoet\Models\SendingQueue;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Idiorm\ORM;
 
 class ScheduledTaskTest extends \MailPoetTest {
   public $task;
@@ -161,11 +160,5 @@ class ScheduledTaskTest extends \MailPoetTest {
 
     expect(Helpers::isJson($task->meta))->false();
     expect($task->meta)->equals($meta);
-  }
-
-  public function _after() {
-    parent::_after();
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
-    ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
   }
 }

--- a/mailpoet/tests/integration/Models/ScheduledTaskTest.php
+++ b/mailpoet/tests/integration/Models/ScheduledTaskTest.php
@@ -164,6 +164,7 @@ class ScheduledTaskTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
     ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
   }

--- a/mailpoet/tests/integration/Models/SegmentTest.php
+++ b/mailpoet/tests/integration/Models/SegmentTest.php
@@ -270,6 +270,7 @@ class SegmentTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
     ORM::raw_execute('TRUNCATE ' . Segment::$_table);
     ORM::raw_execute('TRUNCATE ' . SubscriberSegment::$_table);

--- a/mailpoet/tests/integration/Models/SegmentTest.php
+++ b/mailpoet/tests/integration/Models/SegmentTest.php
@@ -7,7 +7,6 @@ use MailPoet\Models\NewsletterSegment;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
 use MailPoet\Models\SubscriberSegment;
-use MailPoetVendor\Idiorm\ORM;
 
 class SegmentTest extends \MailPoetTest {
   public $segment;
@@ -267,14 +266,5 @@ class SegmentTest extends \MailPoetTest {
     expect($segments[1]['subscribers'])->equals(3);
     expect($segments[0]['name'])->equals($this->segmentData['name']);
     expect($segments[0]['subscribers'])->equals(1);
-  }
-
-  public function _after() {
-    parent::_after();
-    ORM::raw_execute('TRUNCATE ' . Subscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . Segment::$_table);
-    ORM::raw_execute('TRUNCATE ' . SubscriberSegment::$_table);
-    ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
-    ORM::raw_execute('TRUNCATE ' . NewsletterSegment::$_table);
   }
 }

--- a/mailpoet/tests/integration/Models/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Models/SendingQueueTest.php
@@ -123,6 +123,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
     ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
     ORM::raw_execute('TRUNCATE ' . SendingQueue::$_table);

--- a/mailpoet/tests/integration/Models/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Models/SendingQueueTest.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Test\Models;
 
-use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Idiorm\ORM;
@@ -120,12 +118,5 @@ class SendingQueueTest extends \MailPoetTest {
     $sendingQueue = SendingQueue::findOne($queue->id);
     $this->assertInstanceOf(SendingQueue::class, $sendingQueue);
     expect($sendingQueue->newsletterRenderedBody)->equals(json_encode($newsletterRenderedBody));
-  }
-
-  public function _after() {
-    parent::_after();
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
-    ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . SendingQueue::$_table);
   }
 }

--- a/mailpoet/tests/integration/Models/SubscriberCustomFieldTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberCustomFieldTest.php
@@ -77,6 +77,7 @@ class SubscriberCustomFieldTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     SubscriberCustomField::deleteMany();
   }
 }

--- a/mailpoet/tests/integration/Models/SubscriberCustomFieldTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberCustomFieldTest.php
@@ -75,9 +75,4 @@ class SubscriberCustomFieldTest extends \MailPoetTest {
     $records = SubscriberCustomField::findArray();
     expect($records)->count(1);
   }
-
-  public function _after() {
-    parent::_after();
-    SubscriberCustomField::deleteMany();
-  }
 }

--- a/mailpoet/tests/integration/Models/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberSegmentTest.php
@@ -336,6 +336,7 @@ class SubscriberSegmentTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     Segment::deleteMany();
     Subscriber::deleteMany();
     SubscriberSegment::deleteMany();

--- a/mailpoet/tests/integration/Models/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberSegmentTest.php
@@ -334,11 +334,4 @@ class SubscriberSegmentTest extends \MailPoetTest {
     expect($subscribedSegments[0]['name'])->equals($this->wpSegment->name);
     expect($subscribedSegments[1]['name'])->equals($this->wcSegment->name);
   }
-
-  public function _after() {
-    parent::_after();
-    Segment::deleteMany();
-    Subscriber::deleteMany();
-    SubscriberSegment::deleteMany();
-  }
 }

--- a/mailpoet/tests/integration/Models/SubscriberTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberTest.php
@@ -699,37 +699,25 @@ class SubscriberTest extends \MailPoetTest {
     expect($total)->equals(1);
   }
 
-  public function testItCanFindSubscribersInSegments() {
-    // create 3 subscribers, segments and subscriber-segment relations
-    $prepareData = function() {
-      $this->_after();
-      $subscriber = [];
-      $segment = [];
-      $subscriberSegment = [];
-      for ($i = 1; $i <= 3; $i++) {
-        $subscriber[$i] = Subscriber::create();
-        $subscriber[$i]->status = Subscriber::STATUS_SUBSCRIBED;
-        $subscriber[$i]->email = $i . '@test.com';
-        $subscriber[$i]->firstName = 'first ' . $i;
-        $subscriber[$i]->lastName = 'last ' . $i;
-        $subscriber[$i]->save();
-        $segment[$i] = Segment::create();
-        $segment[$i]->name = 'segment ' . $i;
-        $segment[$i]->save();
-        $subscriberSegment[$i] = SubscriberSegment::create();
-        $subscriberSegment[$i]->subscriberId = $subscriber[$i]->id;
-        $subscriberSegment[$i]->segmentId = (int)$segment[$i]->id;
-        $subscriberSegment[$i]->save();
-      }
-      return [
-        $subscriber,
-        $segment,
-        $subscriberSegment,
-      ];
-    };
-
-    // it should not find deleted and nonexistent subscribers
-    list($subscriber, $segment,) = $prepareData();
+  public function testItDoesNotFindDeletedOrNonexistentSubscribersInSegments() {
+    $subscriber = [];
+    $segment = [];
+    $subscriberSegment = [];
+    for ($i = 1; $i <= 3; $i++) {
+      $subscriber[$i] = Subscriber::create();
+      $subscriber[$i]->status = Subscriber::STATUS_SUBSCRIBED;
+      $subscriber[$i]->email = $i . '@test.com';
+      $subscriber[$i]->firstName = 'first ' . $i;
+      $subscriber[$i]->lastName = 'last ' . $i;
+      $subscriber[$i]->save();
+      $segment[$i] = Segment::create();
+      $segment[$i]->name = 'segment ' . $i;
+      $segment[$i]->save();
+      $subscriberSegment[$i] = SubscriberSegment::create();
+      $subscriberSegment[$i]->subscriberId = $subscriber[$i]->id;
+      $subscriberSegment[$i]->segmentId = (int)$segment[$i]->id;
+      $subscriberSegment[$i]->save();
+    }
     $subscriber[1]->deletedAt = date("Y-m-d H:i:s");
     $subscriber[1]->save();
     $subscriber[2]->delete();
@@ -748,9 +736,27 @@ class SubscriberTest extends \MailPoetTest {
     expect(Subscriber::extractSubscribersIds($subscribers))->equals(
       [$subscriber[3]->id]
     );
+  }
 
-    // it should not find subscribers with global unsubscribe status
-    list($subscriber, $segment,) = $prepareData();
+  public function testItDoesNotFindGloballyUnsubscribedSubscribersInSegments() {
+    $subscriber = [];
+    $segment = [];
+    $subscriberSegment = [];
+    for ($i = 1; $i <= 3; $i++) {
+      $subscriber[$i] = Subscriber::create();
+      $subscriber[$i]->status = Subscriber::STATUS_SUBSCRIBED;
+      $subscriber[$i]->email = $i . '@test.com';
+      $subscriber[$i]->firstName = 'first ' . $i;
+      $subscriber[$i]->lastName = 'last ' . $i;
+      $subscriber[$i]->save();
+      $segment[$i] = Segment::create();
+      $segment[$i]->name = 'segment ' . $i;
+      $segment[$i]->save();
+      $subscriberSegment[$i] = SubscriberSegment::create();
+      $subscriberSegment[$i]->subscriberId = $subscriber[$i]->id;
+      $subscriberSegment[$i]->segmentId = (int)$segment[$i]->id;
+      $subscriberSegment[$i]->save();
+    }
     $subscriber[2]->status = Subscriber::STATUS_UNSUBSCRIBED;
     $subscriber[2]->save();
     $subscribers = Subscriber::findSubscribersInSegments(
@@ -771,9 +777,27 @@ class SubscriberTest extends \MailPoetTest {
         $subscriber[3]->id,
       ]
     );
+  }
 
-    // it should not find subscribers unsubscribed from segment or when segment doesn't exist
-    list($subscriber, $segment, $subscriberSegment) = $prepareData();
+  public function testItShouldNotFindSubscribersUnsubscribedFromSegmentOrWhenSegmentDoesNotExist() {
+    $subscriber = [];
+    $segment = [];
+    $subscriberSegment = [];
+    for ($i = 1; $i <= 3; $i++) {
+      $subscriber[$i] = Subscriber::create();
+      $subscriber[$i]->status = Subscriber::STATUS_SUBSCRIBED;
+      $subscriber[$i]->email = $i . '@test.com';
+      $subscriber[$i]->firstName = 'first ' . $i;
+      $subscriber[$i]->lastName = 'last ' . $i;
+      $subscriber[$i]->save();
+      $segment[$i] = Segment::create();
+      $segment[$i]->name = 'segment ' . $i;
+      $segment[$i]->save();
+      $subscriberSegment[$i] = SubscriberSegment::create();
+      $subscriberSegment[$i]->subscriberId = $subscriber[$i]->id;
+      $subscriberSegment[$i]->segmentId = (int)$segment[$i]->id;
+      $subscriberSegment[$i]->save();
+    }
     $subscriberSegment[3]->status = Subscriber::STATUS_UNSUBSCRIBED;
     $subscriberSegment[3]->save();
     $subscriberSegment[2]->delete();

--- a/mailpoet/tests/integration/Models/SubscriberTest.php
+++ b/mailpoet/tests/integration/Models/SubscriberTest.php
@@ -3,10 +3,6 @@
 namespace MailPoet\Test\Models;
 
 use Codeception\Util\Fixtures;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberCustomFieldEntity;
-use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Models\CustomField;
 use MailPoet\Models\Segment;
 use MailPoet\Models\Subscriber;
@@ -874,12 +870,5 @@ class SubscriberTest extends \MailPoetTest {
         '2' => 'France',
       ]
     );
-  }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AbandonedCartContentTest.php
@@ -5,11 +5,7 @@ namespace MailPoet\Newsletter\Renderer\Blocks;
 use MailPoet\AutomaticEmails\WooCommerce\Events\AbandonedCart;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce as WooCommerceEmail;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\NewsletterPostEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler;
@@ -192,15 +188,5 @@ class AbandonedCartContentTest extends \MailPoetTest {
     $parisTask = ScheduledTask::findOne($scheduledTask->getId());
     $this->assertInstanceOf(ScheduledTask::class, $parisTask);
     return Sending::createFromScheduledTask($parisTask);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Blocks/AutomatedLatestContentBlockTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AutomatedLatestContentBlockTest.php
@@ -188,10 +188,4 @@ class AutomatedLatestContentBlockTest extends \MailPoetTest {
     $this->newslettersRepository->flush();
     return $newsletter;
   }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Newsletter/Links/LinksTest.php
+++ b/mailpoet/tests/integration/Newsletter/Links/LinksTest.php
@@ -6,7 +6,6 @@ use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Router\Router;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
@@ -300,12 +299,5 @@ class LinksTest extends \MailPoetTest {
     $result = $this->links->convertHashedLinksToShortcodesAndUrls($content, $newsletterLink1->getQueue()->getId(), $convertAll = true);
     expect($result)->stringContainsString($newsletterLink1->getUrl());
     expect($result)->stringContainsString($newsletterLink2->getUrl());
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Links/LinksTest.php
+++ b/mailpoet/tests/integration/Newsletter/Links/LinksTest.php
@@ -196,14 +196,19 @@ class LinksTest extends \MailPoetTest {
         'hash' => '123',
       ],
     ];
+    $newsletterId = $this->newsletter->getId();
+    $latestQueue = $this->newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $latestQueue);
+    $queueId = $latestQueue->getId();
+
     $this->links->save(
       $links,
-      $newsletterId = 1,
-      $queueId = 1
+      $newsletterId,
+      $queueId
     );
 
     // 1 database record was created
-    $newsletterLink = $this->newsletterLinkRepository->findOneBy(['newsletter' => 1, 'queue' => 1]);
+    $newsletterLink = $this->newsletterLinkRepository->findOneBy(['newsletter' => $newsletterId, 'queue' => $queueId]);
     $this->assertInstanceOf(NewsletterLinkEntity::class, $newsletterLink);
     expect($newsletterLink->getHash())->equals('123');
     expect($newsletterLink->getUrl())->equals('http://example.com');
@@ -225,7 +230,7 @@ class LinksTest extends \MailPoetTest {
       ->withUrl('http://demo.com')
       ->create();
 
-    list($content, $links) = $this->links->process('<a href="http://example.com">x</a>', 1, 2);
+    list($content, $links) = $this->links->process('<a href="http://example.com">x</a>', $this->newsletter->getId(), 2);
     expect(is_array($links))->true();
     expect(count($links))->equals(1);
     expect($links[0]['hash'])->equals('123');

--- a/mailpoet/tests/integration/Newsletter/Listing/NewsletterListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Listing/NewsletterListingRepositoryTest.php
@@ -317,10 +317,4 @@ class NewsletterListingRepositoryTest extends \MailPoetTest {
     expect($filters['segment'][1]['label'])->equals('Segment 1 (1)');
     expect($filters['segment'][1]['value'])->equals($segment1->getId());
   }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -32,7 +32,6 @@ class NewsletterRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(NewslettersRepository::class);
     $this->taskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
   }
@@ -410,24 +409,5 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($statistics);
     $this->entityManager->flush();
     return $statistics;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(StatsNotificationEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(StatisticsWooCommercePurchaseEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsNewsletterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -26,7 +26,6 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->saveController = $this->diContainer->get(NewsletterSaveController::class);
     $this->scheduler = $this->diContainer->get(Scheduler::class);
   }
@@ -350,10 +349,6 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     expect($newsletter->getReplyToAddress())->same('reply@test.com');
   }
 
-  public function _after() {
-    $this->cleanup();
-  }
-
   private function createNewsletter(string $type, string $status = NewsletterEntity::STATUS_DRAFT): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType($type);
@@ -399,15 +394,5 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
       $this->entityManager->persist($newsletterOptionField);
     }
     $this->entityManager->flush();
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -57,6 +57,7 @@ class SendPreviewControllerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions());
   }
 

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -30,8 +30,6 @@ class SendPreviewControllerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
     $this->newsletterUrl = $this->diContainer->get(Url::class);
     $this->subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
     $newsletter = new NewsletterEntity();

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -56,11 +56,6 @@ class SendPreviewControllerTest extends \MailPoetTest {
     $this->newsletter = $newsletter;
   }
 
-  public function _after() {
-    parent::_after();
-    WPFunctions::set(new WPFunctions());
-  }
-
   public function testItCanSendAPreview() {
     $mailer = $this->makeEmpty(Mailer::class, [
       'send' => Expected::once(

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -3,13 +3,9 @@
 namespace MailPoet\Newsletter\Scheduler;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -211,16 +207,5 @@ class AutomaticEmailTest extends \MailPoetTest {
       ]
     );
     return $newsletter;
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
@@ -355,6 +355,7 @@ class PostNotificationTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     Carbon::setTestNow();
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
@@ -9,9 +9,7 @@ use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
@@ -358,13 +356,5 @@ class PostNotificationTest extends \MailPoetTest {
 
   public function _after() {
     Carbon::setTestNow();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
@@ -353,9 +353,4 @@ class PostNotificationTest extends \MailPoetTest {
     $this->newsletterPostsRepository->flush();
     return $newsletterPost;
   }
-
-  public function _after() {
-    parent::_after();
-    Carbon::setTestNow();
-  }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -7,7 +7,6 @@ use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
@@ -37,7 +36,6 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     // Prepare Newsletter field options for configuring re-engagement emails
     $this->afterTimeNumberOptionField = new NewsletterOptionFieldEntity();
     $this->afterTimeNumberOptionField->setName(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER);
@@ -214,23 +212,5 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     $subscriber->setLastSubscribedAt($lastEngagement);
     $this->entityManager->flush();
     return $subscriber;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
@@ -65,6 +65,7 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     Carbon::setTestNow();
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
@@ -3,13 +3,6 @@
 namespace MailPoet\Test\Newsletter\Scheduler;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\NewsletterPostEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterOption as NewsletterOptionFactory;
@@ -73,13 +66,5 @@ class SchedulerTest extends \MailPoetTest {
 
   public function _after() {
     Carbon::setTestNow();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterPostEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/SchedulerTest.php
@@ -63,9 +63,4 @@ class SchedulerTest extends \MailPoetTest {
     expect($this->testee->formatDatetimeString('April 20, 2016 4pm'))
       ->equals('2016-04-20 16:00:00');
   }
-
-  public function _after() {
-    parent::_after();
-    Carbon::setTestNow();
-  }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -462,6 +462,7 @@ class WelcomeTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     Carbon::setTestNow();
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -3,10 +3,7 @@
 namespace MailPoet\Newsletter\Scheduler;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -466,13 +463,5 @@ class WelcomeTest extends \MailPoetTest {
 
   public function _after() {
     Carbon::setTestNow();
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -460,9 +460,4 @@ class WelcomeTest extends \MailPoetTest {
       new Scheduler($wpMock, $this->diContainer->get(NewslettersRepository::class))
     );
   }
-
-  public function _after() {
-    parent::_after();
-    Carbon::setTestNow();
-  }
 }

--- a/mailpoet/tests/integration/Newsletter/Segment/NewsletterSegmentRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Segment/NewsletterSegmentRepositoryTest.php
@@ -24,7 +24,6 @@ class NewsletterSegmentRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(NewsletterSegmentRepository::class);
     $this->welcomeEmailSegmentOption = $this->createNewsletterOptionField(NewsletterEntity::TYPE_WELCOME, NewsletterOptionFieldEntity::NAME_SEGMENT);
     $this->automaticEmailSegmentOption = $this->createNewsletterOptionField(NewsletterEntity::TYPE_AUTOMATIC, NewsletterOptionFieldEntity::NAME_SEGMENT);
@@ -76,10 +75,6 @@ class NewsletterSegmentRepositoryTest extends \MailPoetTest {
     expect($usedSegments[$segmentWithPostNotification->getId()])->equals(['Notification']);
     sort($usedSegments[$segmentWithMultipleActiveEmails->getId()]);
     expect($usedSegments[$segmentWithMultipleActiveEmails->getId()])->equals(['Notification', 'Sending', 'Welcome2']);
-  }
-
-  public function _after() {
-    $this->cleanup();
   }
 
   private function createNewsletter(string $type, $subject, string $status = NewsletterEntity::STATUS_DRAFT): NewsletterEntity {
@@ -146,15 +141,5 @@ class NewsletterSegmentRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($option);
     $this->entityManager->flush();
     return $option;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersListingRepositoryTest.php
@@ -32,7 +32,6 @@ class ScheduledTaskSubscribersListingRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->listingHandler = $this->diContainer->get(Handler::class);
     $this->repository = $this->diContainer->get(ScheduledTaskSubscribersListingRepository::class);
     $this->scheduledTaskFactory = new ScheduledTaskFactory();
@@ -129,11 +128,5 @@ class ScheduledTaskSubscribersListingRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $tasksSubscribers[0]);
     $this->assertInstanceOf(SubscriberEntity::class, $tasksSubscribers[0]->getSubscriber());
     expect($tasksSubscribers[0]->getSubscriber()->getEmail())->equals('subscriberProcessed@email.com');
-  }
-
-  public function cleanup() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
@@ -4,9 +4,7 @@ namespace MailPoet\Newsletter\Sending;
 
 use MailPoet\Cron\Workers\Bounce;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
-use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue;
@@ -204,11 +202,5 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
 
     $tasks = $this->repository->findScheduledSendingTasks();
     $this->assertSame($expectedResult, $tasks);
-  }
-
-  public function cleanup() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
@@ -114,8 +114,8 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
   }
 
   public function testItCanFetchBasicTasksData() {
-    $this->scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDay());
-    $this->scheduledTaskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, Carbon::now()->addDay());
+    $task1 = $this->scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDay());
+    $task2 = $this->scheduledTaskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, Carbon::now()->addDay());
     $data = $this->repository->getLatestTasks();
     expect(count($data))->equals(2);
     $ids = array_map(function ($d){ return $d->getId();
@@ -124,8 +124,8 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
     $types = array_map(function ($d){ return $d->getType();
 
     }, $data);
-    $this->assertContains(1, $ids);
-    $this->assertContains(2, $ids);
+    $this->assertContains($task1->getId(), $ids);
+    $this->assertContains($task2->getId(), $ids);
     $this->assertContains(SendingTask::TASK_TYPE, $types);
     $this->assertContains(Bounce::TASK_TYPE, $types);
     expect(is_int($data[1]->getPriority()))->true();

--- a/mailpoet/tests/integration/Newsletter/Sending/SendingQueuesRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/SendingQueuesRepositoryTest.php
@@ -14,7 +14,6 @@ class SendingQueuesRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(SendingQueuesRepository::class);
   }
 
@@ -152,13 +151,5 @@ class SendingQueuesRepositoryTest extends \MailPoetTest {
     $subscriber->setEmail('a@example.com');
     $this->entityManager->persist($subscriber);
     return $subscriber;
-  }
-
-  public function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesHelperTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesHelperTest.php
@@ -10,7 +10,6 @@ class ShortcodesHelperTest extends \MailPoetTest {
   private $shortcodesHelper;
 
   public function _before() {
-    $this->truncateEntity(CustomFieldEntity::class);
     $this->shortcodesHelper = $this->diContainer->get(ShortcodesHelper::class);
   }
 

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -482,6 +482,7 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->cleanup();
   }
 

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -486,11 +486,6 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
     if ($this->wPPost) wp_delete_post($this->wPPost, true);
     if ($this->wPUser) wp_delete_user($this->wPUser->ID);
   }

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -237,6 +237,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     // reset WP user role
     $wpUser = wp_get_current_user();
     $wpUser->add_role('administrator');

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -68,6 +68,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $subscriber->setLastName('Last');
     $this->subscribersRepository->persist($subscriber);
     $this->subscribersRepository->flush();
+    $this->subscriber = $subscriber;
 
     // create task & queue
     $sendingTask = SendingTask::create();
@@ -148,11 +149,12 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
   }
 
   public function testItSetsSubscriberToLoggedInWPUserWhenPreviewIsEnabled() {
+    $subscriberId = $this->subscriber->getId();
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
+      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) use ($subscriberId) {
         $this->assertNotNull($subscriber); // PHPStan
         expect($subscriber)->notNull();
-        expect($subscriber->getId())->equals(1);
+        expect($subscriber->getId())->equals($subscriberId);
       }),
     ]);
 

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Newsletter\ViewInBrowser;
 
 use Codeception\Stub\Expected;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -69,7 +68,6 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $subscriber->setLastName('Last');
     $this->subscribersRepository->persist($subscriber);
     $this->subscribersRepository->flush();
-    $this->subscriber = $subscriber;
 
     // create task & queue
     $sendingTask = SendingTask::create();
@@ -237,10 +235,6 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
     // reset WP user role
     $wpUser = wp_get_current_user();
     $wpUser->add_role('administrator');

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -4,8 +4,6 @@ namespace MailPoet\Newsletter\ViewInBrowser;
 
 use Codeception\Stub\Expected;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterLinkEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links;
@@ -233,13 +231,5 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     // open tracking data tag should be removed
     expect($renderedBody)->stringNotContainsString('[mailpoet_open_data]');
     expect($renderedBody)->stringContainsString('<img alt="" class="" src="">');
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
   }
 }

--- a/mailpoet/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
+++ b/mailpoet/tests/integration/NewsletterTemplates/NewsletterTemplatesRepositoryTest.php
@@ -9,7 +9,6 @@ class NewsletterTemplatesRepositoryTest extends \MailPoetTest {
   private $newsletterTemplatesRepository;
 
   public function _before() {
-    $this->truncateEntity(NewsletterTemplateEntity::class);
     $this->newsletterTemplatesRepository = $this->diContainer->get(NewsletterTemplatesRepository::class);
   }
 
@@ -63,9 +62,5 @@ class NewsletterTemplatesRepositoryTest extends \MailPoetTest {
     expect($createdTemplate->getName())->equals('Another template');
     expect($createdTemplate->getBody())->equals(['content' => [], 'globalStyles' => []]);
     expect($createdTemplate->getThumbnailData())->equals('data:image/gif;base64,R0lGODlhAQABAAAAACw=');
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterTemplateEntity::class);
   }
 }

--- a/mailpoet/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
+++ b/mailpoet/tests/integration/NewsletterTemplates/ThumbnailSaverTest.php
@@ -10,7 +10,6 @@ class ThumbnailSaverTest extends \MailPoetTest {
   private $thumbnailSaver;
 
   public function _before() {
-    $this->truncateEntity(NewsletterTemplateEntity::class);
     $this->thumbnailSaver = $this->diContainer->get(ThumbnailSaver::class);
   }
 

--- a/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\PostEditorBlocks;
 
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\WooCommerce as WooSegment;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -44,7 +43,6 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(WooHelper::class)
     );
-    $this->cleanup();
   }
 
   public function testItHandlesOptInForGuestCustomer() {
@@ -137,15 +135,5 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
       ->withStatus($status)
       ->withIsWooCommerceUser(true)
       ->create();
-  }
-
-  public function cleanup() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
@@ -146,7 +146,7 @@ class AutomationPutEndpointTest extends AutomationTest {
   }
 
   public function _after() {
-    $this->automationStorage->truncate();
     parent::_after();
+    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
@@ -147,6 +147,5 @@ class AutomationPutEndpointTest extends AutomationTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationPutEndpointTest.php
@@ -144,8 +144,4 @@ class AutomationPutEndpointTest extends AutomationTest {
     }
     return $data;
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
@@ -88,7 +88,7 @@ class AutomationsCreateFromTemplateTest extends AutomationTest {
   }
 
   public function _after() {
-    $this->automationStorage->truncate();
     parent::_after();
+    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
@@ -86,8 +86,4 @@ class AutomationsCreateFromTemplateTest extends AutomationTest {
     $this->assertInstanceOf(Automation::class, $createdAutomation);
     $this->assertSame($createdAutomation->getId(), $response['data']['id']);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsCreateFromTemplateTest.php
@@ -89,6 +89,5 @@ class AutomationsCreateFromTemplateTest extends AutomationTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -74,7 +74,7 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
   }
 
   public function _after() {
-    $this->automationStorage->truncate();
     parent::_after();
+    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -75,6 +75,5 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDeleteEndpointTest.php
@@ -72,8 +72,4 @@ class AutomationsDeleteEndpointTest extends AutomationTest {
     $automation = $this->automationStorage->getAutomation($this->automation->getId());
     $this->assertNull($automation);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -113,7 +113,7 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
   }
 
   public function _after() {
-    $this->automationStorage->truncate();
     parent::_after();
+    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -114,6 +114,5 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -111,8 +111,4 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
     $this->assertInstanceOf(Automation::class, $automation);
     $this->assertTrue($automation->equals($expectedAutomation));
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
@@ -174,10 +174,10 @@ class AutomationsGetTest extends AutomationTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->automationStorage->truncate();
     foreach ($this->userIds as $userId) {
       is_multisite() ? wpmu_delete_user($userId) : wp_delete_user($userId);
     }
-    parent::_after();
   }
 }

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
@@ -175,7 +175,6 @@ class AutomationsGetTest extends AutomationTest {
 
   public function _after() {
     parent::_after();
-    $this->automationStorage->truncate();
     foreach ($this->userIds as $userId) {
       is_multisite() ? wpmu_delete_user($userId) : wp_delete_user($userId);
     }

--- a/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
@@ -31,7 +31,6 @@ class TrackTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     // create newsletter
     $newsletter = new NewsletterEntity();
     $newsletter->setType('type');
@@ -212,18 +211,5 @@ class TrackTest extends \MailPoetTest {
     // assert that the fetched link ID belong to the newly created link
     $processedData = $this->track->_processTrackData($trackData);
     expect($processedData->link->getId())->equals($link->getId());
-  }
-
-  public function _after() {
-    $this->cleanup();
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/DynamicSegmentFilterRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/DynamicSegmentFilterRepositoryTest.php
@@ -18,7 +18,6 @@ class DynamicSegmentFilterRepositoryTest extends \MailPoetTest {
 
   public function _before(): void {
     parent::_before();
-    $this->cleanup();
     $this->dynamicSegmentFilterRepository = $this->diContainer->get(DynamicSegmentFilterRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
   }
@@ -58,15 +57,5 @@ class DynamicSegmentFilterRepositoryTest extends \MailPoetTest {
     $this->dynamicSegmentFilterRepository->persist($filter);
     $this->dynamicSegmentFilterRepository->flush();
     return $filter;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-  }
-
-  public function _after(): void {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
@@ -4,11 +4,7 @@ namespace MailPoet\Segments\DynamicSegments;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -86,13 +82,6 @@ class FilterHandlerTest extends \MailPoetTest {
 
   public function _after(): void {
     $this->cleanWpUsers();
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
   }
 
   private function cleanWpUsers(): void {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
@@ -81,6 +81,7 @@ class FilterHandlerTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanWpUsers();
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
@@ -13,7 +13,6 @@ use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\UserAgentEntity;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -33,7 +32,6 @@ class EmailActionClickAnyTest extends \MailPoetTest {
   public $subscriberOpenedClicked;
 
   public function _before(): void {
-    $this->cleanData();
     $this->emailAction = $this->diContainer->get(EmailActionClickAny::class);
     $this->newsletter = new NewsletterEntity();
     $task = new ScheduledTaskEntity();
@@ -150,19 +148,5 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     );
     $this->entityManager->persist($click);
     $this->entityManager->flush();
-  }
-
-  public function _after(): void {
-    $this->cleanData();
-  }
-
-  private function cleanData(): void {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsNewsletterEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(UserAgentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -38,7 +38,6 @@ class EmailActionTest extends \MailPoetTest {
   public $subscriberOpenedClicked;
 
   public function _before(): void {
-    $this->cleanData();
     $this->emailAction = $this->diContainer->get(EmailAction::class);
     $this->newsletter = new NewsletterEntity();
     $this->newsletter2 = new NewsletterEntity();
@@ -456,19 +455,5 @@ class EmailActionTest extends \MailPoetTest {
     $this->entityManager->persist($click);
     $this->entityManager->flush();
     return $click;
-  }
-
-  public function _after(): void {
-    $this->cleanData();
-  }
-
-  private function cleanData(): void {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsNewsletterEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(UserAgentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -196,12 +196,12 @@ class EmailActionTest extends \MailPoetTest {
 
   public function testGetClickedWithAnyOfLinks(): void {
     // 2 Links each clicked by a different subscriber
-    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
+    $link1 = $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
-    $this->createClickedLink('http://example2.com', $this->newsletter, $subscriberClickedOther); // id 2
+    $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $subscriberClickedOther); // id 2
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
-      'link_ids' => [1, 2],
+      'link_ids' => [$link1->getId(), $link2->getId()],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
     ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
@@ -215,14 +215,14 @@ class EmailActionTest extends \MailPoetTest {
 
   public function testGetClickedWithAllOfLinks(): void {
     // 2 Links both clicked by $this->subscriberOpenedClicked and second one clicked only by other subscriber
-    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
-    $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked); // id 2
+    $link1 = $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
+    $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked);
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
     $this->addClickToLink($link2, $subscriberClickedOther);
 
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
-      'link_ids' => [1, 2],
+      'link_ids' => [$link1->getId(), $link2->getId()],
       'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
     ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
@@ -236,8 +236,8 @@ class EmailActionTest extends \MailPoetTest {
 
   public function testGetClickedWithAllOfAndNoSavedLinks(): void {
     // 2 Links both clicked by $this->subscriberOpenedClicked and second one clicked only by other subscriber
-    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
-    $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked); // id 2
+    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
+    $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked);
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
     $this->addClickToLink($link2, $subscriberClickedOther);
 
@@ -268,10 +268,10 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetClickedWithNoneOfLinks(): void {
-    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
+    $link = $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
-      'link_ids' => [1, 2],
+      'link_ids' => [$link->getId(), 2],
       'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
     ]);
     $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
@@ -287,7 +287,7 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetClickedWithNoneAndNoSavedLinks(): void {
-    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
+    $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
     $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [],

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -21,7 +21,6 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   private $action;
 
   public function _before(): void {
-    $this->cleanData();
     $this->action = $this->diContainer->get(EmailOpensAbsoluteCountAction::class);
     $newsletter1 = $this->createNewsletter();
     $newsletter2 = $this->createNewsletter();
@@ -251,19 +250,5 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     $this->entityManager->persist($open);
     $this->entityManager->flush();
     return $open;
-  }
-
-  public function _after(): void {
-    $this->cleanData();
-  }
-
-  private function cleanData(): void {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(StatisticsNewsletterEntity::class);
-    $this->truncateEntity(UserAgentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
@@ -20,7 +20,6 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
   private $subscribers = [];
 
   public function _before(): void {
-    $this->cleanData();
     $this->filter = $this->diContainer->get(MailPoetCustomFields::class);
     $this->subscribers = [];
     $this->subscribers[] = $this->createSubscriber('subscriber1@example.com');
@@ -457,14 +456,6 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     $customField->setParams($params);
     $customField->setName('custom field' . rand());
     return $customField;
-  }
-
-  private function cleanData(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 
   private function getQueryBuilder(): QueryBuilder {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
@@ -16,7 +16,6 @@ class SubscriberScoreTest extends \MailPoetTest {
 
   public function _before(): void {
     $this->filter = $this->diContainer->get(SubscriberScore::class);
-    $this->cleanUp();
 
     $subscriber = new SubscriberEntity();
     $subscriber->setEngagementScore(0);
@@ -199,11 +198,5 @@ class SubscriberScoreTest extends \MailPoetTest {
     $this->entityManager->persist($dynamicSegmentFilter);
     $segment->addDynamicFilter($dynamicSegmentFilter);
     return $dynamicSegmentFilter;
-  }
-
-  private function cleanUp(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
@@ -23,8 +23,6 @@ class SubscriberSegmentTest extends \MailPoetTest {
   public function _before(): void {
     $this->filter = $this->diContainer->get(SubscriberSegment::class);
 
-    $this->cleanUp();
-
     $subscriber1 = new SubscriberEntity();
     $subscriber1->setLastSubscribedAt(CarbonImmutable::now());
     $subscriber1->setEmail('a1@example.com');
@@ -128,12 +126,5 @@ class SubscriberSegmentTest extends \MailPoetTest {
       ->createQueryBuilder()
       ->select("DISTINCT $subscribersTable.id")
       ->from($subscribersTable);
-  }
-
-  private function cleanUp(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -17,7 +17,6 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
 
   public function _before(): void {
     $this->filter = $this->diContainer->get(SubscriberSubscribedDate::class);
-    $this->cleanUp();
 
     $subscriber = new SubscriberEntity();
     $subscriber->setLastSubscribedAt(CarbonImmutable::now());
@@ -187,11 +186,5 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     $this->entityManager->persist($dynamicSegmentFilter);
     $segment->addDynamicFilter($dynamicSegmentFilter);
     return $dynamicSegmentFilter;
-  }
-
-  private function cleanUp(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -132,7 +132,6 @@ class UserRoleTest extends \MailPoetTest {
 
   private function cleanup(): void {
     $this->cleanWpUsers();
-    $this->truncateEntity(SubscriberEntity::class);
   }
 
   private function cleanWpUsers(): void {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -38,10 +38,10 @@ class WooCommerceCategoryTest extends \MailPoetTest {
 
     $this->cleanUp();
 
-    $customerId1 = $this->createCustomer('customer1@example.com', 'customer');
-    $customerId2 = $this->createCustomer('customer2@example.com', 'customer');
-    $customerId3OnHold = $this->createCustomer('customer-on-hold@example.com', 'customer');
-    $customerId4PendingPayment = $this->createCustomer('customer-pending-payment@example.com', 'customer');
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3OnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
+    $customerId4PendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com', 'customer');
 
     $this->createSubscriber('a1@example.com');
     $this->createSubscriber('a2@example.com');
@@ -142,16 +142,6 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createCustomer(string $email, string $role): int {
-    global $wpdb;
-    $userId = $this->tester->createWordPressUser($email, $role);
-    $this->connection->executeQuery("
-      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
-      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
-    ");
-    return $userId;
-  }
-
   private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
@@ -199,6 +189,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -195,15 +195,6 @@ class WooCommerceCategoryTest extends \MailPoetTest {
 
   private function cleanUp(): void {
     global $wpdb;
-    $emails = [
-      'customer1@example.com',
-      'customer2@example.com',
-      'customer-on-hold@example.com',
-      'customer-pending-payment@example.com',
-    ];
-    foreach ($emails as $email) {
-      $this->tester->deleteWordPressUser($email);
-    }
 
     if (!empty($this->orders)) {
       foreach ($this->orders as $orderId) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -204,8 +204,6 @@ class WooCommerceCategoryTest extends \MailPoetTest {
 
   private function cleanUp(): void {
     global $wpdb;
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
     $emails = [
       'customer1@example.com',
       'customer2@example.com',

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -145,15 +145,11 @@ class WooCommerceCountryTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 
   private function cleanup(): void {
-    $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com', 'customer4@example.com'];
-    foreach ($emails as $email) {
-      $this->tester->deleteWordPressUser($email);
-    }
-    $this->tester->deleteTestWooOrders();
     $this->cleanUpLookUpTables();
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -149,9 +149,6 @@ class WooCommerceCountryTest extends \MailPoetTest {
   }
 
   private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-
     $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com', 'customer4@example.com'];
     foreach ($emails as $email) {
       $this->tester->deleteWordPressUser($email);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -32,9 +32,9 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     $this->numberOfOrders = $this->diContainer->get(WooCommerceNumberOfOrders::class);
     $this->cleanUp();
 
-    $customerId1 = $this->createCustomer('customer1@example.com', 'customer');
-    $customerId2 = $this->createCustomer('customer2@example.com', 'customer');
-    $customerId3 = $this->createCustomer('customer3@example.com', 'customer');
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3 = $this->tester->createCustomer('customer3@example.com', 'customer');
 
     $this->orders[] = $this->createOrder($customerId1, Carbon::now()->subDays(3));
     $this->orders[] = $this->createOrder($customerId2, Carbon::now());
@@ -127,16 +127,6 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createCustomer(string $email, string $role): int {
-    global $wpdb;
-    $userId = $this->tester->createWordPressUser($email, $role);
-    $this->connection->executeQuery("
-      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
-      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
-    ");
-    return $userId;
-  }
-
   private function createOrder(int $customerId, Carbon $createdAt, $status = 'wc-completed'): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
@@ -149,15 +139,12 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 
   private function cleanUp(): void {
     global $wpdb;
-    $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com'];
-    foreach ($emails as $email) {
-      $this->tester->deleteWordPressUser($email);
-    }
 
     if (!empty($this->orders)) {
       foreach ($this->orders as $orderId) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -154,8 +154,6 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
 
   private function cleanUp(): void {
     global $wpdb;
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
     $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com'];
     foreach ($emails as $email) {
       $this->tester->deleteWordPressUser($email);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -33,10 +33,10 @@ class WooCommerceProductTest extends \MailPoetTest {
 
     $this->cleanUp();
 
-    $customerId1 = $this->createCustomer('customer1@example.com', 'customer');
-    $customerId2 = $this->createCustomer('customer2@example.com', 'customer');
-    $customerIdOnHold = $this->createCustomer('customer-on-hold@example.com', 'customer');
-    $customerIdPendingPayment = $this->createCustomer('customer-pending-payment@example.com', 'customer');
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerIdOnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
+    $customerIdPendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com', 'customer');
 
     $this->createSubscriber('a1@example.com');
     $this->createSubscriber('a2@example.com');
@@ -134,16 +134,6 @@ class WooCommerceProductTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createCustomer(string $email, string $role): int {
-    global $wpdb;
-    $userId = $this->tester->createWordPressUser($email, $role);
-    $this->connection->executeQuery("
-      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
-      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
-    ");
-    return $userId;
-  }
-
   private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
@@ -183,20 +173,12 @@ class WooCommerceProductTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 
   private function cleanUp(): void {
     global $wpdb;
-    $emails = [
-      'customer1@example.com',
-      'customer2@example.com',
-      'customer-on-hold@example.com',
-      'customer-pending-payment@example.com',
-    ];
-    foreach ($emails as $email) {
-      $this->tester->deleteWordPressUser($email);
-    }
 
     if (!empty($this->orders)) {
       foreach ($this->orders as $orderId) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -188,8 +188,6 @@ class WooCommerceProductTest extends \MailPoetTest {
 
   private function cleanUp(): void {
     global $wpdb;
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
     $emails = [
       'customer1@example.com',
       'customer2@example.com',

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
@@ -35,9 +35,9 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
     $this->wp = $this->diContainer->get(WPFunctions::class);
     $this->cleanUp();
 
-    $customerId1 = $this->createCustomer('customer1@example.com', 'customer');
-    $customerId2 = $this->createCustomer('customer2@example.com', 'customer');
-    $customerId3 = $this->createCustomer('customer3@example.com', 'customer');
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3 = $this->tester->createCustomer('customer3@example.com', 'customer');
 
     $this->orders[] = $this->createOrder($customerId1, Carbon::now()->subDays(3), 10);
     $this->orders[] = $this->createOrder($customerId1, Carbon::now(), 5);
@@ -147,16 +147,6 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createCustomer(string $email, string $role): int {
-    global $wpdb;
-    $userId = $this->tester->createWordPressUser($email, $role);
-    $this->connection->executeQuery("
-      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
-      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
-    ");
-    return $userId;
-  }
-
   private function createOrder(int $customerId, Carbon $createdAt, int $orderTotal): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
@@ -170,6 +160,7 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 
@@ -177,10 +168,6 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
     global $wpdb;
     $this->truncateEntity(SegmentEntity::class);
     $this->truncateEntity(SubscriberEntity::class);
-    $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com'];
-    foreach ($emails as $email) {
-      $this->tester->deleteWordPressUser($email);
-    }
 
     if (is_array($this->orders)) {
       foreach ($this->orders as $orderId) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -177,6 +177,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -34,9 +34,9 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
     $this->wp = $this->diContainer->get(WPFunctions::class);
     $this->cleanUp();
 
-    $customerId1 = $this->createCustomer('customer1@example.com', 'customer');
-    $customerId2 = $this->createCustomer('customer2@example.com', 'customer');
-    $customerId3 = $this->createCustomer('customer3@example.com', 'customer');
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3 = $this->tester->createCustomer('customer3@example.com', 'customer');
 
     $this->orders[] = $this->createOrder($customerId1, Carbon::now()->subDays(3), 10);
     $this->orders[] = $this->createOrder($customerId1, Carbon::now(), 5);
@@ -151,16 +151,6 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
     return $dynamicSegmentFilter;
   }
 
-  private function createCustomer(string $email, string $role): int {
-    global $wpdb;
-    $userId = $this->tester->createWordPressUser($email, $role);
-    $this->connection->executeQuery("
-      INSERT INTO {$wpdb->prefix}wc_customer_lookup (customer_id, user_id, first_name, last_name, email)
-      VALUES ({$userId}, {$userId}, 'First Name', 'Last Name', '{$email}')
-    ");
-    return $userId;
-  }
-
   private function createOrder(int $customerId, Carbon $createdAt, int $orderTotal): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
@@ -174,15 +164,12 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanUp();
   }
 
   private function cleanUp(): void {
     global $wpdb;
-    $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com'];
-    foreach ($emails as $email) {
-      $this->tester->deleteWordPressUser($email);
-    }
 
     if (is_array($this->orders)) {
       foreach ($this->orders as $orderId) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -179,8 +179,6 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
 
   private function cleanUp(): void {
     global $wpdb;
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
     $emails = ['customer1@example.com', 'customer2@example.com', 'customer3@example.com'];
     foreach ($emails as $email) {
       $this->tester->deleteWordPressUser($email);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
@@ -15,7 +15,6 @@ class SegmentSaveControllerTest extends \MailPoetTest {
 
   public function _before(): void {
     parent::_before();
-    $this->cleanup();
     $this->saveController = $this->diContainer->get(SegmentSaveController::class);
   }
 
@@ -130,10 +129,5 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     $this->entityManager->persist($dynamicFilter);
     $this->entityManager->flush();
     return $dynamicFilter;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/SegmentDependencyValidatorTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentDependencyValidatorTest.php
@@ -10,11 +10,6 @@ use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
 
 class SegmentDependencyValidatorTest extends \MailPoetTest {
-  public function _before() {
-    parent::_before();
-    $this->cleanup();
-  }
-
   public function testItMissingPluginsForWooCommerceDynamicSegment(): void {
     $dynamicSegment = $this->createSegment(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
@@ -58,10 +53,5 @@ class SegmentDependencyValidatorTest extends \MailPoetTest {
       'check' => $subscribersLimitReached,
     ]);
     return new SegmentDependencyValidator($subscribersFeature, $wp);
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/SegmentSaveControllerTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSaveControllerTest.php
@@ -17,7 +17,6 @@ class SegmentSaveControllerTest extends \MailPoetTest {
 
   public function _before(): void {
     parent::_before();
-    $this->cleanup();
     $this->saveController = $this->diContainer->get(SegmentSaveController::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
   }
@@ -97,11 +96,5 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     $this->entityManager->persist($subscriberSegment);
     $this->entityManager->flush();
     return $subscriberSegment;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -247,10 +247,6 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
   }
 
   private function cleanup() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
     $this->clearSubscribersCountCache();
   }
 }

--- a/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsRepositoryTest.php
@@ -21,7 +21,6 @@ class SegmentsRepositoryTest extends \MailPoetTest {
 
   public function _before(): void {
     parent::_before();
-    $this->cleanup();
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->newsletterSegmentRepository = $this->diContainer->get(NewsletterSegmentRepository::class);
   }
@@ -191,17 +190,5 @@ class SegmentsRepositoryTest extends \MailPoetTest {
     $newsletterSegment = new NewsletterSegmentEntity($newsletter, $segmentEntity);
     $this->entityManager->persist($newsletter);
     $this->entityManager->persist($newsletterSegment);
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterSegmentEntity::class);
-  }
-
-  public function _after(): void {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
@@ -27,8 +27,8 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     $populator = $this->diContainer->get(Populator::class);
     $populator->up(); // Prepare WooCommerce and WP Users segments
     // Remove synced WP Users
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
+    $this->truncateEntityBackup(SubscriberEntity::class);
+    $this->truncateEntityBackup(SubscriberSegmentEntity::class);
 
     // Prepare Subscribers
     $wpUserEmail = 'user-role-test1@example.com';

--- a/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
@@ -18,7 +18,6 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
   public function _before(): void {
     parent::_before();
     $segmentRepository = $this->diContainer->get(SegmentsRepository::class);
-    $this->cleanup();
 
     // Prepare Segments
     $this->createDynamicSegmentEntityForEditorUsers();
@@ -27,8 +26,8 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     $populator = $this->diContainer->get(Populator::class);
     $populator->up(); // Prepare WooCommerce and WP Users segments
     // Remove synced WP Users
-    $this->truncateEntityBackup(SubscriberEntity::class);
-    $this->truncateEntityBackup(SubscriberSegmentEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SubscriberSegmentEntity::class);
 
     // Prepare Subscribers
     $wpUserEmail = 'user-role-test1@example.com';
@@ -152,17 +151,5 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($segment);
     $this->entityManager->persist($dynamicFilter);
     return $segment;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-  }
-
-  public function _after(): void {
-    parent::_after();
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -3,12 +3,9 @@
 namespace MailPoet\Segments;
 
 use Codeception\Util\Stub;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
@@ -163,16 +160,6 @@ class SubscribersFinderTest extends \MailPoetTest {
     expect($subscribersCount)->equals(1);
     $subscribersIds = $this->getScheduledTasksSubscribers($this->scheduledTask->getId());
     expect($subscribersIds)->equals([$this->subscriber2->getId()]);
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 
   private function getScheduledTasksSubscribers(int $taskId): array {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -578,6 +578,7 @@ class WPTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanData();
     Carbon::setTestNow();
   }

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -580,7 +580,6 @@ class WPTest extends \MailPoetTest {
   public function _after(): void {
     parent::_after();
     $this->cleanData();
-    Carbon::setTestNow();
   }
 
   private function cleanData(): void {

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -604,6 +604,7 @@ class WooCommerceTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->cleanData();
     $this->removeCustomerRole();
   }

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Test\Services;
 use Codeception\Stub\Expected;
 use InvalidArgumentException;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
@@ -414,10 +413,5 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $senderDomainController = $data['AuthorizedSenderDomainController'] ?? $this->diContainer->get(AuthorizedSenderDomainController::class);
 
     return new AuthorizedEmailsController($this->settings, $bridgeMock, $newslettersRepository, $senderDomainController);
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SettingEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Services/BridgeApiTest.php
+++ b/mailpoet/tests/integration/Services/BridgeApiTest.php
@@ -26,7 +26,6 @@ class BridgeApiTest extends \MailPoetTest {
     $this->wpMock = $this->createMock(WPFunctions::class);
     $this->api = new API('test-api-key', $this->wpMock);
     $this->logRepository = $this->diContainer->get(LogRepository::class);
-    $this->cleanUp();
   }
 
   public function testItDoesntLogsWhenPremiumKeyCheckPass() {
@@ -205,9 +204,5 @@ class BridgeApiTest extends \MailPoetTest {
     expect($errorLog->getLevel())->equals(Logger::ERROR);
     expect($errorLog->getMessage())->stringContainsString('verifyAuthorizedSenderDomain API response was not in expected format.');
     expect($errorLog->getMessage())->stringContainsString('trololo');
-  }
-
-  private function cleanUp() {
-    $this->truncateEntity(LogEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -464,6 +464,7 @@ class BridgeTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -8,7 +8,6 @@ use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
 use MailPoet\Services\Bridge\BridgeTestMockAPI as MockAPI;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -465,6 +464,5 @@ class BridgeTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -461,8 +461,4 @@ class BridgeTest extends \MailPoetTest {
   private function getPremiumKeyState() {
     return $this->settings->get(Bridge::PREMIUM_KEY_STATE_SETTING_NAME);
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Settings/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsControllerTest.php
@@ -15,7 +15,6 @@ class SettingsControllerTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->controller = $this->diContainer->get(SettingsController::class);
-    $this->clear();
   }
 
   public function testItReturnsStoredValue() {
@@ -119,14 +118,6 @@ class SettingsControllerTest extends \MailPoetTest {
     $this->createOrUpdateSetting('test_key', 2);
     $this->assertEquals(1, $this->controller->get('test_key'));
     $this->assertEquals(true, true);
-  }
-
-  private function clear() {
-    $this->truncateEntity(SettingEntity::class);
-  }
-
-  public function _after() {
-    $this->clear();
   }
 
   private function createOrUpdateSetting($name, $value) {

--- a/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
@@ -87,6 +87,7 @@ class UserFlagsControllerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->cleanup();
     WPFunctions::set(new WPFunctions);
   }

--- a/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
@@ -21,7 +21,6 @@ class UserFlagsControllerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
 
     $currentUserId = 1;
     $otherUserId = 2;
@@ -88,7 +87,6 @@ class UserFlagsControllerTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->cleanup();
     WPFunctions::set(new WPFunctions);
   }
 
@@ -114,10 +112,5 @@ class UserFlagsControllerTest extends \MailPoetTest {
     $flag->setValue($value);
     $this->userFlagsRepository->flush();
     return $flag;
-  }
-
-  private function cleanup() {
-    $tableName = $this->entityManager->getClassMetadata(UserFlagEntity::class)->getTableName();
-    $this->connection->executeStatement("TRUNCATE $tableName");
   }
 }

--- a/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/UserFlagsControllerTest.php
@@ -85,11 +85,6 @@ class UserFlagsControllerTest extends \MailPoetTest {
     expect($flag)->null();
   }
 
-  public function _after() {
-    parent::_after();
-    WPFunctions::set(new WPFunctions);
-  }
-
   private function createUserFlag($userId, $name, $value) {
     $flag = new UserFlagEntity();
     $flag->setUserId($userId);

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -69,8 +69,4 @@ class GATrackingTest extends \MailPoetTest {
     expect($result['text'])->stringContainsString('email=[subscriber:email]');
     expect($result['html'])->stringContainsString('email=[subscriber:email]');
   }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Statistics/StatisticsFormsRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/StatisticsFormsRepositoryTest.php
@@ -12,7 +12,6 @@ class StatisticsFormsRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(StatisticsFormsRepository::class);
   }
 
@@ -80,11 +79,5 @@ class StatisticsFormsRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($form);
     $this->entityManager->flush();
     return $form;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(StatisticsFormEntity::class);
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
@@ -29,15 +29,9 @@ class StatisticsOpensRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(StatisticsOpensRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
-  }
-
-  protected function _after() {
-    parent::_after();
-    $this->cleanup();
   }
 
   public function testItLeavesScoreWhenNoData() {
@@ -278,17 +272,5 @@ class StatisticsOpensRepositoryTest extends \MailPoetTest {
     $sub = new ScheduledTaskSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($sub);
     return $task;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(StatisticsNewsletterEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -9,8 +9,6 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsClickEntity;
-use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Newsletter\Shortcodes\Categories\Link as LinkShortcodeCategory;
@@ -55,7 +53,6 @@ class ClicksTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     // create newsletter
     $newsletter = new NewsletterEntity();
     $newsletter->setType('type');
@@ -629,15 +626,5 @@ class ClicksTest extends \MailPoetTest {
     ], $this);
     $clicks->track($data);
     expect($this->subscriber->getLastEngagementAt())->equals($lastEngagement);
-  }
-
-  public function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -41,7 +41,6 @@ class OpensTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     // create newsletter
     $newsletter = new NewsletterEntity();
     $newsletter->setType('type');
@@ -419,18 +418,5 @@ class OpensTest extends \MailPoetTest {
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
-  }
-
-  public function _after() {
-    $this->cleanup();
-  }
-
-  public function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(UserAgentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
@@ -217,7 +217,6 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
     if ($user) {
       wp_delete_user($user->ID);
     }
-    $this->truncateEntity(SubscriberEntity::class);
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
@@ -220,6 +220,7 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->cleanUp();
     $this->wp->wpSetCurrentUser($this->backupUserId);
   }

--- a/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Test\Statistics\Track;
 
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Statistics\StatisticsUnsubscribesRepository;
@@ -26,7 +24,6 @@ class UnsubscribesTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
 
     // create newsletter
     $newsletterFactory = new NewsletterFactory();
@@ -78,16 +75,5 @@ class UnsubscribesTest extends \MailPoetTest {
       );
     }
     expect(count($this->statisticsUnsubscribesRepository->findAll()))->equals(1);
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
-  }
-
-  public function _after() {
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -45,7 +45,6 @@ class WooCommercePurchasesTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
 
     $this->subscriber = $this->createSubscriber('test@example.com');
     $this->newsletter = $this->createNewsletter();
@@ -503,14 +502,5 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     $mock->method('get_total')->willReturn((string)$totalPrice);
     $mock->method('get_currency')->willReturn('EUR');
     return $mock;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(StatisticsWooCommercePurchaseEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailCustomizerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailCustomizerTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Subscribers;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 
@@ -115,10 +114,5 @@ class ConfirmationEmailCustomizerTest extends \MailPoetTest {
 
   private function generateController(): ConfirmationEmailCustomizer {
     return $this->diContainer->get(ConfirmationEmailCustomizer::class);
-  }
-
-  public function _after() {
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SettingEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -3,9 +3,7 @@
 namespace MailPoet\Subscribers;
 
 use Codeception\Stub;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerFactory;
@@ -254,11 +252,5 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       expect($sender->sendConfirmationEmail($this->subscriber))->equals(true);
     }
     expect($sender->sendConfirmationEmail($this->subscriber))->equals(true);
-  }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Export/ExportTestData.json
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Export/ExportTestData.json
@@ -1,5 +1,0 @@
-{
-  "export_format_option": "csv",
-  "segments": ["1", "2"],
-  "subscriber_fields": ["email", "first_name", "1"]
-}

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -879,6 +879,7 @@ class ImportTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     $this->truncateEntity(CustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -6,7 +6,6 @@ use Codeception\Stub;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Entities\SubscriberTagEntity;
@@ -880,12 +879,6 @@ class ImportTest extends \MailPoetTest {
   }
 
   public function _after(): void {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
-    $this->truncateEntity(SubscriberTagEntity::class);
-    $this->truncateEntity(TagEntity::class);
+    $this->truncateEntityBackup(CustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -879,6 +879,6 @@ class ImportTest extends \MailPoetTest {
   }
 
   public function _after(): void {
-    $this->truncateEntityBackup(CustomFieldEntity::class);
+    $this->truncateEntity(CustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -877,9 +877,4 @@ class ImportTest extends \MailPoetTest {
     $this->subscriberRepository->flush();
     return $subscriber;
   }
-
-  public function _after(): void {
-    parent::_after();
-    $this->truncateEntity(CustomFieldEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -797,7 +797,6 @@ class ImportTest extends \MailPoetTest {
       $data['subscribers'][1][2],
     ]]);
     expect($newSubscribers)->count(2);
-    WPFunctions::set(new WPFunctions());
   }
 
   public function testItOnlyAppliesCustomFormatToSitesWithCustomFormat(): void {
@@ -823,7 +822,6 @@ class ImportTest extends \MailPoetTest {
     ]]);
     expect($newSubscribers)->count(1);
     expect($newSubscribers[0]->getEmail())->equals('correctdateformat2@yopmail.com');
-    WPFunctions::set(new WPFunctions());
   }
 
   private function createImportInstance(array $data): Import {

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -363,7 +363,7 @@ class ImportTest extends \MailPoetTest {
       $subscribersData['first_name'][] = $existingSubscriber['first_name'];
       $subscribersData['last_name'][] = $existingSubscriber['last_name'];
       $subscribersData['email'][] = strtolower($existingSubscriber['email']); // import emails are always lowercase
-      $subscribersData[1][] = 'custom_field_' . $i;
+      $subscribersData[$this->subscribersCustomFields[0]][] = 'custom_field_' . $i;
       $subscribersData['created_at'][] = $existingSubscriber['created_at'];
       $subscribersData['subscribed_ip'][] = $existingSubscriber['subscribed_ip'];
       $subscribersData['confirmed_at'][] = $existingSubscriber['confirmed_at'];

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
@@ -178,6 +178,7 @@ class MailChimpTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/MailChimpTest.php
@@ -176,9 +176,4 @@ class MailChimpTest extends \MailPoetTest {
     ];
     expect($this->mailchimp->isSubscriberAllowed($subscribed))->true();
   }
-
-  public function _after(): void {
-    parent::_after();
-    WPFunctions::set(new WPFunctions);
-  }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -3,9 +3,7 @@
 namespace MailPoet\Test\Subscribers\ImportExport;
 
 use MailPoet\Entities\CustomFieldEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
@@ -308,10 +306,6 @@ class ImportExportFactoryTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
     $this->clearSubscribersCountCache();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -306,6 +306,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->clearSubscribersCountCache();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -304,9 +304,4 @@ class ImportExportFactoryTest extends \MailPoetTest {
     expect(count((array)json_decode($exportMenu['subscriberFieldsSelect2'], true)))
       ->equals(3);
   }
-
-  public function _after() {
-    parent::_after();
-    $this->clearSubscribersCountCache();
-  }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
@@ -435,11 +435,5 @@ class ImportExportRepositoryTest extends \MailPoetTest {
 
   private function cleanup() {
     $this->cleanWpUsers();
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
@@ -429,7 +429,8 @@ class ImportExportRepositoryTest extends \MailPoetTest {
     }
   }
 
-  protected function _after() {
+  public function _after() {
+    parent::_after();
     $this->cleanup();
   }
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
@@ -108,13 +108,4 @@ class NewsletterClicksExporterTest extends \MailPoetTest {
     $this->entityManager->persist($statisticsClicks);
     $this->entityManager->flush();
   }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(UserAgentEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
@@ -110,12 +110,4 @@ class NewsletterOpensExporterTest extends \MailPoetTest {
     $this->entityManager->persist($statisticsOpens);
     $this->entityManager->flush();
   }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(UserAgentEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
@@ -33,12 +33,6 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
       $this->diContainer->get(EntityManager::class)
     );
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(StatisticsOpenEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
     $this->entityManager->getConnection()->executeQuery('DROP TABLE IF EXISTS inactive_task_ids');
     $this->newsletter = new NewsletterEntity();
     $this->newsletter->setSubject('Subject');

--- a/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
@@ -25,7 +25,7 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
   private $newsletter;
 
   const INACTIVITY_DAYS_THRESHOLD = 5;
-  const PROCESS_BATCH_SIZE = 100;
+  const PROCESS_BATCH_SIZE = 1000000000;
   const UNOPENED_EMAILS_THRESHOLD = InactiveSubscribersController::UNOPENED_EMAILS_THRESHOLD;
 
   public function _before() {

--- a/mailpoet/tests/integration/Subscribers/LinkTokensTest.php
+++ b/mailpoet/tests/integration/Subscribers/LinkTokensTest.php
@@ -42,11 +42,6 @@ class LinkTokensTest extends \MailPoetTest {
     expect($this->linkTokens->verifyToken($subscriber, 'faketoken'))->false();
   }
 
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(SubscriberEntity::class);
-  }
-
   private function createSubscriber(string $email, ?string $linkToken = null): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);

--- a/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
@@ -6,9 +6,7 @@ use Codeception\Stub;
 use Codeception\Stub\Expected;
 use MailPoet\Config\Renderer;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Settings\SettingsController;
@@ -136,12 +134,5 @@ class NewSubscriberNotificationMailerTest extends \MailPoetTest {
 
     $service = new NewSubscriberNotificationMailer($mailerFactory, $this->diContainer->get(Renderer::class), $this->diContainer->get(SettingsController::class));
     $service->send($subscriberEntity, $segments);
-  }
-
-  public function _after() {
-    $this->truncateEntity(SettingEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/RequiredCustomFieldValidatorTest.php
+++ b/mailpoet/tests/integration/Subscribers/RequiredCustomFieldValidatorTest.php
@@ -18,7 +18,6 @@ class RequiredCustomFieldValidatorTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->customFieldRepository = $this->diContainer->get(CustomFieldsRepository::class);
     $this->validator = new RequiredCustomFieldValidator($this->customFieldRepository);
     $this->customField = $this->customFieldRepository->createOrUpdate([
@@ -70,10 +69,5 @@ class RequiredCustomFieldValidatorTest extends \MailPoetTest {
     $this->entityManager->persist($form);
     $this->entityManager->flush();
     $this->validator->validate(['cf_' . $this->customField->getId() => 'value'], $form);
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(FormEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -4,13 +4,10 @@ namespace MailPoet\Subscribers;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -268,14 +265,6 @@ class SubscriberActionsTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -265,6 +265,7 @@ class SubscriberActionsTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -11,7 +11,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Test\DataFactories\NewsletterOption;
 
 class SubscriberActionsTest extends \MailPoetTest {
@@ -266,6 +265,5 @@ class SubscriberActionsTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -262,8 +262,4 @@ class SubscriberActionsTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $newsletter;
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -47,7 +47,6 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
       $this->diContainer->get(SegmentSubscribersRepository::class),
       $this->diContainer->get(SubscribersCountsController::class)
     );
-    $this->cleanup();
   }
 
   public function testItBuildsFilters() {
@@ -341,13 +340,6 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     return $subscriberSegment;
   }
 
-  private function cleanup() {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(DynamicSegmentFilterEntity::class);
-  }
-
   private function getListingDefinition(): ListingDefinition {
     return new ListingDefinition(
       $this->listingData['group'],
@@ -360,9 +352,5 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
       $this->listingData['limit'],
       $this->listingData['selection']
     );
-  }
-
-  public function _after() {
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberPersonalDataEraserTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberPersonalDataEraserTest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Subscribers;
 
-use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
@@ -98,11 +97,5 @@ class SubscriberPersonalDataEraserTest extends \MailPoetTest {
     $subscriberAfter = $this->subscribersRepository->findOneById($subscriber->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $subscriberAfter);
     expect($subscriberAfter->getEmail())->notEquals('subscriber@for.anon.test');
-  }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -22,7 +22,6 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->saveController = $this->diContainer->get(SubscriberSaveController::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
@@ -163,10 +162,6 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     expect($subscriberSegments)->count(2);
   }
 
-  public function _after(): void {
-    $this->cleanup();
-  }
-
   private function createSubscriber(string $email, string $status): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);
@@ -181,11 +176,5 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     $this->entityManager->persist($subscriberSegment);
     $this->entityManager->flush();
     return $subscriberSegment;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTest.php
@@ -8,8 +8,6 @@ use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
-use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Segments\SegmentsRepository;
@@ -43,7 +41,6 @@ class SubscriberSubscribeControllerTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->settings = $this->diContainer->get(SettingsController::class);
     $this->obfuscator = $this->diContainer->get(FieldNameObfuscator::class);
     $this->obfuscatedEmail = $this->obfuscator->obfuscate('email');
@@ -161,10 +158,6 @@ class SubscriberSubscribeControllerTest extends \MailPoetTest {
     $this->assertNotNull($subscriber->getSubscriberTag($tag));
   }
 
-  public function _after(): void {
-    $this->cleanup();
-  }
-
   /**
    * @param CustomFieldEntity[] $customFields
    * @param TagEntity[] $tags
@@ -214,14 +207,5 @@ class SubscriberSubscribeControllerTest extends \MailPoetTest {
     $this->entityManager->persist($customField);
     $this->entityManager->flush();
     return $customField;
-  }
-
-  private function cleanup(): void {
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(TagEntity::class);
-    $this->truncateEntity(SubscriberTagEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscribersEmailCountsControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersEmailCountsControllerTest.php
@@ -26,11 +26,11 @@ class SubscribersEmailCountsControllerTest extends \MailPoetTest {
       $this->diContainer->get(EntityManager::class)
     );
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
-    $this->truncateEntityBackup(SubscriberEntity::class);
-    $this->truncateEntityBackup(ScheduledTaskEntity::class);
-    $this->truncateEntityBackup(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntityBackup(SendingQueueEntity::class);
-    $this->truncateEntityBackup(NewsletterEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(ScheduledTaskEntity::class);
+    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
+    $this->truncateEntity(SendingQueueEntity::class);
+    $this->truncateEntity(NewsletterEntity::class);
     $this->entityManager->getConnection()->executeQuery('DROP TABLE IF EXISTS processed_task_ids');
     $this->newsletter = new NewsletterEntity();
     $this->newsletter->setSubject('Subject');

--- a/mailpoet/tests/integration/Subscribers/SubscribersEmailCountsControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersEmailCountsControllerTest.php
@@ -26,11 +26,11 @@ class SubscribersEmailCountsControllerTest extends \MailPoetTest {
       $this->diContainer->get(EntityManager::class)
     );
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
+    $this->truncateEntityBackup(SubscriberEntity::class);
+    $this->truncateEntityBackup(ScheduledTaskEntity::class);
+    $this->truncateEntityBackup(ScheduledTaskSubscriberEntity::class);
+    $this->truncateEntityBackup(SendingQueueEntity::class);
+    $this->truncateEntityBackup(NewsletterEntity::class);
     $this->entityManager->getConnection()->executeQuery('DROP TABLE IF EXISTS processed_task_ids');
     $this->newsletter = new NewsletterEntity();
     $this->newsletter->setSubject('Subject');

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -22,7 +22,6 @@ class SubscribersRepositoryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->repository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
@@ -347,13 +346,5 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($subscirberCustomField);
     $this->entityManager->flush();
     return $subscirberCustomField;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscription/CaptchaFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/CaptchaFormRendererTest.php
@@ -72,7 +72,6 @@ class CaptchaFormRendererTest extends \MailPoetTest {
   }
 
   public function _before() {
-    $this->diContainer->get(FormsRepository::class)->truncate();
     parent::_before();
   }
 }

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -8,8 +8,6 @@ use MailPoet\API\JSON\ErrorResponse;
 use MailPoet\API\JSON\Response;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\SettingsRepository;
@@ -147,9 +145,6 @@ class FormTest extends \MailPoetTest {
 
   public function _after() {
     wp_delete_post($this->post);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(FormEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -144,6 +144,7 @@ class FormTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     wp_delete_post($this->post);
     $this->diContainer->get(SettingsRepository::class)->truncate();
   }

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -10,7 +10,6 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Form;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
@@ -146,6 +145,5 @@ class FormTest extends \MailPoetTest {
   public function _after() {
     parent::_after();
     wp_delete_post($this->post);
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -2,9 +2,7 @@
 
 namespace MailPoet\Subscription;
 
-use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
@@ -21,7 +19,6 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
   private $segment;
 
   public function _before() {
-    $this->cleanup();
     $this->segment = $this->getSegment();
     $this->subscriber = $this->getSubscriber($this->segment);
     $this->formRenderer = $this->diContainer->get(ManageSubscriptionFormRenderer::class);
@@ -34,7 +31,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     expect($form)->stringContainsString('<input type="hidden" name="data[email]" value="subscriber@test.com" />');
     expect($form)->regExp('/<input type="text" autocomplete="given-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     expect($form)->regExp('/<input type="text" autocomplete="family-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
-    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="' . $this->segment->getId() .'" checked="checked"  \/> Test segment/');
+    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="' . $this->segment->getId() . '" checked="checked"  \/> Test segment/');
     expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  \/>/');
     expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  \/>/');
 
@@ -86,17 +83,5 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     (new CustomFieldFactory())->withName('custom field 2')->withSubscriber($subscriber->getId(), 'another value')->create();
 
     return $subscriber;
-  }
-
-  private function cleanup() {
-    $this->truncateEntity(CustomFieldEntity::class);
-    $this->truncateEntity(SubscriberCustomFieldEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-  }
-
-  public function _after() {
-    $this->cleanup();
   }
 }

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -14,20 +14,27 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
   /** @var ManageSubscriptionFormRenderer */
   private $formRenderer;
 
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var SegmentEntity */
+  private $segment;
+
   public function _before() {
     $this->cleanup();
+    $this->segment = $this->getSegment();
+    $this->subscriber = $this->getSubscriber($this->segment);
     $this->formRenderer = $this->diContainer->get(ManageSubscriptionFormRenderer::class);
     parent::_before();
   }
 
   public function testItGeneratesForm() {
-    $subscriber = $this->getSubscriber($this->getSegment());
-    $form = $this->formRenderer->renderForm($subscriber);
+    $form = $this->formRenderer->renderForm($this->subscriber);
     expect($form)->regExp('/<form class="mailpoet-manage-subscription" method="post" action="[a-z0-9:\/\._]+wp-admin\/admin-post.php" novalidate>/');
     expect($form)->stringContainsString('<input type="hidden" name="data[email]" value="subscriber@test.com" />');
     expect($form)->regExp('/<input type="text" autocomplete="given-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     expect($form)->regExp('/<input type="text" autocomplete="family-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
-    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="1" checked="checked"  \/> Test segment/');
+    expect($form)->regExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="' . $this->segment->getId() .'" checked="checked"  \/> Test segment/');
     expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  \/>/');
     expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  \/>/');
 
@@ -35,7 +42,6 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
   }
 
   public function testItAppliesFieldsFilter() {
-    $subscriber = $this->getSubscriber($this->getSegment());
     $wp = $this->diContainer->get(WPFunctions::class);
     $wp->addFilter('mailpoet_manage_subscription_page_form_fields', function($fields) {
         $fields[] = [
@@ -48,7 +54,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
         ];
         return $fields;
     });
-    $form = $this->formRenderer->renderForm($subscriber);
+    $form = $this->formRenderer->renderForm($this->subscriber);
     expect($form)->regExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Additional info" value=""  \/>/');
   }
 

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -111,10 +111,4 @@ class ManageTest extends \MailPoetTest {
     });
     return $subscriptions;
   }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -8,10 +8,6 @@ use MailPoet\Cron\Workers\SendingQueue\Tasks\Links;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterLinkEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
@@ -289,19 +285,6 @@ class PagesTest extends \MailPoetTest {
     $clickStat = $this->statisticsClicksRepository->getAllForSubscriber($this->subscriber)->getQuery()->getResult();
     expect($updatedSubscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
     expect($clickStat)->count(1);
-  }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(SendingQueueEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
-    $this->truncateEntity(NewsletterOptionEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
-    $this->truncateEntity(StatisticsUnsubscribeEntity::class);
-    $this->truncateEntity(NewsletterLinkEntity::class);
   }
 
   private function getPages(

--- a/mailpoet/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
+++ b/mailpoet/tests/integration/Subscription/SubscriptionUrlFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Test\Subscription;
 
-use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscription\SubscriptionUrlFactory;
@@ -39,10 +38,5 @@ class SubscriptionUrlFactoryTest extends \MailPoetTest {
 
     $this->assertIsString($expectedUrl, "Permalink is a valid string");
     $this->assertStringContainsString($expectedUrl, $this->subscriptionUrlFactory->getReEngagementUrl($this->subscriber));
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->truncateEntity(SettingEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Subscription/ThrottlingTest.php
+++ b/mailpoet/tests/integration/Subscription/ThrottlingTest.php
@@ -88,8 +88,4 @@ class ThrottlingTest extends \MailPoetTest {
     $this->entityManager->flush();
     return $subscriberIP;
   }
-
-  public function _after() {
-    $this->truncateEntity(SubscriberIPEntity::class);
-  }
 }

--- a/mailpoet/tests/integration/Subscription/UrlTest.php
+++ b/mailpoet/tests/integration/Subscription/UrlTest.php
@@ -6,7 +6,6 @@ use MailPoet\Config\Populator;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscription\SubscriptionUrlFactory;
 use MailPoet\WP\Functions as WPFunctions;
@@ -178,10 +177,5 @@ class UrlTest extends \MailPoetTest {
     $this->entityManager->persist($subscriber);
     $this->entityManager->flush();
     return $subscriber;
-  }
-
-  public function _after() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -216,9 +216,9 @@ class SendingTest extends \MailPoetTest {
     $sending3->save();
 
     $tasks = $this->scheduledTaskRepository->findScheduledSendingTasks(3);
-    expect($tasks[0]->getId())->equals($sending1->id());
-    expect($tasks[1]->getId())->equals($sending3->id());
-    expect($tasks[2]->getId())->equals($sending2->id());
+    expect($tasks[0]->getId())->equals($sending1->taskId);
+    expect($tasks[1]->getId())->equals($sending3->taskId);
+    expect($tasks[2]->getId())->equals($sending2->taskId);
   }
 
   public function testItGetsBatchOfScheduledQueuesSortedByUpdatedTime() {
@@ -233,9 +233,9 @@ class SendingTest extends \MailPoetTest {
     $sending3->save();
 
     $tasks = $this->scheduledTaskRepository->findRunningSendingTasks(3);
-    expect($tasks[0]->getId())->equals($sending1->id());
-    expect($tasks[1]->getId())->equals($sending3->id());
-    expect($tasks[2]->getId())->equals($sending2->id());
+    expect($tasks[0]->getId())->equals($sending1->taskId);
+    expect($tasks[1]->getId())->equals($sending3->taskId);
+    expect($tasks[2]->getId())->equals($sending2->taskId);
   }
 
   public function createNewNewsletter() {

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -282,6 +282,7 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
     ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
     ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -12,7 +12,6 @@ use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Tasks\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Idiorm\ORM;
 
 class SendingTest extends \MailPoetTest {
   public $sending;
@@ -89,7 +88,6 @@ class SendingTest extends \MailPoetTest {
     $sending = SendingTask::getByNewsletterId($this->newsletter->id);
     $queue = $sending->queue();
     $task = $sending->task();
-    expect($queue->id)->equals($this->newsletter->id);
     expect($task->id)->equals($queue->taskId);
   }
 
@@ -170,7 +168,6 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItGetsBatchOfScheduledQueues() {
-    $this->_after();
     $amount = 5;
     for ($i = 0; $i < $amount + 3; $i += 1) {
       $this->createNewSendingTask(['status' => ScheduledTask::STATUS_SCHEDULED]);
@@ -179,7 +176,6 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItDoesNotGetPaused() {
-    $this->_after();
     $this->createNewSendingTask(['status' => ScheduledTask::STATUS_PAUSED]);
     expect($this->scheduledTaskRepository->findScheduledSendingTasks())->count(0);
   }
@@ -201,7 +197,6 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItGetsBatchOfRunningQueues() {
-    $this->_after();
     $amount = 5;
     for ($i = 0; $i < $amount + 3; $i += 1) {
       $this->createNewSendingTask(['status' => null]);
@@ -210,8 +205,6 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItGetsBatchOfRunningQueuesSortedByUpdatedTime() {
-    $this->_after();
-
     $sending1 = $this->createNewSendingTask(['status' => ScheduledTask::STATUS_SCHEDULED]);
     $sending1->updatedAt = '2017-05-04 14:00:00';
     $sending1->save();
@@ -229,8 +222,6 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItGetsBatchOfScheduledQueuesSortedByUpdatedTime() {
-    $this->_after();
-
     $sending1 = $this->createNewSendingTask(['status' => null]);
     $sending1->updatedAt = '2017-05-04 14:00:00';
     $sending1->save();
@@ -279,13 +270,5 @@ class SendingTest extends \MailPoetTest {
     $sending->status = $status;
     $sending->scheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->subHours(1);
     return $sending->save();
-  }
-
-  public function _after() {
-    parent::_after();
-    ORM::raw_execute('TRUNCATE ' . Newsletter::$_table);
-    ORM::raw_execute('TRUNCATE ' . ScheduledTask::$_table);
-    ORM::raw_execute('TRUNCATE ' . ScheduledTaskSubscriber::$_table);
-    ORM::raw_execute('TRUNCATE ' . SendingQueue::$_table);
   }
 }

--- a/mailpoet/tests/integration/Tasks/Subscribers/BatchIteratorTest.php
+++ b/mailpoet/tests/integration/Tasks/Subscribers/BatchIteratorTest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Test\Tasks\Subscribers;
 
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Tasks\Subscribers\BatchIterator;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
@@ -67,11 +65,5 @@ class BatchIteratorTest extends \MailPoetTest {
 
   public function testItCanBeCounted() {
     expect(count($this->iterator))->equals($this->subscriberCount);
-  }
-
-  public function _after() {
-    $this->truncateEntity(ScheduledTaskEntity::class);
-    $this->truncateEntity(ScheduledTaskSubscriberEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
   }
 }

--- a/mailpoet/tests/integration/Twig/FunctionsTest.php
+++ b/mailpoet/tests/integration/Twig/FunctionsTest.php
@@ -23,6 +23,7 @@ class FunctionsTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/integration/Twig/FunctionsTest.php
+++ b/mailpoet/tests/integration/Twig/FunctionsTest.php
@@ -21,9 +21,4 @@ class FunctionsTest extends \MailPoetTest {
     $resultNoRtl = $twig->render('template');
     expect($resultNoRtl)->isEmpty();
   }
-
-  public function _after() {
-    parent::_after();
-    WPFunctions::set(new WPFunctions);
-  }
 }

--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -102,5 +102,6 @@ class ConflictResolverTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
   }
 }

--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -100,8 +100,4 @@ class ConflictResolverTest extends \MailPoetTest {
     // it should not dequeue select2 script
     expect(in_array('select2', $wp_scripts->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
-
-  public function _after() {
-    parent::_after();
-  }
 }

--- a/mailpoet/tests/integration/Util/License/Features/SubscribersTest.php
+++ b/mailpoet/tests/integration/Util/License/Features/SubscribersTest.php
@@ -122,7 +122,6 @@ class SubscribersTest extends \MailPoetTest {
 
   public function _after() {
     parent::_after();
-    $this->truncateEntity(SubscriberEntity::class);
     $this->wp->deleteTransient(Subscribers::SUBSCRIBERS_COUNT_CACHE_KEY);
   }
 

--- a/mailpoet/tests/integration/Util/License/Features/SubscribersTest.php
+++ b/mailpoet/tests/integration/Util/License/Features/SubscribersTest.php
@@ -120,11 +120,6 @@ class SubscribersTest extends \MailPoetTest {
     expect($count)->same(999999);
   }
 
-  public function _after() {
-    parent::_after();
-    $this->wp->deleteTransient(Subscribers::SUBSCRIBERS_COUNT_CACHE_KEY);
-  }
-
   private function createSubscriber(string $email, string $status): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);

--- a/mailpoet/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/HeadersAlreadySentNoticeTest.php
@@ -22,6 +22,7 @@ class HeadersAlreadySentNoticeTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     delete_transient(HeadersAlreadySentNotice::OPTION_NAME);
   }
 

--- a/mailpoet/tests/integration/Util/Notices/InactiveSubscribersNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/InactiveSubscribersNoticeTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Util\Notices;
 
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -62,22 +61,11 @@ class InactiveSubscribersNoticeTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->cleanup();
     $this->notice = new InactiveSubscribersNotice(
       SettingsController::getInstance(),
       $this->diContainer->get(SubscribersRepository::class),
       new WPFunctions()
     );
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
-  }
-
-  private function cleanup() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->truncateEntity(SubscriberEntity::class);
   }
 
   private function createSubscribers($count) {

--- a/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
@@ -14,6 +14,7 @@ class PHPVersionWarningsTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     delete_transient('dismissed-php-version-outdated-notice');
   }
 

--- a/mailpoet/tests/integration/Util/Notices/PendingApprovalNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PendingApprovalNoticeTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Util\Notices;
 
 use MailPoet\Mailer\Mailer;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Settings\SettingsRepository;
 
 class PendingApprovalNoticeTest extends \MailPoetTest {
   /** @var PendingApprovalNotice */
@@ -51,14 +50,5 @@ class PendingApprovalNoticeTest extends \MailPoetTest {
 
     $result = $this->notice->init(true);
     expect($result)->null();
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->cleanup();
-  }
-
-  private function cleanup() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/WP/FunctionsTest.php
+++ b/mailpoet/tests/integration/WP/FunctionsTest.php
@@ -96,6 +96,7 @@ class FunctionsTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     global $content_width; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $content_width = $this->contentWidth; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }

--- a/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
+++ b/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
@@ -7,8 +7,6 @@ use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\API\JSON\v1\Services;
 use MailPoet\API\JSON\v1\Settings;
 use MailPoet\Logging\LoggerFactory;
-use MailPoet\Logging\LogRepository;
-use MailPoet\Settings\SettingsRepository;
 
 class DotcomLicenseProvisionerTest extends \MailPoetTest {
   /** @var DotcomLicenseProvisioner */
@@ -129,10 +127,5 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
       ['isAtomicPlatform' => true]);
     $result = $provisioner->provisionLicense($result, $payload, $eventType);
     expect($result)->equals(true);
-  }
-
-  public function _after() {
-    $this->diContainer->get(SettingsRepository::class)->truncate();
-    $this->diContainer->get(LogRepository::class)->truncate();
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -22,7 +22,7 @@ class HelperTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->tester->deleteTestWooOrders();
+    parent::_after();
     $this->wp->deleteOption('woocommerce_onboarding_profile');
   }
 

--- a/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
@@ -31,7 +31,6 @@ class SubscriberEngagementTest extends \MailPoetTest {
       $this->wooCommerceHelperMock,
       new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($this->wpMock), $this->wpMock)
     );
-    $this->truncateEntity(SubscriberEntity::class);
   }
 
   public function testItUpdatesLastEngagementForSubscriberWhoCreatedNewOrder() {

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -298,6 +298,7 @@ class SubscriptionTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     // restore settings
     $this->settings->set('woocommerce', $this->originalSettings);
   }

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -298,9 +298,6 @@ class SubscriptionTest extends \MailPoetTest {
   }
 
   public function _after() {
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberSegmentEntity::class);
     // restore settings
     $this->settings->set('woocommerce', $this->originalSettings);
   }

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -296,10 +296,4 @@ class SubscriptionTest extends \MailPoetTest {
     $result = ob_get_clean();
     return $result;
   }
-
-  public function _after() {
-    parent::_after();
-    // restore settings
-    $this->settings->set('woocommerce', $this->originalSettings);
-  }
 }

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -3,9 +3,7 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Newsletter;
@@ -26,7 +24,6 @@ class TrackerTest extends \MailPoetTest {
 
   public function _before(): void {
     parent::_before();
-    $this->cleanUp();
     $this->subscriber = (new Subscriber())->create();
     $this->tracker = $this->diContainer->get(Tracker::class);
     // Add dummy option field. This is needed for AUTOMATIC emails analytics
@@ -177,14 +174,5 @@ class TrackerTest extends \MailPoetTest {
     $link = (new NewsletterLink($newsletter))->create();
     $click = (new StatisticsClicks($link, $this->subscriber))->create();
     return (new StatisticsWooCommercePurchases($click, $orderData))->create();
-  }
-
-  private function cleanUp(): void {
-    $this->truncateEntity(NewsletterLinkEntity::class);
-    $this->truncateEntity(NewsletterEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-    $this->truncateEntity(StatisticsWooCommercePurchaseEntity::class);
-    $this->truncateEntity(StatisticsClickEntity::class);
-    $this->truncateEntity(NewsletterOptionFieldEntity::class);
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -244,6 +244,7 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
   }
 
   public function _after() {
+    parent::_after();
     $this->entityManager
       ->createQueryBuilder()
       ->delete()

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -32,9 +32,6 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
   /** @var SettingsController */
   private $settings;
 
-  /** @var array */
-  private $originalWcSettings;
-
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
@@ -43,7 +40,6 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
 
   public function _before() {
     $this->settings = $this->diContainer->get(SettingsController::class);
-    $this->originalWcSettings = $this->settings->get('woocommerce');
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->wp = $this->diContainer->get(WPFunctions::class);
   }
@@ -241,16 +237,5 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
       $this->diContainer->get(TransactionalEmails::class)
     );
 
-  }
-
-  public function _after() {
-    parent::_after();
-    $this->entityManager
-      ->createQueryBuilder()
-      ->delete()
-      ->from(NewsletterEntity::class, 'n')
-      ->getQuery()
-      ->execute();
-    $this->settings->set('woocommerce', $this->originalWcSettings);
   }
 }

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -4,6 +4,7 @@ use Codeception\Stub;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Doctrine\DBAL\Connection;
@@ -97,6 +98,8 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->diContainer = ContainerWrapper::getInstance(WP_DEBUG);
     $this->connection = $this->diContainer->get(Connection::class);
     $this->entityManager = $this->diContainer->get(EntityManager::class);
+    // Cleanup scheduled tasks from previous tests
+    $this->truncateEntity(ScheduledTaskEntity::class);
     // switch cron to Linux method
     $this->diContainer->get(\MailPoet\Cron\DaemonActionSchedulerRunner::class)->deactivate();
     $this->diContainer->get(SettingsController::class)->set('cron_trigger.method', CronTrigger::METHOD_LINUX_CRON);

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -216,6 +216,11 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
       unregister_post_type('product');
     }
   }
+
+  public function _after() {
+    parent::_after();
+    $this->tester->cleanup();
+  }
 }
 
 function asCallable($fn) {

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -156,6 +156,16 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
   }
 
   public function truncateEntity(string $entityName) {
+    return;
+    $classMetadata = $this->entityManager->getClassMetadata($entityName);
+    $tableName = $classMetadata->getTableName();
+    $connection = $this->entityManager->getConnection();
+    $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
+    $connection->executeStatement("TRUNCATE $tableName");
+    $connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
+  }
+
+  public function truncateEntityBackup(string $entityName) {
     $classMetadata = $this->entityManager->getClassMetadata($entityName);
     $tableName = $classMetadata->getTableName();
     $connection = $this->entityManager->getConnection();

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -4,7 +4,6 @@ use Codeception\Stub;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Doctrine\DBAL\Connection;
@@ -98,8 +97,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->diContainer = ContainerWrapper::getInstance(WP_DEBUG);
     $this->connection = $this->diContainer->get(Connection::class);
     $this->entityManager = $this->diContainer->get(EntityManager::class);
-    // Cleanup scheduled tasks from previous tests and switch cron to Linux method
-    $this->truncateEntity(ScheduledTaskEntity::class);
+    // switch cron to Linux method
     $this->diContainer->get(\MailPoet\Cron\DaemonActionSchedulerRunner::class)->deactivate();
     $this->diContainer->get(SettingsController::class)->set('cron_trigger.method', CronTrigger::METHOD_LINUX_CRON);
     // Reset caches
@@ -156,16 +154,6 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
   }
 
   public function truncateEntity(string $entityName) {
-    return;
-    $classMetadata = $this->entityManager->getClassMetadata($entityName);
-    $tableName = $classMetadata->getTableName();
-    $connection = $this->entityManager->getConnection();
-    $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
-    $connection->executeStatement("TRUNCATE $tableName");
-    $connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
-  }
-
-  public function truncateEntityBackup(string $entityName) {
     $classMetadata = $this->entityManager->getClassMetadata($entityName);
     $tableName = $classMetadata->getTableName();
     $connection = $this->entityManager->getConnection();

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -7,6 +7,7 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\Persistence\Mapping\ClassMetadata;
@@ -98,6 +99,8 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->diContainer = ContainerWrapper::getInstance(WP_DEBUG);
     $this->connection = $this->diContainer->get(Connection::class);
     $this->entityManager = $this->diContainer->get(EntityManager::class);
+    // Carbon datetime
+    Carbon::setTestNow();
     // Reset WPFunctions
     WPFunctions::set(new WPFunctions());
     // switch cron to Linux method

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -4,7 +4,6 @@ use Codeception\Stub;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Doctrine\DBAL\Connection;
@@ -98,8 +97,6 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->diContainer = ContainerWrapper::getInstance(WP_DEBUG);
     $this->connection = $this->diContainer->get(Connection::class);
     $this->entityManager = $this->diContainer->get(EntityManager::class);
-    // Cleanup scheduled tasks from previous tests
-    $this->truncateEntity(ScheduledTaskEntity::class);
     // switch cron to Linux method
     $this->diContainer->get(\MailPoet\Cron\DaemonActionSchedulerRunner::class)->deactivate();
     $this->diContainer->get(SettingsController::class)->set('cron_trigger.method', CronTrigger::METHOD_LINUX_CRON);

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -6,6 +6,7 @@ use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\Persistence\Mapping\ClassMetadata;
@@ -97,6 +98,8 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     $this->diContainer = ContainerWrapper::getInstance(WP_DEBUG);
     $this->connection = $this->diContainer->get(Connection::class);
     $this->entityManager = $this->diContainer->get(EntityManager::class);
+    // Reset WPFunctions
+    WPFunctions::set(new WPFunctions());
     // switch cron to Linux method
     $this->diContainer->get(\MailPoet\Cron\DaemonActionSchedulerRunner::class)->deactivate();
     $this->diContainer->get(SettingsController::class)->set('cron_trigger.method', CronTrigger::METHOD_LINUX_CRON);

--- a/mailpoet/tests/unit/API/JSON/ErrorResponseTest.php
+++ b/mailpoet/tests/unit/API/JSON/ErrorResponseTest.php
@@ -40,6 +40,7 @@ class ErrorResponseTest extends \MailPoetUnitTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/unit/Mailer/MailerErrorTest.php
+++ b/mailpoet/tests/unit/Mailer/MailerErrorTest.php
@@ -49,6 +49,7 @@ class MailerErrorTest extends \MailPoetUnitTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/PHPMailMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/PHPMailMapperTest.php
@@ -42,6 +42,7 @@ class PHPMailMapperTest extends \MailPoetUnitTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/SMTPMapperTest.php
@@ -33,6 +33,7 @@ class SMTPMapperTest extends \MailPoetUnitTest {
   }
 
   public function _after() {
+    parent::_after();
     WPFunctions::set(new WPFunctions);
   }
 }


### PR DESCRIPTION
## Description

This PR is an attempt to create more of a clean slate before each integration test is run. This is achieved primarily by deleting all the data in the tables that are part of the plugin before each test is run.

This proved to be much more work than I expected. It turns out many of our tests have assumptions about the IDs of created records, which was the main reason some tests would fail in a full run but would pass when run individually. This made it take a significant amount of time to test some changes because I would have to run the entire suite again. I also ran into some intermittent failures that were very difficult to debug.

### In-memory mount for mysql data
I also added a `tmpfs` mount in 644dff22109ccd452ab7fe9dc79f6f1cffd7a011. It does seem to have sped up test execution times, though not by a huge margin.

Before:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/8656640/230202070-828448fa-bce8-4b41-8650-193f84d2305d.png">

After:
<img width="293" alt="image" src="https://user-images.githubusercontent.com/8656640/230202125-56c7a8d4-5e10-42c4-9d7e-8aec0483315a.png">

For reference, here are some run times from a branch that doesn't include any of the changes in this PR:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/8656640/230202797-1e598a76-0559-470b-a1f7-4f1de039f141.png">

Of course times can vary quite a bit from run to run, so take these with a grain of salt.

### [MAILPOET-5185](https://mailpoet.atlassian.net/browse/MAILPOET-5185) bug discovered and fixed
One of the tests that ended up failing was a legitimate failure and uncovered a bug, [MAILPOET-5185](https://mailpoet.atlassian.net/browse/MAILPOET-5185). I fixed that as part of this PR, otherwise the tests wouldn't pass. This fix ensures that the personal data exporter always includes all custom field data for subscribers (see ticket for more details).

## Code review notes

Although there are many changes, the vast majority are simply removing calls to truncating entities. I didn't remove the helper entirely because a few tests rely on truncating tables within the tests.

In my testing, I found that simply deleting all the rows in all the tables was much faster than truncating the tables. I suspect this may be because we never create all that much data to begin with for any given test. Run locally, the version where I truncated the tables before every test used 320 seconds just for the truncating operations, or about 0.14 seconds per test. I couldn't figure out a way to truncate the tables in a single command.

Simply running a `DELETE FROM table` command instead took a total of around 9 seconds total when executing all 2259 tests. 

## QA notes

The only thing that should require testing is the personal data exporting, MAILPOET-5185.

## Linked PRs

_N/A_

## Linked tickets
https://mailpoet.atlassian.net/browse/MAILPOET-5145
https://mailpoet.atlassian.net/browse/MAILPOET-5185

## After-merge notes

This includes some rather large changes, so I plan on publishing a P2 post summarizing what's changed and what engineers should do differently going forward when it gets merged.

[MAILPOET-5185]: https://mailpoet.atlassian.net/browse/MAILPOET-5185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ