### PR TITLE
Import sql to local Docker environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.2.0
-  grafana: grafana/k6@1.1.3
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
@@ -750,8 +749,6 @@ workflows:
             - static_analysis_php8
             - qa_js
             - qa_php
-      - grafana/k6:
-          cloud: true
       - js_tests:
           <<: *slack-fail-post-step
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,6 @@ jobs:
       - store_test_results:
           path: tests/_output
   performance_tests:
-    cloud: true
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
       image: ubuntu-2204:2022.10.2
@@ -745,6 +744,7 @@ workflows:
       - performance_tests:
           <<: *slack-fail-post-step
           name: performance_tests
+          cloud: true
           requires:
             - unit_tests
             - static_analysis_php8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,7 @@ jobs:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: false
     parameters:
+      cloud: true
       mysql_command:
         type: string
         default: ''

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,7 +531,7 @@ jobs:
             fi
       - store_artifacts:
           path: tests/performance/_output
-      - store_screenshots:
+      - store_artifacts:
           path: tests/performance/_screenshots
       - store_test_results:
           path: tests/performance/_output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,19 @@ jobs:
             cd tests/performance
             docker-compose create || docker-compose create
       - run:
+          name: Get data file size (for MySQL volume cache key)
+          command: wget --spider $WP_TEST_PERFORMANCE_DATA_URL 2>&1 | grep "Length:" > data-file-size.txt
+      - restore_cache:
+          key: performance-test-mysql-data-{{ checksum "data-file-size.txt" }}
+      - run:
+          name: Setup performance tests
+          command: |
+            ./do test:performance-setup
+      - save_cache:
+          key: performance-test-mysql-data-{{ checksum "data-file-size.txt" }}
+          paths:
+            - tests/performance/_data/mysql
+      - run:
           name: Run performance tests
           command: |
             mkdir -p tests/performance/_output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,7 @@ jobs:
       - store_test_results:
           path: tests/_output
   performance_tests:
+    cloud: true
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
       image: ubuntu-2204:2022.10.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,19 +504,6 @@ jobs:
             cd tests/performance
             docker-compose create || docker-compose create
       - run:
-          name: Get data file size (for MySQL volume cache key)
-          command: wget --spider $WP_TEST_PERFORMANCE_DATA_URL 2>&1 | grep "Length:" > data-file-size.txt
-      - restore_cache:
-          key: performance-test-mysql-data-{{ checksum "data-file-size.txt" }}
-      - run:
-          name: Setup performance tests
-          command: |
-            ./do test:performance-setup
-      - save_cache:
-          key: performance-test-mysql-data-{{ checksum "data-file-size.txt" }}
-          paths:
-            - tests/performance/_data/mysql
-      - run:
           name: Run performance tests
           command: |
             mkdir -p tests/performance/_output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,6 +520,7 @@ jobs:
           name: Run performance tests
           command: |
             mkdir -p tests/performance/_output
+            mkdir -p tests/performance/_screenshots
             ./do test:performance --url=<< parameters.url >> --pw=<< parameters.pw >> --scenario=<< parameters.scenario >>
       - run:
           name: Check exceptions
@@ -530,6 +531,8 @@ jobs:
             fi
       - store_artifacts:
           path: tests/performance/_output
+      - store_screenshots:
+          path: tests/performance/_screenshots
       - store_test_results:
           path: tests/performance/_output
   unit_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.2.0
-  grafana: grafana/k6@1.1.3
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
@@ -464,8 +463,6 @@ jobs:
           path: tests/_output
   performance_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
-    executor: grafana/k6
-    cloud: true
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.2.0
+  grafana: grafana/k6@1.1.3
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
@@ -463,6 +464,7 @@ jobs:
           path: tests/_output
   performance_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
+    cloud: true
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: false
@@ -863,7 +865,6 @@ workflows:
           name: performance_latest
           url: https://qawp.net
           pw: $WP_TEST_PERFORMANCE_PW
-          cloud: true
           scenario: nightlytests
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,6 @@ jobs:
           path: tests/_output
   performance_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
-    cloud: true
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: false
@@ -751,6 +750,8 @@ workflows:
             - static_analysis_php8
             - qa_js
             - qa_php
+      - grafana/k6:
+          cloud: true
       - js_tests:
           <<: *slack-fail-post-step
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -744,7 +744,6 @@ workflows:
       - performance_tests:
           <<: *slack-fail-post-step
           name: performance_tests
-          cloud: true
           requires:
             - unit_tests
             - static_analysis_php8
@@ -864,6 +863,7 @@ workflows:
           name: performance_latest
           url: https://qawp.net
           pw: $WP_TEST_PERFORMANCE_PW
+          cloud: true
           scenario: nightlytests
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.2.0
+  grafana: grafana/k6@1.1.3
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
@@ -463,11 +464,12 @@ jobs:
           path: tests/_output
   performance_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
+    executor: grafana/k6
+    cloud: true
     machine:
       image: ubuntu-2204:2022.10.2
       docker_layer_caching: false
     parameters:
-      cloud: true
       mysql_command:
         type: string
         default: ''

--- a/mailpoet/.env.sample
+++ b/mailpoet/.env.sample
@@ -37,3 +37,8 @@ WP_GITHUB_TOKEN=
 # Jira username/email and a token from https://id.atlassian.com/manage/api-tokens:
 WP_JIRA_USER=
 WP_JIRA_TOKEN=
+
+# k6 performance test suite
+# Get following secrets from the Secret Store, look for "MailPoet: plugin .env":
+WP_TEST_PERFORMANCE_DATA_URL=
+WP_TEST_PERFORMANCE_PW=

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -300,7 +300,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->runTestsInContainer($opts);
   }
 
-  public function testPerformance($path = null, $opts = ['url' => null, 'head' => false, 'scenario' => null]) {
+  public function testPerformance($path = null, $opts = ['url' => null, 'pw' => null, 'head' => false, 'scenario' => null]) {
     $dir = __DIR__;
     return $this->collectionBuilder()
       ->addCode([$this, 'testPerformanceSetup'])
@@ -308,6 +308,7 @@ class RoboFile extends \Robo\Tasks {
       ->arg('run')
       ->option('env', 'K6_BROWSER_ENABLED=1')
       ->option('env', 'URL=' . $opts['url'])
+      ->option('env', 'PW=' . $opts['pw'])
       ->option('env', 'HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
       ->option('env', 'SCENARIO=' . $opts['scenario'])
       ->arg($path ?? "$dir/tests/performance/scenarios.js")

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -347,18 +347,6 @@ class RoboFile extends \Robo\Tasks {
       ->dir(__DIR__ . '/tests/performance')
       ->run();
     $this->say('Data imported, WordPress set up.');
-
-    // run performance tests
-    $dir = __DIR__;
-    return $this->taskExec("php $dir/tools/k6.php")
-      ->arg('run')
-      ->option('env', 'K6_BROWSER_ENABLED=1')
-      ->option('env', 'URL=' . $opts['url'])
-      ->option('env', 'PW=' . $opts['pw'])
-      ->option('env', 'HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
-      ->option('env', 'SCENARIO=' . $opts['scenario'])
-      ->arg($path ?? "$dir/tests/performance/scenarios.js")
-      ->dir($dir)->run();
   }
 
   public function testPerformanceClean() {

--- a/mailpoet/tests/performance/.gitignore
+++ b/mailpoet/tests/performance/.gitignore
@@ -1,3 +1,3 @@
 _data
-_output/k6report.html
+_output
 _screenshots

--- a/mailpoet/tests/performance/.gitignore
+++ b/mailpoet/tests/performance/.gitignore
@@ -1,2 +1,3 @@
 _data
 _output/k6report.html
+_screenshots

--- a/mailpoet/tests/performance/.gitignore
+++ b/mailpoet/tests/performance/.gitignore
@@ -1,1 +1,2 @@
 _output/k6report.html
+data.sql

--- a/mailpoet/tests/performance/.gitignore
+++ b/mailpoet/tests/performance/.gitignore
@@ -1,2 +1,2 @@
+_data
 _output/k6report.html
-data.sql

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -4,6 +4,8 @@ export const headlessSet = ['true', '1'].includes(
 );
 export const scenario = __ENV.SCENARIO; // eslint-disable-line
 export const timeoutSet = '2m';
+export const fullPageSet = 'true';
+export const screenshotPath = 'tests/performance/_screenshots/';
 
 export const adminUsername = 'admin';
 export const adminPassword = __ENV.PW || 'password'; // eslint-disable-line

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -53,7 +53,8 @@ services:
       MYSQL_PASSWORD: wordpress
     volumes:
       - /dev/shm:/dev/shm
-      - ./data.sql:/docker-entrypoint-initdb.d/data.sql
+      - ./_data/mysql:/var/lib/mysql
+      - ./_data/data.sql:/docker-entrypoint-initdb.d/data.sql
     healthcheck:
       test: ['CMD-SHELL', 'mysqladmin ping -hmysql --silent']
       interval: 3s

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       MYSQL_PASSWORD: wordpress
     volumes:
       - /dev/shm:/dev/shm
+      - ./data.sql:/docker-entrypoint-initdb.d/data.sql
     healthcheck:
       test: ['CMD-SHELL', 'mysqladmin ping -hmysql --silent']
       interval: 2s

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -56,9 +56,9 @@ services:
       - ./data.sql:/docker-entrypoint-initdb.d/data.sql
     healthcheck:
       test: ['CMD-SHELL', 'mysqladmin ping -hmysql --silent']
-      interval: 2s
-      timeout: 30s
-      retries: 10
+      interval: 3s
+      timeout: 600s
+      retries: 200
 
   mailhog:
     image: mailhog/mailhog:v1.0.0

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -38,14 +38,14 @@ export let options = {
 // Separate scenarios for separate testing needs
 let scenarios = {
   pullrequests: {
-    executor: 'shared-iterations',
+    executor: 'per-vu-iterations',
     vus: 1,
     iterations: 1,
     maxDuration: '5m',
     exec: 'pullRequests',
   },
   nightlytests: {
-    executor: 'shared-iterations',
+    executor: 'per-vu-iterations',
     vus: 1,
     iterations: 3,
     maxDuration: '15m',

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -15,7 +15,7 @@ import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
 import { listsComplexSegment } from './tests/lists-complex-segment.js';
 import { newsletterStatistics } from './tests/newsletter-statistics.js';
-import { onboardingWizzard } from './tests/onboarding-wizzard.js';
+import { onboardingWizard } from './tests/onboarding-wizard.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -64,7 +64,7 @@ if (scenario) {
 
 // Run those tests against a pull request build
 export async function pullRequests() {
-  await onboardingWizzard();
+  await onboardingWizard();
   await newsletterListing();
   await subscribersListing();
   await settingsBasic();

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -67,7 +67,6 @@ export async function pullRequests() {
   await onboardingWizard();
   await newsletterListing();
   await subscribersListing();
-  await settingsBasic();
   await subscribersFiltering();
   await subscribersAdding();
   await formsAdding();
@@ -77,6 +76,7 @@ export async function pullRequests() {
 
 // Run those tests against trunk in a nightly build
 export async function nightly() {
+  await settingsBasic();
   await newsletterListing();
   await subscribersListing();
   await settingsBasic();

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -21,13 +21,13 @@ import { onboardingWizard } from './tests/onboarding-wizard.js';
 export let options = {
   scenarios: {},
   thresholds: {
-    browser_dom_content_loaded: ['p(95) < 1000'],
-    browser_first_contentful_paint: ['p(95) < 500'],
-    browser_first_meaningful_paint: ['p(95) < 500'],
-    browser_first_paint: ['p(95) < 500'],
-    browser_loaded: ['p(95) < 1000'],
-    http_req_duration: ['max < 5000'],
-    http_req_receiving: ['max < 5000'],
+    browser_dom_content_loaded: ['p(95) < 5000'],
+    browser_first_contentful_paint: ['p(95) < 1000'],
+    browser_first_meaningful_paint: ['p(95) < 1000'],
+    browser_first_paint: ['p(95) < 1000'],
+    browser_loaded: ['p(95) < 5000'],
+    http_req_duration: ['max < 8000'],
+    http_req_receiving: ['max < 8000'],
     checks: ['rate==1.0'],
   },
   tags: {

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -66,28 +66,27 @@ if (scenario) {
 export async function pullRequests() {
   await onboardingWizard();
   await newsletterListing();
+  await newsletterSearching();
+  await formsAdding();
   await subscribersListing();
   await subscribersFiltering();
   await subscribersAdding();
-  await formsAdding();
-  await newsletterSearching();
   await listsViewSubscribers();
 }
 
 // Run those tests against trunk in a nightly build
 export async function nightly() {
-  await settingsBasic();
   await newsletterListing();
-  await subscribersListing();
-  await settingsBasic();
-  await subscribersFiltering();
-  await subscribersAdding();
-  await formsAdding();
+  await newsletterStatistics();
   await newsletterSearching();
   await newsletterSending();
+  await formsAdding();
+  await subscribersListing();
+  await subscribersFiltering();
+  await subscribersAdding();
   await listsViewSubscribers();
   await listsComplexSegment();
-  await newsletterStatistics();
+  await settingsBasic();
 }
 
 // HTML report data saved in performance folder

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -21,13 +21,13 @@ import { onboardingWizard } from './tests/onboarding-wizard.js';
 export let options = {
   scenarios: {},
   thresholds: {
-    browser_dom_content_loaded: ['p(90) < 5000'],
-    browser_first_contentful_paint: ['p(90) < 5000'],
-    browser_first_meaningful_paint: ['p(90) < 5000'],
-    browser_first_paint: ['p(90) < 5000'],
-    browser_loaded: ['p(90) < 5000'],
-    http_req_duration: ['p(90) < 15000'],
-    http_req_receiving: ['p(90) < 15000'],
+    browser_dom_content_loaded: ['p(95) < 1000'],
+    browser_first_contentful_paint: ['p(95) < 500'],
+    browser_first_meaningful_paint: ['p(95) < 500'],
+    browser_first_paint: ['p(95) < 500'],
+    browser_loaded: ['p(95) < 1000'],
+    http_req_duration: ['max < 5000'],
+    http_req_receiving: ['max < 5000'],
     checks: ['rate==1.0'],
   },
   tags: {

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -37,14 +37,14 @@ export let options = {
 // Separate scenarios for separate testing needs
 let scenarios = {
   pullrequests: {
-    executor: 'per-vu-iterations',
+    executor: 'shared-iterations',
     vus: 1,
     iterations: 1,
     maxDuration: '5m',
     exec: 'pullRequests',
   },
   nightlytests: {
-    executor: 'per-vu-iterations',
+    executor: 'shared-iterations',
     vus: 1,
     iterations: 3,
     maxDuration: '15m',

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -15,6 +15,7 @@ import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
 import { listsComplexSegment } from './tests/lists-complex-segment.js';
 import { newsletterStatistics } from './tests/newsletter-statistics.js';
+import { onboardingWizzard } from './tests/onboarding-wizzard.js';
 
 // Scenarios, Thresholds and Tags
 export let options = {
@@ -63,6 +64,7 @@ if (scenario) {
 
 // Run those tests against a pull request build
 export async function pullRequests() {
+  await onboardingWizzard();
   await newsletterListing();
   await subscribersListing();
   await settingsBasic();
@@ -70,7 +72,6 @@ export async function pullRequests() {
   await subscribersAdding();
   await formsAdding();
   await newsletterSearching();
-  await newsletterSending();
   await listsViewSubscribers();
 }
 

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
@@ -22,6 +20,8 @@ import {
   timeoutSet,
   defaultListName,
   formsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import {
   authenticate,
@@ -47,6 +47,11 @@ export async function formsAdding() {
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
 
+  await page.screenshot({
+    path: screenshotPath + 'Forms_Adding_01.png',
+    fullPage: fullPageSet,
+  });
+
   // Wait and click the Add New Form button
   waitAndClick(page, '[data-automation-id="create_new_form"]');
   sleep(1);
@@ -70,6 +75,11 @@ export async function formsAdding() {
         'Form saved. Cookies reset — you will see all your dismissed popup forms again.',
       );
     });
+  });
+
+  await page.screenshot({
+    path: screenshotPath + 'Forms_Adding_02.png',
+    fullPage: fullPageSet,
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -61,6 +61,14 @@ export async function formsAdding() {
   waitAndClick(page, '[data-automation-id="select_template_template_1_popup"]');
   sleep(1);
 
+  // Try to close the tutorial video popup
+  try {
+    await page.waitForSelector('[data-automation-id="mailpoet-modal-close"]');
+    await page.locator('[data-automation-id="mailpoet-modal-close"]').click();
+  } catch (error) {
+    console.log("Tutorial video wasn't present, skipping action.");
+  }
+
   // Select the list and save the form
   await page.waitForSelector('[data-automation-id="form_title_input"]');
   selectInSelect2(page, defaultListName);

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -55,18 +55,18 @@ export async function formsAdding() {
   // Wait and click the Add New Form button
   waitAndClick(page, '[data-automation-id="create_new_form"]');
   sleep(1);
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
 
   // Choose the form template
   waitAndClick(page, '[data-automation-id="select_template_template_1_popup"]');
   sleep(1);
 
   // Select the list and save the form
-  page.waitForSelector('[data-automation-id="form_title_input"]');
+  await page.waitForSelector('[data-automation-id="form_title_input"]');
   selectInSelect2(page, defaultListName);
-  page.waitForSelector('[data-automation-id="form_save_button"]');
-  page.locator('[data-automation-id="form_save_button"]').click();
-  page.waitForSelector('.components-notice');
+  await page.waitForSelector('[data-automation-id="form_save_button"]');
+  await page.locator('[data-automation-id="form_save_button"]').click();
+  await page.waitForSelector('.components-notice');
   describe(formsPageTitle, () => {
     describe('should be able to see Forms Saved message', () => {
       expect(

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
@@ -22,6 +20,8 @@ import {
   timeoutSet,
   defaultListName,
   listsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate, selectInReact } from '../utils/helpers.js';
 
@@ -49,6 +49,11 @@ export async function listsComplexSegment() {
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
 
+  await page.screenshot({
+    path: screenshotPath + 'Lists_Complex_Segment_01.png',
+    fullPage: fullPageSet,
+  });
+
   // Click to add a new segment
   page.waitForSelector('[data-automation-id="new-segment"]');
   page.locator('[data-automation-id="new-segment"]').click();
@@ -69,6 +74,11 @@ export async function listsComplexSegment() {
   });
   page.waitForLoadState('networkidle');
 
+  await page.screenshot({
+    path: screenshotPath + 'Lists_Complex_Segment_02.png',
+    fullPage: fullPageSet,
+  });
+
   // Click to add a new segment action
   page
     .locator(
@@ -85,6 +95,11 @@ export async function listsComplexSegment() {
         page.locator('.mailpoet-form-notice-message').innerText(),
       ).to.contain('Calculating segment size…');
     });
+  });
+
+  await page.screenshot({
+    path: screenshotPath + 'Lists_Complex_Segment_03.png',
+    fullPage: fullPageSet,
   });
 
   // Click to add a new segment action
@@ -111,6 +126,11 @@ export async function listsComplexSegment() {
     .click();
   page.waitForSelector('.mailpoet-form-notice-message');
   page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Lists_Complex_Segment_04.png',
+    fullPage: fullPageSet,
+  });
 
   // Save the segment
   await page

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -55,16 +55,16 @@ export async function listsComplexSegment() {
   });
 
   // Click to add a new segment
-  page.waitForSelector('[data-automation-id="new-segment"]');
-  page.locator('[data-automation-id="new-segment"]').click();
-  page
+  await page.waitForSelector('[data-automation-id="new-segment"]');
+  await page.locator('[data-automation-id="new-segment"]').click();
+  await page
     .locator('[data-automation-id="input-name"]')
     .type(complexSegmentName, { delay: 25 });
 
   // Select "Subscribed to a list" action
   selectInReact(page, '#react-select-2-input', 'subscribed to list');
   selectInReact(page, '#react-select-4-input', defaultListName);
-  page.waitForSelector('.mailpoet-form-notice-message');
+  await page.waitForSelector('.mailpoet-form-notice-message');
   describe(listsPageTitle, () => {
     describe('should be able to see calculating message', () => {
       expect(
@@ -72,7 +72,7 @@ export async function listsComplexSegment() {
       ).to.contain('Calculating segment size…');
     });
   });
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
 
   await page.screenshot({
     path: screenshotPath + 'Lists_Complex_Segment_02.png',
@@ -80,7 +80,7 @@ export async function listsComplexSegment() {
   });
 
   // Click to add a new segment action
-  page
+  await page
     .locator(
       '#segments_container > form > div > div.mailpoet-segments-segments-section > button',
     )
@@ -88,7 +88,7 @@ export async function listsComplexSegment() {
 
   // Select "Subscribed date" action
   selectInReact(page, '#react-select-5-input', 'subscribed date');
-  page.waitForSelector('.mailpoet-form-notice-message');
+  await page.waitForSelector('.mailpoet-form-notice-message');
   describe(listsPageTitle, () => {
     describe('should be able to see calculating message', () => {
       expect(
@@ -103,7 +103,7 @@ export async function listsComplexSegment() {
   });
 
   // Click to add a new segment action
-  page
+  await page
     .locator(
       '#segments_container > form > div > div.mailpoet-segments-segments-section > button',
     )
@@ -112,8 +112,8 @@ export async function listsComplexSegment() {
   // WordPress user role action has been automatically added
   // Select a WP user role
   selectInReact(page, '#react-select-8-input', 'Administrator');
-  page.waitForSelector('.mailpoet-form-notice-message');
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('.mailpoet-form-notice-message');
+  await page.waitForLoadState('networkidle');
   describe(listsPageTitle, () => {
     describe('should be able to see Calculating message', () => {
       expect(
@@ -121,11 +121,11 @@ export async function listsComplexSegment() {
       ).to.contain('Calculating segment size…');
     });
   });
-  page
+  await page
     .locator('[data-automation-id="dynamic-segment-condition-type-or"]')
     .click();
-  page.waitForSelector('.mailpoet-form-notice-message');
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('.mailpoet-form-notice-message');
+  await page.waitForLoadState('networkidle');
 
   await page.screenshot({
     path: screenshotPath + 'Lists_Complex_Segment_04.png',
@@ -138,7 +138,7 @@ export async function listsComplexSegment() {
       '#segments_container > form > div > div.mailpoet-form-actions > button > span',
     )
     .click();
-  page.waitForSelector('[data-automation-id="filters_all"]', {
+  await page.waitForSelector('[data-automation-id="filters_all"]', {
     state: 'visible',
   });
   describe(listsPageTitle, () => {

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -47,7 +47,7 @@ export async function listsComplexSegment() {
   authenticate(page);
 
   // Wait for async actions
-  await page.waitForNavigation({ waitUntil: 'networkidle' });
+  await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' })]);
 
   await page.screenshot({
     path: screenshotPath + 'Lists_Complex_Segment_01.png',

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /* eslint-disable no-unused-expressions */
 /**
  * External dependencies
@@ -23,6 +21,8 @@ import {
   timeoutSet,
   defaultListName,
   listsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -46,6 +46,11 @@ export async function listsViewSubscribers() {
 
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Lists_View_Subscribers_01.png',
+    fullPage: fullPageSet,
+  });
 
   // Click to view subscribers of the default list "Newsletter mailing list"
   page.waitForSelector('[data-automation-id="dynamic-segments-tab"]');
@@ -72,6 +77,11 @@ export async function listsViewSubscribers() {
     });
   });
   page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Lists_View_Subscribers_02.png',
+    fullPage: fullPageSet,
+  });
 
   // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -53,30 +53,30 @@ export async function listsViewSubscribers() {
   });
 
   // Click to view subscribers of the default list "Newsletter mailing list"
-  page.waitForSelector('[data-automation-id="dynamic-segments-tab"]');
+  await page.waitForSelector('[data-automation-id="dynamic-segments-tab"]');
   describe(listsPageTitle, () => {
     describe('should be able to see Segments tab', () => {
       expect(page.locator('[data-automation-id="dynamic-segments-tab"]')).to
         .exist;
     });
   });
-  page
+  await page
     .locator('[data-automation-id="segment_name_' + defaultListName + '"]')
     .hover();
-  page
+  await page
     .locator('[data-automation-id="view_subscribers_' + defaultListName + '"]')
     .click();
 
   // Wait for the page to load
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
   describe(listsPageTitle, () => {
     describe('should be able to see Lists Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
         .exist;
     });
   });
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
 
   await page.screenshot({
     path: screenshotPath + 'Lists_View_Subscribers_02.png',

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /* eslint-disable no-unused-expressions */
 /**
  * External dependencies
@@ -43,6 +41,11 @@ export async function newsletterListing() {
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
 
+  await page.screenshot({
+    path: 'tests/performance/_screenshots/01_Newsletter_Listing.png',
+    fullPage: 'true',
+  });
+
   // Check if there is element present and visible
   page.waitForSelector('[data-automation-id="listing_filter_segment"]');
   page.waitForLoadState('networkidle');
@@ -51,6 +54,11 @@ export async function newsletterListing() {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
         .exist;
     });
+  });
+
+  await page.screenshot({
+    path: 'tests/performance/_screenshots/02_Newsletter_Listing.png',
+    fullPage: 'true',
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -20,6 +20,8 @@ import {
   headlessSet,
   timeoutSet,
   emailsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -42,8 +44,8 @@ export async function newsletterListing() {
   await page.waitForNavigation({ waitUntil: 'networkidle' });
 
   await page.screenshot({
-    path: 'tests/performance/_screenshots/01_Newsletter_Listing.png',
-    fullPage: 'true',
+    path: screenshotPath + '01_Newsletter_Listing.png',
+    fullPage: fullPageSet,
   });
 
   // Check if there is element present and visible
@@ -56,8 +58,8 @@ export async function newsletterListing() {
   });
 
   await page.screenshot({
-    path: 'tests/performance/_screenshots/02_Newsletter_Listing.png',
-    fullPage: 'true',
+    path: screenshotPath + '02_Newsletter_Listing.png',
+    fullPage: fullPageSet,
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -49,8 +49,8 @@ export async function newsletterListing() {
   });
 
   // Check if there is element present and visible
-  page.waitForSelector('[data-automation-id="filters_all"]');
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('[data-automation-id="filters_all"]');
+  await page.waitForLoadState('networkidle');
   describe(emailsPageTitle, () => {
     describe('should be able to see All Filter', () => {
       expect(page.locator('[data-automation-id="filters_all"]')).to.exist;

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -44,7 +44,7 @@ export async function newsletterListing() {
   await page.waitForNavigation({ waitUntil: 'networkidle' });
 
   await page.screenshot({
-    path: screenshotPath + '01_Newsletter_Listing.png',
+    path: screenshotPath + 'Newsletter_Listing_01.png',
     fullPage: fullPageSet,
   });
 
@@ -58,7 +58,7 @@ export async function newsletterListing() {
   });
 
   await page.screenshot({
-    path: screenshotPath + '02_Newsletter_Listing.png',
+    path: screenshotPath + 'Newsletter_Listing_02.png',
     fullPage: fullPageSet,
   });
 

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -47,12 +47,11 @@ export async function newsletterListing() {
   });
 
   // Check if there is element present and visible
-  page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+  page.waitForSelector('[data-automation-id="filters_all"]');
   page.waitForLoadState('networkidle');
   describe(emailsPageTitle, () => {
-    describe('should be able to see Lists Filter', () => {
-      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
-        .exist;
+    describe('should be able to see All Filter', () => {
+      expect(page.locator('[data-automation-id="filters_all"]')).to.exist;
     });
   });
 

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /* eslint-disable no-unused-expressions */
 /**
  * External dependencies
@@ -22,6 +20,8 @@ import {
   headlessSet,
   timeoutSet,
   emailsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -42,6 +42,11 @@ export async function newsletterSearching() {
 
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Searching_01.png',
+    fullPage: fullPageSet,
+  });
 
   // Search for a newsletter
   page.locator('#search_input').type('Newsletter 1st', { delay: 50 });
@@ -68,6 +73,11 @@ export async function newsletterSearching() {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
         .exist;
     });
+  });
+
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Searching_02.png',
+    fullPage: fullPageSet,
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -49,10 +49,10 @@ export async function newsletterSearching() {
   });
 
   // Search for a newsletter
-  page.locator('#search_input').type('Newsletter 1st', { delay: 50 });
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="listing_filter_segment"]');
-  page.waitForLoadState('networkidle');
+  await page.locator('#search_input').type('Newsletter 1st', { delay: 50 });
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+  await page.waitForLoadState('networkidle');
   describe(emailsPageTitle, () => {
     describe('should be able to search for Newsletter 1st', () => {
       expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
@@ -62,12 +62,12 @@ export async function newsletterSearching() {
   });
 
   // Filter newsletter results by a default list "Newsletter mailing list"
-  page
+  await page
     .locator('[data-automation-id="listing_filter_segment"]')
     .selectOption('3');
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="listing_filter_segment"]');
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="listing_filter_segment"]');
+  await page.waitForLoadState('networkidle');
   describe(emailsPageTitle, () => {
     describe('should be able to see Lists Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -50,21 +50,21 @@ export async function newsletterSending() {
   });
 
   // Click to add a new standard newsletter
-  page.locator('[data-automation-id="new_email"]').click();
-  page.locator('[data-automation-id="create_standard"]').click();
-  page.waitForSelector('.mailpoet_loading');
-  page.waitForSelector('[data-automation-id="templates-standard"]');
-  page.waitForLoadState('networkidle');
+  await page.locator('[data-automation-id="new_email"]').click();
+  await page.locator('[data-automation-id="create_standard"]').click();
+  await page.waitForSelector('.mailpoet_loading');
+  await page.waitForSelector('[data-automation-id="templates-standard"]');
+  await page.waitForLoadState('networkidle');
 
   // Switch to a Standard templates tab and select the 2nd template
-  page.locator('[data-automation-id="templates-standard"]').click();
+  await page.locator('[data-automation-id="templates-standard"]').click();
   await Promise.all([
     page.waitForNavigation(),
     page.locator('[data-automation-id="select_template_1"]').click(),
   ]);
-  page.waitForSelector('.mailpoet_loading');
-  page.waitForSelector('[data-automation-id="newsletter_title"]');
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('.mailpoet_loading');
+  await page.waitForSelector('[data-automation-id="newsletter_title"]');
+  await page.waitForLoadState('networkidle');
 
   await page.screenshot({
     path: screenshotPath + 'Newsletter_Sending_02.png',
@@ -78,8 +78,8 @@ export async function newsletterSending() {
       .locator('#mailpoet_editor_top > div > div > .mailpoet_save_next')
       .click(),
   ]);
-  page.waitForSelector('[data-automation-id="newsletter_send_heading"]');
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('[data-automation-id="newsletter_send_heading"]');
+  await page.waitForLoadState('networkidle');
 
   // Select the default list and send the newsletter
   selectInSelect2(page, defaultListName);
@@ -95,7 +95,7 @@ export async function newsletterSending() {
   });
 
   // Wait for the success notice message and confirm it
-  page.waitForSelector('#mailpoet_notices');
+  await page.waitForSelector('#mailpoet_notices');
   describe(emailsPageTitle, () => {
     describe('should be able to see Newsletter Sent message', () => {
       expect(page.locator('div > .notice-success').innerText()).to.contain(
@@ -103,7 +103,7 @@ export async function newsletterSending() {
       );
     });
   });
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
 
   await page.screenshot({
     path: screenshotPath + 'Newsletter_Sending_04.png',

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
@@ -22,6 +20,8 @@ import {
   timeoutSet,
   defaultListName,
   emailsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate, selectInSelect2 } from '../utils/helpers.js';
 /* global Promise */
@@ -44,6 +44,11 @@ export async function newsletterSending() {
   // Wait for async actions
   await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' })]);
 
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Sending_01.png',
+    fullPage: fullPageSet,
+  });
+
   // Click to add a new standard newsletter
   page.locator('[data-automation-id="new_email"]').click();
   page.locator('[data-automation-id="create_standard"]').click();
@@ -60,6 +65,11 @@ export async function newsletterSending() {
   page.waitForSelector('.mailpoet_loading');
   page.waitForSelector('[data-automation-id="newsletter_title"]');
   page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Sending_02.png',
+    fullPage: fullPageSet,
+  });
 
   // Click to proceed to the next step (the last one)
   await Promise.all([
@@ -79,6 +89,11 @@ export async function newsletterSending() {
   ]);
   sleep(1);
 
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Sending_03.png',
+    fullPage: fullPageSet,
+  });
+
   // Wait for the success notice message and confirm it
   page.waitForSelector('#mailpoet_notices');
   describe(emailsPageTitle, () => {
@@ -89,6 +104,11 @@ export async function newsletterSending() {
     });
   });
   page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Sending_04.png',
+    fullPage: fullPageSet,
+  });
 
   // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /* eslint-disable no-unused-expressions */
 /**
  * External dependencies
@@ -22,6 +20,8 @@ import {
   headlessSet,
   timeoutSet,
   emailsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
@@ -48,6 +48,11 @@ export async function newsletterStatistics() {
       waitUntil: 'networkidle',
     },
   );
+
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Statistics_01.png',
+    fullPage: fullPageSet,
+  });
 
   // Wait for the page to load and click sold tab
   page.waitForSelector('.mailpoet-listing-table');
@@ -82,6 +87,11 @@ export async function newsletterStatistics() {
       expect(page.locator('[data-automation-id="filters_all_engaged"]')).to
         .exist;
     });
+  });
+
+  await page.screenshot({
+    path: screenshotPath + 'Newsletter_Statistics_02.png',
+    fullPage: fullPageSet,
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -55,11 +55,11 @@ export async function newsletterStatistics() {
   });
 
   // Wait for the page to load and click sold tab
-  page.waitForSelector('.mailpoet-listing-table');
-  page.waitForSelector('[data-automation-id="products-sold-tab"]');
-  page.waitForLoadState('networkidle');
-  page.locator('[data-automation-id="products-sold-tab"]').click();
-  page.waitForLoadState('networkidle');
+  await page.waitForSelector('.mailpoet-listing-table');
+  await page.waitForSelector('[data-automation-id="products-sold-tab"]');
+  await page.waitForLoadState('networkidle');
+  await page.locator('[data-automation-id="products-sold-tab"]').click();
+  await page.waitForLoadState('networkidle');
   await waitForSelectorToBeVisible(
     page,
     '.mailpoet-tab-content > p:nth-child(1)',
@@ -75,13 +75,13 @@ export async function newsletterStatistics() {
   });
 
   // Click the subscribers engagement tab
-  page.locator('[data-automation-id="engagement-tab"]');
-  page.waitForSelector('.mailpoet-listing-table');
+  await page.locator('[data-automation-id="engagement-tab"]');
+  await page.waitForSelector('.mailpoet-listing-table');
   waitForSelectorToBeVisible(
     page,
     '[data-automation-id="filters_all_engaged"]',
   );
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
   describe(emailsPageTitle, () => {
     describe('should be able to see Link Clicked filter', () => {
       expect(page.locator('[data-automation-id="filters_all_engaged"]')).to

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -61,7 +61,9 @@ export async function newsletterStatistics() {
   );
   describe(emailsPageTitle, () => {
     describe('should be able to see text no products sold', () => {
-      expect(page.locator('.mailpoet-tab-content > p:nth-child(1)').innerText()).to.contain(
+      expect(
+        page.locator('.mailpoet-tab-content > p:nth-child(1)').innerText(),
+      ).to.contain(
         'Unfortunately, no products were sold as a result of this email!',
       );
     });
@@ -82,6 +84,7 @@ export async function newsletterStatistics() {
     });
   });
 
+  // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   page.close();
   browser.close();

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -41,7 +41,7 @@ export async function newsletterStatistics() {
   authenticate(page);
 
   // Wait for async actions and open newsletter statistics
-  await page.waitForNavigation({ waitUntil: 'networkidle' });
+  await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' })]);
   await page.goto(
     `${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters#/stats/1`,
     {

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -43,7 +43,7 @@ export async function newsletterStatistics() {
   // Wait for async actions and open newsletter statistics
   await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' })]);
   await page.goto(
-    `${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters#/stats/1`,
+    `${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters#/stats/2`,
     {
       waitUntil: 'networkidle',
     },
@@ -60,27 +60,23 @@ export async function newsletterStatistics() {
   await page.waitForLoadState('networkidle');
   await page.locator('[data-automation-id="products-sold-tab"]').click();
   await page.waitForLoadState('networkidle');
+
+  // Check if you see the product in the sold tab
   await waitForSelectorToBeVisible(
     page,
-    '.mailpoet-tab-content > p:nth-child(1)',
+    '[data-acceptance-id="purchased-product-Simple Product"]',
   );
   describe(emailsPageTitle, () => {
-    describe('should be able to see text no products sold', () => {
+    describe('should be able to see the product as sold', () => {
       expect(
-        page.locator('.mailpoet-tab-content > p:nth-child(1)').innerText(),
-      ).to.contain(
-        'Unfortunately, no products were sold as a result of this email!',
-      );
+        page.locator('[data-acceptance-id="purchased-product-Simple Product"]'),
+      ).to.exist;
     });
   });
 
   // Click the subscribers engagement tab
-  await page.locator('[data-automation-id="engagement-tab"]');
-  await page.waitForSelector('.mailpoet-listing-table');
-  waitForSelectorToBeVisible(
-    page,
-    '[data-automation-id="filters_all_engaged"]',
-  );
+  await page.locator('[data-automation-id="engagement-tab"]').click();
+  await page.waitForSelector('[data-automation-id="filters_all_engaged"]');
   await page.waitForLoadState('networkidle');
   describe(emailsPageTitle, () => {
     describe('should be able to see Link Clicked filter', () => {

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -81,6 +81,12 @@ export async function onboardingWizard() {
     });
   });
 
+  // Take a screenshot of the finished test
+  await page.screenshot({
+    path: 'tests/performance/_screenshots/01_Onboarding_Wizard.png',
+    fullPage: 'true',
+  });
+
   // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   page.close();

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -1,11 +1,13 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
 import { sleep } from 'k6';
 import { chromium } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
 
 /**
  * Internal dependencies
@@ -16,10 +18,11 @@ import {
   thinkTimeMax,
   headlessSet,
   timeoutSet,
+  settingsPageTitle,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
-export async function onboardingWizzard() {
+export async function onboardingWizard() {
   const browser = chromium.launch({
     headless: headlessSet,
     timeout: timeoutSet,
@@ -41,9 +44,21 @@ export async function onboardingWizzard() {
   await page.waitForNavigation({ waitUntil: 'networkidle' });
   await page.locator('#mailpoet_sender_form > a').click();
   await page.waitForLoadState('networkidle');
-  await page.locator('[data-automation-id="check-yes-google-fonts"]').click();
-  await page.locator('[data-automation-id="check-yes-help-improve"]').click();
-  await page.locator('form > .mailpoet-wizard-continue-button').click();
+  await page
+    .locator(
+      '#mailpoet-wizard-3rd-party-libs > div > div > label:nth-child(1) > span',
+    )
+    .click();
+  await page
+    .locator(
+      '#mailpoet-wizard-tracking > div.mailpoet-wizard-woocommerce-toggle > div > label:nth-child(1) > span',
+    )
+    .click();
+  await page
+    .locator(
+      '#mailpoet-wizard-container > div.mailpoet-steps-content > div > div.mailpoet-wizard-step-content > form > button > span',
+    )
+    .click();
   await page.waitForLoadState('networkidle');
   await page.locator('.mailpoet-wizard-step-content > p > a').click();
   sleep(2);
@@ -53,6 +68,18 @@ export async function onboardingWizzard() {
   await page.keyboard.press('Enter');
   await page.waitForNavigation('networkidle');
   await page.waitForLoadState('networkidle');
+  await page.waitForSelector('[data-automation-id="send_with_settings_tab"]');
+
+  // Check if you see Send With tab at the end
+  describe(settingsPageTitle, () => {
+    describe('should be able to see Send With tab present', () => {
+      expect(
+        page
+          .locator('[data-automation-id="send_with_settings_tab"]')
+          .innerText(),
+      ).to.contain('Send With...');
+    });
+  });
 
   // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
@@ -60,6 +87,6 @@ export async function onboardingWizzard() {
   browser.close();
 }
 
-export default async function onboardingWizzardTest() {
-  await onboardingWizzard();
+export default async function onboardingWizardTest() {
+  await onboardingWizard();
 }

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -46,6 +46,12 @@ export async function onboardingWizard() {
   await page.waitForNavigation({ waitUntil: 'networkidle' });
   await page.locator('#mailpoet_sender_form > a').click();
   await page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Onboarding_Wizard_01.png',
+    fullPage: fullPageSet,
+  });
+
   await page
     .locator(
       '#mailpoet-wizard-3rd-party-libs > div > div > label:nth-child(1) > span',
@@ -64,6 +70,10 @@ export async function onboardingWizard() {
   await page.waitForLoadState('networkidle');
   await page.locator('.mailpoet-wizard-step-content > p > a').click();
   sleep(2);
+  await page.screenshot({
+    path: screenshotPath + 'Onboarding_Wizard_02.png',
+    fullPage: fullPageSet,
+  });
   await page.keyboard.press('Tab');
   await page.keyboard.press('Tab');
   await page.keyboard.press('Tab');
@@ -71,6 +81,11 @@ export async function onboardingWizard() {
   await page.waitForNavigation('networkidle');
   await page.waitForLoadState('networkidle');
   await page.waitForSelector('[data-automation-id="send_with_settings_tab"]');
+
+  await page.screenshot({
+    path: screenshotPath + 'Onboarding_Wizard_03.png',
+    fullPage: fullPageSet,
+  });
 
   // Check if you see Send With tab at the end
   describe(settingsPageTitle, () => {
@@ -83,9 +98,8 @@ export async function onboardingWizard() {
     });
   });
 
-  // Take a screenshot of the finished test
   await page.screenshot({
-    path: screenshotPath + '01_Onboarding_Wizard.png',
+    path: screenshotPath + 'Onboarding_Wizard_04.png',
     fullPage: fullPageSet,
   });
 

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -19,6 +19,8 @@ import {
   headlessSet,
   timeoutSet,
   settingsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -83,8 +85,8 @@ export async function onboardingWizard() {
 
   // Take a screenshot of the finished test
   await page.screenshot({
-    path: 'tests/performance/_screenshots/01_Onboarding_Wizard.png',
-    fullPage: 'true',
+    path: screenshotPath + '01_Onboarding_Wizard.png',
+    fullPage: fullPageSet,
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/onboarding-wizzard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizzard.js
@@ -11,54 +11,55 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
  * Internal dependencies
  */
 import {
-	baseURL,
-	thinkTimeMin,
-	thinkTimeMax,
-	headlessSet,
-	timeoutSet,
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
 export async function onboardingWizzard() {
-	const browser = chromium.launch({
-		headless: headlessSet,
-		timeout: timeoutSet,
-	});
-	const page = browser.newPage();
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
 
-	// Go to the page
-	await page.goto(
-		`${baseURL}/wp-admin/admin.php?page=mailpoet-welcome-wizard#/steps/1`,
-		{
-			waitUntil: 'networkidle',
-		},
-	);
+  // Go to the page
+  await page.goto(
+    `${baseURL}/wp-admin/admin.php?page=mailpoet-welcome-wizard#/steps/1`,
+    {
+      waitUntil: 'networkidle',
+    },
+  );
 
-	// Log in to WP Admin
-	authenticate(page);
+  // Log in to WP Admin
+  authenticate(page);
 
-	// Wait for async actions
-	await page.waitForNavigation({ waitUntil: 'networkidle' });
-	await page.locator('#mailpoet_sender_form > a').click();
-	await page.waitForLoadState('networkidle');
-	await page.locator('[data-automation-id="check-yes-google-fonts"]').click();
-	await page.locator('[data-automation-id="check-yes-help-improve"]').click();
-	await page.locator('form > .mailpoet-wizard-continue-button').click();
-	await page.waitForLoadState('networkidle');
-	await page.locator('.mailpoet-wizard-step-content > p > a').click();
-	sleep(2);
-	await page.keyboard.press('Tab');
-	await page.keyboard.press('Tab');
-	await page.keyboard.press('Tab');
-	await page.keyboard.press('Enter');
-	await page.waitForNavigation('networkidle');
-	await page.waitForLoadState('networkidle');
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+  await page.locator('#mailpoet_sender_form > a').click();
+  await page.waitForLoadState('networkidle');
+  await page.locator('[data-automation-id="check-yes-google-fonts"]').click();
+  await page.locator('[data-automation-id="check-yes-help-improve"]').click();
+  await page.locator('form > .mailpoet-wizard-continue-button').click();
+  await page.waitForLoadState('networkidle');
+  await page.locator('.mailpoet-wizard-step-content > p > a').click();
+  sleep(2);
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Enter');
+  await page.waitForNavigation('networkidle');
+  await page.waitForLoadState('networkidle');
 
-	sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-	page.close();
-	browser.close();
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
 }
 
 export default async function onboardingWizzardTest() {
-	await onboardingWizzard();
+  await onboardingWizzard();
 }

--- a/mailpoet/tests/performance/tests/onboarding-wizzard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizzard.js
@@ -1,0 +1,64 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-default-export */
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { chromium } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+	baseURL,
+	thinkTimeMin,
+	thinkTimeMax,
+	headlessSet,
+	timeoutSet,
+} from '../config.js';
+import { authenticate } from '../utils/helpers.js';
+
+export async function onboardingWizzard() {
+	const browser = chromium.launch({
+		headless: headlessSet,
+		timeout: timeoutSet,
+	});
+	const page = browser.newPage();
+
+	// Go to the page
+	await page.goto(
+		`${baseURL}/wp-admin/admin.php?page=mailpoet-welcome-wizard#/steps/1`,
+		{
+			waitUntil: 'networkidle',
+		},
+	);
+
+	// Log in to WP Admin
+	authenticate(page);
+
+	// Wait for async actions
+	await page.waitForNavigation({ waitUntil: 'networkidle' });
+	await page.locator('#mailpoet_sender_form > a').click();
+	await page.waitForLoadState('networkidle');
+	await page.locator('[data-automation-id="check-yes-google-fonts"]').click();
+	await page.locator('[data-automation-id="check-yes-help-improve"]').click();
+	await page.locator('form > .mailpoet-wizard-continue-button').click();
+	await page.waitForLoadState('networkidle');
+	await page.locator('.mailpoet-wizard-step-content > p > a').click();
+	sleep(2);
+	await page.keyboard.press('Tab');
+	await page.keyboard.press('Tab');
+	await page.keyboard.press('Tab');
+	await page.keyboard.press('Enter');
+	await page.waitForNavigation('networkidle');
+	await page.waitForLoadState('networkidle');
+
+	sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+	page.close();
+	browser.close();
+}
+
+export default async function onboardingWizzardTest() {
+	await onboardingWizzard();
+}

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /**
  * External dependencies
  */
@@ -21,6 +19,8 @@ import {
   headlessSet,
   timeoutSet,
   settingsPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -44,6 +44,11 @@ export async function settingsBasic() {
 
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Settings_Basic_01.png',
+    fullPage: fullPageSet,
+  });
 
   // Click to save the settings
   page.locator('[data-automation-id="settings-submit-button"]').click();

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -51,9 +51,9 @@ export async function settingsBasic() {
   });
 
   // Click to save the settings
-  page.locator('[data-automation-id="settings-submit-button"]').click();
-  page.waitForSelector('div.notice');
-  page.waitForLoadState('networkidle');
+  await page.locator('[data-automation-id="settings-submit-button"]').click();
+  await page.waitForSelector('div.notice');
+  await page.waitForLoadState('networkidle');
 
   // Check if there's notice about saved settings
   describe(settingsPageTitle, () => {

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /* eslint-disable no-unused-expressions */
 /**
  * External dependencies
@@ -25,6 +23,8 @@ import {
   lastName,
   defaultListName,
   subscribersPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate, selectInSelect2 } from '../utils/helpers.js';
 
@@ -48,6 +48,11 @@ export async function subscribersAdding() {
 
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Adding_01.png',
+    fullPage: fullPageSet,
+  });
 
   // Add a new subscriber
   page.locator('[data-automation-id="add-new-subscribers-button"]').click();
@@ -75,6 +80,11 @@ export async function subscribersAdding() {
     });
   });
   page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Adding_02.png',
+    fullPage: fullPageSet,
+  });
 
   // Search for a newly added subscriber and verify
   page.locator('#search_input').type(subscriberEmail, { delay: 50 });

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -55,31 +55,33 @@ export async function subscribersAdding() {
   });
 
   // Add a new subscriber
-  page.locator('[data-automation-id="add-new-subscribers-button"]').click();
-  page.locator('input[name="email"]').type(subscriberEmail);
-  page.locator('input[name="first_name"]').type(firstName);
-  page.locator('input[name="last_name"]').type(lastName);
+  await page
+    .locator('[data-automation-id="add-new-subscribers-button"]')
+    .click();
+  await page.locator('input[name="email"]').type(subscriberEmail);
+  await page.locator('input[name="first_name"]').type(firstName);
+  await page.locator('input[name="last_name"]').type(lastName);
   selectInSelect2(page, defaultListName);
-  page.locator('button[type="submit"]').click();
+  await page.locator('button[type="submit"]').click();
 
   // Verify you see the success message and the filter is visible
-  page.waitForSelector('div.notice');
+  await page.waitForSelector('div.notice-success');
   describe(subscribersPageTitle, () => {
     describe('should be able to see Subscriber Added message', () => {
-      expect(page.locator('div.notice').innerText()).to.contain(
+      expect(page.locator('div.notice-success').innerText()).to.contain(
         'Subscriber was added successfully!',
       );
     });
   });
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
   describe(subscribersPageTitle, () => {
     describe('should be able to see Lists Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
         .exist;
     });
   });
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
 
   await page.screenshot({
     path: screenshotPath + 'Subscribers_Adding_02.png',
@@ -87,10 +89,10 @@ export async function subscribersAdding() {
   });
 
   // Search for a newly added subscriber and verify
-  page.locator('#search_input').type(subscriberEmail, { delay: 50 });
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="filters_subscribed"]');
-  page.waitForLoadState('networkidle');
+  await page.locator('#search_input').type(subscriberEmail, { delay: 50 });
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  await page.waitForLoadState('networkidle');
   describe(subscribersPageTitle, () => {
     describe('should be able to search for Newly Added Subscriber', () => {
       expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -1,6 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
-/* eslint-disable no-unused-expressions */
 /**
  * External dependencies
  */
@@ -23,6 +20,8 @@ import {
   timeoutSet,
   adminEmail,
   subscribersPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -44,6 +43,11 @@ export async function subscribersFiltering() {
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
 
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Filtering_01.png',
+    fullPage: fullPageSet,
+  });
+
   // Check the subscribers filter is present
   page.locator('[data-automation-id="filters_subscribed"]').click();
   page.waitForSelector('[data-automation-id="filters_subscribed"]');
@@ -52,6 +56,11 @@ export async function subscribersFiltering() {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
         .exist;
     });
+  });
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Filtering_02.png',
+    fullPage: fullPageSet,
   });
 
   // Select option "Newsletter mailing list" in the subscribers filter
@@ -67,6 +76,11 @@ export async function subscribersFiltering() {
     });
   });
   page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Filtering_03.png',
+    fullPage: fullPageSet,
+  });
 
   // Search for a subscriber in a filtered list
   page.locator('#search_input').type(adminEmail, { delay: 50 });

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -75,7 +75,6 @@ export async function subscribersFiltering() {
         .exist;
     });
   });
-  await page.waitForNavigation({ waitUntil: 'networkidle' });
 
   await page.screenshot({
     path: screenshotPath + 'Subscribers_Filtering_03.png',

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -49,8 +49,8 @@ export async function subscribersFiltering() {
   });
 
   // Check the subscribers filter is present
-  page.locator('[data-automation-id="filters_subscribed"]').click();
-  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  await page.locator('[data-automation-id="filters_subscribed"]').click();
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
   describe(subscribersPageTitle, () => {
     describe('should be able to see Lists Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
@@ -64,18 +64,18 @@ export async function subscribersFiltering() {
   });
 
   // Select option "Newsletter mailing list" in the subscribers filter
-  page
+  await page
     .locator('[data-automation-id="listing_filter_segment"]')
     .selectOption('3');
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
   describe(subscribersPageTitle, () => {
     describe('should be able to see Lists Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
         .exist;
     });
   });
-  page.waitForNavigation({ waitUntil: 'networkidle' });
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
 
   await page.screenshot({
     path: screenshotPath + 'Subscribers_Filtering_03.png',
@@ -83,9 +83,9 @@ export async function subscribersFiltering() {
   });
 
   // Search for a subscriber in a filtered list
-  page.locator('#search_input').type(adminEmail, { delay: 50 });
-  page.waitForSelector('.mailpoet-listing-no-items');
-  page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  await page.locator('#search_input').type(adminEmail, { delay: 50 });
+  await page.waitForSelector('.mailpoet-listing-no-items');
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
   describe(subscribersPageTitle, () => {
     describe('should be able to see Lists Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_segment"]')).to

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -49,7 +49,7 @@ export async function subscribersListing() {
   });
 
   // Verify filter, tag and listing are loaded and visible
-  page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle');
   describe(subscribersPageTitle, () => {
     describe('should be able to see Tags Filter', () => {
       expect(page.locator('[data-automation-id="listing_filter_tag"]')).to

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /* eslint-disable no-unused-expressions */
 /**
  * External dependencies
@@ -22,6 +20,8 @@ import {
   headlessSet,
   timeoutSet,
   subscribersPageTitle,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 import { authenticate } from '../utils/helpers.js';
 
@@ -42,6 +42,11 @@ export async function subscribersListing() {
 
   // Wait for async actions
   await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Listing_01.png',
+    fullPage: fullPageSet,
+  });
 
   // Verify filter, tag and listing are loaded and visible
   page.waitForLoadState('networkidle');

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/no-default-export */
 /**
  * Internal dependencies
  */
@@ -7,12 +5,11 @@ import { adminUsername, adminPassword } from '../config.js';
 /* global Promise */
 
 // WordPress login authorization
-export function authenticate(page) {
+export async function authenticate(page) {
   // Enter login credentials and login
-  page.waitForNavigation({ waitUntil: 'networkidle' });
-  page.waitForLoadState('networkidle');
-  page.locator('input[name="log"]').type(`${adminUsername}`);
-  page.locator('input[name="pwd"]').type(`${adminPassword}`);
+  await page.waitForLoadState('networkidle');
+  await page.locator('input[name="log"]').type(`${adminUsername}`);
+  await page.locator('input[name="pwd"]').type(`${adminPassword}`);
   // Wait for asynchronous operations to complete
   return Promise.all([
     page.waitForNavigation(),


### PR DESCRIPTION
## Description

In this PR, we're going to add SQL with `100k subscribers`, `5k newsletters` to a local test env.

Note: This PR is final PR for the project k6 implementation. There are some small changes not related to the importing SQL to Docker env, but small changes such as:

Additionally, added a new test just to bypass the onboarding wizard for the first time local execution: `onboardingWizard.js`

I also added taking screenshots in tests. Before, after, or in the middle. Now the screenshots will be included in the artifacts on CircleCI or `_screenshots` folder locally.

Refactored all codes to include `await`. This is very normal in Playwright testing of the E2E suite (on Solaris' side).

There's 1min to import data from the `data.sql` file to local env. I think this is fine for now, until we figure out how to better optimize it. The test run took 3min to complete.

I set the thresholds to pass always, but it's not literally always... If something's wrong it will always fail in the PR checks. The values set are very high but not too much.

## Code review notes

Sorry for the messy commit listing, but please focus on the `file changed`.

If you'd like to test it locally, feel free to execute:

`./do test:performance --scenario=pullrequests`

## Linked tickets

[MAILPOET-4950]


[MAILPOET-4950]: https://mailpoet.atlassian.net/browse/MAILPOET-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ