### PR TITLE
Fix PNPM permission error when setting up the dev env [MAILPOET-5177]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       PHP_IDE_CONFIG: 'serverName=Mailpoet'
       COMPOSER_HOME: '/tmp/.composer'
       NPM_CONFIG_CACHE: '/tmp/.npm'
+      XDG_CACHE_HOME: '/tmp/.cache'
       MAILPOET_DEV_SITE: 1
     volumes:
       - './wordpress:/var/www/html'


### PR DESCRIPTION
## Description

This PR fixes the following error when running ./do setup to configure the dev env on a new Linux machine:

```
[ExecStack] Running pnpm install --frozen-lockfile --prefer-offline
Internal Error: EACCES: permission denied, mkdir '/.cache'
Error: EACCES: permission denied, mkdir '/.cache'
```

It sets the $XDG_DATA_HOME variable to /tmp/.cache in docker-compose.yml. This will affect other programs that rely on $XDG_DATA_HOME, but it is probably harmless. I was not able to find an env variable that is specific to PNPM, and that would affect only the location of its cache directory (https://pnpm.io/next/npmrc#cache-dir).

There is a bit more information in the Jira ticket.

## Code review notes

_N/A_

## QA notes

QA is not needed for this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5177]

## After-merge notes

_N/A_


[MAILPOET-5177]: https://mailpoet.atlassian.net/browse/MAILPOET-5177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ