### PR TITLE
Make sure newsletter segment entities are deleted when list is deleted [MAILPOET-5153]

### DIFF
--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -7,6 +7,7 @@ use MailPoet\ConflictException;
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\FormsRepository;
@@ -224,6 +225,12 @@ class SegmentsRepository extends Repository {
         ->andWhere('s.type = :type')
         ->setParameter('ids', $ids, Connection::PARAM_INT_ARRAY)
         ->setParameter('type', $type, \PDO::PARAM_STR)
+        ->getQuery()->execute();
+
+      $queryBuilder = $entityManager->createQueryBuilder();
+      $queryBuilder->delete(NewsletterSegmentEntity::class, 'ns')
+        ->where('ns.segment IN (:ids)')
+        ->setParameter('ids', $ids, Connection::PARAM_INT_ARRAY)
         ->getQuery()->execute();
     });
     return $count;


### PR DESCRIPTION
## Description

This PR adds code to delete corresponding newsletter segment entities when a given list is deleted. This is necessary to fix an error when duplicating a newsletter that was sent with a list that was deleted.

Without this change, users see the following SQL error:

```
An exception occurred while executing ‘UPDATE wp_mailpoet_newsletter_segment SET segment_id = ?, updated_at = ? WHERE id = ?’ with params [null, “2023-03-23 09:07:52”, 66]: SQLSTATE[23000]: Integrity constraint violation: 1048 Column ‘segment_id’ cannot be null
```

## Code review notes

_N/A_

## QA notes

Steps to reproduce this problem:

- Create a list
- Create a newsletter and send it to this list
- Trash and delete the list
- Duplicate the newsletter – you see a SQL error in the admin

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5153]

## After-merge notes

_N/A_


[MAILPOET-5153]: https://mailpoet.atlassian.net/browse/MAILPOET-5153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ