### PR TITLE
Hide WooCommerce integration until transactional emails are ready

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
@@ -3,6 +3,9 @@ import { step as OrderStatusChanged } from './steps/order_status_changed';
 import { MailPoet } from '../../../mailpoet';
 
 export const initialize = (): void => {
+  // @ToDo Register once transactional emails are implemented
+  return;
+
   if (!MailPoet.isWoocommerceActive) {
     return;
   }


### PR DESCRIPTION
## Description
Hides the order status change trigger.

## QA notes
You should not be able to add the order status change trigger once this PR is merged.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_
