### PR TITLE
Restore subject and preview text tooltips [MAILPOET-5151]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/components/heading.js
+++ b/mailpoet/assets/js/src/newsletter_editor/components/heading.js
@@ -44,13 +44,18 @@ Module.HeadingView = Marionette.View.extend({
 App.on('start', function (StartApp) {
   var model = StartApp.getNewsletter();
 
-  var subjectToolTip = document.getElementById('tooltip-designer-subject-line');
-  var preheaderToolTip = document.getElementById('tooltip-designer-preheader');
-
   StartApp._appView.showChildView(
     'headingRegion',
     new Module.HeadingView({ model: model }),
   );
+
+  const subjectToolTip = document.getElementById(
+    'tooltip-designer-subject-line',
+  );
+  const preheaderToolTip = document.getElementById(
+    'tooltip-designer-preheader',
+  );
+
   if (!model.isWoocommerceTransactional() && !model.isAutomationEmail()) {
     if (subjectToolTip) {
       MailPoet.helpTooltip.show(subjectToolTip, {


### PR DESCRIPTION
## Description

We used to display a tooltip next to the fields subject and preview text in the email editor. Those tooltips were accidentally in 4367f44. The referenced commit changed the code and tried to get the elements used to display the tooltip before they were present in the browser.

This commit fixes this problem by making sure that the code tries to get those elements after StartApp._appView.showChildView() runs, and the elements are present.

[MAILPOET-5151]

## Code review notes

_N/A_

## QA notes

See Jira ticket for testing instructions.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_


[MAILPOET-5151]: https://mailpoet.atlassian.net/browse/MAILPOET-5151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ