### PR TITLE
Send stats reports also for underprivileged keys [MAILPOET-5165]

### DIFF
--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -155,20 +155,31 @@ class ServicesChecker {
   }
 
   /**
-   * Returns MSS or Premium valid key.
+   * Return a key when it can be used for account administration purposes (stats report, auth. addresses or domains administration)
+   * Key can be used when it is valid for MSS or Premium, but also when it is valid but has no privileges for MSS or Premium (API returns 403).
    */
-  public function getAnyValidKey(): ?string {
+  public function getValidAccountKey(): ?string {
     if ($this->isMailPoetAPIKeyValid(false, true)) {
       return $this->settings->get(Bridge::API_KEY_SETTING_NAME);
     }
+    $mssKeyState = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME);
+    if (($mssKeyState['state'] ?? null) === Bridge::KEY_VALID_UNDERPRIVILEGED) {
+      return $this->settings->get(Bridge::API_KEY_SETTING_NAME);
+    }
+
     if ($this->isPremiumKeyValid(false)) {
       return $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
     }
+    $premiumKeyState = $this->settings->get(Bridge::PREMIUM_KEY_STATE_SETTING_NAME);
+    if (($premiumKeyState['state'] ?? null) === Bridge::KEY_VALID_UNDERPRIVILEGED) {
+      return $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
+    }
+
     return null;
   }
 
   public function generatePartialApiKey(): string {
-    $key = (string)($this->getAnyValidKey());
+    $key = (string)($this->getValidAccountKey());
     if ($key) {
       $halfKeyLength = (int)(strlen($key) / 2);
 

--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -195,7 +195,7 @@ class WordPress {
   }
 
   private function isSubscriberStatsReportActive(): bool {
-    $isAnyKeyValid = $this->serviceChecker->getValidAccountKey();
+    $validAccountKey = $this->serviceChecker->getValidAccountKey();
     $statsReportDueTasks = $this->getTasksCount([
       'type' => SubscribersStatsReport::TASK_TYPE,
       'scheduled_in' => [self::SCHEDULED_IN_THE_PAST],
@@ -207,7 +207,7 @@ class WordPress {
       'status' => [ScheduledTaskEntity::STATUS_SCHEDULED],
     ]);
 
-    return ($isAnyKeyValid && ($statsReportDueTasks || !$statsReportFutureTasks));
+    return ($validAccountKey && ($statsReportDueTasks || !$statsReportFutureTasks));
   }
 
   private function isBeamerCheckActive(): bool {

--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -195,7 +195,7 @@ class WordPress {
   }
 
   private function isSubscriberStatsReportActive(): bool {
-    $isAnyKeyValid = $this->serviceChecker->getAnyValidKey();
+    $isAnyKeyValid = $this->serviceChecker->getValidAccountKey();
     $statsReportDueTasks = $this->getTasksCount([
       'type' => SubscribersStatsReport::TASK_TYPE,
       'scheduled_in' => [self::SCHEDULED_IN_THE_PAST],

--- a/mailpoet/lib/Cron/Workers/SubscribersStatsReport.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersStatsReport.php
@@ -34,11 +34,11 @@ class SubscribersStatsReport extends SimpleWorker {
   }
 
   public function checkProcessingRequirements() {
-    return (bool)$this->serviceChecker->getAnyValidKey();
+    return (bool)$this->serviceChecker->getValidAccountKey();
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer): bool {
-    $key = $this->serviceChecker->getAnyValidKey();
+    $key = $this->serviceChecker->getValidAccountKey();
     if ($key === null) {
       return false;
     }

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -310,10 +310,10 @@ class Bridge {
       $premiumState = $this->checkPremiumKey($premiumKey);
       $this->storePremiumKeyAndState($premiumKey, $premiumState);
     }
-    if ($apiKey && !empty($apiKeyState) && $apiKeyState['state'] === self::KEY_VALID) {
+    if ($apiKey && !empty($apiKeyState) && in_array($apiKeyState['state'], [self::KEY_VALID, self::KEY_VALID_UNDERPRIVILEGED], true)) {
       return $this->updateSubscriberCount($apiKey);
     }
-    if ($premiumKey && !empty($premiumState) && $premiumState['state'] === self::KEY_VALID) {
+    if ($premiumKey && !empty($premiumState) && in_array($premiumState['state'], [self::KEY_VALID, self::KEY_VALID_UNDERPRIVILEGED], true)) {
       return $this->updateSubscriberCount($apiKey);
     }
   }

--- a/mailpoet/tests/integration/Config/ServicesCheckerTest.php
+++ b/mailpoet/tests/integration/Config/ServicesCheckerTest.php
@@ -178,7 +178,7 @@ class ServicesCheckerTest extends \MailPoetTest {
         'state' => Bridge::KEY_VALID,
       ]
     );
-    expect($this->servicesChecker->getAnyValidKey())->equals($mssKey);
+    expect($this->servicesChecker->getValidAccountKey())->equals($mssKey);
 
     // Only Premium is Valid
     $this->settings->set(
@@ -193,7 +193,7 @@ class ServicesCheckerTest extends \MailPoetTest {
         'state' => '',
       ]
     );
-    expect($this->servicesChecker->getAnyValidKey())->equals($premiumKey);
+    expect($this->servicesChecker->getValidAccountKey())->equals($premiumKey);
 
     // Both Valid (lets use MSS in that case)
     $this->settings->set(
@@ -202,7 +202,37 @@ class ServicesCheckerTest extends \MailPoetTest {
         'state' => Bridge::KEY_VALID,
       ]
     );
-    expect($this->servicesChecker->getAnyValidKey())->equals($mssKey);
+    expect($this->servicesChecker->getValidAccountKey())->equals($mssKey);
+
+    // MSS is valid but underprivileged premium invalid
+    $this->settings->set(
+      Bridge::API_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_VALID_UNDERPRIVILEGED,
+      ]
+    );
+    $this->settings->set(
+      Bridge::PREMIUM_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_INVALID,
+      ]
+    );
+    expect($this->servicesChecker->getValidAccountKey())->equals($mssKey);
+
+    // MSS is invalid, premium valid but underprivileged
+    $this->settings->set(
+      Bridge::API_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_INVALID,
+      ]
+    );
+    $this->settings->set(
+      Bridge::PREMIUM_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_VALID_UNDERPRIVILEGED,
+      ]
+    );
+    expect($this->servicesChecker->getValidAccountKey())->equals($premiumKey);
 
     // None valid
     // Only MSS is Valid
@@ -218,7 +248,7 @@ class ServicesCheckerTest extends \MailPoetTest {
         'state' => '',
       ]
     );
-    expect($this->servicesChecker->getAnyValidKey())->null();
+    expect($this->servicesChecker->getValidAccountKey())->null();
   }
 
   public function testItReturnsTrueIfUserIsActivelyPaying() {

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersStatsReportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersStatsReportTest.php
@@ -48,14 +48,14 @@ class SubscribersStatsReportTest extends \MailPoetTest {
 
   public function testItFailsRequirementsCheckIfThereIsNoValidKey() {
     $this->servicesCheckerMock->expects($this->once())
-      ->method('getAnyValidKey')
+      ->method('getValidAccountKey')
       ->willReturn(null);
     expect($this->worker->checkProcessingRequirements())->false();
   }
 
   public function testItSucceedsRequirementsCheckIfThereIsValidKey() {
     $this->servicesCheckerMock->expects($this->once())
-      ->method('getAnyValidKey')
+      ->method('getValidAccountKey')
       ->willReturn('a_valid_key');
     expect($this->worker->checkProcessingRequirements())->true();
   }
@@ -64,7 +64,7 @@ class SubscribersStatsReportTest extends \MailPoetTest {
     $task = new ScheduledTaskEntity();
     $timer = time();
     $this->servicesCheckerMock->expects($this->once())
-      ->method('getAnyValidKey')
+      ->method('getValidAccountKey')
       ->willReturn('a_valid_key');
     $this->bridgeMock->expects($this->once())
       ->method('updateSubscriberCount')
@@ -76,7 +76,7 @@ class SubscribersStatsReportTest extends \MailPoetTest {
     $task = new ScheduledTaskEntity();
     $timer = time();
     $this->servicesCheckerMock->expects($this->once())
-      ->method('getAnyValidKey')
+      ->method('getValidAccountKey')
       ->willReturn(null);
     $this->bridgeMock->expects($this->never())
       ->method('updateSubscriberCount');
@@ -87,7 +87,7 @@ class SubscribersStatsReportTest extends \MailPoetTest {
     $task = new ScheduledTaskEntity();
     $timer = time();
     $this->servicesCheckerMock->expects($this->once())
-      ->method('getAnyValidKey')
+      ->method('getValidAccountKey')
       ->willReturn('a_valid_key');
     $this->bridgeMock->expects($this->once())
       ->method('updateSubscriberCount')


### PR DESCRIPTION
## Description

This PR is a part of the "graceful limits enforcement" project. 

The shop will restrict access rights to keys used on sites exceeding limits. The MSS will then start reporting the keys as underprivileged (403). The plugin has to send stats reports even with the underprivileged keys to be able to report the lowered number of subscribers so that the shop could lift the restrictions. The Bridge API already supports passing such requests to the shop.

## Code review notes

_N/A_

## QA notes

You will need a special key that is valid but has no access to premium or MSS. Please ping @costasovo to obtain one.

Instructions:
1) Set the api key
2) Trigger stats report on your site. You can trigger it by re-saving settings or by modifying schedulet_at date for the scheduled task `subscribers_stats_report `
3) Check in the Metabase the stats were reported to the shop. Please ping @costasovo for guidance.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5165]

## After-merge notes

_N/A_


[MAILPOET-5165]: https://mailpoet.atlassian.net/browse/MAILPOET-5165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ