### PR TITLE
Automation filters [MAILPOET-4946] [MAILPOET-4419] [MAILPOET-5002]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_filters.scss
@@ -5,3 +5,31 @@ button.components-button.mailpoet-automation-filters-panel-add-filter {
     margin-right: 4px;
   }
 }
+
+.mailpoet-automation-filters-list {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.mailpoet-automation-filters-list-item {
+  align-items: center;
+  background: #f0f0f0;
+  display: grid;
+  grid-template-columns: 1fr auto;
+
+  .mailpoet-automation-filters-list-item-content {
+    padding: 8px 12px;
+  }
+
+  .mailpoet-automation-filters-list-item-remove {
+    color: #757575;
+    margin: 4px;
+    padding: 0;
+  }
+}
+
+.mailpoet-automation-filters-list-item-field,
+.mailpoet-automation-filters-list-item-value {
+  font-weight: 600;
+}

--- a/mailpoet/assets/css/src/components-automation-editor/_filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_filters.scss
@@ -1,0 +1,7 @@
+button.components-button.mailpoet-automation-filters-panel-add-filter {
+  padding-right: 12px;
+
+  &.has-icon > svg {
+    margin-right: 4px;
+  }
+}

--- a/mailpoet/assets/css/src/components-automation-editor/_panel.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_panel.scss
@@ -2,6 +2,12 @@
   padding-bottom: 100px;
 }
 
+.mailpoet-automation-panel-description {
+  color: #646970;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
 .components-panel__body-title.mailpoet-automation-panel-plain-body-title {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/mailpoet/assets/css/src/mailpoet-automation-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-editor.scss
@@ -22,6 +22,7 @@
 @import './components-automation-editor/status';
 @import './components-automation-editor/step';
 @import './components-automation-editor/step-card';
+@import './components-automation-editor/filters';
 @import './components-automation-editor/notices';
 @import './components-automation-editor/deactivate-modal';
 

--- a/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
@@ -4,12 +4,20 @@ export type NextStep = {
   id: string;
 };
 
+export type Filter = {
+  field_type: string;
+  field_key: string;
+  condition: string;
+  args: Record<string, unknown>;
+};
+
 export type Step = {
   id: string;
   type: 'root' | 'trigger' | 'action';
   key: string;
   args: Record<string, unknown>;
   next_steps: NextStep[];
+  filters: Filter[];
 };
 
 export type Automation = {

--- a/mailpoet/assets/js/src/automation/editor/components/filters/index.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/index.ts
@@ -1,0 +1,1 @@
+export * from './panel';

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
+import { Value } from './value';
 import { Filter } from '../automation/types';
 import { storeName } from '../../store';
 import { PremiumModal } from '../../../../common/premium_modal';
@@ -65,9 +66,7 @@ export function FiltersList(): JSX.Element | null {
               <span className="mailpoet-automation-filters-list-item-condition">
                 {filter.condition}
               </span>{' '}
-              <span className="mailpoet-automation-filters-list-item-value">
-                {filter.args.value as string}
-              </span>
+              <Value filter={filter} />
             </div>
             <Button
               className="mailpoet-automation-filters-list-item-remove"

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -1,10 +1,17 @@
+import { useCallback, useState } from 'react';
+import { Hooks } from 'wp-js-hooks';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
+import { Filter } from '../automation/types';
 import { storeName } from '../../store';
+import { PremiumModal } from '../../../../common/premium_modal';
+import { DeleteStepFilterType } from '../../../types/filters';
 
 export function FiltersList(): JSX.Element | null {
+  const [showPremiumModal, setShowPremiumModal] = useState(false);
+
   const { step, fields } = useSelect(
     (select) => ({
       step: select(storeName).getSelectedStep(),
@@ -13,37 +20,65 @@ export function FiltersList(): JSX.Element | null {
     [],
   );
 
+  const onDelete = useCallback((stepId: string, filter: Filter) => {
+    const deleteFilterCallback: DeleteStepFilterType = Hooks.applyFilters(
+      'mailpoet.automation.filters.delete_step_filter_callback',
+      () => setShowPremiumModal(true),
+    );
+    deleteFilterCallback(stepId, filter);
+  }, []);
+
   if (step.filters.length === 0) {
     return null;
   }
 
   return (
-    <div className="mailpoet-automation-filters-list">
-      {step.filters.map((filter) => (
-        <div
-          key={filter.field_key}
-          className="mailpoet-automation-filters-list-item"
+    <>
+      {showPremiumModal && (
+        <PremiumModal
+          onRequestClose={() => {
+            setShowPremiumModal(false);
+          }}
+          tracking={{
+            utm_medium: 'upsell_modal',
+            utm_campaign: 'automation_premium_filters',
+          }}
         >
-          <div className="mailpoet-automation-filters-list-item-content">
-            <span className="mailpoet-automation-filters-list-item-field">
-              {fields[filter.field_key]?.name ??
-                sprintf(__('Unknown field "%s"', 'mailpoet'), filter.field_key)}
-            </span>{' '}
-            <span className="mailpoet-automation-filters-list-item-condition">
-              {filter.condition}
-            </span>{' '}
-            <span className="mailpoet-automation-filters-list-item-value">
-              {filter.args.value as string}
-            </span>
-          </div>
-          <Button
-            className="mailpoet-automation-filters-list-item-remove"
-            isSmall
+          {__('Removing trigger filters is a premium feature.', 'mailpoet')}
+        </PremiumModal>
+      )}
+
+      <div className="mailpoet-automation-filters-list">
+        {step.filters.map((filter) => (
+          <div
+            key={filter.field_key}
+            className="mailpoet-automation-filters-list-item"
           >
-            <Icon icon={closeSmall} />
-          </Button>
-        </div>
-      ))}
-    </div>
+            <div className="mailpoet-automation-filters-list-item-content">
+              <span className="mailpoet-automation-filters-list-item-field">
+                {fields[filter.field_key]?.name ??
+                  sprintf(
+                    __('Unknown field "%s"', 'mailpoet'),
+                    filter.field_key,
+                  )}
+              </span>{' '}
+              <span className="mailpoet-automation-filters-list-item-condition">
+                {filter.condition}
+              </span>{' '}
+              <span className="mailpoet-automation-filters-list-item-value">
+                {filter.args.value as string}
+              </span>
+            </div>
+            <Button
+              className="mailpoet-automation-filters-list-item-remove"
+              isSmall
+              onClick={() => onDelete(step.id, filter)}
+            >
+              <Icon icon={closeSmall} />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, closeSmall } from '@wordpress/icons';
+import { storeName } from '../../store';
+
+export function FiltersList(): JSX.Element | null {
+  const { step, fields } = useSelect(
+    (select) => ({
+      step: select(storeName).getSelectedStep(),
+      fields: select(storeName).getRegistry().fields,
+    }),
+    [],
+  );
+
+  if (step.filters.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mailpoet-automation-filters-list">
+      {step.filters.map((filter) => (
+        <div
+          key={filter.field_key}
+          className="mailpoet-automation-filters-list-item"
+        >
+          <div className="mailpoet-automation-filters-list-item-content">
+            <span className="mailpoet-automation-filters-list-item-field">
+              {fields[filter.field_key]?.name ??
+                sprintf(__('Unknown field "%s"', 'mailpoet'), filter.field_key)}
+            </span>{' '}
+            <span className="mailpoet-automation-filters-list-item-condition">
+              {filter.condition}
+            </span>{' '}
+            <span className="mailpoet-automation-filters-list-item-value">
+              {filter.args.value as string}
+            </span>
+          </div>
+          <Button
+            className="mailpoet-automation-filters-list-item-remove"
+            isSmall
+          >
+            <Icon icon={closeSmall} />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -13,10 +13,11 @@ import { DeleteStepFilterType } from '../../../types/filters';
 export function FiltersList(): JSX.Element | null {
   const [showPremiumModal, setShowPremiumModal] = useState(false);
 
-  const { step, fields } = useSelect(
+  const { step, fields, filters } = useSelect(
     (select) => ({
       step: select(storeName).getSelectedStep(),
       fields: select(storeName).getRegistry().fields,
+      filters: select(storeName).getRegistry().filters,
     }),
     [],
   );
@@ -64,7 +65,9 @@ export function FiltersList(): JSX.Element | null {
                   )}
               </span>{' '}
               <span className="mailpoet-automation-filters-list-item-condition">
-                {filter.condition}
+                {filters[filter.field_type]?.conditions.find(
+                  ({ key }) => key === filter.condition,
+                )?.label ?? __('unknown condition', 'mailpoet')}
               </span>{' '}
               <Value filter={filter} />
             </div>

--- a/mailpoet/assets/js/src/automation/editor/components/filters/panel.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/panel.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useState } from 'react';
+import { Hooks } from 'wp-js-hooks';
+import { Button, PanelBody } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { plus } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { storeName } from '../../store';
+import { FiltersPanelContentType } from '../../../types/filters';
+import { PremiumModal } from '../../../../common/premium_modal';
+
+function FiltersPanelContent(): JSX.Element {
+  const [showPremiumModal, setShowPremiumModal] = useState(false);
+  return (
+    <>
+      {showPremiumModal && (
+        <PremiumModal
+          onRequestClose={() => {
+            setShowPremiumModal(false);
+          }}
+          tracking={{
+            utm_medium: 'upsell_modal',
+            utm_campaign: 'automation_premium_filters',
+          }}
+        >
+          {__('Adding trigger filters is a premium feature.', 'mailpoet')}
+        </PremiumModal>
+      )}
+      <Button
+        className="mailpoet-automation-filters-panel-add-filter"
+        variant="secondary"
+        icon={plus}
+        onClick={() => setShowPremiumModal(true)}
+      >
+        {__('Add trigger filter', 'mailpoet')}
+      </Button>
+    </>
+  );
+}
+
+export function FiltersPanel(): JSX.Element {
+  const selectedStep = useSelect(
+    (select) => select(storeName).getSelectedStep(),
+    [],
+  );
+
+  const content: FiltersPanelContentType = useMemo(
+    () =>
+      Hooks.applyFilters(
+        'mailpoet.automation.filters.panel.content',
+        FiltersPanelContent,
+      ) as FiltersPanelContentType,
+    [],
+  );
+
+  return (
+    <PanelBody initialOpen title={__('Trigger filters', 'mailpoet')}>
+      <div className="mailpoet-automation-panel-description">
+        {__(
+          'The automation would only be started if the following trigger conditions are met:',
+          'mailpoet',
+        )}
+      </div>
+      {content(selectedStep)}
+    </PanelBody>
+  );
+}

--- a/mailpoet/assets/js/src/automation/editor/components/filters/panel.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/panel.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { storeName } from '../../store';
 import { FiltersPanelContentType } from '../../../types/filters';
 import { PremiumModal } from '../../../../common/premium_modal';
+import { FiltersList } from './list';
 
 function FiltersPanelContent(): JSX.Element {
   const [showPremiumModal, setShowPremiumModal] = useState(false);
@@ -60,6 +61,7 @@ export function FiltersPanel(): JSX.Element {
           'mailpoet',
         )}
       </div>
+      <FiltersList />
       {content(selectedStep)}
     </PanelBody>
   );

--- a/mailpoet/assets/js/src/automation/editor/components/filters/value.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/value.tsx
@@ -1,0 +1,46 @@
+import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
+import { Filter } from '../automation/types';
+import { storeName } from '../../store';
+
+const getValue = ({ field_key, args }: Filter): string => {
+  const field = select(storeName).getRegistry().fields[field_key];
+  switch (field.type) {
+    case 'string':
+      return args.value as string;
+    case 'enum_array': {
+      const options = (field.args.options ?? []) as {
+        id: string;
+        name: string;
+      }[];
+      const values = Array.isArray(args.value) ? args.value : [args.value];
+      const labels = values
+        .map((v) => options.find(({ id }) => id === v)?.name)
+        .filter((v) => v !== undefined);
+
+      if (labels.length === 0) {
+        return __('Unknown value', 'mailpoet');
+      }
+
+      const suffix =
+        labels.length < values.length
+          ? __('and unknown values', 'mailpoet')
+          : '';
+      return `${labels.join(', ')}${suffix}`;
+    }
+    default:
+      return __('Unknown value', 'mailpoet');
+  }
+};
+
+type Props = {
+  filter: Filter;
+};
+
+export function Value({ filter }: Props): JSX.Element {
+  return (
+    <span className="mailpoet-automation-filters-list-item-value">
+      {getValue(filter)}
+    </span>
+  );
+}

--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/step/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/step/index.tsx
@@ -1,6 +1,7 @@
 import { Notice, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { storeName } from '../../../store';
+import { FiltersPanel } from '../../filters';
 import { StepCard } from '../../step-card';
 
 function StepSidebarGeneralError(): JSX.Element {
@@ -61,6 +62,8 @@ export function StepSidebar(): JSX.Element {
         // This can happen e.g. when having "useState" or "useRef" internally.
         key={selectedStep.id}
       />
+
+      {selectedStep.type === 'trigger' && <FiltersPanel />}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -20,6 +20,27 @@ export type Registry = {
       };
     }
   >;
+  subjects: Record<
+    string,
+    {
+      key: string;
+      name: string;
+      args_schema: {
+        type: 'object';
+        properties?: Record<string, { type: string; default?: unknown }>;
+      };
+      field_keys: string[];
+    }
+  >;
+  fields: Record<
+    string,
+    {
+      key: string;
+      type: 'string' | 'enum_array';
+      name: string;
+      args: Record<string, unknown>;
+    }
+  >;
 };
 
 export type Context = Record<string, unknown>;

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -41,6 +41,14 @@ export type Registry = {
       args: Record<string, unknown>;
     }
   >;
+  filters: Record<
+    string,
+    {
+      field_type: string;
+      conditions: { key: string; label: string }[];
+      args_schema: Record<string, unknown>;
+    }
+  >;
 };
 
 export type Context = Record<string, unknown>;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role_panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role_panel.tsx
@@ -18,8 +18,12 @@ function SettingsInfoText(): JSX.Element {
           'mailpoet',
         ),
         /\[link\](.*?)\[\/link\]/g,
-        (match) => (
-          <a href="admin.php?page=mailpoet-settings#/basics" target="_blank">
+        (match, i) => (
+          <a
+            key={i}
+            href="admin.php?page=mailpoet-settings#/basics"
+            target="_blank"
+          >
             {match}
           </a>
         ),

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -6,7 +6,7 @@
 import { Dispatch, SetStateAction } from 'react';
 import { DropdownMenu } from '@wordpress/components';
 import { Item } from '../editor/components/inserter/item';
-import { Step } from '../editor/components/automation/types';
+import { Filter, Step } from '../editor/components/automation/types';
 import { EditorStoreConfig } from '../editor/store';
 
 interface ControlWithSetIsBusy extends Omit<DropdownMenu.Control, 'onClick'> {
@@ -56,3 +56,6 @@ export type OrderStatusOptions = Map<
 
 // mailpoet.automation.filters.panel.content
 export type FiltersPanelContentType = (step: Step) => JSX.Element;
+
+// mailpoet.automation.filters.delete_step_filter_callback
+export type DeleteStepFilterType = (stepId: string, filter: Filter) => void;

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -53,3 +53,6 @@ export type OrderStatusOptions = Map<
     isDisabled: boolean;
   }
 >;
+
+// mailpoet.automation.filters.panel.content
+export type FiltersPanelContentType = (step: Step) => JSX.Element;

--- a/mailpoet/assets/js/src/webpack_admin_expose.js
+++ b/mailpoet/assets/js/src/webpack_admin_expose.js
@@ -13,6 +13,7 @@ export * as Slugify from 'slugify';
 export { Button as WordpressComponentsButton } from '@wordpress/components';
 export { CheckboxControl as WordpressComponentsCheckboxControl } from '@wordpress/components';
 export { ExternalLink as WordpressComponentsExternalLink } from '@wordpress/components';
+export { FormTokenField as WordpressComponentsFormTokenField } from '@wordpress/components';
 export { RadioControl as WordpressComponentsRadioControl } from '@wordpress/components';
 export { SelectControl as WordpressComponentsSelectControl } from '@wordpress/components';
 export { TextControl as WordpressComponentsTextControl } from '@wordpress/components';

--- a/mailpoet/assets/js/src/webpack_admin_expose.js
+++ b/mailpoet/assets/js/src/webpack_admin_expose.js
@@ -10,6 +10,7 @@ export * as ReactRouter from 'react-router-dom';
 export * as ReactTooltip from 'react-tooltip';
 export * as ReactStringReplace from 'react-string-replace';
 export * as Slugify from 'slugify';
+export { Button as WordpressComponentsButton } from '@wordpress/components';
 export { CheckboxControl as WordpressComponentsCheckboxControl } from '@wordpress/components';
 export { ExternalLink as WordpressComponentsExternalLink } from '@wordpress/components';
 export { RadioControl as WordpressComponentsRadioControl } from '@wordpress/components';

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -128,10 +128,27 @@ class AutomationEditor {
       ];
     }
 
+    $filters = [];
+    foreach ($this->registry->getFilters() as $fieldType => $filter) {
+      $conditions = [];
+      foreach ($filter->getConditions() as $key => $label) {
+        $conditions[] = [
+          'key' => $key,
+          'label' => $label,
+        ];
+      }
+      $filters[$fieldType] = [
+        'field_type' => $filter->getFieldType(),
+        'conditions' => $conditions,
+        'args_schema' => $filter->getArgsSchema()->toArray(),
+      ];
+    }
+
     return [
       'steps' => $steps,
       'subjects' => $subjects,
       'fields' => $fields,
+      'filters' => $filters,
     ];
   }
 

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -105,7 +105,34 @@ class AutomationEditor {
         'args_schema' => $step->getArgsSchema()->toArray(),
       ];
     }
-    return ['steps' => $steps];
+
+    $subjects = [];
+    foreach ($this->registry->getSubjects() as $key => $subject) {
+      $subjects[$key] = [
+        'key' => $subject->getKey(),
+        'name' => $subject->getName(),
+        'args_schema' => $subject->getArgsSchema()->toArray(),
+        'field_keys' => array_map(function ($field) {
+          return $field->getKey();
+        }, $subject->getFields()),
+      ];
+    }
+
+    $fields = [];
+    foreach ($this->registry->getFields() as $key => $field) {
+      $fields[$key] = [
+        'key' => $field->getKey(),
+        'type' => $field->getType(),
+        'name' => $field->getName(),
+        'args' => $field->getArgs(),
+      ];
+    }
+
+    return [
+      'steps' => $steps,
+      'subjects' => $subjects,
+      'fields' => $fields,
+    ];
   }
 
   private function buildContext(): array {

--- a/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Registry;
+
+class FilterHandler {
+  /** @var Registry */
+  private $registry;
+
+  public function __construct(
+    Registry $registry
+  ) {
+    $this->registry = $registry;
+  }
+
+  public function matchesFilters(StepRunArgs $args): bool {
+    $filters = $args->getStep()->getFilters();
+    foreach ($filters as $filter) {
+      $value = $args->getFieldValue($filter->getFieldKey());
+      if (!$this->matchesFilter($filter, $value)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @param mixed $value */
+  private function matchesFilter(FilterData $data, $value): bool {
+    $filter = $this->registry->getFilter($data->getFieldType());
+    if (!$filter) {
+      throw Exceptions::filterNotFound($data->getFieldType());
+    }
+    return $filter->matches($data, $value);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -28,6 +28,9 @@ class TriggerHandler {
   /** @var SubjectTransformerHandler */
   private $subjectTransformerHandler;
 
+  /** @var FilterHandler */
+  private $filterHandler;
+
   /** @var WordPress */
   private $wordPress;
 
@@ -37,6 +40,7 @@ class TriggerHandler {
     AutomationRunStorage $automationRunStorage,
     SubjectLoader $subjectLoader,
     SubjectTransformerHandler $subjectTransformerHandler,
+    FilterHandler $filterHandler,
     WordPress $wordPress
   ) {
     $this->actionScheduler = $actionScheduler;
@@ -44,6 +48,7 @@ class TriggerHandler {
     $this->automationRunStorage = $automationRunStorage;
     $this->subjectLoader = $subjectLoader;
     $this->subjectTransformerHandler = $subjectTransformerHandler;
+    $this->filterHandler = $filterHandler;
     $this->wordPress = $wordPress;
   }
 
@@ -70,6 +75,11 @@ class TriggerHandler {
 
       $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);
       $stepRunArgs = new StepRunArgs($automation, $automationRun, $step, $subjectEntries);
+
+      if (!$this->filterHandler->matchesFilters($stepRunArgs)) {
+        continue;
+      }
+
       $createAutomationRun = $trigger->isTriggeredBy($stepRunArgs);
       $createAutomationRun = $this->wordPress->applyFilters(
         Hooks::AUTOMATION_RUN_CREATE,

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -59,8 +59,12 @@ class TriggerHandler {
 
   /** @param Subject[] $subjects */
   public function processTrigger(Trigger $trigger, array $subjects): void {
-    $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
     $automations = $this->automationStorage->getActiveAutomationsByTrigger($trigger);
+    if (!$automations) {
+      return;
+    }
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
     foreach ($automations as $automation) {
       $step = $automation->getTrigger($trigger->getKey());
       if (!$step) {

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -17,12 +17,6 @@ class TriggerHandler {
   /** @var ActionScheduler */
   private $actionScheduler;
 
-  /** @var SubjectLoader */
-  private $subjectLoader;
-
-  /** @var WordPress */
-  private $wordPress;
-
   /** @var AutomationStorage */
   private $automationStorage;
 
@@ -32,25 +26,31 @@ class TriggerHandler {
   /** @var Functions  */
   private $wp;
 
+  /** @var SubjectLoader */
+  private $subjectLoader;
+
   /** @var SubjectTransformerHandler */
   private $subjectTransformerHandler;
 
+  /** @var WordPress */
+  private $wordPress;
+
   public function __construct(
     ActionScheduler $actionScheduler,
-    SubjectLoader $subjectLoader,
-    WordPress $wordPress,
     AutomationStorage $automationStorage,
     AutomationRunStorage $automationRunStorage,
     Functions $wp,
-    SubjectTransformerHandler $subjectTransformerHandler
+    SubjectLoader $subjectLoader,
+    SubjectTransformerHandler $subjectTransformerHandler,
+    WordPress $wordPress
   ) {
     $this->actionScheduler = $actionScheduler;
-    $this->wordPress = $wordPress;
     $this->automationStorage = $automationStorage;
     $this->automationRunStorage = $automationRunStorage;
-    $this->subjectLoader = $subjectLoader;
     $this->wp = $wp;
+    $this->subjectLoader = $subjectLoader;
     $this->subjectTransformerHandler = $subjectTransformerHandler;
+    $this->wordPress = $wordPress;
   }
 
   public function initialize(): void {
@@ -64,12 +64,9 @@ class TriggerHandler {
       return;
     }
 
-    // ensure subjects are registered and loadable
+    // expand all subject transformations and load subject entries
     $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
     $subjectEntries = $this->subjectLoader->getSubjectsEntries($subjects);
-    foreach ($subjectEntries as $entry) {
-      $entry->getPayload();
-    }
 
     foreach ($automations as $automation) {
       $step = $automation->getTrigger($trigger->getKey());

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -11,7 +11,6 @@ use MailPoet\Automation\Engine\Integration\Trigger;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
-use MailPoet\WP\Functions;
 
 class TriggerHandler {
   /** @var ActionScheduler */
@@ -22,9 +21,6 @@ class TriggerHandler {
 
   /** @var AutomationRunStorage */
   private $automationRunStorage;
-
-  /** @var Functions  */
-  private $wp;
 
   /** @var SubjectLoader */
   private $subjectLoader;
@@ -39,7 +35,6 @@ class TriggerHandler {
     ActionScheduler $actionScheduler,
     AutomationStorage $automationStorage,
     AutomationRunStorage $automationRunStorage,
-    Functions $wp,
     SubjectLoader $subjectLoader,
     SubjectTransformerHandler $subjectTransformerHandler,
     WordPress $wordPress
@@ -47,7 +42,6 @@ class TriggerHandler {
     $this->actionScheduler = $actionScheduler;
     $this->automationStorage = $automationStorage;
     $this->automationRunStorage = $automationRunStorage;
-    $this->wp = $wp;
     $this->subjectLoader = $subjectLoader;
     $this->subjectTransformerHandler = $subjectTransformerHandler;
     $this->wordPress = $wordPress;
@@ -77,7 +71,7 @@ class TriggerHandler {
       $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);
       $stepRunArgs = new StepRunArgs($automation, $automationRun, $step, $subjectEntries);
       $createAutomationRun = $trigger->isTriggeredBy($stepRunArgs);
-      $createAutomationRun = $this->wp->applyFilters(
+      $createAutomationRun = $this->wordPress->applyFilters(
         Hooks::AUTOMATION_RUN_CREATE,
         $createAutomationRun,
         $stepRunArgs

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -64,17 +64,17 @@ class TriggerHandler {
       return;
     }
 
+    // ensure subjects are registered and loadable
     $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
+    $subjectEntries = $this->subjectLoader->getSubjectsEntries($subjects);
+    foreach ($subjectEntries as $entry) {
+      $entry->getPayload();
+    }
+
     foreach ($automations as $automation) {
       $step = $automation->getTrigger($trigger->getKey());
       if (!$step) {
         throw Exceptions::automationTriggerNotFound($automation->getId(), $trigger->getKey());
-      }
-
-      // ensure subjects are registered and loadable
-      $subjectEntries = $this->subjectLoader->getSubjectsEntries($subjects);
-      foreach ($subjectEntries as $entry) {
-        $entry->getPayload();
       }
 
       $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);

--- a/mailpoet/lib/Automation/Engine/Data/Field.php
+++ b/mailpoet/lib/Automation/Engine/Data/Field.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Automation\Engine\Data;
 
+use MailPoet\Automation\Engine\Integration\Payload;
+
 class Field {
   public const TYPE_BOOLEAN = 'boolean';
   public const TYPE_INTEGER = 'integer';
@@ -55,11 +57,9 @@ class Field {
     return $this->factory;
   }
 
-  /**
-   * @return mixed
-   */
-  public function getValue() {
-    return $this->getFactory()();
+  /** @return mixed */
+  public function getValue(Payload $payload) {
+    return $this->getFactory()($payload);
   }
 
   public function getArgs(): array {

--- a/mailpoet/lib/Automation/Engine/Data/Field.php
+++ b/mailpoet/lib/Automation/Engine/Data/Field.php
@@ -7,6 +7,7 @@ class Field {
   public const TYPE_INTEGER = 'integer';
   public const TYPE_STRING = 'string';
   public const TYPE_ENUM = 'enum';
+  public const TYPE_ENUM_ARRAY = 'enum_array';
 
   /** @var string */
   private $key;

--- a/mailpoet/lib/Automation/Engine/Data/Filter.php
+++ b/mailpoet/lib/Automation/Engine/Data/Filter.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+class Filter {
+  /** @var string */
+  private $fieldType;
+
+  /** @var string */
+  private $fieldKey;
+
+  /** @var string */
+  private $condition;
+
+  /** @var array */
+  private $args;
+
+  public function __construct(
+    string $fieldType,
+    string $fieldKey,
+    string $condition,
+    array $args
+  ) {
+    $this->fieldType = $fieldType;
+    $this->fieldKey = $fieldKey;
+    $this->condition = $condition;
+    $this->args = $args;
+  }
+
+  public function getFieldType(): string {
+    return $this->fieldType;
+  }
+
+  public function getFieldKey(): string {
+    return $this->fieldKey;
+  }
+
+  public function getCondition(): string {
+    return $this->condition;
+  }
+
+  public function getArgs(): array {
+    return $this->args;
+  }
+
+  public function toArray(): array {
+    return [
+      'field_type' => $this->fieldType,
+      'field_key' => $this->fieldKey,
+      'condition' => $this->condition,
+      'args' => $this->args,
+    ];
+  }
+
+  public static function fromArray(array $data): self {
+    return new self(
+      $data['field_type'],
+      $data['field_key'],
+      $data['condition'],
+      $data['args']
+    );
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/Step.php
+++ b/mailpoet/lib/Automation/Engine/Data/Step.php
@@ -22,22 +22,28 @@ class Step {
   /** @var NextStep[] */
   protected $nextSteps;
 
+  /** @var Filter[] */
+  private $filters;
+
   /**
    * @param array<string, mixed> $args
    * @param NextStep[] $nextSteps
+   * @param Filter[] $filters
    */
   public function __construct(
     string $id,
     string $type,
     string $key,
     array $args,
-    array $nextSteps
+    array $nextSteps,
+    array $filters = []
   ) {
     $this->id = $id;
     $this->type = $type;
     $this->key = $key;
     $this->args = $args;
     $this->nextSteps = $nextSteps;
+    $this->filters = $filters;
   }
 
   public function getId(): string {
@@ -66,6 +72,11 @@ class Step {
     return $this->args;
   }
 
+  /** @return Filter[] */
+  public function getFilters(): array {
+    return $this->filters;
+  }
+
   public function toArray(): array {
     return [
       'id' => $this->id,
@@ -75,6 +86,9 @@ class Step {
       'next_steps' => array_map(function (NextStep $nextStep) {
         return $nextStep->toArray();
       }, $this->nextSteps),
+      'filters' => array_map(function (Filter $filter) {
+        return $filter->toArray();
+      }, $this->filters),
     ];
   }
 
@@ -86,7 +100,10 @@ class Step {
       $data['args'],
       array_map(function (array $nextStep) {
         return NextStep::fromArray($nextStep);
-      }, $data['next_steps'])
+      }, $data['next_steps']),
+      array_map(function (array $filter) {
+        return Filter::fromArray($filter);
+      }, $data['filters'] ?? [])
     );
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -9,7 +9,6 @@ use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Utils\Json;
 
 class Exceptions {
-  private const MIGRATION_FAILED = 'mailpoet_automation_migration_failed';
   private const DATABASE_ERROR = 'mailpoet_automation_database_error';
   private const JSON_NOT_OBJECT = 'mailpoet_automation_json_not_object';
   private const AUTOMATION_NOT_FOUND = 'mailpoet_automation_not_found';
@@ -41,13 +40,6 @@ class Exceptions {
     throw new InvalidStateException(
       "This is a static factory class. Use it via 'Exception::someError()' factories."
     );
-  }
-
-  public static function migrationFailed(string $error): InvalidStateException {
-    return InvalidStateException::create()
-      ->withErrorCode(self::MIGRATION_FAILED)
-      // translators: %s is the error message.
-      ->withMessage(sprintf(__('Migration failed: %s', 'mailpoet'), $error));
   }
 
   public static function databaseError(string $error): InvalidStateException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -25,6 +25,8 @@ class Exceptions {
   private const MULTIPLE_SUBJECTS_FOUND = 'mailpoet_automation_multiple_subjects_found';
   private const PAYLOAD_NOT_FOUND = 'mailpoet_automation_payload_not_found';
   private const MULTIPLE_PAYLOADS_FOUND = 'mailpoet_automation_multiple_payloads_found';
+  private const FIELD_NOT_FOUND = 'mailpoet_automation_field_not_found';
+  private const FIELD_LOAD_FAILED = 'mailpoet_automation_field_load_failed';
   private const AUTOMATION_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_structure_modification_not_supported';
   private const AUTOMATION_STRUCTURE_NOT_VALID = 'mailpoet_automation_structure_not_valid';
   private const AUTOMATION_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_step_modified_when_unknown';
@@ -165,6 +167,20 @@ class Exceptions {
       ->withMessage(
         sprintf(__("Multiple payloads of class '%1\$s' found for automation run with ID '%2\$d'.", 'mailpoet'), $class, $automationRunId)
       );
+  }
+
+  public static function fieldNotFound(string $key): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::FIELD_NOT_FOUND)
+      // translators: %s is the key of the field not found.
+      ->withMessage(sprintf(__("Field with key '%s' not found.", 'mailpoet'), $key));
+  }
+
+  public static function fieldLoadFailed(string $key, array $args): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::FIELD_LOAD_FAILED)
+      // translators: %1$s is the key of the field, %2$s its arguments.
+      ->withMessage(sprintf(__('Field with key "%1$s" and args "%2$s" failed to load.', 'mailpoet'), $key, Json::encode($args)));
   }
 
   public static function automationStructureModificationNotSupported(): UnexpectedValueException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -27,6 +27,7 @@ class Exceptions {
   private const MULTIPLE_PAYLOADS_FOUND = 'mailpoet_automation_multiple_payloads_found';
   private const FIELD_NOT_FOUND = 'mailpoet_automation_field_not_found';
   private const FIELD_LOAD_FAILED = 'mailpoet_automation_field_load_failed';
+  private const FILTER_NOT_FOUND = 'mailpoet_automation_filter_not_found';
   private const AUTOMATION_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_structure_modification_not_supported';
   private const AUTOMATION_STRUCTURE_NOT_VALID = 'mailpoet_automation_structure_not_valid';
   private const AUTOMATION_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_step_modified_when_unknown';
@@ -181,6 +182,13 @@ class Exceptions {
       ->withErrorCode(self::FIELD_LOAD_FAILED)
       // translators: %1$s is the key of the field, %2$s its arguments.
       ->withMessage(sprintf(__('Field with key "%1$s" and args "%2$s" failed to load.', 'mailpoet'), $key, Json::encode($args)));
+  }
+
+  public static function filterNotFound(string $fieldType): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::FILTER_NOT_FOUND)
+      // translators: %s is the type of the field for which a filter was not found.
+      ->withMessage(sprintf(__("Filter for field of type '%s' not found.", 'mailpoet'), $fieldType));
   }
 
   public static function automationStructureModificationNotSupported(): UnexpectedValueException {

--- a/mailpoet/lib/Automation/Engine/Integration/Filter.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Filter.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Integration;
+
+use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Validator\Schema\ObjectSchema;
+
+interface Filter {
+  public function getFieldType(): string;
+
+  /** @return array<string, string> */
+  public function getConditions(): array;
+
+  public function getArgsSchema(): ObjectSchema;
+
+  /** @param mixed $value */
+  public function matches(FilterData $data, $value): bool;
+}

--- a/mailpoet/lib/Automation/Engine/Integration/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Subject.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\Integration;
 
+use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Engine\Data\Subject as SubjectData;
 use MailPoet\Validator\Schema\ObjectSchema;
 
@@ -14,6 +15,9 @@ interface Subject {
   public function getName(): string;
 
   public function getArgsSchema(): ObjectSchema;
+
+  /** @return Field[] */
+  public function getFields(): array;
 
   /** @return T */
   public function getPayload(SubjectData $subjectData): Payload;

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Engine\Mappers;
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
+use MailPoet\Automation\Engine\Data\Filter;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
@@ -42,6 +43,9 @@ class AutomationMapper {
           'next_steps' => array_map(function (NextStep $nextStep) {
             return $nextStep->toArray();
           }, $step->getNextSteps()),
+          'filters' => array_map(function (Filter $filter) {
+            return $filter->toArray();
+          }, $step->getFilters()),
         ];
       }, $automation->getSteps()),
       'meta' => (object)$automation->getAllMetas(),

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\Control\RootStep;
+use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Engine\Integration\Action;
 use MailPoet\Automation\Engine\Integration\Payload;
 use MailPoet\Automation\Engine\Integration\Step;
@@ -19,6 +20,9 @@ class Registry {
 
   /** @var SubjectTransformer[] */
   private $subjectTransformers = [];
+
+  /** @var array<string, Field> */
+  private $fields = [];
 
   /** @var array<string, Trigger> */
   private $triggers = [];
@@ -65,6 +69,23 @@ class Registry {
 
   public function getSubjectTransformers(): array {
     return $this->subjectTransformers;
+  }
+
+  public function addField(Field $field): void {
+    $key = $field->getKey();
+    if (isset($this->fields[$key])) {
+      throw new \Exception(); // TODO
+    }
+    $this->fields[$key] = $field;
+  }
+
+  public function getField(string $key): ?Field {
+    return $this->fields[$key] ?? null;
+  }
+
+  /** @return array<string, Field> */
+  public function getFields(): array {
+    return $this->fields;
   }
 
   public function addStep(Step $step): void {

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -51,6 +51,9 @@ class Registry {
       throw new \Exception(); // TODO
     }
     $this->subjects[$key] = $subject;
+    foreach ($subject->getFields() as $field) {
+      $this->addField($field);
+    }
   }
 
   /** @return Subject<Payload>|null */

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Engine;
 use MailPoet\Automation\Engine\Control\RootStep;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Engine\Integration\Action;
+use MailPoet\Automation\Engine\Integration\Filter;
 use MailPoet\Automation\Engine\Integration\Payload;
 use MailPoet\Automation\Engine\Integration\Step;
 use MailPoet\Automation\Engine\Integration\Subject;
@@ -23,6 +24,9 @@ class Registry {
 
   /** @var array<string, Field> */
   private $fields = [];
+
+  /** @var array<string, Filter> */
+  private $filters = [];
 
   /** @var array<string, Trigger> */
   private $triggers = [];
@@ -89,6 +93,23 @@ class Registry {
   /** @return array<string, Field> */
   public function getFields(): array {
     return $this->fields;
+  }
+
+  public function addFilter(Filter $filter): void {
+    $fieldType = $filter->getFieldType();
+    if (isset($this->filters[$fieldType])) {
+      throw new \Exception(); // TODO
+    }
+    $this->filters[$fieldType] = $filter;
+  }
+
+  public function getFilter(string $fieldType): ?Filter {
+    return $this->filters[$fieldType] ?? null;
+  }
+
+  /** @return array<string, Filter> */
+  public function getFilters(): array {
+    return $this->filters;
   }
 
   public function addStep(Step $step): void {

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Validation\AutomationRules;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationNode;
+use MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationNodeVisitor;
+use MailPoet\Validator\Validator;
+
+class ValidStepFiltersRule implements AutomationNodeVisitor {
+  /** @var Registry */
+  private $registry;
+
+  /** @var Validator */
+  private $validator;
+
+  public function __construct(
+    Registry $registry,
+    Validator $validator
+  ) {
+    $this->registry = $registry;
+    $this->validator = $validator;
+  }
+
+  public function initialize(Automation $automation): void {
+  }
+
+  public function visitNode(Automation $automation, AutomationNode $node): void {
+    $step = $node->getStep();
+    foreach ($step->getFilters() as $filter) {
+      $registryFilter = $this->registry->getFilter($filter->getFieldType());
+      if (!$registryFilter) {
+        continue;
+      }
+      $this->validator->validate($registryFilter->getArgsSchema(), $filter->getArgs());
+    }
+  }
+
+  public function complete(Automation $automation): void {
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationSchema.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationSchema.php
@@ -29,6 +29,7 @@ class AutomationSchema {
       'key' => Builder::string()->required(),
       'args' => Builder::object()->required(),
       'next_steps' => self::getNextStepsSchema()->required(),
+      'filters' => self::getFiltersSchema()->required(),
     ]);
   }
 
@@ -48,5 +49,16 @@ class AutomationSchema {
         'id' => Builder::string()->required(),
       ])
     )->maxItems(1);
+  }
+
+  public static function getFiltersSchema(): ArraySchema {
+    return Builder::array(
+      Builder::object([
+        'field_type' => Builder::string()->required(),
+        'field_key' => Builder::string()->required(),
+        'condition' => Builder::string()->required(),
+        'args' => Builder::object()->required(),
+      ])
+    );
   }
 }

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationValidator.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationValidator.php
@@ -15,6 +15,7 @@ use MailPoet\Automation\Engine\Validation\AutomationRules\TriggerNeedsToBeFollow
 use MailPoet\Automation\Engine\Validation\AutomationRules\TriggersUnderRootRule;
 use MailPoet\Automation\Engine\Validation\AutomationRules\UnknownStepRule;
 use MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepArgsRule;
+use MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepFiltersRule;
 use MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepOrderRule;
 use MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepRule;
 use MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepValidationRule;
@@ -25,6 +26,9 @@ class AutomationValidator {
 
   /** @var ValidStepArgsRule */
   private $validStepArgsRule;
+
+  /** @var ValidStepFiltersRule */
+  private $validStepFiltersRule;
 
   /** @var ValidStepOrderRule */
   private $validStepOrderRule;
@@ -38,12 +42,14 @@ class AutomationValidator {
   public function __construct(
     UnknownStepRule $unknownStepRule,
     ValidStepArgsRule $validStepArgsRule,
+    ValidStepFiltersRule $validStepFiltersRule,
     ValidStepOrderRule $validStepOrderRule,
     ValidStepValidationRule $validStepValidationRule,
     AutomationWalker $automationWalker
   ) {
     $this->unknownStepRule = $unknownStepRule;
     $this->validStepArgsRule = $validStepArgsRule;
+    $this->validStepFiltersRule = $validStepFiltersRule;
     $this->validStepOrderRule = $validStepOrderRule;
     $this->validStepValidationRule = $validStepValidationRule;
     $this->automationWalker = $automationWalker;
@@ -63,6 +69,7 @@ class AutomationValidator {
       new TriggerNeedsToBeFollowedByActionRule(),
       new ValidStepRule([
         $this->validStepArgsRule,
+        $this->validStepFiltersRule,
         $this->validStepOrderRule,
         $this->validStepValidationRule,
       ]),

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -14,6 +14,15 @@ class WordPress {
     do_action($hookName, ...$arg);
   }
 
+  /**
+   * @param mixed $value
+   * @param mixed ...$args
+   * @return mixed
+   */
+  public function applyFilters(string $hookName, $value, ...$args) {
+    return apply_filters($hookName, $value, ...$args);
+  }
+
   public function wpGetCurrentUser(): WP_User {
     return wp_get_current_user();
   }

--- a/mailpoet/lib/Automation/Integrations/Core/CoreIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/Core/CoreIntegration.php
@@ -20,5 +20,6 @@ class CoreIntegration implements Integration {
     $registry->addAction($this->delayAction);
 
     $registry->addFilter(new Filters\StringFilter());
+    $registry->addFilter(new Filters\EnumArrayFilter());
   }
 }

--- a/mailpoet/lib/Automation/Integrations/Core/CoreIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/Core/CoreIntegration.php
@@ -18,5 +18,7 @@ class CoreIntegration implements Integration {
 
   public function register(Registry $registry): void {
     $registry->addAction($this->delayAction);
+
+    $registry->addFilter(new Filters\StringFilter());
   }
 }

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/StringFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/StringFilter.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\Core\Filters;
+
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Integration\Filter;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema\ObjectSchema;
+
+class StringFilter implements Filter {
+  public const CONDITION_CONTAINS = 'contains';
+  public const CONDITION_DOES_NOT_CONTAIN = 'does-not-contain';
+  public const CONDITION_IS = 'is';
+  public const CONDITION_IS_NOT = 'is-not';
+  public const CONDITION_STARTS_WITH = 'starts-with';
+  public const CONDITION_ENDS_WITH = 'ends-with';
+  public const CONDITION_IS_BLANK = 'is-blank';
+  public const CONDITION_IS_NOT_BLANK = 'is-not-blank';
+  public const CONDITION_MATCHES_REGEX = 'matches-regex';
+
+  public function getFieldType(): string {
+    return Field::TYPE_STRING;
+  }
+
+  public function getConditions(): array {
+    return [
+      self::CONDITION_IS => __('is', 'mailpoet'),
+      self::CONDITION_IS_NOT => __('is not', 'mailpoet'),
+      self::CONDITION_CONTAINS => __('contains', 'mailpoet'),
+      self::CONDITION_DOES_NOT_CONTAIN => __('does not contain', 'mailpoet'),
+      self::CONDITION_STARTS_WITH => __('starts with', 'mailpoet'),
+      self::CONDITION_ENDS_WITH => __('ends with', 'mailpoet'),
+      self::CONDITION_IS_BLANK => __('is blank', 'mailpoet'),
+      self::CONDITION_IS_NOT_BLANK => __('is not blank', 'mailpoet'),
+      self::CONDITION_MATCHES_REGEX => __('matches regex', 'mailpoet'),
+    ];
+  }
+
+  public function getArgsSchema(): ObjectSchema {
+    return Builder::object([
+      'value' => Builder::string()->required(),
+    ]);
+  }
+
+  public function matches(FilterData $data, $value): bool {
+    $filterValue = $data->getArgs()['value'] ?? null;
+    if (!is_string($value) || !is_string($filterValue)) {
+      return false;
+    }
+
+    // match regex as it is
+    $condition = $data->getCondition();
+    if ($condition === self::CONDITION_MATCHES_REGEX) {
+      return $this->matchesRegex($filterValue, $value);
+    }
+
+    // match all other conditions case insensitively
+    $value = mb_strtolower($value);
+    $filterValue = mb_strtolower($filterValue);
+
+    switch ($data->getCondition()) {
+      case self::CONDITION_IS:
+        return $value === $filterValue;
+      case self::CONDITION_IS_NOT:
+        return $value !== $filterValue;
+      case self::CONDITION_CONTAINS:
+        return str_contains($value, $filterValue);
+      case self::CONDITION_DOES_NOT_CONTAIN:
+        return !str_contains($value, $filterValue);
+      case self::CONDITION_STARTS_WITH:
+        return str_starts_with($value, $filterValue);
+      case self::CONDITION_ENDS_WITH:
+        return str_ends_with($value, $filterValue);
+      case self::CONDITION_IS_BLANK:
+        return strlen($value) === 0;
+      case self::CONDITION_IS_NOT_BLANK:
+        return strlen($value) > 0;
+      default:
+        return false;
+    }
+  }
+
+  protected function matchesRegex(string $regex, string $value): bool {
+    // add '/' delimiters, if missing
+    if (!@preg_match('#^/.*/[a-z]*$#ui', $regex)) {
+      $regex = '/' . str_replace('/', '\\/', $regex) . '/u';
+    }
+
+    // add unicode flag, if not present
+    if (!@preg_match('#/.*u.*$#ui', $regex)) {
+      $regex .= 'u';
+    }
+
+    if (@preg_match($regex, '') === false) {
+      throw new InvalidStateException("Invalid regular expression: '$regex'");
+    }
+
+    return @preg_match($regex, $value) === 1;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
@@ -54,6 +54,8 @@ class SegmentSubject implements Subject {
   /** @return Field[] */
   public function getFields(): array {
     return [
+      // phpcs:disable Squiz.PHP.CommentedOutCode.Found -- temporarily hide those fields
+      /*
       new Field(
         'mailpoet:segment:id',
         Field::TYPE_INTEGER,
@@ -70,6 +72,7 @@ class SegmentSubject implements Subject {
           return $payload->getName();
         }
       ),
+      */
     ];
   }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
@@ -40,4 +40,8 @@ class CustomerSubject implements Subject {
     }
     return new CustomerPayload($customer);
   }
+
+  public function getFields(): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/OrderStatusChangeSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/OrderStatusChangeSubject.php
@@ -37,4 +37,8 @@ class OrderStatusChangeSubject implements Subject {
   public function getKey(): string {
     return self::KEY;
   }
+
+  public function getFields(): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/OrderSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/OrderSubject.php
@@ -49,4 +49,8 @@ class OrderSubject implements Subject {
   public function getKey(): string {
     return self::KEY;
   }
+
+  public function getFields(): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -140,6 +140,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationWalker::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\UnknownStepRule::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepArgsRule::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepFiltersRule::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepOrderRule::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepValidationRule::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationValidator::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -122,6 +122,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateAutomationController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\RootStep::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\FilterHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\StepHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\SubjectTransformerHandler::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Engine\Control\SubjectLoader::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -387,6 +387,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\WooCommerce::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\WP::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SubscribersFinder::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\SegmentsFinder::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SegmentsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SegmentSubscribersRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SegmentListingRepository::class)->setPublic(true);

--- a/mailpoet/lib/Segments/SegmentsFinder.php
+++ b/mailpoet/lib/Segments/SegmentsFinder.php
@@ -56,7 +56,7 @@ class SegmentsFinder {
 
     $matchingSegments = [];
     foreach ($segments as $segment) {
-      $result = $this->filterHandler->apply($queryBuilder, $segment)->execute();
+      $result = $this->filterHandler->apply(clone $queryBuilder, $segment)->execute();
       if ($result instanceof Result && $result->fetchOne()) {
         $matchingSegments[] = $segment;
       }

--- a/mailpoet/lib/Segments/SegmentsFinder.php
+++ b/mailpoet/lib/Segments/SegmentsFinder.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\FilterHandler;
+use MailPoetVendor\Doctrine\DBAL\Result;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class SegmentsFinder {
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var FilterHandler */
+  private $filterHandler;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  public function __construct(
+    EntityManager $entityManager,
+    FilterHandler $filterHandler,
+    SegmentsRepository $segmentsRepository
+  ) {
+    $this->entityManager = $entityManager;
+    $this->filterHandler = $filterHandler;
+    $this->segmentsRepository = $segmentsRepository;
+  }
+
+  /** @return SegmentEntity[] */
+  public function findSegments(SubscriberEntity $subscriber): array {
+    return array_merge(
+      $this->findStaticSegments($subscriber),
+      $this->findDynamicSegments($subscriber)
+    );
+  }
+
+  /** @return SegmentEntity[] */
+  public function findStaticSegments(SubscriberEntity $subscriber): array {
+    return $subscriber->getSegments()->toArray();
+  }
+
+  /** @return SegmentEntity[] */
+  public function findDynamicSegments(SubscriberEntity $subscriber): array {
+    $segments = $this->segmentsRepository->findBy([
+      'type' => SegmentEntity::TYPE_DYNAMIC,
+    ]);
+
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder()
+      ->select('id')
+      ->from($subscribersTable)
+      ->where('id = :subscriberId')
+      ->setParameter('subscriberId', $subscriber->getId());
+
+    $matchingSegments = [];
+    foreach ($segments as $segment) {
+      $result = $this->filterHandler->apply($queryBuilder, $segment)->execute();
+      if ($result instanceof Result && $result->fetchOne()) {
+        $matchingSegments[] = $segment;
+      }
+    }
+    return $matchingSegments;
+  }
+}

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -111,6 +111,7 @@ class SubscriberSegmentRepository extends Repository {
       $subscriber->getSubscriberSegments()->add($subscriberSegment);
       $this->entityManager->persist($subscriberSegment);
     }
+    $this->entityManager->flush();
 
     // fire subscribed hook for new subscriptions
     if (
@@ -122,7 +123,6 @@ class SubscriberSegmentRepository extends Repository {
       $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
     }
 
-    $this->entityManager->flush();
     return $subscriberSegment;
   }
 }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -939,3 +939,9 @@ parameters:
 			message: "#^Method MailPoet\\\\Newsletter\\\\NewslettersRepository\\:\\:getStandardNewsletterList\\(\\) should return array\\<MailPoet\\\\Entities\\\\NewsletterEntity\\> but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Newsletter/NewslettersRepository.php
+
+		-
+		  # https://github.com/phpstan/phpstan/issues/7732
+			message: "#^Function str_(\\w+) not found.$#"
+			count: 4
+			path: ../../lib/Automation/Integrations/Core/Filters/StringFilter.php

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -98,6 +98,7 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
           'key' => 'core:root',
           'args' => [],
           'next_steps' => [],
+          'filters' => [],
         ],
       ],
       'meta' => [],

--- a/mailpoet/tests/integration/Segments/SegmentsFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsFinderTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\SegmentsFinder;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetTest;
+
+class SegmentsFinderTest extends MailPoetTest {
+  public function testItFindsStaticSegments(): void {
+    $static = [
+      $this->createSegment(SegmentEntity::TYPE_DEFAULT),
+      $this->createSegment(SegmentEntity::TYPE_WP_USERS),
+      $this->createSegment(SegmentEntity::TYPE_WC_USERS),
+      $this->createSegment(SegmentEntity::TYPE_WC_MEMBERSHIPS),
+    ];
+    $this->createSegment(SegmentEntity::TYPE_DYNAMIC);
+    $this->createSegment(SegmentEntity::TYPE_WITHOUT_LIST);
+
+    $subscribed = $this->createSubscriber(SubscriberEntity::STATUS_SUBSCRIBED, $static);
+    $unsubscribed = $this->createSubscriber(SubscriberEntity::STATUS_UNSUBSCRIBED, $static);
+    $unconfirmed = $this->createSubscriber(SubscriberEntity::STATUS_UNCONFIRMED, $static);
+    $inactive = $this->createSubscriber(SubscriberEntity::STATUS_INACTIVE, $static);
+    $bounced = $this->createSubscriber(SubscriberEntity::STATUS_BOUNCED, $static);
+
+    $segmentsFinder = $this->diContainer->get(SegmentsFinder::class);
+    foreach ([$subscribed, $unsubscribed, $unconfirmed, $inactive, $bounced] as $subscriber) {
+      $segments = $segmentsFinder->findStaticSegments($subscriber);
+      $this->assertCount(4, $segments);
+      $this->assertSame('Segment default', $segments[0]->getName());
+      $this->assertSame('Segment wp_users', $segments[1]->getName());
+      $this->assertSame('Segment woocommerce_users', $segments[2]->getName());
+      $this->assertSame('Segment woocommerce_memberships', $segments[3]->getName());
+    }
+  }
+
+  public function testItFindsDynamicSegments(): void {
+    $this->createSegment(SegmentEntity::TYPE_DEFAULT);
+    $this->createSegment(SegmentEntity::TYPE_DYNAMIC);
+    $this->createSegment(SegmentEntity::TYPE_WP_USERS);
+    $this->createSegment(SegmentEntity::TYPE_WC_USERS);
+    $this->createSegment(SegmentEntity::TYPE_WC_MEMBERSHIPS);
+    $this->createSegment(SegmentEntity::TYPE_WITHOUT_LIST);
+
+    $subscribed = $this->createSubscriber(SubscriberEntity::STATUS_SUBSCRIBED);
+    $unsubscribed = $this->createSubscriber(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $unconfirmed = $this->createSubscriber(SubscriberEntity::STATUS_UNCONFIRMED);
+    $inactive = $this->createSubscriber(SubscriberEntity::STATUS_INACTIVE);
+    $bounced = $this->createSubscriber(SubscriberEntity::STATUS_BOUNCED);
+
+    $segmentsFinder = $this->diContainer->get(SegmentsFinder::class);
+    foreach ([$subscribed, $unsubscribed, $unconfirmed, $inactive, $bounced] as $subscriber) {
+      $segments = $segmentsFinder->findDynamicSegments($subscriber);
+      $this->assertCount(1, $segments);
+      $this->assertSame('Segment dynamic', $segments[0]->getName());
+    }
+  }
+
+  public function testItFindsAllSegments(): void {
+    $default = $this->createSegment(SegmentEntity::TYPE_DEFAULT);
+    $this->createSegment(SegmentEntity::TYPE_DYNAMIC);
+    $unsubscribed = $this->createSubscriber(SubscriberEntity::STATUS_UNCONFIRMED, [$default]);
+
+    $segmentsFinder = $this->diContainer->get(SegmentsFinder::class);
+    $segments = $segmentsFinder->findSegments($unsubscribed);
+    $this->assertCount(2, $segments);
+    $this->assertSame('Segment default', $segments[0]->getName());
+    $this->assertSame('Segment dynamic', $segments[1]->getName());
+  }
+
+  private function createSubscriber(string $status, array $lists = []): SubscriberEntity {
+    $subscriberFactory = new SubscriberFactory();
+    return $subscriberFactory
+      ->withEmail("{$status}@example.com")
+      ->withStatus($status)
+      ->withSegments($lists)
+      ->create();
+  }
+
+  private function createSegment(string $type): SegmentEntity {
+    $segmentFactory = new SegmentFactory();
+    return $segmentFactory
+      ->withName("Segment $type")
+      ->withType($type)
+      ->create();
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Control;
+
+use Codeception\Stub;
+use MailPoet\Automation\Engine\Control\FilterHandler;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\Subject as SubjectData;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Integration\Filter;
+use MailPoet\Automation\Engine\Integration\Payload;
+use MailPoet\Automation\Engine\Integration\Subject;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoetUnitTest;
+
+class FilterHandlerTest extends MailPoetUnitTest {
+  /** @dataProvider dataForTestItFilters */
+  public function testItFilters(array $stepFilters, bool $expectation): void {
+    $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $stepFilters);
+    $subject = $this->createSubject('subject', [
+      new Field('test:field-string', Field::TYPE_STRING, 'Test field string', function () {
+        return 'abc';
+      }),
+      new Field('test:field-integer', Field::TYPE_INTEGER, 'Test field integer', function () {
+        return 123;
+      }),
+      new Field('test:field-boolean', Field::TYPE_BOOLEAN, 'Test field boolean', function () {
+        return true;
+      }),
+    ]);
+
+    $stepRunArgs = new StepRunArgs(
+      $this->createMock(Automation::class),
+      $this->createMock(AutomationRun::class),
+      $step,
+      [new SubjectEntry($subject, new SubjectData($subject->getKey(), []))]
+    );
+
+    $registry = Stub::make(Registry::class, [
+      'filters' => [
+        Field::TYPE_STRING => $this->createFilter(Field::TYPE_STRING),
+        Field::TYPE_INTEGER => $this->createFilter(Field::TYPE_INTEGER),
+        Field::TYPE_BOOLEAN => $this->createFilter(Field::TYPE_BOOLEAN),
+      ],
+    ]);
+
+    $handler = new FilterHandler($registry);
+    $result = $handler->matchesFilters($stepRunArgs);
+    $this->assertSame($expectation, $result);
+  }
+
+  public function dataForTestItFilters(): array {
+    return [
+      // no filters
+      [
+        [],
+        true,
+      ],
+
+      // matching
+      [
+        [
+          new FilterData(Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData(Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 123]),
+        ],
+        true,
+      ],
+
+      // not matching
+      [
+        [
+          new FilterData(Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
+        ],
+        false,
+      ],
+      [
+        [
+          new FilterData(Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData(Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
+          new FilterData(Field::TYPE_BOOLEAN, 'test:field-boolean', '', ['value' => true]),
+        ],
+        false,
+      ],
+    ];
+  }
+
+  /** @return Subject<Payload> */
+  private function createSubject(string $key, array $fields): Subject {
+    return new class($key, $fields) implements Subject {
+      /** @var string */
+      private $key;
+
+      /** @var array */
+      private $fields;
+
+      public function __construct(
+        string $key,
+        array $fields
+      ) {
+        $this->key = $key;
+        $this->fields = $fields;
+      }
+
+      public function getKey(): string {
+        return 'test:' . $this->key;
+      }
+
+      public function getName(): string {
+        return 'Test subject ' . $this->key;
+      }
+
+      public function getArgsSchema(): ObjectSchema {
+        return Builder::object();
+      }
+
+      public function getFields(): array {
+        return $this->fields;
+      }
+
+      public function getPayload(SubjectData $subjectData): Payload {
+        return new class implements Payload {
+        };
+      }
+    };
+  }
+
+  private function createFilter(string $fieldType): Filter {
+    return new class($fieldType) implements Filter {
+      /** @var string */
+      private $fieldType;
+
+      public function __construct(
+        string $fieldType
+      ) {
+        $this->fieldType = $fieldType;
+      }
+
+      public function getFieldType(): string {
+        return $this->fieldType;
+      }
+
+      public function getConditions(): array {
+        return [];
+      }
+
+      public function getArgsSchema(): ObjectSchema {
+        return Builder::object();
+      }
+
+      public function matches(FilterData $data, $value): bool {
+        return $data->getArgs()['value'] === $value;
+      }
+    };
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace unit\Automation\Engine\Validation\AutomationRules;
+
+require_once __DIR__ . '/AutomationRuleTest.php';
+
+use Codeception\Stub\Expected;
+use MailPoet\Automation\Engine\Control\RootStep;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Integration\Filter;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationWalker;
+use MailPoet\Automation\Engine\Validation\AutomationRules\AutomationRuleTest;
+use MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepFiltersRule;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoet\Validator\Validator;
+
+class ValidStepFiltersRuleTest extends AutomationRuleTest {
+  public function testItRunsFiltersValidation(): void {
+    $registry = $this->make(Registry::class, [
+      'steps' => ['core:root' => new RootStep()],
+      'filters' => ['string' => $this->getFilter()],
+    ]);
+
+    $validator = $this->make(Validator::class, [
+      'validate' => Expected::once(),
+    ]);
+
+    $filters = [new FilterData('string', 'test:key', 'is', ['value' => 'test'])];
+    $rule = new ValidStepFiltersRule($registry, $validator);
+    $automation = $this->getAutomation($filters);
+    (new AutomationWalker())->walk($automation, [$rule]);
+  }
+
+  public function testItSkipsFiltersValidationForNonExistentFilter(): void {
+    $registry = $this->make(Registry::class);
+    $validator = $this->make(Validator::class, [
+      'validate' => Expected::never(),
+    ]);
+
+    $filters = [new FilterData('string', 'test:key', 'is', ['value' => 'test'])];
+    $rule = new ValidStepFiltersRule($registry, $validator);
+    $automation = $this->getAutomation($filters);
+    (new AutomationWalker())->walk($automation, [$rule]);
+  }
+
+  private function getAutomation(array $filters): Automation {
+    return $this->make(Automation::class, [
+      'getSteps' => [
+        'root' => new Step('root', 'root', 'core:root', [], [], $filters),
+      ],
+    ]);
+  }
+
+  private function getFilter(): Filter {
+    return new class() implements Filter {
+      public function getFieldType(): string {
+        return '';
+      }
+
+      public function getConditions(): array {
+        return [];
+      }
+
+      public function getArgsSchema(): ObjectSchema {
+        return Builder::object();
+      }
+
+      public function matches(FilterData $data, $value): bool {
+        return true;
+      }
+    };
+  }
+}

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\Core\Filters;
+
+use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Integrations\Core\Filters\EnumArrayFilter;
+use MailPoetUnitTest;
+use stdClass;
+
+class EnumArrayFilterTest extends MailPoetUnitTest {
+  public function testItReturnsCorrectConfiguration(): void {
+    $filter = new EnumArrayFilter();
+    $this->assertSame('enum_array', $filter->getFieldType());
+
+    $this->assertSame([
+      'matches-any' => 'matches any',
+      'matches-all' => 'matches all',
+      'matches-none' => 'matches none',
+    ], $filter->getConditions());
+
+    $this->assertSame([
+      'type' => 'object',
+      'properties' => [
+        'value' => [
+          'oneOf' => [
+            ['type' => 'array', 'items' => ['type' => 'string'], 'minItems' => 1],
+            ['type' => 'array', 'items' => ['type' => 'integer'], 'minItems' => 1],
+          ],
+          'required' => true,
+        ],
+      ],
+    ], $filter->getArgsSchema()->toArray());
+  }
+
+  public function testInvalidValues(): void {
+    $this->assertNotMatches('is', [], null);
+    $this->assertNotMatches('is', [], 123);
+    $this->assertNotMatches('is', [], new stdClass());
+    $this->assertNotMatches('is', [], true);
+    $this->assertNotMatches('is', [], false);
+    $this->assertNotMatches('is', [1], 1);
+
+    $this->assertNotMatches('is', null, []);
+    $this->assertNotMatches('is', 123, []);
+    $this->assertNotMatches('is', new stdClass(), []);
+    $this->assertNotMatches('is', true, []);
+    $this->assertNotMatches('is', false, []);
+    $this->assertNotMatches('is', 1, [1]);
+  }
+
+  public function testMatchesAnyCondition(): void {
+    $this->assertMatches('matches-any', [1, 2, 3], [1]);
+    $this->assertMatches('matches-any', [1, 2, 3], [1, 3, 9]);
+    $this->assertMatches('matches-any', [1], [1, 1, 1]);
+    $this->assertMatches('matches-any', [1, 1, 1], [1]);
+    $this->assertNotMatches('matches-any', [], []);
+    $this->assertNotMatches('matches-any', [], [1]);
+    $this->assertNotMatches('matches-any', [1, 2, 3], []);
+    $this->assertNotMatches('matches-any', [1, 2, 3], [7, 8, 9]);
+  }
+
+  public function testMatchesAllCondition(): void {
+    $this->assertMatches('matches-all', [1], [1]);
+    $this->assertMatches('matches-all', [1, 2], [2, 1]);
+    $this->assertMatches('matches-all', [1, 2], [2, 1, 3]);
+    $this->assertMatches('matches-all', [1], [1, 1, 1]);
+    $this->assertMatches('matches-all', [1, 1, 1], [1]);
+    $this->assertNotMatches('matches-all', [], []);
+    $this->assertNotMatches('matches-all', [], [1]);
+    $this->assertNotMatches('matches-all', [1, 2, 3], []);
+    $this->assertNotMatches('matches-all', [1, 2, 3], [2, 3, 4]);
+  }
+
+  public function testMatchesNoneCondition(): void {
+    $this->assertMatches('matches-none', [], []);
+    $this->assertMatches('matches-none', [], [1]);
+    $this->assertMatches('matches-none', [1], []);
+    $this->assertMatches('matches-none', [1], [2]);
+    $this->assertMatches('matches-none', [1, 2, 3], []);
+    $this->assertMatches('matches-none', [1, 2, 3], [4, 5, 6]);
+    $this->assertMatches('matches-none', [1], [2, 2, 2]);
+    $this->assertMatches('matches-none', [1, 1, 1], [2]);
+    $this->assertNotMatches('matches-none', [1], [1]);
+    $this->assertNotMatches('matches-none', [1, 2, 3], [2]);
+    $this->assertNotMatches('matches-none', [1, 2, 3], [3, 4, 5]);
+    $this->assertNotMatches('matches-none', [1], [1, 1, 1]);
+    $this->assertNotMatches('matches-none', [1, 1, 1], [1]);
+  }
+
+  public function testUnknownCondition(): void {
+    $this->assertNotMatches('unknown', '', '');
+    $this->assertNotMatches('unknown', 'abc', 'abc');
+  }
+
+  private function assertMatches(string $condition, $filterValue, $value): void {
+    $this->assertTrue($this->matchesFilter($condition, $filterValue, $value));
+  }
+
+  private function assertNotMatches(string $condition, $filterValue, $value): void {
+    $this->assertFalse($this->matchesFilter($condition, $filterValue, $value));
+  }
+
+  private function matchesFilter(string $condition, $filterValue, $value): bool {
+    $filter = new EnumArrayFilter();
+    return $filter->matches(new Filter('string', '', $condition, ['value' => $filterValue]), $value);
+  }
+}

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/StringFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/StringFilterTest.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\Core\Filters;
+
+use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Integrations\Core\Filters\StringFilter;
+use MailPoetUnitTest;
+use stdClass;
+
+class StringFilterTest extends MailPoetUnitTest {
+  public function testItReturnsCorrectConfiguration(): void {
+    $filter = new StringFilter();
+    $this->assertSame('string', $filter->getFieldType());
+
+    $this->assertSame([
+      'is' => 'is',
+      'is-not' => 'is not',
+      'contains' => 'contains',
+      'does-not-contain' => 'does not contain',
+      'starts-with' => 'starts with',
+      'ends-with' => 'ends with',
+      'is-blank' => 'is blank',
+      'is-not-blank' => 'is not blank',
+      'matches-regex' => 'matches regex',
+    ], $filter->getConditions());
+
+    $this->assertSame([
+      'type' => 'object',
+      'properties' => [
+        'value' => [
+          'type' => 'string',
+          'required' => true,
+        ],
+      ],
+    ], $filter->getArgsSchema()->toArray());
+  }
+
+  public function testInvalidValues(): void {
+    $this->assertNotMatches('is', '', null);
+    $this->assertNotMatches('is', '', 123);
+    $this->assertNotMatches('is', '', []);
+    $this->assertNotMatches('is', '', [1, 2, 3, 'a', 'b', 'c']);
+    $this->assertNotMatches('is', '', new stdClass());
+    $this->assertNotMatches('is', '', true);
+    $this->assertNotMatches('is', '', false);
+
+    $this->assertNotMatches('is', null, '');
+    $this->assertNotMatches('is', 123, '');
+    $this->assertNotMatches('is', [], '');
+    $this->assertNotMatches('is', [1, 2, 3, 'a', 'b', 'c'], '');
+    $this->assertNotMatches('is', new stdClass(), '');
+    $this->assertNotMatches('is', true, '');
+    $this->assertNotMatches('is', false, '');
+  }
+
+  public function testIsCondition(): void {
+    $this->assertMatches('is', '', '');
+    $this->assertMatches('is', 'abc', 'abc');
+    $this->assertNotMatches('is', 'abc', 'xyz');
+    $this->assertNotMatches('is', 'abc', 'abcd');
+  }
+
+  public function testIsNotCondition(): void {
+    $this->assertMatches('is-not', 'abc', 'xyz');
+    $this->assertMatches('is-not', 'abc', 'abcd');
+    $this->assertNotMatches('is-not', '', '');
+    $this->assertNotMatches('is-not', 'abc', 'abc');
+  }
+
+  public function testContainsCondition(): void {
+    $this->assertMatches('contains', '', '');
+    $this->assertMatches('contains', '', 'abc');
+    $this->assertMatches('contains', 'b', 'abc');
+    $this->assertMatches('contains', 'bc', 'abc');
+    $this->assertMatches('contains', 'abc', 'abc');
+    $this->assertNotMatches('contains', 'abc', '');
+    $this->assertNotMatches('contains', 'abc', 'b');
+    $this->assertNotMatches('contains', 'abx', 'abc');
+    $this->assertNotMatches('contains', 'abcd', 'abc');
+  }
+
+  public function testNotContainsCondition(): void {
+    $this->assertMatches('does-not-contain', 'abc', '');
+    $this->assertMatches('does-not-contain', 'abc', 'b');
+    $this->assertMatches('does-not-contain', 'abx', 'abc');
+    $this->assertMatches('does-not-contain', 'abcd', 'abc');
+    $this->assertNotMatches('does-not-contain', '', '');
+    $this->assertNotMatches('does-not-contain', '', 'abc');
+    $this->assertNotMatches('does-not-contain', 'b', 'abc');
+    $this->assertNotMatches('does-not-contain', 'bc', 'abc');
+    $this->assertNotMatches('does-not-contain', 'abc', 'abc');
+  }
+
+  public function testStartsWithCondition(): void {
+    $this->assertMatches('starts-with', '', 'abc');
+    $this->assertMatches('starts-with', 'a', 'abc');
+    $this->assertMatches('starts-with', 'ab', 'abc');
+    $this->assertMatches('starts-with', 'abc', 'abc');
+    $this->assertNotMatches('starts-with', 'abc', '');
+    $this->assertNotMatches('starts-with', 'abc', 'a');
+    $this->assertNotMatches('starts-with', 'abc', 'ab');
+    $this->assertNotMatches('starts-with', 'abc', 'abx');
+  }
+
+  public function testEndsWithCondition(): void {
+    $this->assertMatches('ends-with', '', 'abc');
+    $this->assertMatches('ends-with', 'c', 'abc');
+    $this->assertMatches('ends-with', 'bc', 'abc');
+    $this->assertMatches('ends-with', 'abc', 'abc');
+    $this->assertNotMatches('ends-with', 'abc', '');
+    $this->assertNotMatches('ends-with', 'abc', 'c');
+    $this->assertNotMatches('ends-with', 'abc', 'bc');
+    $this->assertNotMatches('ends-with', 'abc', 'abx');
+  }
+
+  public function testIsBlankCondition(): void {
+    $this->assertMatches('is-blank', '', '');
+    $this->assertNotMatches('is-blank', '', ' ');
+    $this->assertNotMatches('is-blank', '', 'a');
+    $this->assertNotMatches('is-blank', '', 'abc');
+  }
+
+  public function testIsNotBlankCondition(): void {
+    $this->assertMatches('is-not-blank', '', ' ');
+    $this->assertMatches('is-not-blank', '', 'a');
+    $this->assertMatches('is-not-blank', '', 'abc');
+    $this->assertNotMatches('is-not-blank', '', '');
+  }
+
+  public function testMatchesRegex(): void {
+    $this->assertMatches('matches-regex', '', '');
+    $this->assertMatches('matches-regex', 'a', 'abc');
+    $this->assertMatches('matches-regex', 'b', 'abc');
+    $this->assertMatches('matches-regex', 'abc', 'abc');
+    $this->assertMatches('matches-regex', '/a/', 'abc');
+    $this->assertMatches('matches-regex', '/b/', 'abc');
+    $this->assertMatches('matches-regex', '/abc/', 'abc');
+    $this->assertMatches('matches-regex', '/^ab/', 'abc');
+    $this->assertMatches('matches-regex', '/bc$/', 'abc');
+    $this->assertMatches('matches-regex', '/^abc$/', 'abc');
+    $this->assertMatches('matches-regex', '/^abc$/i', 'ABC');
+
+    $this->assertNotMatches('matches-regex', 'a', '');
+    $this->assertNotMatches('matches-regex', 'a', 'x');
+    $this->assertNotMatches('matches-regex', 'abc', 'ab');
+    $this->assertNotMatches('matches-regex', '/a/', 'x');
+    $this->assertNotMatches('matches-regex', '/abc/', 'ab');
+    $this->assertNotMatches('matches-regex', '/^ab/', 'bc');
+    $this->assertNotMatches('matches-regex', '/bc$/', 'ab');
+    $this->assertNotMatches('matches-regex', '/^abc$/', 'ab');
+    $this->assertNotMatches('matches-regex', '/^abc$/', 'ABC');
+  }
+
+  public function testUnknownCondition(): void {
+    $this->assertNotMatches('unknown', '', '');
+    $this->assertNotMatches('unknown', 'abc', 'abc');
+  }
+
+  private function assertMatches(string $condition, $filterValue, $value): void {
+    $this->assertTrue($this->matchesFilter($condition, $filterValue, $value));
+  }
+
+  private function assertNotMatches(string $condition, $filterValue, $value): void {
+    $this->assertFalse($this->matchesFilter($condition, $filterValue, $value));
+  }
+
+  private function matchesFilter(string $condition, $filterValue, $value): bool {
+    $filter = new StringFilter();
+    return $filter->matches(new Filter('string', '', $condition, ['value' => $filterValue]), $value);
+  }
+}


### PR DESCRIPTION
## Description

This PR:
1. Finalizes subject `fields`.
2. Adds support for field `filters` on triggers (definition, saving, validation, UI, filtering logic).
3. Implements two filters (`string` and `enum_array`).
4. Adds `Subscriber segments` filter.
5. Adds test coverage.
6. Adds a few small fixes for issues encountered on the way.

Note that filters will work in the free plugin itself, but it's only premium that allows adding, removing, or modifying them. This is consistent with how we treat automation steps.

## Code review notes

I opted for adding a new `filters` step field. Does that make sense? At the moment, we use the filters only for triggers. I'm guessing we could reuse the same `filters` field as well for conditional steps, for instance.

## QA notes

Please test with and without the premium plugin and make sure that the subscriber segment filter works with all condition types. Please also check that updating a site with already existing and active automations works.

**Please, ping @JanJakes before merging.**

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/704

## Linked tickets

[MAILPOET-4946] (Filters, Subscriber segments filter)
[MAILPOET-4419] (String filter)
[MAILPOET-5002] (Enum array filter)

## After-merge notes

_N/A_


[MAILPOET-4946]: https://mailpoet.atlassian.net/browse/MAILPOET-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4419]: https://mailpoet.atlassian.net/browse/MAILPOET-4419
[MAILPOET-5002]: https://mailpoet.atlassian.net/browse/MAILPOET-5002