### PR TITLE
Ensure PHPMailer validator is the default

### DIFF
--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -55,6 +55,8 @@ class AmazonSESTest extends \MailPoetTest {
       new AmazonSESMapper(),
       new WPFunctions()
     );
+    // Ensure the default validator is in place
+    $this->mailer->mailer::$validator = 'php';
     $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
       'subject' => 'testing AmazonSES … © & ěščřžýáíéůėę€żąß∂ 😊👨‍👩‍👧‍👧', // try some special chars


### PR DESCRIPTION
MAILPOET-5190

## Description

This PR ensures the PHPMailer's static $validator is the default value of `php`. WordPress can override this if `wp_mail` is called, leading to unexpected test results.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_
