### PR TITLE
Simplify and move test to more appropriate spot [MAILPOET-5190]

### DIFF
--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -231,6 +231,14 @@ class AmazonSESTest extends \MailPoetTest {
     expect($result['response'])->false();
   }
 
+  public function testItCatchesSendingErrors() {
+    $this->mailer->sender['from_name_email'] = 'invalid';
+    $result = $this->mailer->send($this->newsletter, 'test@example.com');
+    expect($result['response'])->false();
+    expect($result['error'])->isInstanceOf(MailerError::class);
+    expect($result['error']->getMessage())->stringContainsString("Missing final '@domain'");
+  }
+
   public function testItChecksBlacklistBeforeSending() {
     $blacklistedSubscriber = 'blacklist_test@example.com';
     $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -231,17 +231,6 @@ class AmazonSESTest extends \MailPoetTest {
     expect($result['response'])->false();
   }
 
-  public function testItCatchesSendingErrors() {
-    $invalidSubscriber = 'john.@doe.com';
-    $result = $this->mailer->send(
-      $this->newsletter,
-      $invalidSubscriber
-    );
-    expect($result['response'])->false();
-    expect($result['error'])->isInstanceOf(MailerError::class);
-    expect($result['error']->getMessage())->stringContainsString('Invalid address');
-  }
-
   public function testItChecksBlacklistBeforeSending() {
     $blacklistedSubscriber = 'blacklist_test@example.com';
     $blacklist = Stub::make(new BlacklistCheck(), ['isBlacklisted' => true], $this);

--- a/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -155,4 +155,13 @@ class PHPMailTest extends \MailPoetTest {
     );
     expect($result['response'])->true();
   }
+
+  public function testItCanValidateEmailAddresses() {
+    // a call to wp_mail can override PHPMailer's validator to is_email, which is
+    // less strict. This ensures the default of 'php' is set in case a previous test
+    // caused an override.
+    $this->mailer->mailer::$validator = 'php';
+    $result = $this->mailer->mailer::validateAddress('john.@doe.com');
+    expect($result)->false();
+  }
 }


### PR DESCRIPTION
## Description

This test was sometimes failing, most likely due to PHPMailer's static $validator being overridden somehow (my guess is due to some call to `wp_mail`, [see here](https://github.com/WordPress/WordPress/blame/master/wp-includes/pluggable.php#L256-L258)). 

The expected error itself was not actually coming from Amazon in the first place as far as I could tell, but rather from PHPMailer, so it made sense to me to move this to a more generic place and test the functionality more directly.

It turns out that Amazon SES does not consider the email address `john.@doe.com` to be a problem, so when the validation was passing, the call to AmazonSES was not resulting in an error.

## Code review notes

_N/A_

## QA notes

No QA needed since this is just a change to test code

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5190]

## After-merge notes

_N/A_


[MAILPOET-5190]: https://mailpoet.atlassian.net/browse/MAILPOET-5190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ