### PR TITLE
Consistent statuses for WooCommerce purchase filters [MAILPOET-5083]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Util\DBCollationChecker;
 use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -19,12 +20,17 @@ class WooCommerceNumberOfOrders implements Filter {
   /** @var DBCollationChecker */
   private $collationChecker;
 
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
   public function __construct(
     EntityManager $entityManager,
-    DBCollationChecker $collationChecker
+    DBCollationChecker $collationChecker,
+    WooFilterHelper $wooFilterHelper
   ) {
     $this->entityManager = $entityManager;
     $this->collationChecker = $collationChecker;
+    $this->wooFilterHelper = $wooFilterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -53,7 +59,7 @@ class WooCommerceNumberOfOrders implements Filter {
         'customer',
         $wpdb->prefix . 'wc_order_stats',
         'orderStats',
-        'customer.customer_id = orderStats.customer_id AND orderStats.date_created >= :date' . $parameterSuffix . ' AND orderStats.status NOT IN ("wc-cancelled", "wc-failed")'
+        'customer.customer_id = orderStats.customer_id AND orderStats.date_created >= :date' . $parameterSuffix . ' AND orderStats.status IN (:allowedStatuses' . $parameterSuffix . ')'
       );
 
     $queryBuilder->add('join', [
@@ -70,6 +76,7 @@ class WooCommerceNumberOfOrders implements Filter {
       ],
     ], \true)
       ->setParameter('date' . $parameterSuffix, $date->toDateTimeString())
+      ->setParameter('allowedStatuses' . $parameterSuffix, $this->wooFilterHelper->defaultIncludedStatuses(), Connection::PARAM_STR_ARRAY)
       ->groupBy('inner_subscriber_id');
 
     if ($type === '=') {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -61,7 +61,6 @@ class WooCommerceProduct implements Filter {
       // application subQuery for negation
       $queryBuilder->where("{$subscribersTable}.id NOT IN ({$this->filterHelper->getInterpolatedSQL($subQuery)})");
     }
-    codecept_debug($this->filterHelper->getInterpolatedSQL($queryBuilder));
     return $queryBuilder
       ->setParameter("products_{$parameterSuffix}", $productIds, Connection::PARAM_STR_ARRAY);
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -5,7 +5,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Util\DBCollationChecker;
 use MailPoet\Util\Security;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -17,15 +16,20 @@ class WooCommerceProduct implements Filter {
   /** @var EntityManager */
   private $entityManager;
 
-  /** @var DBCollationChecker */
-  private $collationChecker;
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
+  /** @var FilterHelper */
+  private $filterHelper;
 
   public function __construct(
     EntityManager $entityManager,
-    DBCollationChecker $collationChecker
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper
   ) {
     $this->entityManager = $entityManager;
-    $this->collationChecker = $collationChecker;
+    $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -36,69 +40,39 @@ class WooCommerceProduct implements Filter {
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
 
     if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
-      $this->applyCustomerJoin($queryBuilder);
-      $this->applyOrderJoin($queryBuilder);
-      $this->applyProductJoin($queryBuilder);
-      $queryBuilder->where("product.product_id IN (:products_{$parameterSuffix})");
-
+      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->applyProductJoin($queryBuilder, $orderStatsAlias);
+      $queryBuilder->andWhere("product.product_id IN (:products_{$parameterSuffix})");
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
-      $this->applyCustomerJoin($queryBuilder);
-      $this->applyOrderJoin($queryBuilder);
-      $this->applyProductJoin($queryBuilder);
-      $queryBuilder->where("product.product_id IN (:products_{$parameterSuffix})")
-        ->groupBy("{$subscribersTable}.id, orderStats.order_id")
-        ->having('COUNT(orderStats.order_id) = :count' . $parameterSuffix)
+      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->applyProductJoin($queryBuilder, $orderStatsAlias);
+      $queryBuilder->andWhere("product.product_id IN (:products_{$parameterSuffix})")
+        ->groupBy("{$subscribersTable}.id, $orderStatsAlias.order_id")
+        ->having("COUNT($orderStatsAlias.order_id) = :count" . $parameterSuffix)
         ->setParameter('count' . $parameterSuffix, count($productIds));
 
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
       // subQuery with subscriber ids that bought products
       $subQuery = $this->createQueryBuilder($subscribersTable);
       $subQuery->select("DISTINCT $subscribersTable.id");
-      $subQuery = $this->applyCustomerJoin($subQuery);
-      $subQuery = $this->applyOrderJoin($subQuery);
-      $subQuery = $this->applyProductJoin($subQuery);
-      $subQuery->where("product.product_id IN (:products_{$parameterSuffix})");
+      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+      $subQuery = $this->applyProductJoin($subQuery, $orderStatsAlias);
+      $subQuery->andWhere("product.product_id IN (:products_{$parameterSuffix})");
       // application subQuery for negation
-      $queryBuilder->where("{$subscribersTable}.id NOT IN ({$subQuery->getSQL()})");
+      $queryBuilder->where("{$subscribersTable}.id NOT IN ({$this->filterHelper->getInterpolatedSQL($subQuery)})");
     }
+    codecept_debug($this->filterHelper->getInterpolatedSQL($queryBuilder));
     return $queryBuilder
       ->setParameter("products_{$parameterSuffix}", $productIds, Connection::PARAM_STR_ARRAY);
   }
 
-  private function applyCustomerJoin(QueryBuilder $queryBuilder): QueryBuilder {
-    global $wpdb;
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $collation = $this->collationChecker->getCollateIfNeeded(
-      $subscribersTable,
-      'email',
-      $wpdb->prefix . 'wc_customer_lookup',
-      'email'
-    );
-    return $queryBuilder->innerJoin(
-      $subscribersTable,
-      $wpdb->prefix . 'wc_customer_lookup',
-      'customer',
-      "$subscribersTable.email = customer.email $collation"
-    );
-  }
-
-  private function applyOrderJoin(QueryBuilder $queryBuilder): QueryBuilder {
-    global $wpdb;
-    return $queryBuilder->join(
-      'customer',
-      $wpdb->prefix . 'wc_order_stats',
-      'orderStats',
-      'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN ("wc-cancelled", "wc-on-hold", "wc-pending", "wc-failed")'
-    );
-  }
-
-  private function applyProductJoin(QueryBuilder $queryBuilder): QueryBuilder {
+  private function applyProductJoin(QueryBuilder $queryBuilder, string $orderStatsAlias): QueryBuilder {
     global $wpdb;
     return $queryBuilder->innerJoin(
-      'orderStats',
+      $orderStatsAlias,
       $wpdb->prefix . 'wc_order_product_lookup',
       'product',
-      'orderStats.order_id = product.order_id'
+      "$orderStatsAlias.order_id = product.order_id"
     );
   }
 

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -214,19 +214,24 @@ class IntegrationTester extends \Codeception\Actor {
     $filterEntity = new DynamicSegmentFilterEntity($segment, $data);
     $this->entityManager->persist($filterEntity);
     $segment->addDynamicFilter($filterEntity);
-
     $queryBuilder = $filter->apply($this->getSubscribersQueryBuilder(), $filterEntity);
+    return $this->getSubscriberEmailsFromQueryBuilder($queryBuilder);
+  }
+
+  /**
+   * @param QueryBuilder $queryBuilder
+   * @return string[] - array of subscriber emails
+   */
+  public function getSubscriberEmailsFromQueryBuilder(QueryBuilder $queryBuilder): array {
     $statement = $queryBuilder->execute();
     $results = $statement instanceof Statement ? $statement->fetchAllAssociative() : [];
-    $emails = array_map(function($row) {
+    return array_map(function($row) {
       $subscriber = $this->entityManager->find(SubscriberEntity::class, $row['inner_subscriber_id']);
       if (!$subscriber instanceof SubscriberEntity) {
         throw new \Exception('this is for PhpStan');
       }
       return $subscriber->getEmail();
     }, $results);
-
-    return $emails;
   }
 
   public function getSubscribersQueryBuilder(): QueryBuilder {

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types = 1);
 
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore;
+use Codeception\Scenario;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
@@ -9,8 +10,16 @@ use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\Filters\Filter;
 use MailPoet\Util\Security;
 use MailPoet\WooCommerce\Helper;
+use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 require_once(ABSPATH . 'wp-admin/includes/user.php');
 require_once(ABSPATH . 'wp-admin/includes/ms.php');
@@ -34,9 +43,19 @@ require_once(ABSPATH . 'wp-admin/includes/ms.php');
 class IntegrationTester extends \Codeception\Actor {
   use _generated\IntegrationTesterActions;
 
+  /** @var EntityManager */
+  private $entityManager;
+
   private $wooOrderIds = [];
 
   private $createdUsers = [];
+
+  public function __construct(
+    Scenario $scenario
+  ) {
+    parent::__construct($scenario);
+    $this->entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+  }
 
   public function createWordPressUser(string $email, string $role) {
     $userId = wp_insert_user([
@@ -187,6 +206,36 @@ class IntegrationTester extends \Codeception\Actor {
     );
     $automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
     return $automationRunStorage->getAutomationRun($automationRunStorage->createAutomationRun($automationRun));
+  }
+
+  public function getSubscriberEmailsMatchingDynamicFilter(DynamicSegmentFilterData $data, Filter $filter): array {
+    $segment = new SegmentEntity('temporary segment', SegmentEntity::TYPE_DYNAMIC, 'description');
+    $this->entityManager->persist($segment);
+    $filterEntity = new DynamicSegmentFilterEntity($segment, $data);
+    $this->entityManager->persist($filterEntity);
+    $segment->addDynamicFilter($filterEntity);
+
+    $queryBuilder = $filter->apply($this->getSubscribersQueryBuilder(), $filterEntity);
+    $statement = $queryBuilder->execute();
+    $results = $statement instanceof Statement ? $statement->fetchAllAssociative() : [];
+    $emails = array_map(function($row) {
+      $subscriber = $this->entityManager->find(SubscriberEntity::class, $row['inner_subscriber_id']);
+      if (!$subscriber instanceof SubscriberEntity) {
+        throw new \Exception('this is for PhpStan');
+      }
+      return $subscriber->getEmail();
+    }, $results);
+
+    return $emails;
+  }
+
+  public function getSubscribersQueryBuilder(): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select("DISTINCT $subscribersTable.id as inner_subscriber_id")
+      ->from($subscribersTable);
   }
 
   public function cleanup() {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
@@ -3,18 +3,14 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class EmailActionClickAnyTest extends \MailPoetTest {
   /** @var EmailActionClickAny */
@@ -71,37 +67,17 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     $this->addClickedToLink('[link:newsletter_view_in_browser_url]', $this->newsletter, $subscriberClickedExcludedLinks);
     $this->addClickedToLink('[link:subscription_manage_url]', $this->newsletter, $subscriberClickedExcludedLinks);
 
-    $segmentFilter = $this->getSegmentFilter(EmailActionClickAny::TYPE);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
+    $data = $this->getSegmentFilterData(EmailActionClickAny::TYPE);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($data, $this->emailAction);
+    expect($emails)->count(1);
+    expect($emails[0])->equals('opened_clicked@example.com');
   }
 
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(string $action, int $newsletterId = null, int $linkId = null): DynamicSegmentFilterEntity {
-    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
+  private function getSegmentFilterData(string $action, int $newsletterId = null, int $linkId = null): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'newsletter_id' => $newsletterId,
       'link_id' => $linkId,
     ]);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 
   private function createSubscriber(string $email): SubscriberEntity {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -3,19 +3,15 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class EmailActionTest extends \MailPoetTest {
   /** @var EmailAction */
@@ -104,93 +100,56 @@ class EmailActionTest extends \MailPoetTest {
   }
 
   public function testGetOpened(): void {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_OPENED, [
       'newsletters' => [$this->newsletter->getId()],
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(2);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
-    expect($subscriber2->getEmail())->equals('opened_not_clicked@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com', 'opened_not_clicked@example.com'], $emails);
   }
 
   public function testGetOpenedOperatorAny(): void {
-    $segmentFilter = $this->getSegmentFilter(
+    $segmentFilterData = $this->getSegmentFilterData(
       EmailAction::ACTION_OPENED,
       [
         'newsletters' => [(int)$this->newsletter->getId(), (int)$this->newsletter2->getId()],
         'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       ]
     );
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(4);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
-    $subscriber4 = $this->entityManager->find(SubscriberEntity::class, $result[3]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber4);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
-    expect($subscriber2->getEmail())->equals('opened_not_clicked@example.com');
-    expect($subscriber3->getEmail())->equals('opened_not_clicked2@example.com');
-    expect($subscriber4->getEmail())->equals('opened_not_clicked4@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com', 'opened_not_clicked@example.com', 'opened_not_clicked2@example.com', 'opened_not_clicked4@example.com'], $emails);
   }
 
   public function testGetOpenedOperatorAll(): void {
-    $segmentFilter = $this->getSegmentFilter(
+    $segmentFilterData = $this->getSegmentFilterData(
       EmailAction::ACTION_OPENED,
       [
         'newsletters' => [(int)$this->newsletter2->getId(), (int)$this->newsletter3->getId()],
         'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
       ]
     );
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(1);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_not_clicked4@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_not_clicked4@example.com'], $emails);
   }
 
   public function testGetOpenedOperatorNone(): void {
-    $segmentFilter = $this->getSegmentFilter(
+    $segmentFilterData = $this->getSegmentFilterData(
       EmailAction::ACTION_OPENED,
       [
         'newsletters' => [(int)$this->newsletter->getId()],
         'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
       ]
     );
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(1);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('not_opened@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['not_opened@example.com'], $emails);
   }
 
   public function testGetClickedWithoutSavedLinks(): void {
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(1);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com'], $emails);
   }
 
   public function testGetClickedWithAnyOfLinks(): void {
@@ -198,18 +157,13 @@ class EmailActionTest extends \MailPoetTest {
     $link1 = $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
     $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $subscriberClickedOther); // id 2
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [$link1->getId(), $link2->getId()],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(2);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com', 'second_click@example.com'], $emails);
   }
 
   public function testGetClickedWithAllOfLinks(): void {
@@ -218,19 +172,13 @@ class EmailActionTest extends \MailPoetTest {
     $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked);
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
     $this->addClickToLink($link2, $subscriberClickedOther);
-
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [$link1->getId(), $link2->getId()],
       'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(1); // Only $this->subscriberOpenedClicked clicked all
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com'], $emails);
   }
 
   public function testGetClickedWithAllOfAndNoSavedLinks(): void {
@@ -239,69 +187,45 @@ class EmailActionTest extends \MailPoetTest {
     $link2 = $this->createClickedLink('http://example2.com', $this->newsletter, $this->subscriberOpenedClicked);
     $subscriberClickedOther = $this->createSubscriber('second_click@example.com');
     $this->addClickToLink($link2, $subscriberClickedOther);
-
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [],
       'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(1); // Only $this->subscriberOpenedClicked clicked all
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened_clicked@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com'], $emails);
   }
 
   public function testGetClickedWrongLink(): void {
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [2],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(0);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    expect($emails)->count(0);
   }
 
   public function testGetClickedWithNoneOfLinks(): void {
     $link = $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [$link->getId(), 2],
       'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(2);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber1->getEmail())->equals('opened_not_clicked@example.com');
-    expect($subscriber2->getEmail())->equals('not_opened@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_not_clicked@example.com', 'not_opened@example.com'], $emails);
   }
 
   public function testGetClickedWithNoneAndNoSavedLinks(): void {
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked);
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_CLICKED, [
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
       'newsletter_id' => (int)$this->newsletter->getId(),
       'link_ids' => [],
       'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
     ]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAllAssociative();
-    expect(count($result))->equals(2);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber1->getEmail())->equals('opened_not_clicked@example.com');
-    expect($subscriber2->getEmail())->equals('not_opened@example.com');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_not_clicked@example.com', 'not_opened@example.com'], $emails);
   }
 
   public function testOpensNotIncludeMachineOpens(): void {
@@ -314,11 +238,9 @@ class EmailActionTest extends \MailPoetTest {
     $open->setUserAgent($userAgent);
     $this->entityManager->flush();
 
-    $segmentFilter = $this->getSegmentFilter(EmailAction::ACTION_OPENED, ['newsletters' => [(int)$this->newsletter->getId()]]);
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->rowCount();
-    expect($result)->equals(2);
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_OPENED, ['newsletters' => [(int)$this->newsletter->getId()]]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_clicked@example.com', 'opened_not_clicked@example.com'], $emails);
   }
 
   public function testMachineOpensAny(): void {
@@ -331,17 +253,15 @@ class EmailActionTest extends \MailPoetTest {
     $open->setUserAgent($userAgent);
     $this->entityManager->flush();
 
-    $segmentFilter = $this->getSegmentFilter(
+    $segmentFilterData = $this->getSegmentFilterData(
       EmailAction::ACTION_MACHINE_OPENED,
       ['newsletters' => [
         (int)$this->newsletter->getId(),
         (int)$this->newsletter2->getId(),
       ]]
     );
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->rowCount();
-    expect($result)->equals(1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_machine@example.com'], $emails);
   }
 
   public function testMachineOpensAll(): void {
@@ -358,7 +278,7 @@ class EmailActionTest extends \MailPoetTest {
     $open2->setUserAgent($userAgent);
     $this->entityManager->flush();
 
-    $segmentFilter = $this->getSegmentFilter(
+    $segmentFilterData = $this->getSegmentFilterData(
       EmailAction::ACTION_MACHINE_OPENED,
       [
         'newsletters' => [
@@ -368,29 +288,12 @@ class EmailActionTest extends \MailPoetTest {
         'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
       ]
     );
-    $statement = $this->emailAction->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->rowCount();
-    expect($result)->equals(1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+    $this->assertEqualsCanonicalizing(['opened_machine@example.com'], $emails);
   }
 
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("DISTINCT $subscribersTable.id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(string $action, array $data): DynamicSegmentFilterEntity {
-    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, $data);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
+  private function getSegmentFilterData(string $action, array $data): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, $data);
   }
 
   private function createSubscriber(string $email): SubscriberEntity {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -3,18 +3,14 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   /** @var EmailOpensAbsoluteCountAction */
@@ -91,120 +87,47 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   }
 
   public function testGetOpened(): void {
-    $segmentFilter = $this->getSegmentFilter(2, 'more', 3);
-    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened-3-newsletters@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(2, 'more', 3);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com'], $emails);
   }
 
   public function testGetMachineOpened(): void {
-    $segmentFilter = $this->getSegmentFilter(1, 'more', 5, EmailOpensAbsoluteCountAction::MACHINE_TYPE);
-    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened-3-newsletters@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(1, 'more', 5, EmailOpensAbsoluteCountAction::MACHINE_TYPE);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com'], $emails);
   }
 
   public function testGetOpenedOld(): void {
-    $segmentFilter = $this->getSegmentFilter(2, 'more', 7);
-    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(2);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened-3-newsletters@example.com');
-    $this->assertIsArray($result[1]);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber2->getEmail())->equals('opened-old-opens@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(2, 'more', 7);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com', 'opened-old-opens@example.com'], $emails);
   }
 
   public function testGetOpenedLess(): void {
-    $segmentFilter = $this->getSegmentFilter(3, 'less', 3);
-    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(2);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('opened-less-opens@example.com');
-    $this->assertIsArray($result[1]);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber2->getEmail())->equals('opened-old-opens@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(3, 'less', 3);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-less-opens@example.com', 'opened-old-opens@example.com'], $emails);
   }
 
   public function testGetOpenedEquals(): void {
-    $segmentFilter = $this->getSegmentFilter(1, 'equals', 3);
-    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    $this->assertCount(1, $result);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame('opened-old-opens@example.com', $subscriber1->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData(1, 'equals', 3);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-old-opens@example.com'], $emails);
   }
 
   public function testGetOpenedNotEquals(): void {
-    $segmentFilter = $this->getSegmentFilter(2, 'not_equals', 3);
-    $statement = $this->action->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    $this->assertCount(2, $result);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame('opened-3-newsletters@example.com', $subscriber1->getEmail());
-    $this->assertIsArray($result[1]);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    $this->assertSame('opened-old-opens@example.com', $subscriber2->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData(2, 'not_equals', 3);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com', 'opened-old-opens@example.com'], $emails);
   }
 
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(int $opens, string $operator, int $days, string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterEntity {
-    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
+  private function getSegmentFilterData(int $opens, string $operator, int $days, string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'operator' => $operator,
       'opens' => $opens,
       'days' => $days,
     ]);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 
   private function createSubscriber(string $email): SubscriberEntity {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
@@ -4,8 +4,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 
 class SubscriberScoreTest extends \MailPoetTest {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberScoreTest.php
@@ -6,8 +6,6 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberScoreTest extends \MailPoetTest {
 
@@ -51,152 +49,45 @@ class SubscriberScoreTest extends \MailPoetTest {
   }
 
   public function testGetHigherThan(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberScore::HIGHER_THAN, '80');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12345@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(SubscriberScore::HIGHER_THAN, '80');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e12345@example.com'], $emails);
   }
 
   public function testGetLowerThan(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberScore::LOWER_THAN, '30');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(2);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1@example.com');
-
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(SubscriberScore::LOWER_THAN, '30');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com'], $emails);
   }
 
   public function testGetEquals(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberScore::EQUALS, '50');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e123@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(SubscriberScore::EQUALS, '50');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e123@example.com'], $emails);
   }
 
   public function testGetNotEquals(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberScore::NOT_EQUALS, '50');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(4);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1@example.com');
-
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12@example.com');
-
-    $this->assertIsArray($result[2]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1234@example.com');
-
-    $this->assertIsArray($result[3]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[3]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12345@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(SubscriberScore::NOT_EQUALS, '50');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com', 'e1234@example.com', 'e12345@example.com'], $emails);
   }
 
   public function testGetUnknown(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberScore::UNKNOWN, '');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e123456@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(SubscriberScore::UNKNOWN, '');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e123456@example.com'], $emails);
   }
 
   public function testGetNotUnknown(): void {
-    $segmentFilter = $this->getSegmentFilter(SubscriberScore::NOT_UNKNOWN, '');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(5);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1@example.com');
-
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12@example.com');
-
-    $this->assertIsArray($result[2]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e123@example.com');
-
-    $this->assertIsArray($result[3]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[3]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1234@example.com');
-
-    $this->assertIsArray($result[4]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[4]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12345@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(SubscriberScore::NOT_UNKNOWN, '');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com', 'e123@example.com', 'e1234@example.com', 'e12345@example.com'], $emails);
   }
 
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(string $operator, string $value): DynamicSegmentFilterEntity {
-    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberScore::TYPE, [
+  private function getSegmentFilterData(string $operator, string $value): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberScore::TYPE, [
       'operator' => $operator,
       'value' => $value,
     ]);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
@@ -8,8 +8,6 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberSegmentTest extends \MailPoetTest {
   /** @var SubscriberSegment */
@@ -51,80 +49,28 @@ class SubscriberSegmentTest extends \MailPoetTest {
   }
 
   public function testSubscribedAnyOf(): void {
-    $segmentFilter = $this->getSegmentFilter(DynamicSegmentFilterData::OPERATOR_ANY, [$this->segment1->getId(), $this->segment2->getId()]);
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
+    $segmentFilterData = $this->getSegmentFilterData(DynamicSegmentFilterData::OPERATOR_ANY, [$this->segment1->getId(), $this->segment2->getId()]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['a1@example.com', 'a2@example.com'], $emails);
 
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    expect(count($result))->equals(2);
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('a1@example.com');
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('a2@example.com');
   }
 
   public function testSubscribedAllOf(): void {
-    $segmentFilter = $this->getSegmentFilter(DynamicSegmentFilterData::OPERATOR_ALL, [$this->segment1->getId(), $this->segment2->getId()]);
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('a1@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(DynamicSegmentFilterData::OPERATOR_ALL, [$this->segment1->getId(), $this->segment2->getId()]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['a1@example.com'], $emails);
   }
 
   public function testSubscribedNoneOf(): void {
-    $segmentFilter = $this->getSegmentFilter(DynamicSegmentFilterData::OPERATOR_NONE, [$this->segment1->getId()]);
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    expect(count($result))->equals(2);
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('a2@example.com');
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('a3@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(DynamicSegmentFilterData::OPERATOR_NONE, [$this->segment1->getId()]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['a2@example.com', 'a3@example.com'], $emails);
   }
 
-  private function getSegmentFilter(string $operator, array $segments): DynamicSegmentFilterEntity {
-    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberSegment::TYPE, [
+  private function getSegmentFilterData(string $operator, array $segments): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberSegment::TYPE, [
       'operator' => $operator,
       'segments' => $segments,
     ]);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
-  }
-
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("DISTINCT $subscribersTable.id")
-      ->from($subscribersTable);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -7,8 +7,6 @@ use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberSubscribedDateTest extends \MailPoetTest {
 
@@ -46,145 +44,45 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
   }
 
   public function testGetBefore(): void {
-    $segmentFilter = $this->getSegmentFilter('before', CarbonImmutable::now()->subDays(3)->format('Y-m-d'));
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(1);
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12345@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('before', CarbonImmutable::now()->subDays(3)->format('Y-m-d'));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e12345@example.com'], $emails);
   }
 
   public function testGetAfter(): void {
-    $segmentFilter = $this->getSegmentFilter('after', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(2);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1@example.com');
-
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('after', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com'], $emails);
   }
 
   public function testGetOn(): void {
-    $segmentFilter = $this->getSegmentFilter('on', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    $this->assertCount(1, $result);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    $this->assertSame('e123@example.com', $subscriber->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData('on', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e123@example.com'], $emails);
   }
 
   public function testGetNotOn(): void {
-    $segmentFilter = $this->getSegmentFilter('notOn', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-
-    $this->assertCount(4, $result);
-
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame('e1@example.com', $subscriber1->getEmail());
-
-    $this->assertIsArray($result[1]);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    $this->assertSame('e12@example.com', $subscriber2->getEmail());
-
-    $this->assertIsArray($result[2]);
-    $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
-    $this->assertSame('e1234@example.com', $subscriber3->getEmail());
-
-    $this->assertIsArray($result[3]);
-    $subscriber4 = $this->entityManager->find(SubscriberEntity::class, $result[3]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber4);
-    $this->assertSame('e12345@example.com', $subscriber4->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData('notOn', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com', 'e1234@example.com', 'e12345@example.com'], $emails);
   }
 
   public function testGetInTheLast(): void {
-    $segmentFilter = $this->getSegmentFilter('inTheLast', '2');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(2);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1@example.com');
-
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('inTheLast', '2');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com'], $emails);
   }
 
   public function testGetNotInTheLast(): void {
-    $segmentFilter = $this->getSegmentFilter('notInTheLast', '3');
-    $statement = $this->filter->apply($this->getQueryBuilder(), $segmentFilter)
-      ->orderBy('email')
-      ->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    $result = $statement->fetchAll();
-    expect(count($result))->equals(2);
-
-    $this->assertIsArray($result[0]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e1234@example.com');
-
-    $this->assertIsArray($result[1]);
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getEmail())->equals('e12345@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('notInTheLast', '3');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1234@example.com', 'e12345@example.com'], $emails);
   }
 
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(string $operator, string $value): DynamicSegmentFilterEntity {
-    $segmentFilterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberSubscribedDate::TYPE, [
+  private function getSegmentFilterData(string $operator, string $value): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberSubscribedDate::TYPE, [
       'operator' => $operator,
       'value' => $value,
     ]);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $segmentFilterData);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Carbon\CarbonImmutable;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -3,20 +3,16 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class UserRoleTest extends \MailPoetTest {
 
   /** @var UserRole */
-  private $userRole;
+  private $userRoleFilter;
 
   public function _before(): void {
     global $wpdb;
-    $this->userRole = $this->diContainer->get(UserRole::class);
+    $this->userRoleFilter = $this->diContainer->get(UserRole::class);
     $this->cleanup();
     // Insert WP users and subscribers are created automatically
     $this->tester->createWordPressUser('user-role-test1@example.com', 'editor');
@@ -34,95 +30,48 @@ class UserRoleTest extends \MailPoetTest {
   }
 
   public function testItAppliesFilter(): void {
-    $segmentFilter = $this->getSegmentFilter('editor');
-    $result = $this->applyFilter($this->userRole, $this->getQueryBuilder(), $segmentFilter);
-    expect(count($result))->equals(2);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber1->getEmail())->equals('user-role-test1@example.com');
-    expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('editor');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->userRoleFilter);
+    $this->assertEqualsCanonicalizing(['user-role-test1@example.com', 'user-role-test3@example.com'], $emails);
   }
 
   public function testItAppliesFilterAny(): void {
-    $segmentFilter = $this->getSegmentFilter(['editor', 'author']);
-    $result = $this->applyFilter($this->userRole, $this->getQueryBuilder(), $segmentFilter);
-    expect(count($result))->equals(3);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    $subscriber3 = $this->entityManager->find(SubscriberEntity::class, $result[2]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
-    expect($subscriber1->getEmail())->equals('user-role-test1@example.com');
-    expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
-    expect($subscriber3->getEmail())->equals('user-role-test4@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(['editor', 'author']);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->userRoleFilter);
+    $this->assertEqualsCanonicalizing(['user-role-test1@example.com', 'user-role-test3@example.com', 'user-role-test4@example.com'], $emails);
   }
 
   public function testItAppliesFilterNone(): void {
-    $segmentFilter = $this->getSegmentFilter(['administrator', 'author', 'subscriber'], DynamicSegmentFilterData::OPERATOR_NONE);
-    $result = $this->applyFilter($this->userRole, $this->getQueryBuilder(), $segmentFilter);
-    expect(count($result))->equals(2);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber1->getEmail())->equals('user-role-test1@example.com');
-    expect($subscriber2->getEmail())->equals('user-role-test3@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(['administrator', 'author', 'subscriber'], DynamicSegmentFilterData::OPERATOR_NONE);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->userRoleFilter);
+    $this->assertEqualsCanonicalizing(['user-role-test1@example.com', 'user-role-test3@example.com'], $emails);
   }
 
   public function testItAppliesFilterAll(): void {
-    $segmentFilter = $this->getSegmentFilter(['subscriber', 'merchant'], DynamicSegmentFilterData::OPERATOR_ALL);
-    $result = $this->applyFilter($this->userRole, $this->getQueryBuilder(), $segmentFilter);
-    expect(count($result))->equals(1);
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1->getEmail())->equals('user-role-test5@example.com');
+    $segmentFilterData = $this->getSegmentFilterData(['subscriber', 'merchant'], DynamicSegmentFilterData::OPERATOR_ALL);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->userRoleFilter);
+    $this->assertEqualsCanonicalizing(['user-role-test5@example.com'], $emails);
   }
 
   public function testItDoesntGetSubString(): void {
-    $segmentFilter = $this->getSegmentFilter('edit');
-    $result = $this->applyFilter($this->userRole, $this->getQueryBuilder(), $segmentFilter);
-    expect(count($result))->equals(0);
-  }
-
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->orderBy('email')
-      ->select("$subscribersTable.id")
-      ->from($subscribersTable);
-  }
-
-  private function applyFilter(UserRole $userRole, QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $segmentFilter): array {
-    $queryBuilder = $userRole->apply($queryBuilder, $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    return $statement->fetchAll();
+    $segmentFilterData = $this->getSegmentFilterData('edit');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->userRoleFilter);
+    expect($emails)->count(0);
   }
 
   /**
    * @param string[]|string $role
-   * @param string $operator
-   * @return DynamicSegmentFilterEntity
+   * @param string|null $operator
+   * @return DynamicSegmentFilterData
    */
-  private function getSegmentFilter($role, $operator = null): DynamicSegmentFilterEntity {
+  private function getSegmentFilterData($role, string $operator = null): DynamicSegmentFilterData {
     $filterData = [
       'wordpressRole' => $role,
     ];
     if ($operator) {
       $filterData['operator'] = $operator;
     }
-    $data = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, $filterData);
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, $filterData);
   }
 
   public function _after(): void {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\SubscriberEntity;
 
 class UserRoleTest extends \MailPoetTest {
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 require_once(ABSPATH . 'wp-admin/includes/taxonomy.php');
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -5,20 +5,17 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 require_once(ABSPATH . 'wp-admin/includes/taxonomy.php');
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @group woo
  */
 class WooCommerceCategoryTest extends \MailPoetTest {
   /** @var WooCommerceCategory */
-  private $wooCommerceCategory;
+  private $wooCommerceCategoryFilter;
 
   /** @var SubscribersRepository */
   private $subscribersRepository;
@@ -33,7 +30,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   private $categoryIds;
 
   public function _before(): void {
-    $this->wooCommerceCategory = $this->diContainer->get(WooCommerceCategory::class);
+    $this->wooCommerceCategoryFilter = $this->diContainer->get(WooCommerceCategory::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
 
     $this->cleanUp();
@@ -64,14 +61,9 @@ class WooCommerceCategoryTest extends \MailPoetTest {
 
   public function testItGetsSubscribersThatPurchasedProductsInAnyCategory(): void {
     $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
-    $segmentFilter = $this->getSegmentFilter($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ANY);
-    $queryBuilder = $this->wooCommerceCategory->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(2, count($result));
-    $emails = array_map([$this, 'getSubscriberEmail'], $result);
-    sort($emails, SORT_STRING);
-    $this->assertSame($expectedEmails, $emails);
+    $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ANY);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
   public function testItGetsSubscribersThatDidNotPurchasedProducts(): void {
@@ -82,64 +74,32 @@ class WooCommerceCategoryTest extends \MailPoetTest {
       'customer-pending-payment@example.com',
       'customer2@example.com',
     ];
-    $segmentFilter = $this->getSegmentFilter([$this->categoryIds[0]], DynamicSegmentFilterData::OPERATOR_NONE);
-    $queryBuilder = $this->wooCommerceCategory->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(count($expectedEmails), count($result));
-    $emails = array_map([$this, 'getSubscriberEmail'], $result);
-    sort($emails, SORT_STRING);
-    $this->assertSame($expectedEmails, $emails);
+    $segmentFilterData = $this->getSegmentFilterData([$this->categoryIds[0]], DynamicSegmentFilterData::OPERATOR_NONE);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
   public function testItGetsSubscribersThatPurchasedAllProducts(): void {
-    $segmentFilter = $this->getSegmentFilter($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
-    $queryBuilder = $this->wooCommerceCategory->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(0, count($result));
-
+    $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
+    expect($emails)->count(0);
     $expectedEmails = ['customer1@example.com'];
-    $segmentFilter = $this->getSegmentFilter([$this->categoryIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
-    $queryBuilder = $this->wooCommerceCategory->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(1, count($result));
-    $emails = array_map([$this, 'getSubscriberEmail'], $result);
-    $this->assertSame($expectedEmails, $emails);
+    $segmentFilterData = $this->getSegmentFilterData([$this->categoryIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  private function getSubscriberEmail(array $value): string {
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $value['inner_subscriber_id']);
-    return $subscriber instanceof SubscriberEntity ? $subscriber->getEmail() : '';
-  }
-
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id as inner_subscriber_id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(array $categoryIds, string $operator): DynamicSegmentFilterEntity {
+  private function getSegmentFilterData(array $categoryIds, string $operator): DynamicSegmentFilterData {
     $filterData = [
       'category_ids' => $categoryIds,
       'operator' => $operator,
     ];
 
-    $data = new DynamicSegmentFilterData(
+    return new DynamicSegmentFilterData(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       WooCommerceCategory::ACTION_CATEGORY,
       $filterData
     );
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 
   private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -66,7 +66,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  public function testItGetsSubscribersThatDidNotPurchasedProducts(): void {
+  public function testItGetsSubscribersThatDidNotPurchaseProducts(): void {
     $expectedEmails = [
       'a1@example.com',
       'a2@example.com',

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -4,8 +4,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
 
 /**
  * @group woo

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -70,47 +70,6 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing([$createdSub->getEmail()], $emails);
   }
 
-  /**
-   * @dataProvider allowedStatuses
-   */
-  public function testItIncludesAllowedStatuses($status) {
-    $email = "$status@example.com";
-    $customerId = $this->tester->createCustomer($email, 'customer');
-    $this->createOrder($customerId, Carbon::now(), $status);
-    $segmentFilterData = $this->getSegmentFilterData('=', 1, 1);
-    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
-    expect($emails)->contains($email);
-  }
-
-  /**
-   * @dataProvider disallowedStatuses
-   */
-  public function testItExcludesDisallowedOrderStatuses($status) {
-    $email = "$status@example.com";
-    $customerId = $this->tester->createCustomer($email, 'customer');
-    $this->createOrder($customerId, Carbon::now(), $status);
-    $segmentFilterData = $this->getSegmentFilterData('=', 1, 1);
-    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
-    expect($emails)->notContains($email);
-  }
-
-  public function allowedStatuses() {
-    return [
-      'completed' => ['wc-completed'],
-      'processing' => ['wc-processing'],
-    ];
-  }
-
-  public function disallowedStatuses() {
-    return [
-      'refunded' => ['wc-refunded'],
-      'cancelled' => ['wc-cancelled'],
-      'on hold' => ['wc-on-hold'],
-      'pending' => ['wc-pending'],
-      'failed' => ['wc-failed'],
-    ];
-  }
-
   private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
       'number_of_orders_type' => $comparisonType,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -16,9 +16,6 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
   /** @var WooCommerceNumberOfOrders */
   private $numberOfOrdersFilter;
 
-  /** @var array */
-  private $orders;
-
   /**
    * @var SubscriberFactory
    */
@@ -33,10 +30,10 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
     $customerId3 = $this->tester->createCustomer('customer3@example.com', 'customer');
 
-    $this->orders[] = $this->createOrder($customerId1, Carbon::now()->subDays(3));
-    $this->orders[] = $this->createOrder($customerId2, Carbon::now());
-    $this->orders[] = $this->createOrder($customerId2, Carbon::now());
-    $this->orders[] = $this->createOrder($customerId3, Carbon::now());
+    $this->createOrder($customerId1, Carbon::now()->subDays(3));
+    $this->createOrder($customerId2, Carbon::now());
+    $this->createOrder($customerId2, Carbon::now());
+    $this->createOrder($customerId3, Carbon::now());
   }
 
   public function testItGetsCustomersThatPlacedTwoOrdersInTheLastDay(): void {
@@ -78,7 +75,7 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
    */
   public function testItIncludesAllowedStatuses($status) {
     $email = "$status@example.com";
-    $customerId = $this->createCustomer($email, 'customer');
+    $customerId = $this->tester->createCustomer($email, 'customer');
     $this->createOrder($customerId, Carbon::now(), $status);
     $segmentFilterData = $this->getSegmentFilterData('=', 1, 1);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
@@ -90,7 +87,7 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
    */
   public function testItExcludesDisallowedOrderStatuses($status) {
     $email = "$status@example.com";
-    $customerId = $this->createCustomer($email, 'customer');
+    $customerId = $this->tester->createCustomer($email, 'customer');
     $this->createOrder($customerId, Carbon::now(), $status);
     $segmentFilterData = $this->getSegmentFilterData('=', 1, 1);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -3,21 +3,18 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\Source;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @group woo
  */
 class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
   /** @var WooCommerceNumberOfOrders */
-  private $numberOfOrders;
+  private $numberOfOrdersFilter;
 
   /** @var array */
   private $orders;
@@ -29,7 +26,7 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
 
   public function _before(): void {
     $this->subscriberFactory = new SubscriberFactory();
-    $this->numberOfOrders = $this->diContainer->get(WooCommerceNumberOfOrders::class);
+    $this->numberOfOrdersFilter = $this->diContainer->get(WooCommerceNumberOfOrders::class);
     $this->cleanUp();
 
     $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
@@ -43,41 +40,27 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
   }
 
   public function testItGetsCustomersThatPlacedTwoOrdersInTheLastDay(): void {
-    $segmentFilter = $this->getSegmentFilter('=', 2, 1);
-    $result = $this->applyFilter($this->numberOfOrders, $this->getQueryBuilder(), $segmentFilter);
-    $this->assertSame(1, count($result));
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame('customer2@example.com', $subscriber1->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData('=', 2, 1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing(['customer2@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatPlacedZeroOrdersInTheLastDay(): void {
-    $segmentFilter = $this->getSegmentFilter('=', 0, 1);
-    $result = $this->applyFilter($this->numberOfOrders, $this->getQueryBuilder(), $segmentFilter);
-
-    $this->assertSame(1, count($result));
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame('customer1@example.com', $subscriber1->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData('=', 0, 1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatDidNotPlaceTwoOrdersInTheLastWeek(): void {
-    $segmentFilter = $this->getSegmentFilter('!=', 2, 7);
-    $result = $this->applyFilter($this->numberOfOrders, $this->getQueryBuilder(), $segmentFilter);
-
-    $this->assertSame(2, count($result));
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame('customer1@example.com', $subscriber1->getEmail());
-    $subscriber2 = $this->entityManager->find(SubscriberEntity::class, $result[1]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    $this->assertSame('customer3@example.com', $subscriber2->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData('!=', 2, 7);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer3@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatPlacedAtLeastOneOrderInTheLastWeek(): void {
-    $segmentFilter = $this->getSegmentFilter('>', 0, 7);
-    $result = $this->applyFilter($this->numberOfOrders, $this->getQueryBuilder(), $segmentFilter);
-    $this->assertSame(3, count($result));
+    $segmentFilterData = $this->getSegmentFilterData('>', 0, 7);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
   }
 
   public function testItGetsNoneCustomerSubscriberInLastDays() {
@@ -85,46 +68,17 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
       ->withSource(Source::API)
       ->withCreatedAt(Carbon::now()->subDays(5))
       ->create();
-    $segmentFilter = $this->getSegmentFilter('=', 0, 30);
-    $queryBuilder = $this->numberOfOrders->apply($this->getQueryBuilder(), $segmentFilter);
-    $compatibilityResult = $queryBuilder->execute();
-    $this->assertInstanceOf(Statement::class, $compatibilityResult);
-    $result = $compatibilityResult->fetchAllAssociative();
-    $this->assertSame(1, count($result));
-    $subscriber1 = $this->entityManager->find(SubscriberEntity::class, $result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    $this->assertSame($createdSub->getEmail(), $subscriber1->getEmail());
+    $segmentFilterData = $this->getSegmentFilterData('=', 0, 30);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing([$createdSub->getEmail()], $emails);
   }
 
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id as inner_subscriber_id")
-      ->from($subscribersTable);
-  }
-
-  private function applyFilter(WooCommerceNumberOfOrders $numberOfOrders, QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $segmentFilter): array {
-    $queryBuilder = $numberOfOrders->apply($queryBuilder, $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $this->assertInstanceOf(Statement::class, $statement);
-    return $statement->fetchAll();
-  }
-
-  private function getSegmentFilter(string $comparisonType, int $ordersCount, int $days): DynamicSegmentFilterEntity {
-    $data = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
+  private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
       'number_of_orders_type' => $comparisonType,
       'number_of_orders_count' => $ordersCount,
       'number_of_orders_days' => $days,
     ]);
-
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 
   private function createOrder(int $customerId, Carbon $createdAt, $status = 'wc-completed'): int {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\Source;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
@@ -96,9 +94,6 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
 
   private function cleanUp(): void {
     global $wpdb;
-    $this->truncateEntity(SegmentEntity::class);
-    $this->truncateEntity(SubscriberEntity::class);
-
     $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
     $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -3,20 +3,17 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @group woo
  */
 class WooCommerceProductTest extends \MailPoetTest {
   /** @var WooCommerceProduct */
-  private $wooCommerceProduct;
+  private $wooCommerceProductFilter;
 
   /** @var SubscribersRepository */
   private $subscribersRepository;
@@ -28,7 +25,7 @@ class WooCommerceProductTest extends \MailPoetTest {
   private $orderIds;
 
   public function _before(): void {
-    $this->wooCommerceProduct = $this->diContainer->get(WooCommerceProduct::class);
+    $this->wooCommerceProductFilter = $this->diContainer->get(WooCommerceProduct::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
 
     $this->cleanUp();
@@ -56,14 +53,9 @@ class WooCommerceProductTest extends \MailPoetTest {
 
   public function testItGetsSubscribersThatPurchasedAnyProducts(): void {
     $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
-    $segmentFilter = $this->getSegmentFilter($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
-    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(2, count($result));
-    $emails = array_map([$this, 'getSubscriberEmail'], $result);
-    sort($emails, SORT_STRING);
-    $this->assertSame($expectedEmails, $emails);
+    $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
   public function testItGetsSubscribersThatDidNotPurchasedProducts(): void {
@@ -74,64 +66,33 @@ class WooCommerceProductTest extends \MailPoetTest {
       'customer-pending-payment@example.com',
       'customer2@example.com',
     ];
-    $segmentFilter = $this->getSegmentFilter([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_NONE);
-    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(count($expectedEmails), count($result));
-    $emails = array_map([$this, 'getSubscriberEmail'], $result);
-    sort($emails, SORT_STRING);
-    $this->assertSame($expectedEmails, $emails);
+    $segmentFilterData = $this->getSegmentFilterData([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_NONE);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
   public function testItGetsSubscribersThatPurchasedAllProducts(): void {
-    $segmentFilter = $this->getSegmentFilter($this->productIds, DynamicSegmentFilterData::OPERATOR_ALL);
-    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(0, count($result));
+    $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ALL);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
+    expect($emails)->count(0);
 
     $expectedEmails = ['customer1@example.com'];
-    $segmentFilter = $this->getSegmentFilter([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
-    $queryBuilder = $this->wooCommerceProduct->apply($this->getQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    $this->assertSame(1, count($result));
-    $emails = array_map([$this, 'getSubscriberEmail'], $result);
-    $this->assertSame($expectedEmails, $emails);
+    $segmentFilterData = $this->getSegmentFilterData([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  private function getSubscriberEmail(array $value): string {
-    $subscriber = $this->entityManager->find(SubscriberEntity::class, $value['inner_subscriber_id']);
-    return $subscriber instanceof SubscriberEntity ? $subscriber->getEmail() : '';
-  }
-
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id as inner_subscriber_id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(array $productIds, string $operator): DynamicSegmentFilterEntity {
+  private function getSegmentFilterData(array $productIds, string $operator): DynamicSegmentFilterData {
     $filterData = [
       'product_ids' => $productIds,
       'operator' => $operator,
     ];
 
-    $data = new DynamicSegmentFilterData(
+    return new DynamicSegmentFilterData(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       WooCommerceProduct::ACTION_PRODUCT,
       $filterData
     );
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 
   private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -81,49 +81,6 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  /**
-   * @dataProvider allowedStatuses
-   */
-  public function testItIncludesAllowedStatuses($status) {
-    $email = "status-customer@example.com";
-    $customerId = $this->tester->createCustomer($email, 'customer');
-    $orderId = $this->createOrder($customerId, Carbon::now(), $status);
-    $this->addToOrder(5, $orderId, $this->productIds[0], $customerId);
-    $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
-    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
-    expect($emails)->contains($email);
-  }
-
-  /**
-   * @dataProvider disallowedStatuses
-   */
-  public function testItExcludesDisallowedOrderStatuses($status) {
-    $email = "status-customer@example.com";
-    $customerId = $this->tester->createCustomer($email, 'customer');
-    $orderId = $this->createOrder($customerId, Carbon::now(), $status);
-    $this->addToOrder(5, $orderId, $this->productIds[0], $customerId);
-    $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
-    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
-    expect($emails)->notContains($email);
-  }
-
-  public function allowedStatuses() {
-    return [
-      'completed' => ['wc-completed'],
-      'processing' => ['wc-processing'],
-    ];
-  }
-
-  public function disallowedStatuses() {
-    return [
-      'refunded' => ['wc-refunded'],
-      'cancelled' => ['wc-cancelled'],
-      'on hold' => ['wc-on-hold'],
-      'pending' => ['wc-pending'],
-      'failed' => ['wc-failed'],
-    ];
-  }
-
   private function getSegmentFilterData(array $productIds, string $operator): DynamicSegmentFilterData {
     $filterData = [
       'product_ids' => $productIds,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;
@@ -87,7 +86,7 @@ class WooCommerceProductTest extends \MailPoetTest {
    */
   public function testItIncludesAllowedStatuses($status) {
     $email = "status-customer@example.com";
-    $customerId = $this->createCustomer($email, 'customer');
+    $customerId = $this->tester->createCustomer($email, 'customer');
     $orderId = $this->createOrder($customerId, Carbon::now(), $status);
     $this->addToOrder(5, $orderId, $this->productIds[0], $customerId);
     $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
@@ -100,7 +99,7 @@ class WooCommerceProductTest extends \MailPoetTest {
    */
   public function testItExcludesDisallowedOrderStatuses($status) {
     $email = "status-customer@example.com";
-    $customerId = $this->createCustomer($email, 'customer');
+    $customerId = $this->tester->createCustomer($email, 'customer');
     $orderId = $this->createOrder($customerId, Carbon::now(), $status);
     $this->addToOrder(5, $orderId, $this->productIds[0], $customerId);
     $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -8,8 +8,6 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @group woo
@@ -138,34 +136,7 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
         'value' => $value,
       ]
     );
-    $segment = new SegmentEntity('temporary segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $filter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($filter);
-    $segment->addDynamicFilter($filter);
-
-    $queryBuilder = $this->wooCommercePurchaseDate->apply($this->getQueryBuilder(), $filter);
-    $statement = $queryBuilder->execute();
-    $results = $statement instanceof Statement ? $statement->fetchAllAssociative() : [];
-    $emails = array_map(function($row) {
-      $subscriber = $this->entityManager->find(SubscriberEntity::class, $row['id']);
-      if (!$subscriber instanceof SubscriberEntity) {
-        throw new \Exception('this is for PhpStan');
-      }
-      return $subscriber->getEmail();
-    }, $results);
-
-
-    return $emails;
-  }
-
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id")
-      ->from($subscribersTable);
+    return $this->tester->getSubscriberEmailsMatchingDynamicFilter($data, $this->wooCommercePurchaseDate);
   }
 
   private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -3,9 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoetVendor\Carbon\Carbon;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -3,13 +3,7 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\WooCommerceSubscription as WooCommerceSubscriptionFactory;
-use MailPoetVendor\Doctrine\DBAL\ForwardCompatibility\DriverStatement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @group woo
@@ -35,9 +29,12 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   private $products = [];
   /** @var WooCommerceSubscriptionFactory */
   private $subscriptionsFactory;
+  /** @var WooCommerceSubscription */
+  private $wooCommerceSubscriptionFilter;
 
   public function _before(): void {
     $this->cleanup();
+    $this->wooCommerceSubscriptionFilter = $this->diContainer->get(WooCommerceSubscription::class);
     $productId = $this->createProduct('Premium Newsletter');
     $this->subscriptionsFactory = new WooCommerceSubscriptionFactory();
     foreach (self::SUBSCRIBER_EMAILS as $email) {
@@ -49,19 +46,11 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
   }
 
   public function testAllSubscribersFoundWithOperatorAny(): void {
-    $testee = $this->diContainer->get(WooCommerceSubscription::class);
-    $queryBuilder = $this->getQueryBuilder();
-    $filter = $this->getSegmentFilter(
+    $filterData = $this->getSegmentFilterData(
       DynamicSegmentFilterData::OPERATOR_ANY
     );
-
-    $resultQuery = $testee->apply($queryBuilder, $filter);
-    $foundSubscribers = $this->getEmailsFromQueryBuilder($resultQuery);
-
-    $this->assertCount(3, $foundSubscribers, "Did not find expected three subscribers.");
-    foreach ($foundSubscribers as $email) {
-      $this->assertTrue(in_array($email, self::ACTIVE_EMAILS));
-    }
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->wooCommerceSubscriptionFilter);
+    $this->assertEqualsCanonicalizing(self::ACTIVE_EMAILS, $emails);
   }
 
   public function testAllSubscribersFoundWithOperatorNoneOf(): void {
@@ -70,19 +59,13 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     $subscriberId = $this->tester->createWordPressUser($notToBeFoundEmail, "subscriber");
     $this->assertTrue(!is_wp_error($subscriberId), "User could not be created $notToBeFoundEmail");
     $this->subscriptionsFactory->createSubscription($subscriberId, $productId);
-    $testee = $this->diContainer->get(WooCommerceSubscription::class);
-    $queryBuilder = $this->getQueryBuilder();
-    $filter = $this->getSegmentFilter(
+    $filterData = $this->getSegmentFilterData(
       DynamicSegmentFilterData::OPERATOR_NONE,
       [$productId]
     );
-
-    $resultQuery = $testee->apply($queryBuilder, $filter);
-
-    $foundSubscribers = $this->getEmailsFromQueryBuilder($resultQuery);
-
-    $this->assertCount(3, $foundSubscribers);
-    $this->assertFalse(in_array($notToBeFoundEmail, $foundSubscribers));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->wooCommerceSubscriptionFilter);
+    expect($emails)->count(3);
+    expect(in_array($notToBeFoundEmail, $emails))->false();
     $this->tester->deleteWordPressUser($notToBeFoundEmail);
   }
 
@@ -100,41 +83,14 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     foreach ($this->products as $productId) {
       $this->subscriptionsFactory->createSubscription($toBeFoundSubscriberId, $productId);
     }
-    $testee = $this->diContainer->get(WooCommerceSubscription::class);
-    $queryBuilder = $this->getQueryBuilder();
-    $filter = $this->getSegmentFilter(
+    $filterData = $this->getSegmentFilterData(
       DynamicSegmentFilterData::OPERATOR_ALL,
       $this->products
     );
-
-    $resultQuery = $testee->apply($queryBuilder, $filter);
-
-    $foundSubscribers = $this->getEmailsFromQueryBuilder($resultQuery);
-
-    $this->assertCount(1, $foundSubscribers);
-    $this->assertTrue(in_array($toBeFoundEmail, $foundSubscribers));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->wooCommerceSubscriptionFilter);
+    $this->assertEqualsCanonicalizing([$toBeFoundEmail], $emails);
     $this->tester->deleteWordPressUser($notToBeFoundEmail);
     $this->tester->deleteWordPressUser($toBeFoundEmail);
-  }
-
-  private function getEmailsFromQueryBuilder(QueryBuilder $builder): array {
-
-    $repository = $this->diContainer->get(SubscribersRepository::class);
-    $statement = $builder->execute();
-    if (!$statement instanceof DriverStatement) {
-      throw new \RuntimeException("Could not create statement.");
-    }
-    $data = $statement->fetchAllAssociative();
-    return array_map(
-      function(array $data) use ($repository): ?string {
-        /**
-         * @var SubscriberEntity|null $subscriber
-         */
-        $subscriber = $repository->findOneById($data['id']);
-        return $subscriber ? $subscriber->getEmail() : null;
-      },
-      $data
-    );
   }
 
   private function createProduct(string $name): int {
@@ -148,32 +104,17 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     return (int)$productId;
   }
 
-  private function getSegmentFilter(string $operator, array $productIds = null): DynamicSegmentFilterEntity {
+  private function getSegmentFilterData(string $operator, array $productIds = null): DynamicSegmentFilterData {
     $filterData = [
       'operator' => $operator,
-      'product_ids' => $productIds ? $productIds : $this->products,
+      'product_ids' => $productIds ?: $this->products,
     ];
 
-    $data = new DynamicSegmentFilterData(
+    return new DynamicSegmentFilterData(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION,
       WooCommerceSubscription::ACTION_HAS_ACTIVE,
       $filterData
     );
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
-  }
-
-  private function getQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("DISTINCT $subscribersTable.id")
-      ->from($subscribersTable);
   }
 
   public function _after(): void {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -3,34 +3,26 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
-use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @group woo
  */
 class WooCommerceTotalSpentTest extends \MailPoetTest {
   /** @var WooCommerceTotalSpent */
-  private $totalSpent;
+  private $totalSpentFilter;
 
   /** @var WPFunctions */
   private $wp;
-
-  /** @var SubscribersRepository */
-  private $subscribersRepository;
 
   /** @var int[] */
   private $orders;
 
   public function _before(): void {
-    $this->totalSpent = $this->diContainer->get(WooCommerceTotalSpent::class);
-    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->totalSpentFilter = $this->diContainer->get(WooCommerceTotalSpent::class);
     $this->wp = $this->diContainer->get(WPFunctions::class);
     $this->cleanUp();
 
@@ -45,110 +37,47 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
   }
 
   public function testItGetsCustomersThatSpentFifteenInTheLastDay(): void {
-    $segmentFilter = $this->getSegmentFilter('=', 15, 1);
-    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    expect($result)->count(1);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber1->getEmail())->equals('customer2@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('=', 15, 1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer2@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatSpentFifteenInTheLastWeek(): void {
-    $segmentFilter = $this->getSegmentFilter('=', 15, 7);
-    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    expect($result)->count(2);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber1->getEmail())->equals('customer1@example.com');
-    $this->assertIsArray($result[1]);
-    $subscriber2 = $this->subscribersRepository->findOneById($result[1]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber2)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber2->getEmail())->equals('customer2@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('=', 15, 7);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatDidNotSpendFifteenInTheLastDay(): void {
-    $segmentFilter = $this->getSegmentFilter('!=', 15, 1);
-    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    expect($result)->count(2);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber1->getEmail())->equals('customer1@example.com');
-    $this->assertIsArray($result[1]);
-    $subscriber2 = $this->subscribersRepository->findOneById($result[1]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
-    expect($subscriber2)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber2->getEmail())->equals('customer3@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('!=', 15, 1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer3@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatSpentMoreThanTwentyInTheLastDay(): void {
-    $segmentFilter = $this->getSegmentFilter('>', 20, 1);
-    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    expect($result)->count(1);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber1->getEmail())->equals('customer3@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('>', 20, 1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer3@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatSpentLessThanTenInTheLastDay(): void {
-    $segmentFilter = $this->getSegmentFilter('<', 10, 1);
-    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    expect($result)->count(1);
-    $this->assertIsArray($result[0]);
-    $subscriber1 = $this->subscribersRepository->findOneById($result[0]['inner_subscriber_id']);
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
-    expect($subscriber1)->isInstanceOf(SubscriberEntity::class);
-    expect($subscriber1->getEmail())->equals('customer1@example.com');
+    $segmentFilterData = $this->getSegmentFilterData('<', 10, 1);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com'], $emails);
   }
 
   public function testItGetsCustomersThatSpentMoreThanTenInTheLastWeek(): void {
-    $segmentFilter = $this->getSegmentFilter('>', 10, 7);
-    $queryBuilder = $this->totalSpent->apply($this->createQueryBuilder(), $segmentFilter);
-    $statement = $queryBuilder->execute();
-    $result = $statement instanceof Statement ? $statement->fetchAll() : [];
-    expect($result)->count(3);
+    $segmentFilterData = $this->getSegmentFilterData('>', 10, 7);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
   }
 
-  private function createQueryBuilder(): QueryBuilder {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    return $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder()
-      ->select("$subscribersTable.id as inner_subscriber_id")
-      ->from($subscribersTable);
-  }
-
-  private function getSegmentFilter(string $type, float $amount, int $days): DynamicSegmentFilterEntity {
-    $data = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT, [
+  private function getSegmentFilterData(string $type, float $amount, int $days): DynamicSegmentFilterData {
+    return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT, [
       'total_spent_type' => $type,
       'total_spent_amount' => $amount,
       'total_spent_days' => $days,
     ]);
-
-    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $this->entityManager->persist($segment);
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $data);
-    $this->entityManager->persist($dynamicSegmentFilter);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
-    return $dynamicSegmentFilter;
   }
 
   private function createOrder(int $customerId, Carbon $createdAt, int $orderTotal): int {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooFilterHelperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooFilterHelperTest.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Segments\DynamicSegments\Filters\WooFilterHelper;
+
+class WooFilterHelperTest extends \MailPoetTest {
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
+  public function _before() {
+    parent::_before();
+    $this->wooFilterHelper = $this->diContainer->get(WooFilterHelper::class);
+  }
+
+  /**
+   * @dataProvider allowedStatuses
+   */
+  public function testItCanJoinCustomersBasedOnPurchaseStatus($status) {
+    $customerId = $this->tester->createCustomer('customer@example.com');
+    $this->createOrder($customerId, $status);
+    $queryBuilder = $this->tester->getSubscribersQueryBuilder();
+    $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $emails = $this->tester->getSubscriberEmailsFromQueryBuilder($queryBuilder);
+    expect($emails)->contains('customer@example.com');
+  }
+
+  /**
+   * @dataProvider disallowedStatuses
+   */
+  public function testItExcludesDisallowedOrderStatuses($status) {
+    $customerId = $this->tester->createCustomer('customer@example.com');
+    $this->createOrder($customerId, $status);
+    $queryBuilder = $this->tester->getSubscribersQueryBuilder();
+    $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $emails = $this->tester->getSubscriberEmailsFromQueryBuilder($queryBuilder);
+    expect($emails)->notContains('customer@example.com');
+  }
+
+  public function testOrderStatusesCanBeOverridden() {
+    $customerId = $this->tester->createCustomer('refunded@example.com');
+    $this->createOrder($customerId, 'wc-refunded');
+    $customerId2 = $this->tester->createCustomer('completed@example.com');
+    $this->createOrder($customerId2, 'wc-completed');
+    $queryBuilder = $this->tester->getSubscribersQueryBuilder();
+    $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, ['wc-refunded']);
+    $emails = $this->tester->getSubscriberEmailsFromQueryBuilder($queryBuilder);
+    expect($emails)->contains('refunded@example.com');
+    expect($emails)->notContains('completed@example.com');
+  }
+
+  public function allowedStatuses() {
+    return [
+      'completed' => ['wc-completed'],
+      'processing' => ['wc-processing'],
+    ];
+  }
+
+  public function disallowedStatuses() {
+    return [
+      'refunded' => ['wc-refunded'],
+      'cancelled' => ['wc-cancelled'],
+      'on hold' => ['wc-on-hold'],
+      'pending' => ['wc-pending'],
+      'failed' => ['wc-failed'],
+    ];
+  }
+
+  private function createOrder(int $customerId, string $status): int {
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_status($status);
+    $order->save();
+    $this->tester->updateWooOrderStats($order->get_id());
+
+    return $order->get_id();
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooFilterHelperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooFilterHelperTest.php
@@ -4,6 +4,9 @@ namespace integration\Segments\DynamicSegments\Filters;
 
 use MailPoet\Segments\DynamicSegments\Filters\WooFilterHelper;
 
+/**
+ * @group woo
+ */
 class WooFilterHelperTest extends \MailPoetTest {
   /** @var WooFilterHelper */
   private $wooFilterHelper;

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooFilterHelperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooFilterHelperTest.php
@@ -3,6 +3,7 @@
 namespace integration\Segments\DynamicSegments\Filters;
 
 use MailPoet\Segments\DynamicSegments\Filters\WooFilterHelper;
+use MailPoetVendor\Carbon\Carbon;
 
 /**
  * @group woo
@@ -72,10 +73,19 @@ class WooFilterHelperTest extends \MailPoetTest {
   private function createOrder(int $customerId, string $status): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
+    $order->set_date_created(Carbon::now()->toDateTimeString());
     $order->set_status($status);
     $order->save();
     $this->tester->updateWooOrderStats($order->get_id());
 
     return $order->get_id();
+  }
+
+  public function _after() {
+    parent::_after();
+    global $wpdb;
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_product_lookup");
   }
 }


### PR DESCRIPTION
## Description

This PR updates all of the dynamic segment filters that look at WooCommerce orders to use the same order statuses, specifically only including completed and processing orders.

I used this as an opportunity to clean up some of the test code. There was a lot of duplication in how we were checking for emails that matched a filter before, so I extracted that logic to a helper.

## Code review notes

_N/A_

## QA notes

Please carefully test dynamic segments related to Woo. Test also combinations of multiple filters.
## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5083](https://mailpoet.atlassian.net/browse/MAILPOET-5083)

## After-merge notes

_N/A_


[MAILPOET-5083]: https://mailpoet.atlassian.net/browse/MAILPOET-5083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ