### PR TITLE
Decrease k6 nightly tests max duration to 12m and update email in test

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -54,7 +54,7 @@ let scenarios = {
     executor: 'per-vu-iterations',
     vus: 1,
     iterations: 3,
-    maxDuration: '15m',
+    maxDuration: '12m',
     exec: 'nightly',
   },
 };

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -36,7 +36,9 @@ export async function subscribersAdding() {
   const page = browser.newPage();
 
   let subscriberEmail =
-    'test+' + Math.floor(Math.random() * 9999 + 1) + '@test.com';
+    'blackhole+automation' +
+    Math.floor(Math.random() * 9999 + 1) +
+    '@mailpoet.com';
 
   // Go to the page
   await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
@@ -58,7 +60,9 @@ export async function subscribersAdding() {
   await page
     .locator('[data-automation-id="add-new-subscribers-button"]')
     .click();
-  await page.locator('input[name="email"]').type(subscriberEmail);
+  await page
+    .locator('input[name="email"]')
+    .type(subscriberEmail, { delay: 25 });
   await page.locator('input[name="first_name"]').type(firstName);
   await page.locator('input[name="last_name"]').type(lastName);
   selectInSelect2(page, defaultListName);
@@ -89,7 +93,7 @@ export async function subscribersAdding() {
   });
 
   // Search for a newly added subscriber and verify
-  await page.locator('#search_input').type(subscriberEmail, { delay: 50 });
+  await page.locator('#search_input').type(subscriberEmail, { delay: 25 });
   await page.waitForSelector('.mailpoet-listing-no-items');
   await page.waitForSelector('[data-automation-id="filters_subscribed"]');
   await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Description

There is max duration time for free plan in k6 cloud and we don't need more than that so in order to let nightlytests execution we need to decrease max duration limit in test suite.

Also, speeding up typing subscriber email in test and using `blackhole+automation+randomnumber@mailpoet.com`, so we don't get banned for bounce emails if we use `@test.com`.

## Code review notes

_N/A_

## Linked tickets

[MAILPOET-5208]

[MAILPOET-5208]: https://mailpoet.atlassian.net/browse/MAILPOET-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5208]: https://mailpoet.atlassian.net/browse/MAILPOET-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ