### PR TITLE
Remove fix for lodash/underscore conflict [MAILPOET-5127]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/behaviors/MediaManagerBehavior.js
+++ b/mailpoet/assets/js/src/newsletter_editor/behaviors/MediaManagerBehavior.js
@@ -63,13 +63,6 @@ BL.MediaManagerBehavior = Marionette.Behavior.extend({
 
     MediaManager = window.wp.media.view.MediaFrame.Select.extend({
       initialize: function () {
-        /**
-         * As of importing @wordpress/i18n, and since it's using lodash, we need to reset window._ back to
-         * underscore for the media manage to work.
-         * The media manager is using _.each and changes the context using the 3 parameter, however _.each of
-         * lodash doesn't accept a third parameter.
-         */
-        window._ = _;
         window.wp.media.view.MediaFrame.prototype.initialize.apply(
           this,
           arguments,


### PR DESCRIPTION
## Description

This PR removes the workaround added for lodash/underscore conflict since the newer versions of `@wordpress/i18n` are not using lodash anymore.
Also Underscore is needed on the window object in newsletter editor, because how internally it’s used by Backbone/Marionette so [this line](https://github.com/mailpoet/mailpoet/blob/7b8dcb3fb15e52b39bb0b8fa09bd9e7d22ef36df/mailpoet/assets/js/src/newsletter_editor/App.js#L12) was not removed.

## QA notes

No QA is needed if tests pass on the CI.

## Linked PRs

[Use wordpress i 18 n in all of our codebase](https://github.com/mailpoet/mailpoet/pull/4627)

## Linked tickets

[MAILPOET-5127]

[MAILPOET-5127]: https://mailpoet.atlassian.net/browse/MAILPOET-5127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ