### PR TITLE
Force sync with customers lookup table after a change in Woo core to fix a few integration tests [MAILPOET-5148]

### DIFF
--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\DataStore as CustomersStatsDataStore;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
@@ -133,6 +134,7 @@ class WooCommerceCountryTest extends \MailPoetTest {
     $order->save();
     // Force sync to lookup table
     OrdersStatsDataStore::sync_order($order->get_id());
+    CustomersStatsDataStore::sync_order_customer($order->get_id());
   }
 
   private function cleanUpLookUpTables(): void {


### PR DESCRIPTION
## Description

An unintentional side-effect in Woo core < 7.6 synched the customer lookup table immediately after the creation of an order. This unintentional behavior was removed in Woo 7.6, and now we need to call \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::sync_order_customer() explicitly for Woo to add to the customer lookup table.

Without this change, a few tests in WooCommerceCountryTest failed when running with Woo 7.6. As far as I could check, this change does not affect anything else in MP other than the tests.

Here is the link to the CircleCI build where the tests failed due to the change in Woo 7.6:

https://app.circleci.com/pipelines/github/mailpoet/mailpoet/13934

And here there is more context about the change in Woo:

p1680718833523789-slack-C0E1AV8T0

## Code review notes

_N/A_

## QA notes

I don't think QA is needed for this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5148]

## After-merge notes

_N/A_

[MAILPOET-5148]: https://mailpoet.atlassian.net/browse/MAILPOET-5148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5148]: https://mailpoet.atlassian.net/browse/MAILPOET-5148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ