### PR TITLE
Change 'score' label to 'engagement score' [MAILPOET-4995]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_opitions.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber_opitions.ts
@@ -3,13 +3,13 @@ import { SegmentTypes, SubscriberActionTypes } from '../types';
 
 export const SubscriberSegmentOptions = [
   {
-    value: SubscriberActionTypes.MAILPOET_CUSTOM_FIELD,
-    label: MailPoet.I18n.t('mailpoetCustomField'),
+    value: SubscriberActionTypes.SUBSCRIBER_SCORE,
+    label: MailPoet.I18n.t('subscriberScore'),
     group: SegmentTypes.WordPressRole,
   },
   {
-    value: SubscriberActionTypes.SUBSCRIBER_SCORE,
-    label: MailPoet.I18n.t('subscriberScore'),
+    value: SubscriberActionTypes.MAILPOET_CUSTOM_FIELD,
+    label: MailPoet.I18n.t('mailpoetCustomField'),
     group: SegmentTypes.WordPressRole,
   },
   {

--- a/mailpoet/tests/acceptance/Segments/CreateSubscriberScoreSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSubscriberScoreSegmentCest.php
@@ -29,7 +29,7 @@ class CreateSubscriberScoreSegmentCest {
     $segmentTitle = 'Subscriber score segment';
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], 'description');
-    $i->selectOptionInReactSelect('score', '[data-automation-id="select-segment-action"]');
+    $i->selectOptionInReactSelect('engagement score', '[data-automation-id="select-segment-action"]');
     $i->waitForElementVisible('[data-automation-id="segment-subscriber-score-operator"]');
     $i->selectOption('[data-automation-id="segment-subscriber-score-operator"]', 'lower than');
     $i->fillField('[data-automation-id="segment-subscriber-score-value"]', '20.51');
@@ -69,7 +69,7 @@ class CreateSubscriberScoreSegmentCest {
     $segmentTitle = 'Subscriber unknown score segment';
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], 'description');
-    $i->selectOptionInReactSelect('score', '[data-automation-id="select-segment-action"]');
+    $i->selectOptionInReactSelect('engagement score', '[data-automation-id="select-segment-action"]');
     $i->waitForElementVisible('[data-automation-id="segment-subscriber-score-operator"]');
     $i->selectOption('[data-automation-id="segment-subscriber-score-operator"]', 'unknown');
     $i->dontSeeElement('[data-automation-id="segment-subscriber-score-value"]');

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -174,7 +174,7 @@
     'segmentsTipText': __('segments allow you to group your subscribers by other criteria, such as events and actions.'),
     'segmentsTipLink': __('Read more.'),
     'subscribedDate': __('subscribed date'),
-    'subscriberScore': _x('score', 'Subscriber engagement score'),
+    'subscriberScore': _x('engagement score', 'Subscriber engagement score'),
     'subscriberScorePlaceholder': _x('score', 'Placeholder for input: subscriber engagement score'),
     'subscriberScoreSentence': _x('{condition} {score} %', 'The result will be "higher than 20 %"'),
     'subscribedToList': __('subscribed to list'),


### PR DESCRIPTION
[MAILPOET-4995](https://mailpoet.atlassian.net/browse/MAILPOET-4995)

## Description

This changes the 'score' label to 'engagement score' when creating a segment.

Before:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/8656640/231273337-4767e95c-ffd7-4c28-8ef7-83508fc419e1.png">


After:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/8656640/231273391-4727c3b4-842f-424b-a412-8869c433b74a.png">


## Code review notes
I decided not to update the placeholder text because "engagement score" would get cut off with the input at its current size and I didn't want to change the size just for the placeholder text. It also seems fine to use "score" as a shorthand since the label itself has the full string. Please let me know if you disagree with this approach or can think of any potential issues.

I updated the existing translation instead of adding a new one. Could that cause any problems with sites running in other languages?

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_


[MAILPOET-4995]: https://mailpoet.atlassian.net/browse/MAILPOET-4995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ