### PR TITLE
Fix issues related to purchase date filter [MAILPOET-5220]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/date_fields.tsx
@@ -144,7 +144,7 @@ export function DateFields({ filterIndex }: Props): JSX.Element {
   );
 }
 
-export function dateFieldValidator(formItems: DateFormItem): boolean {
+export function validateDateField(formItems: DateFormItem): boolean {
   if (!formItems.operator || !formItems.value) {
     return false;
   }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -7,7 +7,7 @@ import {
   SubscriberScoreFields,
   validateSubscriberScore,
 } from './subscriber_score';
-import { DateFields, dateFieldValidator, DateOperator } from './date_fields';
+import { DateFields, DateOperator, validateDateField } from './date_fields';
 import {
   MailPoetCustomFields,
   validateMailPoetCustomField,
@@ -46,7 +46,7 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
   if (
     Object.values(DateOperator).includes(formItems.operator as DateOperator)
   ) {
-    return dateFieldValidator(formItems);
+    return validateDateField(formItems);
   }
   return false;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -15,7 +15,7 @@ import {
   WindowWooCommerceCountries,
   WooCommerceFormItem,
 } from '../types';
-import { DateFields, DateOperator, validateDateField } from './date_fields';
+import { DateFields, validateDateField } from './date_fields';
 import { storeName } from '../store';
 import {
   actionTypesWithDefaultTypeAny,
@@ -75,17 +75,15 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
     return false;
   }
   if (
-    Object.values(DateOperator).includes(formItems.operator as DateOperator)
-  ) {
-    return validateDateField(formItems);
-  }
-  if (
     formItems.action === WooCommerceActionTypes.SINGLE_ORDER_VALUE &&
     (!formItems.single_order_value_amount ||
       !formItems.single_order_value_days ||
       !formItems.single_order_value_type)
   ) {
     return false;
+  }
+  if (formItems.action === WooCommerceActionTypes.PURCHASE_DATE) {
+    return validateDateField(formItems);
   }
   return true;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -136,6 +136,8 @@ export const WooCommerceFields: FunctionComponent<Props> = ({
     label: country.name,
   }));
 
+  const dateFields = DateFields({ filterIndex });
+
   let optionFields;
 
   useEffect(() => {
@@ -291,7 +293,7 @@ export const WooCommerceFields: FunctionComponent<Props> = ({
       </>
     );
   } else if (segment.action === WooCommerceActionTypes.PURCHASE_DATE) {
-    optionFields = DateFields({ filterIndex });
+    optionFields = dateFields;
   } else if (segment.action === WooCommerceActionTypes.NUMBER_OF_ORDERS) {
     optionFields = (
       <>

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -15,7 +15,7 @@ import {
   WindowWooCommerceCountries,
   WooCommerceFormItem,
 } from '../types';
-import { DateFields, dateFieldValidator, DateOperator } from './date_fields';
+import { DateFields, DateOperator, validateDateField } from './date_fields';
 import { storeName } from '../store';
 import {
   actionTypesWithDefaultTypeAny,
@@ -77,7 +77,7 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (
     Object.values(DateOperator).includes(formItems.operator as DateOperator)
   ) {
-    return dateFieldValidator(formItems);
+    return validateDateField(formItems);
   }
   if (
     formItems.action === WooCommerceActionTypes.SINGLE_ORDER_VALUE &&

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
@@ -50,11 +50,6 @@ export const WooCommerceOptions = [
   },
 ];
 
-export const actionTypesWithDefaultTypeAny: Array<string> = [
-  WooCommerceActionTypes.PURCHASED_PRODUCT,
-  WooCommerceActionTypes.PURCHASED_CATEGORY,
-];
-
 // WooCommerce Memberships
 export enum WooCommerceMembershipsActionTypes {
   MEMBER_OF = 'isMemberOf',


### PR DESCRIPTION
## Description

This PR fixes a few issues related to the new purchase date dynamic filter:

1. There should no longer be an error when switching from a purchase date filter to another woo commerce filter
2. The "single order value" filter will no longer be considered valid when it doesn't have all of its values filled in, which is currently possible when switching from "subscribed date" to "single order value".

## Code review notes

I ended up needing to do some refactoring to be able to re-use the shared `DateFields`. The original issue was coming from the fact that `DateFields` calls its own React hooks, and it was being included inside a conditional, causing `WooCommerceFields` to call a variable number of hooks inside the same function on subsequent calls. `WooCommerceFields` now operates more like `SubscriberFields` (see [here](https://github.com/mailpoet/mailpoet/blob/1ca06b615f41b9f7f95ccfd3c57c46a52dcd2677/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx#L54-L61)), which I think is better in general.

## QA notes

Please test all of the WooCommerce fields, as the refactoring could have affected any of them.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_
