### PR TITLE
Two updates to Woo versions in the CircleCI configuration file [MAILPOET-5225]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 7.4.0
+            ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,7 +847,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 6.8.0
+          woo_core_version: 7.3.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0


### PR DESCRIPTION
## Description

This PR implements the following updates on the CircleCI configuration file:

- Change [this line](https://github.com/mailpoet/mailpoet/blob/c25567ae643b026c1eadbe11c62cdd15ee03f23d/.circleci/config.yml#L182) to download the latest version of Woo instead of using a hardcoded version. This is the version of Woo that is used by default in all CircleCI build jobs unless overwritten in a particular job. This change should simply what we need to do when a new Woo version is released.

- Bump the Woo version in the acceptance_oldest job from 6.8.0 to 7.3.x which is the oldest version that we still support.

## Code review notes

_N/A_

## QA notes

I don't think QA is needed for this.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5225]

## After-merge notes

_N/A_


[MAILPOET-5225]: https://mailpoet.atlassian.net/browse/MAILPOET-5225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ