### PR TITLE
Add "was sent email" filter [MAILPOET-5004]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
@@ -43,6 +43,7 @@ const componentsMap = {
     EmailOpensAbsoluteCountFields,
   [EmailActionTypes.CLICKED]: EmailClickStatisticsFields,
   [EmailActionTypes.OPENED]: EmailOpenStatisticsFields,
+  [EmailActionTypes.WAS_SENT]: EmailOpenStatisticsFields,
   [EmailActionTypes.MACHINE_OPENED]: EmailOpenStatisticsFields,
   [EmailActionTypes.CLICKED_ANY]: null,
 };

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email_options.ts
@@ -13,6 +13,11 @@ export const EmailSegmentOptions = [
     group: SegmentTypes.Email,
   },
   {
+    value: EmailActionTypes.WAS_SENT,
+    label: MailPoet.I18n.t('emailActionWasSent'),
+    group: SegmentTypes.Email,
+  },
+  {
     value: EmailActionTypes.OPENED,
     label: MailPoet.I18n.t('emailActionOpened'),
     group: SegmentTypes.Email,

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -12,6 +12,7 @@ export enum EmailActionTypes {
   MACHINE_OPENS_ABSOLUTE_COUNT = 'machineOpensAbsoluteCount',
   OPENED = 'opened',
   MACHINE_OPENED = 'machineOpened',
+  WAS_SENT = 'wasSent',
   CLICKED = 'clicked',
   CLICKED_ANY = 'clickedAny',
 }

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -137,6 +137,7 @@
     'selectUserRolePlaceholder': __('Search user roles'),
     'selectCustomFieldPlaceholder': __('Select custom field'),
     'emailActionOpened': _x('opened', 'Dynamic segment creation: when newsletter was opened'),
+    'emailActionWasSent': _x('was sent', 'Dynamic segment creation: when newsletter was sent'),
     'emailActionMachineOpened': _x('machine-opened', 'Dynamic segment creation: list of all subscribers that opened the newsletter automatically in the background'),
     'emailActionOpensAbsoluteCount': __('# of opens'),
     'emailActionMachineOpensAbsoluteCount': __('# of machine-opens'),


### PR DESCRIPTION
## Description

This adds a "was sent" email filter to dynamic segments.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-5004](https://mailpoet.atlassian.net/browse/MAILPOET-5004)

## After-merge notes

_N/A_


[MAILPOET-5004]: https://mailpoet.atlassian.net/browse/MAILPOET-5004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ