### PR TITLE
Update texts in subscriber limit notice [MAILPOET-5203]

### DIFF
--- a/mailpoet/assets/js/src/notices/subscribers_limit_notice.tsx
+++ b/mailpoet/assets/js/src/notices/subscribers_limit_notice.tsx
@@ -28,10 +28,13 @@ function SubscribersLimitNotice(): JSX.Element {
   };
 
   const youCanDisableWpSegmentMessage = ReactStringReplace(
-    MailPoet.I18n.t('youCanDisableWPUsersList'),
+    MailPoet.I18n.t('checkHowToManageSubscribers'),
     /\[link](.*?)\[\/link]/g,
     (match) => (
-      <a key="goToSegments" href="?page=mailpoet-segments">
+      <a
+        key="checkManageSubscribers"
+        href="https://kb.mailpoet.com/article/348-subscribers-limit-for-sending-plans"
+      >
         {match}
       </a>
     ),

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -140,9 +140,9 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'freeVersionLimit': __('Our free version is limited to [subscribersLimit] subscribers.'),
   'yourPlanLimit': __('Your plan is limited to [subscribersLimit] subscribers.'),
   'youNeedToUpgrade': __('You need to upgrade now to be able to continue using MailPoet.'),
-  'youCanDisableWPUsersList': __('If you do not send emails to your WordPress Users list, you can [link]disable it[/link] to lower your number of subscribers.'),
+  'checkHowToManageSubscribers': __('Alternatively, [link]check how to manage your subscribers[/link] to keep your numbers below your plan’s limit.'),
   'upgradeNow': __('Upgrade Now'),
-  'refreshMySubscribers': __('I’ve upgraded my subscription, refresh subscriber limit'),
+  'refreshMySubscribers': __('Refresh subscriber limit'),
 
   'emailVolumeLimitNoticeTitle': __('Congratulations, you sent more than [emailVolumeLimit] emails this month!'),
   'youReachedEmailVolumeLimit': __('You have sent more emails this month than your MailPoet plan includes ([emailVolumeLimit]), and sending has been temporarily paused.'),


### PR DESCRIPTION
## Description

#### No API key message
<img width="1021" alt="Screenshot 2023-04-14 at 11 13 13" src="https://user-images.githubusercontent.com/1082140/232030748-2d046c5c-0a8d-42d1-9dbd-eea94b37a6ba.png">

#### Message with API key
<img width="1014" alt="Screenshot 2023-04-14 at 11 11 53" src="https://user-images.githubusercontent.com/1082140/232030764-ecaf449c-f5f1-45e5-852e-80d3ee9d1963.png">


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5203]

## After-merge notes

_N/A_


[MAILPOET-5203]: https://mailpoet.atlassian.net/browse/MAILPOET-5203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ