### PR TITLE
Make sure generated empty index files contain PHP open tag [MAILPOET-5236]

### DIFF
--- a/mailpoet/build.sh
+++ b/mailpoet/build.sh
@@ -145,7 +145,7 @@ php "$(dirname "$0")"/tasks/fix-full-path-disclosure.php $plugin_name
 # Add index.php files if they don't exist to all folders
 echo '[BUILD] Adding index.php files to all project folders (to avoid directory listing disclosure)'
 find $plugin_name -type d -print0 | while read -d $'\0' dir; do
-  if [ ! -f "$dir/Index.php" ]; then
+  if [ ! -f "$dir/index.php" ] && [ ! -f "$dir/Index.php" ]; then
     echo "<?php" > "$dir/index.php"
   fi
 done

--- a/mailpoet/build.sh
+++ b/mailpoet/build.sh
@@ -132,7 +132,6 @@ rm -f $plugin_name/vendor-prefixed/egulias/email-validator/psalm*.xml
 # Copy release files.
 echo '[BUILD] Copying release files'
 cp license.txt $plugin_name
-cp index.php $plugin_name
 cp $plugin_name-cron.php $plugin_name
 cp $plugin_name.php $plugin_name
 cp mailpoet_initializer.php $plugin_name

--- a/mailpoet/build.sh
+++ b/mailpoet/build.sh
@@ -146,7 +146,7 @@ php "$(dirname "$0")"/tasks/fix-full-path-disclosure.php $plugin_name
 echo '[BUILD] Adding index.php files to all project folders (to avoid directory listing disclosure)'
 find $plugin_name -type d -print0 | while read -d $'\0' dir; do
   if [ ! -f "$dir/Index.php" ]; then
-    touch "$dir/index.php"
+    echo "<?php" > "$dir/index.php"
   fi
 done
 

--- a/mailpoet/index.php
+++ b/mailpoet/index.php
@@ -1,3 +1,0 @@
-<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
-
-// Silence is golden


### PR DESCRIPTION
## Description

This error was detected by a rule "Internal.NoCodeFound" with the following message:

No PHP code was found in this file and short open tags are not allowed by this install of PHP. This file may be using short open tags but PHP does not allow them.

## QA notes

Check that the `index.php` files in any random folders in the plugin ZIP file contain "<?php" (and nothing else).

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/711

## Linked tickets

[MAILPOET-5236]


[MAILPOET-5236]: https://mailpoet.atlassian.net/browse/MAILPOET-5236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ