### PR TITLE
Fix scheduling post notifications by minute resolution [MAILPOET-5244]

### DIFF
--- a/mailpoet/lib/Migrations/Migration_20230419_080000.php
+++ b/mailpoet/lib/Migrations/Migration_20230419_080000.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Migrator\Migration;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
+
+class Migration_20230419_080000 extends Migration {
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var PostNotificationScheduler */
+  private $postNotificationScheduler;
+
+  public function run(): void {
+    $this->newslettersRepository = $this->container->get(NewslettersRepository::class);
+    $this->postNotificationScheduler = $this->container->get(PostNotificationScheduler::class);
+    $this->fixPostNotificationScheduleTime();
+  }
+
+  /**
+   * Because we released PostNotificationScheduler that didn't schedule notifications with the minute resolution,
+   * which was added in version 4.10.0, we need to fix the scheduled time for all notifications.
+   *
+   * Ticket with bug: https://mailpoet.atlassian.net/browse/MAILPOET-5244
+   * Ticket with adding minute resolution: https://mailpoet.atlassian.net/browse/MAILPOET-4602
+   *
+   * @return void
+   */
+  private function fixPostNotificationScheduleTime() {
+    $newsletters = $this->newslettersRepository->findBy(['type' => NewsletterEntity::TYPE_NOTIFICATION]);
+    foreach ($newsletters as $newsletter) {
+      $this->postNotificationScheduler->processPostNotificationSchedule($newsletter);
+    }
+  }
+}

--- a/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
@@ -20,6 +20,7 @@ use MailPoet\WP\Posts;
 
 class PostNotificationScheduler {
 
+  const SECONDS_IN_MINUTE = 60;
   const SECONDS_IN_HOUR = 3600;
   const LAST_WEEKDAY_FORMAT = 'L';
   const INTERVAL_DAILY = 'daily';
@@ -162,7 +163,8 @@ class PostNotificationScheduler {
     $intervalType = $intervalTypeOption ? $intervalTypeOption->getValue() : null;
 
     $timeOfDayOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_TIME_OF_DAY);
-    $hour = $timeOfDayOption ? (int)$timeOfDayOption->getValue() / self::SECONDS_IN_HOUR : null;
+    $hour = $timeOfDayOption ? (int)floor((int)$timeOfDayOption->getValue() / self::SECONDS_IN_HOUR) : null;
+    $minute = $timeOfDayOption ? ((int)$timeOfDayOption->getValue() - (int)($hour * self::SECONDS_IN_HOUR)) / self::SECONDS_IN_MINUTE : null;
 
     $weekDayOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_WEEK_DAY);
     $weekDay = $weekDayOption ? $weekDayOption->getValue() : null;
@@ -176,16 +178,16 @@ class PostNotificationScheduler {
     switch ($intervalType) {
       case self::INTERVAL_IMMEDIATE:
       case self::INTERVAL_DAILY:
-        $schedule = sprintf('0 %s * * *', $hour);
+        $schedule = sprintf('%s %s * * *', $minute, $hour);
         break;
       case self::INTERVAL_WEEKLY:
-        $schedule = sprintf('0 %s * * %s', $hour, $weekDay);
+        $schedule = sprintf('%s %s * * %s', $minute, $hour, $weekDay);
         break;
       case self::INTERVAL_NTHWEEKDAY:
-        $schedule = sprintf('0 %s ? * %s%s', $hour, $weekDay, $nthWeekDay);
+        $schedule = sprintf('%s %s ? * %s%s', $minute, $hour, $weekDay, $nthWeekDay);
         break;
       case self::INTERVAL_MONTHLY:
-        $schedule = sprintf('0 %s %s * *', $hour, $monthDay);
+        $schedule = sprintf('%s %s %s * *', $minute, $hour, $monthDay);
         break;
       case self::INTERVAL_IMMEDIATELY:
       default:


### PR DESCRIPTION
## Description

I recently allowed scheduling emails with the minute resolution, but I overlooked a logic in the PostNotificationScheduler class. This PR extends integration tests and also adds support for the minute resolution in the mentioned class.

## Code review notes

The third commit adds a migration that fixes the invalid value of the scheduled time for already existing post notifications. Nevertheless, it does not create a new record in the scheduled tasks.

## QA notes

1. Create a post notification on the trunk
2. Install the fixed build
3. Verify that migrations were executed (The migrations table contains a record with the name `Migration_20230419_080000`)
4. Update or create a new post and check that newsletter was scheduled properly

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/4783

## Linked tickets

[MAILPOET-5244]

## After-merge notes

_N/A_


[MAILPOET-5244]: https://mailpoet.atlassian.net/browse/MAILPOET-5244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ