### PR TITLE
Add Semgrep security scan [MAILPOET-5230]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ anchors:
       - static_analysis_php8
     <<: *only_trunk_and_release
 
+  command_add_github_key: &command_add_github_key
+    command: |
+      # Add GitHub to known_hosts (for jobs without a checkout step that need to clone repos)
+      echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> ~/.ssh/known_hosts
+
 executors:
   wpcli_php_oldest:
     <<: *default_job_config
@@ -202,10 +207,11 @@ jobs:
           at: /home/circleci
       - add_ssh_keys
       - run:
+          name: 'Add GitHub to known_hosts'
+          <<: *command_add_github_key
+      - run:
           name: 'Install Premium plugin'
           command: |
-            # Add GitHub to known_hosts because there is no checkout step in this job
-            echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> ~/.ssh/known_hosts
             git clone ${MAILPOET_PREMIUM_REPO_URL} mailpoet-premium
       - restore_cache:
           key: premium-tools-{{ checksum "mailpoet-premium/tools/install.php" }}
@@ -250,6 +256,26 @@ jobs:
       - run:
           name: 'Static analysis'
           command: ./do qa:phpstan --php-version=<< parameters.php_version >>
+  security_analysis:
+    working_directory: /home/circleci/mailpoet/mailpoet
+    machine:
+      image: ubuntu-2204:2022.10.2
+      docker_layer_caching: false
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - add_ssh_keys
+      - run:
+          name: 'Add GitHub to known_hosts'
+          <<: *command_add_github_key
+      - run:
+          name: 'Set up PHP'
+          command: |
+            sudo apt update
+            sudo apt install -y php8.1-cli
+      - run:
+          name: 'QA Security'
+          command: ./do qa:semgrep
   qa_js:
     executor: wpcli_php_latest
     working_directory: /home/circleci/mailpoet/mailpoet
@@ -693,6 +719,10 @@ workflows:
           <<: *slack-fail-post-step
           name: static_analysis_php8
           php_version: 80000
+          requires:
+            - build
+      - security_analysis:
+          <<: *slack-fail-post-step
           requires:
             - build
       - qa_js:

--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,7 @@ vendor-prefixed
 /mailpoet/temp
 /mailpoet/tests/javascript_newsletter_editor/testBundles
 /mailpoet/tests/plugins
+/mailpoet/tools/wpscan-semgrep-rules
 /mailpoet/views
 /mailpoet-premium
 /wordpress

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -725,6 +725,10 @@ class RoboFile extends \Robo\Tasks {
       ->run();
   }
 
+  public function qaSemgrep() {
+    return $this->_exec('./tools/semgrep.sh lib/ lib-3rd-party/');
+  }
+
   public function storybookBuild() {
     return $this->_exec('pnpm run build-storybook');
   }

--- a/mailpoet/lib/Form/Util/Export.php
+++ b/mailpoet/lib/Form/Util/Export.php
@@ -32,7 +32,7 @@ class Export {
           'height="100%"',
           'scrolling="no"',
           'frameborder="0"',
-          'src="' . esc_url($iframeUrl) . '"',
+          'src="' . WPFunctions::get()->escUrl($iframeUrl) . '"',
           'class="mailpoet_form_iframe"',
           'id="mailpoet_form_iframe"',
           'vspace="0"',

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -81,7 +81,7 @@ class Functions {
   }
 
   public function addQueryArg($key, $value = false, $url = false) {
-    return add_query_arg($key, $value, $url);
+    return add_query_arg($key, $value, $url); // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.xss.query-arg
   }
 
   public function addScreenOption($option, $args = []) {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -701,6 +701,7 @@ class Functions {
     require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
     require_once ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
     require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';
+    // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.arbitrary-plugin-install
     $upgrader = new Plugin_Upgrader(new WP_Ajax_Upgrader_Skin());
     return $upgrader->install($package, $args);
   }

--- a/mailpoet/tools/.gitignore
+++ b/mailpoet/tools/.gitignore
@@ -1,0 +1,1 @@
+wpscan-semgrep-rules

--- a/mailpoet/tools/semgrep.sh
+++ b/mailpoet/tools/semgrep.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Save our starting location, so we can jump back there later.
+scriptdirectory=${PWD}
+rulesdirectory='tools/wpscan-semgrep-rules'
+
+# Make sure we have a copy of WPScan's Semgrep rules.
+if [ ! -d $scriptdirectory/$rulesdirectory ]
+    then
+        echo "Cloning WPScan's Semgrep rules repository..."
+        git clone git@github.com:Automattic/wpscan-semgrep-rules.git $scriptdirectory/$rulesdirectory
+fi
+
+# Run Semgrep
+docker run --rm -v "${scriptdirectory}:/src" returntocorp/semgrep semgrep --error --text --metrics=off -c "/src/${rulesdirectory}/audit" $@

--- a/mailpoet/tools/semgrep.sh
+++ b/mailpoet/tools/semgrep.sh
@@ -8,7 +8,7 @@ rulesdirectory='tools/wpscan-semgrep-rules'
 if [ ! -d $scriptdirectory/$rulesdirectory ]
     then
         echo "Cloning WPScan's Semgrep rules repository..."
-        git clone git@github.com:Automattic/wpscan-semgrep-rules.git $scriptdirectory/$rulesdirectory
+        git clone --depth=1 git@github.com:Automattic/wpscan-semgrep-rules.git $scriptdirectory/$rulesdirectory
 fi
 
 # Run Semgrep


### PR DESCRIPTION
## Description

This PR does two things:
1. Adds a Semgrep security check to our CI build (and a `./do qa:semgrep` command for local use). Requires Docker to be running. [Sample run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/14045/workflows/e32df982-5229-4425-990a-600a43285ee8/jobs/238445);
2. Ignores two issues found by Semgrep as false positives:
    - `Potential Unsafe usage (non escaped) of remove_query_arg() or
  add_query_arg()`. It was complaining about a wrapped WP function which is not doing anything unsafe by itself. I manually checked all use cases of `->addQueryArg()` and found them to be escaped or used in a safe context. This points to a larger issue with Semgrep checking our plugin: since we use wrapped WP functions, they do not get scanned all over the codebase. Should we keep it as-is, add and maintain a MailPoet-specific rule set with camel cased WP functions, unwrap WP functions (replace CamelCase back to snake_case) specifically for this job as suggested by @JanJakes, or do something else?
    - `Potential unsafe usage of Plugin_Upgrader()->install()`. We are not using it to download arbitrary plugins, only `mailpoet-premum`.
    
P.S.: It seems ignoring Semgrep errors instead of fixing will be common, because it doesn't understand usage context. It sees a function being called with a variable argument and result not escaped on the same line - it throws a complaint.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/715

## Linked tickets

[MAILPOET-5230]

## After-merge notes

_N/A_


[MAILPOET-5230]: https://mailpoet.atlassian.net/browse/MAILPOET-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ