### PR TITLE
Fix usage of wp_set_current_user

### DIFF
--- a/mailpoet/lib/Newsletter/AutomatedLatestContent.php
+++ b/mailpoet/lib/Newsletter/AutomatedLatestContent.php
@@ -49,7 +49,8 @@ class AutomatedLatestContent {
     $this->newsletterId = $query->newsletterId;
     // Get posts as logged out user, so private posts hidden by other plugins (e.g. UAM) are also excluded
     $currentUserId = $this->wp->getCurrentUserId();
-    $this->wp->wpSetCurrentUser(0);
+    // phpcs:ignore Generic.PHP.ForbiddenFunctions.Discouraged
+    wp_set_current_user(0);
 
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
       'loading automated latest content',
@@ -75,7 +76,8 @@ class AutomatedLatestContent {
 
     $this->wp->removeAction('pre_get_posts', [$this, 'ensureConsistentQueryType'], $filterPriority);
     $this->_detachSentPostsFilter($query->newsletterId);
-    $this->wp->wpSetCurrentUser($currentUserId);
+    // phpcs:ignore Generic.PHP.ForbiddenFunctions.Discouraged
+    wp_set_current_user($currentUserId);
     return $posts;
   }
 

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -599,10 +599,6 @@ class Functions {
     return wp_safe_redirect($location, $status);
   }
 
-  public function wpSetCurrentUser($id, $name = '') {
-    return wp_set_current_user($id, $name);
-  }
-
   public function wpStaticizeEmoji($text) {
     return wp_staticize_emoji($text);
   }

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
@@ -137,7 +137,7 @@ class AutomatedLatestContentAPITest extends \MailPoetTest {
 
     $user->add_role($role);
 
-    $this->wp->wpSetCurrentUser($user->ID);
+    wp_set_current_user($user->ID);
     $this->createdUsers[] = $user;
 
     return $user;

--- a/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
@@ -48,7 +48,7 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
 
   public function testItUpdatesPageViewCookieAndSubscriberEngagement() {
     $this->diContainer->get(SettingsController::class)->set('tracking.level', TrackingConfig::LEVEL_FULL);
-    $this->wp->wpSetCurrentUser(0);
+    wp_set_current_user(0);
     $subscriber = $this->createSubscriber();
     $oldEngagementTime = Carbon::now()->subMinutes(2);
     $subscriber->setLastEngagementAt($oldEngagementTime);
@@ -72,7 +72,7 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
     };
     $this->tracker->registerCallback('mailpoet_test', $callback);
     $this->diContainer->get(SettingsController::class)->set('tracking.level', TrackingConfig::LEVEL_FULL);
-    $this->wp->wpSetCurrentUser(0);
+    wp_set_current_user(0);
     $subscriber = $this->createSubscriber();
     $oldEngagementTime = Carbon::now()->subMinutes(2);
     $subscriber->setLastEngagementAt($oldEngagementTime);
@@ -93,7 +93,7 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
     $wpUserEmail = 'pageview_track_user@test.com';
     $this->tester->deleteWordPressUser($wpUserEmail);
     $user = (new User())->createUser('tracking_enabled', 'editor', $wpUserEmail);
-    $this->wp->wpSetCurrentUser($user->ID);
+    wp_set_current_user($user->ID);
     $oldPageViewTimestamp = $this->wp->currentTime('timestamp') - 180; // 3 minutes ago
     $this->setPageViewCookieTimestamp($oldPageViewTimestamp);
     $this->setSubscriberCookieSubscriber(null);
@@ -152,7 +152,7 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
     $wpUserEmail = 'pageview_track_user@test.com';
     $this->tester->deleteWordPressUser($wpUserEmail);
     $user = (new User())->createUser('no_tracking', 'editor', $wpUserEmail);
-    $this->wp->wpSetCurrentUser($user->ID);
+    wp_set_current_user($user->ID);
     $subscriber = $this->entityManager->getRepository(SubscriberEntity::class)->findOneBy(['wpUserId' => $user->ID]);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $subscriber->setLastEngagementAt(Carbon::now()->subMonth());
@@ -168,7 +168,7 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
 
   public function testItDoesntTrackWhenCookieTrackingIsDisabledAndThereInNoWPUser() {
     $this->diContainer->get(SettingsController::class)->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
-    $this->wp->wpSetCurrentUser(0);
+    wp_set_current_user(0);
     $result = $this->tracker->trackActivity();
     $subscriber = $this->createSubscriber();
     $oldPageViewTimestamp = $this->wp->currentTime('timestamp') - 180; // 3 minutes ago
@@ -222,6 +222,6 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
   public function _after() {
     parent::_after();
     $this->cleanUp();
-    $this->wp->wpSetCurrentUser($this->backupUserId);
+    wp_set_current_user($this->backupUserId);
   }
 }


### PR DESCRIPTION
## Description

wp_set_current_user is a discouraged function and triggers warning in the QIT

## Linked tickets

[MAILPOET-5245]



[MAILPOET-5245]: https://mailpoet.atlassian.net/browse/MAILPOET-5245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ