### PR TITLE
Return same data object on empty or null subscriber

### DIFF
--- a/mailpoet/lib/Newsletter/Url.php
+++ b/mailpoet/lib/Newsletter/Url.php
@@ -47,7 +47,7 @@ class Url {
       $newsletterId,
       $newsletterHash,
       $subscriber && $subscriber->getId() ? $subscriber->getId() : 0,
-      $subscriber ? $this->linkTokens->getToken($subscriber) : 0,
+      $subscriber && $subscriber->getId() ? $this->linkTokens->getToken($subscriber) : 0,
       $sendingQueueId,
       (int)$preview,
     ];

--- a/mailpoet/tests/integration/Newsletter/UrlTest.php
+++ b/mailpoet/tests/integration/Newsletter/UrlTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Util\Security;
+
+class UrlTest extends \MailPoetTest {
+  public function testPreviewUrlIsTheSameForNullOrEmptySubscriber() {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setSubject('some subject');
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setHash(Security::generateHash());
+    $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+
+    $urlNullSubscriber = $newsletterUrl->getViewInBrowserUrl($newsletter);
+
+    $emptySubscriber = new SubscriberEntity();
+    $urlEmptySubscriber = $newsletterUrl->getViewInBrowserUrl($newsletter, $emptySubscriber);
+
+    expect($urlNullSubscriber)->equals($urlEmptySubscriber);
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes duplicated URLs for the same newsletter when displaying an archive of newsletters that have a `Preview in browser` shortcode.
The duplicated URLs get flagged by SEO scanners as 'duplicated URL without a canonical'

## Code review notes

_N/A_

## QA notes

Testing steps:

- Create a newsletter with a template that has a preview in browser URL. Send it.
- Create an archive page
- Log out
- Open the archive page
- Click on the newsletter URL, and take note of the &data value on the URL.
- Click the link to preview in browser, check that the &data value is the same.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5248]

## After-merge notes

_N/A_


[MAILPOET-5248]: https://mailpoet.atlassian.net/browse/MAILPOET-5248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ