### PR TITLE
Use unconfirmed data for custom fields [MAILPOET-5246]

### DIFF
--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -471,6 +471,13 @@ class SubscriberEntity {
     return $this->subscriberCustomFields;
   }
 
+  public function getSubscriberCustomField(CustomFieldEntity $customField): ?SubscriberCustomFieldEntity {
+    $criteria = Criteria::create()
+      ->where(Criteria::expr()->eq('customField', $customField))
+      ->setMaxResults(1);
+    return $this->getSubscriberCustomFields()->matching($criteria)->first() ?: null;
+  }
+
   /**
    * @return Collection<int, SubscriberTagEntity>
    */

--- a/mailpoet/lib/Subscribers/SubscriberActions.php
+++ b/mailpoet/lib/Subscribers/SubscriberActions.php
@@ -77,15 +77,14 @@ class SubscriberActions {
     if (!$subscriber || !$signupConfirmationEnabled) {
       // create new subscriber or update if no confirmation is required
       $subscriber = $this->subscriberSaveController->createOrUpdate($subscriberData, $subscriber);
+      // custom fields should use the same approach as the subscriber main data that means to wait on confirmation
+      $this->subscriberSaveController->updateCustomFields($subscriberData, $subscriber);
     } else {
       // store subscriber data to be updated after confirmation
       $unconfirmedData = $this->subscriberSaveController->filterOutReservedColumns($subscriberData);
       $unconfirmedData = json_encode($unconfirmedData);
       $subscriber->setUnconfirmedData($unconfirmedData ?: null);
     }
-
-    // Update custom fields
-    $this->subscriberSaveController->updateCustomFields($subscriberData, $subscriber);
 
     // restore trashed subscriber
     if ($subscriber->getDeletedAt()) {

--- a/mailpoet/lib/Subscribers/SubscriberCustomFieldRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberCustomFieldRepository.php
@@ -25,6 +25,7 @@ class SubscriberCustomFieldRepository extends Repository {
     } else {
       $subscriberCustomField = new SubscriberCustomFieldEntity($subscriber, $customField, $value);
       $this->entityManager->persist($subscriberCustomField);
+      $subscriber->getSubscriberCustomFields()->add($subscriberCustomField);
     }
     $this->entityManager->flush();
     return $subscriberCustomField;

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -237,6 +237,7 @@ class Pages {
     // Update subscriber from stored data after confirmation
     if (!empty($subscriberData)) {
       $this->subscriberSaveController->createOrUpdate((array)$subscriberData, $this->subscriber);
+      $this->subscriberSaveController->updateCustomFields((array)$subscriberData, $this->subscriber);
     }
   }
 


### PR DESCRIPTION
## Description

This PR extends the functionality of the column _unconfirmed data_ on the custom fields. This column was used primarily for the first name and last name, but we want to use also for custom fields.

## Code review notes

_N/A_

## QA notes

1. Create a form with a custom field
2. Check that double opt-in is enabled
3. Subscribe via this form and fill the custom field
4. Click on the confirmation link
5. Check values in the admin
6. Resubscribe via the form and use a different value in the custom field
7. Check in the admin that the custom field value was not changed
8. Click on the confirmation link
9. Check that the custom field value was updated

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5246]

## After-merge notes

_N/A_


[MAILPOET-5246]: https://mailpoet.atlassian.net/browse/MAILPOET-5246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ