### PR TITLE
Filter data format + feature flag [MAILPOET-5257]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
@@ -11,13 +11,23 @@ export type Filter = {
   args: Record<string, unknown>;
 };
 
+export type FilterGroup = {
+  operator: 'and' | 'or';
+  filters: Filter[];
+};
+
+export type Filters = {
+  operator: 'and' | 'or';
+  groups: FilterGroup[];
+};
+
 export type Step = {
   id: string;
   type: 'root' | 'trigger' | 'action';
   key: string;
   args: Record<string, unknown>;
   next_steps: NextStep[];
-  filters: Filter[];
+  filters?: Filters;
 };
 
 export type Automation = {

--- a/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/types.ts
@@ -5,6 +5,7 @@ export type NextStep = {
 };
 
 export type Filter = {
+  id: string;
   field_type: string;
   field_key: string;
   condition: string;
@@ -12,6 +13,7 @@ export type Filter = {
 };
 
 export type FilterGroup = {
+  id: string;
   operator: 'and' | 'or';
   filters: Filter[];
 };

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -30,7 +30,8 @@ export function FiltersList(): JSX.Element | null {
     deleteFilterCallback(stepId, filter);
   }, []);
 
-  if (step.filters.length === 0) {
+  const groups = step.filters?.groups ?? [];
+  if (groups.length === 0) {
     return null;
   }
 
@@ -51,35 +52,37 @@ export function FiltersList(): JSX.Element | null {
       )}
 
       <div className="mailpoet-automation-filters-list">
-        {step.filters.map((filter) => (
-          <div
-            key={filter.field_key}
-            className="mailpoet-automation-filters-list-item"
-          >
-            <div className="mailpoet-automation-filters-list-item-content">
-              <span className="mailpoet-automation-filters-list-item-field">
-                {fields[filter.field_key]?.name ??
-                  sprintf(
-                    __('Unknown field "%s"', 'mailpoet'),
-                    filter.field_key,
-                  )}
-              </span>{' '}
-              <span className="mailpoet-automation-filters-list-item-condition">
-                {filters[filter.field_type]?.conditions.find(
-                  ({ key }) => key === filter.condition,
-                )?.label ?? __('unknown condition', 'mailpoet')}
-              </span>{' '}
-              <Value filter={filter} />
-            </div>
-            <Button
-              className="mailpoet-automation-filters-list-item-remove"
-              isSmall
-              onClick={() => onDelete(step.id, filter)}
+        {groups.map((group) =>
+          group.filters.map((filter) => (
+            <div
+              key={filter.field_key}
+              className="mailpoet-automation-filters-list-item"
             >
-              <Icon icon={closeSmall} />
-            </Button>
-          </div>
-        ))}
+              <div className="mailpoet-automation-filters-list-item-content">
+                <span className="mailpoet-automation-filters-list-item-field">
+                  {fields[filter.field_key]?.name ??
+                    sprintf(
+                      __('Unknown field "%s"', 'mailpoet'),
+                      filter.field_key,
+                    )}
+                </span>{' '}
+                <span className="mailpoet-automation-filters-list-item-condition">
+                  {filters[filter.field_type]?.conditions.find(
+                    ({ key }) => key === filter.condition,
+                  )?.label ?? __('unknown condition', 'mailpoet')}
+                </span>{' '}
+                <Value filter={filter} />
+              </div>
+              <Button
+                className="mailpoet-automation-filters-list-item-remove"
+                isSmall
+                onClick={() => onDelete(step.id, filter)}
+              >
+                <Icon icon={closeSmall} />
+              </Button>
+            </div>
+          )),
+        )}
       </div>
     </>
   );

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -55,7 +55,7 @@ export function FiltersList(): JSX.Element | null {
         {groups.map((group) =>
           group.filters.map((filter) => (
             <div
-              key={filter.field_key}
+              key={filter.id}
               className="mailpoet-automation-filters-list-item"
             >
               <div className="mailpoet-automation-filters-list-item-content">

--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/step/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/step/index.tsx
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { storeName } from '../../../store';
 import { FiltersPanel } from '../../filters';
 import { StepCard } from '../../step-card';
+import { MailPoet } from '../../../../../mailpoet';
 
 function StepSidebarGeneralError(): JSX.Element {
   const { errors } = useSelect(
@@ -63,7 +64,8 @@ export function StepSidebar(): JSX.Element {
         key={selectedStep.id}
       />
 
-      {selectedStep.type === 'trigger' && <FiltersPanel />}
+      {MailPoet.FeaturesController.isSupported('automation_filters') &&
+        selectedStep.type === 'trigger' && <FiltersPanel />}
     </div>
   );
 }

--- a/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
@@ -19,10 +19,13 @@ class FilterHandler {
 
   public function matchesFilters(StepRunArgs $args): bool {
     $filters = $args->getStep()->getFilters();
-    foreach ($filters as $filter) {
-      $value = $args->getFieldValue($filter->getFieldKey());
-      if (!$this->matchesFilter($filter, $value)) {
-        return false;
+    $groups = $filters ? $filters->getGroups() : [];
+    foreach ($groups as $group) {
+      foreach ($group->getFilters() as $filter) {
+        $value = $args->getFieldValue($filter->getFieldKey());
+        if (!$this->matchesFilter($filter, $value)) {
+          return false;
+        }
       }
     }
     return true;

--- a/mailpoet/lib/Automation/Engine/Data/Filter.php
+++ b/mailpoet/lib/Automation/Engine/Data/Filter.php
@@ -4,6 +4,9 @@ namespace MailPoet\Automation\Engine\Data;
 
 class Filter {
   /** @var string */
+  private $id;
+
+  /** @var string */
   private $fieldType;
 
   /** @var string */
@@ -16,15 +19,21 @@ class Filter {
   private $args;
 
   public function __construct(
+    string $id,
     string $fieldType,
     string $fieldKey,
     string $condition,
     array $args
   ) {
+    $this->id = $id;
     $this->fieldType = $fieldType;
     $this->fieldKey = $fieldKey;
     $this->condition = $condition;
     $this->args = $args;
+  }
+
+  public function getId(): string {
+    return $this->id;
   }
 
   public function getFieldType(): string {
@@ -45,6 +54,7 @@ class Filter {
 
   public function toArray(): array {
     return [
+      'id' => $this->id,
       'field_type' => $this->fieldType,
       'field_key' => $this->fieldKey,
       'condition' => $this->condition,
@@ -54,6 +64,7 @@ class Filter {
 
   public static function fromArray(array $data): self {
     return new self(
+      $data['id'],
       $data['field_type'],
       $data['field_key'],
       $data['condition'],

--- a/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
+++ b/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
@@ -7,17 +7,26 @@ class FilterGroup {
   public const OPERATOR_OR = 'or';
 
   /** @var string */
+  private $id;
+
+  /** @var string */
   private $operator;
 
   /** @var Filter[] */
   private $filters;
 
   public function __construct(
+    string $id,
     string $operator,
     array $filters
   ) {
+    $this->id = $id;
     $this->operator = $operator;
     $this->filters = $filters;
+  }
+
+  public function getId(): string {
+    return $this->id;
   }
 
   public function getOperator(): string {
@@ -30,6 +39,7 @@ class FilterGroup {
 
   public function toArray(): array {
     return [
+      'id' => $this->id,
       'operator' => $this->operator,
       'filters' => array_map(function (Filter $filter): array {
         return $filter->toArray();
@@ -39,6 +49,7 @@ class FilterGroup {
 
   public static function fromArray(array $data): self {
     return new self(
+      $data['id'],
       $data['operator'],
       array_map(function (array $filter) {
         return Filter::fromArray($filter);

--- a/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
+++ b/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+class FilterGroup {
+  public const OPERATOR_AND = 'and';
+  public const OPERATOR_OR = 'or';
+
+  /** @var string */
+  private $operator;
+
+  /** @var Filter[] */
+  private $filters;
+
+  public function __construct(
+    string $operator,
+    array $filters
+  ) {
+    $this->operator = $operator;
+    $this->filters = $filters;
+  }
+
+  public function getOperator(): string {
+    return $this->operator;
+  }
+
+  public function getFilters(): array {
+    return $this->filters;
+  }
+
+  public function toArray(): array {
+    return [
+      'operator' => $this->operator,
+      'filters' => array_map(function (Filter $filter): array {
+        return $filter->toArray();
+      }, $this->filters),
+    ];
+  }
+
+  public static function fromArray(array $data): self {
+    return new self(
+      $data['operator'],
+      array_map(function (array $filter) {
+        return Filter::fromArray($filter);
+      }, $data['filters'])
+    );
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/Filters.php
+++ b/mailpoet/lib/Automation/Engine/Data/Filters.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Data;
+
+class Filters {
+  public const OPERATOR_AND = 'and';
+  public const OPERATOR_OR = 'or';
+
+  /** @var string */
+  private $operator;
+
+  /** @var FilterGroup[] */
+  private $groups;
+
+  public function __construct(
+    string $operator,
+    array $groups
+  ) {
+    $this->operator = $operator;
+    $this->groups = $groups;
+  }
+
+  public function getOperator(): string {
+    return $this->operator;
+  }
+
+  public function getGroups(): array {
+    return $this->groups;
+  }
+
+  public function toArray(): array {
+    return [
+      'operator' => $this->operator,
+      'groups' => array_map(function (FilterGroup $group): array {
+        return $group->toArray();
+      }, $this->groups),
+    ];
+  }
+
+  public static function fromArray(array $data): self {
+    return new self(
+      $data['operator'],
+      array_map(function (array $group) {
+        return FilterGroup::fromArray($group);
+      }, $data['groups'])
+    );
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Data/Step.php
+++ b/mailpoet/lib/Automation/Engine/Data/Step.php
@@ -22,13 +22,12 @@ class Step {
   /** @var NextStep[] */
   protected $nextSteps;
 
-  /** @var Filter[] */
+  /** @var Filters|null */
   private $filters;
 
   /**
    * @param array<string, mixed> $args
    * @param NextStep[] $nextSteps
-   * @param Filter[] $filters
    */
   public function __construct(
     string $id,
@@ -36,7 +35,7 @@ class Step {
     string $key,
     array $args,
     array $nextSteps,
-    array $filters = []
+    Filters $filters = null
   ) {
     $this->id = $id;
     $this->type = $type;
@@ -72,8 +71,7 @@ class Step {
     return $this->args;
   }
 
-  /** @return Filter[] */
-  public function getFilters(): array {
+  public function getFilters(): ?Filters {
     return $this->filters;
   }
 
@@ -86,9 +84,7 @@ class Step {
       'next_steps' => array_map(function (NextStep $nextStep) {
         return $nextStep->toArray();
       }, $this->nextSteps),
-      'filters' => array_map(function (Filter $filter) {
-        return $filter->toArray();
-      }, $this->filters),
+      'filters' => $this->filters ? $this->filters->toArray() : null,
     ];
   }
 
@@ -101,9 +97,7 @@ class Step {
       array_map(function (array $nextStep) {
         return NextStep::fromArray($nextStep);
       }, $data['next_steps']),
-      array_map(function (array $filter) {
-        return Filter::fromArray($filter);
-      }, $data['filters'] ?? [])
+      isset($data['filters']) ? Filters::fromArray($data['filters']) : null
     );
   }
 }

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -5,7 +5,6 @@ namespace MailPoet\Automation\Engine\Mappers;
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
-use MailPoet\Automation\Engine\Data\Filter;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
@@ -43,9 +42,7 @@ class AutomationMapper {
           'next_steps' => array_map(function (NextStep $nextStep) {
             return $nextStep->toArray();
           }, $step->getNextSteps()),
-          'filters' => array_map(function (Filter $filter) {
-            return $filter->toArray();
-          }, $step->getFilters()),
+          'filters' => $step->getFilters() ? $step->getFilters()->toArray() : null,
         ];
       }, $automation->getSteps()),
       'meta' => (object)$automation->getAllMetas(),

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
@@ -27,13 +27,16 @@ class ValidStepFiltersRule implements AutomationNodeVisitor {
   }
 
   public function visitNode(Automation $automation, AutomationNode $node): void {
-    $step = $node->getStep();
-    foreach ($step->getFilters() as $filter) {
-      $registryFilter = $this->registry->getFilter($filter->getFieldType());
-      if (!$registryFilter) {
-        continue;
+    $filters = $node->getStep()->getFilters();
+    $groups = $filters ? $filters->getGroups() : [];
+    foreach ($groups as $group) {
+      foreach ($group->getFilters() as $filter) {
+        $registryFilter = $this->registry->getFilter($filter->getFieldType());
+        if (!$registryFilter) {
+          continue;
+        }
+        $this->validator->validate($registryFilter->getArgsSchema(), $filter->getArgs());
       }
-      $this->validator->validate($registryFilter->getArgsSchema(), $filter->getArgs());
     }
   }
 

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationSchema.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationSchema.php
@@ -29,7 +29,7 @@ class AutomationSchema {
       'key' => Builder::string()->required(),
       'args' => Builder::object()->required(),
       'next_steps' => self::getNextStepsSchema()->required(),
-      'filters' => self::getFiltersSchema()->required(),
+      'filters' => self::getFiltersSchema()->nullable()->required(),
     ]);
   }
 
@@ -51,14 +51,24 @@ class AutomationSchema {
     )->maxItems(1);
   }
 
-  public static function getFiltersSchema(): ArraySchema {
-    return Builder::array(
-      Builder::object([
-        'field_type' => Builder::string()->required(),
-        'field_key' => Builder::string()->required(),
-        'condition' => Builder::string()->required(),
-        'args' => Builder::object()->required(),
-      ])
-    );
+  public static function getFiltersSchema(): ObjectSchema {
+    $operatorSchema = Builder::string()->pattern('^and|or$')->required();
+
+    $filterSchema = Builder::object([
+      'field_type' => Builder::string()->required(),
+      'field_key' => Builder::string()->required(),
+      'condition' => Builder::string()->required(),
+      'args' => Builder::object()->required(),
+    ]);
+
+    $filterGroupSchema = Builder::object([
+      'operator' => $operatorSchema,
+      'filters' => Builder::array($filterSchema)->minItems(1)->required(),
+    ]);
+
+    return Builder::object([
+      'operator' => $operatorSchema,
+      'groups' => Builder::array($filterGroupSchema)->minItems(1)->required(),
+    ]);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationSchema.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationSchema.php
@@ -55,6 +55,7 @@ class AutomationSchema {
     $operatorSchema = Builder::string()->pattern('^and|or$')->required();
 
     $filterSchema = Builder::object([
+      'id' => Builder::string()->required(),
       'field_type' => Builder::string()->required(),
       'field_key' => Builder::string()->required(),
       'condition' => Builder::string()->required(),
@@ -62,6 +63,7 @@ class AutomationSchema {
     ]);
 
     $filterGroupSchema = Builder::object([
+      'id' => Builder::string()->required(),
       'operator' => $operatorSchema,
       'filters' => Builder::array($filterSchema)->minItems(1)->required(),
     ]);

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -9,9 +9,9 @@ use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
 
 class EnumArrayFilter implements Filter {
-  public const CONDITION_MATCHES_ANY = 'matches-any';
-  public const CONDITION_MATCHES_ALL = 'matches-all';
-  public const CONDITION_MATCHES_NONE = 'matches-none';
+  public const CONDITION_MATCHES_ANY_OF = 'matches-any-of';
+  public const CONDITION_MATCHES_ALL_OF = 'matches-all-of';
+  public const CONDITION_MATCHES_NONE_OF = 'matches-none-of';
 
   public function getFieldType(): string {
     return Field::TYPE_ENUM_ARRAY;
@@ -19,9 +19,9 @@ class EnumArrayFilter implements Filter {
 
   public function getConditions(): array {
     return [
-      self::CONDITION_MATCHES_ANY => __('matches any', 'mailpoet'),
-      self::CONDITION_MATCHES_ALL => __('matches all', 'mailpoet'),
-      self::CONDITION_MATCHES_NONE => __('matches none', 'mailpoet'),
+      self::CONDITION_MATCHES_ANY_OF => __('matches any of', 'mailpoet'),
+      self::CONDITION_MATCHES_ALL_OF => __('matches all of', 'mailpoet'),
+      self::CONDITION_MATCHES_NONE_OF => __('matches none of', 'mailpoet'),
     ];
   }
 
@@ -46,11 +46,11 @@ class EnumArrayFilter implements Filter {
     $filterCount = count($filterValue);
     $matchedCount = count(array_intersect($value, $filterValue));
     switch ($data->getCondition()) {
-      case self::CONDITION_MATCHES_ANY:
+      case self::CONDITION_MATCHES_ANY_OF:
         return $filterCount > 0 && $matchedCount > 0;
-      case self::CONDITION_MATCHES_ALL:
+      case self::CONDITION_MATCHES_ALL_OF:
         return $filterCount > 0 && $matchedCount === count($filterValue);
-      case self::CONDITION_MATCHES_NONE:
+      case self::CONDITION_MATCHES_NONE_OF:
         return $matchedCount === 0;
       default:
         return false;

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -7,12 +7,14 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 class FeaturesController {
   const LANDINGPAGE_AB_TEST_DEBUGGER = 'landingpage_ab_test_debugger';
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
+  const AUTOMATION_FILTERS = 'automation_filters';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::LANDINGPAGE_AB_TEST_DEBUGGER => false,
     self::FEATURE_BRAND_TEMPLATES => false,
+    self::AUTOMATION_FILTERS => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -173,8 +173,8 @@ class TriggerHandlerTest extends \MailPoetTest {
 
     // automation that doesn't match segments filter
     $unknownId = $segment->getId() + 1;
-    $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$unknownId]]);
-    $filters = new Filters('and', [new FilterGroup('and', [$filter])]);
+    $filter = new Filter('f1', 'enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$unknownId]]);
+    $filters = new Filters('and', [new FilterGroup('g1', 'and', [$filter])]);
     $automation = $this->tester->createAutomation(
       'Will not run',
       new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], $filters)
@@ -185,8 +185,8 @@ class TriggerHandlerTest extends \MailPoetTest {
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
 
     // matches segments filter
-    $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$segment->getId()]]);
-    $filters = new Filters('and', [new FilterGroup('and', [$filter])]);
+    $filter = new Filter('f1', 'enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$segment->getId()]]);
+    $filters = new Filters('and', [new FilterGroup('g1', 'and', [$filter])]);
     $automation = $this->tester->createAutomation(
       'Will run',
       new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], $filters)

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -5,6 +5,8 @@ namespace MailPoet\Test\Automation\Engine\Control;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
@@ -172,9 +174,10 @@ class TriggerHandlerTest extends \MailPoetTest {
     // automation that doesn't match segments filter
     $unknownId = $segment->getId() + 1;
     $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$unknownId]]);
+    $filters = new Filters('and', [new FilterGroup('and', [$filter])]);
     $automation = $this->tester->createAutomation(
       'Will not run',
-      new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], [$filter])
+      new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], $filters)
     );
     $this->assertInstanceOf(Automation::class, $automation);
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
@@ -183,9 +186,10 @@ class TriggerHandlerTest extends \MailPoetTest {
 
     // matches segments filter
     $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$segment->getId()]]);
+    $filters = new Filters('and', [new FilterGroup('and', [$filter])]);
     $automation = $this->tester->createAutomation(
       'Will run',
-      new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], [$filter])
+      new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], $filters)
     );
     $this->assertInstanceOf(Automation::class, $automation);
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -171,7 +171,7 @@ class TriggerHandlerTest extends \MailPoetTest {
 
     // automation that doesn't match segments filter
     $unknownId = $segment->getId() + 1;
-    $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any', ['value' => [$unknownId]]);
+    $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$unknownId]]);
     $automation = $this->tester->createAutomation(
       'Will not run',
       new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], [$filter])
@@ -182,7 +182,7 @@ class TriggerHandlerTest extends \MailPoetTest {
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
 
     // matches segments filter
-    $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any', ['value' => [$segment->getId()]]);
+    $filter = new Filter('enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$segment->getId()]]);
     $automation = $this->tester->createAutomation(
       'Will run',
       new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], [$filter])

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -98,7 +98,7 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
           'key' => 'core:root',
           'args' => [],
           'next_steps' => [],
-          'filters' => [],
+          'filters' => null,
         ],
       ],
       'meta' => [],

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -8,6 +8,8 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject as SubjectData;
@@ -23,7 +25,8 @@ use MailPoetUnitTest;
 class FilterHandlerTest extends MailPoetUnitTest {
   /** @dataProvider dataForTestItFilters */
   public function testItFilters(array $stepFilters, bool $expectation): void {
-    $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $stepFilters);
+    $filters = new Filters('and', [new FilterGroup('and', $stepFilters)]);
+    $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $filters);
     $subject = $this->createSubject('subject', [
       new Field('test:field-string', Field::TYPE_STRING, 'Test field string', function () {
         return 'abc';

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -25,7 +25,7 @@ use MailPoetUnitTest;
 class FilterHandlerTest extends MailPoetUnitTest {
   /** @dataProvider dataForTestItFilters */
   public function testItFilters(array $stepFilters, bool $expectation): void {
-    $filters = new Filters('and', [new FilterGroup('and', $stepFilters)]);
+    $filters = new Filters('and', [new FilterGroup('g1', 'and', $stepFilters)]);
     $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $filters);
     $subject = $this->createSubject('subject', [
       new Field('test:field-string', Field::TYPE_STRING, 'Test field string', function () {
@@ -70,8 +70,8 @@ class FilterHandlerTest extends MailPoetUnitTest {
       // matching
       [
         [
-          new FilterData(Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
-          new FilterData(Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 123]),
+          new FilterData('f1', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData('f2', Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 123]),
         ],
         true,
       ],
@@ -79,15 +79,15 @@ class FilterHandlerTest extends MailPoetUnitTest {
       // not matching
       [
         [
-          new FilterData(Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
+          new FilterData('f1', Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
         ],
         false,
       ],
       [
         [
-          new FilterData(Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
-          new FilterData(Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
-          new FilterData(Field::TYPE_BOOLEAN, 'test:field-boolean', '', ['value' => true]),
+          new FilterData('f1', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData('f2', Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
+          new FilterData('f3', Field::TYPE_BOOLEAN, 'test:field-boolean', '', ['value' => true]),
         ],
         false,
       ],

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
@@ -8,6 +8,8 @@ use Codeception\Stub\Expected;
 use MailPoet\Automation\Engine\Control\RootStep;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\Filter as FilterData;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Integration\Filter;
 use MailPoet\Automation\Engine\Registry;
@@ -48,6 +50,7 @@ class ValidStepFiltersRuleTest extends AutomationRuleTest {
   }
 
   private function getAutomation(array $filters): Automation {
+    $filters = new Filters('and', [new FilterGroup('and', $filters)]);
     return $this->make(Automation::class, [
       'getSteps' => [
         'root' => new Step('root', 'root', 'core:root', [], [], $filters),

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
@@ -31,7 +31,7 @@ class ValidStepFiltersRuleTest extends AutomationRuleTest {
       'validate' => Expected::once(),
     ]);
 
-    $filters = [new FilterData('string', 'test:key', 'is', ['value' => 'test'])];
+    $filters = [new FilterData('f1', 'string', 'test:key', 'is', ['value' => 'test'])];
     $rule = new ValidStepFiltersRule($registry, $validator);
     $automation = $this->getAutomation($filters);
     (new AutomationWalker())->walk($automation, [$rule]);
@@ -43,14 +43,14 @@ class ValidStepFiltersRuleTest extends AutomationRuleTest {
       'validate' => Expected::never(),
     ]);
 
-    $filters = [new FilterData('string', 'test:key', 'is', ['value' => 'test'])];
+    $filters = [new FilterData('f1', 'string', 'test:key', 'is', ['value' => 'test'])];
     $rule = new ValidStepFiltersRule($registry, $validator);
     $automation = $this->getAutomation($filters);
     (new AutomationWalker())->walk($automation, [$rule]);
   }
 
   private function getAutomation(array $filters): Automation {
-    $filters = new Filters('and', [new FilterGroup('and', $filters)]);
+    $filters = new Filters('and', [new FilterGroup('g1', 'and', $filters)]);
     return $this->make(Automation::class, [
       'getSteps' => [
         'root' => new Step('root', 'root', 'core:root', [], [], $filters),

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
@@ -102,6 +102,6 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
 
   private function matchesFilter(string $condition, $filterValue, $value): bool {
     $filter = new EnumArrayFilter();
-    return $filter->matches(new Filter('string', '', $condition, ['value' => $filterValue]), $value);
+    return $filter->matches(new Filter('f1', 'string', '', $condition, ['value' => $filterValue]), $value);
   }
 }

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
@@ -13,9 +13,9 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
     $this->assertSame('enum_array', $filter->getFieldType());
 
     $this->assertSame([
-      'matches-any' => 'matches any',
-      'matches-all' => 'matches all',
-      'matches-none' => 'matches none',
+      'matches-any-of' => 'matches any of',
+      'matches-all-of' => 'matches all of',
+      'matches-none-of' => 'matches none of',
     ], $filter->getConditions());
 
     $this->assertSame([
@@ -49,42 +49,42 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
   }
 
   public function testMatchesAnyCondition(): void {
-    $this->assertMatches('matches-any', [1, 2, 3], [1]);
-    $this->assertMatches('matches-any', [1, 2, 3], [1, 3, 9]);
-    $this->assertMatches('matches-any', [1], [1, 1, 1]);
-    $this->assertMatches('matches-any', [1, 1, 1], [1]);
-    $this->assertNotMatches('matches-any', [], []);
-    $this->assertNotMatches('matches-any', [], [1]);
-    $this->assertNotMatches('matches-any', [1, 2, 3], []);
-    $this->assertNotMatches('matches-any', [1, 2, 3], [7, 8, 9]);
+    $this->assertMatches('matches-any-of', [1, 2, 3], [1]);
+    $this->assertMatches('matches-any-of', [1, 2, 3], [1, 3, 9]);
+    $this->assertMatches('matches-any-of', [1], [1, 1, 1]);
+    $this->assertMatches('matches-any-of', [1, 1, 1], [1]);
+    $this->assertNotMatches('matches-any-of', [], []);
+    $this->assertNotMatches('matches-any-of', [], [1]);
+    $this->assertNotMatches('matches-any-of', [1, 2, 3], []);
+    $this->assertNotMatches('matches-any-of', [1, 2, 3], [7, 8, 9]);
   }
 
   public function testMatchesAllCondition(): void {
-    $this->assertMatches('matches-all', [1], [1]);
-    $this->assertMatches('matches-all', [1, 2], [2, 1]);
-    $this->assertMatches('matches-all', [1, 2], [2, 1, 3]);
-    $this->assertMatches('matches-all', [1], [1, 1, 1]);
-    $this->assertMatches('matches-all', [1, 1, 1], [1]);
-    $this->assertNotMatches('matches-all', [], []);
-    $this->assertNotMatches('matches-all', [], [1]);
-    $this->assertNotMatches('matches-all', [1, 2, 3], []);
-    $this->assertNotMatches('matches-all', [1, 2, 3], [2, 3, 4]);
+    $this->assertMatches('matches-all-of', [1], [1]);
+    $this->assertMatches('matches-all-of', [1, 2], [2, 1]);
+    $this->assertMatches('matches-all-of', [1, 2], [2, 1, 3]);
+    $this->assertMatches('matches-all-of', [1], [1, 1, 1]);
+    $this->assertMatches('matches-all-of', [1, 1, 1], [1]);
+    $this->assertNotMatches('matches-all-of', [], []);
+    $this->assertNotMatches('matches-all-of', [], [1]);
+    $this->assertNotMatches('matches-all-of', [1, 2, 3], []);
+    $this->assertNotMatches('matches-all-of', [1, 2, 3], [2, 3, 4]);
   }
 
   public function testMatchesNoneCondition(): void {
-    $this->assertMatches('matches-none', [], []);
-    $this->assertMatches('matches-none', [], [1]);
-    $this->assertMatches('matches-none', [1], []);
-    $this->assertMatches('matches-none', [1], [2]);
-    $this->assertMatches('matches-none', [1, 2, 3], []);
-    $this->assertMatches('matches-none', [1, 2, 3], [4, 5, 6]);
-    $this->assertMatches('matches-none', [1], [2, 2, 2]);
-    $this->assertMatches('matches-none', [1, 1, 1], [2]);
-    $this->assertNotMatches('matches-none', [1], [1]);
-    $this->assertNotMatches('matches-none', [1, 2, 3], [2]);
-    $this->assertNotMatches('matches-none', [1, 2, 3], [3, 4, 5]);
-    $this->assertNotMatches('matches-none', [1], [1, 1, 1]);
-    $this->assertNotMatches('matches-none', [1, 1, 1], [1]);
+    $this->assertMatches('matches-none-of', [], []);
+    $this->assertMatches('matches-none-of', [], [1]);
+    $this->assertMatches('matches-none-of', [1], []);
+    $this->assertMatches('matches-none-of', [1], [2]);
+    $this->assertMatches('matches-none-of', [1, 2, 3], []);
+    $this->assertMatches('matches-none-of', [1, 2, 3], [4, 5, 6]);
+    $this->assertMatches('matches-none-of', [1], [2, 2, 2]);
+    $this->assertMatches('matches-none-of', [1, 1, 1], [2]);
+    $this->assertNotMatches('matches-none-of', [1], [1]);
+    $this->assertNotMatches('matches-none-of', [1, 2, 3], [2]);
+    $this->assertNotMatches('matches-none-of', [1, 2, 3], [3, 4, 5]);
+    $this->assertNotMatches('matches-none-of', [1], [1, 1, 1]);
+    $this->assertNotMatches('matches-none-of', [1, 1, 1], [1]);
   }
 
   public function testUnknownCondition(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/StringFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/StringFilterTest.php
@@ -166,6 +166,6 @@ class StringFilterTest extends MailPoetUnitTest {
 
   private function matchesFilter(string $condition, $filterValue, $value): bool {
     $filter = new StringFilter();
-    return $filter->matches(new Filter('string', '', $condition, ['value' => $filterValue]), $value);
+    return $filter->matches(new Filter('f1', 'string', '', $condition, ['value' => $filterValue]), $value);
   }
 }


### PR DESCRIPTION
## Description

This PR changes the format of `filters` to allow for their grouping with AND/OR operators. It also adds some small fixes, and hides filters UI behind a feature flag. This will ensure that empty filters will be saved as `null` rather than an empty array (we need that for forward compatibility for the AND/OR filter grouping).

I intentionally made the root `filter` object to accept filter `group`s and the groups to accept `filter`s. This is so we don't end up trying to resolve and validate an infinitely nested data structure. The new data structure is made to support UIs such as these:

![Screenshot 2023-04-11 at 12 48 52](https://user-images.githubusercontent.com/141436/233648671-ea053ee4-90b0-4270-acc0-77edf892646c.png)
![Screenshot 2023-04-11 at 12 45 32](https://user-images.githubusercontent.com/141436/233648680-fba01c64-4d15-4f67-baa8-07bff14ece2f.png)

## QA notes

Please make sure this is merged before the next release, as it contains the filter data type fix and the feature flat.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/717

## Linked tickets

[MAILPOET-5257]

[MAILPOET-5257]: https://mailpoet.atlassian.net/browse/MAILPOET-5257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ