### PR TITLE
Automation transactional emails [MAILPOET-5258]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/components/content.js
+++ b/mailpoet/assets/js/src/newsletter_editor/components/content.js
@@ -25,7 +25,9 @@ Module.NewsletterModel = SuperModel.extend({
     return this.get('type') === 'wc_transactional';
   },
   isAutomationEmail: function isAutomationEmail() {
-    return ['automation', 'transactional'].includes(this.get('type'));
+    return ['automation', 'automation_transactional'].includes(
+      this.get('type'),
+    );
   },
   isConfirmationEmailTemplate: function isConfirmationEmailTemplate() {
     return this.get('type') === 'confirmation_email';

--- a/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter_editor/initializer.jsx
@@ -13,7 +13,9 @@ const renderHeading = (newsletterType, newsletterOptions) => {
     const stepsHeadingContainer = document.getElementById(
       'mailpoet_editor_steps_heading',
     );
-    const step = ['automation', 'transactional'].includes(newsletterType)
+    const step = ['automation', 'automation_transactional'].includes(
+      newsletterType,
+    )
       ? 2
       : 3;
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -126,7 +126,7 @@ class SendEmailAction implements Action {
       'status' => SubscriberEntity::STATUS_SUBSCRIBED,
     ]);
 
-    if ($newsletter->getType() !== NewsletterEntity::TYPE_TRANSACTIONAL && !$subscriberSegment) {
+    if ($newsletter->getType() !== NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL && !$subscriberSegment) {
       throw InvalidStateException::create()->withMessage(sprintf("Subscriber ID '%s' is not subscribed to segment ID '%s'.", $subscriberId, $segmentId));
     }
 
@@ -136,7 +136,7 @@ class SendEmailAction implements Action {
     }
 
     $subscriberStatus = $subscriber->getStatus();
-    if ($newsletter->getType() !== NewsletterEntity::TYPE_TRANSACTIONAL && $subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED) {
+    if ($newsletter->getType() !== NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL && $subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED) {
       throw InvalidStateException::create()->withMessage(sprintf("Cannot schedule a newsletter for subscriber ID '%s' because their status is '%s'.", $subscriberId, $subscriberStatus));
     }
 
@@ -158,7 +158,7 @@ class SendEmailAction implements Action {
     }
 
     $email = $this->getEmailForStep($step);
-    $email->setType($this->isTransactional($step, $automation) ? NewsletterEntity::TYPE_TRANSACTIONAL : NewsletterEntity::TYPE_AUTOMATION);
+    $email->setType($this->isTransactional($step, $automation) ? NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL : NewsletterEntity::TYPE_AUTOMATION);
     $email->setStatus(NewsletterEntity::STATUS_ACTIVE);
     $email->setSubject($args['subject'] ?? '');
     $email->setPreheader($args['preheader'] ?? '');
@@ -213,7 +213,7 @@ class SendEmailAction implements Action {
     $email = $this->newslettersRepository->findOneBy([
       'id' => $emailId,
     ]);
-    if (!$email || !in_array($email->getType(), [NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::TYPE_TRANSACTIONAL], true)) {
+    if (!$email || !in_array($email->getType(), [NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL], true)) {
       throw InvalidStateException::create()->withMessage(
         // translators: %s is the ID of email.
         sprintf(__("Automation email with ID '%s' not found.", 'mailpoet'), $emailId)

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -127,7 +127,7 @@ class Scheduler {
         $this->processReEngagementEmail($queue);
       } elseif ($newsletter->type === NewsletterEntity::TYPE_AUTOMATION) {
         $this->processScheduledAutomationEmail($queue);
-      } elseif ($newsletter->type === NewsletterEntity::TYPE_TRANSACTIONAL) {
+      } elseif ($newsletter->type === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
         $this->processScheduledTransactionalEmail($queue);
       }
       $this->cronHelper->enforceExecutionLimit($timer);
@@ -371,7 +371,7 @@ class Scheduler {
 
   public function verifySubscriber($subscriber, $queue) {
     $newsletter = $queue->newsletterId ? $this->newslettersRepository->findOneById($queue->newsletterId) : null;
-    if ($newsletter && $newsletter->getType() === NewsletterEntity::TYPE_TRANSACTIONAL) {
+    if ($newsletter && $newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
       return $subscriber->status !== Subscriber::STATUS_BOUNCED;
     }
     if ($subscriber->status === Subscriber::STATUS_UNCONFIRMED) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -227,7 +227,7 @@ class SendingQueue {
         // No segments = Welcome emails or some Automatic emails.
         // Welcome emails or some Automatic emails use segments only for scheduling and store them as a newsletter option
         $foundSubscribers = SubscriberModel::whereIn('id', $subscribersToProcessIds);
-        $foundSubscribers = $newsletter->type === NewsletterEntity::TYPE_TRANSACTIONAL ?
+        $foundSubscribers = $newsletter->type === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL ?
           $foundSubscribers->whereNotEqual('status', SubscriberModel::STATUS_BOUNCED) :
           $foundSubscribers->where('status', SubscriberModel::STATUS_SUBSCRIBED);
         $foundSubscribers = $foundSubscribers

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -24,7 +24,7 @@ class NewsletterEntity {
   // types
   const TYPE_AUTOMATIC = 'automatic';
   const TYPE_AUTOMATION = 'automation';
-  const TYPE_TRANSACTIONAL = 'transactional';
+  const TYPE_AUTOMATION_TRANSACTIONAL = 'automation_transactional';
   const TYPE_STANDARD = 'standard';
   const TYPE_WELCOME = 'welcome';
   const TYPE_NOTIFICATION = 'notification';

--- a/mailpoet/lib/Migrations/Migration_20230421_135915.php
+++ b/mailpoet/lib/Migrations/Migration_20230421_135915.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Migrator\Migration;
+
+class Migration_20230421_135915 extends Migration {
+  public function run(): void {
+    $newslettersTable = $this->getTableName(NewsletterEntity::class);
+    $this->connection->executeQuery("
+      ALTER TABLE $newslettersTable
+      CHANGE type type varchar(150) NOT NULL DEFAULT 'standard'
+    ");
+    $this->connection->executeQuery("
+      UPDATE $newslettersTable
+      SET type = 'automation_transactional'
+      WHERE type = 'transactional'
+    ");
+  }
+}

--- a/mailpoet/lib/Models/Newsletter.php
+++ b/mailpoet/lib/Models/Newsletter.php
@@ -45,7 +45,7 @@ class Newsletter extends Model {
   public static $_table = MP_NEWSLETTERS_TABLE; // phpcs:ignore PSR2.Classes.PropertyDeclaration
   const TYPE_AUTOMATIC = NewsletterEntity::TYPE_AUTOMATIC;
   const TYPE_AUTOMATION = NewsletterEntity::TYPE_AUTOMATION;
-  const TYPE_TRANSACTIONAL = NewsletterEntity::TYPE_TRANSACTIONAL;
+  const TYPE_AUTOMATION_TRANSACTIONAL = NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL;
   const TYPE_STANDARD = NewsletterEntity::TYPE_STANDARD;
   const TYPE_WELCOME = NewsletterEntity::TYPE_WELCOME;
   const TYPE_NOTIFICATION = NewsletterEntity::TYPE_NOTIFICATION;

--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -29,10 +29,10 @@ class AutomationEmailScheduler {
   }
 
   public function createSendingTask(NewsletterEntity $email, SubscriberEntity $subscriber): ScheduledTaskEntity {
-    if (!in_array($email->getType(), [NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::TYPE_TRANSACTIONAL], true)) {
+    if (!in_array($email->getType(), [NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL], true)) {
       throw InvalidStateException::create()->withMessage(
         // translators: %s is the type which was given.
-        sprintf(__("Email with type 'automation' or 'transactional' expected, '%s' given.", 'mailpoet'), $email->getType())
+        sprintf(__("Email with type 'automation' or 'automation_transactional' expected, '%s' given.", 'mailpoet'), $email->getType())
       );
     }
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -299,7 +299,7 @@ class SendEmailActionTest extends \MailPoetTest {
 
     $isTransactional = [
       'steps' => [$root, $trigger, $emailStep],
-      'expected_type' => NewsletterEntity::TYPE_TRANSACTIONAL,
+      'expected_type' => NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
     ];
 
     $nonTransactionalTrigger = new Step('trigger', Step::TYPE_TRIGGER, 'some-other-trigger', [], [new NextStep('emailstep')]);

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -726,7 +726,7 @@ class SchedulerTest extends \MailPoetTest {
    */
   public function testItSchedulesTransactionalEmails(string $subscriberStatus, bool $isExpectedToBeScheduled) {
 
-    $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_TRANSACTIONAL, Newsletter::STATUS_SCHEDULED);
+    $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, Newsletter::STATUS_SCHEDULED);
     $subscriber = $this->_createSubscriber(null, $subscriberStatus);
     $queue = $this->_createQueue($newsletter->id);
     $queue->setSubscribers([$subscriber->id]);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -981,7 +981,7 @@ class SendingQueueTest extends \MailPoetTest {
    */
   public function testItSendsTransactionalEmails(string $subscriberStatus, bool $expectSending) {
 
-    $this->newsletter->type = NewsletterEntity::TYPE_TRANSACTIONAL;
+    $this->newsletter->type = NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL;
     $this->newsletter->save();
     $this->newsletterSegment->delete();
     $sendingQueueWorker = $this->sendingQueueWorker;


### PR DESCRIPTION
## Description

Transactional emails for automations were implemented with a new type `transactional`.

It turns out [we’re using that type already for WP transactional emails](https://github.com/mailpoet/mailpoet/blob/b35b772eb16db915f6724ce5e2c2ce8326021e86/mailpoet/lib/Mailer/MetaInfo.php#L21-L27) (the string is hard-coded in there, we missed that because no such constant exists).

This PR renames the new transactional email type to `automation_transactional`.

## Code review notes

QA not needed, can be merged after code review.

## QA notes

QA not needed.

## Linked tickets

[MAILPOET-5258]

[MAILPOET-5258]: https://mailpoet.atlassian.net/browse/MAILPOET-5258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ