### PR TITLE
Limit rows deleted from mailpoet_logs  [MAILPOET-5071]

### DIFF
--- a/mailpoet/lib/Logging/LogHandler.php
+++ b/mailpoet/lib/Logging/LogHandler.php
@@ -14,6 +14,11 @@ class LogHandler extends AbstractProcessingHandler {
   const DAYS_TO_KEEP_LOGS = 30;
 
   /**
+   * How many records to delete on one run of purge routine
+   */
+  const PURGE_LIMIT = 1000;
+
+  /**
    * Percentage value, what is the probability of running purge routine
    * @var int
    */
@@ -76,6 +81,6 @@ class LogHandler extends AbstractProcessingHandler {
   }
 
   private function purgeOldLogs() {
-    $this->logRepository->purgeOldLogs(self::DAYS_TO_KEEP_LOGS);
+    $this->logRepository->purgeOldLogs(self::DAYS_TO_KEEP_LOGS, self::PURGE_LIMIT);
   }
 }

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -70,7 +70,8 @@ class LogRepository extends Repository {
     $logsTable = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
     $this->entityManager->getConnection()->executeStatement("
       DELETE FROM $logsTable
-      WHERE `created_at` < :date LIMIT :limit
+      WHERE `created_at` < :date
+      ORDER BY `id` ASC LIMIT :limit
     ", [
       'date' => Carbon::now()->subDays($daysToKeepLogs)->toDateTimeString(),
       'limit' => $limit,

--- a/mailpoet/tests/DataFactories/Log.php
+++ b/mailpoet/tests/DataFactories/Log.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\LogEntity;
+use MailPoet\Logging\LogRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+class Log {
+  /** @var array */
+  private $data;
+
+  /** @var LogRepository */
+  private $repository;
+
+  public function __construct() {
+    $this->repository = ContainerWrapper::getInstance()->get(LogRepository::class);
+    $this->data = [
+      'name' => 'Log' . bin2hex(random_bytes(7)),
+      'level' => 5,
+      'message' => 'Message' . bin2hex(random_bytes(7)),
+      'created_at' => Carbon::now(),
+    ];
+  }
+
+  /**
+   * @return $this
+   */
+  public function withCreatedAt(\DateTimeInterface $date): Log {
+    return $this->update('created_at', $date);
+  }
+
+  public function create(): LogEntity {
+    $entity = new LogEntity();
+    $entity->setName( $this->data['name']);
+    $entity->setLevel($this->data['level']);
+    $entity->setMessage($this->data['message']);
+    $entity->setCreatedAt($this->data['created_at']);
+
+    $this->repository->persist($entity);
+    $this->repository->flush();
+    return $entity;
+  }
+
+  /**
+   * @return $this
+   */
+  private function update(string $item, $value): Log {
+    $data = $this->data;
+    $data[$item] = $value;
+    $new = clone $this;
+    $new->data = $data;
+    return $new;
+  }
+}

--- a/mailpoet/tests/integration/Logging/LogRepositoryTest.php
+++ b/mailpoet/tests/integration/Logging/LogRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging;
+
+use MailPoet\Test\DataFactories\Log;
+use MailPoetVendor\Carbon\Carbon;
+
+class LogRepositoryTest extends \MailPoetTest {
+  /** @var LogRepository */
+  private $repository;
+
+  public function _before() {
+    $this->repository = $this->diContainer->get(LogRepository::class);
+  }
+
+  public function testDeletesOldLogs() {
+    $logFactory = new Log();
+    $logFactory->withCreatedAt(Carbon::now()->subDays(50))->create(); // Oldest one to delete
+    $log2 = $logFactory->withCreatedAt(Carbon::now()->subDays(40))->create(); // Old enough to delete but not the oldest one
+    $log3 = $logFactory->withCreatedAt(Carbon::now()->subDays(20))->create(); // Not old enough
+    $log4 = $logFactory->withCreatedAt(Carbon::now())->create(); // New
+
+    // Delete 1 log older than 30 days
+    $this->repository->purgeOldLogs(30, 1);
+
+    $allLogs = $this->repository->getLogs();
+    $logsInDB = [];
+    foreach ($allLogs as $log) {
+      $logsInDB[] = $log->getId();
+    }
+    sort($logsInDB);
+    expect([$log2->getId(), $log3->getId(), $log4->getId()])->equals($logsInDB);
+  }
+}


### PR DESCRIPTION
## Description
We want to make sure that we don't lock the log table by deleting too many rows in one query.
If the probability of running the delete routine is 5%  for each log writing, the limit of 1000 should be fine.

## Code review notes

_N/A_

## QA notes

You can test this doesn't break logging.
Go to MailPoet > Settings > Advanced and set Logging to `everything`
Then you can play with the plugin, send some emails and check `wp-admin/admin.php?page=mailpoet-logs` that logs are written.

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-5071]

## After-merge notes

_N/A_


[MAILPOET-5071]: https://mailpoet.atlassian.net/browse/MAILPOET-5071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ