### PR TITLE
Add average order value filter [MAILPOET-4987]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -81,7 +81,9 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   }
   if (
     formItems.action === WooCommerceActionTypes.AVERAGE_SPENT &&
-    (!formItems.amount || !formItems.operator || !formItems.days)
+    (!formItems.average_spent_amount ||
+      !formItems.average_spent_type ||
+      !formItems.average_spent_days)
   ) {
     return false;
   }
@@ -418,11 +420,15 @@ function AverageSpentFields({ filterIndex }: Props): JSX.Element {
       <Grid.CenteredRow>
         <Select
           key="select"
-          value={segment.operator}
+          value={segment.average_spent_type}
           onChange={(e): void => {
-            void updateSegmentFilterFromEvent('operator', filterIndex, e);
+            void updateSegmentFilterFromEvent(
+              'average_spent_type',
+              filterIndex,
+              e,
+            );
           }}
-          automationId="select-average-spent-operator"
+          automationId="select-average-spent-type"
         >
           <option value=">">{MailPoet.I18n.t('moreThan')}</option>
           <option value=">=">{MailPoet.I18n.t('moreThanOrEqual')}</option>
@@ -436,10 +442,14 @@ function AverageSpentFields({ filterIndex }: Props): JSX.Element {
           type="number"
           min={0}
           step={0.01}
-          value={segment.amount || ''}
+          value={segment.average_spent_amount || ''}
           placeholder={MailPoet.I18n.t('wooSpentAmount')}
           onChange={(e): void => {
-            void updateSegmentFilterFromEvent('amount', filterIndex, e);
+            void updateSegmentFilterFromEvent(
+              'average_spent_amount',
+              filterIndex,
+              e,
+            );
           }}
         />
         <div>{wooCurrencySymbol}</div>
@@ -451,10 +461,14 @@ function AverageSpentFields({ filterIndex }: Props): JSX.Element {
           type="number"
           min={1}
           step={1}
-          value={segment.days || ''}
+          value={segment.average_spent_days || ''}
           placeholder={MailPoet.I18n.t('daysPlaceholder')}
           onChange={(e): void => {
-            void updateSegmentFilterFromEvent('days', filterIndex, e);
+            void updateSegmentFilterFromEvent(
+              'average_spent_days',
+              filterIndex,
+              e,
+            );
           }}
         />
         <div>{MailPoet.I18n.t('days')}</div>

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -410,9 +410,9 @@ function AverageSpentFields({ filterIndex }: Props): JSX.Element {
     [],
   );
   useEffect(() => {
-    const allowedOperators = ['=', '!=', '>', '<'];
-    if (!allowedOperators.includes(segment.operator)) {
-      void updateSegmentFilter({ operator: '>' }, filterIndex);
+    const allowedOperators = ['>', '>=', '=', '!=', '<=', '<'];
+    if (!allowedOperators.includes(segment.average_spent_type)) {
+      void updateSegmentFilter({ average_spent_type: '>' }, filterIndex);
     }
   }, [updateSegmentFilter, segment, filterIndex]);
   return (

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -421,9 +421,11 @@ function AverageSpentFields({ filterIndex }: Props): JSX.Element {
           }}
           automationId="select-average-spent-operator"
         >
+          <option value=">">{MailPoet.I18n.t('moreThan')}</option>
+          <option value=">=">{MailPoet.I18n.t('moreThanOrEqual')}</option>
           <option value="=">{MailPoet.I18n.t('equals')}</option>
           <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
-          <option value=">">{MailPoet.I18n.t('moreThan')}</option>
+          <option value="<">{MailPoet.I18n.t('lessThanOrEqual')}</option>
           <option value="<">{MailPoet.I18n.t('lessThan')}</option>
         </Select>
         <Input

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -79,8 +79,11 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   ) {
     return false;
   }
-  if (formItems.action === WooCommerceActionTypes.AVERAGE_SPENT) {
-    return !!formItems.amount && !!formItems.operator && !!formItems.days;
+  if (
+    formItems.action === WooCommerceActionTypes.AVERAGE_SPENT &&
+    (!formItems.amount || !formItems.operator || !formItems.days)
+  ) {
+    return false;
   }
   if (formItems.action === WooCommerceActionTypes.PURCHASE_DATE) {
     return validateDateField(formItems);

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -428,7 +428,7 @@ function AverageSpentFields({ filterIndex }: Props): JSX.Element {
           <option value=">=">{MailPoet.I18n.t('moreThanOrEqual')}</option>
           <option value="=">{MailPoet.I18n.t('equals')}</option>
           <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
-          <option value="<">{MailPoet.I18n.t('lessThanOrEqual')}</option>
+          <option value="<=">{MailPoet.I18n.t('lessThanOrEqual')}</option>
           <option value="<">{MailPoet.I18n.t('lessThan')}</option>
         </Select>
         <Input
@@ -498,7 +498,7 @@ function SingleOrderValueFields({ filterIndex }: Props): JSX.Element {
           <option value=">=">{MailPoet.I18n.t('moreThanOrEqual')}</option>
           <option value="=">{MailPoet.I18n.t('equals')}</option>
           <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
-          <option value="<">{MailPoet.I18n.t('lessThanOrEqual')}</option>
+          <option value="<=">{MailPoet.I18n.t('lessThanOrEqual')}</option>
           <option value="<">{MailPoet.I18n.t('lessThan')}</option>
         </Select>
         <Input

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
@@ -8,11 +8,17 @@ export enum WooCommerceActionTypes {
   PURCHASE_DATE = 'purchaseDate',
   PURCHASED_PRODUCT = 'purchasedProduct',
   TOTAL_SPENT = 'totalSpent',
+  AVERAGE_SPENT = 'averageSpent',
   CUSTOMER_IN_COUNTRY = 'customerInCountry',
   SINGLE_ORDER_VALUE = 'singleOrderValue',
 }
 
 export const WooCommerceOptions = [
+  {
+    value: WooCommerceActionTypes.AVERAGE_SPENT,
+    label: MailPoet.I18n.t('wooAverageSpent'),
+    group: SegmentTypes.WooCommerce,
+  },
   {
     value: WooCommerceActionTypes.CUSTOMER_IN_COUNTRY,
     label: MailPoet.I18n.t('wooCustomerInCountry'),

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -94,6 +94,8 @@ export interface WooCommerceFormItem extends FormItem {
   single_order_value_type?: string;
   single_order_value_amount?: number;
   single_order_value_days?: number;
+  amount?: number;
+  days?: string;
 }
 
 export interface WooCommerceMembershipFormItem extends FormItem {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -94,8 +94,9 @@ export interface WooCommerceFormItem extends FormItem {
   single_order_value_type?: string;
   single_order_value_amount?: number;
   single_order_value_days?: number;
-  amount?: number;
-  days?: string;
+  average_spent_type?: number;
+  average_spent_amount?: number;
+  average_spent_days?: string;
 }
 
 export interface WooCommerceMembershipFormItem extends FormItem {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -94,8 +94,8 @@ export interface WooCommerceFormItem extends FormItem {
   single_order_value_type?: string;
   single_order_value_amount?: number;
   single_order_value_days?: number;
-  average_spent_type?: number;
-  average_spent_amount?: number;
+  average_spent_type?: string;
+  average_spent_amount?: string;
   average_spent_days?: string;
 }
 

--- a/mailpoet/lib/API/JSON/v1/DynamicSegments.php
+++ b/mailpoet/lib/API/JSON/v1/DynamicSegments.php
@@ -149,6 +149,7 @@ class DynamicSegments extends APIEndpoint {
         return __('Please select a type for the comparison, a number of orders and a number of days.', 'mailpoet');
       case InvalidFilterException::MISSING_TOTAL_SPENT_FIELDS:
       case InvalidFilterException::MISSING_SINGLE_ORDER_VALUE_FIELDS:
+      case InvalidFilterException::MISSING_AVERAGE_SPENT_FIELDS:
         return __('Please select a type for the comparison, an amount and a number of days.', 'mailpoet');
       case InvalidFilterException::MISSING_FILTER:
         return __('Please add at least one condition for filtering.', 'mailpoet');

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -411,6 +411,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberSegment::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\SubscriberTag::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\UserRole::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
@@ -22,4 +22,5 @@ class InvalidFilterException extends InvalidStateException {
   const MISSING_OPERATOR = 15;
   const MISSING_PLAN_ID = 16;
   const MISSING_SINGLE_ORDER_VALUE_FIELDS = 17;
+  const MISSING_AVERAGE_SPENT_FIELDS = 18;
 };

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -14,6 +14,7 @@ use MailPoet\Segments\DynamicSegments\Filters\SubscriberSegment;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedViaForm;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberTag;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
@@ -283,6 +284,10 @@ class FilterDataMapper {
     } elseif ($data['action'] === WooCommercePurchaseDate::ACTION) {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
+    } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {
+      $filterData['days'] = $data['days'];
+      $filterData['amount'] = $data['amount'];
+      $filterData['operator'] = $data['operator'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -285,6 +285,13 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
     } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {
+      if (
+        !isset($data['average_spent_type'])
+        || !isset($data['average_spent_amount']) || $data['average_spent_amount'] < 0
+        || !isset($data['average_spent_days']) || $data['average_spent_days'] < 1
+      ) {
+        throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_AVERAGE_SPENT_FIELDS);
+      }
       $filterData['average_spent_days'] = $data['average_spent_days'];
       $filterData['average_spent_amount'] = $data['average_spent_amount'];
       $filterData['average_spent_type'] = $data['average_spent_type'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -285,9 +285,9 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
     } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {
-      $filterData['days'] = $data['days'];
-      $filterData['amount'] = $data['amount'];
-      $filterData['operator'] = $data['operator'];
+      $filterData['average_spent_days'] = $data['average_spent_days'];
+      $filterData['average_spent_amount'] = $data['average_spent_amount'];
+      $filterData['average_spent_type'] = $data['average_spent_type'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -16,6 +16,7 @@ use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedDate;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberSubscribedViaForm;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberTag;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
@@ -32,6 +33,9 @@ class FilterFactory {
 
   /** @var UserRole */
   private $userRole;
+
+  /** @var WooCommerceAverageSpent */
+  private $wooCommerceAverageSpent;
 
   /** @var WooCommerceProduct */
   private $wooCommerceProduct;
@@ -103,7 +107,8 @@ class FilterFactory {
     SubscriberTag $subscriberTag,
     SubscriberSegment $subscriberSegment,
     SubscriberSubscribedViaForm $subscribedViaForm,
-    WooCommerceSingleOrderValue $wooCommerceSingleOrderValue
+    WooCommerceSingleOrderValue $wooCommerceSingleOrderValue,
+    WooCommerceAverageSpent $wooCommerceAverageSpent
   ) {
     $this->emailAction = $emailAction;
     $this->userRole = $userRole;
@@ -124,6 +129,7 @@ class FilterFactory {
     $this->emailActionClickAny = $emailActionClickAny;
     $this->wooCommerceSingleOrderValue = $wooCommerceSingleOrderValue;
     $this->subscribedViaForm = $subscribedViaForm;
+    $this->wooCommerceAverageSpent = $wooCommerceAverageSpent;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -206,6 +212,8 @@ class FilterFactory {
       return $this->wooCommerceSingleOrderValue;
     } elseif ($action === WooCommercePurchaseDate::ACTION) {
       return $this->wooCommercePurchaseDate;
+    } elseif ($action === WooCommerceAverageSpent::ACTION) {
+      return $this->wooCommerceAverageSpent;
     }
     return $this->wooCommerceCategory;
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -1,0 +1,55 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooCommerceAverageSpent implements Filter {
+  const ACTION = 'averageSpent';
+
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  public function __construct(
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper
+  ) {
+    $this->filterHelper = $filterHelper;
+    $this->wooFilterHelper = $wooFilterHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $operator = $filterData->getParam('operator');
+    $amount = $filterData->getParam('amount');
+    $days = intval($filterData->getParam('days'));
+
+    $date = Carbon::now()->subDays($days);
+    $dateParam = $this->filterHelper->getUniqueParameterName('date');
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+
+    $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
+      ->setParameter($dateParam, $date->toDateTimeString())
+      ->groupBy('inner_subscriber_id');
+
+    $amountParam = $this->filterHelper->getUniqueParameterName('amount');
+    if ($operator === '=') {
+      $queryBuilder->having("AVG($orderStatsAlias.total_sales) = :$amountParam");
+    } elseif ($operator === '!=') {
+      $queryBuilder->having("AVG($orderStatsAlias.total_sales) != :$amountParam");
+    } elseif ($operator === '>') {
+      $queryBuilder->having("AVG($orderStatsAlias.total_sales) > :$amountParam");
+    } elseif ($operator === '<') {
+      $queryBuilder->having("AVG($orderStatsAlias.total_sales) < :$amountParam");
+    }
+
+    $queryBuilder->setParameter($amountParam, $amount);
+
+    return $queryBuilder;
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -46,6 +46,10 @@ class WooCommerceAverageSpent implements Filter {
       $queryBuilder->having("AVG($orderStatsAlias.total_sales) > :$amountParam");
     } elseif ($operator === '<') {
       $queryBuilder->having("AVG($orderStatsAlias.total_sales) < :$amountParam");
+    } elseif ($operator === '<=') {
+      $queryBuilder->having("AVG($orderStatsAlias.total_sales) <= :$amountParam");
+    } elseif ($operator === '>=') {
+      $queryBuilder->having("AVG($orderStatsAlias.total_sales) >= :$amountParam");
     }
 
     $queryBuilder->setParameter($amountParam, $amount);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -25,9 +25,9 @@ class WooCommerceAverageSpent implements Filter {
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $filterData = $filter->getFilterData();
-    $operator = $filterData->getParam('operator');
-    $amount = $filterData->getParam('amount');
-    $days = intval($filterData->getParam('days'));
+    $operator = $filterData->getParam('average_spent_type');
+    $amount = $filterData->getParam('average_spent_amount');
+    $days = intval($filterData->getParam('average_spent_days'));
 
     $date = Carbon::now()->subDays($days);
     $dateParam = $this->filterHelper->getUniqueParameterName('date');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -3,38 +3,23 @@
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Util\DBCollationChecker;
 use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class WooCommerceTotalSpent implements Filter {
   const ACTION_TOTAL_SPENT = 'totalSpent';
-
-  /** @var EntityManager */
-  private $entityManager;
-
-  /** @var DBCollationChecker */
-  private $collationChecker;
 
   /** @var WooFilterHelper */
   private $wooFilterHelper;
 
   public function __construct(
-    EntityManager $entityManager,
-    DBCollationChecker $collationChecker,
     WooFilterHelper $wooFilterHelper
   ) {
-    $this->entityManager = $entityManager;
-    $this->collationChecker = $collationChecker;
     $this->wooFilterHelper = $wooFilterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
-    global $wpdb;
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('total_spent_type');
     $amount = $filterData->getParam('total_spent_amount');
@@ -42,13 +27,6 @@ class WooCommerceTotalSpent implements Filter {
 
     $date = Carbon::now()->subDays($days);
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
-    $collation = $this->collationChecker->getCollateIfNeeded(
-      $subscribersTable,
-      'email',
-      $wpdb->prefix . 'wc_customer_lookup',
-      'email'
-    );
-
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
     $dateParam = "date_$parameterSuffix";
 

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -97,9 +97,20 @@ class IntegrationTester extends \Codeception\Actor {
     }
   }
 
+  /**
+   * @param array $data - includes default args for wc_create_order plus some extras.
+   * The defaults are currently:
+   *    'status'        => null,
+   *    'customer_id'   => null,
+   *    'customer_note' => null,
+   *    'parent'        => null,
+   *    'created_via'   => null,
+   *    'cart_hash'     => null,
+   * @return WC_Order
+   */
   public function createWooCommerceOrder(array $data = []): \WC_Order {
     $helper = ContainerWrapper::getInstance()->get(Helper::class);
-    $order = $helper->wcCreateOrder([]);
+    $order = $helper->wcCreateOrder($data);
 
     if (isset($data['date_created'])) {
       $order->set_date_created($data['date_created']);
@@ -109,9 +120,15 @@ class IntegrationTester extends \Codeception\Actor {
       $order->set_billing_email($data['billing_email']);
     }
 
+    if (isset($data['total'])) {
+      $order->set_total($data['total']);
+    }
+
     $order->save();
 
-    $this->wooOrderIds[] = $order->get_id();
+    $orderId = $order->get_id();
+    $this->wooOrderIds[] = $orderId;
+    $this->updateWooOrderStats($orderId);
 
     return $order;
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * @group woo
+ */
+class WooCommerceAverageSpentTest extends \MailPoetTest {
+  /** @var WooCommerceAverageSpent */
+  private $averageSpentFilter;
+
+  public function _before(): void {
+    $this->averageSpentFilter = $this->diContainer->get(WooCommerceAverageSpent::class);
+  }
+
+  public function testItWorksWithAmountEquals(): void {
+    $this->createCustomerWithOrderValues('1@e.com', [10, 20]);
+    $this->createCustomerWithOrderValues('2@e.com', [5]);
+    $this->createCustomerWithOrderValues('3@e.com', [1, 1, 43]);
+    $this->createCustomerWithOrderValues('4@e.com', [15.01]);
+
+    $matchingEmails = $this->getMatchingEmails('=', 15);
+    $this->assertEqualsCanonicalizing(['1@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('=', 5);
+    $this->assertEqualsCanonicalizing(['2@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('=', 15.01);
+    $this->assertEqualsCanonicalizing(['4@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('=', 13.13);
+    $this->assertEqualsCanonicalizing([], $matchingEmails);
+  }
+
+  public function testItWorksWithAmountGreaterThan(): void {
+    $this->createCustomerWithOrderValues('1@e.com', [10, 20]);
+    $this->createCustomerWithOrderValues('2@e.com', [20]);
+    $this->createCustomerWithOrderValues('3@e.com', [15, 15.01]);
+
+    $matchingEmails = $this->getMatchingEmails('>', 19.99);
+    $this->assertEqualsCanonicalizing(['2@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>', 15);
+    $this->assertEqualsCanonicalizing(['2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>', 14.99);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>', 20);
+    $this->assertEqualsCanonicalizing([], $matchingEmails);
+  }
+
+  public function testItWorksWithAmountLessThan(): void {
+    $this->createCustomerWithOrderValues('1@e.com', [100, 110, 2000]); // average = ~$736.67
+    $this->createCustomerWithOrderValues('2@e.com', [0.01]);
+    $this->createCustomerWithOrderValues('3@e.com', [2000, 10, 25]); // average = ~$678.33
+
+    $matchingEmails = $this->getMatchingEmails('<', 678.34);
+    $this->assertEqualsCanonicalizing(['2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('<', 678.33);
+    $this->assertEqualsCanonicalizing(['2@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('<', 0.01);
+    $this->assertEqualsCanonicalizing([], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('<', 736.68);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
+  }
+
+  public function testItWorksWithAmountNotEqual(): void {
+    $this->createCustomerWithOrderValues('1@e.com', [1, 2, 3, 4]); // average = 2.50
+    $this->createCustomerWithOrderValues('2@e.com', [22.22, 33.33, 44.44]); // average = 33.33
+    $this->createCustomerWithOrderValues('3@e.com', [30000, 30000, 30000]); // big spender!
+
+    $matchingEmails = $this->getMatchingEmails('!=', 2.50);
+    $this->assertEqualsCanonicalizing(['2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('!=', 33.33);
+    $this->assertEqualsCanonicalizing(['1@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('!=', 30000);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('!=', 8);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
+  }
+
+  public function testItWorksWithDateRanges(): void {
+    $id1 = $this->tester->createCustomer('1@e.com');
+    $this->createOrder($id1, 100, 3);
+    $this->createOrder($id1, 200, 6); // 150 average
+    $this->createOrder($id1, 60, 9); // 120 average
+    $this->createOrder($id1, 400, 100); // 190 average
+
+    $emails = $this->getMatchingEmails('=', 100, 3);
+    $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
+    $emails = $this->getMatchingEmails('=', 100, 6);
+    $this->assertEqualsCanonicalizing([], $emails);
+    $emails = $this->getMatchingEmails('=', 150, 6);
+    $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
+    $emails = $this->getMatchingEmails('=', 120, 9);
+    $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
+    $emails = $this->getMatchingEmails('=', 120, 99);
+    $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
+    $emails = $this->getMatchingEmails('=', 190, 100);
+    $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
+  }
+
+  private function getMatchingEmails(string $operator, float $amount, int $days = 365): array {
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
+      'operator' => $operator,
+      'amount' => $amount,
+      'days' => $days,
+    ]);
+
+    return $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->averageSpentFilter);
+  }
+
+  private function createCustomerWithOrderValues(string $customerEmail, array $values): void {
+    $customerId = $this->tester->createCustomer($customerEmail);
+    foreach ($values as $value) {
+      $this->createOrder($customerId, $value );
+    }
+  }
+
+  private function createOrder(int $customerId, float $orderTotal, int $daysAgo = 0) {
+    $createdAt = Carbon::now();
+    $createdAt->subDays($daysAgo)->addMinute();
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_date_created($createdAt->toDateTimeString());
+    $order->set_status('wc-completed');
+    $order->set_total((string)$orderTotal);
+    $order->save();
+    $this->tester->updateWooOrderStats($order->get_id());
+
+    return $order->get_id();
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -133,9 +133,9 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
 
   private function getMatchingEmails(string $operator, float $amount, int $days = 365): array {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
-      'operator' => $operator,
-      'amount' => $amount,
-      'days' => $days,
+      'average_spent_type' => $operator,
+      'average_spent_amount' => $amount,
+      'average_spent_days' => $days,
     ]);
 
     return $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->averageSpentFilter);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -99,6 +99,38 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
   }
 
+  public function testItWorksWithGreaterThanOrEqual() {
+    $this->createCustomerWithOrderValues('1@e.com', [5, 10]);
+    $this->createCustomerWithOrderValues('2@e.com', [5, 15]);
+    $this->createCustomerWithOrderValues('3@e.com', [5, 20]);
+    $matchingEmails = $this->getMatchingEmails('>=', 7.50);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>=', 7.51);
+    $this->assertEqualsCanonicalizing(['2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>=', 10);
+    $this->assertEqualsCanonicalizing(['2@e.com', '3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>=', 10.01);
+    $this->assertEqualsCanonicalizing(['3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>=', 12.50);
+    $this->assertEqualsCanonicalizing(['3@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('>=', 12.51);
+    $this->assertEqualsCanonicalizing([], $matchingEmails);
+  }
+
+  public function testItWorksWithLessThanOrEqual() {
+    $this->createCustomerWithOrderValues('1@e.com', [5, 10]);
+    $this->createCustomerWithOrderValues('2@e.com', [5, 15]);
+    $this->createCustomerWithOrderValues('3@e.com', [5, 20]);
+    $matchingEmails = $this->getMatchingEmails('<=', 7.49);
+    $this->assertEqualsCanonicalizing([], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('<=', 7.50);
+    $this->assertEqualsCanonicalizing(['1@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('<=', 10);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com'], $matchingEmails);
+    $matchingEmails = $this->getMatchingEmails('<=', 12.50);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
+  }
+
   private function getMatchingEmails(string $operator, float $amount, int $days = 365): array {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
       'operator' => $operator,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -148,17 +148,14 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
     }
   }
 
-  private function createOrder(int $customerId, float $orderTotal, int $daysAgo = 0) {
+  private function createOrder(int $customerId, float $orderTotal, int $daysAgo = 0): void {
     $createdAt = Carbon::now();
     $createdAt->subDays($daysAgo)->addMinute();
-    $order = $this->tester->createWooCommerceOrder();
-    $order->set_customer_id($customerId);
-    $order->set_date_created($createdAt->toDateTimeString());
-    $order->set_status('wc-completed');
-    $order->set_total((string)$orderTotal);
-    $order->save();
-    $this->tester->updateWooOrderStats($order->get_id());
-
-    return $order->get_id();
+    $this->tester->createWooCommerceOrder([
+      'date_created' => $createdAt->toDateTimeString(),
+      'status' => 'wc-completed',
+      'customer_id' => $customerId,
+      'total' => (string)$orderTotal,
+    ]);
   }
 }

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -214,6 +214,7 @@
     'daysPlaceholder': __('days'),
     'days': _x('days', 'Appears together with `inTheLast` when creating a new WooCommerce segment based on the number of orders.'),
     'inTheLast': _x('in the last', 'Appears together with `days` when creating a new WooCommerce segment based on the number of orders.'),
+    'wooAverageSpent': __('average order value'),
     'wooNumberOfOrdersOrders': __('orders'),
     'wooPurchasedCategory': __('purchased in category'),
     'wooPurchaseDate': __('purchase date'),


### PR DESCRIPTION
## Description

This adds a new WooCommerce dynamic segment filter to filter subscribers based on the average value of their orders within the last `n` days. It works very similarly to the "single order value" filter.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4987](https://mailpoet.atlassian.net/browse/MAILPOET-4987)

## After-merge notes

_N/A_


[MAILPOET-4987]: https://mailpoet.atlassian.net/browse/MAILPOET-4987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ