### PR TITLE
Bump WP require at least to 6.0 and tested up to 6.2 [MAILPOET-5075]

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 5.9
+ * Requires at least: 6.0
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -27,7 +27,7 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '5.9';
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.0';
 const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '6.4';// Older versions lead to fatal errors
 
 function mailpoet_deactivate_plugin() {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,8 +1,8 @@
 === MailPoet - emails and newsletters in WordPress ===
 Contributors: mailpoet
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
-Requires at least: 5.9
-Tested up to: 6.1
+Requires at least: 6.0
+Tested up to: 6.2
 Stable tag: 4.14.0
 Requires PHP: 7.2
 License: GPLv3


### PR DESCRIPTION
## Description

This PR simply bumps up the required at least and tested up to WP versions to 6.0 and 6.2, respectively.

## Code review notes

_N/A_

## QA notes

Per the documentation, please check with QA if they want to do a final test of WP 6.2 or not. Probably not necessary since this WP version was released a while ago, and no problems were reported.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5075]

## After-merge notes

_N/A_


[MAILPOET-5075]: https://mailpoet.atlassian.net/browse/MAILPOET-5075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ