### PR TITLE
Update WP versions used in the automated tests [MAILPOET-5075]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,7 +855,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-5.9_php7.3_20230213.1
+          wordpress_image_version: wp-6.0_php7.4_20230425.1
           requires:
             - build
       - performance_tests:

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.1_php8.0_20201122.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.2_php8.0_20230425.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
## Description

This PR updates the WP version used in the default Docker container to WP 6.2 and the WP version used in the Docker container for the acceptance_oldest CircleCI build job to WP 6.0.

## Code review notes

_N/A_

## QA notes

QA is probably not needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5075]

## After-merge notes

_N/A_


[MAILPOET-5075]: https://mailpoet.atlassian.net/browse/MAILPOET-5075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ