### PR TITLE
Update Tracy to version 2.9.7 to get rid of PHP 8.2 warnings [MAILPOET-5265]

### DIFF
--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -3,7 +3,7 @@
 $tools = [
   'https://github.com/composer/composer/releases/download/2.3.5/composer.phar' => 'composer.phar',
   'https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar' => 'php-scoper.phar',
-  'https://github.com/nette/tracy/releases/download/v2.9.1/tracy.phar' => 'tracy.phar',
+  'https://github.com/nette/tracy/releases/download/v2.9.7/tracy.phar' => 'tracy.phar',
 ];
 // ensure installation in dev-mode only
 $isDevMode = (bool)getenv('COMPOSER_DEV_MODE');


### PR DESCRIPTION
## Description

We were running Tracy 2.9.1, and this version was generating warnings when running PHP 8.2. Example:

```
ErrorException: Creation of dynamic property Tracy\DefaultBarPanel::$time is deprecated in phar:///var/www/html/wp-content/plugins/mailpoet/tools/vendor/tracy.phar/Tracy/Bar/panels/info.tab.phtml:2
```

## Code review notes

_N/A_

## QA notes

QA is not needed

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5265]

## After-merge notes

_N/A_


[MAILPOET-5265]: https://mailpoet.atlassian.net/browse/MAILPOET-5265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ