### PR TITLE
Cast step array keys to string [MAILPOET-5267]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -42,7 +42,7 @@ class Automation {
   /** @var ?DateTimeImmutable */
   private $activatedAt = null;
 
-  /** @var array<string, Step> */
+  /** @var array<string|int, Step> */
   private $steps;
 
   /** @var array<string, mixed> */
@@ -118,12 +118,12 @@ class Automation {
     return $this->activatedAt;
   }
 
-  /** @return array<string, Step> */
+  /** @return array<string|int, Step> */
   public function getSteps(): array {
     return $this->steps;
   }
 
-  /** @param array<string, Step> $steps */
+  /** @param array<string|int, Step> $steps */
   public function setSteps(array $steps): void {
     $this->steps = $steps;
     $this->setUpdatedAt();

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationGraph/AutomationWalker.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationGraph/AutomationWalker.php
@@ -35,11 +35,11 @@ class AutomationWalker {
   }
 
   /**
-   * @param array<string, Step> $steps
-   * @return Generator<array{0: Step, 1: array<string, Step>}>
+   * @param array<string|int, Step> $steps
+   * @return Generator<array{0: Step, 1: array<string|int, Step>}>
    */
   private function walkStepsDepthFirstPreOrder(array $steps, Step $root): Generator {
-    /** @var array{0: Step, 1: array<string, Step>}[] $stack */
+    /** @var array{0: Step, 1: array<string|int, Step>}[] $stack */
     $stack = [
       [$root, []],
     ];

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ConsistentStepMapRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ConsistentStepMapRule.php
@@ -12,7 +12,7 @@ class ConsistentStepMapRule implements AutomationNodeVisitor {
 
   public function initialize(Automation $automation): void {
     foreach ($automation->getSteps() as $id => $step) {
-      if ($id !== $step->getId()) {
+      if ((string)$id !== $step->getId()) {
         // translators: %1$s is the ID of the step, %2$s is its index in the steps object.
         throw Exceptions::automationStructureNotValid(
           sprintf(__("Step with ID '%1\$s' stored under a mismatched index '%2\$s'.", 'mailpoet'), $step->getId(), $id),


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

This PR just casts the key to a string. The disadvantage is that the keys might still be `integers`. I searched the code base and did not find any other instance where we use the keys of the array.

Another possibility would be to force the keys to be a string e.g. by adding a preceding `a`, but I am not sure what this would mean in terms of already existing automations and migrations :thinking:

Imo, the type cast is enough. I do not see a lot of other scenarios, where we will use the array key instead of `$step->getId()`.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5267]

## After-merge notes

_N/A_


[MAILPOET-5267]: https://mailpoet.atlassian.net/browse/MAILPOET-5267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ