### PR TITLE
Update WooCommerce versions for release 7.6.1 [MAILPOET-5268]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,7 +877,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 7.3.0
+          woo_core_version: 7.4.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 7.2.0
- * WC tested up to: 7.4.0
+ * WC requires at least: 7.4.0
+ * WC tested up to: 7.6.1
  *
  * @package WordPress
  * @author MailPoet


### PR DESCRIPTION
MAILPOET-5268

## Description
This just bumps the required/tested up to WooCommerce versions to reflect the April 26th release of WooCommerce 
7.6.1.

## Code review notes

I wanted to make the Jira ticket something that would be easy to duplicate and that would contain all the relevant information for this type of change. I would appreciate it if you would take a look and edit anything you think could be improved.

## QA notes
Per our current process, we're leaving it up to you if you want to do additional manual testing. Our acceptance tests automatically pull the latest version of WooCommerce.

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5268

## After-merge notes

_N/A_
