### PR TITLE
Remove or replace calls to the deprecated utf8_encode() function [MAILPOET-4865]

### DIFF
--- a/mailpoet/lib/Helpscout/Beacon.php
+++ b/mailpoet/lib/Helpscout/Beacon.php
@@ -80,7 +80,7 @@ class Beacon {
       'WordPress version' => $this->wp->getBloginfo('version'),
       'Database version' => $dbVersion,
       'Web server' => (!empty($_SERVER["SERVER_SOFTWARE"])) ? sanitize_text_field(wp_unslash($_SERVER["SERVER_SOFTWARE"])) : 'N/A',
-      'Server OS' => (function_exists('php_uname')) ? utf8_encode(php_uname()) : 'N/A',
+      'Server OS' => (function_exists('php_uname')) ? php_uname() : 'N/A',
       'WP info' => 'WP_MEMORY_LIMIT: ' . WP_MEMORY_LIMIT . ' - WP_MAX_MEMORY_LIMIT: ' . WP_MAX_MEMORY_LIMIT . ' - WP_DEBUG: ' . WP_DEBUG .
         ' - WordPress language: ' . $this->wp->getLocale(),
       'PHP info' => 'PHP max_execution_time: ' . ini_get('max_execution_time') . ' - PHP memory_limit: ' . ini_get('memory_limit') .

--- a/mailpoet/lib/Mailer/WordPress/WordPressMailer.php
+++ b/mailpoet/lib/Mailer/WordPress/WordPressMailer.php
@@ -79,7 +79,7 @@ class WordPressMailer extends PHPMailer {
     if (strpos($this->ContentType, 'text/plain') === 0) {
       $email['body']['text'] = $this->Body;
     } elseif (strpos($this->ContentType, 'text/html') === 0) {
-      $text = @Html2Text::convert(strtolower($this->CharSet) === 'utf-8' ? $this->Body : utf8_encode($this->Body));
+      $text = @Html2Text::convert(strtolower($this->CharSet) === 'utf-8' ? $this->Body : mb_convert_encoding($this->Body, 'UTF-8', mb_list_encodings()));
       $email['body']['text'] = $text;
       $email['body']['html'] = $this->Body;
     } elseif (strpos($this->ContentType, 'multipart/alternative') === 0) {

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -217,7 +217,7 @@ class Renderer {
    * @return string
    */
   private function renderTextVersion($template) {
-    $template = (mb_detect_encoding($template, 'UTF-8', true)) ? $template : utf8_encode($template);
+    $template = (mb_detect_encoding($template, 'UTF-8', true)) ? $template : mb_convert_encoding($template, 'UTF-8', mb_list_encodings());
     return @Html2Text::convert($template);
   }
 

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -113,7 +113,7 @@ class ConfirmationEmailMailer {
 
     //create a text version. @ is important here, Html2Text throws warnings
     $text = @Html2Text::convert(
-      (mb_detect_encoding($body, 'UTF-8', true)) ? $body : utf8_encode($body),
+      (mb_detect_encoding($body, 'UTF-8', true)) ? $body : mb_convert_encoding($body, 'UTF-8', mb_list_encodings()),
       true
     );
 

--- a/mailpoet/tests/integration/Helpscout/BeaconTest.php
+++ b/mailpoet/tests/integration/Helpscout/BeaconTest.php
@@ -143,7 +143,7 @@ class BeaconTest extends \MailPoetTest {
   }
 
   public function testItReturnsServerOSInformation() {
-    expect($this->beaconData['Server OS'])->equals(utf8_encode(php_uname()));
+    expect($this->beaconData['Server OS'])->equals(php_uname());
   }
 
   public function testItReturnsCronPingUrl() {


### PR DESCRIPTION
## Description

This PR removes or replaces calls to the deprecated utf8_encode() function. See the commit messages for more details.

I was not able to find calls to utf8_decode() in our code base.

For more information on why those two functions were deprecated and the alternatives, check this post: https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated

## Code review notes

_N/A_

## QA notes

QA is probably not needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4865]

## After-merge notes

_N/A_


[MAILPOET-4865]: https://mailpoet.atlassian.net/browse/MAILPOET-4865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ