### PR TITLE
Remove notices for hooks that were deprecated over six months ago [MAILPOET-5272]

### DIFF
--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -103,16 +103,6 @@ class Shortcodes {
       $this, 'renderArchiveSubject',
     ], 2, 3);
 
-    // This deprecated notice can be removed after 2023-01-11
-    if ($this->wp->hasFilter('mailpoet_archive_email_subject')) {
-      $this->wp->deprecatedHook(
-        'mailpoet_archive_email_subject_line',
-        '3.92.1',
-        'mailpoet_archive_email_subject',
-        __('Please note that mailpoet_archive_email_subject no longer runs and that the list of parameters of the new filter is different.', 'mailpoet')
-      );
-    }
-
     // initialize subscription pages data
     $this->subscriptionPages->init();
     // initialize subscription management shortcodes

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -168,16 +168,6 @@ class Newsletter {
       $renderedNewsletter = $this->gaTracking->applyGATracking($renderedNewsletter, $newsletter);
     }
 
-    // This deprecated notice can be removed after 2023-03-23
-    if ($this->wp->hasFilter('mailpoet_sending_newsletter_render_after')) {
-      $this->wp->deprecatedHook(
-        'mailpoet_sending_newsletter_render_after',
-        '3.98.1',
-        'mailpoet_sending_newsletter_render_after_pre_process',
-        __('Please note that mailpoet_sending_newsletter_render_after no longer runs and that the list of parameters of the new filter is different.', 'mailpoet')
-      );
-    }
-
     // check if this is a post notification and if it contains at least 1 ALC post
     if (
       $newsletter->getType() === NewsletterEntity::TYPE_NOTIFICATION_HISTORY &&


### PR DESCRIPTION
## Description

This PR simply remove the notices for hooks that were deprecated over six months ago.

## Code review notes

_N/A_

## QA notes

No QA is needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5272]

## After-merge notes

_N/A_


[MAILPOET-5272]: https://mailpoet.atlassian.net/browse/MAILPOET-5272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ