### PR TITLE
Ignore existing coupons with unknown types

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/existingCoupons.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/existingCoupons.tsx
@@ -72,6 +72,13 @@ class ExistingCoupons extends Component<Props, State> {
           .includes(this.state.couponSearch.toLowerCase()),
       );
     }
+    const allDiscountTypes = this.availableDiscountTypes
+      .map((type) => type.value)
+      .filter((type) => type !== '');
+    // Ensure we only include coupons with a known discount type
+    coupons = coupons.filter((coupon) =>
+      allDiscountTypes.includes(coupon.discountType),
+    );
     return coupons;
   };
 


### PR DESCRIPTION
## Description

This PR prevents WooCommerce coupons with an unknown `discount_type` from breaking the newsletter editor's coupon block settings. This was observed on a user's site where they had an old coupon with the no-longer-used `percent_product` type.

## Code review notes

_N/A_

## QA notes

See the ticket for steps to reproduce.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5271](https://mailpoet.atlassian.net/browse/MAILPOET-5271)

## After-merge notes

_N/A_


[MAILPOET-5271]: https://mailpoet.atlassian.net/browse/MAILPOET-5271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ