### PR TITLE
Update notifications for exceeded limits [MAILPOET-5191]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -102,6 +102,7 @@ interface Window {
   mailpoet_has_valid_api_key: boolean;
   mailpoet_has_valid_premium_key: string;
   mailpoet_mss_key_invalid: boolean;
+  mailpoet_mss_key_valid: boolean;
   mailpoet_mta_method: string;
   mailpoet_date_offset: string;
   mailpoet_time_format: string;

--- a/mailpoet/assets/js/src/homepage/notices.tsx
+++ b/mailpoet/assets/js/src/homepage/notices.tsx
@@ -1,21 +1,14 @@
 import { MailPoet } from 'mailpoet';
 import { Notices } from 'notices/notices';
-import { SubscribersLimitNotice } from 'notices/subscribers_limit_notice';
-import { EmailVolumeLimitNotice } from 'notices/email_volume_limit_notice';
-import { InvalidMssKeyNotice } from 'notices/invalid_mss_key_notice';
 import { TransactionalEmailsProposeOptInNotice } from 'notices/transactional_emails_propose_opt_in_notice';
 import { MailerError } from 'notices/mailer_error';
+import { MssAccessNotices } from 'notices/mss_access_notices';
 
 export function HomepageNotices(): JSX.Element {
   return (
     <>
       <Notices />
-      <SubscribersLimitNotice />
-      <EmailVolumeLimitNotice />
-      <InvalidMssKeyNotice
-        mssKeyInvalid={MailPoet.hasInvalidMssApiKey}
-        subscribersCount={MailPoet.subscribersCount}
-      />
+      <MssAccessNotices />
       <TransactionalEmailsProposeOptInNotice
         mailpoetInstalledDaysAgo={MailPoet.installedDaysAgo}
         sendTransactionalEmails={MailPoet.transactionalEmailsEnabled}

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -27,8 +27,11 @@ export const MailPoet = {
   subscribersLimitReached: window.mailpoet_subscribers_limit_reached,
   subscribersCount: window.mailpoet_subscribers_count,
   hasPremiumSupport: window.mailpoet_has_premium_support,
+  // The key is valid and can be authenticated by the API (but still might not have access to premium or MSS
   hasValidApiKey: window.mailpoet_has_valid_api_key,
+  // The key is valid and has access to premium features
   hasValidPremiumKey: window.mailpoet_has_valid_premium_key,
+  // The key is invalid and has no access to MSS
   hasInvalidMssApiKey: window.mailpoet_mss_key_invalid,
   mtaMethod: window.mailpoet_mta_method,
   mtaLog: window.mailpoet_mta_log,

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -31,6 +31,8 @@ export const MailPoet = {
   hasValidApiKey: window.mailpoet_has_valid_api_key,
   // The key is valid and has access to premium features
   hasValidPremiumKey: window.mailpoet_has_valid_premium_key,
+  // The key is valid and has access to MSS
+  hasValidMssApiKey: window.mailpoet_mss_key_valid,
   // The key is invalid and has no access to MSS
   hasInvalidMssApiKey: window.mailpoet_mss_key_invalid,
   mtaMethod: window.mailpoet_mta_method,

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
@@ -3,7 +3,7 @@ import { __, _x } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import { MailPoet } from 'mailpoet';
 import { withRouter } from 'react-router-dom';
-import { InvalidMssKeyNotice } from 'notices/invalid_mss_key_notice';
+import { MssAccessNotices } from 'notices/mss_access_notices';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { HideScreenOptions } from 'common/hide_screen_options/hide_screen_options';
 import { RemoveWrapMargin } from 'common/remove_wrap_margin/remove_wrap_margin';
@@ -111,10 +111,7 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
       <TopBarWithBeamer />
 
       <div className="mailpoet-stats-page">
-        <InvalidMssKeyNotice
-          mssKeyInvalid={window.mailpoet_mss_key_invalid}
-          subscribersCount={window.mailpoet_subscribers_count}
-        />
+        <MssAccessNotices />
 
         <ErrorBoundary>
           <NewsletterStatsInfo newsletter={newsletter} />

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -35,10 +35,8 @@ import { ErrorBoundary, registerTranslations, Tab, withBoundary } from 'common';
 import { withNpsPoll } from 'nps_poll.jsx';
 import { ListingHeading } from 'newsletters/listings/heading.jsx';
 import { ListingHeadingDisplay } from 'newsletters/listings/heading_display.jsx';
-import { SubscribersLimitNotice } from 'notices/subscribers_limit_notice';
-import { InvalidMssKeyNotice } from 'notices/invalid_mss_key_notice';
 import { TransactionalEmailsProposeOptInNotice } from 'notices/transactional_emails_propose_opt_in_notice';
-import { EmailVolumeLimitNotice } from 'notices/email_volume_limit_notice';
+import { MssAccessNotices } from 'notices/mss_access_notices';
 import { CampaignStatsPage } from './campaign_stats/page';
 import { CorruptEmailNotice } from '../notices/corrupt_email_notice';
 
@@ -248,12 +246,6 @@ function App() {
       <HashRouter>
         <Notices />
         <ErrorBoundary>
-          <SubscribersLimitNotice />
-        </ErrorBoundary>
-        <ErrorBoundary>
-          <EmailVolumeLimitNotice />
-        </ErrorBoundary>
-        <ErrorBoundary>
           <TransactionalEmailsProposeOptInNotice
             mailpoetInstalledDaysAgo={MailPoet.installedDaysAgo}
             sendTransactionalEmails={MailPoet.transactionalEmailsEnabled}
@@ -263,10 +255,7 @@ function App() {
           />
         </ErrorBoundary>
         <ErrorBoundary>
-          <InvalidMssKeyNotice
-            mssKeyInvalid={MailPoet.hasInvalidMssApiKey}
-            subscribersCount={MailPoet.subscribersCount}
-          />
+          <MssAccessNotices />
         </ErrorBoundary>
         <Switch>
           <Route

--- a/mailpoet/assets/js/src/notices/email_volume_limit_notice.tsx
+++ b/mailpoet/assets/js/src/notices/email_volume_limit_notice.tsx
@@ -7,13 +7,20 @@ import { withBoundary } from 'common';
 function EmailVolumeLimitNotice(): JSX.Element {
   if (!MailPoet.emailVolumeLimitReached) return null;
 
-  const title = MailPoet.I18n.t('emailVolumeLimitNoticeTitle').replace(
-    '[emailVolumeLimit]',
-    MailPoet.emailVolumeLimit,
+  let title = MailPoet.I18n.t('emailVolumeLimitNoticeTitleUnknownLimit');
+  let youReachedEmailVolumeLimit = MailPoet.I18n.t(
+    'youReachedEmailVolumeLimitUnknownLimit',
   );
-  const youReachedEmailVolumeLimit = MailPoet.I18n.t(
-    'youReachedEmailVolumeLimit',
-  ).replace('[emailVolumeLimit]', MailPoet.emailVolumeLimit);
+  if (MailPoet.emailVolumeLimit) {
+    title = MailPoet.I18n.t('emailVolumeLimitNoticeTitle').replace(
+      '[emailVolumeLimit]',
+      MailPoet.emailVolumeLimit,
+    );
+    youReachedEmailVolumeLimit = MailPoet.I18n.t(
+      'youReachedEmailVolumeLimit',
+    ).replace('[emailVolumeLimit]', MailPoet.emailVolumeLimit);
+  }
+
   const upgradeLink = MailPoet.MailPoetComUrlFactory.getUpgradeUrl(
     MailPoet.pluginPartialKey,
   );

--- a/mailpoet/assets/js/src/notices/mailer_error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer_error.tsx
@@ -193,7 +193,10 @@ export function MailerError({
     );
   }
 
-  if (mtaLog.error.operation === 'insufficient_privileges') {
+  if (
+    mtaLog.error.operation === 'insufficient_privileges' ||
+    mtaLog.error.operation === 'subscriber_limit_reached'
+  ) {
     return (
       <div className={className}>
         <p>{message}</p>

--- a/mailpoet/assets/js/src/notices/mailer_error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer_error.tsx
@@ -112,6 +112,18 @@ export function MailerError({
     return null;
   }
 
+  // When plugin detects that the subscriber limit has been reached (via regular key check)
+  // it displays a notification on all pages (based on MailPoet.subscribersLimitReached).
+  // So in such case we ignore the email volume limit error notification coming from mailer log to avoid duplication.
+  // We still need to display the error in case the plugin doesn't know the limit has been reached from the API key check.
+  if (
+    mtaMethod === 'MailPoet' &&
+    mtaLog.error.operation === 'subscriber_limit_reached' &&
+    MailPoet.subscribersLimitReached
+  ) {
+    return null;
+  }
+
   if (mtaLog.error.operation === 'migration') {
     const className = classnames('mailpoet_notice notice notice-warning', {
       inline: isInline,

--- a/mailpoet/assets/js/src/notices/mailer_error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer_error.tsx
@@ -100,10 +100,14 @@ export function MailerError({
   ) {
     return null;
   }
-  // do not display Email Volume Limit reached error twice
+  // When plugin detects that the volume limit has been reached (via regular key check)
+  // it displays a notification on all pages (based on MailPoet.emailVolumeLimitReached).
+  // So in such case we ignore the email volume limit error notification coming from mailer log to avoid duplication.
+  // We still need to display the error in case the plugin doesn't know the limit has been reached from the API key check.
   if (
     mtaMethod === 'MailPoet' &&
-    mtaLog.error.operation === 'email_limit_reached'
+    mtaLog.error.operation === 'email_limit_reached' &&
+    MailPoet.emailVolumeLimitReached
   ) {
     return null;
   }

--- a/mailpoet/assets/js/src/notices/mailer_error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer_error.tsx
@@ -207,7 +207,8 @@ export function MailerError({
 
   if (
     mtaLog.error.operation === 'insufficient_privileges' ||
-    mtaLog.error.operation === 'subscriber_limit_reached'
+    mtaLog.error.operation === 'subscriber_limit_reached' ||
+    mtaLog.error.operation === 'email_limit_reached'
   ) {
     return (
       <div className={className}>

--- a/mailpoet/assets/js/src/notices/mss_access_notices.tsx
+++ b/mailpoet/assets/js/src/notices/mss_access_notices.tsx
@@ -4,6 +4,36 @@ import { SubscribersLimitNotice } from './subscribers_limit_notice';
 import { EmailVolumeLimitNotice } from './email_volume_limit_notice';
 import { InvalidMssKeyNotice } from './invalid_mss_key_notice';
 
+/**
+ * This component handles notices for exceeded limits and invalid MSS key.
+ * We display three types of notices:
+ * - Subscribers limit reached notice
+ * - Email volume limit reached notice
+ * - Invalid MSS key notice
+ *
+ * Subscribers limit reached notice
+ * ================================
+ * This notice is displayed when the number of that plugin knows from the DB is higher than plan's limit or
+ * the basic plugin limit (in case there is no API key).
+ * The notice is also displayed when an API key check returns access_restriction 'subscribers_limit_reached'.
+ *
+ * Note: there might be also a subscriber limit notice displayed when mailer log contains subscribers_limit_reached error.
+ * The second notice is handled in mailer_log.tsx and is hidden in case this notice for subscriber limit reached notice is displayed.
+ *
+ * Email volume limit reached notice
+ * =================================
+ * This notice is displayed when the number of sent emails reported by MSS key check API is higher than plan's limit.
+ * The notice is also displayed when an API key check returns access_restriction 'emails_limit_reached'.
+ *
+ * Note: there might be also a email limits notice displayed when mailer log contains email_limit_reached error.
+ * The second notice is handled in mailer_log.tsx and is hidden in case this notice for email limit reached notice is displayed.
+ *
+ * Invalid MSS key notice
+ * =================================
+ * This notice is displayed when the MSS key is invalid and MailPoet sending service is set as the sending method.
+ * The notice is hidden when the MSS key has reached some of the limits.
+ */
+
 export function MssAccessNotices() {
   return (
     <ErrorBoundary>

--- a/mailpoet/assets/js/src/notices/mss_access_notices.tsx
+++ b/mailpoet/assets/js/src/notices/mss_access_notices.tsx
@@ -1,0 +1,21 @@
+import { ErrorBoundary } from 'common';
+import { MailPoet } from 'mailpoet';
+import { SubscribersLimitNotice } from './subscribers_limit_notice';
+import { EmailVolumeLimitNotice } from './email_volume_limit_notice';
+import { InvalidMssKeyNotice } from './invalid_mss_key_notice';
+
+export function MssAccessNotices() {
+  return (
+    <ErrorBoundary>
+      {MailPoet.subscribersLimitReached && <SubscribersLimitNotice />}
+      {MailPoet.emailVolumeLimitReached && <EmailVolumeLimitNotice />}
+      {!MailPoet.subscribersLimitReached &&
+        !MailPoet.emailVolumeLimitReached && (
+          <InvalidMssKeyNotice
+            mssKeyInvalid={MailPoet.hasInvalidMssApiKey}
+            subscribersCount={MailPoet.subscribersCount}
+          />
+        )}
+    </ErrorBoundary>
+  );
+}

--- a/mailpoet/assets/js/src/notices/subscribers_limit_notice.tsx
+++ b/mailpoet/assets/js/src/notices/subscribers_limit_notice.tsx
@@ -6,13 +6,17 @@ function SubscribersLimitNotice(): JSX.Element {
   if (!MailPoet.subscribersLimitReached) return null;
   const hasValidApiKey = MailPoet.hasValidApiKey;
   const subscribersLimit = MailPoet.subscribersLimit.toString();
-  const title = MailPoet.I18n.t('subscribersLimitNoticeTitle').replace(
-    '[subscribersLimit]',
-    subscribersLimit,
-  );
-  const youReachedTheLimit = MailPoet.I18n.t(
-    hasValidApiKey ? 'yourPlanLimit' : 'freeVersionLimit',
-  ).replace('[subscribersLimit]', subscribersLimit);
+  let title = MailPoet.I18n.t('subscribersLimitNoticeTitleUnknownLimit');
+  let youReachedTheLimit = '';
+  if (MailPoet.subscribersLimit) {
+    title = MailPoet.I18n.t('subscribersLimitNoticeTitle').replace(
+      '[subscribersLimit]',
+      subscribersLimit,
+    );
+    youReachedTheLimit = MailPoet.I18n.t(
+      hasValidApiKey ? 'yourPlanLimit' : 'freeVersionLimit',
+    ).replace('[subscribersLimit]', subscribersLimit);
+  }
   const upgradeLink = hasValidApiKey
     ? MailPoet.MailPoetComUrlFactory.getUpgradeUrl(MailPoet.pluginPartialKey)
     : MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(

--- a/mailpoet/assets/js/src/segments/heading.jsx
+++ b/mailpoet/assets/js/src/segments/heading.jsx
@@ -3,9 +3,7 @@ import { MailPoet } from 'mailpoet';
 import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { plusIcon } from 'common/button/icon/plus';
 import { SubscribersInPlan } from 'common/subscribers_in_plan';
-import { SubscribersLimitNotice } from 'notices/subscribers_limit_notice';
-import { EmailVolumeLimitNotice } from 'notices/email_volume_limit_notice';
-import { InvalidMssKeyNotice } from 'notices/invalid_mss_key_notice';
+import { MssAccessNotices } from 'notices/mss_access_notices';
 import { SubscribersCacheMessage } from 'common/subscribers_cache_message';
 
 function ListHeading() {
@@ -35,12 +33,7 @@ function ListHeading() {
         cacheCalculation={window.mailpoet_subscribers_counts_cache_created_at}
       />
 
-      <SubscribersLimitNotice />
-      <EmailVolumeLimitNotice />
-      <InvalidMssKeyNotice
-        mssKeyInvalid={MailPoet.hasInvalidMssApiKey}
-        subscribersCount={MailPoet.subscribersCount}
-      />
+      <MssAccessNotices />
     </>
   );
 }

--- a/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
+++ b/mailpoet/assets/js/src/settings/store/actions/mss_and_premium.ts
@@ -29,6 +29,7 @@ export function* verifyMssKey(key: string) {
   }
   const fields: Partial<KeyActivationState> = {
     mssMessage: res.data.message || null,
+    mssAccessRestriction: null,
   };
 
   if (res.data.state === 'valid_underprivileged') {
@@ -106,10 +107,13 @@ export function* verifyPremiumKey(key: string) {
     premiumStatus: status,
     code: res?.meta?.code,
     downloadUrl: res?.meta?.premium_plugin_info?.download_link,
+    premiumAccessRestriction: null,
   };
 
   if (res.data?.state === 'valid_underprivileged') {
     fields.premiumStatus = PremiumStatus.VALID_UNDERPRIVILEGED;
+    fields.premiumAccessRestriction =
+      res.data?.result?.access_restriction ?? null;
   }
 
   yield updateKeyActivationState(fields);

--- a/mailpoet/assets/js/src/subscribers/list.jsx
+++ b/mailpoet/assets/js/src/subscribers/list.jsx
@@ -8,9 +8,7 @@ import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal.tsx';
 import { Selection } from 'form/fields/selection.jsx';
-import { SubscribersLimitNotice } from 'notices/subscribers_limit_notice';
-import { InvalidMssKeyNotice } from 'notices/invalid_mss_key_notice';
-import { EmailVolumeLimitNotice } from 'notices/email_volume_limit_notice';
+import { MssAccessNotices } from 'notices/mss_access_notices';
 import { SubscribersCacheMessage } from 'common/subscribers_cache_message';
 import { SubscribersInPlan } from 'common/subscribers_in_plan';
 import { ListingsEngagementScore } from './listings_engagement_score';
@@ -487,12 +485,7 @@ function SubscriberList({ match }) {
         subscribersInPlanLimit={MailPoet.subscribersLimit}
       />
 
-      <SubscribersLimitNotice />
-      <EmailVolumeLimitNotice />
-      <InvalidMssKeyNotice
-        mssKeyInvalid={window.mailpoet_mss_key_invalid}
-        subscribersCount={window.mailpoet_subscribers_count}
-      />
+      <MssAccessNotices />
 
       <SubscribersCacheMessage
         cacheCalculation={window.mailpoet_subscribers_counts_cache_created_at}

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -150,7 +150,7 @@ class Settings extends APIEndpoint {
 
       // when pending approval, leave this to cron / Key Activation tab logic
       if (!$this->servicesChecker->isMailPoetAPIKeyPendingApproval()) {
-        $this->bridge->onSettingsSave($settings);
+        $this->settingsChangeHandler->updateBridge($settings);
       }
 
       $meta = $this->authorizedEmailsController->onSettingsSave($settings);

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -150,7 +150,7 @@ class Settings extends APIEndpoint {
 
       // when pending approval, leave this to cron / Key Activation tab logic
       if (!$this->servicesChecker->isMailPoetAPIKeyPendingApproval()) {
-        $this->settingsChangeHandler->updateBridge($settings);
+        $this->settingsChangeHandler->updateApiKeyState($settings);
       }
 
       $meta = $this->authorizedEmailsController->onSettingsSave($settings);

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -162,6 +162,7 @@ class PageRenderer {
       'has_premium_support' => $this->subscribersFeature->hasPremiumSupport(),
       'has_mss_key_specified' => Bridge::isMSSKeySpecified(),
       'mss_key_invalid' => $this->servicesChecker->isMailPoetAPIKeyValid() === false,
+      'mss_key_valid' => $this->subscribersFeature->hasValidMssKey(),
       'mss_key_pending_approval' => $this->servicesChecker->isMailPoetAPIKeyPendingApproval(),
       'mss_active' => $this->bridge->isMailpoetSendingServiceEnabled(),
       'plugin_partial_key' => $this->servicesChecker->generatePartialApiKey(),

--- a/mailpoet/lib/Cron/Workers/SubscribersStatsReport.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersStatsReport.php
@@ -5,15 +5,15 @@ namespace MailPoet\Cron\Workers;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Services\Bridge;
+use MailPoet\Services\SubscribersCountReporter;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class SubscribersStatsReport extends SimpleWorker {
   const TASK_TYPE = 'subscribers_stats_report';
 
-  /** @var Bridge */
-  private $bridge;
+  /** @var SubscribersCountReporter */
+  private $subscribersCountReporter;
 
   /** @var ServicesChecker */
   private $serviceChecker;
@@ -22,13 +22,13 @@ class SubscribersStatsReport extends SimpleWorker {
   private $workerScheduler;
 
   public function __construct(
-    Bridge $bridge,
+    SubscribersCountReporter $subscribersCountReporter,
     ServicesChecker $servicesChecker,
     CronWorkerScheduler $workerScheduler,
     WPFunctions $wp
   ) {
     parent::__construct($wp);
-    $this->bridge = $bridge;
+    $this->subscribersCountReporter = $subscribersCountReporter;
     $this->serviceChecker = $servicesChecker;
     $this->workerScheduler = $workerScheduler;
   }
@@ -42,7 +42,7 @@ class SubscribersStatsReport extends SimpleWorker {
     if ($key === null) {
       return false;
     }
-    $result = $this->bridge->updateSubscriberCount($key);
+    $result = $this->subscribersCountReporter->report($key);
     // We have a valid key, but request failed
     if ($result === false) {
       $this->workerScheduler->rescheduleProgressively($task);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -428,6 +428,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Services\AuthorizedEmailsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Services\CongratulatoryMssEmailController::class)->setPublic(true);
     $container->autowire(\MailPoet\Services\AuthorizedSenderDomainController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Services\SubscribersCountReporter::class)->setPublic(true);
     // Settings
     $container->autowire(\MailPoet\Settings\SettingsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Settings\SettingsChangeHandler::class)->setPublic(true);

--- a/mailpoet/lib/Mailer/MailerError.php
+++ b/mailpoet/lib/Mailer/MailerError.php
@@ -7,6 +7,7 @@ class MailerError {
   const OPERATION_SEND = 'send';
   const OPERATION_AUTHORIZATION = 'authorization';
   const OPERATION_INSUFFICIENT_PRIVILEGES = 'insufficient_privileges';
+  const OPERATION_SUBSCRIBER_LIMIT_REACHED = 'subscriber_limit_reached';
   const OPERATION_EMAIL_LIMIT_REACHED = 'email_limit_reached';
   const OPERATION_PENDING_APPROVAL = 'pending_approval';
 

--- a/mailpoet/lib/Mailer/MailerFactory.php
+++ b/mailpoet/lib/Mailer/MailerFactory.php
@@ -15,6 +15,7 @@ use MailPoet\Mailer\Methods\PHPMail;
 use MailPoet\Mailer\Methods\SendGrid;
 use MailPoet\Mailer\Methods\SMTP;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Url;
 use MailPoet\WP\Functions as WPFunctions;
@@ -69,6 +70,7 @@ class MailerFactory {
           $replyTo,
           ContainerWrapper::getInstance()->get(MailPoetMapper::class),
           ContainerWrapper::getInstance()->get(AuthorizedEmailsController::class),
+          ContainerWrapper::getInstance()->get(Bridge::class),
           ContainerWrapper::getInstance()->get(Url::class)
         );
         break;

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -134,7 +134,7 @@ class MailPoetMapper {
     return $message;
   }
 
-  private function getInsufficientPrivilegesMessage(): string {
+  private function getSubscribersLimitReachedMessage(): string {
     $message = __('You have reached the subscriber limit of your plan. Please [link1]upgrade your plan[/link1], or [link2]contact our support team[/link2] if you have any questions.', 'mailpoet');
     $message = Helpers::replaceLinkTags(
       $message,
@@ -248,9 +248,18 @@ class MailPoetMapper {
       return [$operation, $message];
     }
 
+    // Backward compatibility for older blocked keys.
+    // Exceeded subscribers limit used to use the same error message as insufficient privileges.
+    // We can change the message to "Insufficient privileges" like wording a couple of months after releasing SHOP-1228
     if ($result['error'] === API::ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES) {
       $operation = MailerError::OPERATION_INSUFFICIENT_PRIVILEGES;
-      $message = $this->getInsufficientPrivilegesMessage();
+      $message = $this->getSubscribersLimitReachedMessage();
+      return [$operation, $message];
+    }
+
+    if ($result['error'] === API::ERROR_MESSAGE_SUBSCRIBERS_LIMIT_REACHED) {
+      $operation = MailerError::OPERATION_SUBSCRIBER_LIMIT_REACHED;
+      $message = $this->getSubscribersLimitReachedMessage();
       return [$operation, $message];
     }
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -7,9 +7,7 @@ use MailPoet\Config\ServicesChecker;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\SubscriberError;
-use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
-use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\Util\Notices\UnauthorizedEmailNotice;
@@ -24,9 +22,6 @@ class MailPoetMapper {
 
   const TEMPORARY_UNAVAILABLE_RETRY_INTERVAL = 300; // seconds
 
-  /** @var Bridge */
-  private $bridge;
-
   /** @var ServicesChecker */
   private $servicesChecker;
 
@@ -36,21 +31,14 @@ class MailPoetMapper {
   /** @var WPFunctions */
   private $wp;
 
-  /** @var SettingsController */
-  private $settings;
-
   public function __construct(
-    Bridge $bridge,
     ServicesChecker $servicesChecker,
-    SettingsController $settings,
     SubscribersFeature $subscribers,
     WPFunctions $wp
   ) {
     $this->servicesChecker = $servicesChecker;
     $this->subscribersFeature = $subscribers;
     $this->wp = $wp;
-    $this->bridge = $bridge;
-    $this->settings = $settings;
   }
 
   public function getInvalidApiKeyError() {
@@ -264,11 +252,6 @@ class MailPoetMapper {
     }
 
     if ($result['error'] === API::ERROR_MESSAGE_EMAIL_VOLUME_LIMIT_REACHED) {
-      // Update the current email volume limit from MSS
-      $premiumKey = $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
-      $result = $this->bridge->checkPremiumKey($premiumKey);
-      $this->bridge->storePremiumKeyAndState($premiumKey, $result);
-
       $operation = MailerError::OPERATION_EMAIL_LIMIT_REACHED;
       $message = $this->getEmailVolumeLimitReachedMessage();
       return [$operation, $message];

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -193,12 +193,21 @@ class MailPoetMapper {
     $partialApiKey = $this->servicesChecker->generatePartialApiKey();
     $emailVolumeLimit = $this->subscribersFeature->getEmailVolumeLimit();
     $date = Carbon::now()->startOfMonth()->addMonth();
-    $message = sprintf(
+    if ($emailVolumeLimit) {
+      $message = sprintf(
       // translators: %1$s is email volume limit and %2$s the date when you can resume sending.
-      __('You have sent more emails this month than your MailPoet plan includes (%1$s), and sending has been temporarily paused. To continue sending with MailPoet Sending Service please [link]upgrade your plan[/link], or wait until sending is automatically resumed on <b>%2$s</b>.', 'mailpoet'),
-      $emailVolumeLimit,
-      $this->wp->dateI18n(get_option('date_format'), $date->getTimestamp())
-    );
+        __('You have sent more emails this month than your MailPoet plan includes (%1$s), and sending has been temporarily paused. To continue sending with MailPoet Sending Service please [link]upgrade your plan[/link], or wait until sending is automatically resumed on %2$s.', 'mailpoet'),
+        $emailVolumeLimit,
+        $this->wp->dateI18n($this->wp->getOption('date_format'), $date->getTimestamp())
+      );
+    } else {
+      $message = sprintf(
+        // translators: %1$s the date when you can resume sending.
+        __('You have sent more emails this month than your MailPoet plan includes, and sending has been temporarily paused. To continue sending with MailPoet Sending Service please [link]upgrade your plan[/link], or wait until sending is automatically resumed on %1$s.', 'mailpoet'),
+        $this->wp->dateI18n($this->wp->getOption('date_format'), $date->getTimestamp())
+      );
+    }
+
     $message = Helpers::replaceLinkTags(
       $message,
       "https://account.mailpoet.com/orders/upgrade/{$partialApiKey}",

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -29,12 +29,16 @@ class MailPoet implements MailerMethod {
   /*** @var Url */
   private $url;
 
+  /** @var Bridge */
+  private $bridge;
+
   public function __construct(
     $apiKey,
     $sender,
     $replyTo,
     MailPoetMapper $errorMapper,
     AuthorizedEmailsController $authorizedEmailsController,
+    Bridge $bridge,
     Url $url
   ) {
     $this->api = new API($apiKey);
@@ -42,6 +46,7 @@ class MailPoet implements MailerMethod {
     $this->replyTo = $replyTo;
     $this->servicesChecker = new ServicesChecker();
     $this->errorMapper = $errorMapper;
+    $this->bridge = $bridge;
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->blacklist = new BlacklistCheck();
     $this->url = $url;
@@ -78,7 +83,7 @@ class MailPoet implements MailerMethod {
 
   public function processSendError($result, $subscriber, $newsletter) {
     if (!empty($result['code']) && $result['code'] === API::RESPONSE_CODE_KEY_INVALID) {
-      Bridge::invalidateKey();
+      $this->bridge->invalidateMssKey();
     } elseif (
       !empty($result['code'])
       && $result['code'] === API::RESPONSE_CODE_CAN_NOT_SEND

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -206,24 +206,7 @@ class Bridge {
   }
 
   public function storeMSSKeyAndState($key, $state) {
-    if (
-      empty($state['state'])
-      || $state['state'] === self::KEY_CHECK_ERROR
-    ) {
-      return false;
-    }
-
-    // store the key itself
-    $this->settings->set(
-      self::API_KEY_SETTING_NAME,
-      $key
-    );
-
-    // store the key state
-    $this->settings->set(
-      self::API_KEY_STATE_SETTING_NAME,
-      $state
-    );
+    return $this->storeKeyAndState(API::KEY_CHECK_TYPE_MSS, $key, $state);
   }
 
   public function checkPremiumKey($key) {
@@ -277,6 +260,18 @@ class Bridge {
   }
 
   public function storePremiumKeyAndState($key, $state) {
+    return $this->storeKeyAndState(API::KEY_CHECK_TYPE_PREMIUM, $key, $state);
+  }
+
+  private function storeKeyAndState(string $keyType, ?string $key, ?array $state) {
+    if ($keyType === API::KEY_CHECK_TYPE_PREMIUM) {
+      $keySettingName = self::PREMIUM_KEY_SETTING_NAME;
+      $keyStateSettingName = self::PREMIUM_KEY_STATE_SETTING_NAME;
+    } else {
+      $keySettingName = self::API_KEY_SETTING_NAME;
+      $keyStateSettingName = self::API_KEY_STATE_SETTING_NAME;
+    }
+
     if (
       empty($state['state'])
       || $state['state'] === self::KEY_CHECK_ERROR
@@ -286,26 +281,24 @@ class Bridge {
 
     // store the key itself
     $this->settings->set(
-      self::PREMIUM_KEY_SETTING_NAME,
+      $keySettingName,
       $key
     );
 
     // store the key state
     $this->settings->set(
-      self::PREMIUM_KEY_STATE_SETTING_NAME,
+      $keyStateSettingName,
       $state
     );
   }
 
-  private function buildKeyState($keyState, $result, ?string $accessRestriction) {
-    $state = [
+  private function buildKeyState($keyState, $result, ?string $accessRestriction): array {
+    return [
       'state' => $keyState,
       'access_restriction' => $accessRestriction,
       'data' => !empty($result['data']) ? $result['data'] : null,
       'code' => !empty($result['code']) ? $result['code'] : self::CHECK_ERROR_UNKNOWN,
     ];
-
-    return $state;
   }
 
   public function updateSubscriberCount(string $key): bool {

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -305,11 +305,12 @@ class Bridge {
     return $this->getApi($key)->updateSubscriberCount($this->subscribersFeature->getSubscribersCount());
   }
 
-  public static function invalidateKey() {
-    $settings = SettingsController::getInstance();
-    $settings->set(
-      self::API_KEY_STATE_SETTING_NAME,
-      ['state' => self::KEY_INVALID]
+  public function invalidateMssKey() {
+    $key = $this->settings->get(self::API_KEY_SETTING_NAME);
+    $this->storeMSSKeyAndState($key, $this->buildKeyState(
+      self::KEY_INVALID,
+      [ 'code' => API::RESPONSE_CODE_KEY_INVALID ],
+      null)
     );
   }
 

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -2,11 +2,9 @@
 
 namespace MailPoet\Services;
 
-use MailPoet\DI\ContainerWrapper;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Services\Bridge\API;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Bridge {
@@ -42,21 +40,13 @@ class Bridge {
   /** @var SettingsController */
   private $settings;
 
-  /** @var SubscribersFeature */
-  private $subscribersFeature;
-
   public function __construct(
-    SettingsController $settingsController = null,
-    SubscribersFeature $subscribersFeature = null
+    SettingsController $settingsController = null
   ) {
     if ($settingsController === null) {
       $settingsController = SettingsController::getInstance();
     }
-    if ($subscribersFeature === null) {
-      $subscribersFeature = ContainerWrapper::getInstance()->get(SubscribersFeature::class);
-    }
     $this->settings = $settingsController;
-    $this->subscribersFeature = $subscribersFeature;
   }
 
   /**
@@ -301,8 +291,8 @@ class Bridge {
     ];
   }
 
-  public function updateSubscriberCount(string $key): bool {
-    return $this->getApi($key)->updateSubscriberCount($this->subscribersFeature->getSubscribersCount());
+  public function updateSubscriberCount(string $key, int $count): bool {
+    return $this->getApi($key)->updateSubscriberCount($count);
   }
 
   public function invalidateMssKey() {

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -303,23 +303,4 @@ class Bridge {
       null)
     );
   }
-
-  public function onSettingsSave($settings) {
-    $apiKey = $settings[Mailer::MAILER_CONFIG_SETTING_NAME]['mailpoet_api_key'] ?? null;
-    $premiumKey = $settings['premium']['premium_key'] ?? null;
-    if (!empty($apiKey)) {
-      $apiKeyState = $this->checkMSSKey($apiKey);
-      $this->storeMSSKeyAndState($apiKey, $apiKeyState);
-    }
-    if (!empty($premiumKey)) {
-      $premiumState = $this->checkPremiumKey($premiumKey);
-      $this->storePremiumKeyAndState($premiumKey, $premiumState);
-    }
-    if ($apiKey && !empty($apiKeyState) && in_array($apiKeyState['state'], [self::KEY_VALID, self::KEY_VALID_UNDERPRIVILEGED], true)) {
-      return $this->updateSubscriberCount($apiKey);
-    }
-    if ($premiumKey && !empty($premiumState) && in_array($premiumState['state'], [self::KEY_VALID, self::KEY_VALID_UNDERPRIVILEGED], true)) {
-      return $this->updateSubscriberCount($apiKey);
-    }
-  }
 }

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -269,11 +269,23 @@ class Bridge {
       return false;
     }
 
+    $previousKey = $this->settings->get($keySettingName);
+    // If the key remain the same and the new state is not valid we want to preserve the data from the previous state.
+    // The data contain information about state limits. We need those to display the correct information to users.
+    if (empty($state['data']) && $previousKey === $key) {
+      $previousState = $this->settings->get($keyStateSettingName);
+      if (!empty($previousState['data'])) {
+        $state['data'] = $previousState['data'];
+      }
+    }
+
     // store the key itself
-    $this->settings->set(
-      $keySettingName,
-      $key
-    );
+    if ($previousKey !== $key) {
+      $this->settings->set(
+        $keySettingName,
+        $key
+      );
+    }
 
     // store the key state
     $this->settings->set(

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -47,8 +47,8 @@ class API {
   public const ERROR_MESSAGE_SENDER_DOMAIN_INVALID = 'Invalid domain. Please enter a valid domain name.';
   public const ERROR_MESSAGE_SENDER_DOMAIN_ALREADY_ADDED = 'This domain was already added to the list.';
 
-  private const KEY_CHECK_TYPE_PREMIUM = 'premium';
-  private const KEY_CHECK_TYPE_MSS = 'mss';
+  public const KEY_CHECK_TYPE_PREMIUM = 'premium';
+  public const KEY_CHECK_TYPE_MSS = 'mss';
 
   private $apiKey;
   private $wp;

--- a/mailpoet/lib/Services/SubscribersCountReporter.php
+++ b/mailpoet/lib/Services/SubscribersCountReporter.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Services;
+
+use MailPoet\Util\License\Features\Subscribers;
+
+class SubscribersCountReporter {
+  /** @var Bridge */
+  private $bridge;
+
+  /** @var Subscribers */
+  private $subscribersFeature;
+
+  public function __construct(
+    Bridge $bridge,
+    Subscribers $subscribersFeature
+  ) {
+    $this->bridge = $bridge;
+    $this->subscribersFeature = $subscribersFeature;
+  }
+
+  public function report(string $key): bool {
+    $subscribersCount = $this->subscribersFeature->getSubscribersCount();
+    return $this->bridge->updateSubscriberCount($key, $subscribersCount);
+  }
+}

--- a/mailpoet/lib/Settings/SettingsChangeHandler.php
+++ b/mailpoet/lib/Settings/SettingsChangeHandler.php
@@ -106,7 +106,7 @@ class SettingsChangeHandler {
       return $this->subscribersCountReporter->report($apiKey);
     }
     if ($premiumKey && !empty($premiumState) && in_array($premiumState['state'], [Bridge::KEY_VALID, Bridge::KEY_VALID_UNDERPRIVILEGED], true)) {
-      return $this->subscribersCountReporter->report($apiKey);
+      return $this->subscribersCountReporter->report($premiumKey);
     }
   }
 }

--- a/mailpoet/lib/Settings/SettingsChangeHandler.php
+++ b/mailpoet/lib/Settings/SettingsChangeHandler.php
@@ -91,7 +91,7 @@ class SettingsChangeHandler {
     return $task;
   }
 
-  public function updateBridge($settings) {
+  public function updateApiKeyState($settings) {
     $apiKey = $settings[Mailer::MAILER_CONFIG_SETTING_NAME]['mailpoet_api_key'] ?? null;
     $premiumKey = $settings['premium']['premium_key'] ?? null;
     if (!empty($apiKey)) {

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -50,12 +50,16 @@ class Subscribers {
   }
 
   public function checkEmailVolumeLimitIsReached(): bool {
+    // We have data from MSS and we can determine based on the data
     $emailVolumeLimit = $this->getEmailVolumeLimit();
-    if (!$emailVolumeLimit) {
-      return false;
-    }
     $emailsSent = $this->getEmailsSent();
-    return $emailsSent > $emailVolumeLimit;
+    if ($emailVolumeLimit && $emailsSent > $emailVolumeLimit) {
+      return true;
+    }
+    // We don't have data from MSS, or they might be outdated so we need to check accessibility restrictions
+    $mssStateData = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME);
+    $restriction = $mssStateData['access_restriction'] ?? '';
+    return $restriction === Bridge::KEY_ACCESS_EMAIL_VOLUME_LIMIT;
   }
 
   public function getSubscribersCount(): int {

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -44,9 +44,14 @@ class Subscribers {
 
   public function check(): bool {
     $limit = $this->getSubscribersLimit();
-    if ($limit === false) return false;
     $subscribersCount = $this->getSubscribersCount();
-    return $subscribersCount > $limit;
+    if ($limit && $subscribersCount > $limit) {
+      return true;
+    }
+    // We don't have data from MSS, or they might be outdated so we need to check accessibility restrictions
+    $mssStateData = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME);
+    $restriction = $mssStateData['access_restriction'] ?? '';
+    return $restriction === Bridge::KEY_ACCESS_SUBSCRIBERS_LIMIT;
   }
 
   public function checkEmailVolumeLimitIsReached(): bool {

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -100,12 +100,13 @@ class Subscribers {
     if (!$this->hasValidApiKey()) {
       return $this->getFreeSubscribersLimit();
     }
-
-    if ($this->hasValidMssKey() && $this->hasMssSubscribersLimit()) {
+    $mssState = $this->settings->get(self::MSS_KEY_STATE);
+    if (($this->hasValidMssKey() || $mssState === Bridge::KEY_VALID_UNDERPRIVILEGED) && $this->hasMssSubscribersLimit()) {
       return $this->getMssSubscribersLimit();
     }
 
-    if ($this->hasValidPremiumKey() && $this->hasPremiumSubscribersLimit()) {
+    $premiumState = $this->settings->get(self::PREMIUM_KEY_STATE);
+    if (($this->hasValidPremiumKey() || $premiumState === Bridge::KEY_VALID_UNDERPRIVILEGED) && $this->hasPremiumSubscribersLimit()) {
       return $this->getPremiumSubscribersLimit();
     }
 

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -16,8 +16,8 @@ class Subscribers {
   const MSS_SUPPORT_SETTING_KEY = 'mta.mailpoet_api_key_state.data.support_tier';
   const PREMIUM_KEY_STATE = 'premium.premium_key_state.state';
   const PREMIUM_SUBSCRIBERS_LIMIT_SETTING_KEY = 'premium.premium_key_state.data.site_active_subscriber_limit';
-  const PREMIUM_EMAIL_VOLUME_LIMIT_SETTING_KEY = 'premium.premium_key_state.data.email_volume_limit';
-  const PREMIUM_EMAILS_SENT_SETTING_KEY = 'premium.premium_key_state.data.emails_sent';
+  const MSS_EMAIL_VOLUME_LIMIT_SETTING_KEY = 'mta.mailpoet_api_key_state.data.email_volume_limit';
+  const MSS_EMAILS_SENT_SETTING_KEY = 'mta.mailpoet_api_key_state.data.emails_sent';
   const PREMIUM_SUPPORT_SETTING_KEY = 'premium.premium_key_state.data.support_tier';
   const SUBSCRIBERS_COUNT_CACHE_KEY = 'mailpoet_subscribers_count';
   const SUBSCRIBERS_COUNT_CACHE_EXPIRATION_MINUTES = 60;
@@ -93,11 +93,11 @@ class Subscribers {
   }
 
   public function getEmailVolumeLimit(): int {
-    return (int)$this->settings->get(self::PREMIUM_EMAIL_VOLUME_LIMIT_SETTING_KEY);
+    return (int)$this->settings->get(self::MSS_EMAIL_VOLUME_LIMIT_SETTING_KEY);
   }
 
   public function getEmailsSent(): int {
-    return (int)$this->settings->get(self::PREMIUM_EMAILS_SENT_SETTING_KEY);
+    return (int)$this->settings->get(self::MSS_EMAILS_SENT_SETTING_KEY);
   }
 
   public function hasValidMssKey() {

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -81,8 +81,19 @@ class Subscribers {
     return $count;
   }
 
+  /**
+   * Returns true if key is valid or valid but underprivileged
+   * Do not use the method to check if key is valid for sending emails or premium
+   * This only means that the Bridge can authenticate the key.
+   * @return bool
+   */
   public function hasValidApiKey(): bool {
-    return $this->hasValidMssKey() || $this->hasValidPremiumKey();
+    $mssState = $this->settings->get(self::MSS_KEY_STATE);
+    $premiumState = $this->settings->get(self::PREMIUM_KEY_STATE);
+    return $this->hasValidMssKey()
+      || $this->hasValidPremiumKey()
+      || $mssState === Bridge::KEY_VALID_UNDERPRIVILEGED
+      || $premiumState === Bridge::KEY_VALID_UNDERPRIVILEGED;
   }
 
   public function getSubscribersLimit() {

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -129,6 +129,21 @@ class Settings {
     return $this;
   }
 
+  public function withSendingMethodMailpoetWithRestrictedAccess(string $restrictedAccess = Bridge::KEY_ACCESS_SUBSCRIBERS_LIMIT, int $planLimit = 0) {
+    $mailPoetSendingKey = getenv('WP_TEST_MAILER_MAILPOET_API');
+    $this->settings->set('mta_group', 'mailpoet');
+    $this->settings->set('mta.method', 'MailPoet');
+    $this->settings->set('mta.mailpoet_api_key', $mailPoetSendingKey);
+    $this->settings->set('mta.mailpoet_api_key_state.state', 'valid_underprivileged');
+    $this->settings->set('mta.mailpoet_api_key_state.access_restriction', $restrictedAccess);
+    $this->settings->set('mta.mailpoet_api_key_state.code', 403);
+    $this->settings->set('mta.mailpoet_api_key_state.data', [
+        'site_active_subscriber_limit' => $planLimit,
+        'email_volume_limit' => $planLimit,
+    ]);
+    return $this;
+  }
+
   public function withValidPremiumKey($key) {
     $this->settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, $key);
     $this->settings->set(Bridge::PREMIUM_KEY_STATE_SETTING_NAME, ['state' => Bridge::PREMIUM_KEY_VALID, 'code' => 200]);
@@ -139,6 +154,19 @@ class Settings {
     $this->settings->set(Bridge::API_KEY_SETTING_NAME, $key);
     $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_VALID, 'code' => 200]);
     return $this;
+  }
+
+  public function withInvalidMssKey() {
+    $this->settings->set(Bridge::API_KEY_SETTING_NAME, 'ivalid');
+    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_INVALID, 'code' => 400]);
+    return $this;
+  }
+
+  public function withBothKeysInvalid() {
+      $this->settings->set(Bridge::API_KEY_SETTING_NAME, 'abc');
+      $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_INVALID, 'code' => 400]);
+      $this->settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, 'abc');
+      $this->settings->set(Bridge::PREMIUM_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_INVALID, 'code' => 400]);
   }
 
   public function withMssKeyPendingApproval() {

--- a/mailpoet/tests/acceptance/Misc/ExceededLimitsErrorNoticesCest.php
+++ b/mailpoet/tests/acceptance/Misc/ExceededLimitsErrorNoticesCest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Mailer\Mailer;
+use MailPoet\Services\Bridge;
+use MailPoet\Test\DataFactories\Settings;
+
+class ExceededLimitsErrorNoticesCest {
+  public function emailVolumeLimitsNotices(\AcceptanceTester $i) {
+    $i->wantTo('Check the plugin displays correct messages for exceeded email volume limits');
+    $mailerErrorMessage = 'Email volume limit message from mailer log!';
+
+    $i->wantTo('Check when the error is logged only in mailer log it is displayed');
+    $settings = new Settings();
+    $settings->withSendingError($mailerErrorMessage, 'email_limit_reached');
+
+    $i->login();
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText($mailerErrorMessage);
+
+    $i->wantTo('Check when the access restriction is logged from key check it displays proper message and hides the mailer log message');
+    $settings->withSendingMethodMailpoetWithRestrictedAccess(Bridge::KEY_ACCESS_EMAIL_VOLUME_LIMIT, 5000);
+
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText('Congratulations, you sent more than 5000 emails this month!');
+    $i->dontSee($mailerErrorMessage);
+
+    $i->wantTo('Check the alternative message without limit info is displayed when the limit info is not available');
+    $settings->withSendingMethodMailpoetWithRestrictedAccess(Bridge::KEY_ACCESS_EMAIL_VOLUME_LIMIT, 0);
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText('Congratulations, you sent a lot of emails this month!');
+    $i->dontSee($mailerErrorMessage);
+  }
+
+  public function subscribersLimitsNotices(\AcceptanceTester $i) {
+    $i->wantTo('Check the plugin displays correct messages for exceeded subscribers limits');
+    $mailerErrorMessage = 'Subscriber limit message from mailer log!';
+
+    $i->wantTo('Check when the error is logged only in mailer log it is displayed');
+    $settings = new Settings();
+    $settings->withSendingError($mailerErrorMessage, 'subscriber_limit_reached');
+
+    $i->login();
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText($mailerErrorMessage);
+
+    $i->wantTo('Check when the access restriction is logged from key check it displays proper message and hides the mailer log message');
+    $settings->withSendingMethodMailpoetWithRestrictedAccess(Bridge::KEY_ACCESS_SUBSCRIBERS_LIMIT, 5000);
+
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText('Congratulations, you now have more than 5000 subscribers!');
+    $i->dontSee($mailerErrorMessage);
+
+    $i->wantTo('Check the alternative message without limit info is displayed when the limit info is not available');
+    $settings->withSendingMethodMailpoetWithRestrictedAccess(Bridge::KEY_ACCESS_SUBSCRIBERS_LIMIT, 0);
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText('Congratulations, you now have more subscribers than the limit of your plan!');
+    $i->dontSee($mailerErrorMessage);
+  }
+
+  public function allSendingPausedInvalidKeyNotice(\AcceptanceTester $i) {
+    $i->wantTo('Check the plugin displays correct messages for invalid API key');
+    $settings = new Settings();
+    $settings->withSendingMethod(Mailer::METHOD_MAILPOET);
+    $settings->withInvalidMssKey();
+
+    $i->login();
+    $i->amOnMailpoetPage('Homepage');
+    $i->waitForText('All sending is currently paused!');
+
+    $i->wantTo('Check the doesnt display all sending paused notice when user sets another sending method');
+    $settings->withSendingMethod('smtl');
+    $i->amOnMailpoetPage('Homepage');
+    $i->dontSee('All sending is currently paused!');
+  }
+}

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -15,6 +15,7 @@ use MailPoet\Mailer\MailerLog;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\CongratulatoryMssEmailController;
+use MailPoet\Services\SubscribersCountReporter;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -614,6 +615,7 @@ class ServicesTest extends \MailPoetTest {
       $this->diContainer->get(SendingServiceKeyCheck::class),
       $this->diContainer->get(PremiumKeyCheck::class),
       $this->diContainer->get(ServicesChecker::class),
+      $this->diContainer->get(SubscribersCountReporter::class),
       $mocks['congratulatoryEmailController'] ?? $this->diContainer->get(CongratulatoryMssEmailController::class),
       $this->diContainer->get(WPFunctions::class),
       $mocks['senderDomain'] ?? $this->diContainer->get(AuthorizedSenderDomainController::class)

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -101,7 +101,7 @@ class SettingsTest extends \MailPoetTest {
 
     $this->endpoint = new Settings(
       $this->settings,
-      $this->make(Bridge::class, ['onSettingsSave' => Expected::once()]),
+      $this->diContainer->get(Bridge::class),
       $this->make(AuthorizedEmailsController::class, ['onSettingsSave' => Expected::once()]),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
@@ -113,7 +113,7 @@ class SettingsTest extends \MailPoetTest {
       $this->diContainer->get(FormMessageController::class),
       $this->make(ServicesChecker::class, ['isMailPoetAPIKeyPendingApproval' => false]),
       $this->diContainer->get(SegmentsRepository::class),
-      $this->diContainer->get(SettingsChangeHandler::class),
+      $this->make(SettingsChangeHandler::class, ['updateBridge' => Expected::once()]),
       $this->diContainer->get(SubscribersCountsController::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(ConfirmationEmailCustomizer::class)

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersStatsReportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersStatsReportTest.php
@@ -5,7 +5,7 @@ namespace MailPoet\Cron\Workers;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Services\Bridge;
+use MailPoet\Services\SubscribersCountReporter;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -20,8 +20,8 @@ class SubscribersStatsReportTest extends \MailPoetTest {
   /** @var SubscribersStatsReport */
   private $worker;
 
-  /** @var Bridge & MockObject */
-  private $bridgeMock;
+  /** @var SubscribersCountReporter & MockObject */
+  private $countReporerMock;
 
   /** @var CronWorkerScheduler & MockObject */
   private $schedulerMock;
@@ -34,12 +34,12 @@ class SubscribersStatsReportTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->bridgeMock = $this->createMock(Bridge::class);
+    $this->countReporerMock = $this->createMock(SubscribersCountReporter::class);
     $this->schedulerMock = $this->createMock(CronWorkerScheduler::class);
     $this->servicesCheckerMock = $this->createMock(ServicesChecker::class);
     $this->wpMock = $this->createMock(WPFunctions::class);
     $this->worker = new SubscribersStatsReport(
-      $this->bridgeMock,
+      $this->countReporerMock,
       $this->servicesCheckerMock,
       $this->schedulerMock,
       $this->wpMock
@@ -66,8 +66,8 @@ class SubscribersStatsReportTest extends \MailPoetTest {
     $this->servicesCheckerMock->expects($this->once())
       ->method('getValidAccountKey')
       ->willReturn('a_valid_key');
-    $this->bridgeMock->expects($this->once())
-      ->method('updateSubscriberCount')
+    $this->countReporerMock->expects($this->once())
+      ->method('report')
       ->willReturn(true);
     expect($this->worker->processTaskStrategy($task, $timer))->true();
   }
@@ -78,8 +78,8 @@ class SubscribersStatsReportTest extends \MailPoetTest {
     $this->servicesCheckerMock->expects($this->once())
       ->method('getValidAccountKey')
       ->willReturn(null);
-    $this->bridgeMock->expects($this->never())
-      ->method('updateSubscriberCount');
+    $this->countReporerMock->expects($this->never())
+      ->method('report');
     expect($this->worker->processTaskStrategy($task, $timer))->false();
   }
 
@@ -89,8 +89,8 @@ class SubscribersStatsReportTest extends \MailPoetTest {
     $this->servicesCheckerMock->expects($this->once())
       ->method('getValidAccountKey')
       ->willReturn('a_valid_key');
-    $this->bridgeMock->expects($this->once())
-      ->method('updateSubscriberCount')
+    $this->countReporerMock->expects($this->once())
+      ->method('report')
       ->willReturn(false);
     $this->schedulerMock->expects($this->once())
       ->method('rescheduleProgressively');

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -10,6 +10,7 @@ use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
 use MailPoet\Mailer\Methods\MailPoet;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
 use MailPoet\Util\Url;
 
@@ -47,6 +48,7 @@ class MailPoetAPITest extends \MailPoetTest {
       $this->replyTo,
       $this->diContainer->get(MailPoetMapper::class),
       $this->makeEmpty(AuthorizedEmailsController::class),
+      $this->diContainer->get(Bridge::class),
       $this->diContainer->get(Url::class)
     );
     $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
@@ -89,6 +91,7 @@ class MailPoetAPITest extends \MailPoetTest {
       $replyTo,
       $this->diContainer->get(MailPoetMapper::class),
       $this->makeEmpty(AuthorizedEmailsController::class),
+      $this->diContainer->get(Bridge::class),
       $this->diContainer->get(Url::class)
     );
     $body = $mailer->getBody($this->newsletter, $this->subscriber);
@@ -297,6 +300,7 @@ class MailPoetAPITest extends \MailPoetTest {
       $this->replyTo,
       $this->diContainer->get(MailPoetMapper::class),
       $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::once()]),
+      $this->diContainer->get(Bridge::class),
       $this->diContainer->get(Url::class)
     );
     $mailer->api = $this->makeEmpty(

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -9,7 +9,6 @@ use MailPoet\Services\Bridge\API;
 use MailPoet\Services\Bridge\BridgeTestMockAPI as MockAPI;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
-use PHPUnit\Framework\MockObject\MockObject;
 
 require_once('BridgeTestMockAPI.php');
 
@@ -209,49 +208,6 @@ class BridgeTest extends \MailPoetTest {
     $this->bridge->invalidateMssKey();
     $storedState = $this->getMssKeyState() ?? [];
     expect($storedState['state'])->equals(Bridge::KEY_INVALID);
-  }
-
-  public function testItChecksAndStoresKeysOnSettingsSave() {
-    $response = ['state' => Bridge::KEY_VALID];
-    /** @var Bridge&MockObject $bridge */
-    $bridge = Stub::makeEmptyExcept(
-      Bridge::class,
-      'onSettingsSave',
-      [
-        'checkMSSKey' => $response,
-        'checkPremiumKey' => $response,
-      ],
-      $this
-    );
-    $bridge->expects($this->once())
-      ->method('checkMSSKey')
-      ->with($this->equalTo($this->validKey));
-    $bridge->expects($this->once())
-      ->method('storeMSSKeyAndState')
-      ->with(
-        $this->equalTo($this->validKey),
-        $this->equalTo($response)
-      );
-
-    $bridge->expects($this->once())
-      ->method('checkPremiumKey')
-      ->with($this->equalTo($this->validKey));
-    $bridge->expects($this->once())
-      ->method('storePremiumKeyAndState')
-      ->with(
-        $this->equalTo($this->validKey),
-        $this->equalTo($response)
-      );
-    $bridge->expects($this->once())
-      ->method('updateSubscriberCount')
-      ->with($this->equalTo($this->validKey));
-
-    $settings = [];
-    $settings[Mailer::MAILER_CONFIG_SETTING_NAME]['mailpoet_api_key'] = $this->validKey;
-    $settings['premium']['premium_key'] = $this->validKey;
-
-    $this->setMailPoetSendingMethod();
-    $bridge->onSettingsSave($settings);
   }
 
   public function testItPingsBridge() {

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -203,12 +203,12 @@ class BridgeTest extends \MailPoetTest {
   }
 
   public function testItInvalidatesMSSKey() {
-    $this->settings->set(
-      Bridge::API_KEY_STATE_SETTING_NAME,
-      ['state' => Bridge::KEY_VALID]
-    );
-    Bridge::invalidateKey();
-    expect($this->getMSSKeyState())->equals(['state' => Bridge::KEY_INVALID]);
+    $this->bridge->storeMSSKeyAndState($this->validKey, ['state' => Bridge::KEY_VALID]);
+    $storedState = $this->getMssKeyState() ?? [];
+    expect($storedState['state'])->equals(Bridge::KEY_VALID);
+    $this->bridge->invalidateMssKey();
+    $storedState = $this->getMssKeyState() ?? [];
+    expect($storedState['state'])->equals(Bridge::KEY_INVALID);
   }
 
   public function testItChecksAndStoresKeysOnSettingsSave() {

--- a/mailpoet/tests/integration/Settings/SettingsChangeHandlerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsChangeHandlerTest.php
@@ -122,7 +122,7 @@ class SettingsChangeHandlerTest extends \MailPoetTest {
       'subscribersCountReporter' => $countReporterMock,
     ]);
 
-    $changeHandler->updateBridge($settings);
+    $changeHandler->updateApiKeyState($settings);
   }
 
   private function getScheduledTaskByType(string $type): ?ScheduledTaskEntity {

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -100,6 +100,21 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     expect($error->getMessage())->stringContainsString('You have reached the subscriber limit of your plan.');
   }
 
+  public function testGetErrorSubscribersLimits(): void {
+    $apiResult = [
+      'code' => API::RESPONSE_CODE_CAN_NOT_SEND,
+      'status' => API::SENDING_STATUS_SEND_ERROR,
+      'message' => API::ERROR_MESSAGE_SUBSCRIBERS_LIMIT_REACHED,
+      'error' => API::ERROR_MESSAGE_SUBSCRIBERS_LIMIT_REACHED,
+    ];
+    $error = $this->mapper->getErrorForResult($apiResult, $this->subscribers);
+
+    expect($error)->isInstanceOf(MailerError::class);
+    expect($error->getOperation())->equals(MailerError::OPERATION_SUBSCRIBER_LIMIT_REACHED);
+    expect($error->getLevel())->equals(MailerError::LEVEL_HARD);
+    expect($error->getMessage())->stringContainsString('You have reached the subscriber limit of your plan.');
+  }
+
   public function testGetErrorUnauthorizedEmail() {
     $apiResult = [
       'code' => API::RESPONSE_CODE_CAN_NOT_SEND,

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -6,9 +6,7 @@ use Codeception\Stub;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\ErrorMappers\MailPoetMapper;
-use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
-use MailPoet\Settings\SettingsController;
 use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -30,9 +28,7 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
       },
     ]);
     $this->mapper = new MailPoetMapper(
-      Stub::make(Bridge::class),
       Stub::make(ServicesChecker::class),
-      Stub::make(SettingsController::class),
       Stub::make(Subscribers::class),
       $wpFunctions
     );

--- a/mailpoet/tests/unit/Util/License/Features/SubscribersTest.php
+++ b/mailpoet/tests/unit/Util/License/Features/SubscribersTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Util\License\Features;
 
 use Codeception\Util\Stub;
+use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -41,6 +42,19 @@ class SubscribersTest extends \MailPoetUnitTest {
       'subscribers_count' => 1500,
       'premium_subscribers_limit' => 500,
       'mss_subscribers_limit' => 500,
+    ]);
+    expect($subscribersFeature->check())->true();
+  }
+
+  public function testCheckReturnsTrueIfNoUserLimitReachedButShotRestrictsAccess() {
+    $subscribersFeature = $this->constructWith([
+      'mss_key_state' => 'invalid',
+      'premium_key_state' => 'invalid',
+      'installed_at' => '2019-11-11',
+      'subscribers_count' => 200,
+      'premium_subscribers_limit' => 500,
+      'mss_subscribers_limit' => 500,
+      'access_restriction' => Bridge::KEY_ACCESS_SUBSCRIBERS_LIMIT,
     ]);
     expect($subscribersFeature->check())->true();
   }
@@ -177,6 +191,7 @@ class SubscribersTest extends \MailPoetUnitTest {
         if ($name === SubscribersFeature::PREMIUM_SUBSCRIBERS_LIMIT_SETTING_KEY) return $specs['premium_subscribers_limit'];
         if ($name === SubscribersFeature::MSS_SUBSCRIBERS_LIMIT_SETTING_KEY) return $specs['mss_subscribers_limit'];
         if ($name === SubscribersFeature::PREMIUM_SUPPORT_SETTING_KEY) return isset($specs['support_tier']) ? $specs['support_tier'] : 'free';
+        if ($name === Bridge::API_KEY_STATE_SETTING_NAME) return ['access_restriction' => $specs['access_restriction'] ?? null];
       },
     ]);
 

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -151,7 +151,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'youReachedEmailVolumeLimit': __('You have sent more emails this month than your MailPoet plan includes ([emailVolumeLimit]), and sending has been temporarily paused.'),
   'youReachedEmailVolumeLimitUnknownLimit': __('You have sent more emails this month than your MailPoet plan includes, and sending has been temporarily paused.'),
   'toContinueUpgradeYourPlanOrWaitUntil': __('To continue sending with MailPoet Sending Service please [link]upgrade your plan[/link], or wait until sending is automatically resumed on <b>[date]</b>.'),
-  'refreshMyEmailVolumeLimit': __('I’ve upgraded my subscription, refresh monthly email limit'),
+  'refreshMyEmailVolumeLimit': __('Refresh monthly email limit'),
 
   'manageSenderDomainHeaderSubtitle': __('To help your audience and MailPoet authenticate you as the domain owner, please add the following DNS records to your domain’s DNS and click “Verify the DNS records”. Please note that it may take up to 24 hours for DNS changes to propagate after you make the change. [link]Read the guide[/link].', 'mailpoet'),
 

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -138,6 +138,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'confirmEdit': __('Sending is in progress. Do you want to pause sending and edit the newsletter?'),
   'confirmAutomaticNewsletterEdit': __('To edit this email, it needs to be deactivated. You can activate it again after you make the changes.'),
   'subscribersLimitNoticeTitle': __('Congratulations, you now have more than [subscribersLimit] subscribers!'),
+  'subscribersLimitNoticeTitleUnknownLimit': __('Congratulations, you now have more subscribers than the limit of your plan!'),
   'freeVersionLimit': __('Our free version is limited to [subscribersLimit] subscribers.'),
   'yourPlanLimit': __('Your plan is limited to [subscribersLimit] subscribers.'),
   'youNeedToUpgrade': __('You need to upgrade now to be able to continue using MailPoet.'),

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -99,6 +99,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   var mailpoet_has_premium_support = <%= json_encode(has_premium_support) %>;
   var has_mss_key_specified = <%= json_encode(has_mss_key_specified) %>;
   var mailpoet_mss_key_invalid = <%= json_encode(mss_key_invalid) %>;
+  var mailpoet_mss_key_valid = <%= json_encode(mss_key_valid) %>;
   var mailpoet_mss_key_pending_approval = '<%= mss_key_pending_approval %>';
   var mailpoet_mss_active = <%= json_encode(mss_active) %>;
   var mailpoet_plugin_partial_key = '<%= plugin_partial_key %>';

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -145,7 +145,9 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   'refreshMySubscribers': __('Refresh subscriber limit'),
 
   'emailVolumeLimitNoticeTitle': __('Congratulations, you sent more than [emailVolumeLimit] emails this month!'),
+  'emailVolumeLimitNoticeTitleUnknownLimit': __('Congratulations, you sent a lot of emails this month!'),
   'youReachedEmailVolumeLimit': __('You have sent more emails this month than your MailPoet plan includes ([emailVolumeLimit]), and sending has been temporarily paused.'),
+  'youReachedEmailVolumeLimitUnknownLimit': __('You have sent more emails this month than your MailPoet plan includes, and sending has been temporarily paused.'),
   'toContinueUpgradeYourPlanOrWaitUntil': __('To continue sending with MailPoet Sending Service please [link]upgrade your plan[/link], or wait until sending is automatically resumed on <b>[date]</b>.'),
   'refreshMyEmailVolumeLimit': __('I’ve upgraded my subscription, refresh monthly email limit'),
 


### PR DESCRIPTION
## Description

This PR adds caching of the plan's limit data so that we can display better notification messages (including limit details) even when the key loses access to premium or MSS and can no longer retrieve those data. Because there still might be cases when the plugin doesn't have the info about the plan's limits, I added variants of the notifications that don't contain plan details and are used as a fallback.

When working on the ticket made a small audit of how the messages work. I found that some messages were not displayed properly. I fixed that and refactored the display logic a bit.

### Subscriber limit notices
#### Notice when sending fails (displayed on the homepage and emails page)
<img width="1138" alt="Screenshot 2023-04-28 at 17 05 48" src="https://user-images.githubusercontent.com/1082140/235187265-b367ef58-dd5c-493b-b71f-01b75b710959.png">

Note: we hide this message if the key check fails with the subscriber limit error and we display the other 👇  message instead

#### Notice when the API key check fails and we have the plan's data
<img width="1136" alt="Screenshot 2023-04-28 at 16 54 31" src="https://user-images.githubusercontent.com/1082140/235187334-485684f4-a90a-4374-835f-2d1b7da8ecd7.png">

#### Notice when the API key check fails and doesn't have the plan's data (fallback)
<img width="1128" alt="Screenshot 2023-04-28 at 16 57 00" src="https://user-images.githubusercontent.com/1082140/235187472-6c411139-0232-4155-bebf-3ee701c5c843.png">


### Email volume limit notices
#### Notice when sending fails (displayed on the homepage and emails page)

<img width="1132" alt="Screenshot 2023-04-28 at 16 56 01" src="https://user-images.githubusercontent.com/1082140/235188222-4a3d78e0-a3c3-4c1a-9691-2f10567d9e87.png">

Note: we hide this message if the key check fails with the error volume limit error and we display the other 👇  message instead

#### Notice when the API key check fails and we have the plan's data
<img width="1129" alt="Screenshot 2023-04-28 at 17 07 18" src="https://user-images.githubusercontent.com/1082140/235188269-d9149de8-1ae7-4e38-8d53-ef2d6ce62ba4.png">


#### Notice when the API key check fails and doesn't have the plan's data (fallback)
<img width="1135" alt="Screenshot 2023-04-28 at 17 08 02" src="https://user-images.githubusercontent.com/1082140/235188316-491e59ac-a953-4b83-b2bc-68b091dab6f7.png">

## Code review notes

Sorry for the big PR! Please review commit by commit. 

Initially, I wanted to store the plan data per API key so that the plugin would cache the plan's limit data even when users swap keys, but I found that the complexity of the change was not worth it compared to the added value. So I added caching only for one key, and I added the fallback variants of messages for cases when we know the key is blocked, but we don't have the plan's details. When working on the initial idea, I made a couple of refactors around the Bridge service. These are not really needed for the simpler approach, but I decided to keep them because I believe they improve our codebase. They are in the first couple of commits.

## QA notes

Related changes in the shop are not released yet, because we first we need to release plugins that would show proper messages.
Because of that, we need to mock API responses to be able to display the message. 
You need a valid API key for testing.

### 1) Verify the valid key in the plugin settings.
### 2) Mock the key check response. This will simulate that the key was blocked in the shop. 
You can mock the API key check response in mailpoet/lib/Services/Bridge/API.php

<img width="674" alt="Screenshot 2023-04-28 at 17 35 56" src="https://user-images.githubusercontent.com/1082140/235192137-1a07da9a-bb8b-4055-86cf-83e193648190.png">


add `return ['code' => 403, 'data' => null, 'error_message' => self::ERROR_MESSAGE_EMAIL_VOLUME_LIMIT_REACHED];`
to get email volume limit reached notice

add `return ['code' => 403, 'data' => null, 'error_message' => self::ERROR_MESSAGE_SUBSCRIBERS_LIMIT_REACHED];`
to get subscriber limit reached notice

### 3) Go to settings, re-enter the key and verify that the correct notice is displayed across the plugin

Note: To test the fallback message variants, you need to start with a fresh site (no API key), and skip step one. This will cause the data from the valid key will not be cached. It simulates a situation when a user tries using a blocked key on a new site.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5191]

## After-merge notes

_N/A_


[MAILPOET-5191]: https://mailpoet.atlassian.net/browse/MAILPOET-5191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ