### PR TITLE
Do not run PR stats workflow for dependabot PRs [MAILPOET-5260]

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -3,6 +3,8 @@ name: Pull Request Stats
 on:
   pull_request:
     types: [opened]
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   stats:


### PR DESCRIPTION
## Description

Currently there is only one person per week who is supposed to review dependabot PRs (the porter), so it makes the most sense to me to simply skip this workflow for any dependabot PRs.

## Code review notes

_N/A_

## QA notes

No QA required.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5260](https://mailpoet.atlassian.net/browse/MAILPOET-5260)

## After-merge notes

We could test this after it's been merged by pushing a branch with a name like a dependabot branch (`dependabot/etc/etc`) to ensure the stats workflow doesn't run for it.


[MAILPOET-5260]: https://mailpoet.atlassian.net/browse/MAILPOET-5260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ