### PR TITLE
Filter operators [MAILPOET-5218]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_filters.scss
@@ -12,6 +12,16 @@ button.components-button.mailpoet-automation-filters-panel-add-filter {
   margin-bottom: 16px;
 }
 
+.mailpoet-automation-filters-list-group-operator {
+  .components-base-control__field > div {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    justify-content: flex-start;
+  }
+}
+
 .mailpoet-automation-filters-list-item {
   align-items: center;
   background: #f0f0f0;

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -59,3 +59,10 @@ export type FiltersPanelContentType = (step: Step) => JSX.Element;
 
 // mailpoet.automation.filters.delete_step_filter_callback
 export type DeleteStepFilterType = (stepId: string, filter: Filter) => void;
+
+// mailpoet.automation.filters.group_operator_change_callback
+export type FilterGroupOperatorChangeType = (
+  stepId: string,
+  groupId: string,
+  operator: 'and' | 'or',
+) => void;

--- a/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine\Control;
 
 use MailPoet\Automation\Engine\Data\Filter as FilterData;
 use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Registry;
@@ -24,12 +25,17 @@ class FilterHandler {
       return true;
     }
 
+    $operator = $filters->getOperator();
     foreach ($filters->getGroups() as $group) {
-      if ($this->matchesGroup($group, $args)) {
+      $matches = $this->matchesGroup($group, $args);
+      if ($operator === Filters::OPERATOR_AND && !$matches) {
         return false;
       }
+      if ($operator === Filters::OPERATOR_OR && $matches) {
+        return true;
+      }
     }
-    return true;
+    return $operator === Filters::OPERATOR_AND;
   }
 
   private function matchesGroup(FilterGroup $group, StepRunArgs $args): bool {

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -59,6 +59,32 @@ class FilterHandlerTest extends MailPoetUnitTest {
     $this->assertSame($expectation, $result);
   }
 
+  /** @dataProvider dataForTestItEvaluatesGroupOperators */
+  public function testItEvaluatesGroupOperators(FilterGroup $group, bool $expectation): void {
+    $filters = new Filters('and', [$group]);
+    $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $filters);
+    $subject = $this->createSubject('subject', [
+      new Field('test:field-string', Field::TYPE_STRING, 'Test field string', function () {
+        return 'abc';
+      }),
+    ]);
+
+    $stepRunArgs = new StepRunArgs(
+      $this->createMock(Automation::class),
+      $this->createMock(AutomationRun::class),
+      $step,
+      [new SubjectEntry($subject, new SubjectData($subject->getKey(), []))]
+    );
+
+    $registry = Stub::make(Registry::class, [
+      'filters' => [Field::TYPE_STRING => $this->createFilter(Field::TYPE_STRING)],
+    ]);
+
+    $handler = new FilterHandler($registry);
+    $result = $handler->matchesFilters($stepRunArgs);
+    $this->assertSame($expectation, $result);
+  }
+
   public function dataForTestItFilters(): array {
     return [
       // no filters
@@ -89,6 +115,41 @@ class FilterHandlerTest extends MailPoetUnitTest {
           new FilterData('f2', Field::TYPE_INTEGER, 'test:field-integer', '', ['value' => 999]),
           new FilterData('f3', Field::TYPE_BOOLEAN, 'test:field-boolean', '', ['value' => true]),
         ],
+        false,
+      ],
+    ];
+  }
+
+  public function dataForTestItEvaluatesGroupOperators(): array {
+    return [
+      [
+        new FilterGroup('g1', 'and', [
+          new FilterData('f1', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData('f2', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData('f3', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+        ]),
+        true,
+      ],
+      [
+        new FilterGroup('g2', 'and', [
+          new FilterData('f1', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData('f2', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'xyz']),
+        ]),
+        false,
+      ],
+      [
+        new FilterGroup('g3', 'or', [
+          new FilterData('f1', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'def']),
+          new FilterData('f2', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'abc']),
+          new FilterData('f2', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'xyz']),
+        ]),
+        true,
+      ],
+      [
+        new FilterGroup('g4', 'or', [
+          new FilterData('f1', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'def']),
+          new FilterData('f2', Field::TYPE_STRING, 'test:field-string', '', ['value' => 'xyz']),
+        ]),
         false,
       ],
     ];


### PR DESCRIPTION
## Description

Implements AND/OR for filters and filter groups.

Note that in the UI, we only support a single filter group at the moment.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/721

## Linked tickets

[MAILPOET-5218]

[MAILPOET-5218]: https://mailpoet.atlassian.net/browse/MAILPOET-5218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ