### PR TITLE
Track Dotcom plans

### DIFF
--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -38,6 +38,7 @@ use MailPoet\Tags\TagRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class Reporter {
@@ -80,6 +81,9 @@ class Reporter {
   /*** @var UnsubscribeReporter */
   private $unsubscribeReporter;
 
+  /*** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
     SegmentsRepository $segmentsRepository,
@@ -93,7 +97,8 @@ class Reporter {
     TrackingConfig $trackingConfig,
     SubscriberListingRepository $subscriberListingRepository,
     AutomationStorage $automationStorage,
-    UnsubscribeReporter $unsubscribeReporter
+    UnsubscribeReporter $unsubscribeReporter,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsRepository = $segmentsRepository;
@@ -108,6 +113,7 @@ class Reporter {
     $this->subscriberListingRepository = $subscriberListingRepository;
     $this->automationStorage = $automationStorage;
     $this->unsubscribeReporter = $unsubscribeReporter;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function getData() {
@@ -206,6 +212,8 @@ class Reporter {
       'Support tier' => $this->subscribersFeature->hasPremiumSupport() ? 'premium' : 'free',
       'Unauthorized email notice shown' => !empty($this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING)),
       'Sign-up confirmation: Confirmation Template > using html email editor template' => (boolean)$this->settings->get(ConfirmationEmailCustomizer::SETTING_ENABLE_EMAIL_CUSTOMIZER, false),
+      'Is WordPress.com' => $this->dotcomHelperFunctions->isDotcom() ? 'yes' : 'no',
+      'WordPress.com plan' => $this->dotcomHelperFunctions->getDotcomPlan(),
     ];
 
     $result = array_merge(

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -543,6 +543,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WP\AutocompletePostListLoader::class)->setPublic(true);
     // WordPress.com
     $container->autowire(\MailPoet\WPCOM\DotcomLicenseProvisioner::class)->setPublic(true);
+    $container->autowire(\MailPoet\WPCOM\DotcomHelperFunctions::class)->setPublic(true);
     // Third party classes
     $container->autowire(\MailPoetVendor\CSS::class)->setClass(\MailPoetVendor\CSS::class)->setPublic(true);
     $container->autowire(\MailPoetVendor\csstidy::class)->setClass(\MailPoetVendor\csstidy::class);

--- a/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
+++ b/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WPCOM;
+
+class DotcomHelperFunctions {
+  /**
+   * Returns true if in the context of WordPress.com Atomic platform.
+   *
+   * @return bool
+   */
+  public function isAtomicPlatform(): bool {
+    // ATOMIC_CLIENT_ID === '2' corresponds to WordPress.com client on the Atomic platform
+    return defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
+  }
+
+  /**
+   * Returns true if the site is on WordPress.com.
+   */
+  public function isDotcom(): bool {
+    return $this->isAtomicPlatform() ;
+  }
+
+  /**
+   * Returns true if the site has an ecommerce-related plans on WordPress.com.
+   * See https://github.com/Automattic/wc-calypso-bridge#active-plan-detection
+   */
+  public function isCommerce(): bool {
+    return function_exists('wc_calypso_bridge_has_ecommerce_features') && wc_calypso_bridge_has_ecommerce_features() ;
+  }
+
+  /**
+   * Returns true if the site has a business plan on WordPress.com.
+   * See https://github.com/Automattic/wc-calypso-bridge#active-plan-detection
+   */
+  public function isBusiness(): bool {
+    return function_exists('wc_calypso_bridge_is_business_plan') && wc_calypso_bridge_is_business_plan() ;
+  }
+
+  /**
+   * Returns the plan name for the current site if hosted on WordPress.com.
+   * Empty otherwise.
+   */
+  public function getDotcomPlan(): string {
+    if ($this->isCommerce()) {
+      return 'commerce' ;
+    };
+
+    if ($this->isBusiness()) {
+      return 'business' ;
+    };
+
+    return '';
+  }
+}

--- a/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
+++ b/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
@@ -42,11 +42,11 @@ class DotcomHelperFunctions {
    */
   public function getDotcomPlan(): string {
     if ($this->isCommerce()) {
-      return 'commerce' ;
+      return 'commerce';
     };
 
     if ($this->isBusiness()) {
-      return 'business' ;
+      return 'business';
     };
 
     return '';

--- a/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
+++ b/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php
@@ -23,24 +23,19 @@ class DotcomLicenseProvisioner {
   /** @var Services */
   private $services;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     LoggerFactory $loggerFactory,
     Settings $settings,
-    Services $services
+    Services $services,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->loggerFactory = $loggerFactory;
     $this->settings = $settings;
     $this->services = $services;
-  }
-
-  /**
-   * Returns true if in the context of WordPress.com Atomic platform.
-   *
-   * @return bool
-   */
-  public function isAtomicPlatform(): bool {
-    // ATOMIC_CLIENT_ID === '2' corresponds to WordPress.com client on the Atomic platform
-    return defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   /**
@@ -52,7 +47,7 @@ class DotcomLicenseProvisioner {
    * @return bool|WP_Error
    */
   public function provisionLicense(bool $result, array $licensePayload, string $eventType) {
-    if (!$this->isAtomicPlatform() || $eventType !== self::EVENT_TYPE_PROVISION_LICENSE) {
+    if (!$this->dotcomHelperFunctions->isAtomicPlatform() || $eventType !== self::EVENT_TYPE_PROVISION_LICENSE) {
       return $result;
     }
 

--- a/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
+++ b/mailpoet/tests/integration/WPCOM/DotcomLicenseProvisionerTest.php
@@ -20,8 +20,8 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
         $this->diContainer->get(LoggerFactory::class),
         $this->make(Settings::class),
         $this->make(Services::class),
-      ],
-      ['isAtomicPlatform' => true]);
+        $this->make(DotcomHelperFunctions::class, ['isAtomicPlatform' => true]),
+      ]);
   }
 
   public function testItReturnsResultIfNotAtomic() {
@@ -33,8 +33,8 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
         $this->make(LoggerFactory::class),
         $this->make(Settings::class),
         $this->make(Services::class),
-      ],
-      ['isAtomicPlatform' => false]);
+        $this->make(DotcomHelperFunctions::class, ['isAtomicPlatform' => false]),
+      ]);
     expect($provisioner->provisionLicense($result, $payload, DotcomLicenseProvisioner::EVENT_TYPE_PROVISION_LICENSE))->equals($result);
   }
 
@@ -64,8 +64,8 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
         $this->diContainer->get(LoggerFactory::class),
         $this->make(Settings::class, ['setKeyAndSetupMss' => new ErrorResponse(['error' => 'some-error'])]),
         $this->make(Services::class, ['refreshMSSKeyStatus' => new SuccessResponse()]),
-      ],
-      ['isAtomicPlatform' => true]);
+        $this->make(DotcomHelperFunctions::class, ['isAtomicPlatform' => true]),
+      ]);
     $error = $provisioner->provisionLicense($result, $payload, $eventType);
     $this->assertInstanceOf(\WP_Error::class, $error);
     expect($error->get_error_message())->equals('some-error ');
@@ -81,8 +81,8 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
         $this->diContainer->get(LoggerFactory::class),
         $this->make(Settings::class, ['setKeyAndSetupMss' => new SuccessResponse()]),
         $this->make(Services::class, ['refreshMSSKeyStatus' => new ErrorResponse(['error' => 'some-error'])]),
-      ],
-      ['isAtomicPlatform' => true]);
+        $this->make(DotcomHelperFunctions::class, ['isAtomicPlatform' => true]),
+      ]);
     $error = $provisioner->provisionLicense($result, $payload, $eventType);
     $this->assertInstanceOf(\WP_Error::class, $error);
     expect($error->get_error_message())->equals('some-error ');
@@ -102,8 +102,8 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
             'refreshMSSKeyStatus' => new SuccessResponse(),
             'refreshPremiumKeyStatus' => new ErrorResponse(['error' => 'some-error']),
           ]),
-      ],
-      ['isAtomicPlatform' => true]);
+        $this->make(DotcomHelperFunctions::class, ['isAtomicPlatform' => true]),
+      ]);
     $error = $provisioner->provisionLicense($result, $payload, $eventType);
     $this->assertInstanceOf(\WP_Error::class, $error);
     expect($error->get_error_message())->equals('some-error ');
@@ -123,8 +123,8 @@ class DotcomLicenseProvisionerTest extends \MailPoetTest {
             'refreshMSSKeyStatus' => new SuccessResponse(),
             'refreshPremiumKeyStatus' => new SuccessResponse(),
           ]),
-      ],
-      ['isAtomicPlatform' => true]);
+        $this->make(DotcomHelperFunctions::class, ['isAtomicPlatform' => true]),
+      ]);
     $result = $provisioner->provisionLicense($result, $payload, $eventType);
     expect($result)->equals(true);
   }

--- a/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
+++ b/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace unit\WPCOM;
-
-use MailPoet\WPCOM\DotcomHelperFunctions;
+namespace MailPoet\WPCOM;
 
 class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   /*** @var DotcomHelperFunctions */

--- a/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
+++ b/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace unit\WPCOM;
+
+use MailPoet\WPCOM\DotcomHelperFunctions;
+
+class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
+  /*** @var DotcomHelperFunctions */
+  private $dotcomHelper;
+
+  public function _before() {
+    parent::_before();
+    $this->dotcomHelper = new DotcomHelperFunctions();
+  }
+
+  public function testItReturnsFalseIfNotDotcom() {
+    expect($this->dotcomHelper->isDotcom())->false();
+  }
+
+  public function testItReturnsTrueIfDotcom() {
+    define('IS_ATOMIC', true);
+    define('ATOMIC_CLIENT_ID', '2');
+    expect($this->dotcomHelper->isDotcom())->true();
+  }
+
+  public function testItReturnsEmptyStringIfNoPlan() {
+    expect($this->dotcomHelper->getDotcomPlan())->equals('');
+  }
+
+  public function testItReturnsCommerce() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isCommerce', ]);
+    $dotcomHelper->method('isCommerce')->willReturn(
+      true
+    );
+    expect($dotcomHelper->getDotcomPlan())->equals('commerce');
+  }
+
+  public function testItReturnsBusiness() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isBusiness', ]);
+    $dotcomHelper->method('isBusiness')->willReturn(
+      true
+    );
+    expect($dotcomHelper->getDotcomPlan())->equals('business');
+  }
+}


### PR DESCRIPTION
## Description

This PR adds to the reporter the information about WordPress.com plan:
- "Is WordPress.com" -> 'yes' or 'no'
- "WordPress.com plan" -> 'business', 'commerce' or '' if no plan.

## Code review notes

_N/A_

## QA notes

To test:
- grab the zip with the build and install it on a WordPress.com site with a Business or Ecommerce plan.
- Make sure WooCommerce is installed and the wizard completed
- Make sure MailPoet is setup to allow for tracking
- Go to any MailPoet admin screen and open the browser console
- Enter `window.mailpoet_analytics_data` and check the data contain the new values
- If `window.mailpoet_analytics_data` is null, open phpMyAdmin from Settings > Hosting Configuration
- On table wp_mailpoet_settings, delete the row for `analytics_last_sent`
- Load again one of MailPoet admin screens and view the value.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4974]

## After-merge notes

_N/A_


[MAILPOET-4974]: https://mailpoet.atlassian.net/browse/MAILPOET-4974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ