### PR TITLE
Install older version of Tracy based on PHP version [MAILPOET-5277]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,18 @@ jobs:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
           command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
+      - run:
+          name: Create docker containers for test
+          # We experienced some failures when creating containers so we do it explicitly with one retry
+          command: |
+            cd tests/docker
+            docker-compose create || docker-compose create
+      - run:
+          # Some tools we use may need different version based on PHP version used in docker
+          name: Ensure correct versions of tools
+          command: |
+            cd tests/docker
+            docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_acceptance
       - when:
           condition: << parameters.woo_core_version >>
           steps:
@@ -450,12 +462,6 @@ jobs:
               circleci tests glob "tests/acceptance/**/*Cest.php" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
             fi
             cat tests/acceptance/_groups/circleci_split_group
-      - run:
-          name: Create docker containers for test
-          # We experienced some failures when creating containers so we do it explicitly with one retry
-          command: |
-            cd tests/docker
-            docker-compose create || docker-compose create
       - run:
           name: Run acceptance tests
           command: |
@@ -565,6 +571,10 @@ jobs:
           name: 'Prepare example.com for testing'
           command: echo 127.0.0.1 example.com | sudo tee -a /etc/hosts
       - run:
+          # Some tools we use may need different version based on PHP version used in docker
+          name: Ensure correct versions of tools
+          command: COMPOSER_DEV_MODE=1 php tools/install.php
+      - run:
           name: 'Set up test environment'
           command: source ../.circleci/setup.bash && setup php7
       - run:
@@ -629,6 +639,12 @@ jobs:
           command: |
             cd tests/docker
             docker-compose create || docker-compose create
+      - run:
+          # Some tools we use may need different version based on PHP version used in docker
+          name: Ensure correct versions of tools
+          command: |
+            cd tests/docker
+            docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_integration
       - run:
           name: 'PHP Integration tests'
           command: |

--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -1,9 +1,15 @@
 <?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
+$tracyVersion = '2.9.7';
+// The newer tracy version doesn't support PHP 7.X which we still support in tests and also in development environment.
+if (PHP_VERSION_ID < 80000) {
+  $tracyVersion = '2.9.4';
+}
+
 $tools = [
   'https://github.com/composer/composer/releases/download/2.3.5/composer.phar' => 'composer.phar',
   'https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar' => 'php-scoper.phar',
-  'https://github.com/nette/tracy/releases/download/v2.9.7/tracy.phar' => 'tracy.phar',
+  "https://github.com/nette/tracy/releases/download/v$tracyVersion/tracy.phar" => 'tracy.phar',
 ];
 // ensure installation in dev-mode only
 $isDevMode = (bool)getenv('COMPOSER_DEV_MODE');


### PR DESCRIPTION
## Description

This PR fixes failing nightly builds and is also needed for fixing failing builds of the premium plugin.

I decided to use the approach that we install the version based on the PHP version of the environment.
Locally when developers need to switch to PHP 7.4, they only need to call `./do install` to get the correct version of the Tracy.

This will also allow us to upgrade to the newest Tracy version for PHP8.x

## Code review notes

There is also a PR in the premium plugin repository https://github.com/mailpoet/mailpoet-premium/pull/722

I created a branch `use-proper-tracy-version-delme` where I allowed the "oldest" tests to demonstrate the fix works.
Here is [a passing build](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/14178/workflows/eefd6022-004f-4d93-a260-949364916bac).

## QA notes
As this is related only to the test environment, this doesn't require QA.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/722

## Linked tickets

[MAILPOET-5277]

## After-merge notes

Please delete also `use-proper-tracy-version-delme` branch


[MAILPOET-5277]: https://mailpoet.atlassian.net/browse/MAILPOET-5277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ