### PR TITLE
Fix opt-in block appearance in the post editor [MAILPOET-5276]

### DIFF
--- a/mailpoet/assets/js/src/marketing_optin_block/editor.scss
+++ b/mailpoet/assets/js/src/marketing_optin_block/editor.scss
@@ -11,6 +11,8 @@
 
   .wc-block-components-checkbox {
     margin-top: 0 !important;
+    pointer-events: none;
+    user-select: none;
   }
 }
 

--- a/mailpoet/assets/js/src/marketing_optin_block/editor.scss
+++ b/mailpoet/assets/js/src/marketing_optin_block/editor.scss
@@ -1,16 +1,19 @@
 .wc-block-checkout__marketing {
   align-items: flex-start;
   display: flex;
-  margin: 20px 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  margin: 1em 0;
 
   .block-editor-rich-text__editable {
-    line-height: em(24px);
+    font-size: .875em;
+    line-height: inherit;
     vertical-align: middle;
   }
 
   .wc-block-components-checkbox {
-    margin-top: 0;
+    margin-top: 0 !important;
   }
+}
+
+.wc-block-checkout__additional_fields .block-editor-inner-blocks .block-editor-block-list__layout {
+  padding-left: 0;
 }


### PR DESCRIPTION
## Description

This PR fixes visual issues of the MailPoet opt-in checkbox when displayed within the checkout block in the post editor.

### Before
![Screenshot 2023-05-04 at 10 22 47](https://user-images.githubusercontent.com/1082140/236149639-8c2e161a-fd01-4526-a84c-e4164189271e.png)
![Screenshot 2023-05-04 at 10 21 02](https://user-images.githubusercontent.com/1082140/236149674-29410647-c1f1-4b72-9e47-38a60c6b9032.png)

### After
![Screenshot 2023-05-04 at 10 20 20](https://user-images.githubusercontent.com/1082140/236149733-78b58db3-f234-4d34-bc4e-9201dc32f7df.png)
![Screenshot 2023-05-04 at 10 20 35](https://user-images.githubusercontent.com/1082140/236149761-f467251c-0454-4ffc-afea-87845404be3d.png)

## Code review notes

_N/A_

## QA notes

Steps to replicate/verify.
1) Install Woo Commerce
2) Go to Pages > Checkout page and open it in the post editor
3) Replace the checkout shortcode block with a checkout block and observe the issue.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5276] Closes https://github.com/mailpoet/mailpoet/issues/4894

## After-merge notes

_N/A_


[MAILPOET-5276]: https://mailpoet.atlassian.net/browse/MAILPOET-5276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ