### PR TITLE
Synchronize Opt out with AutomateWoo

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -12,6 +12,7 @@ use MailPoet\Subscription\Comment;
 use MailPoet\Subscription\Form;
 use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
+use MailPoet\WooCommerce\Integrations\AutomateWooHooks;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WPCOM\DotcomLicenseProvisioner;
 
@@ -58,6 +59,9 @@ class Hooks {
   /** @var DotcomLicenseProvisioner */
   private $dotcomLicenseProvisioner;
 
+  /** @var AutomateWooHooks */
+  private $automateWooHooks;
+
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -72,7 +76,8 @@ class Hooks {
     SubscriberHandler $subscriberHandler,
     SubscriberChangesNotifier $subscriberChangesNotifier,
     WP $wpSegment,
-    DotcomLicenseProvisioner $dotcomLicenseProvisioner
+    DotcomLicenseProvisioner $dotcomLicenseProvisioner,
+    AutomateWooHooks $automateWooHooks
   ) {
     $this->subscriptionForm = $subscriptionForm;
     $this->subscriptionComment = $subscriptionComment;
@@ -88,6 +93,7 @@ class Hooks {
     $this->hooksWooCommerce = $hooksWooCommerce;
     $this->subscriberChangesNotifier = $subscriberChangesNotifier;
     $this->dotcomLicenseProvisioner = $dotcomLicenseProvisioner;
+    $this->automateWooHooks = $automateWooHooks;
   }
 
   public function init() {
@@ -100,6 +106,7 @@ class Hooks {
     $this->setupListing();
     $this->setupSubscriptionEvents();
     $this->setupWooCommerceSubscriptionEvents();
+    $this->setupAutomateWooSubscriptionEvents();
     $this->setupPostNotifications();
     $this->setupWooCommerceSettings();
     $this->setupFooter();
@@ -260,6 +267,10 @@ class Hooks {
       10,
       1
     );
+  }
+
+  public function setupAutomateWooSubscriptionEvents() {
+    $this->automateWooHooks->setup();
   }
 
   public function setupWPUsers() {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -527,6 +527,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(Validator::class)->setPublic(true);
     // WooCommerce
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\Integrations\AutomateWooHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\SubscriberEngagement::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -25,6 +25,7 @@ class SubscriberEntity {
   public const HOOK_SUBSCRIBER_CREATED = 'mailpoet_subscriber_created';
   public const HOOK_SUBSCRIBER_DELETED = 'mailpoet_subscriber_deleted';
   public const HOOK_SUBSCRIBER_UPDATED = 'mailpoet_subscriber_updated';
+  public const HOOK_SUBSCRIBER_STATUS_CHANGED = 'mailpoet_subscriber_status_changed';
   public const HOOK_MULTIPLE_SUBSCRIBERS_CREATED = 'mailpoet_multiple_subscribers_created';
   public const HOOK_MULTIPLE_SUBSCRIBERS_DELETED = 'mailpoet_multiple_subscribers_deleted';
   public const HOOK_MULTIPLE_SUBSCRIBERS_UPDATED = 'mailpoet_multiple_subscribers_updated';

--- a/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
+++ b/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce\Integrations;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\WP\Functions as WPFunctions;
+
+class AutomateWooHooks {
+  const AUTOMATE_WOO_PLUGIN_SLUG = 'automatewoo/automatewoo.php';
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    SubscribersRepository $subscribersRepository,
+    WPFunctions $wp
+  ) {
+    $this->subscribersRepository = $subscribersRepository;
+    $this->wp = $wp;
+  }
+
+  public function isAutomateWooActive(): bool {
+    return $this->wp->isPluginActive(self::AUTOMATE_WOO_PLUGIN_SLUG);
+  }
+
+  public function areMethodsAvailable(): bool {
+    return class_exists('AutomateWoo\Customer_Factory') && method_exists('AutomateWoo\Customer_Factory', 'get_by_email') &&
+      class_exists('AutomateWoo\Customer') && method_exists('AutomateWoo\Customer', 'opt_out');
+  }
+
+  public function getAutomateWooCustomer(string $email): ?\AutomateWoo\Customer {
+    // AutomateWoo\Customer_Factory::get_by_email() returns false if customer is not found
+    // Second parameter is set to false to prevent creating new customer if not found
+    return \AutomateWoo\Customer_Factory::get_by_email($email, false);
+  }
+
+  public function setup(): void {
+    if (!$this->isAutomateWooActive() || !$this->areMethodsAvailable()) {
+      return;
+    }
+    $this->wp->addAction(SubscriberEntity::HOOK_SUBSCRIBER_STATUS_CHANGED, [$this, 'maybeOptOutSubscriber'], 10, 1);
+  }
+
+  public function maybeOptOutSubscriber(int $subscriberId): void {
+    if (!$this->isAutomateWooActive() || !$this->areMethodsAvailable()) {
+      return;
+    }
+
+    $subscriber = $this->subscribersRepository->findOneById($subscriberId);
+    if (!$subscriber || !$subscriber->getEmail() || $subscriber->getStatus() !== SubscriberEntity::STATUS_UNSUBSCRIBED) {
+      return;
+    }
+
+    $automateWooCustomer = $this->getAutomateWooCustomer($subscriber->getEmail());
+    if (!$automateWooCustomer) {
+      return;
+    }
+
+    $automateWooCustomer->opt_out();
+  }
+}

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -223,6 +223,7 @@ class Subscription {
     $signupConfirmation = $this->settings->get('signup_confirmation');
 
     if (!$checkoutOptin) {
+      $this->wp->doAction('mailpoet_woocommerce_segment_unsubscribed', $subscriber);
       // Opt-in is disabled or checkbox is unchecked
       $this->subscriberSegmentRepository->unsubscribeFromSegments($subscriber, [$wcSegment]);
 

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -44,3 +44,18 @@ namespace WP_CLI\Utils {
     }
   }
 }
+
+namespace AutomateWoo {
+  if (!class_exists(\AutomateWoo\Customer::class)) {
+    class Customer {
+      public function opt_out() {
+      }
+    }
+  }
+  if (!class_exists(\AutomateWoo\Customer_Factory::class)) {
+    class Customer_Factory {
+      public static function get_by_email(string $customer_email, bool $create_if_not_found = true) {
+      }
+    }
+  }
+}

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -77,4 +77,20 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->see($customerEmail, '.automatewoo-content');
     $i->seeConfirmationEmailWasReceived();
   }
+
+  public function checkoutOptInCheckedAndUnchecked(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_check@example.com';
+    $i->orderProductWithRegistration($this->product, $customerEmail, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->see($customerEmail, '.automatewoo-content');
+    $i->logout();
+    $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->dontSee($customerEmail, '.automatewoo-content');
+  }
 }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
@@ -6,6 +6,7 @@ use Codeception\Stub\Expected;
 use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -45,6 +46,19 @@ class SubscriberListenerTest extends EventListenersBaseTest {
 
     $subscriber->setFirstName('John');
     $subscriber->setLastName('Doe');
+    $this->entityManager->flush();
+  }
+
+  public function testItNotifiesAboutUpdatedStatusSubscriber(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $this->wp,
+      'subscriberStatusChanged' => Expected::once(),
+    ]);
+    $this->subscriberListener = new SubscriberListener($changesNotifier);
+    $this->replaceEntityListener($this->subscriberListener);
+
+    $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
   }
 

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce\Integrations;
+
+use Codeception\Stub\Expected;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AutomateWooHooksTest extends \MailPoetTest {
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var MockObject */
+  private $subscribersRepository;
+
+  /** @var SubscriberFactory */
+  private $subscriberFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->wp = $this->make(new WPFunctions, [
+      'isPluginActive' => function($name) {
+        if ($name === 'automatewoo/automatewoo.php') {
+          return true;
+        }
+        return false;
+      },
+    ]);
+    $this->subscribersRepository = $this->createMock(SubscribersRepository::class);
+    $this->subscriberFactory = new SubscriberFactory();
+  }
+
+  public function testSetup() {
+    $wp = $this->make(new WPFunctions, [
+      'isPluginActive' => function($name) {
+        if ($name === 'automatewoo/automatewoo.php') {
+          return true;
+        }
+        return false;
+      },
+      'addAction' => function($name, $callback) {
+        expect($name)->equals(SubscriberEntity::HOOK_SUBSCRIBER_STATUS_CHANGED);
+      },
+    ]);
+    $subscribersRepository = $this->createMock(SubscribersRepository::class);
+    $automateWooHooks = new AutomateWooHooks($subscribersRepository, $wp);
+    $automateWooHooks->setup();
+  }
+
+  public function testOptsOutUnsubscribedSubscriber() {
+    $unsubscribedSubscriber = $this->subscriberFactory
+      ->withEmail('unsubscribedUser@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)->create();
+    $this->subscribersRepository->method('findOneById')->willReturn($unsubscribedSubscriber);
+
+    $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
+    ->setConstructorArgs([$this->subscribersRepository, $this->wp])
+    ->onlyMethods(['getAutomateWooCustomer'])
+    ->getMock();
+
+    $automateWooCustomer = $this->make(new \AutomateWoo\Customer, ['opt_out' => Expected::once(function() {
+    })]);
+    $automateWooHooksPartialMock->expects($this->once())->method('getAutomateWooCustomer')->willReturn($automateWooCustomer);
+
+    $automateWooHooksPartialMock->maybeOptOutSubscriber((int)$unsubscribedSubscriber->getId());
+  }
+
+  public function testDoesNotOptOutSubscribedSubscriber() {
+    $subscribedSubscriber = $this->subscriberFactory
+      ->withEmail('subscribedUser@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $this->subscribersRepository->method('findOneById')->willReturn($subscribedSubscriber);
+
+    $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
+      ->setConstructorArgs([$this->subscribersRepository, $this->wp])
+      ->onlyMethods(['getAutomateWooCustomer'])
+      ->getMock();
+    $automateWooHooksPartialMock->expects($this->never())->method('getAutomateWooCustomer');
+
+    $automateWooHooksPartialMock->maybeOptOutSubscriber((int)$subscribedSubscriber->getId());
+  }
+}

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -41,13 +41,16 @@ class AutomateWooHooksTest extends \MailPoetTest {
         }
         return false;
       },
-      'addAction' => function($name, $callback) {
-        expect($name)->equals(SubscriberEntity::HOOK_SUBSCRIBER_STATUS_CHANGED);
-      },
+      'addAction' => Expected::exactly(2),
     ]);
-    $subscribersRepository = $this->createMock(SubscribersRepository::class);
-    $automateWooHooks = new AutomateWooHooks($subscribersRepository, $wp);
-    $automateWooHooks->setup();
+
+    $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
+      ->setConstructorArgs([$this->subscribersRepository, $wp])
+      ->onlyMethods(['areMethodsAvailable'])
+      ->getMock();
+    $automateWooHooksPartialMock->expects($this->once())->method('areMethodsAvailable')->willReturn(true);
+
+    $automateWooHooksPartialMock->setup();
   }
 
   public function testOptsOutUnsubscribedSubscriber() {
@@ -58,12 +61,10 @@ class AutomateWooHooksTest extends \MailPoetTest {
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
     ->setConstructorArgs([$this->subscribersRepository, $this->wp])
-    ->onlyMethods(['getAutomateWooCustomer'])
+    ->onlyMethods(['optOutSubscriber'])
     ->getMock();
 
-    $automateWooCustomer = $this->make(new \AutomateWoo\Customer, ['opt_out' => Expected::once(function() {
-    })]);
-    $automateWooHooksPartialMock->expects($this->once())->method('getAutomateWooCustomer')->willReturn($automateWooCustomer);
+    $automateWooHooksPartialMock->expects($this->once())->method('optOutSubscriber');
 
     $automateWooHooksPartialMock->maybeOptOutSubscriber((int)$unsubscribedSubscriber->getId());
   }
@@ -76,9 +77,9 @@ class AutomateWooHooksTest extends \MailPoetTest {
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
       ->setConstructorArgs([$this->subscribersRepository, $this->wp])
-      ->onlyMethods(['getAutomateWooCustomer'])
+      ->onlyMethods(['optOutSubscriber'])
       ->getMock();
-    $automateWooHooksPartialMock->expects($this->never())->method('getAutomateWooCustomer');
+    $automateWooHooksPartialMock->expects($this->never())->method('optOutSubscriber');
 
     $automateWooHooksPartialMock->maybeOptOutSubscriber((int)$subscribedSubscriber->getId());
   }

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -60,6 +60,19 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
     $notifier->notify();
   }
 
+  public function testItNotifiesUpdatedSubscriberIdWithStatusChange(): void {
+    $this->wpFunctions->method('currentTime')
+      ->willReturn(4567);
+    $this->wpFunctions->expects($this->at(1))
+      ->method('doAction')
+      ->with(SubscriberEntity::HOOK_SUBSCRIBER_STATUS_CHANGED, 2)
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberStatusChanged(2);
+    $notifier->notify();
+  }
+
   public function testItNotifyMultipleSubscribersUpdated(): void {
     $this->wpFunctions->expects($this->at(0))
       ->method('currentTime')


### PR DESCRIPTION
## Description

This PR covers 2 cases:

- Customer unsubscribes on checkout
- Customer globally unsubscribes to any marketing emails

For those cases, we opt_out the customer in AutomateWoo.

This PR does not cover:
- Changes to WooCommerce segment subscription on bulk updates
- Changes to WooCommerce segment subscription on WooCommerce customer list synchronization

## Code review notes

I have added 2 new action hooks:

1. mailpoet_subscriber_status_changed
Triggered when Subscriber Entity Status changes, using a Doctrine EventListener on postUpdate.
There are limitations to this approach that we have accepted:
- It is not executed when subscriber is updated with a query
- It is not executed on bulk updates

3. mailpoet_woocommerce_segment_unsubscribed
Triggered on checkout when customer is unsubscribed to WooCommerce segment.
For now, this is only added on checkout/order-pay but we might decide later to add it in other places, like the customer list synchronization.
I have added a hook instead of calling directly the AtomateWoo functions. This is a more generic approach that we could use with other integrations.

There is an existing ticket to review the behavior of the opt-in checkbox on checkout. The action on checkout might need to be revisited then.

## QA notes

1. With WooCommerce and AutomateWoo active.
2. Go to AutomateWoo > Settings. Make sure Opt-in is selected and Show on Checkout page
3. Purchase a product and opt-in on checkout. The email should be added to AutomateWoo > Opt-in
4. Purchase a product again with same customer. The opt-in checkbox on checkout needs to be unchecked.
5. Verify the email is removed from AutomateWoo > Opt-ins

6. Repeat steps 1-3
7. On MailPoet> Subscribers, edit the subscriber, set the status to 'unsubscribed'
8. Verify the email is removed from AutomateWoo > Opt-ins

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5219]

## After-merge notes

_N/A_


[MAILPOET-5219]: https://mailpoet.atlassian.net/browse/MAILPOET-5219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ