### PR TITLE
Add tracking for signups from upgrade page [MAILPOET-5141]

### DIFF
--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -16,9 +16,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade&ref=plugin-upgrade-page' %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
           <% endif %>
           class="mailpoet-button button-primary"
         >
@@ -46,7 +46,7 @@
     </p>
     <a
       target="_blank"
-      href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=starter&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' | escape('html_attr') %>"
+      href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=starter&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' | escape('html_attr') %>"
       class="mailpoet-button button-primary"
     >
       <%= _x('Sign up for free', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -178,9 +178,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade&ref=plugin-upgrade-page' %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
           <% endif %>
         class="mailpoet-button button-primary"
         >
@@ -218,9 +218,9 @@
         <a
           target="_blank"
           <% if (has_valid_api_key) %>
-            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
+            href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade&ref=plugin-upgrade-page' %>"
           <% else %>
-            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
+            href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
           <% endif %>
           class="mailpoet-button button-primary"
         >
@@ -267,9 +267,9 @@
       <a
         target="_blank"
         <% if (has_valid_api_key) %>
-          href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
+          href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade&ref=plugin-upgrade-page' %>"
         <% else %>
-          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
+          href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
         <% endif %>
         class="mailpoet-button button-primary"
       >
@@ -295,9 +295,9 @@
     <a
       target="_blank"
       <% if (has_valid_api_key) %>
-        href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade' %>"
+        href="<%= 'https://account.mailpoet.com/orders/upgrade/' ~ plugin_partial_key ~ '?utm_source=plugin&utm_medium=premium&utm_campaign=upgrade&ref=plugin-upgrade-page' %>"
       <% else %>
-        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase' %>"
+        href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
       <% endif %>
       class="mailpoet-button button-primary"
     >
@@ -307,7 +307,7 @@
       <% set allowedHtml = {'a': {'href': [], 'target': []}} %>
       <%=
         _x('And if you’re not sure which plan is the right one for you, our [link]Customer Support team[/link] are on hand to help you decide.', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade')
-        |replaceLinkTags('https://www.mailpoet.com/support/sales-pre-sales-questions/', {'target': '_blank'})
+        |replaceLinkTags('https://www.mailpoet.com/support/sales-pre-sales-questions/?ref=plugin-upgrade-page', {'target': '_blank'})
         |wpKses(allowedHtml)
       %>
     </p>

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -20,7 +20,7 @@
           <% else %>
             href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
           <% endif %>
-          class="mailpoet-button button-primary"
+          class="mailpoet-button button-primary mailpoet-premium-shop-link"
         >
 
           <%= _x('Upgrade', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
@@ -47,7 +47,7 @@
     <a
       target="_blank"
       href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=starter&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' | escape('html_attr') %>"
-      class="mailpoet-button button-primary"
+      class="mailpoet-button button-primary mailpoet-premium-shop-link"
     >
       <%= _x('Sign up for free', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
     </a>
@@ -182,7 +182,7 @@
           <% else %>
             href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
           <% endif %>
-        class="mailpoet-button button-primary"
+        class="mailpoet-button button-primary mailpoet-premium-shop-link"
         >
           <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
         </a>
@@ -222,7 +222,7 @@
           <% else %>
             href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=creator&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
           <% endif %>
-          class="mailpoet-button button-primary"
+          class="mailpoet-button button-primary mailpoet-premium-shop-link"
         >
           <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
         </a>
@@ -271,7 +271,7 @@
         <% else %>
           href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=agency&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
         <% endif %>
-        class="mailpoet-button button-primary"
+        class="mailpoet-button button-primary mailpoet-premium-shop-link"
       >
         <%= _x('Buy Now', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
       </a>
@@ -299,7 +299,7 @@
       <% else %>
         href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=business&billing=monthly&email=" ~ current_wp_user.user_email ~ '&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page' %>"
       <% endif %>
-      class="mailpoet-button button-primary"
+      class="mailpoet-button button-primary mailpoet-premium-shop-link"
     >
       <%= _x('Upgrade now', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
     </a>
@@ -325,5 +325,11 @@
 <% block after_javascript %>
 <script type="text/javascript">
   MailPoet.trackEvent('Premium page viewed');
+
+  jQuery(function($) {
+    $('.mailpoet-premium-page a.mailpoet-premium-shop-link').on('click', function() {
+      MailPoet.trackEvent('Upgrade page CTA clicked');
+    });
+  });
 </script>
 <% endblock %>


### PR DESCRIPTION
## Description

This PR adds the `?ref=plugin-upgrade-page` parameter to all links on the Upgrade page and adds a Mixpanel event called `Upgrade page CTA clicked` when any of the CTA’s on the update page is clicked.

## Code review notes

_N/A_

## QA notes

Go to the upgrade page and check the changes (`/wp-admin/admin.php?page=mailpoet-upgrade`). The premium plugin must be disabled to be able to access the upgrade page.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5141]

## After-merge notes

_N/A_


[MAILPOET-5141]: https://mailpoet.atlassian.net/browse/MAILPOET-5141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ