### PR TITLE
Refactor/remove some methods from ModelValidator [MAILPOET-4343]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/ImportExport.php
+++ b/mailpoet/lib/API/JSON/v1/ImportExport.php
@@ -15,6 +15,7 @@ use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Segments\SegmentSaveController;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\WP;
+use MailPoet\Services\Validator;
 use MailPoet\Subscribers\ImportExport\Export\Export;
 use MailPoet\Subscribers\ImportExport\Import\Import;
 use MailPoet\Subscribers\ImportExport\Import\MailChimp;
@@ -51,6 +52,9 @@ class ImportExport extends APIEndpoint {
   /** @var TagRepository */
   private $tagRepository;
 
+  /** @var Validator */
+  private $validator;
+
   /** @var CronWorkerScheduler */
   private $cronWorkerScheduler;
 
@@ -68,7 +72,8 @@ class ImportExport extends APIEndpoint {
     SegmentsResponseBuilder $segmentsResponseBuilder,
     CronWorkerScheduler $cronWorkerScheduler,
     SubscribersRepository $subscribersRepository,
-    TagRepository $tagRepository
+    TagRepository $tagRepository,
+    Validator $validator
   ) {
     $this->wpSegment = $wpSegment;
     $this->customFieldsRepository = $customFieldsRepository;
@@ -80,6 +85,7 @@ class ImportExport extends APIEndpoint {
     $this->cronWorkerScheduler = $cronWorkerScheduler;
     $this->segmentsResponseBuilder = $segmentsResponseBuilder;
     $this->tagRepository = $tagRepository;
+    $this->validator = $validator;
   }
 
   public function getMailChimpLists($data) {
@@ -133,6 +139,7 @@ class ImportExport extends APIEndpoint {
         $this->newsletterOptionsRepository,
         $this->subscriberRepository,
         $this->tagRepository,
+        $this->validator,
         json_decode($data, true)
       );
       $process = $import->process();

--- a/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
+++ b/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
@@ -4,7 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Form\Block;
-use MailPoet\Models\ModelValidator;
+use MailPoet\Services\Validator;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
 
 class SubscribersImport {
@@ -30,7 +30,7 @@ class SubscribersImport {
       'date_formats' => $this->dateBlock->getDateFormats(),
       'month_names' => $this->dateBlock->getMonthNames(),
       'sub_menu' => 'mailpoet-subscribers',
-      'role_based_emails' => json_encode(ModelValidator::ROLE_EMAILS),
+      'role_based_emails' => json_encode(Validator::ROLE_EMAILS),
     ]);
     $this->pageRenderer->displayPage('subscribers/importExport/import.html', $data);
   }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -433,6 +433,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Services\CongratulatoryMssEmailController::class)->setPublic(true);
     $container->autowire(\MailPoet\Services\AuthorizedSenderDomainController::class)->setPublic(true);
     $container->autowire(\MailPoet\Services\SubscribersCountReporter::class)->setPublic(true);
+    $container->autowire(\MailPoet\Services\Validator::class)->setPublic(true);
     // Settings
     $container->autowire(\MailPoet\Settings\SettingsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Settings\SettingsChangeHandler::class)->setPublic(true);

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -3,7 +3,7 @@
 namespace MailPoet\Form\Block;
 
 use MailPoet\Form\Util\FieldNameObfuscator;
-use MailPoet\Models\ModelValidator;
+use MailPoet\Services\Validator;
 use MailPoet\WP\Functions as WPFunctions;
 
 /**
@@ -32,8 +32,8 @@ class BlockRendererHelper {
 
     if ($blockId === 'email') {
       $rules['required'] = true;
-      $rules['minlength'] = ModelValidator::EMAIL_MIN_LENGTH;
-      $rules['maxlength'] = ModelValidator::EMAIL_MAX_LENGTH;
+      $rules['minlength'] = Validator::EMAIL_MIN_LENGTH;
+      $rules['maxlength'] = Validator::EMAIL_MAX_LENGTH;
       $rules['type-message'] = __('This value should be a valid email.', 'mailpoet');
     }
 

--- a/mailpoet/lib/Models/ModelValidator.php
+++ b/mailpoet/lib/Models/ModelValidator.php
@@ -87,8 +87,4 @@ class ModelValidator extends \MailPoetVendor\Sudzy\Engine {
     }
     return (is_null($newsletterBody) || (is_array($newsletterBody) && !empty($newsletterBody['html']) && !empty($newsletterBody['text'])));
   }
-
-  public function validateIPAddress(string $ip): bool {
-    return (bool)filter_var($ip, FILTER_VALIDATE_IP);
-  }
 }

--- a/mailpoet/lib/Models/ModelValidator.php
+++ b/mailpoet/lib/Models/ModelValidator.php
@@ -2,49 +2,12 @@
 
 namespace MailPoet\Models;
 
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Services\Validator;
 use MailPoet\Util\Helpers;
-use MailPoet\WP\Functions as WPFunctions;
 
 class ModelValidator extends \MailPoetVendor\Sudzy\Engine {
   public $validators;
-
-  const EMAIL_MIN_LENGTH = 6;
-  const EMAIL_MAX_LENGTH = 150;
-
-  const ROLE_EMAILS = [
-    'abuse',
-    'compliance',
-    'devnull',
-    'dns',
-    'ftp',
-    'hostmaster',
-    'inoc',
-    'ispfeedback',
-    'ispsupport',
-    'list-request',
-    'list',
-    'maildaemon',
-    'noc',
-    'no-reply',
-    'noreply',
-    'nospam',
-    'null',
-    'phish',
-    'phishing',
-    'postmaster',
-    'privacy',
-    'registrar',
-    'root',
-    'security',
-    'spam',
-    'sysadmin',
-    'undisclosed-recipients',
-    'unsubscribe',
-    'usenet',
-    'uucp',
-    'webmaster',
-    'www',
-  ];
 
   public function __construct() {
     parent::__construct();
@@ -68,15 +31,8 @@ class ModelValidator extends \MailPoetVendor\Sudzy\Engine {
   }
 
   public function validateEmail($email) {
-    $permittedLength = (strlen($email) >= self::EMAIL_MIN_LENGTH && strlen($email) <= self::EMAIL_MAX_LENGTH);
-    $validEmail = WPFunctions::get()->isEmail($email) !== false && parent::_isEmail($email, null);
-    return ($permittedLength && $validEmail);
-  }
-
-  public function validateNonRoleEmail($email) {
-    if (!$this->validateEmail($email)) return false;
-    $firstPart = strtolower(substr($email, 0, (int)strpos($email, '@')));
-    return array_search($firstPart, self::ROLE_EMAILS) === false;
+    $validator = ContainerWrapper::getInstance()->get(Validator::class);
+    return $validator->validateEmail($email);
   }
 
   public function validateRenderedNewsletterBody($newsletterBody) {

--- a/mailpoet/lib/Services/Validator.php
+++ b/mailpoet/lib/Services/Validator.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Services;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * This class contains validation methods that were extracted from the \MailPoet\Models\ModelValidator class.
+ * It is used only in a few places and there is a chance in the future we can remove it.
+ */
+class Validator {
+  const EMAIL_MIN_LENGTH = 6;
+  const EMAIL_MAX_LENGTH = 150;
+  const ROLE_EMAILS = [
+    'abuse',
+    'compliance',
+    'devnull',
+    'dns',
+    'ftp',
+    'hostmaster',
+    'inoc',
+    'ispfeedback',
+    'ispsupport',
+    'list-request',
+    'list',
+    'maildaemon',
+    'noc',
+    'no-reply',
+    'noreply',
+    'nospam',
+    'null',
+    'phish',
+    'phishing',
+    'postmaster',
+    'privacy',
+    'registrar',
+    'root',
+    'security',
+    'spam',
+    'sysadmin',
+    'undisclosed-recipients',
+    'unsubscribe',
+    'usenet',
+    'uucp',
+    'webmaster',
+    'www',
+  ];
+
+  public function validateEmail($email) {
+    $permittedLength = (strlen($email) >= self::EMAIL_MIN_LENGTH && strlen($email) <= self::EMAIL_MAX_LENGTH);
+    $validEmail = WPFunctions::get()->isEmail($email) !== false && filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    return ($permittedLength && $validEmail);
+  }
+
+  public function validateNonRoleEmail($email) {
+    if (!$this->validateEmail($email)) return false;
+    $firstPart = strtolower(substr($email, 0, (int)strpos($email, '@')));
+    return array_search($firstPart, self::ROLE_EMAILS) === false;
+  }
+}

--- a/mailpoet/lib/Services/Validator.php
+++ b/mailpoet/lib/Services/Validator.php
@@ -46,13 +46,13 @@ class Validator {
     'www',
   ];
 
-  public function validateEmail($email) {
+  public function validateEmail($email): bool {
     $permittedLength = (strlen($email) >= self::EMAIL_MIN_LENGTH && strlen($email) <= self::EMAIL_MAX_LENGTH);
     $validEmail = WPFunctions::get()->isEmail($email) !== false && filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
     return ($permittedLength && $validEmail);
   }
 
-  public function validateNonRoleEmail($email) {
+  public function validateNonRoleEmail($email): bool {
     if (!$this->validateEmail($email)) return false;
     $firstPart = strtolower(substr($email, 0, (int)strpos($email, '@')));
     return array_search($firstPart, self::ROLE_EMAILS) === false;

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -236,8 +236,8 @@ class Import {
       }
       if (in_array($column, ['confirmed_ip', 'subscribed_ip'], true)) {
         $data = array_map(
-          function($index, $ip) use($validator) {
-            if (!$validator->validateIPAddress($ip)) {
+          function($index, $ip) {
+            if (!filter_var($ip, FILTER_VALIDATE_IP)) {
               // if invalid or empty, we allow the import but remove the IP
               return null;
             }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -56,7 +56,7 @@ parameters:
 			path: ../../lib/API/JSON/v1/ImportExport.php
 
 		-
-			message: "#^Parameter \\#7 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
+			message: "#^Parameter \\#8 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/v1/ImportExport.php
 

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -56,7 +56,7 @@ parameters:
 			path: ../../lib/API/JSON/v1/ImportExport.php
 
 		-
-			message: "#^Parameter \\#7 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
+			message: "#^Parameter \\#8 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/v1/ImportExport.php
 

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -55,7 +55,7 @@ parameters:
 			path: ../../lib/API/JSON/v1/ImportExport.php
 
 		-
-			message: "#^Parameter \\#7 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
+			message: "#^Parameter \\#8 \\$data of class MailPoet\\\\Subscribers\\\\ImportExport\\\\Import\\\\Import constructor expects array, mixed given\\.$#"
 			count: 1
 			path: ../../lib/API/JSON/v1/ImportExport.php
 

--- a/mailpoet/tests/integration/Models/ModelValidatorTest.php
+++ b/mailpoet/tests/integration/Models/ModelValidatorTest.php
@@ -27,12 +27,6 @@ class ModelValidatorTest extends \MailPoetTest {
     expect($this->validator->validateEmail('a@b.c'))->false();
   }
 
-  public function testItValidatesNonRoleEmail() {
-    expect($this->validator->validateNonRoleEmail('test'))->false();
-    expect($this->validator->validateNonRoleEmail('webmaster@example.com'))->false();
-    expect($this->validator->validateNonRoleEmail('test@example.com'))->true();
-  }
-
   public function testItValidatesRenderedNewsletterBody() {
     expect($this->validator->validateRenderedNewsletterBody('test'))->false();
     expect($this->validator->validateRenderedNewsletterBody(serialize('test')))->false();

--- a/mailpoet/tests/integration/Services/ValidatorTest.php
+++ b/mailpoet/tests/integration/Services/ValidatorTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Services;
+
+use MailPoet\Services\Validator;
+
+class ValidatorTest extends \MailPoetTest {
+  public $validator;
+
+  public function _before() {
+    parent::_before();
+    $this->validator = $this->diContainer->get(Validator::class);
+  }
+
+  public function testItValidatesEmail() {
+    expect($this->validator->validateEmail('test'))->false();
+    expect($this->validator->validateEmail('tést@éxample.com'))->false();
+    expect($this->validator->validateEmail('test@example.com'))->true();
+    expect($this->validator->validateEmail('loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_email@example.com'))->false();
+    expect($this->validator->validateEmail('a@b.c'))->false();
+  }
+
+  public function testItValidatesNonRoleEmail() {
+    expect($this->validator->validateNonRoleEmail('test'))->false();
+    expect($this->validator->validateNonRoleEmail('webmaster@example.com'))->false();
+    expect($this->validator->validateNonRoleEmail('test@example.com'))->true();
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -13,6 +13,7 @@ use MailPoet\Entities\TagEntity;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\WP;
+use MailPoet\Services\Validator;
 use MailPoet\Subscribers\ImportExport\ImportExportRepository;
 use MailPoet\Subscribers\SubscriberCustomFieldRepository;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
@@ -71,6 +72,9 @@ class ImportTest extends \MailPoetTest {
   /** @var SubscriberTagRepository */
   private $subscribersTagRepository;
 
+  /** @var Validator */
+  private $validator;
+
   public function _before(): void {
     $this->wpSegment = $this->diContainer->get(WP::class);
     $this->customFieldsRepository = $this->diContainer->get(CustomFieldsRepository::class);
@@ -81,6 +85,7 @@ class ImportTest extends \MailPoetTest {
     $this->subscriberRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
     $this->tagRepository = $this->diContainer->get(TagRepository::class);
+    $this->validator = $this->diContainer->get(Validator::class);
     $this->subscribersTagRepository = $this->diContainer->get(SubscriberTagRepository::class);
     $customField = $this->customFieldsRepository->createOrUpdate([
       'name' => 'country',
@@ -832,6 +837,7 @@ class ImportTest extends \MailPoetTest {
       $this->newsletterOptionsRepository,
       $this->subscriberRepository,
       $this->tagRepository,
+      $this->validator,
       $data
     );
   }


### PR DESCRIPTION
## Description

This PR refactors/removes some of the methods from the old ModelValidator class. Now this class is only used in the context of the remaining Paris models.

## Code review notes

@lysyjan, there are two things that I did in this PR that I'm not sure if they match what you had in mind when you created the ticket:

- Two public methods were left in the ModelValidator class (validateEmail() and validateRenderedNewsletterBody()) as they are still used in the Paris validator system. My suggestion is that we remove them only when we finish removing the remaining models. I assumed it was not worth the effort of checking how to use them in the models without using the Paris validator system.
- The ticket description suggests when possible to move functionality from ModelValidator to a service. I created a new \MailPoet\Services\Validator class. I'm not sure if this is the service that you had in mind or if it was something else.

Let me know if you prefer a different approach.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4343]

## After-merge notes

_N/A_


[MAILPOET-4343]: https://mailpoet.atlassian.net/browse/MAILPOET-4343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ