### PR TITLE
Guest user should trigger Order status change trigger [MAILPOET-5290]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -6,20 +6,20 @@ use MailPoet\Automation\Engine\Integration\Payload;
 
 class CustomerPayload implements Payload {
 
-  /** @var \WC_Customer */
+  /** @var \WC_Customer | null */
   private $customer;
 
   public function __construct(
-    \WC_Customer $customer
+    \WC_Customer $customer = null
   ) {
     $this->customer = $customer;
   }
 
-  public function getCustomer(): \WC_Customer {
+  public function getCustomer(): ?\WC_Customer {
     return $this->customer;
   }
 
   public function getId(): int {
-    return $this->customer->get_id();
+    return $this->customer ? $this->customer->get_id() : 0;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -22,4 +22,8 @@ class CustomerPayload implements Payload {
   public function getId(): int {
     return $this->customer ? $this->customer->get_id() : 0;
   }
+
+  public function isGuest(): bool {
+    return $this->customer === null;
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
@@ -33,6 +33,9 @@ class CustomerSubject implements Subject {
 
   public function getPayload(SubjectData $subjectData): Payload {
     $id = $subjectData->getArgs()['customer_id'];
+    if (!$id) {
+      return new CustomerPayload(null);
+    }
     $customer = new \WC_Customer($id);
     if (!$customer->get_id()) {
       // translators: %d is the ID of the customer.


### PR DESCRIPTION
## Description

A guest user has no ID and thus the construction of the `CustomerPayload` failed. This PR allows for `null` instead of `\WC_Customer` in the payloads constructor and handles the consequeuences for the methods `getCustomer()` and `getId()`. In addition it adds a method `isGuest()` to the payload to be more expressive than just returning `null` on `getCustomer()`.

## Code review notes

Currently, we do not use the `CustomerSubject` actively. The Subject transformer transforms the `OrderSubject` to a `SubscriberSubject`.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5290]

## After-merge notes

_N/A_


[MAILPOET-5290]: https://mailpoet.atlassian.net/browse/MAILPOET-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ