### PR TITLE
Switch the site for k6 nightlytests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -907,7 +907,7 @@ workflows:
       - performance_tests:
           <<: *slack-fail-post-step
           name: performance_latest
-          url: https://qawp.net
+          url: https://mpperftesting.mystagingwebsite.com
           pw: $WP_TEST_PERFORMANCE_PW
           scenario: nightlytests
           requires:


### PR DESCRIPTION
Small change [MAILPOET-5292]

Switching k6 nightlytests to Pressable hosted test site: mpperftesting.mystagingwebsite.com
Credentials stored in the secret store (search for MailPoet: K6 Pressable Test Site)

[MAILPOET-5292]: https://mailpoet.atlassian.net/browse/MAILPOET-5292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ