### PR TITLE
Add an option to disable the Tracy panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ To switch the environment to a different PHP version:
 To switch back to the default PHP version remove what was added in 2) and, run `docker-compose build wordpress` for application container and `docker-compose build test_wordpress` for tests container,
 and start the stack using `./do start`.
 
+## Disabling the Tracy panel
+
+To disable the Tracy panel, add the following to `docker-compose.override.yml`:
+
+```yaml
+services:
+  wordpress:
+    environment:
+      MAILPOET_DISABLE_TRACY_PANEL: 1
+```
+
 ## ✅ TODO
 
 - install woo commerce, members and other useful plugins by default

--- a/mailpoet/mailpoet_initializer.php
+++ b/mailpoet/mailpoet_initializer.php
@@ -52,6 +52,10 @@ if (WP_DEBUG && PHP_VERSION_ID >= 70100 && file_exists($tracyPath)) {
     add_action('admin_enqueue_scripts', 'render_tracy', PHP_INT_MAX, 0);
     session_start();
     Debugger::enable(Debugger::DEVELOPMENT);
+
+    if (getenv('MAILPOET_DISABLE_TRACY_PANEL')) {
+      Debugger::$showBar = false;
+    }
   }
   define('MAILPOET_DEVELOPMENT', true);
 }


### PR DESCRIPTION
## Description

This PR adds the option to disable the Tracy panel via a environment variable.

## Code review notes

I considered adding the variable to `.env`, but unless I'm missing something, we don't load the variables in this file in the plugin. So I opted to add the env variable in `docker-compose.override.yml` which we are already using for other env variables. I like the idea of consolidating everything in a single file as we discussed in Slack, but I didn't want to spend too much time on this ticket.

## QA notes

QA is probably not needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5293]

## After-merge notes

_N/A_


[MAILPOET-5293]: https://mailpoet.atlassian.net/browse/MAILPOET-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ