### PR TITLE
Modify MailPoet when bundled and using AutomateWoo

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -126,6 +126,7 @@ interface Window {
   mailpoet_premium_plugin_download_url: string;
   mailpoet_premium_plugin_activation_url: string;
   mailpoet_plugin_partial_key: string;
+  mailpoet_hide_automations: boolean;
   mailpoet_email_volume_limit: string;
   mailpoet_email_volume_limit_reached: boolean;
   mailpoet_current_wp_user_email: string;

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -63,6 +63,7 @@ export const MailPoet = {
   premiumPluginDownloadUrl: window.mailpoet_premium_plugin_download_url,
   premiumPluginActivationUrl: window.mailpoet_premium_plugin_activation_url,
   pluginPartialKey: window.mailpoet_plugin_partial_key,
+  hideAutomations: window.mailpoet_hide_automations,
   emailVolumeLimit: window.mailpoet_email_volume_limit,
   emailVolumeLimitReached: window.mailpoet_email_volume_limit_reached,
   currentWpUserEmail: window.mailpoet_current_wp_user_email,

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -98,6 +98,7 @@ const Tabs = withNpsPoll(() => {
           <NewsletterListReEngagement />
         </Tab>
         {window.mailpoet_woocommerce_active &&
+          !MailPoet.hideAutomations &&
           _.map(automaticEmails, (email) => (
             <Tab
               key={email.slug}

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -103,12 +103,48 @@ function NewsletterTypesComponent({
     );
   };
 
+  const getRedirectToAutomateWooType = () => {
+    const redirectToAutomateWoo = (): void => {
+      MailPoet.trackEvent('Emails > Type selected', {
+        'Email type': 'woocommerce_automatewoo',
+      });
+      window.location.href = `edit.php?post_type=aw_workflow#presets`;
+      return null;
+    };
+    return {
+      slug: 'woocommerce_automatewoo',
+      title: __('Automations', 'mailpoet'),
+      description: __(
+        'Convert and retain customers with automated marketing that does the hard work for you. AutomateWoo has the tools you need to grow your store and make more money.',
+        'mailpoet',
+      ),
+      action: (
+        <Button
+          automationId="woocommerce_automatewoo"
+          onClick={redirectToAutomateWoo}
+          tabIndex={0}
+          onKeyDown={(event): void => {
+            if (
+              ['keydown', 'keypress'].includes(event.type) &&
+              ['Enter', ' '].includes(event.key)
+            ) {
+              event.preventDefault();
+              redirectToAutomateWoo();
+            }
+          }}
+        >
+          {__('Set up', 'mailpoet')}
+        </Button>
+      ),
+    };
+  };
+
   const getAdditionalTypes = (): Record<string, unknown>[] => {
     const show = MailPoet.isWoocommerceActive;
     if (!show) {
       return [];
     }
-    return [
+    const additionalTypes = [
       {
         slug: 'wc_transactional',
         title: __('WooCommerce Emails Customizer', 'mailpoet'),
@@ -136,6 +172,10 @@ function NewsletterTypesComponent({
         ),
       },
     ];
+    if (MailPoet.hideAutomations) {
+      additionalTypes.push(getRedirectToAutomateWooType());
+    }
+    return additionalTypes;
   };
 
   const getAutomaticEmails = (): JSX.Element[] => {
@@ -158,9 +198,9 @@ function NewsletterTypesComponent({
               <div className="mailpoet-newsletter-types-separator-line" />
             </div>
           )}
-
-          <AutomaticEmailEventsList email={email} history={history} />
-
+          {email.slug === 'woocommerce' && !MailPoet.hideAutomations && (
+            <AutomaticEmailEventsList email={email} history={history} />
+          )}
           {email.slug === 'woocommerce' &&
             getAdditionalTypes().map((type) => renderType(type), this)}
         </Fragment>

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -105,11 +105,17 @@ function NewsletterTypesComponent({
 
   const getRedirectToAutomateWooType = () => {
     const redirectToAutomateWoo = (): void => {
-      MailPoet.trackEvent('Emails > Type selected', {
-        'Email type': 'woocommerce_automatewoo',
-      });
-      window.location.href = `edit.php?post_type=aw_workflow#presets`;
-      return null;
+      MailPoet.trackEvent(
+        'Emails > Type selected',
+        {
+          'Email type': 'woocommerce_automatewoo',
+        },
+        { send_immediately: true }, // This tell Mixpanel client to send events from buffer immediately
+        () => {
+          // Anonymous callback which does the redirect
+          window.location.href = `edit.php?post_type=aw_workflow#presets`;
+        },
+      );
     };
     return {
       slug: 'woocommerce_automatewoo',

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -166,6 +166,7 @@ class PageRenderer {
       'mss_key_pending_approval' => $this->servicesChecker->isMailPoetAPIKeyPendingApproval(),
       'mss_active' => $this->bridge->isMailpoetSendingServiceEnabled(),
       'plugin_partial_key' => $this->servicesChecker->generatePartialApiKey(),
+      'mailpoet_hide_automations' => $this->servicesChecker->isBundledSubscription() && $this->wp->isPluginActive('automatewoo/automatewoo.php'),
       'subscriber_count' => $this->subscribersFeature->getSubscribersCount(),
       'subscribers_counts_cache_created_at' => $subscribersCacheCreatedAt->format('Y-m-d\TH:i:sO'),
       'subscribers_limit' => $this->subscribersFeature->getSubscribersLimit(),

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -482,8 +482,14 @@ class Menu {
   }
 
   private function registerAutomationMenu(bool $showEntries) {
+    $parentSlug = self::MAIN_PAGE_SLUG;
+    // Automations menu is hidden when the subscription is part of a bundle and AutomateWoo is active but pages can be accessed directly
+    if ($this->wp->isPluginActive('automatewoo/automatewoo.php') && $this->servicesChecker->isBundledSubscription()) {
+      $parentSlug = null;
+    }
+
     $automationPage = $this->wp->addSubmenuPage(
-      $showEntries ? self::MAIN_PAGE_SLUG : true,
+      $showEntries ? $parentSlug : true,
       $this->setPageTitle(__('Automations', 'mailpoet')),
       // @ToDo Remove Beta once Automation is no longer beta.
       '<span>' . esc_html__('Automations', 'mailpoet') . '</span><span class="mailpoet-beta-badge">Beta</span>',
@@ -503,6 +509,7 @@ class Menu {
     );
 
     // Automation templates
+
     $this->wp->addSubmenuPage(
       true,
       $this->setPageTitle(__('Automation Templates', 'mailpoet')),

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -133,6 +133,14 @@ class ServicesChecker {
     return false;
   }
 
+  public function isBundledSubscription(): bool {
+    if ($this->isMailPoetAPIKeyValid(false, true) || $this->isPremiumKeyValid(false)) {
+      $subscriptionType = $this->settings->get(Bridge::SUBSCRIPTION_TYPE_SETTING_NAME);
+      return $subscriptionType === Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE;
+    }
+    return false;
+  }
+
   public function isMailPoetAPIKeyPendingApproval(): bool {
     $mssActive = Bridge::isMPSendingServiceEnabled();
     $mssKeyValid = $this->isMailPoetAPIKeyValid();

--- a/mailpoet/lib/Config/ServicesChecker.php
+++ b/mailpoet/lib/Config/ServicesChecker.php
@@ -134,11 +134,8 @@ class ServicesChecker {
   }
 
   public function isBundledSubscription(): bool {
-    if ($this->isMailPoetAPIKeyValid(false, true) || $this->isPremiumKeyValid(false)) {
-      $subscriptionType = $this->settings->get(Bridge::SUBSCRIPTION_TYPE_SETTING_NAME);
-      return $subscriptionType === Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE;
-    }
-    return false;
+    $subscriptionType = $this->settings->get(Bridge::SUBSCRIPTION_TYPE_SETTING_NAME);
+    return $subscriptionType === Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE;
   }
 
   public function isMailPoetAPIKeyPendingApproval(): bool {

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -10,6 +10,19 @@ use MailPoet\WP\Functions as WPFunctions;
 class Bridge {
   const API_KEY_SETTING_NAME = 'mta.mailpoet_api_key';
   const API_KEY_STATE_SETTING_NAME = 'mta.mailpoet_api_key_state';
+  const SUBSCRIPTION_TYPE_SETTING_NAME = 'mta.mailpoet_subscription_type';
+  const MANUAL_SUBSCRIPTION_TYPE = 'MANUAL';
+  const STRIPE_SUBSCRIPTION_TYPE = 'STRIPE';
+  const WCCOM_SUBSCRIPTION_TYPE = 'WCCOM';
+  const WPCOM_SUBSCRIPTION_TYPE = 'WPCOM';
+  const WPCOM_BUNDLE_SUBSCRIPTION_TYPE = 'WPCOM_BUNDLE';
+  const SUBSCRIPTION_TYPES = [
+    self::MANUAL_SUBSCRIPTION_TYPE,
+    self::STRIPE_SUBSCRIPTION_TYPE,
+    self::WCCOM_SUBSCRIPTION_TYPE,
+    self::WPCOM_SUBSCRIPTION_TYPE,
+    self::WPCOM_BUNDLE_SUBSCRIPTION_TYPE,
+  ];
 
   const AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING_NAME = 'authorized_emails_addresses_check';
 
@@ -195,6 +208,15 @@ class Bridge {
     return $this->processKeyCheckResult($result);
   }
 
+  private function storeSubscriptionType(?string $subscriptionType): void {
+    if (in_array($subscriptionType, self::SUBSCRIPTION_TYPES, true)) {
+      $this->settings->set(
+        self::SUBSCRIPTION_TYPE_SETTING_NAME,
+        $subscriptionType
+      );
+    }
+  }
+
   public function storeMSSKeyAndState($key, $state) {
     return $this->storeKeyAndState(API::KEY_CHECK_TYPE_MSS, $key, $state);
   }
@@ -292,6 +314,11 @@ class Bridge {
       $keyStateSettingName,
       $state
     );
+
+    // store the subscription type
+    if (!empty($state['data']) && !empty($state['data']['subscription_type'])) {
+      $this->storeSubscriptionType($state['data']['subscription_type']);
+    }
   }
 
   private function buildKeyState($keyState, $result, ?string $accessRestriction): array {

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -169,6 +169,11 @@ class Settings {
       $this->settings->set(Bridge::PREMIUM_KEY_STATE_SETTING_NAME, ['state' => Bridge::KEY_INVALID, 'code' => 400]);
   }
 
+  public function withSubscriptionType($type = Bridge::STRIPE_SUBSCRIPTION_TYPE) {
+    $this->settings->set(Bridge::SUBSCRIPTION_TYPE_SETTING_NAME, $type);
+    return $this;
+  }
+
   public function withMssKeyPendingApproval() {
     $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME . '.data.is_approved', false);
     return $this;

--- a/mailpoet/tests/acceptance/Newsletters/HideAutomationsForBundlesAndAutomateWooCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/HideAutomationsForBundlesAndAutomateWooCest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Services\Bridge;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Settings;
+
+class HideAutomationsForBundlesAndAutomateWooCest {
+  public function dontSeeWooCommerceTabForBundleAndAutomateWoo(\AcceptanceTester $i) {
+    $i->wantTo('do not see WooCommerce Tab for bundles when AutomateWoo and WooCommerce are active');
+    $newsletterFactory = new Newsletter();
+    $newsletterFactory
+      ->withSubject('Testing AutomateWoo Automations for bundles')
+      ->create();
+    $i->activateWooCommerce();
+    $i->activateAutomateWoo();
+    $settings = new Settings();
+    $settings->withValidMssKey('apiKey');
+    $settings->withSubscriptionType(Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE);
+    $i->login();
+    $i->amOnMailpoetPage('Emails');
+    $i->dontSeeElement('[data-automation-id="tab-WooCommerce"]');
+  }
+}

--- a/mailpoet/tests/acceptance/Newsletters/HideAutomationsForBundlesAndAutomateWooCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/HideAutomationsForBundlesAndAutomateWooCest.php
@@ -22,4 +22,30 @@ class HideAutomationsForBundlesAndAutomateWooCest {
     $i->amOnMailpoetPage('Emails');
     $i->dontSeeElement('[data-automation-id="tab-WooCommerce"]');
   }
+
+  public function seeAutomateWooAutomationsForBundleAndAutomateWoo(\AcceptanceTester $i) {
+    $i->wantTo('see AutomateWoo Automations for bundles when AutomateWoo is active');
+    $i->activateWooCommerce();
+    $i->activateAutomateWoo();
+    $settings = new Settings();
+    $settings->withValidMssKey('apiKey');
+    $settings->withSubscriptionType(Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE);
+    $i->login();
+    $i->amOnMailpoetPage('Emails');
+    $i->wantTo('Not see WooCommerce Automatic emails');
+    $i->dontSeeElement('[data-automation-id="create_woocommerce_product_purchased_in_category"]');
+    $i->wantTo('See WooCommerce Email Customizer');
+    $i->seeElement('[data-automation-id="customize_woocommerce"]');
+    $i->wantTo('See AutomateWoo Automations');
+    $i->seeElement('[data-automation-id="woocommerce_automatewoo"]');
+    $i->click('[data-automation-id="woocommerce_automatewoo"]');
+    $i->seeElement('#automatewoo-workflow-tabs-root');
+    $i->deactivateAutomateWoo();
+    $i->login();
+    $i->amOnMailpoetPage('Emails');
+    $i->wantTo('See WooCommerce Automatic emails');
+    $i->seeElement('[data-automation-id="create_woocommerce_product_purchased_in_category"]');
+    $i->wantTo('Not see AutomateWoo Automations');
+    $i->dontSeeElement('[data-automation-id="woocommerce_automatewoo"]');
+  }
 }

--- a/mailpoet/tests/integration/Config/ServicesCheckerTest.php
+++ b/mailpoet/tests/integration/Config/ServicesCheckerTest.php
@@ -302,6 +302,74 @@ class ServicesCheckerTest extends \MailPoetTest {
     expect($result)->true();
   }
 
+  public function testItReturnsTrueIfKeyActiveAndBundled() {
+    $this->settings->set(
+      Bridge::API_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_VALID,
+        'data' => ['support_tier' => 'premium'],
+      ]
+    );
+
+    $this->settings->set(
+      Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
+      Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE
+    );
+
+    $result = $this->servicesChecker->isBundledSubscription();
+    expect($result)->true();
+  }
+
+  public function testItReturnsTrueIfPremiumKeyActiveAndBundled() {
+    $this->settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, 'premium_key');
+
+    $this->settings->set(
+      Bridge::PREMIUM_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_VALID,
+      ]
+    );
+
+    $this->settings->set(
+      Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
+      Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE
+    );
+
+    $result = $this->servicesChecker->isBundledSubscription();
+    expect($result)->true();
+  }
+
+  public function testItReturnsFalseIfNoKeys() {
+    $this->settings->set(
+      Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
+      Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE
+    );
+
+    $result = $this->servicesChecker->isBundledSubscription();
+    expect($result)->false();
+  }
+
+  public function testItReturnsFalseIfNoSubscriptionTypeOrNotBundled() {
+    $this->settings->set(
+      Bridge::API_KEY_STATE_SETTING_NAME,
+      [
+        'state' => Bridge::KEY_VALID,
+        'data' => ['support_tier' => 'premium'],
+      ]
+    );
+
+    $result = $this->servicesChecker->isBundledSubscription();
+    expect($result)->false();
+
+    $this->settings->set(
+      Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
+      Bridge::STRIPE_SUBSCRIPTION_TYPE
+    );
+
+    $result = $this->servicesChecker->isBundledSubscription();
+    expect($result)->false();
+  }
+
   private function setMailPoetSendingMethod() {
     $this->settings->set(
       Mailer::MAILER_CONFIG_SETTING_NAME,

--- a/mailpoet/tests/integration/Config/ServicesCheckerTest.php
+++ b/mailpoet/tests/integration/Config/ServicesCheckerTest.php
@@ -302,15 +302,7 @@ class ServicesCheckerTest extends \MailPoetTest {
     expect($result)->true();
   }
 
-  public function testItReturnsTrueIfKeyActiveAndBundled() {
-    $this->settings->set(
-      Bridge::API_KEY_STATE_SETTING_NAME,
-      [
-        'state' => Bridge::KEY_VALID,
-        'data' => ['support_tier' => 'premium'],
-      ]
-    );
-
+  public function testItReturnsTrueIfSubscriptionIsBundled() {
     $this->settings->set(
       Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
       Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE
@@ -318,46 +310,9 @@ class ServicesCheckerTest extends \MailPoetTest {
 
     $result = $this->servicesChecker->isBundledSubscription();
     expect($result)->true();
-  }
-
-  public function testItReturnsTrueIfPremiumKeyActiveAndBundled() {
-    $this->settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, 'premium_key');
-
-    $this->settings->set(
-      Bridge::PREMIUM_KEY_STATE_SETTING_NAME,
-      [
-        'state' => Bridge::KEY_VALID,
-      ]
-    );
-
-    $this->settings->set(
-      Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
-      Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE
-    );
-
-    $result = $this->servicesChecker->isBundledSubscription();
-    expect($result)->true();
-  }
-
-  public function testItReturnsFalseIfNoKeys() {
-    $this->settings->set(
-      Bridge::SUBSCRIPTION_TYPE_SETTING_NAME,
-      Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE
-    );
-
-    $result = $this->servicesChecker->isBundledSubscription();
-    expect($result)->false();
   }
 
   public function testItReturnsFalseIfNoSubscriptionTypeOrNotBundled() {
-    $this->settings->set(
-      Bridge::API_KEY_STATE_SETTING_NAME,
-      [
-        'state' => Bridge::KEY_VALID,
-        'data' => ['support_tier' => 'premium'],
-      ]
-    );
-
     $result = $this->servicesChecker->isBundledSubscription();
     expect($result)->false();
 

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -201,6 +201,26 @@ class BridgeTest extends \MailPoetTest {
     }
   }
 
+  public function testItStoresSubscriptionTypeOnPremiumCheck() {
+    $state = ['state' => Bridge::KEY_VALID, 'data' => ['subscription_type' => Bridge::WPCOM_SUBSCRIPTION_TYPE]];
+    $this->bridge->storePremiumKeyAndState($this->validKey, $state);
+    expect($this->getSubscriptionType())->equals(Bridge::WPCOM_SUBSCRIPTION_TYPE);
+  }
+
+  public function testItStoresSubscriptionTypeOnMSSCheck() {
+    $state = ['state' => Bridge::KEY_VALID, 'data' => ['subscription_type' => Bridge::WCCOM_SUBSCRIPTION_TYPE]];
+    $this->bridge->storeMSSKeyAndState($this->validKey, $state);
+    expect($this->getSubscriptionType())->equals(Bridge::WCCOM_SUBSCRIPTION_TYPE);
+  }
+
+  public function testItDoesNotStoreInvalidSubscriptionType() {
+    $state = ['state' => Bridge::KEY_VALID, 'data' => ['subscription_type' => 'INVALID']];
+    $this->bridge->storePremiumKeyAndState($this->validKey, $state);
+    expect($this->getSubscriptionType())->notEquals('INVALID');
+    $this->bridge->storeMSSKeyAndState($this->validKey, $state);
+    expect($this->getSubscriptionType())->notEquals('INVALID');
+  }
+
   public function testItInvalidatesMSSKey() {
     $this->bridge->storeMSSKeyAndState($this->validKey, ['state' => Bridge::KEY_VALID]);
     $storedState = $this->getMssKeyState() ?? [];
@@ -615,6 +635,10 @@ class BridgeTest extends \MailPoetTest {
       Bridge::PREMIUM_KEY_SETTING_NAME,
       '123457890abcdef'
     );
+  }
+
+  private function getSubscriptionType() {
+    return $this->settings->get(Bridge::SUBSCRIPTION_TYPE_SETTING_NAME);
   }
 
   private function getPremiumKey() {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -103,6 +103,7 @@ jQuery('#adminmenu #toplevel_page_mailpoet-newsletters')
   var mailpoet_mss_key_pending_approval = '<%= mss_key_pending_approval %>';
   var mailpoet_mss_active = <%= json_encode(mss_active) %>;
   var mailpoet_plugin_partial_key = '<%= plugin_partial_key %>';
+  var mailpoet_hide_automations = <%= json_encode(mailpoet_hide_automations) %>;
   var mailpoet_subscribers_count = <%= subscriber_count %>;
   var mailpoet_subscribers_counts_cache_created_at = <%= json_encode(subscribers_counts_cache_created_at) %>;
   var mailpoet_subscribers_limit = <%= subscribers_limit ? subscribers_limit : 'false'  %>;


### PR DESCRIPTION
## Description

This PR removes the following MailPoet Automations when the plugin is using an API key that belongs to a subscription bundled with a Dotcom eCommerce plan and AutomateWoo is active:
- Automations Menu entry from MailPoet Menu
- WooCommerce tab on emails
- Automated WooCommerce emails (First purchase etc)

WooCommerce email customizer is still available.

The PR also adds a new box on emails > new, linking to AutomateWoo

When there is no API key or the API key does not belong to a bundle, there are no changes.

## Code review notes

- @costasovo I have assigned it to you as you have recently worked on the API key data storage. Please check I am not missing anything on the changes in the Bridge and ServiceChecker. 🙌 
- The API key will be automatically provisioned using [DotcomLicenseProvisioner](https://github.com/mailpoet/mailpoet/blob/dddd116b34121d3c3bfa77b533e403cdeafb82f8/mailpoet/lib/WPCOM/DotcomLicenseProvisioner.php#L54)
- The subscription type is not yet available, it will be added on SS-355

## QA notes

Changes can not be manually tested.

Please test there are no regressions in:
- MailPoet Menu
- MailPoet Emails tabs
- MailPoet Emails > New

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5223]

## After-merge notes

_N/A_


[MAILPOET-5223]: https://mailpoet.atlassian.net/browse/MAILPOET-5223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ