### PR TITLE
Fix helper method for creating a complex segment

### DIFF
--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -66,7 +66,7 @@ export async function listsComplexSegment() {
   selectInReact(page, '#react-select-4-input', defaultListName);
   await page.waitForSelector('.mailpoet-form-notice-message');
   describe(listsPageTitle, () => {
-    describe('should be able to see calculating message', () => {
+    describe('should be able to see calculating message 1st time', () => {
       expect(
         page.locator('.mailpoet-form-notice-message').innerText(),
       ).to.contain('Calculating segment size…');
@@ -90,7 +90,7 @@ export async function listsComplexSegment() {
   selectInReact(page, '#react-select-5-input', 'subscribed date');
   await page.waitForSelector('.mailpoet-form-notice-message');
   describe(listsPageTitle, () => {
-    describe('should be able to see calculating message', () => {
+    describe('should be able to see calculating message 2nd time', () => {
       expect(
         page.locator('.mailpoet-form-notice-message').innerText(),
       ).to.contain('Calculating segment size…');
@@ -115,7 +115,7 @@ export async function listsComplexSegment() {
   await page.waitForSelector('.mailpoet-form-notice-message');
   await page.waitForLoadState('networkidle');
   describe(listsPageTitle, () => {
-    describe('should be able to see Calculating message', () => {
+    describe('should be able to see Calculating message 3rd time', () => {
       expect(
         page.locator('.mailpoet-form-notice-message').innerText(),
       ).to.contain('Calculating segment size…');

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -19,15 +19,14 @@ export async function authenticate(page) {
 
 // Select a segment or a list from a select2 search field
 export function selectInSelect2(page, listName) {
-  // Click and write a list name from a dropdown
+  // Type a list name from a dropdown and hit Enter
   page.locator('.select2-selection').type(listName);
   page.keyboard.press('Enter');
 }
 
 // Select a segment or a list from a react search field
 export function selectInReact(page, reactSelector, reactValue) {
-  // Click to write a list name from a dropdown
-  page.locator(reactSelector).click();
+  // Type a list name from a dropdown and hit Enter
   page.locator(reactSelector).type(reactValue);
   page.keyboard.press('Enter');
 }


### PR DESCRIPTION
## Description

Fixed helper method for the test lists-complex-segment.js.
Removed step to click the field, since that is unnecessary and just blocking the test by opening the dropdown and hiding the `+ Add a condition` link.

## Code review notes

_N/A_

## Linked tickets

[MAILPOET-5298]


[MAILPOET-5298]: https://mailpoet.atlassian.net/browse/MAILPOET-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ