### PR TITLE
Add new k6 test for mass trashing and restoring subscribers

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -16,6 +16,7 @@ import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
 import { listsComplexSegment } from './tests/lists-complex-segment.js';
 import { newsletterStatistics } from './tests/newsletter-statistics.js';
 import { onboardingWizard } from './tests/onboarding-wizard.js';
+import { subscribersTrashingRestoring } from './tests/subscribers-trashing-restoring.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -55,7 +56,7 @@ let scenarios = {
     executor: 'per-vu-iterations',
     vus: 1,
     iterations: 3,
-    maxDuration: '12m',
+    maxDuration: '15m',
     exec: 'nightly',
   },
 };
@@ -91,6 +92,7 @@ export async function nightly() {
   await subscribersListing();
   await subscribersFiltering();
   await subscribersAdding();
+  await subscribersTrashingRestoring();
   await listsViewSubscribers();
   await listsComplexSegment();
   await settingsBasic();

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { chromium } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  headlessSet,
+  timeoutSet,
+  subscribersPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import { authenticate, waitForSelectorToBeVisible } from '../utils/helpers.js';
+
+export async function subscribersTrashingRestoring() {
+  const browser = chromium.launch({
+    headless: headlessSet,
+    timeout: timeoutSet,
+  });
+  const page = browser.newPage();
+
+  // Go to the page
+  await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+    waitUntil: 'networkidle',
+  });
+
+  // Log in to WP Admin
+  authenticate(page);
+
+  // Wait for async actions
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Trashing_Restoring_01.png',
+    fullPage: fullPageSet,
+  });
+
+  // Check the subscribers filter is present
+  await page.waitForSelector('[data-automation-id="filters_subscribed"]');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see Lists Filter', () => {
+      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+        .exist;
+    });
+  });
+
+  // Select all subscribers
+  await page.locator('[data-automation-id="select_all"]').click();
+  await page.waitForSelector('.mailpoet-listing-select-all');
+  await page.locator('.mailpoet-listing-select-all > a').click();
+  await page.waitForSelector('.mailpoet-listing-select-all');
+
+  // Move to trash all the subscribers
+  await page.locator('[data-automation-id="action-trash"]').click();
+  await page.waitForSelector('.notice-success');
+  await page.waitForSelector('.colspanchange');
+  describe(subscribersPageTitle, () => {
+    describe('should be able to see the message', () => {
+      expect(page.locator('.colspanchange').innerText()).to.contain(
+        'No emails found.',
+      );
+    });
+  });
+
+  // Restore from trash all the trashed subscribers
+  await page.locator('[data-automation-id="filters_trash"]').click();
+  await page.waitForSelector('[data-automation-id="empty_trash"]');
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  await page.locator('[data-automation-id="select_all"]').click();
+  await page.waitForSelector('.mailpoet-listing-select-all');
+  await page.locator('.mailpoet-listing-select-all > a').click();
+  await page.waitForSelector('[data-automation-id="action-restore"]');
+  await page.locator('[data-automation-id="action-restore"]').click();
+  await page.waitForSelector('.notice-success');
+  waitForSelectorToBeVisible(page, '.colspanchange');
+  waitForSelectorToBeVisible(page, '[data-automation-id="filters_subscribed"]');
+
+  // Thinking time and closing
+  sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  page.close();
+  browser.close();
+}
+
+export default async function subscribersTrashingRestoringTest() {
+  await subscribersTrashingRestoring();
+}

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.44.0';
+$version = 'v0.44.1';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Updated k6 to latest version 0.44.1
Added a new k6 test to cover mass trashing and restoring of subscribers.
I excluded this test from `pullrequests`, takes a bit to execute it so I added it in the `nightlytests` workflow.

## Code review notes

Code review will be enough. Thanks.

## Linked tickets

[MAILPOET-5300]


[MAILPOET-5300]: https://mailpoet.atlassian.net/browse/MAILPOET-5300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ