### PR TITLE
Add ability to duplicate dynamic segments [MAILPOET-4635]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/list.jsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.jsx
@@ -4,6 +4,7 @@ import ReactStringReplace from 'react-string-replace';
 
 import { MailPoet } from 'mailpoet';
 import { Listing } from 'listing/listing.jsx';
+import { escapeHTML } from '@wordpress/escape-html';
 
 const columns = [
   {
@@ -88,6 +89,36 @@ const itemActions = [
       <Link to={`/edit-segment/${item.id}`}>{MailPoet.I18n.t('edit')}</Link>
     ),
     display: (item) => !item.is_plugin_missing,
+  },
+  {
+    name: 'duplicate_segment',
+    className: 'mailpoet-hide-on-mobile',
+    label: MailPoet.I18n.t('duplicate'),
+    onClick: (item, refresh) =>
+      MailPoet.Ajax.post({
+        api_version: window.mailpoet_api_version,
+        endpoint: 'dynamic_segments',
+        action: 'duplicate',
+        data: {
+          id: item.id,
+        },
+      })
+        .done((response) => {
+          MailPoet.Notice.success(
+            MailPoet.I18n.t('segmentDuplicated').replace(
+              '%1$s',
+              escapeHTML(response.data.name),
+              { scroll: true },
+            ),
+          );
+          refresh();
+        })
+        .fail((response) => {
+          MailPoet.Notice.error(
+            response.errors.map((error) => error.message),
+            { scroll: true },
+          );
+        }),
   },
   {
     name: 'edit_disabled',

--- a/mailpoet/lib/Entities/DynamicSegmentFilterEntity.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterEntity.php
@@ -38,6 +38,11 @@ class DynamicSegmentFilterEntity {
     $this->filterData = $filterData;
   }
 
+  public function __clone() {
+    $this->id = null;
+    $this->segment = null;
+  }
+
   /**
    * @return SegmentEntity|null
    */

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -87,6 +87,7 @@ class SegmentEntity {
   public function __clone() {
     // reset ID
     $this->id = null;
+    $this->dynamicFilters = new ArrayCollection();
   }
 
   /**

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -64,6 +64,7 @@
     'multipleSegmentsRestored': __('%1$d lists have been restored from the Trash.'),
     'duplicate': __('Duplicate'),
     'listDuplicated': __('List "%1$s" has been duplicated.'),
+    'segmentDuplicated': __('Segment "%1$s" has been duplicated.'),
     'update': __('Update'),
     'forceSync': __('Force Sync'),
     'readMore': __('Read More'),


### PR DESCRIPTION
## Description

This PR adds the ability to duplicate dynamic segments in the UI.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4635](https://mailpoet.atlassian.net/browse/MAILPOET-4635)

## After-merge notes

_N/A_


[MAILPOET-4635]: https://mailpoet.atlassian.net/browse/MAILPOET-4635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ