### PR TITLE
Change the behavior of the checkbox to subscribe on the checkout [MAILPOET-4178]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -60,7 +60,6 @@ declare module '@woocommerce/settings' {
   interface MailPoetSettings {
     optinEnabled: boolean;
     defaultText: string;
-    defaultStatus: boolean;
   }
 
   function getSetting(name: 'mailpoet_data'): MailPoetSettings;

--- a/mailpoet/assets/js/src/marketing_optin_block/block.tsx
+++ b/mailpoet/assets/js/src/marketing_optin_block/block.tsx
@@ -6,8 +6,7 @@ import { CheckboxControl } from '@woocommerce/blocks-checkout';
 import { RawHTML, useEffect, useState } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
 
-const { optinEnabled, defaultText, defaultStatus } =
-  getSetting('mailpoet_data');
+const { optinEnabled, defaultText } = getSetting('mailpoet_data');
 
 export function FrontendBlock({
   text,
@@ -18,7 +17,7 @@ export function FrontendBlock({
     setExtensionData: (namespace: string, key: string, value: unknown) => void;
   };
 }): JSX.Element {
-  const [checked, setChecked] = useState(defaultStatus);
+  const [checked, setChecked] = useState(false);
   const { setExtensionData } = checkoutExtensionData || {};
   useEffect(() => {
     if (optinEnabled && setExtensionData) {

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -95,7 +95,7 @@ class WooCommerceBlocksIntegration {
       [
       'defaultText' => $this->settings->get('woocommerce.optin_on_checkout.message', ''),
       'optinEnabled' => $this->settings->get('woocommerce.optin_on_checkout.enabled', false),
-      'defaultStatus' => $this->woocommerceSubscription->isCurrentUserSubscribed(),
+      'defaultStatus' => false,
       ],
       $this->wp
     ));
@@ -129,7 +129,6 @@ class WooCommerceBlocksIntegration {
   }
 
   public function processCheckoutBlockOptin(\WC_Order $order, $request) {
-    $checkoutOptinEnabled = (bool)$this->settings->get(WooCommerceSubscription::OPTIN_ENABLED_SETTING_NAME);
     $checkoutOptin = isset($request['extensions']['mailpoet']['optin']) ? (bool)$request['extensions']['mailpoet']['optin'] : false;
 
     if (!$order->get_billing_email()) {
@@ -149,6 +148,6 @@ class WooCommerceBlocksIntegration {
       return null;
     }
 
-    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptinEnabled, $checkoutOptin);
+    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptin);
   }
 }

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -95,7 +95,6 @@ class WooCommerceBlocksIntegration {
       [
       'defaultText' => $this->settings->get('woocommerce.optin_on_checkout.message', ''),
       'optinEnabled' => $this->settings->get('woocommerce.optin_on_checkout.enabled', false),
-      'defaultStatus' => false,
       ],
       $this->wp
     ));

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -17,7 +17,6 @@ use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
-use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Idiorm\ORM;
@@ -120,14 +119,6 @@ class WP {
     $status = $signupConfirmationEnabled ? Subscriber::STATUS_UNCONFIRMED : Subscriber::STATUS_SUBSCRIBED;
     // we want to mark a new subscriber as unsubscribe when the checkbox from registration is unchecked
     if (isset($_POST['mailpoet']['subscribe_on_register_active']) && (bool)$_POST['mailpoet']['subscribe_on_register_active'] === true) {
-      $status = SubscriberEntity::STATUS_UNSUBSCRIBED;
-    }
-
-    // we want to mark a new subscriber as unsubscribed when the checkbox on Woo checkout is unchecked
-    if (
-      isset($_POST[WooCommerceSubscription::CHECKOUT_OPTIN_PRESENCE_CHECK_INPUT_NAME])
-      && !isset($_POST[WooCommerceSubscription::CHECKOUT_OPTIN_INPUT_NAME])
-    ) {
       $status = SubscriberEntity::STATUS_UNSUBSCRIBED;
     }
 

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -227,4 +227,23 @@ class Helper {
   public function getPaymentGateways() {
     return $this->WC()->payment_gateways();
   }
+
+  /**
+   * Check whether the current request is processing a WooCommerce checkout.
+   * Works for both the normal checkout and the block checkout.
+   *
+   * This solution is not ideal, but I cheched with a few WooCommerce developers,
+   * and it is what they suggested. There is no helper function provided by Woo
+   * for this.
+   *
+   * @return bool
+   */
+  public function isCheckoutRequest(): bool {
+    $requestUri = !empty($_SERVER['REQUEST_URI']) ? sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI'])) : '';
+    $isRegularCheckout = is_checkout();
+    $isBlockCheckout = WC()->is_rest_api_request()
+      && (strpos($requestUri, 'wc/store/checkout') !== false || strpos($requestUri, 'wc/store/v1/checkout') !== false);
+
+    return $isRegularCheckout || $isBlockCheckout;
+  }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -232,7 +232,7 @@ class Helper {
    * Check whether the current request is processing a WooCommerce checkout.
    * Works for both the normal checkout and the block checkout.
    *
-   * This solution is not ideal, but I cheched with a few WooCommerce developers,
+   * This solution is not ideal, but I checked with a few WooCommerce developers,
    * and it is what they suggested. There is no helper function provided by Woo
    * for this.
    *

--- a/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
+++ b/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
@@ -46,7 +46,6 @@ class AutomateWooHooks {
       return;
     }
     $this->wp->addAction(SubscriberEntity::HOOK_SUBSCRIBER_STATUS_CHANGED, [$this, 'maybeOptOutSubscriber'], 10, 1);
-    $this->wp->addAction('mailpoet_woocommerce_segment_unsubscribed', [$this, 'optOutSubscriber'], 10, 1);
   }
 
   public function optOutSubscriber($subscriber): void {

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -60,7 +60,7 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $customerEmail = 'woo_guest_uncheck@example.com';
     $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, null, ['WooCommerce Customers']);
     $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
     $i->dontSee($customerEmail, '.automatewoo-content');
     $i->seeConfirmationEmailWasNotReceived();

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -77,20 +77,4 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->see($customerEmail, '.automatewoo-content');
     $i->seeConfirmationEmailWasReceived();
   }
-
-  public function checkoutOptInCheckedAndUnchecked(\AcceptanceTester $i) {
-    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $this->settingsFactory->withConfirmationEmailEnabled();
-    $customerEmail = 'woo_guest_check@example.com';
-    $i->orderProductWithRegistration($this->product, $customerEmail, true);
-    $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
-    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
-    $i->see($customerEmail, '.automatewoo-content');
-    $i->logout();
-    $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
-    $i->login();
-    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
-    $i->dontSee($customerEmail, '.automatewoo-content');
-  }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -95,7 +95,7 @@ class WooCheckoutBlocksCest {
     $customerEmail = 'woo_customer_uncheck@example.com';
     $this->orderProduct($i, $customerEmail, true, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 
@@ -137,7 +137,7 @@ class WooCheckoutBlocksCest {
     $customerEmail = 'woo_customer_uncheck@example.com';
     $this->orderProduct($i, $customerEmail, true, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_SUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
@@ -55,7 +55,7 @@ class WooCheckoutCustomerSubscriptionsCest {
     $customerEmail = 'woo_customer_uncheck@example.com';
     $i->orderProductWithRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 
@@ -85,7 +85,7 @@ class WooCheckoutCustomerSubscriptionsCest {
     $customerEmail = 'woo_customer_uncheck@example.com';
     $i->orderProductWithRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_SUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
@@ -55,7 +55,7 @@ class WooCheckoutGuestSubscriptionsCest {
     $customerEmail = 'woo_guest_uncheck@example.com';
     $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, null, ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 
@@ -85,7 +85,7 @@ class WooCheckoutGuestSubscriptionsCest {
     $customerEmail = 'woo_guest_uncheck@example.com';
     $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_SUBSCRIBED, null, ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 

--- a/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
@@ -60,7 +60,7 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
     expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNCONFIRMED);
   }
 
-  public function testItHandlesOptOutForGuestCustomer() {
+  public function testItDoesNotChangeStatusForGuestCustomer() {
     $this->settings->set('woocommerce.optin_on_checkout.enabled', true);
     $email = 'guest@customer.com';
     $this->wcOrderMock->method('get_billing_email')
@@ -72,7 +72,7 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
     $subscriber = $this->entityManager->getRepository(SubscriberEntity::class)->findOneBy(['email' => $email]);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $this->entityManager->refresh($subscriber);
-    expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNCONFIRMED);
   }
 
   public function testItHandlesOptinForExistingUnsubscribedCustomer() {
@@ -105,7 +105,7 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
     expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
-  public function testItHandlesOptOutForExistingSubscribedCustomer() {
+  public function testItDoesNotChangeStatusForExistingSubscribedCustomer() {
     $this->settings->set('woocommerce.optin_on_checkout.enabled', true);
     $email = 'exising@customer.com';
     $this->wcOrderMock->method('get_billing_email')
@@ -117,7 +117,7 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
     $subscriber = $this->entityManager->getRepository(SubscriberEntity::class)->findOneBy(['email' => $email]);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $this->entityManager->refresh($subscriber);
-    expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
   private function setupSyncGuestUserMock(string $email) {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -434,7 +434,7 @@ class WPTest extends \MailPoetTest {
     expect($deletedAt->timestamp)->equals(Carbon::now()->timestamp, 1);
   }
 
-  public function testItAddsNewUserWhoUncheckedOptInOnCheckoutPageAsUnsubscribed(): void {
+  public function testItAddsNewUserWhoUncheckedOptInOnCheckoutPageAsUnconfirmed(): void {
     $id = $this->insertUser();
     $wp = Stub::make(
       $this->diContainer->get(Functions::class),
@@ -447,7 +447,7 @@ class WPTest extends \MailPoetTest {
     $_POST[Subscription::CHECKOUT_OPTIN_PRESENCE_CHECK_INPUT_NAME] = 1;
     $wpSegment->synchronizeUser($id);
     $subscriber = Subscriber::where("wp_user_id", $id)->findOne();
-    expect($subscriber->status)->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    expect($subscriber->status)->equals(SubscriberEntity::STATUS_UNCONFIRMED);
   }
 
   public function testItDoesNotSendConfirmationEmailForNewUserWhenWPSegmentIsDisabledOnRegisterEnabled(): void {

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -41,7 +41,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
         }
         return false;
       },
-      'addAction' => Expected::exactly(2),
+      'addAction' => Expected::exactly(1),
     ]);
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
@@ -80,14 +79,14 @@ class SubscriptionTest extends \MailPoetTest {
     $this->originalSettings = $this->settings->get('woocommerce');
   }
 
-  public function testItDisplaysACheckedCheckboxIfCurrentUserIsSubscribed() {
+  public function testItDisplaysAnUncheckedCheckboxIfCurrentUserIsSubscribed() {
     $this->wp->synchronizeUsers();
     $wpUsers = get_users();
     wp_set_current_user($wpUsers[0]->ID);
     $subscriber = $this->subscribersRepository->getCurrentWPUser();
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $this->subscribeToSegment($subscriber, $this->wcSegment);
-    expect($this->getRenderedOptinField())->stringContainsString('checked');
+    expect($this->getRenderedOptinField())->isEmpty();
   }
 
   public function testItDisplaysAnUncheckedCheckboxIfCurrentUserIsNotSubscribed() {
@@ -165,7 +164,7 @@ class SubscriptionTest extends \MailPoetTest {
     expect($this->subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
-  public function testItUnsubscribesIfCheckboxIsNotChecked() {
+  public function testItDoesNotUnsubscribesIfCheckboxIsNotChecked() {
     $this->subscribeToSegment($this->subscriber, $this->wcSegment);
     $this->entityManager->clear();
     $subscriber = $this->subscribersRepository->findOneById($this->subscriber->getId());
@@ -185,10 +184,7 @@ class SubscriptionTest extends \MailPoetTest {
     $this->entityManager->clear();
     $subscriber = $this->subscribersRepository->findOneById($this->subscriber->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_UNSUBSCRIBED);
-    $unsubscribeLog = $this->entityManager->getRepository(StatisticsUnsubscribeEntity::class)->findOneBy(['subscriber' => $subscriber]);
-    $this->assertInstanceOf(StatisticsUnsubscribeEntity::class, $unsubscribeLog);
-    expect($unsubscribeLog->getSource())->equals(StatisticsUnsubscribeEntity::SOURCE_ORDER_CHECKOUT);
+    expect($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
   public function testItSubscribesIfCheckboxIsChecked() {


### PR DESCRIPTION
## Description

MailPoet adds a checkbox to the WooCommerce checkout to let users subscribe to mailing lists. This PR changes its behavior. It affects both the regular and the block checkout.

Now the checkbox is not checked by default for logged in users who already subscribed to a list. Also, users won't be unsubscribed anymore and have their global status change to unsubscribed if they uncheck the checkbox.

After the changes proposed here, the only action that is performed during checkout is to subscribe users if they check the checkbox.

It was necessary to change the behavior of
\MailPoet\Segments\WooCommerce::synchronizeRegisteredCustomer(). This method is called when a new WooCommerce customer is created. Before, it would always add the customer to the Woo segment expecting \MailPoet\WooCommerce\Subscription::subscribeOnCheckout() to unsubscribe the customer if the checkbox was not checked. Since the behavior of the latter method changed, the former method was updated to only subscriber the customer if not in checkout context or if in checkout context and optin checkbox is enabled and checked.

## Code review notes

I left a few GitHub comments in some parts of the code.

I checked the discussion about the complexities and inconsistencies in the MailPoet integration with WooCommerce (pcD9cT-1Ym-p2), but I'm afraid I was not able to help much in terms of simplifying this part of the code.

## QA notes

This PR touches a core part of the MailPoet integration with WooCommerce. The optin checkbox in the WooCommerce checkout. It seems to have extensive automated test coverage, but it might still be worth checking all possible paths during checkout with different configurations (guest checkout, logged in checkout, create account during checkout, optin checkbox enabled and disabled, confirmation email enabled and disabled) just to make sure nothing was missed. Pay special attention to the lists and the status of the subscriber after checkout.

Maybe it i also worth checking other ways to create a subscriber like when a new WP user is registered, creating a subscriber via wp-admin and creating subscribers for all existing WooCommerce customers.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4178]

## After-merge notes

_N/A_


[MAILPOET-4178]: https://mailpoet.atlassian.net/browse/MAILPOET-4178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ