### PR TITLE
Update PHP version used for integration_tests - MAILPOET-5302

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,6 +626,9 @@ jobs:
       mysql_image:
         type: string
         default: ''
+      woo_core_version:
+        type: string
+        default: ''
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -645,6 +648,14 @@ jobs:
           command: |
             cd tests/docker
             docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_integration
+      - when:
+          condition: << parameters.woo_core_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Core
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - run:
           name: 'PHP Integration tests'
           command: |
@@ -931,7 +942,8 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          codeception_image_version: 7.4-cli_20220605.0
+          woo_core_version: 7.5.0
+          codeception_image_version: 7.2-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -931,7 +931,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          codeception_image_version: 7.2-cli_20220605.0
+          codeception_image_version: 7.4-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,6 +629,18 @@ jobs:
       woo_core_version:
         type: string
         default: ''
+      woo_subscriptions_version:
+        type: string
+        default: ''
+      woo_memberships_version:
+        type: string
+        default: ''
+      woo_blocks_version:
+        type: string
+        default: ''
+      automate_woo_version:
+        type: string
+        default: ''
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -656,6 +668,38 @@ jobs:
                 command: |
                   cd tests/docker
                   docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+      - when:
+          condition: << parameters.woo_subscriptions_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Subscriptions
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+      - when:
+          condition: << parameters.woo_memberships_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Memberships
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+      - when:
+          condition: << parameters.woo_blocks_version >>
+          steps:
+            - run:
+                name: Download WooCommerce Blocks
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-blocks-zip << parameters.woo_blocks_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+      - when:
+          condition: << parameters.automate_woo_version >>
+          steps:
+            - run:
+                name: Download AutomateWoo
+                command: |
+                  cd tests/docker
+                  docker-compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - run:
           name: 'PHP Integration tests'
           command: |
@@ -943,6 +987,10 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           woo_core_version: 7.5.0
+          woo_subscriptions_version: 4.3.0
+          woo_memberships_version: 1.21.0
+          woo_blocks_version: 6.8.0
+          automate_woo_version: 5.1.1
           codeception_image_version: 7.2-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5


### PR DESCRIPTION


## Description

Update the PHP version used for Nightly integration_tests 

Note: The Nightly test is still falling due to https://mailpoet.atlassian.net/browse/MAILPOET-5304

## Code review notes

_N/A_

## QA notes

We can skip QA for this PR

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5302](https://mailpoet.atlassian.net/browse/MAILPOET-5302)

## After-merge notes

_N/A_


[MAILPOET-5302]: https://mailpoet.atlassian.net/browse/MAILPOET-5302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ