### PR TITLE
Fix placement of the opt-in checkbox in WooCommerce checkout when using Twenty Twenty-Three and Twenty Twenty-Two themes [MAILPOET-4133]

### DIFF
--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -119,18 +119,12 @@ class Subscription {
   }
 
   private function getSubscriptionField($inputName, $checked, $labelString) {
-    return $this->wcHelper->woocommerceFormField(
-      $this->wp->escAttr($inputName),
-      [
-        'type' => 'checkbox',
-        'label' => $this->wp->escHtml($labelString),
-        'input_class' => ['woocommerce-form__input', 'woocommerce-form__input-checkbox', 'input-checkbox'],
-        'label_class' => ['woocommerce-form__label', 'woocommerce-form__label-for-checkbox', 'checkbox'],
-        'custom_attributes' => ['data-automation-id' => 'woo-commerce-subscription-opt-in'],
-        'return' => true,
-      ],
-      $checked ? '1' : '0'
-    );
+    $checked = checked($checked, true, false);
+
+    return '<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox" data-automation-id="woo-commerce-subscription-opt-in">
+      <input id="mailpoet_woocommerce_checkout_optin" class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" ' . $checked . ' type="checkbox" name="' . $this->wp->escAttr($inputName) . '" value="1" />
+      <span>' . $this->wp->escHtml($labelString) . '</span>
+    </label>';
   }
 
   private function getSubscriptionPresenceCheckField() {

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -49,20 +49,12 @@ class SubscriptionTest extends \MailPoetTest {
   public function _before() {
     $this->orderId = 123; // dummy
     $this->settings = SettingsController::getInstance();
-    $wcHelper = $this->make(
-      Helper::class,
-      [
-        'woocommerceFormField' => function ($key, $args, $value) {
-          return ($args['label'] ?? '') . ($value ? 'checked' : '');
-        },
-      ]
-    );
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->confirmationEmailMailer = $this->createMock(ConfirmationEmailMailer::class);
     $this->subscription = $this->getServiceWithOverrides(
       Subscription::class,
-      ['wcHelper' => $wcHelper, 'confirmationEmailMailer' => $this->confirmationEmailMailer]
+      ['confirmationEmailMailer' => $this->confirmationEmailMailer]
     );
     $this->wcSegment = $this->segmentsRepository->getWooCommerceSegment();
     $this->wp = $this->diContainer->get(WP::class);


### PR DESCRIPTION
## Description

This PR fix a layout error in the optin checkbox that MailPoet adds to the WooCommerce checkout when the site is using the themes Twenty Twenty-Two and Twenty Twenty-Three.

This problem was happening because WooCommerce add CSS to make its own checkboxes work with those two themes, but it broke checkboxes the layout of checkboxes created with woocommerce_form_field().

The Woo checkboxes in the checkout display the text inside an <span> element and that doesn't happen for checkboxes created with woocommerce_form_field(). The problem is in those CSS rules:

https://github.com/woocommerce/woocommerce/blob/0ea5205672ea785ffa8ef3ad2a8b0048dd2b501e/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss#L731-L757

I opted to use HTML directly instead of woocommerce_form_field() as this is what WooCommerce itself uses for the checkboxes it adds to the checkout page.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4133]

## After-merge notes

_N/A_


[MAILPOET-4133]: https://mailpoet.atlassian.net/browse/MAILPOET-4133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ