### PR TITLE
Cache subscriber counts in admin UI [MAILPOET-5180]

### DIFF
--- a/mailpoet/lib/Cache/TransientCache.php
+++ b/mailpoet/lib/Cache/TransientCache.php
@@ -10,6 +10,8 @@ class TransientCache {
   public const SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_global_status_cache';
   public const SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_homepage_cache';
 
+  private $cacheEnabled;
+
   /** @var WPFunctions */
   private $wp;
 
@@ -17,6 +19,7 @@ class TransientCache {
     WPFunctions $wp
   ) {
     $this->wp = $wp;
+    $this->cacheEnabled = $this->wp->applyFilters('mailpoet_transient_cache_enabled', true);
   }
 
   public function getItem(string $key, int $id): ?array {
@@ -63,6 +66,12 @@ class TransientCache {
     $this->deleteItems($key);
   }
 
+  public function invalidateAllItems(): void {
+    $this->invalidateItems(self::SUBSCRIBERS_STATISTICS_COUNT_KEY);
+    $this->invalidateItems(self::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY);
+    $this->invalidateItems(self::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY);
+  }
+
   private function deleteItems(string $key): void {
     $this->wp->deleteTransient($key);
   }
@@ -72,6 +81,17 @@ class TransientCache {
   }
 
   public function getItems(string $key): array {
+    if (!$this->cacheEnabled) {
+      return [];
+    }
     return $this->wp->getTransient($key) ?: [];
+  }
+
+  public function enableCache(): void {
+    $this->cacheEnabled = true;
+  }
+
+  public function disableCache(): void {
+    $this->cacheEnabled = false;
   }
 }

--- a/mailpoet/lib/Cache/TransientCache.php
+++ b/mailpoet/lib/Cache/TransientCache.php
@@ -8,6 +8,7 @@ use MailPoetVendor\Carbon\Carbon;
 class TransientCache {
   public const SUBSCRIBERS_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_cache';
   public const SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_global_status_cache';
+  public const SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_homepage_cache';
 
   /** @var WPFunctions */
   private $wp;

--- a/mailpoet/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
@@ -46,7 +46,10 @@ class SubscribersCountCacheRecalculation extends SimpleWorker {
     // update cache for subscribers without segment
     $this->recalculateSegmentCache($timer, 0);
 
+    $this->recalculateHomepageCache($timer);
+
     // remove redundancies from cache
+    $this->cronHelper->enforceExecutionLimit($timer);
     $this->subscribersCountsController->removeRedundancyFromStatisticsCache();
 
     return true;
@@ -65,6 +68,16 @@ class SubscribersCountCacheRecalculation extends SimpleWorker {
       } else {
         $this->subscribersCountsController->recalculateSubscribersWithoutSegmentStatisticsCache();
       }
+    }
+  }
+
+  private function recalculateHomepageCache($timer): void {
+    $this->cronHelper->enforceExecutionLimit($timer);
+    $now = Carbon::now();
+    $item = $this->transientCache->getItem(TransientCache::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY, 0);
+    if ($item === null || !isset($item['created_at']) || $now->diffInMinutes($item['created_at']) > self::EXPIRATION_IN_MINUTES) {
+      $this->cronHelper->enforceExecutionLimit($timer);
+      $this->subscribersCountsController->recalculateHomepageStatisticsCache();
     }
   }
 

--- a/mailpoet/lib/Homepage/HomepageDataController.php
+++ b/mailpoet/lib/Homepage/HomepageDataController.php
@@ -14,7 +14,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Util\License\Features\Subscribers;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -40,8 +40,8 @@ class HomepageDataController {
   /** @var AutomationStorage */
   private $automationStorage;
 
-  /** @var Subscribers */
-  private $subscribers;
+  /** @var SubscribersFeature */
+  private $subscribersFeature;
 
   /** @var WPFunctions */
   private $wp;
@@ -52,7 +52,7 @@ class HomepageDataController {
     FormsRepository $formsRepository,
     NewslettersRepository $newslettersRepository,
     AutomationStorage $automationStorage,
-    Subscribers $subscribers,
+    SubscribersFeature $subscribersFeature,
     WPFunctions $wp,
     WooCommerceHelper $wooCommerceHelper
   ) {
@@ -63,11 +63,11 @@ class HomepageDataController {
     $this->automationStorage = $automationStorage;
     $this->wp = $wp;
     $this->wooCommerceHelper = $wooCommerceHelper;
-    $this->subscribers = $subscribers;
+    $this->subscribersFeature = $subscribersFeature;
   }
 
   public function getPageData(): array {
-    $subscribersCount = $this->subscribersRepository->getTotalSubscribers();
+    $subscribersCount = $this->subscribersFeature->getSubscribersCount();
     $formsCount = $this->formsRepository->count();
     $showTaskList = !$this->settingsController->get('homepage.task_list_dismissed', false);
     $showProductDiscovery = !$this->settingsController->get('homepage.product_discovery_dismissed', false);
@@ -133,7 +133,7 @@ class HomepageDataController {
    * @return array{canDisplay:bool}
    */
   private function getUpsellStatus(int $subscribersCount): array {
-    $hasValidMssKey = $this->subscribers->hasValidMssKey();
+    $hasValidMssKey = $this->subscribersFeature->hasValidMssKey();
 
     return [
       'canDisplay' => !$hasValidMssKey && $subscribersCount > self::UPSELL_SUBSCRIBERS_COUNT_REQUIRED,

--- a/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
+++ b/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
@@ -32,7 +32,6 @@ class SegmentsSimpleListRepository {
   public function getListWithSubscribedSubscribersCounts(array $segmentTypes = []): array {
     return $this->getList(
       $segmentTypes,
-      SubscriberEntity::STATUS_SUBSCRIBED,
       SubscriberEntity::STATUS_SUBSCRIBED
     );
   }
@@ -67,8 +66,7 @@ class SegmentsSimpleListRepository {
    */
   private function getList(
     array $segmentTypes = [],
-    string $subscriberGlobalStatus = null,
-    string $subscriberSegmentStatus = null
+    string $subscriberGlobalStatus = null
   ): array {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $subscribersSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
@@ -78,26 +76,10 @@ class SegmentsSimpleListRepository {
       ->getConnection()
       ->createQueryBuilder();
 
-    $countCondition = "subscribers.deleted_at IS NULL AND subsegments.id IS NOT NULL AND subscribers.id IS NOT NULL";
-    if ($subscriberGlobalStatus) {
-      $countCondition .= " AND subscribers.status= :subscriberGlobalStatus";
-      $segmentsDataQuery->setParameter('subscriberGlobalStatus', $subscriberGlobalStatus);
-    }
-
-    if ($subscriberSegmentStatus) {
-      $countCondition .= " AND subsegments.status = :subscriberSegmentStatus";
-      $segmentsDataQuery->setParameter('subscriberSegmentStatus', $subscriberSegmentStatus);
-    }
-
     $segmentsDataQuery->select(
-        "segments.id, segments.name, segments.type, COUNT(IF($countCondition, 1, NULL)) as subscribers"
+        "segments.id, segments.name, segments.type"
       )->from($segmentsTable, 'segments')
-      ->leftJoin('segments', $subscribersSegmentsTable, 'subsegments', "subsegments.segment_id = segments.id")
-      ->leftJoin('subsegments', $subscribersTable, 'subscribers', "subscribers.id = subsegments.subscriber_id")
       ->where('segments.deleted_at IS NULL')
-      ->groupBy('segments.id')
-      ->addGroupBy('segments.name')
-      ->addGroupBy('segments.type')
       ->orderBy('segments.name');
 
     if (!empty($segmentTypes)) {
@@ -112,16 +94,12 @@ class SegmentsSimpleListRepository {
     }
     $segments = $statement->fetchAll();
 
-    // Fetch subscribers counts for dynamic segments and correct data types
+    // Fetch subscribers counts for static and dynamic segments and correct data types
     foreach ($segments as $key => $segment) {
       // BC compatibility fix. PHP8.1+ returns integer but JS apps expect string
       $segments[$key]['id'] = (string)$segment['id'];
-      if ($segment['type'] === SegmentEntity::TYPE_DYNAMIC) {
-        $statisticsKey = $subscriberGlobalStatus ?: 'all';
-        $segments[$key]['subscribers'] = (int)$this->subscribersCountsController->getSegmentStatisticsCountById($segment['id'])[$statisticsKey];
-      } else {
-        $segments[$key]['subscribers'] = (int)$segment['subscribers'];
-      }
+      $statisticsKey = $subscriberGlobalStatus ?: 'all';
+      $segments[$key]['subscribers'] = (int)$this->subscribersCountsController->getSegmentStatisticsCountById($segment['id'])[$statisticsKey];
     }
     return $segments;
   }

--- a/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
+++ b/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
@@ -4,7 +4,6 @@ namespace MailPoet\Segments;
 
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Subscribers\SubscribersCountsController;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
@@ -68,8 +67,6 @@ class SegmentsSimpleListRepository {
     array $segmentTypes = [],
     string $subscriberGlobalStatus = null
   ): array {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $subscribersSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
 
     $segmentsDataQuery = $this->entityManager

--- a/mailpoet/lib/Subscribers/SubscribersCountsController.php
+++ b/mailpoet/lib/Subscribers/SubscribersCountsController.php
@@ -4,10 +4,14 @@ namespace MailPoet\Subscribers;
 
 use MailPoet\Cache\TransientCache;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SegmentSubscribersRepository;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Tags\TagRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
 
 class SubscribersCountsController {
   /** @var SegmentsRepository */
@@ -16,23 +20,33 @@ class SubscribersCountsController {
   /** @var SegmentSubscribersRepository */
   private $segmentSubscribersRepository;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
   /** @var TagRepository */
   private $tagRepository;
 
   /** @var TransientCache */
   private $transientCache;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     SegmentsRepository $segmentsRepository,
     SegmentSubscribersRepository $segmentSubscribersRepository,
+    SubscribersRepository $subscribersRepository,
     TagRepository $subscriberTagRepository,
-    TransientCache $transientCache
+    TransientCache $transientCache,
+    WPFunctions $wp
   ) {
 
     $this->segmentSubscribersRepository = $segmentSubscribersRepository;
     $this->transientCache = $transientCache;
     $this->segmentsRepository = $segmentsRepository;
+    $this->subscribersRepository = $subscribersRepository;
     $this->tagRepository = $subscriberTagRepository;
+    $this->wp = $wp;
   }
 
   public function getSubscribersWithoutSegmentStatisticsCount(): array {
@@ -71,6 +85,14 @@ class SubscribersCountsController {
     return $result;
   }
 
+  public function getHomepageStatistics(): array {
+    $result = $this->transientCache->getItem(TransientCache::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY, 0) ?? [];
+    if (!$result) {
+      $result = $this->recalculateHomepageStatisticsCache();
+    }
+    return $result;
+  }
+
   public function recalculateSegmentGlobalStatusStatisticsCache(SegmentEntity $segment): array {
     $result = $this->segmentSubscribersRepository->getSubscribersGlobalStatusStatisticsCount($segment);
     $this->transientCache->setItem(
@@ -94,6 +116,22 @@ class SubscribersCountsController {
   public function recalculateSubscribersWithoutSegmentStatisticsCache(): array {
     $result = $this->segmentSubscribersRepository->getSubscribersWithoutSegmentStatisticsCount();
     $this->transientCache->setItem(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY, $result, 0);
+    return $result;
+  }
+
+  public function recalculateHomepageStatisticsCache(): array {
+    $thirtyDaysAgo = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'))->subDays(30);
+    $result = [];
+    $result['listsDataSubscribed'] = $this->subscribersRepository->getListLevelCountsOfSubscribedAfter($thirtyDaysAgo);
+    $result['listsDataUnsubscribed'] = $this->subscribersRepository->getListLevelCountsOfUnsubscribedAfter($thirtyDaysAgo);
+    $result['subscribedCount'] = $this->subscribersRepository->getCountOfLastSubscribedAfter($thirtyDaysAgo);
+    $result['unsubscribedCount'] = $this->subscribersRepository->getCountOfUnsubscribedAfter($thirtyDaysAgo);
+    $result['subscribedSubscribersCount'] = $this->subscribersRepository->getCountOfSubscribersForStates([SubscriberEntity::STATUS_SUBSCRIBED]);
+    $this->transientCache->setItem(
+      TransientCache::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY,
+      $result,
+      0
+    );
     return $result;
   }
 

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -21,7 +21,7 @@ class Subscribers {
   const PREMIUM_SUPPORT_SETTING_KEY = 'premium.premium_key_state.data.support_tier';
   const SUBSCRIBERS_COUNT_CACHE_KEY = 'mailpoet_subscribers_count';
   const SUBSCRIBERS_COUNT_CACHE_EXPIRATION_MINUTES = 60;
-  const SUBSCRIBERS_COUNT_CACHE_MIN_VALUE = 1000;
+  const SUBSCRIBERS_COUNT_CACHE_MIN_VALUE = 2000;
 
   /** @var SettingsController */
   private $settings;
@@ -75,10 +75,17 @@ class Subscribers {
     $count = $this->subscribersRepository->getTotalSubscribers();
 
     // cache only when number of subscribers exceeds minimum value
-    if ($count > self::SUBSCRIBERS_COUNT_CACHE_MIN_VALUE) {
+    if ($this->isSubscribersCountEnoughForCache($count)) {
       $this->wp->setTransient(self::SUBSCRIBERS_COUNT_CACHE_KEY, $count, self::SUBSCRIBERS_COUNT_CACHE_EXPIRATION_MINUTES * 60);
     }
     return $count;
+  }
+
+  public function isSubscribersCountEnoughForCache(int $count = null): bool {
+    if (is_null($count)) {
+      $count = $this->getSubscribersCount();
+    }
+    return $count > self::SUBSCRIBERS_COUNT_CACHE_MIN_VALUE;
   }
 
   /**

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -647,16 +647,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'subscribers' on mixed\\.$#"
-			count: 3
-			path: ../../lib/Segments/SegmentsSimpleListRepository.php
-
-		-
-			message: "#^Cannot access offset 'type' on mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentsSimpleListRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php
 

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -647,16 +647,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'subscribers' on mixed\\.$#"
-			count: 3
-			path: ../../lib/Segments/SegmentsSimpleListRepository.php
-
-		-
-			message: "#^Cannot access offset 'type' on mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentsSimpleListRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php
 

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -646,16 +646,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'subscribers' on mixed\\.$#"
-			count: 3
-			path: ../../lib/Segments/SegmentsSimpleListRepository.php
-
-		-
-			message: "#^Cannot access offset 'type' on mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentsSimpleListRepository.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php
 

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 use Facebook\WebDriver\Exception\UnrecognizedExceptionException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\WebDriverKeys;
+use MailPoet\Cache\TransientCache;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Form\FormMessageController;
@@ -768,5 +769,10 @@ class AcceptanceTester extends \Codeception\Actor {
       }
     }
     $i->seeInCurrentURL(urlencode('group[' . $name . ']'));
+  }
+
+  public function clearTransientCache(): void {
+    $cache = ContainerWrapper::getInstance()->get(TransientCache::class);
+    $cache->invalidateAllItems();
   }
 }

--- a/mailpoet/tests/acceptance/Homepage/HomepageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageBasicsCest.php
@@ -69,6 +69,7 @@ class HomepageBasicsCest {
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
       ->withSegments([$segment])
       ->create();
+    $i->clearTransientCache();
     $i->reloadPage();
     $i->waitForText('Subscribers', 10, $subscribersSection);
     $i->see('New 1', $subscribersSection);

--- a/mailpoet/tests/integration/Homepage/HomepageDataControllerTest.php
+++ b/mailpoet/tests/integration/Homepage/HomepageDataControllerTest.php
@@ -20,6 +20,7 @@ class HomepageDataControllerTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->homepageDataController = $this->diContainer->get(HomepageDataController::class);
+    $this->cleanup();
   }
 
   public function testItFetchesBasicData(): void {
@@ -240,6 +241,7 @@ class HomepageDataControllerTest extends \MailPoetTest {
     for ($i = 0; $i < 6; $i++) {
       (new Subscriber())->withLastSubscribedAt($thirtyOneDaysAgo)->create();
     }
+    $this->clearSubscribersCountCache();
     $subscribersStats = $this->homepageDataController->getPageData()['subscribersStats'];
     expect($subscribersStats['global']['changePercent'])->equals(166.7);
 
@@ -249,6 +251,7 @@ class HomepageDataControllerTest extends \MailPoetTest {
       $this->entityManager->persist(new StatisticsUnsubscribeEntity(null, null, $unsubscribed));
       $this->entityManager->flush();
     }
+    $this->clearSubscribersCountCache();
     $subscribersStats = $this->homepageDataController->getPageData()['subscribersStats'];
     expect($subscribersStats['global']['changePercent'])->equals(0);
 
@@ -256,6 +259,7 @@ class HomepageDataControllerTest extends \MailPoetTest {
     $unsubscribed = (new Subscriber())->withLastSubscribedAt($thirtyOneDaysAgo)->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)->create();
     $this->entityManager->persist(new StatisticsUnsubscribeEntity(null, null, $unsubscribed));
     $this->entityManager->flush();
+    $this->clearSubscribersCountCache();
     $subscribersStats = $this->homepageDataController->getPageData()['subscribersStats'];
     expect($subscribersStats['global']['changePercent'])->equals(-5.9);
   }
@@ -323,5 +327,9 @@ class HomepageDataControllerTest extends \MailPoetTest {
     expect($subscribersStats['lists'][0]['name'])->equals($segment->getName());
     expect($subscribersStats['lists'][0]['unsubscribed'])->equals(1);
     expect($subscribersStats['lists'][0]['subscribed'])->equals(0);
+  }
+
+  private function cleanup() {
+    $this->clearSubscribersCountCache();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -54,6 +54,8 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $this->importFactory = new ImportExportFactory('import');
     $this->exportFactory = new ImportExportFactory('export');
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+
+    $this->cleanup();
   }
 
   public function testItCanGetSegmentsWithSubscriberCount() {
@@ -79,6 +81,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $subscriber = $this->subscribersRepository->findOneBy(['email' => 'mike@mailpoet.com', 'deletedAt' => null]);
     expect($subscriber)->null();
 
+    $this->clearSubscribersCountCache();
     $segments = $this->importFactory->getSegments();
     expect($segments[0]['count'])->equals(0);
     expect($segments[1]['count'])->equals(0);
@@ -94,6 +97,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $this->subscribersRepository->persist($subscriber);
     $this->subscribersRepository->flush();
 
+    $this->clearSubscribersCountCache();
     $segments = $this->exportFactory->getSegments();
     expect(count($segments))->equals(1);
   }
@@ -303,5 +307,9 @@ class ImportExportFactoryTest extends \MailPoetTest {
     // action, system fields, user fields
     expect(count((array)json_decode($exportMenu['subscriberFieldsSelect2'], true)))
       ->equals(3);
+  }
+
+  private function cleanup() {
+    $this->clearSubscribersCountCache();
   }
 }

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -191,8 +191,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 
   public function clearSubscribersCountCache() {
     $cache = $this->diContainer->get(TransientCache::class);
-    $cache->invalidateItems(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY);
-    $cache->invalidateItems(TransientCache::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY);
+    $cache->invalidateAllItems();
   }
 
   protected function backupGlobals(): void {


### PR DESCRIPTION
## Description

This PR makes subscriber counts cached on most admin UI pages, making them load fast even with a huge number of subscribers (1M-5M+).

I chose the cutoff value for disabling caching to be 2000 subscribers, it covers the vast majority of users, although experience shows that actual performance issues start between 10K-100K, so the value can be increased later. Subscriber listing needs special treatment, there's a Jira ticket for that.

## Code review notes

N/A

## QA notes

Please test on Hetzner and Atomic. I have already uploaded the build on test sites, but you can do it too if in doubt.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5180]

## After-merge notes

_N/A_


[MAILPOET-5180]: https://mailpoet.atlassian.net/browse/MAILPOET-5180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ