### PR TITLE
Update KB link for sender domain DMARC policy message - MAILPOET-5305

### DIFF
--- a/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
+++ b/mailpoet/assets/js/src/common/sender_email_address_warning.jsx
@@ -77,7 +77,7 @@ function SenderEmailAddressWarning({
                 <a
                   key={match}
                   className="mailpoet-link"
-                  href="https://kb.mailpoet.com/article/295-spf-and-dkim"
+                  href="https://kb.mailpoet.com/article/369-how-to-fix-email-violates-sender-domains-dmarc-policy-error"
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={(e) => loadModal(e, 'sender_domain')}


### PR DESCRIPTION


## Description

Update KB link for sender domain DMARC policy message

## Code review notes

_N/A_

## QA notes

We can probably skip QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5305](https://mailpoet.atlassian.net/browse/MAILPOET-5305)

## After-merge notes

_N/A_


[MAILPOET-5305]: https://mailpoet.atlassian.net/browse/MAILPOET-5305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ