### PR TITLE
Run CodeSniffer in multiple processes [MAILPOET-5335]

### DIFF
--- a/.circleci/nproc.js
+++ b/.circleci/nproc.js
@@ -1,0 +1,23 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+
+// Get logical CPU count for a container on CircleCI. Adapted from:
+//   https://circleci.canny.io/cloud-feature-requests/p/have-nproc-accurately-reporter-number-of-cpus-available-to-container
+
+async function cgroupCpuCount() {
+  const quotaS = await fs.readFile('/sys/fs/cgroup/cpu/cpu.cfs_quota_us');
+  const periodS = await fs.readFile('/sys/fs/cgroup/cpu/cpu.cfs_period_us');
+  const quota = parseInt(quotaS);
+  const period = parseInt(periodS);
+  return quota / period;
+}
+
+async function cpuCount() {
+  try {
+    return await cgroupCpuCount();
+  } catch {
+    return os.cpus().length;
+  }
+}
+
+cpuCount().then(console.log);

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -564,6 +564,7 @@ class RoboFile extends \Robo\Tasks {
     $task = implode(' ', [
       'php -d memory_limit=-1',
       './tasks/code_sniffer/vendor/bin/phpcs',
+      "--parallel=" . $this->getParallelism(),
       '--extensions=php',
       $severityFlag,
       '--standard=tasks/code_sniffer/MailPoet/free-ruleset.xml',
@@ -613,6 +614,7 @@ class RoboFile extends \Robo\Tasks {
     $task = implode(' ', [
       'php -d memory_limit=-1',
       './tasks/code_sniffer/vendor/bin/phpcs',
+      '--parallel=' . $this->getParallelism(),
       '--extensions=php',
       $severityFlag,
       '--standard=tasks/code_sniffer/vendor/wporg/plugin-directory/MinimalPluginStandard',
@@ -1455,5 +1457,11 @@ class RoboFile extends \Robo\Tasks {
       (isset($opts['stop-on-fail']) && $opts['stop-on-fail'] ? '-f ' : '') .
       (isset($opts['file']) && $opts['file'] ? $opts['file'] : '')
     )->dir(__DIR__ . '/tests/docker')->run();
+  }
+
+  private function getParallelism(int $multiplier = 1, int $min = 4, int $max = 32): int {
+    $path = __DIR__ . '/../.circleci/nproc.js';
+    $nproc = (int)$this->taskExec("node $path")->printOutput(false)->run()->stopOnFail()->getMessage();
+    return max(min($nproc * $multiplier, $max), $min);
   }
 }


### PR DESCRIPTION
## Description

On my MacBook Pro M1, this speeds up `./do qa:code-sniffer` from almost 40s to about 10s.

On CircleCI, the speedup is smaller, about 40% to 50%, and it doesn't affect the total CI run times, as it's run in parallel with longer jobs, but at least it saves some credits.

## Code review notes

QA not needed.

## QA notes

QA not needed.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/728

## Linked tickets

[MAILPOET-5335]

[MAILPOET-5335]: https://mailpoet.atlassian.net/browse/MAILPOET-5335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ