### PR TITLE
Fix Automatoin editor for WP 6.0 [MAILPOET-5304] 

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -172,10 +172,18 @@ function Editor(): JSX.Element {
 window.addEventListener('DOMContentLoaded', () => {
   setLocaleData(window.wp.i18n.getLocaleData());
 
-  const dateSettings = window.wp as unknown as {
-    date: { getSettings: typeof getSettings };
-  };
-  setSettings(dateSettings.date.getSettings());
+  if (window.wp.date.getSettings !== undefined) {
+    const dateSettings = window.wp as unknown as {
+      date: { getSettings: typeof getSettings };
+    };
+    setSettings(dateSettings.date.getSettings());
+  } else {
+    const dateSettings = window.wp as unknown as {
+      /* eslint-disable no-underscore-dangle */
+      date: { __experimentalGetSettings: typeof getSettings };
+    };
+    setSettings(dateSettings.date.__experimentalGetSettings());
+  }
 
   createStore();
 

--- a/mailpoet/assets/js/src/common/translations/i18n.tsx
+++ b/mailpoet/assets/js/src/common/translations/i18n.tsx
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     wp: {
       i18n: { getLocaleData: typeof getLocaleData };
+      date: Record<string, unknown>;
     };
   }
 }


### PR DESCRIPTION
## Description
In Wp 6.0 the `date.getSettings()` was still experimental. This PR provides a fallback to the experimental feature.

## Linked tickets

[MAILPOET-5304] 


[MAILPOET-5304]: https://mailpoet.atlassian.net/browse/MAILPOET-5304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ