### PR TITLE
Update acceptance tests ScheduleNewsletter and few more about duplicating newsletters

### DIFF
--- a/mailpoet/tests/acceptance/Newsletters/DuplicateAutomaticEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicateAutomaticEmailCest.php
@@ -13,12 +13,16 @@ class DuplicateAutomaticEmailCest {
     $i->activateWooCommerce();
     $emailSubject = 'Duplicate Automatic Email Test';
     $newsletterFactory = new Newsletter();
-    $newsletterFactory->withSubject($emailSubject)->withAutomaticTypeWooCommerceFirstPurchase()->create();
+    $newsletterFactory->withSubject($emailSubject)
+      ->withAutomaticTypeWooCommerceFirstPurchase()
+      ->withActiveStatus()
+      ->create();
     $i->login();
     $i->amOnMailpoetPage('Emails');
     $i->click('[data-automation-id="tab-WooCommerce"]');
     $i->waitForText($emailSubject);
     $i->clickItemRowActionByItemName($emailSubject, 'Duplicate');
+    $i->waitForElementVisible('.notice-success');
     $i->waitForText('Email "Copy of ' . $emailSubject . '" has been duplicated.', 20);
     $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName('Copy of ' . $emailSubject, 'Edit');

--- a/mailpoet/tests/acceptance/Newsletters/DuplicateNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicateNewsletterCest.php
@@ -14,6 +14,21 @@ class DuplicateNewsletterCest {
     $i->amOnMailpoetPage('Emails');
     $i->waitForText($newsletterName);
     $i->clickItemRowActionByItemName($newsletterName, 'Duplicate');
+    $i->waitForText('Email "Copy of ' . $newsletterName . '" has been duplicated.');
+    $i->waitForText('Copy of ' . $newsletterName);
+  }
+
+  public function duplicateScheduledNewsletter(\AcceptanceTester $i) {
+    $newsletterName = 'Duplicate Scheduled Newsletter';
+    $newsletter = new Newsletter();
+    $newsletter->withSubject($newsletterName)->withScheduledStatus()->create();
+    $i->wantTo('Duplicate a scheduled newsletter');
+    $i->login();
+    $i->amOnMailpoetPage('Emails');
+    $i->waitForText($newsletterName);
+    $i->clickItemRowActionByItemName($newsletterName, 'Duplicate');
+    $i->waitForElementVisible('.notice-success');
+    $i->waitForText('Email "Copy of ' . $newsletterName . '" has been duplicated.');
     $i->waitForText('Copy of ' . $newsletterName);
   }
 }

--- a/mailpoet/tests/acceptance/Newsletters/DuplicatePostNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DuplicatePostNotificationCest.php
@@ -13,6 +13,7 @@ class DuplicatePostNotificationCest {
     $newsletterFactory = new Newsletter();
     $newsletterFactory->withSubject($newsletterTitle)
       ->withPostNotificationsType()
+      ->withActiveStatus()
       ->create();
 
     // step 2 - Open list of post notifications
@@ -23,6 +24,8 @@ class DuplicatePostNotificationCest {
     // step 3 - Duplicate post notification
     $i->waitForText($newsletterTitle);
     $i->clickItemRowActionByItemName($newsletterTitle, 'Duplicate');
+    $i->waitForElementVisible('.notice-success');
+    $i->waitForText('Email "Copy of ' . $newsletterTitle . '" has been duplicated.', 20);
     $i->waitForText('Copy of ' . $newsletterTitle);
     $i->waitForListingItemsToLoad();
 

--- a/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
@@ -10,7 +10,7 @@ class ScheduleNewsletterCest {
     $i->wantTo('Schedule a newsletter');
     $newsletterTitle = 'Schedule Test Newsletter';
 
-    // step 1 - Prepare post notification data
+    // step 1 - Prepare standard newsletter
     $newsletterFactory = new Newsletter();
     $newsletter = $newsletterFactory->withSubject($newsletterTitle)
       ->create();
@@ -28,8 +28,11 @@ class ScheduleNewsletterCest {
     $i->click('select[name=time]');
     $i->selectOption('form select[name=time]', '6:00');
     $i->click('Schedule');
+    $i->waitForElement('.mailpoet_modal_overlay');
+    $i->waitForElementVisible('.notice-success');
+    $i->waitForText('The newsletter has been scheduled.');
     $i->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
-
+    $i->waitForText('6:00 am');
   }
 
   public function scheduleStandardNewsletterButtonCaption(\AcceptanceTester $i) {
@@ -73,5 +76,10 @@ class ScheduleNewsletterCest {
     // `Send` caption - change time to 1 hour before now
     $i->selectOption('form select[name=time]', $currentDateTime->modify("-1 hour")->format('g:00 a'));
     $i->see("Send", "button span");
+
+    $i->wantTo('Pick tomorrow‘s date');
+    $i->click('select[name=time]');
+    $i->selectOption('form select[name=time]', $currentDateTime->modify("26 hour")->format('g:00 a'));
+    $i->see("Schedule", "button span");
   }
 }


### PR DESCRIPTION
## Description

Updated the test case ScheduledNewsletterCest with additional checks.
Updated all other tests with duplicating newsletters where I added new test for duplicating scheduled newsletter but also some checks for duplicating other types of newsletters.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5310]

## After-merge notes

_N/A_


[MAILPOET-5310]: https://mailpoet.atlassian.net/browse/MAILPOET-5310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ