### PR TITLE
Update the PHP 7.3 Docker image for CircleCI build jobs [MAILPOET-4939]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ executors:
   wpcli_php_oldest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:7.3_20190705.2
+      - image: mailpoet/wordpress:7.3_20230518.1
 
   wpcli_php_max_wporg:
     <<: *default_job_config
@@ -102,7 +102,7 @@ executors:
   wpcli_php_mysql_oldest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:7.3_20190705.2
+      - image: mailpoet/wordpress:7.3_20230518.1
       - image: cimg/mysql:5.7
 
   wpcli_php_mysql_latest:


### PR DESCRIPTION
## Description

In 9a5960c, I replaced the PHP 7.2 images with PHP 7.3 images for the CircleCI jobs that use the latest supported version of PHP. I opted to reuse an image that was created by us back in 2019. It turns out that this image was missing some dependencies like Node.

This PR updates to a newly created PHP 7.3 image. This should fix the CircleCI build jobs that were failing.

I created a branch to run the nightly build jobs to show that unit_oldest is now passing. The other build job that was failing was qa_php_oldest.

https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=test-nightly-unit-oldest

Please, delete the branch `test-nightly-unit-oldest` after merging this PR.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4939]

## After-merge notes

_N/A_


[MAILPOET-4939]: https://mailpoet.atlassian.net/browse/MAILPOET-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ