### PR TITLE
Replace most of the models from Scheduler with Doctrine code [MAILPOET-4370]

### DIFF
--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -340,12 +340,8 @@ class Scheduler {
     return true;
   }
 
-  public function verifyMailpoetSubscriber($subscriberId, NewsletterEntity $newsletter, $queue) {
-    if (is_int($subscriberId)) {
-      $subscriber = $this->subscribersRepository->findOneById($subscriberId);
-    } else {
-      $subscriber = null;
-    }
+  public function verifyMailpoetSubscriber(int $subscriberId, NewsletterEntity $newsletter, $queue): bool {
+    $subscriber = $this->subscribersRepository->findOneById($subscriberId);
 
     // check if subscriber is in proper segment
     $subscriberInSegment = $this->subscriberSegmentRepository->findOneBy(

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -388,17 +388,13 @@ class Scheduler {
     return true;
   }
 
-  public function deleteQueueOrUpdateNextRunDate($queue, $newsletter) {
-    if ($newsletter instanceof NewsletterEntity) {
-      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
-    }
-
-    if ($newsletter->intervalType === PostNotificationScheduler::INTERVAL_IMMEDIATELY) {
+  public function deleteQueueOrUpdateNextRunDate($queue, NewsletterEntity $newsletter) {
+    if ($newsletter->getOptionValue('intervalType') === PostNotificationScheduler::INTERVAL_IMMEDIATELY) {
       $queue->delete();
       $this->updateScheduledTaskEntity($queue, true);
       return;
     } else {
-      $nextRunDate = $this->scheduler->getNextRunDate($newsletter->schedule);
+      $nextRunDate = $this->scheduler->getNextRunDate($newsletter->getOptionValue('schedule'));
       if (!$nextRunDate) {
         $queue->delete();
         $this->updateScheduledTaskEntity($queue, true);

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -358,7 +358,7 @@ class Scheduler {
     return $this->verifySubscriber($subscriber, $queue);
   }
 
-  public function verifyWPSubscriber($subscriberId, NewsletterEntity $newsletter, $queue) {
+  public function verifyWPSubscriber(int $subscriberId, NewsletterEntity $newsletter, $queue): bool {
     // check if user has the proper role
     $subscriber = $this->subscribersRepository->findOneById($subscriberId);
     if (!$subscriber || $subscriber->isWPUser() === false || is_null($subscriber->getWpUserId())) {

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -135,6 +135,10 @@ class Scheduler {
   }
 
   public function processWelcomeNewsletter($newsletter, $queue) {
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
+    }
+
     $subscribers = $queue->getSubscribers();
     if (empty($subscribers[0])) {
       $queue->delete();
@@ -160,6 +164,10 @@ class Scheduler {
   }
 
   public function processPostNotificationNewsletter($newsletter, SendingTask $queue) {
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
+    }
+
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
       'process post notification in scheduler',
       ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
@@ -301,6 +309,10 @@ class Scheduler {
   }
 
   public function processScheduledStandardNewsletter($newsletter, SendingTask $task) {
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
+    }
+
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
 
     $taskEntity = null;
@@ -333,6 +345,10 @@ class Scheduler {
   }
 
   public function verifyMailpoetSubscriber($subscriberId, $newsletter, $queue) {
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
+    }
+
     $subscriber = Subscriber::findOne($subscriberId);
     // check if subscriber is in proper segment
     $subscriberInSegment =
@@ -348,6 +364,10 @@ class Scheduler {
   }
 
   public function verifyWPSubscriber($subscriberId, $newsletter, $queue) {
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
+    }
+
     // check if user has the proper role
     $subscriber = Subscriber::findOne($subscriberId);
     if (!$subscriber || $subscriber->isWPUser() === false) {
@@ -391,6 +411,10 @@ class Scheduler {
   }
 
   public function deleteQueueOrUpdateNextRunDate($queue, $newsletter) {
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
+    }
+
     if ($newsletter->intervalType === PostNotificationScheduler::INTERVAL_IMMEDIATELY) {
       $queue->delete();
       $this->updateScheduledTaskEntity($queue, true);

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -380,7 +380,7 @@ class Scheduler {
     return $this->verifySubscriber($subscriber, $queue);
   }
 
-  public function verifySubscriber(SubscriberEntity $subscriber, $queue) {
+  public function verifySubscriber(SubscriberEntity $subscriber, $queue): bool {
     $newsletter = $queue->newsletterId ? $this->newslettersRepository->findOneById($queue->newsletterId) : null;
     if ($newsletter && $newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
       return $subscriber->getStatus() !== SubscriberEntity::STATUS_BOUNCED;

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -122,7 +122,7 @@ class Scheduler {
       } elseif ($newsletter->type === NewsletterEntity::TYPE_STANDARD) {
         $this->processScheduledStandardNewsletter($newsletterEntity, $queue);
       } elseif ($newsletter->type === NewsletterEntity::TYPE_AUTOMATIC) {
-        $this->processScheduledAutomaticEmail($newsletter, $queue);
+        $this->processScheduledAutomaticEmail($newsletterEntity, $queue);
       } elseif ($newsletter->type === NewsletterEntity::TYPE_RE_ENGAGEMENT) {
         $this->processReEngagementEmail($queue);
       } elseif ($newsletter->type === NewsletterEntity::TYPE_AUTOMATION) {
@@ -219,9 +219,9 @@ class Scheduler {
     return true;
   }
 
-  public function processScheduledAutomaticEmail($newsletter, $queue) {
-    if ($newsletter->sendTo === 'segment') {
-      $segment = $this->segmentsRepository->findOneById($newsletter->segment);
+  public function processScheduledAutomaticEmail(NewsletterEntity $newsletter, $queue) {
+    if ($newsletter->getOptionValue('sendTo') === 'segment') {
+      $segment = $this->segmentsRepository->findOneById($newsletter->getOptionValue('segment'));
       if ($segment instanceof SegmentEntity) {
         $taskModel = $queue->task();
         $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -117,7 +117,7 @@ class Scheduler {
       } elseif ($newsletter->status !== NewsletterEntity::STATUS_ACTIVE && $newsletter->status !== NewsletterEntity::STATUS_SCHEDULED) {
         continue;
       } elseif ($newsletter->type === NewsletterEntity::TYPE_WELCOME) {
-        $this->processWelcomeNewsletter($newsletter, $queue);
+        $this->processWelcomeNewsletter($newsletterEntity, $queue);
       } elseif ($newsletter->type === NewsletterEntity::TYPE_NOTIFICATION) {
         $this->processPostNotificationNewsletter($newsletter, $queue);
       } elseif ($newsletter->type === NewsletterEntity::TYPE_STANDARD) {
@@ -135,11 +135,7 @@ class Scheduler {
     }
   }
 
-  public function processWelcomeNewsletter($newsletter, $queue) {
-    if ($newsletter instanceof NewsletterEntity) {
-      $newsletter = Newsletter::filter('filterWithOptions', $newsletter->getType())->findOne($newsletter->getId());
-    }
-
+  public function processWelcomeNewsletter(NewsletterEntity $newsletter, $queue) {
     $subscribers = $queue->getSubscribers();
     if (empty($subscribers[0])) {
       $queue->delete();
@@ -147,12 +143,12 @@ class Scheduler {
       return false;
     }
     $subscriberId = (int)$subscribers[0];
-    if ($newsletter->event === 'segment') {
+    if ($newsletter->getOptionValue('event') === 'segment') {
       if ($this->verifyMailpoetSubscriber($subscriberId, $newsletter, $queue) === false) {
         return false;
       }
     } else {
-      if ($newsletter->event === 'user') {
+      if ($newsletter->getOptionValue('event') === 'user') {
         if ($this->verifyWPSubscriber($subscriberId, $newsletter, $queue) === false) {
           return false;
         }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -533,6 +533,7 @@ class SchedulerTest extends \MailPoetTest {
         $this->security,
         $this->newsletterScheduler,
         $this->subscriberSegmentRepository,
+        $this->subscribersRepository,
       ], [
       'deleteQueueOrUpdateNextRunDate' => Expected::exactly(1, function() {
         return false;
@@ -797,6 +798,7 @@ class SchedulerTest extends \MailPoetTest {
     $task->setSubscribers([$subscriber->getId()]);
     $task->save();
     $this->subscribersRepository->bulkDelete([$subscriber->getId()]);
+    $this->subscribersRepository->remove($subscriber);
 
     // scheduled task should exist
     $task = SendingTask::getByNewsletterId($newsletter->getId());
@@ -882,6 +884,7 @@ class SchedulerTest extends \MailPoetTest {
     $task->setSubscribers([$subscriber->getId()]);
     $task->save();
     $this->subscribersRepository->bulkDelete([$subscriber->getId()]);
+    $this->subscribersRepository->remove($subscriber);
 
     // scheduled task should exist
     $task = SendingTask::getByNewsletterId($newsletter->getId());

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -227,7 +227,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // return false and delete queue when subscriber is not a WP user
-    $result = $scheduler->verifyWPSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyWPSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->false();
     expect($this->sendingQueuesRepository->findAll())->count(0);
   }
@@ -244,7 +244,7 @@ class SchedulerTest extends \MailPoetTest {
 
     // return false and delete queue when subscriber role is different from the one
     // specified for the welcome email
-    $result = $scheduler->verifyWPSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyWPSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->false();
     expect($this->sendingQueuesRepository->findAll())->count(0);
   }
@@ -260,7 +260,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // return true when user exists and WP role matches the one specified for the welcome email
-    $result = $scheduler->verifyWPSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyWPSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->true();
     expect(count($this->sendingQueuesRepository->findAll()))->greaterOrEquals(1);
   }
@@ -276,7 +276,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // true when user exists and has any role
-    $result = $scheduler->verifyWPSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyWPSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->true();
     expect(count($this->sendingQueuesRepository->findAll()))->greaterOrEquals(1);
   }
@@ -352,7 +352,7 @@ class SchedulerTest extends \MailPoetTest {
     $queue = $this->_createQueue($newsletter->getId());
     $queue->setSubscribers([1]);
     $scheduler = Stub::make(Scheduler::class, [
-      'verifyWPSubscriber' => Expected::exactly(1),
+      'verifyWPSubscriber' => Expected::exactly(1, true),
       'scheduledTasksRepository' => $this->diContainer->get(ScheduledTasksRepository::class),
     ], $this);
     expect($queue->status)->notNull();

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -617,6 +617,7 @@ class SchedulerTest extends \MailPoetTest {
       'processWelcomeNewsletter' => Expected::exactly(1),
       'cronHelper' => $this->cronHelper,
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     $scheduler->process();
   }
@@ -630,6 +631,7 @@ class SchedulerTest extends \MailPoetTest {
       'processPostNotificationNewsletter' => Expected::exactly(1),
       'cronHelper' => $this->cronHelper,
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     $scheduler->process();
   }
@@ -643,6 +645,7 @@ class SchedulerTest extends \MailPoetTest {
       'processScheduledStandardNewsletter' => Expected::exactly(1),
       'cronHelper' => $this->cronHelper,
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     $scheduler->process();
   }
@@ -658,6 +661,7 @@ class SchedulerTest extends \MailPoetTest {
         'enforceExecutionLimit' => Expected::exactly(2), // call at start + during processing
       ]),
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     $scheduler->process();
   }
@@ -672,6 +676,7 @@ class SchedulerTest extends \MailPoetTest {
       'processScheduledStandardNewsletter' => Expected::never(),
       'cronHelper' => $this->cronHelper,
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     // scheduled job is not processed
     $scheduler->process();
@@ -687,6 +692,7 @@ class SchedulerTest extends \MailPoetTest {
       'processScheduledStandardNewsletter' => Expected::once(),
       'cronHelper' => $this->cronHelper,
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     // scheduled job is processed
     $scheduler->process();
@@ -751,6 +757,7 @@ class SchedulerTest extends \MailPoetTest {
       'processScheduledStandardNewsletter' => Expected::once(),
       'cronHelper' => $this->cronHelper,
       'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'newslettersRepository' => $this->newslettersRepository,
     ], $this);
     // scheduled job is processed
     $scheduler->process();

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -532,6 +532,7 @@ class SchedulerTest extends \MailPoetTest {
         WPFunctions::get(),
         $this->security,
         $this->newsletterScheduler,
+        $this->subscriberSegmentRepository,
       ], [
       'deleteQueueOrUpdateNextRunDate' => Expected::exactly(1, function() {
         return false;

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -332,7 +332,7 @@ class SchedulerTest extends \MailPoetTest {
     $queue = $this->_createQueue($newsletter->getId());
     $queue->setSubscribers([1]);
     $scheduler = Stub::make(Scheduler::class, [
-      'verifyMailpoetSubscriber' => Expected::exactly(1),
+      'verifyMailpoetSubscriber' => Expected::exactly(1, true),
       'scheduledTasksRepository' => $this->diContainer->get(ScheduledTasksRepository::class),
     ], $this);
     expect($queue->status)->notNull();
@@ -371,7 +371,7 @@ class SchedulerTest extends \MailPoetTest {
     $queue = $this->_createQueue($newsletter->getId());
 
     // return false
-    $result = $scheduler->verifyMailpoetSubscriber(null, $newsletter, $queue);
+    $result = $scheduler->verifyMailpoetSubscriber(PHP_INT_MAX, $newsletter, $queue);
     expect($result)->false();
     // delete queue when subscriber can't be found
     expect($this->sendingQueuesRepository->findAll())->count(0);
@@ -389,7 +389,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // return false
-    $result = $scheduler->verifyMailpoetSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyMailpoetSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->false();
     // delete queue when subscriber is not in segment specified for the newsletter
     expect($this->sendingQueuesRepository->findAll())->count(0);
@@ -416,7 +416,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // return false
-    $result = $scheduler->verifyMailpoetSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyMailpoetSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->false();
     // update the time queue is scheduled to run at
     $sendingQueue = $this->sendingQueuesRepository->findOneById($queue->id);
@@ -441,7 +441,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // return false
-    $result = $scheduler->verifyMailpoetSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyMailpoetSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->false();
     // update the time queue is scheduled to run at
     expect($this->sendingQueuesRepository->findOneById($queue->id))->null();
@@ -460,7 +460,7 @@ class SchedulerTest extends \MailPoetTest {
     $scheduler = $this->getScheduler();
 
     // return true after successful verification
-    $result = $scheduler->verifyMailpoetSubscriber($subscriber->getId(), $newsletter, $queue);
+    $result = $scheduler->verifyMailpoetSubscriber((int)$subscriber->getId(), $newsletter, $queue);
     expect($result)->true();
   }
 


### PR DESCRIPTION
## Description

This PR replaces most of the Paris models from the Scheduler class with Doctrine code. The model ScheduledTask was left as it will be easier to replace it when we decide what to do with the `MailPoet\Tasks\Sending` class. The remaining model from SchedulerTest was also replaced with Doctrine code.

## Code review notes

_N/A_

## QA notes

This PR should not change any functionality, but it touches one of the core classes of MailPoet that is responsible for sending all types of emails. Please carefully test sending as many emails as possible. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4370]

## After-merge notes

_N/A_


[MAILPOET-4370]: https://mailpoet.atlassian.net/browse/MAILPOET-4370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ