### PR TITLE
Updated 3 tests and added new methods to tester

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -58,14 +58,6 @@ class AcceptanceTester extends \Codeception\Actor {
   /**
    * Define custom actions here
    */
-  public function getBackToSite() {
-    $i = $this;
-    $i->amOnUrl(self::WP_URL);
-  }
-
-  /**
-   * Define custom actions here
-   */
   public function login() {
     $i = $this;
     $i->amOnPage('/wp-login.php');
@@ -124,6 +116,14 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->amOnUrl(self::MAIL_URL);
     // ensure that angular is loaded by checking angular specific class
     $i->waitForElement('.messages.ng-scope');
+  }
+
+  /**
+   * Define custom actions here
+   */
+  public function amOnSiteHomepage() {
+    $i = $this;
+    $i->amOnUrl(self::WP_URL);
   }
 
   /**

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -58,6 +58,14 @@ class AcceptanceTester extends \Codeception\Actor {
   /**
    * Define custom actions here
    */
+  public function getBackToSite() {
+    $i = $this;
+    $i->amOnUrl(self::WP_URL);
+  }
+
+  /**
+   * Define custom actions here
+   */
   public function login() {
     $i = $this;
     $i->amOnPage('/wp-login.php');
@@ -116,6 +124,18 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->amOnUrl(self::MAIL_URL);
     // ensure that angular is loaded by checking angular specific class
     $i->waitForElement('.messages.ng-scope');
+  }
+
+  /**
+   * Navigate to Mailhog page and empty the mailbox
+   */
+  public function emptyMailbox() {
+    $i = $this;
+    $i->amOnMailboxAppPage();
+    // click to empty the mailbox
+    $i->click('.glyphicon-remove-circle');
+    $i->waitForElementVisible('.btn-danger');
+    $i->click('.btn-danger');
   }
 
   public function clickItemRowActionByItemName($itemName, $link) {
@@ -648,6 +668,19 @@ class AcceptanceTester extends \Codeception\Actor {
       $i->amOnMailboxAppPage();
       $i->waitForText($subject, 60);
     }
+  }
+
+  /**
+   * Checks that email was not received by looking for a subject in inbox.
+   * @param string $subject
+   */
+  public function checkEmailWasNotReceived($subject) {
+    $i = $this;
+    $i->amOnMailboxAppPage();
+    $i->dontSee($subject);
+    // click refresh button to seek for new emails once again
+    $i->click('.glyphicon-refresh');
+    $i->dontSee($subject);
   }
 
   /**

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -54,6 +54,7 @@ class AcceptanceTester extends \Codeception\Actor {
   const WOO_COMMERCE_MEMBERSHIPS_PLUGIN = 'woocommerce-memberships';
   const WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN = 'woocommerce-subscriptions';
   const AUTOMATE_WOO_PLUGIN = 'automatewoo';
+  const MAILHOG_DATA_PATH = '/mailhog-data';
 
   /**
    * Define custom actions here
@@ -127,15 +128,10 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   /**
-   * Navigate to Mailhog page and empty the mailbox
+   * Clear the Mailbox so it's empty
    */
   public function emptyMailbox() {
-    $i = $this;
-    $i->amOnMailboxAppPage();
-    // click to empty the mailbox
-    $i->click('.glyphicon-remove-circle');
-    $i->waitForElementVisible('.btn-danger');
-    $i->click('.btn-danger');
+    exec('rm -rf ' . self::MAILHOG_DATA_PATH . '/*', $output);
   }
 
   public function clickItemRowActionByItemName($itemName, $link) {
@@ -676,6 +672,7 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function checkEmailWasNotReceived($subject) {
     $i = $this;
+    $i->triggerMailPoetActionScheduler();
     $i->amOnMailboxAppPage();
     $i->dontSee($subject);
     // click refresh button to seek for new emails once again

--- a/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
@@ -55,7 +55,7 @@ class SendCategoryPurchaseEmailCest {
     $i->wantTo('Buy in the same category once again and don\'t receive the newsletter');
 
     $i->emptyMailbox();
-    $i->getBackToSite();
+    $i->amOnSiteHomepage();
 
     // Add additional random product to cart to buy 2 products
     $i->addProductToCart($product2);

--- a/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
@@ -27,8 +27,10 @@ class SendFirstPurchaseEmailCest {
     $i->wantTo('Send a "First purchase email"');
 
     $productName = 'First Purchase Product';
+    $productName = 'Second Purchase Product';
     $productFactory = new WooCommerceProduct($i);
-    $product = $productFactory->withName($productName)->create();
+    $product1 = $productFactory->withName($productName)->create();
+    $product2 = $productFactory->withName($productName)->create();
 
     $emailSubject = 'First Purchase Test';
     $newsletterFactory = new Newsletter();
@@ -39,14 +41,20 @@ class SendFirstPurchaseEmailCest {
       ->create();
 
     $userEmail = 'user@email.test';
-    $i->orderProduct($product, $userEmail);
-
+    $i->orderProduct($product1, $userEmail);
     $i->triggerMailPoetActionScheduler();
-
     $i->checkEmailWasReceived($emailSubject);
 
     $i->click(Locator::contains('span.subject', $emailSubject));
     $i->waitForText($userEmail, 20);
+
+    $i->wantTo('Purchase second product and check if I didn\'t get "First purchase email"');
+
+    $i->emptyMailbox();
+    $i->getBackToSite();
+    $i->orderProductWithoutRegistration($product2, $userEmail);
+    $i->triggerMailPoetActionScheduler();
+    $i->checkEmailWasNotReceived($emailSubject);
   }
 
   public function doNotSendFirstPurchaseEmailIfUserHasNotOptedIn(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
@@ -51,7 +51,7 @@ class SendFirstPurchaseEmailCest {
     $i->wantTo('Purchase second product and check if I didn\'t get "First purchase email"');
 
     $i->emptyMailbox();
-    $i->getBackToSite();
+    $i->amOnSiteHomepage();
     $i->orderProductWithoutRegistration($product2, $userEmail);
     $i->triggerMailPoetActionScheduler();
     $i->checkEmailWasNotReceived($emailSubject);

--- a/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
@@ -28,24 +28,39 @@ class SendProductPurchaseEmailCest {
 
     $productName = 'Product Purchase Test Product';
     $productFactory = new WooCommerceProduct($i);
-    $product = $productFactory->withName($productName)->create();
+    $product1 = $productFactory->withName($productName)->create();
+    $product2 = $productFactory->withName($productName)->create();
 
     $emailSubject = 'Product Purchase Test';
     $newsletterFactory = new Newsletter();
     $newsletterFactory
       ->withSubject($emailSubject)
-      ->withAutomaticTypeWooCommerceProductPurchased([$product])
+      ->withAutomaticTypeWooCommerceProductPurchased([$product1])
       ->withActiveStatus()
       ->create();
 
     $userEmail = 'user2@email.test';
-    $i->orderProduct($product, $userEmail);
+    $i->orderProduct($product1, $userEmail);
 
     $i->triggerMailPoetActionScheduler();
 
     $i->checkEmailWasReceived($emailSubject);
     $i->click(Locator::contains('span.subject', $emailSubject));
     $i->waitForText($userEmail, 20);
+
+    $i->wantTo('Buy the same product once again and don\'t receive the newsletter');
+
+    $i->emptyMailbox();
+
+    $i->getBackToSite();
+
+    // Add additional random product to cart to buy 2 products
+    $i->addProductToCart($product2);
+
+    // Order 2 products with 1 attached to WC Automatic email
+    $i->orderProductWithoutRegistration($product1, $userEmail);
+    $i->triggerMailPoetActionScheduler();
+    $i->checkEmailWasNotReceived($emailSubject);
   }
 
   public function doNotSendProductPurchaseEmailIfUserHasNotOptedIn(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
@@ -52,7 +52,7 @@ class SendProductPurchaseEmailCest {
 
     $i->emptyMailbox();
 
-    $i->getBackToSite();
+    $i->amOnSiteHomepage();
 
     // Add additional random product to cart to buy 2 products
     $i->addProductToCart($product2);


### PR DESCRIPTION
## Description

Updated 3 tests with similar scenarios, added new methods to `AcceptanceTester.php`.

These are the 3 tests improved:
`SendFirstPurchaseEmailCest`
`SendProductPurchaseEmailCest`
`SendCategoryPurchaseEmailCest`

These are the added methods to the tester:
`getBackToSite()`
`emptyMailbox()`
`checkEmailWasNotReceived($subject)`

I think these methods are worth having even for the other or new tests.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5312] & [MAILPOET-5313]

## After-merge notes

_N/A_


[MAILPOET-5312]: https://mailpoet.atlassian.net/browse/MAILPOET-5312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5313]: https://mailpoet.atlassian.net/browse/MAILPOET-5313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ