### PR TITLE
Improve the test to include checks for the blank form

### DIFF
--- a/mailpoet/tests/acceptance/Forms/EditorCreateBlankFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateBlankFormCest.php
@@ -6,13 +6,16 @@ use MailPoet\Test\DataFactories\Segment;
 
 class EditorCreateBlankFormCest {
   public function createBlankForm(\AcceptanceTester $i) {
-    $i->wantTo('Create a blamk form');
+    $i->wantTo('Create a blank form');
+
     $segmentFactory = new Segment();
     $segmentName = 'Fancy List';
     $segmentFactory->withName($segmentName)->create();
 
     $i->login();
+
     $i->amOnMailPoetPage('Forms');
+
     // Create a new form
     $formName = 'My awesome form';
     $i->click('[data-automation-id="create_new_form"]');
@@ -20,9 +23,26 @@ class EditorCreateBlankFormCest {
     $i->click('[data-automation-id="create_blank_form"]');
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->fillField('[data-automation-id="form_title_input"]', $formName);
+
+    // Verify the elements of a blank form
+    $i->seeElement('[data-automation-id="editor_email_input"]');
+    $i->seeElement('[data-automation-id="editor_submit_input"]');
+    $i->dontSeeElement('[data-automation-id="editor_first_name_input"]');
+    $i->dontSeeElement('[data-automation-id="editor_divider_block"]');
+    $i->dontSeeElement('[data-automation-id="editor_spacer_block"]');
+
+    // Verify the form default toggles
+    $i->seeCheckboxIsChecked('.components-form-toggle__input');
+    $i->click('[data-automation-id="form_preview_button"]');
+    $i->waitForElementVisible('[data-automation-id="form_type_selection"]');
+    $i->seeOptionIsSelected('[data-automation-id="form_type_selection"]', 'Others (widget)');
+    $i->click('[data-automation-id="mailpoet-modal-close"]');
+
     // Select list and save form
+    $i->waitForElementVisible('[data-automation-id="editor_submit_input"]');
     $i->selectOptionInSelect2($segmentName);
     $i->saveFormInEditor();
+
     // Reload page and check data were saved
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');


### PR DESCRIPTION
## Description

I updated the test `EditorCreateBlankFormCest` to include checks of the blank form. Now, we also check for the 2 vital blocks inside but also form placement and default toggles. We want to ensure the blank form is properly created.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5316]

## After-merge notes

_N/A_


[MAILPOET-5316]: https://mailpoet.atlassian.net/browse/MAILPOET-5316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ