### PR TITLE
Change the behavior of the country segment [MAILPOET-4188]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCountry.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCountry.php
@@ -53,13 +53,7 @@ class WooCommerceCountry implements Filter {
       $wpdb->prefix . 'wc_customer_lookup',
       'customer',
       "$subscribersTable.email = customer.email $collation"
-    )->innerJoin(
-      'customer',
-      $wpdb->prefix . 'wc_order_stats',
-      'orderStats',
-      'customer.customer_id = orderStats.customer_id'
-    )->where($condition)
-      ->andWhere('orderStats.status NOT IN ("wc-cancelled", "wc-failed")');
+    )->where($condition);
 
     foreach ($countryCode as $key => $userCountryCode) {
       $qb->setParameter(':countryCode' . $key . $countryFilterParam, '%' . $userCountryCode . '%');


### PR DESCRIPTION
## Description

This PR changes the behavior of the country segment to include subscribers that never placed an order (or placed orders that failed or were canceled) as long as they have a country set in the WooCommerce customer lookup table.

## Code review notes

_N/A_

## QA notes

To test this PR:

- Place an order using a new customer that never placed an order before.
- Change the status of the order to failed or canceled.
- Create a new segment based on the country of this new customer and make sure the customer is included in it.

Ideally, we would want to test if a customer that never placed an order is included as well, but I'm not sure if there is UI to set the country of a customer without placing an order.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4188]

## After-merge notes

_N/A_


[MAILPOET-4188]: https://mailpoet.atlassian.net/browse/MAILPOET-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ