### PR TITLE
Fix: subscriber segmentation can now target contacts who did not open any emails [MAILPOET-5347]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
@@ -36,7 +36,7 @@ class EmailOpensAbsoluteCountAction implements Filter {
       $subscribersTable,
       $statsTable,
       'opens',
-      "$subscribersTable.id = opens.subscriber_id AND opens.created_at > :newer" . $parameterSuffix
+      "{$subscribersTable}.id = opens.subscriber_id AND opens.created_at > :newer{$parameterSuffix} AND opens.user_agent_type = :userAgentType{$parameterSuffix}"
     );
     $queryBuilder->setParameter('newer' . $parameterSuffix, CarbonImmutable::now()->subDays($days)->startOfDay());
     $queryBuilder->groupBy("$subscribersTable.id");
@@ -50,13 +50,13 @@ class EmailOpensAbsoluteCountAction implements Filter {
       $queryBuilder->having("count(opens.id) > :opens" . $parameterSuffix);
     }
     $queryBuilder->setParameter('opens' . $parameterSuffix, $filterData->getParam('opens'));
+
     if ($action === EmailOpensAbsoluteCountAction::TYPE) {
-      $queryBuilder->andWhere('opens.user_agent_type = :userAgentType')
-        ->setParameter('userAgentType', UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+      $queryBuilder->setParameter('userAgentType' . $parameterSuffix, UserAgentEntity::USER_AGENT_TYPE_HUMAN);
     } else {
-      $queryBuilder->andWhere('opens.user_agent_type = :userAgentType')
-        ->setParameter('userAgentType', UserAgentEntity::USER_AGENT_TYPE_MACHINE);
+      $queryBuilder->setParameter('userAgentType' . $parameterSuffix, UserAgentEntity::USER_AGENT_TYPE_MACHINE);
     }
+
     return $queryBuilder;
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -107,7 +107,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   public function testGetOpenedLess(): void {
     $segmentFilterData = $this->getSegmentFilterData(3, 'less', 3);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
-    $this->assertEqualsCanonicalizing(['opened-less-opens@example.com', 'opened-old-opens@example.com'], $emails);
+    $this->assertEqualsCanonicalizing(['opened-less-opens@example.com', 'opened-no-opens@example.com', 'opened-old-opens@example.com'], $emails);
   }
 
   public function testGetOpenedEquals(): void {
@@ -119,7 +119,19 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   public function testGetOpenedNotEquals(): void {
     $segmentFilterData = $this->getSegmentFilterData(2, 'not_equals', 3);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
-    $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com', 'opened-old-opens@example.com'], $emails);
+    $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com', 'opened-no-opens@example.com', 'opened-old-opens@example.com'], $emails);
+  }
+
+  public function testGetOpenedEqualsZero(): void {
+    $segmentFilterData = $this->getSegmentFilterData(0, 'equals', 2);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-old-opens@example.com', 'opened-no-opens@example.com'], $emails);
+  }
+
+  public function testGetOpenedLessThanOne(): void {
+    $segmentFilterData = $this->getSegmentFilterData(1, 'less', 2);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing(['opened-old-opens@example.com', 'opened-no-opens@example.com'], $emails);
   }
 
   private function getSegmentFilterData(int $opens, string $operator, int $days, string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {


### PR DESCRIPTION
## Description

This PR fixes a bug in the query that is used to get the subscribers that opened emails that was preventing it from working when trying to get subscribers that opened zero emails.

The problem was that we were adding the user_agent_type	as a condition on the WHERE part of the clause. Meaning that it was being used to filter the overall results and thus excluding all subscribers that had no entries in the wp_mailpoet_statistics_opens table. By moving this condition to the ON clause in the LEFT JOIN, we use the user_agent_type field to match rows between tables. The value of this field will still be taken into consideration when counting the number of opens as we are counting the number of entries in the wp_mailpoet_statistics_opens table.

## Code review notes

_N/A_

## QA notes

In a MailPoet install with a few emails sent and a few emails opened by different subscribers, create a "number of opens" segment and make sure that the number of matched subscribers is equal to what is expected. Especially when setting the segment criteria to match zero opens or less than one open.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5347]

## After-merge notes

_N/A_


[MAILPOET-5347]: https://mailpoet.atlassian.net/browse/MAILPOET-5347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ