### PR TITLE
Fix testItDisplaysAnUncheckedCheckboxIfCurrentUserIsSubscribed() test [MAILPOET-5368]

### DIFF
--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -78,7 +78,7 @@ class SubscriptionTest extends \MailPoetTest {
     $subscriber = $this->subscribersRepository->getCurrentWPUser();
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $this->subscribeToSegment($subscriber, $this->wcSegment);
-    expect($this->getRenderedOptinField())->isEmpty();
+    expect($this->getRenderedOptinField())->stringNotContainsString('checked');
   }
 
   public function testItDisplaysAnUncheckedCheckboxIfCurrentUserIsNotSubscribed() {


### PR DESCRIPTION
## Description

Two different PRs changed the behavior of the checkbox that is tested in the failing test: https://github.com/mailpoet/mailpoet/pull/4921 and https://github.com/mailpoet/mailpoet/pull/4924.

The first PR changed the behavior of the checkbox and thus updated the testItDisplaysAnUncheckedCheckboxIfCurrentUserIsSubscribed(). This test class was mocking the method Helper::woocommerceFormField() and that is why the affected test expected the rendered opt-in checkbox field to be empty.

But https://github.com/mailpoet/mailpoet/pull/4924 changed how the checkbox is generated, stopped using woocommerceFormField(), and removed the mock
(https://github.com/mailpoet/mailpoet/pull/4924/files#diff-6b8e70b6fb9886a41b8ca1040c4e455184f6d2436458d4579b5f8e5eeb9e666fL52). That is what made the test start failing. Now that the mock is not used anymore, we should check for the actual string instead of empty.

## Code review notes

_N/A_

## QA notes

QA is probably not needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5368]

## After-merge notes

_N/A_


[MAILPOET-5368]: https://mailpoet.atlassian.net/browse/MAILPOET-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ