### PR TITLE
Fix alignment of buttons in error notices displayed on WPCOM [MAILPOET-5367]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_notice.scss
+++ b/mailpoet/assets/css/src/components-plugin/_notice.scss
@@ -3,6 +3,10 @@
   position: relative;
 
   p:empty { display: none; }
+
+  .button {
+    overflow: initial;
+  }
 }
 
 .mailpoet_notice_server {

--- a/mailpoet/assets/js/src/notices/notice.tsx
+++ b/mailpoet/assets/js/src/notices/notice.tsx
@@ -63,7 +63,7 @@ function Notice({
   const content = (
     <div
       ref={elementRef}
-      className={`notice inline ${type} notice-${type} ${
+      className={`mailpoet_notice notice inline ${type} notice-${type} ${
         closable ? 'is-dismissible' : ''
       }`}
     >


### PR DESCRIPTION
## Description

When testing subscribers limit notifications. I noticed that on the WPCOM site, the buttons in the notice were not aligned correctly. I found that this was caused by CSS that was added to .button on the WPCOM site.

This PR adds a CSS rule to make sure the buttons in mailpoet notices are displayed correctly.

![Screenshot 2023-06-01 at 10 41 23](https://github.com/mailpoet/mailpoet/assets/1082140/86d1996e-a963-4206-b539-ccb2e787f8b5)

After fixing

![Screenshot 2023-06-02 at 11 00 10](https://github.com/mailpoet/mailpoet/assets/1082140/b2640c17-0b0f-4382-b276-56080cafe8b7)


## Code review notes

_N/A_

## QA notes

You can upload the zip on the WPCOM test site import subscribers to trigger the error. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5367]

## After-merge notes

_N/A_


[MAILPOET-5367]: https://mailpoet.atlassian.net/browse/MAILPOET-5367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ