### PR TITLE
Fix k6 test by updating the text to items

### DIFF
--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -69,7 +69,7 @@ export async function subscribersTrashingRestoring() {
   describe(subscribersPageTitle, () => {
     describe('should be able to see the message', () => {
       expect(page.locator('.colspanchange').innerText()).to.contain(
-        'No emails found.',
+        'No items found.',
       );
     });
   });


### PR DESCRIPTION
## Description

Fixed issue in k6 test where it searched for `emails` instead `items`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5370]

## After-merge notes

_N/A_


[MAILPOET-5370]: https://mailpoet.atlassian.net/browse/MAILPOET-5370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ