### PR TITLE
Update WordPress.org plugin name and add contributors [MAILPOET-5371]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,4 +1,4 @@
-=== MailPoet - emails and newsletters in WordPress ===
+=== MailPoet - newsletters, email marketing and automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 6.0

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,5 +1,5 @@
 === MailPoet - emails and newsletters in WordPress ===
-Contributors: mailpoet
+Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 6.0
 Tested up to: 6.2


### PR DESCRIPTION
## Description

Updated plugin's `readme.txt` to add WooCommerce and Automattic as contributors and include relevant features in the plugin name.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5371]

## After-merge notes

_N/A_


[MAILPOET-5371]: https://mailpoet.atlassian.net/browse/MAILPOET-5371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ