### PR TITLE
Add new "used shipping method" segment [MAILPOET-4992]

### DIFF
--- a/mailpoet/assets/css/src/generic/_forms-select.scss
+++ b/mailpoet/assets/css/src/generic/_forms-select.scss
@@ -137,6 +137,7 @@
 .mailpoet-form-react-select-option {
   align-items: center;
   display: flex;
+  overflow: auto;
 }
 
 .mailpoet-form-react-select-tag {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
@@ -27,7 +27,9 @@ export function validateUsedShippingMethod(
   return !usedShippingMethodIsInvalid;
 }
 
-export function UsedShippingMethodFields({ filterIndex }: FilterProps): JSX.Element {
+export function UsedShippingMethodFields({
+  filterIndex,
+}: FilterProps): JSX.Element {
   const segment: WooCommerceFormItem = useSelect(
     (select) => select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
@@ -41,7 +41,7 @@ export function UsedShippingMethodFields({
     [],
   );
   const shippingMethodOptions = shippingMethods.map((method) => ({
-    value: method.id,
+    value: method.instanceId,
     label: method.name,
   }));
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
@@ -39,7 +39,7 @@ export function UsedShippingMethodFields({ filterIndex }: FilterProps): JSX.Elem
     [],
   );
   const shippingMethodOptions = shippingMethods.map((method) => ({
-    value: method.name,
+    value: method.id,
     label: method.name,
   }));
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
@@ -1,0 +1,117 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { Grid } from 'common/grid';
+import { Input, Select } from 'common';
+import { MailPoet } from 'mailpoet';
+import { ReactSelect } from 'common/form/react_select/react_select';
+import { filter } from 'lodash/fp';
+import {
+  WooCommerceFormItem,
+  FilterProps,
+  WooShippingMethod,
+  AnyValueTypes,
+  SelectOption,
+} from '../../../types';
+import { storeName } from '../../../store';
+
+export function validateUsedShippingMethod(
+  formItems: WooCommerceFormItem,
+): boolean {
+  const usedShippingMethodIsInvalid =
+    !formItems.shipping_methods ||
+    formItems.shipping_methods.length < 1 ||
+    !formItems.operator ||
+    !formItems.used_shipping_method_days ||
+    parseInt(formItems.used_shipping_method_days, 10) < 1;
+
+  return !usedShippingMethodIsInvalid;
+}
+
+export function UsedShippingMethodFields({ filterIndex }: FilterProps): JSX.Element {
+  const segment: WooCommerceFormItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const { updateSegmentFilter, updateSegmentFilterFromEvent } =
+    useDispatch(storeName);
+  const shippingMethods: WooShippingMethod[] = useSelect(
+    (select) => select(storeName).getShippingMethods(),
+    [],
+  );
+  const shippingMethodOptions = shippingMethods.map((method) => ({
+    value: method.name,
+    label: method.name,
+  }));
+
+  useEffect(() => {
+    if (
+      segment.operator !== AnyValueTypes.ANY &&
+      segment.operator !== AnyValueTypes.ALL &&
+      segment.operator !== AnyValueTypes.NONE
+    ) {
+      void updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
+
+  return (
+    <>
+      <Grid.CenteredRow>
+        <Select
+          isMaxContentWidth
+          key="select-operator-used-shipping-methods"
+          value={segment.operator}
+          onChange={(e): void => {
+            void updateSegmentFilter({ operator: e.target.value }, filterIndex);
+          }}
+          automationId="select-operator-used-shipping-methods"
+        >
+          <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+          <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+          <option value={AnyValueTypes.NONE}>
+            {MailPoet.I18n.t('noneOf')}
+          </option>
+        </Select>
+        <ReactSelect
+          key="select-shipping-methods"
+          isFullWidth
+          isMulti
+          placeholder={MailPoet.I18n.t('selectWooShippingMethods')}
+          options={shippingMethodOptions}
+          value={filter((option) => {
+            if (!segment.shipping_methods) return undefined;
+            return segment.shipping_methods.indexOf(option.value) !== -1;
+          }, shippingMethodOptions)}
+          onChange={(options: SelectOption[]): void => {
+            void updateSegmentFilter(
+              {
+                shipping_methods: (options || []).map(
+                  (x: SelectOption) => x.value,
+                ),
+              },
+              filterIndex,
+            );
+          }}
+          automationId="select-shipping-methods"
+        />
+      </Grid.CenteredRow>
+      <Grid.CenteredRow>
+        <div>{MailPoet.I18n.t('inTheLast')}</div>
+        <Input
+          data-automation-id="input-used-shipping-days"
+          type="number"
+          min={1}
+          value={segment.used_shipping_method_days || ''}
+          placeholder={MailPoet.I18n.t('daysPlaceholder')}
+          onChange={(e): void => {
+            void updateSegmentFilterFromEvent(
+              'used_shipping_method_days',
+              filterIndex,
+              e,
+            );
+          }}
+        />
+        <div>{MailPoet.I18n.t('days')}</div>
+      </Grid.CenteredRow>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -35,6 +35,10 @@ import {
   UsedPaymentMethodFields,
   validateUsedPaymentMethod,
 } from './fields/woocommerce/used_payment_method';
+import {
+  UsedShippingMethodFields,
+  validateUsedShippingMethod,
+} from './fields/woocommerce/used_shipping_method';
 import { TextField, validateTextField } from './fields/text_field';
 
 export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
@@ -67,6 +71,9 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (formItems.action === WooCommerceActionTypes.USED_PAYMENT_METHOD) {
     return validateUsedPaymentMethod(formItems);
   }
+  if (formItems.action === WooCommerceActionTypes.USED_SHIPPING_METHOD) {
+    return validateUsedShippingMethod(formItems);
+  }
   if (formItems.action === WooCommerceActionTypes.PURCHASE_DATE) {
     return validateDateField(formItems);
   }
@@ -93,6 +100,7 @@ const componentsMap = {
   [WooCommerceActionTypes.TOTAL_SPENT]: TotalSpentFields,
   [WooCommerceActionTypes.AVERAGE_SPENT]: AverageSpentFields,
   [WooCommerceActionTypes.USED_PAYMENT_METHOD]: UsedPaymentMethodFields,
+  [WooCommerceActionTypes.USED_SHIPPING_METHOD]: UsedShippingMethodFields,
 };
 
 export function WooCommerceFields({ filterIndex }: FilterProps): JSX.Element {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
@@ -14,6 +14,7 @@ export enum WooCommerceActionTypes {
   CUSTOMER_IN_POSTAL_CODE = 'customerInPostalCode',
   SINGLE_ORDER_VALUE = 'singleOrderValue',
   USED_PAYMENT_METHOD = 'usedPaymentMethod',
+  USED_SHIPPING_METHOD = 'usedShippingMethod',
 }
 
 export const WooCommerceOptions = [
@@ -70,6 +71,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.USED_PAYMENT_METHOD,
     label: MailPoet.I18n.t('wooUsedPaymentMethod'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.USED_SHIPPING_METHOD,
+    label: MailPoet.I18n.t('wooUsedShippingMethod'),
     group: SegmentTypes.WooCommerce,
   },
 ];

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial_state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial_state.ts
@@ -22,6 +22,7 @@ export const getInitialState = (): StateType => ({
   wooCurrencySymbol: window.mailpoet_woocommerce_currency_symbol,
   wooCountries: window.mailpoet_woocommerce_countries,
   wooPaymentMethods: window.mailpoet_woocommerce_payment_methods,
+  wooShippingMethods: window.mailpoet_woocommerce_shipping_methods,
   customFieldsList: window.mailpoet_custom_fields,
   tags: window.mailpoet_tags,
   signupForms: window.mailpoet_signup_forms,

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -18,6 +18,7 @@ import {
   WindowSubscriptionProducts,
   WindowWooCommerceCountries,
   WooPaymentMethod,
+  WooShippingMethod,
 } from '../types';
 
 export const getProducts = (state: StateType): WindowProducts => state.products;
@@ -52,6 +53,8 @@ export const getSignupForms = (state: StateType): SignupForm[] =>
   state.signupForms;
 export const getPaymentMethods = (state: StateType): WooPaymentMethod[] =>
   state.wooPaymentMethods;
+export const getShippingMethods = (state: StateType): WooShippingMethod[] =>
+  state.wooShippingMethods;
 export const getSegmentFilter = (
   state: StateType,
   index: number,

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -304,5 +304,6 @@ export type WooPaymentMethod = {
 };
 
 export type WooShippingMethod = {
+  id: string;
   name: string;
 };

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -304,6 +304,6 @@ export type WooPaymentMethod = {
 };
 
 export type WooShippingMethod = {
-  id: string;
+  instanceId: string;
   name: string;
 };

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -107,6 +107,8 @@ export interface WooCommerceFormItem extends FormItem {
   average_spent_days?: string;
   payment_methods?: string[];
   used_payment_method_days?: string;
+  shipping_methods?: string[];
+  used_shipping_method_days?: string;
 }
 
 export interface WooCommerceMembershipFormItem extends FormItem {
@@ -212,6 +214,7 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_product_categories: WindowProductCategories;
   mailpoet_woocommerce_countries: WindowWooCommerceCountries;
   mailpoet_woocommerce_payment_methods: WooPaymentMethod[];
+  mailpoet_woocommerce_shipping_methods: WooShippingMethod[];
   mailpoet_newsletters_list: WindowNewslettersList;
   mailpoet_custom_fields: WindowCustomFields;
   mailpoet_can_use_woocommerce_memberships: boolean;
@@ -234,6 +237,7 @@ export interface StateType {
   wooCurrencySymbol: string;
   wooCountries: WindowWooCommerceCountries;
   wooPaymentMethods: WooPaymentMethod[];
+  wooShippingMethods: WooShippingMethod[];
   customFieldsList: WindowCustomFields;
   segment: Segment;
   subscriberCount: SubscriberCount;
@@ -296,5 +300,9 @@ export type SignupForm = {
 
 export type WooPaymentMethod = {
   id: string;
+  name: string;
+};
+
+export type WooShippingMethod = {
   name: string;
 };

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -151,13 +151,7 @@ class Segments {
       }
       $data['woocommerce_payment_methods'] = $paymentMethods;
 
-      $shippingMethods = [];
-      foreach ($this->woocommerceHelper->getShippingMethods() as $shippingMethod) {
-        $shippingMethods[] = [
-          'name' => $shippingMethod->get_method_title(),
-        ];
-      }
-      $data['woocommerce_shipping_methods'] = $shippingMethods;
+      $data['woocommerce_shipping_methods'] = $this->woocommerceHelper->getShippingMethodInstancesData();
     }
 
     $this->pageRenderer->displayPage('segments.html', $data);

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -136,7 +136,10 @@ class Segments {
         'name' => $form->getName(),
       ];
     }, $this->formsRepository->findAll());
+
     $data['woocommerce_payment_methods'] = [];
+    $data['woocommerce_shipping_methods'] = [];
+
     if ($this->woocommerceHelper->isWooCommerceActive()) {
       $allGateways = $this->woocommerceHelper->getPaymentGateways()->payment_gateways();
       $paymentMethods = [];
@@ -147,7 +150,16 @@ class Segments {
         ];
       }
       $data['woocommerce_payment_methods'] = $paymentMethods;
+
+      $shippingMethods = [];
+      foreach ($this->woocommerceHelper->getShippingMethods() as $shippingMethod) {
+        $shippingMethods[] = [
+          'name' => $shippingMethod->get_method_title(),
+        ];
+      }
+      $data['woocommerce_shipping_methods'] = $shippingMethods;
     }
+
     $this->pageRenderer->displayPage('segments.html', $data);
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -446,6 +446,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooFilterHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\SegmentSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterDataMapper::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -27,6 +27,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
 use MailPoet\WP\Functions as WPFunctions;
 
 class FilterDataMapper {
@@ -374,6 +375,19 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['payment_methods'] = $data['payment_methods'];
       $filterData['used_payment_method_days'] = intval($data['used_payment_method_days']);
+    } elseif ($data['action'] === WooCommerceUsedShippingMethod::ACTION) {
+      if (!isset($data['operator']) || !in_array($data['operator'], WooCommerceUsedShippingMethod::VALID_OPERATORS, true)) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
+      if (!isset($data['shipping_methods']) || !is_array($data['shipping_methods']) || empty($data['shipping_methods'])) {
+        throw new InvalidFilterException('Missing shipping methods', InvalidFilterException::MISSING_VALUE);
+      }
+      if (!isset($data['used_shipping_method_days']) || intval($data['used_shipping_method_days']) < 1) {
+        throw new InvalidFilterException('Missing days', InvalidFilterException::MISSING_VALUE);
+      }
+      $filterData['operator'] = $data['operator'];
+      $filterData['shipping_methods'] = $data['shipping_methods'];
+      $filterData['used_shipping_method_days'] = intval($data['used_shipping_method_days']);
     } elseif (in_array($data['action'], WooCommerceCustomerTextField::ACTIONS)) {
       if (empty($data['value'])) {
         throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -29,6 +29,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
 
 class FilterFactory {
   /** @var EmailAction */
@@ -97,6 +98,9 @@ class FilterFactory {
   /** @var WooCommerceUsedPaymentMethod */
   private $wooCommerceUsedPaymentMethod;
 
+  /** @var WooCommerceUsedShippingMethod */
+  private $wooCommerceUsedShippingMethod;
+
   /** @var WooCommerceCustomerTextField */
   private $wooCommerceCustomerTextField;
 
@@ -123,6 +127,7 @@ class FilterFactory {
     WooCommerceSingleOrderValue $wooCommerceSingleOrderValue,
     WooCommerceAverageSpent $wooCommerceAverageSpent,
     WooCommerceUsedPaymentMethod $wooCommerceUsedPaymentMethod,
+    WooCommerceUsedShippingMethod $wooCommerceUsedShippingMethod,
     SubscriberTextField $subscriberTextField
   ) {
     $this->emailAction = $emailAction;
@@ -147,6 +152,7 @@ class FilterFactory {
     $this->subscribedViaForm = $subscribedViaForm;
     $this->wooCommerceAverageSpent = $wooCommerceAverageSpent;
     $this->wooCommerceUsedPaymentMethod = $wooCommerceUsedPaymentMethod;
+    $this->wooCommerceUsedShippingMethod = $wooCommerceUsedShippingMethod;
     $this->wooCommerceCustomerTextField = $wooCommerceCustomerTextField;
   }
 
@@ -237,6 +243,8 @@ class FilterFactory {
       return $this->wooCommerceAverageSpent;
     } elseif ($action === WooCommerceUsedPaymentMethod::ACTION) {
       return $this->wooCommerceUsedPaymentMethod;
+    } elseif ($action === WooCommerceUsedShippingMethod::ACTION) {
+      return $this->wooCommerceUsedShippingMethod;
     } elseif (in_array($action, WooCommerceCustomerTextField::ACTIONS)) {
       return $this->wooCommerceCustomerTextField;
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\WooCommerce\Helper;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooCommerceUsedShippingMethod implements Filter {
+  const ACTION = 'usedShippingMethod';
+
+  const VALID_OPERATORS = [
+    DynamicSegmentFilterData::OPERATOR_NONE,
+    DynamicSegmentFilterData::OPERATOR_ANY,
+    DynamicSegmentFilterData::OPERATOR_ALL,
+  ];
+
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
+  /** @var Helper */
+  private $wooHelper;
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  public function __construct(
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper,
+    Helper $wooHelper
+  ) {
+    $this->wooFilterHelper = $wooFilterHelper;
+    $this->wooHelper = $wooHelper;
+    $this->filterHelper = $filterHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $operator = $filterData->getParam('operator');
+    $shippingMethods = $filterData->getParam('shipping_methods');
+    $days = $filterData->getParam('used_shipping_method_days');
+
+    if (!is_string($operator) || !in_array($operator, self::VALID_OPERATORS, true)) {
+      throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
+    }
+
+    if (!is_array($shippingMethods) || count($shippingMethods) < 1) {
+      throw new InvalidFilterException('Missing payment methods', InvalidFilterException::MISSING_VALUE);
+    }
+
+    if (!is_int($days) || $days < 1) {
+      throw new InvalidFilterException('Missing days', InvalidFilterException::MISSING_VALUE);
+    }
+
+    $includedStatuses = array_keys($this->wooHelper->getOrderStatuses());
+    $failedKey = array_search('wc-failed', $includedStatuses, true);
+    if ($failedKey !== false) {
+      unset($includedStatuses[$failedKey]);
+    }
+    $date = Carbon::now()->subDays($days);
+
+    switch ($operator) {
+      case DynamicSegmentFilterData::OPERATOR_ANY:
+        $this->applyForAnyOperator($queryBuilder, $includedStatuses, $shippingMethods, $date);
+        break;
+      case DynamicSegmentFilterData::OPERATOR_ALL:
+        $this->applyForAllOperator($queryBuilder, $includedStatuses, $shippingMethods, $date);
+        break;
+      case DynamicSegmentFilterData::OPERATOR_NONE:
+        $this->applyForNoneOperator($queryBuilder, $includedStatuses, $shippingMethods, $date);
+        break;
+    }
+
+    return $queryBuilder;
+  }
+
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethods, Carbon $date): void {
+    $dateParam = $this->filterHelper->getUniqueParameterName('date');
+    $shippingMethodParam = $this->filterHelper->getUniqueParameterName('shippingMethod');
+
+    $orderItemsTable = $this->filterHelper->getPrefixedTable('woocommerce_order_items');
+    $orderItemsTableAlias = 'orderItems';
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+    $queryBuilder
+      ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsTableAlias, "$orderStatsAlias.order_id = $orderItemsTableAlias.order_id")
+      ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
+      ->andWhere("$orderItemsTableAlias.order_item_name IN (:$shippingMethodParam)")
+      ->andWhere("$orderItemsTableAlias.order_item_type = 'shipping'")
+      ->setParameter($dateParam, $date->toDateTimeString())
+      ->setParameter($shippingMethodParam, $shippingMethods, Connection::PARAM_STR_ARRAY);
+  }
+
+  private function applyForAllOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethods, Carbon $date): void {
+    $dateParam = $this->filterHelper->getUniqueParameterName('date');
+    $orderItemTypeParam = $this->filterHelper->getUniqueParameterName('orderItemType');
+    $shippingMethodsParam = $this->filterHelper->getUniqueParameterName('shippingMethod');
+
+    $orderItemsTable = $this->filterHelper->getPrefixedTable('woocommerce_order_items');
+    $orderItemsAlias = 'orderItems';
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+    $queryBuilder
+      ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsAlias, "$orderStatsAlias.order_id = $orderItemsAlias.order_id")
+      ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
+      ->andWhere("$orderItemsAlias.order_item_type = :$orderItemTypeParam")
+      ->andWhere("$orderItemsAlias.order_item_name IN (:$shippingMethodsParam)")
+      ->setParameter($dateParam, $date->toDateTimeString())
+      ->setParameter($orderItemTypeParam, 'shipping')
+      ->setParameter($shippingMethodsParam, $shippingMethods, Connection::PARAM_STR_ARRAY)
+      ->groupBy('inner_subscriber_id')->having("COUNT(DISTINCT $orderItemsAlias.order_item_name) = " . count($shippingMethods));
+  }
+
+  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethods, Carbon $date): void {
+    $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+    $this->applyForAnyOperator($subQuery, $includedStatuses, $shippingMethods, $date);
+    $subscribersTable = $this->filterHelper->getSubscribersTable();
+    $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -41,14 +41,15 @@ class WooCommerceUsedShippingMethod implements Filter {
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('operator');
-    $shippingMethods = $filterData->getParam('shipping_methods');
+    list($shippingMethodIds, $instanceIds) = $this->extractShippingMethodIdsAndInstanceIds((array)$filterData->getParam('shipping_methods'));
+
     $days = $filterData->getParam('used_shipping_method_days');
 
     if (!is_string($operator) || !in_array($operator, self::VALID_OPERATORS, true)) {
       throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
     }
 
-    if (!is_array($shippingMethods) || count($shippingMethods) < 1) {
+    if (!is_array($shippingMethodIds) || empty($shippingMethodIds) || !is_array($instanceIds) || empty($instanceIds)) {
       throw new InvalidFilterException('Missing shipping methods', InvalidFilterException::MISSING_VALUE);
     }
 
@@ -65,58 +66,106 @@ class WooCommerceUsedShippingMethod implements Filter {
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:
-        $this->applyForAnyOperator($queryBuilder, $includedStatuses, $shippingMethods, $date);
+        $this->applyForAnyOperator($queryBuilder, $includedStatuses, $shippingMethodIds, $instanceIds, $date);
         break;
       case DynamicSegmentFilterData::OPERATOR_ALL:
-        $this->applyForAllOperator($queryBuilder, $includedStatuses, $shippingMethods, $date);
+        $this->applyForAllOperator($queryBuilder, $includedStatuses, $shippingMethodIds, $instanceIds, $date);
         break;
       case DynamicSegmentFilterData::OPERATOR_NONE:
-        $this->applyForNoneOperator($queryBuilder, $includedStatuses, $shippingMethods, $date);
+        $this->applyForNoneOperator($queryBuilder, $includedStatuses, $shippingMethodIds, $instanceIds, $date);
         break;
     }
 
     return $queryBuilder;
   }
 
-  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethods, Carbon $date): void {
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodIds, array $instanceIds, Carbon $date): void {
     $dateParam = $this->filterHelper->getUniqueParameterName('date');
-    $shippingMethodParam = $this->filterHelper->getUniqueParameterName('shippingMethod');
+    $shippingMethodsParam = $this->filterHelper->getUniqueParameterName('shippingMethods');
+    $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 
     $orderItemsTable = $this->filterHelper->getPrefixedTable('woocommerce_order_items');
     $orderItemsTableAlias = 'orderItems';
+    $orderItemMetaTable = $this->filterHelper->getPrefixedTable('woocommerce_order_itemmeta');
+    $orderItemMetaTableAlias1 = 'orderItemMeta1';
+    $orderItemMetaTableAlias2 = 'orderItemMeta2';
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
     $queryBuilder
       ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsTableAlias, "$orderStatsAlias.order_id = $orderItemsTableAlias.order_id")
+      ->innerJoin($orderItemsTableAlias, $orderItemMetaTable, $orderItemMetaTableAlias1, "$orderItemsTableAlias.order_item_id = $orderItemMetaTableAlias1.order_item_id")
+      ->innerJoin($orderItemsTableAlias, $orderItemMetaTable, $orderItemMetaTableAlias2, "$orderItemsTableAlias.order_item_id = $orderItemMetaTableAlias2.order_item_id")
       ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-      ->andWhere("$orderItemsTableAlias.order_item_name IN (:$shippingMethodParam)")
       ->andWhere("$orderItemsTableAlias.order_item_type = 'shipping'")
+      ->andWhere("$orderItemMetaTableAlias1.meta_key = 'method_id'")
+      ->andWhere("$orderItemMetaTableAlias1.meta_value IN (:$shippingMethodsParam)")
+      ->andWhere("$orderItemMetaTableAlias2.meta_key = 'instance_id'")
+      ->andWhere("$orderItemMetaTableAlias2.meta_value IN (:$instanceIdsParam)")
       ->setParameter($dateParam, $date->toDateTimeString())
-      ->setParameter($shippingMethodParam, $shippingMethods, Connection::PARAM_STR_ARRAY);
+      ->setParameter($shippingMethodsParam, $shippingMethodIds, Connection::PARAM_STR_ARRAY)
+      ->setParameter($instanceIdsParam, $instanceIds, Connection::PARAM_STR_ARRAY);
   }
 
-  private function applyForAllOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethods, Carbon $date): void {
+  private function applyForAllOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodIds, array $instanceIds, Carbon $date): void {
     $dateParam = $this->filterHelper->getUniqueParameterName('date');
     $orderItemTypeParam = $this->filterHelper->getUniqueParameterName('orderItemType');
-    $shippingMethodsParam = $this->filterHelper->getUniqueParameterName('shippingMethod');
+    $shippingMethodsParam = $this->filterHelper->getUniqueParameterName('shippingMethods');
+    $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 
     $orderItemsTable = $this->filterHelper->getPrefixedTable('woocommerce_order_items');
-    $orderItemsAlias = 'orderItems';
+    $orderItemsTableAlias = 'orderItems';
+    $orderItemMetaTable = $this->filterHelper->getPrefixedTable('woocommerce_order_itemmeta');
+    $orderItemMetaTableAlias1 = 'orderItemMeta1';
+    $orderItemMetaTableAlias2 = 'orderItemMeta2';
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+
     $queryBuilder
-      ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsAlias, "$orderStatsAlias.order_id = $orderItemsAlias.order_id")
+      ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsTableAlias, "$orderStatsAlias.order_id = $orderItemsTableAlias.order_id")
+      ->innerJoin($orderItemsTableAlias, $orderItemMetaTable, $orderItemMetaTableAlias1, "$orderItemsTableAlias.order_item_id = $orderItemMetaTableAlias1.order_item_id")
+      ->innerJoin($orderItemsTableAlias, $orderItemMetaTable, $orderItemMetaTableAlias2, "$orderItemsTableAlias.order_item_id = $orderItemMetaTableAlias2.order_item_id")
       ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-      ->andWhere("$orderItemsAlias.order_item_type = :$orderItemTypeParam")
-      ->andWhere("$orderItemsAlias.order_item_name IN (:$shippingMethodsParam)")
+      ->andWhere("$orderItemsTableAlias.order_item_type = :$orderItemTypeParam")
+      ->andWhere("$orderItemMetaTableAlias1.meta_key = 'method_id'")
+      ->andWhere("$orderItemMetaTableAlias1.meta_value IN (:$shippingMethodsParam)")
+      ->andWhere("$orderItemMetaTableAlias2.meta_key = 'instance_id'")
+      ->andWhere("$orderItemMetaTableAlias2.meta_value IN (:$instanceIdsParam)")
       ->setParameter($dateParam, $date->toDateTimeString())
       ->setParameter($orderItemTypeParam, 'shipping')
-      ->setParameter($shippingMethodsParam, $shippingMethods, Connection::PARAM_STR_ARRAY)
-      ->groupBy('inner_subscriber_id')->having("COUNT(DISTINCT $orderItemsAlias.order_item_name) = " . count($shippingMethods));
+      ->setParameter($shippingMethodsParam, $shippingMethodIds, Connection::PARAM_STR_ARRAY)
+      ->setParameter($instanceIdsParam, $instanceIds, Connection::PARAM_STR_ARRAY)
+      ->groupBy('inner_subscriber_id')
+      ->having("COUNT(DISTINCT(CONCAT($orderItemMetaTableAlias1.meta_value, $orderItemMetaTableAlias2.meta_value))) = " . count($shippingMethodIds));
   }
 
-  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethods, Carbon $date): void {
+  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodIds, array $instanceIds, Carbon $date): void {
     $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-    $this->applyForAnyOperator($subQuery, $includedStatuses, $shippingMethods, $date);
+    $this->applyForAnyOperator($subQuery, $includedStatuses, $shippingMethodIds, $instanceIds, $date);
     $subscribersTable = $this->filterHelper->getSubscribersTable();
     $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
+  }
+
+  /**
+   * Extracts shipping method ids and instance ids from the given array of strings.
+   * The format of each shipping method string is "shippingMethod:instanceId". For example,
+   * "flat_rate:1" or "local_pickup:2".
+   *
+   * @param array $shippingMethodStrings
+   * @return array[]
+   */
+  private function extractShippingMethodIdsAndInstanceIds(array $shippingMethodStrings): array {
+    $shippingMethodIds = [];
+    $instanceIds = [];
+
+    foreach ($shippingMethodStrings as $shippingMethodString) {
+      if (preg_match('/^\w+:\d+$/', $shippingMethodString)) {
+        $parts = preg_split('/:/', $shippingMethodString);
+
+        if (is_array($parts) && is_string($parts[0]) && is_string($parts[1])) {
+          $shippingMethodIds[] = $parts[0];
+          $instanceIds[] = $parts[1];
+        }
+      }
+    }
+
+    return [$shippingMethodIds, $instanceIds];
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -49,7 +49,7 @@ class WooCommerceUsedShippingMethod implements Filter {
     }
 
     if (!is_array($shippingMethods) || count($shippingMethods) < 1) {
-      throw new InvalidFilterException('Missing payment methods', InvalidFilterException::MISSING_VALUE);
+      throw new InvalidFilterException('Missing shipping methods', InvalidFilterException::MISSING_VALUE);
     }
 
     if (!is_int($days) || $days < 1) {

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -245,6 +245,13 @@ class Helper {
   }
 
   /**
+   * @return \WC_Shipping_Method[]
+   */
+  public function getShippingMethods(): array {
+    return $this->WC()->shipping()->get_shipping_methods();
+  }
+
+  /**
    * Check whether the current request is processing a WooCommerce checkout.
    * Works for both the normal checkout and the block checkout.
    *

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -274,7 +274,7 @@ class Helper {
 
     foreach ($shippingMethods as $shippingMethod) {
       $formattedShippingMethods[] = [
-        'id' => "{$shippingMethod->id}:{$shippingMethod->instance_id}", // combines the method id with the instance id - phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        'instanceId' => $shippingMethod->instance_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         'name' => "{$shippingMethod->title} ({$shippingZoneName})",
       ];
     }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -245,10 +245,41 @@ class Helper {
   }
 
   /**
-   * @return \WC_Shipping_Method[]
+   * Returns a list of all available shipping methods formatted
+   * in a way to be used in the 'used shipping method' segment.
    */
-  public function getShippingMethods(): array {
-    return $this->WC()->shipping()->get_shipping_methods();
+  public function getShippingMethodInstancesData(): array {
+    $shippingZones = \WC_Shipping_Zones::get_zones();
+    $formattedShippingMethodData = [];
+
+    foreach ($shippingZones as $shippingZone) {
+      $formattedShippingMethodData = array_merge(
+        $formattedShippingMethodData,
+        $this->formatShippingMethods($shippingZone['shipping_methods'], $shippingZone['zone_name'])
+      );
+    }
+
+    // special shipping zone that includes locations not covered by the configured shipping zones
+    $outOfCoverageShippingZone = new \WC_Shipping_Zone(0);
+    $formattedShippingMethodData = array_merge(
+      $formattedShippingMethodData,
+      $this->formatShippingMethods($outOfCoverageShippingZone->get_shipping_methods(), $outOfCoverageShippingZone->get_zone_name())
+    );
+
+    return $formattedShippingMethodData;
+  }
+
+  protected function formatShippingMethods(array $shippingMethods, string $shippingZoneName): array {
+    $formattedShippingMethods = [];
+
+    foreach ($shippingMethods as $shippingMethod) {
+      $formattedShippingMethods[] = [
+        'id' => "{$shippingMethod->id}:{$shippingMethod->instance_id}", // combines the method id with the instance id - phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        'name' => "{$shippingMethod->title} ({$shippingZoneName})",
+      ];
+    }
+
+    return $formattedShippingMethods;
   }
 
   /**

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * @group woo
+ */
+class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
+
+  /** @var WooCommerceUsedShippingMethod */
+  private $filter;
+
+  public function _before(): void {
+    $this->filter = $this->diContainer->get(WooCommerceUsedShippingMethod::class);
+  }
+
+  public function testItWorksWithAnyOperator(): void {
+    $customerId1 = $this->tester->createCustomer('c1@e.com');
+    $customerId2 = $this->tester->createCustomer('c2@e.com');
+    $customerId3 = $this->tester->createCustomer('c3@e.com');
+
+    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId2, Carbon::now(), 'Local pickup');
+    $this->createOrder($customerId3, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId3, Carbon::now(), 'Free shipping');
+
+    $this->assertFilterReturnsEmails('any', ['Flat rate'], 1, ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', ['Local pickup'], 1, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', ['Nonexistent method'], 1000, []);
+  }
+
+  public function testItWorksWithAllOperator(): void {
+    $customerId1 = $this->tester->createCustomer('c1@e.com');
+    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+
+    $customerId2 = $this->tester->createCustomer('c2@e.com');
+    $this->createOrder($customerId2, Carbon::now(), 'Free shipping');
+
+    $customerId3 = $this->tester->createCustomer('c3@e.com');
+    $this->createOrder($customerId3, Carbon::now(), 'Free shipping');
+    $this->createOrder($customerId3, Carbon::now(), 'Flat rate');
+
+    $this->assertfilterreturnsemails('all', ['Flat rate'], 1, ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['Free shipping'], 1, ['c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['Free shipping', 'Flat rate'], 1, ['c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['Nonexistent method', 'Flat rate'], 1000, []);
+  }
+
+  public function testItWorksWithNoneOperator(): void {
+    $customerId1 = $this->tester->createCustomer('c1@e.com');
+    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+
+    $customerId2 = $this->tester->createCustomer('c2@e.com');
+    $this->createOrder($customerId2, Carbon::now(), 'Free shipping');
+
+    $customerId3 = $this->tester->createCustomer('c3@e.com');
+    $this->createOrder($customerId3, Carbon::now(), 'Free shipping');
+    $this->createOrder($customerId3, Carbon::now(), 'Flat rate');
+
+    (new Subscriber)->withEmail('sub@e.com')->create();
+
+    $this->assertFilterReturnsEmails('none', ['Flat rate'], 1, ['sub@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['Free shipping'], 1, ['sub@e.com', 'c1@e.com']);
+    $this->assertFilterReturnsEmails('none', ['Nonexistent method'], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('none', ['Flat rate', 'Free shipping'], 1, ['sub@e.com']);
+  }
+
+  public function testItWorksWithDateRanges(): void {
+    $customerId1 = $this->tester->createCustomer('c1@e.com');
+    $this->createOrder($customerId1, Carbon::now()->subDays(2)->addMinute(), 'Flat rate');
+    $this->createOrder($customerId1, Carbon::now()->subDays(5)->addMinute(), 'Free shipping');
+
+    $customerId2 = $this->tester->createCustomer('c2@e.com');
+    $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'Local pickup');
+    $this->assertFilterReturnsEmails('any', ['Flat rate'], 1, []);
+    $this->assertFilterReturnsEmails('any', ['Flat rate'], 2, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', ['Free shipping'], 4, []);
+    $this->assertFilterReturnsEmails('any', ['Free shipping'], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', ['Local pickup'], 99, []);
+    $this->assertFilterReturnsEmails('any', ['Local pickup'], 100, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', ['Local pickup', 'Flat rate'], 100, ['c1@e.com', 'c2@e.com']);
+
+    $this->assertFilterReturnsEmails('all', ['Flat rate'], 1, []);
+    $this->assertFilterReturnsEmails('all', ['Flat rate'], 2, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', ['Flat rate', 'Free shipping'], 2, []);
+    $this->assertFilterReturnsEmails('all', ['Flat rate', 'Free shipping'], 5, ['c1@e.com']);
+
+    $this->assertFilterReturnsEmails('none', ['Flat rate'], 1, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['Flat rate'], 2, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['Free shipping'], 2, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['Free shipping'], 5, ['c2@e.com']);
+  }
+
+  private function assertFilterReturnsEmails(string $operator, array $shippingMethods, int $days, array $expectedEmails): void {
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
+      'operator' => $operator,
+      'shipping_methods' => $shippingMethods,
+      'used_shipping_method_days' => $days,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  private function createOrder(int $customerId, Carbon $createdAt, string $shippingMethodTitle): int {
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_date_created($createdAt->toDateTimeString());
+    $order->set_status('wc-completed');
+
+    $shippingItem = new \WC_Order_Item_Shipping();
+    $shippingItem->set_method_title($shippingMethodTitle);
+    $order->add_item($shippingItem);
+
+    $order->save();
+    $this->tester->updateWooOrderStats($order->get_id());
+
+    return $order->get_id();
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
@@ -23,99 +23,104 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $customerId1 = $this->tester->createCustomer('c1@e.com');
     $customerId2 = $this->tester->createCustomer('c2@e.com');
     $customerId3 = $this->tester->createCustomer('c3@e.com');
+    $customerId4 = $this->tester->createCustomer('c4@e.com');
 
-    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
-    $this->createOrder($customerId2, Carbon::now(), 'Local pickup');
-    $this->createOrder($customerId3, Carbon::now(), 'Flat rate');
-    $this->createOrder($customerId3, Carbon::now(), 'Free shipping');
+    $this->createOrder($customerId1, Carbon::now(), 'flat_rate', 1);
+    $this->createOrder($customerId2, Carbon::now(), 'local_pickup', 2);
+    $this->createOrder($customerId2, Carbon::now(), 'flat_rate', 4);
+    $this->createOrder($customerId3, Carbon::now(), 'flat_rate', 1);
+    $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 3);
+    $this->createOrder($customerId4, Carbon::now(), 'flat_rate', 4);
 
-    $this->assertFilterReturnsEmails('any', ['Flat rate'], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', ['Local pickup'], 1, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', ['Nonexistent method'], 1000, []);
+    $this->assertFilterReturnsEmails('any', ['flat_rate:1'], 1, ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', ['local_pickup:2'], 1, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', ['local_pickup:2', 'flat_rate:1'], 1, ['c1@e.com', 'c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', ['nonexistent_method:1'], 1000, []);
   }
 
   public function testItWorksWithAllOperator(): void {
     $customerId1 = $this->tester->createCustomer('c1@e.com');
-    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
-    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId1, Carbon::now(), 'flat_rate', 1);
+    $this->createOrder($customerId1, Carbon::now(), 'flat_rate', 1);
 
     $customerId2 = $this->tester->createCustomer('c2@e.com');
-    $this->createOrder($customerId2, Carbon::now(), 'Free shipping');
+    $this->createOrder($customerId2, Carbon::now(), 'free_shipping', 2);
 
     $customerId3 = $this->tester->createCustomer('c3@e.com');
-    $this->createOrder($customerId3, Carbon::now(), 'Free shipping');
-    $this->createOrder($customerId3, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 2);
+    $this->createOrder($customerId3, Carbon::now(), 'flat_rate', 1);
 
-    $this->assertfilterreturnsemails('all', ['Flat rate'], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['Free shipping'], 1, ['c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['Free shipping', 'Flat rate'], 1, ['c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['Nonexistent method', 'Flat rate'], 1000, []);
+    $this->assertfilterreturnsemails('all', ['flat_rate:1'], 1, ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['free_shipping:2'], 1, ['c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['free_shipping:2', 'flat_rate:1'], 1, ['c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['nonexistent_method:1', 'flat_rate:1'], 1000, []);
   }
 
   public function testItWorksWithNoneOperator(): void {
     $customerId1 = $this->tester->createCustomer('c1@e.com');
-    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
-    $this->createOrder($customerId1, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId1, Carbon::now(), 'flat_rate', 1);
+    $this->createOrder($customerId1, Carbon::now(), 'flat_rate', 1);
 
     $customerId2 = $this->tester->createCustomer('c2@e.com');
-    $this->createOrder($customerId2, Carbon::now(), 'Free shipping');
+    $this->createOrder($customerId2, Carbon::now(), 'free_shipping', 2);
 
     $customerId3 = $this->tester->createCustomer('c3@e.com');
-    $this->createOrder($customerId3, Carbon::now(), 'Free shipping');
-    $this->createOrder($customerId3, Carbon::now(), 'Flat rate');
+    $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 2);
+    $this->createOrder($customerId3, Carbon::now(), 'flat_rate', 1);
 
     (new Subscriber)->withEmail('sub@e.com')->create();
 
-    $this->assertFilterReturnsEmails('none', ['Flat rate'], 1, ['sub@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['Free shipping'], 1, ['sub@e.com', 'c1@e.com']);
-    $this->assertFilterReturnsEmails('none', ['Nonexistent method'], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('none', ['Flat rate', 'Free shipping'], 1, ['sub@e.com']);
+    $this->assertFilterReturnsEmails('none', ['flat_rate:1'], 1, ['sub@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['free_shipping:2'], 1, ['sub@e.com', 'c1@e.com']);
+    $this->assertFilterReturnsEmails('none', ['nonexistent_method:1'], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('none', ['flat_rate:1', 'free_shipping:2'], 1, ['sub@e.com']);
   }
 
   public function testItWorksWithDateRanges(): void {
     $customerId1 = $this->tester->createCustomer('c1@e.com');
-    $this->createOrder($customerId1, Carbon::now()->subDays(2)->addMinute(), 'Flat rate');
-    $this->createOrder($customerId1, Carbon::now()->subDays(5)->addMinute(), 'Free shipping');
+    $this->createOrder($customerId1, Carbon::now()->subDays(2)->addMinute(), 'flat_rate', 1);
+    $this->createOrder($customerId1, Carbon::now()->subDays(5)->addMinute(), 'free_shipping', 2);
 
     $customerId2 = $this->tester->createCustomer('c2@e.com');
-    $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'Local pickup');
-    $this->assertFilterReturnsEmails('any', ['Flat rate'], 1, []);
-    $this->assertFilterReturnsEmails('any', ['Flat rate'], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', ['Free shipping'], 4, []);
-    $this->assertFilterReturnsEmails('any', ['Free shipping'], 5, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', ['Local pickup'], 99, []);
-    $this->assertFilterReturnsEmails('any', ['Local pickup'], 100, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', ['Local pickup', 'Flat rate'], 100, ['c1@e.com', 'c2@e.com']);
+    $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'local_pickup', 3);
+    $this->assertFilterReturnsEmails('any', ['flat_rate:1'], 1, []);
+    $this->assertFilterReturnsEmails('any', ['flat_rate:1'], 2, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', ['free_shipping:2'], 4, []);
+    $this->assertFilterReturnsEmails('any', ['free_shipping:2'], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', ['local_pickup:3'], 99, []);
+    $this->assertFilterReturnsEmails('any', ['local_pickup:3'], 100, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', ['local_pickup:3', 'flat_rate:1'], 100, ['c1@e.com', 'c2@e.com']);
 
-    $this->assertFilterReturnsEmails('all', ['Flat rate'], 1, []);
-    $this->assertFilterReturnsEmails('all', ['Flat rate'], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('all', ['Flat rate', 'Free shipping'], 2, []);
-    $this->assertFilterReturnsEmails('all', ['Flat rate', 'Free shipping'], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', ['flat_rate:1'], 1, []);
+    $this->assertFilterReturnsEmails('all', ['flat_rate:1'], 2, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', ['flat_rate:1', 'free_shipping:2'], 2, []);
+    $this->assertFilterReturnsEmails('all', ['flat_rate:1', 'free_shipping:2'], 5, ['c1@e.com']);
 
-    $this->assertFilterReturnsEmails('none', ['Flat rate'], 1, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['Flat rate'], 2, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['Free shipping'], 2, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['Free shipping'], 5, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['flat_rate:1'], 1, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['flat_rate:1'], 2, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['free_shipping:2'], 2, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['free_shipping:2'], 5, ['c2@e.com']);
   }
 
-  private function assertFilterReturnsEmails(string $operator, array $shippingMethods, int $days, array $expectedEmails): void {
+  private function assertFilterReturnsEmails(string $operator, array $shippingMethodStrings, int $days, array $expectedEmails): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
       'operator' => $operator,
-      'shipping_methods' => $shippingMethods,
+      'shipping_methods' => $shippingMethodStrings,
       'used_shipping_method_days' => $days,
     ]);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  private function createOrder(int $customerId, Carbon $createdAt, string $shippingMethodTitle): int {
+  private function createOrder(int $customerId, Carbon $createdAt, string $shippingMethodId, $shippingInstanceId): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
     $order->set_date_created($createdAt->toDateTimeString());
     $order->set_status('wc-completed');
 
     $shippingItem = new \WC_Order_Item_Shipping();
-    $shippingItem->set_method_title($shippingMethodTitle);
+    $shippingItem->set_method_id($shippingMethodId);
+    $shippingItem->set_instance_id($shippingInstanceId);
     $order->add_item($shippingItem);
 
     $order->save();

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
@@ -32,10 +32,10 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 3);
     $this->createOrder($customerId4, Carbon::now(), 'flat_rate', 4);
 
-    $this->assertFilterReturnsEmails('any', ['flat_rate:1'], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', ['local_pickup:2'], 1, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', ['local_pickup:2', 'flat_rate:1'], 1, ['c1@e.com', 'c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', ['nonexistent_method:1'], 1000, []);
+    $this->assertFilterReturnsEmails('any', [1], 1, ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', [2], 1, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', [2, 1], 1, ['c1@e.com', 'c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', [8], 1000, []); // non-existing shipping method
   }
 
   public function testItWorksWithAllOperator(): void {
@@ -50,10 +50,10 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 2);
     $this->createOrder($customerId3, Carbon::now(), 'flat_rate', 1);
 
-    $this->assertfilterreturnsemails('all', ['flat_rate:1'], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['free_shipping:2'], 1, ['c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['free_shipping:2', 'flat_rate:1'], 1, ['c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['nonexistent_method:1', 'flat_rate:1'], 1000, []);
+    $this->assertfilterreturnsemails('all', [1], 1, ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [2], 1, ['c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [2, 1], 1, ['c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [8, 1], 1000, []); // includes non-existing shipping method
   }
 
   public function testItWorksWithNoneOperator(): void {
@@ -70,10 +70,10 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
 
     (new Subscriber)->withEmail('sub@e.com')->create();
 
-    $this->assertFilterReturnsEmails('none', ['flat_rate:1'], 1, ['sub@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['free_shipping:2'], 1, ['sub@e.com', 'c1@e.com']);
-    $this->assertFilterReturnsEmails('none', ['nonexistent_method:1'], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('none', ['flat_rate:1', 'free_shipping:2'], 1, ['sub@e.com']);
+    $this->assertFilterReturnsEmails('none', [1], 1, ['sub@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 1, ['sub@e.com', 'c1@e.com']);
+    $this->assertFilterReturnsEmails('none', [8], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']); // non-existing shipping method
+    $this->assertFilterReturnsEmails('none', [1, 2], 1, ['sub@e.com']);
   }
 
   public function testItWorksWithDateRanges(): void {
@@ -83,23 +83,23 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
 
     $customerId2 = $this->tester->createCustomer('c2@e.com');
     $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'local_pickup', 3);
-    $this->assertFilterReturnsEmails('any', ['flat_rate:1'], 1, []);
-    $this->assertFilterReturnsEmails('any', ['flat_rate:1'], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', ['free_shipping:2'], 4, []);
-    $this->assertFilterReturnsEmails('any', ['free_shipping:2'], 5, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', ['local_pickup:3'], 99, []);
-    $this->assertFilterReturnsEmails('any', ['local_pickup:3'], 100, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', ['local_pickup:3', 'flat_rate:1'], 100, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('any', [1], 1, []);
+    $this->assertFilterReturnsEmails('any', [1], 2, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', [2], 4, []);
+    $this->assertFilterReturnsEmails('any', [2], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', [3], 99, []);
+    $this->assertFilterReturnsEmails('any', [3], 100, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', [3, 1], 100, ['c1@e.com', 'c2@e.com']);
 
-    $this->assertFilterReturnsEmails('all', ['flat_rate:1'], 1, []);
-    $this->assertFilterReturnsEmails('all', ['flat_rate:1'], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('all', ['flat_rate:1', 'free_shipping:2'], 2, []);
-    $this->assertFilterReturnsEmails('all', ['flat_rate:1', 'free_shipping:2'], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', [1], 1, []);
+    $this->assertFilterReturnsEmails('all', [1], 2, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', [1, 2], 2, []);
+    $this->assertFilterReturnsEmails('all', [1, 2], 5, ['c1@e.com']);
 
-    $this->assertFilterReturnsEmails('none', ['flat_rate:1'], 1, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['flat_rate:1'], 2, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['free_shipping:2'], 2, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['free_shipping:2'], 5, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [1], 1, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [1], 2, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 2, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 5, ['c2@e.com']);
   }
 
   private function assertFilterReturnsEmails(string $operator, array $shippingMethodStrings, int $days, array $expectedEmails): void {

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -22,8 +22,13 @@ class HelperTest extends \MailPoetTest {
   }
 
   public function _after() {
+    global $wpdb;
+
     parent::_after();
     $this->wp->deleteOption('woocommerce_onboarding_profile');
+    $wpdb->query("TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods");
+    $wpdb->query("TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_locations");
+    $wpdb->query("TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zones");
   }
 
   public function testGetDataMailPoetNotInstalledViaWooCommerceOnboardingWizard() {
@@ -44,5 +49,83 @@ class HelperTest extends \MailPoetTest {
     $this->tester->createWooCommerceOrder(['date_created' => '2022-08-01 00:00:00']);
 
     $this->assertSame(2, $this->helper->getOrdersCountCreatedBefore('2022-08-01 00:00:00'));
+  }
+
+  public function testGetShippingMethodInstances() {
+    $this->createShippingZonesWithShippingMethods();
+
+    $expectedResult = [
+      [
+        'id' => 'flat_rate:2',
+        'name' => 'Flat rate custom name (Argentina)',
+      ],
+      [
+        'id' => 'local_pickup:3',
+        'name' => 'Local pickup custom name (Argentina)',
+      ],
+      [
+        'id' => 'free_shipping:4',
+        'name' => 'Free shipping custom name (Brazil)',
+      ],
+      [
+        'id' => 'flat_rate:1',
+        'name' => 'Flat rate custom name (Locations not covered by your other zones)',
+      ],
+    ];
+
+    $this->assertEquals($expectedResult, $this->helper->getShippingMethodInstancesData());
+  }
+
+  protected function createShippingZonesWithShippingMethods() {
+    $outOfCoverageShippingZone = new \WC_Shipping_Zone(0);
+    $outOfCoverageShippingZone->save();
+
+    $this->addShippingMethodToZone($outOfCoverageShippingZone, 'flat_rate', [
+      'woocommerce_flat_rate_title' => 'Flat rate custom name',
+      'woocommerce_flat_rate_tax_status' => 'none',
+      'woocommerce_flat_rate_cost' => '100',
+    ]);
+
+    $shippingZoneArgentina = $this->createShippingZone('Argentina', 'AR');
+
+    $this->addShippingMethodToZone($shippingZoneArgentina, 'flat_rate', [
+      'woocommerce_flat_rate_title' => 'Flat rate custom name',
+      'woocommerce_flat_rate_tax_status' => 'none',
+      'woocommerce_flat_rate_cost' => '15',
+    ]);
+
+    $this->addShippingMethodToZone($shippingZoneArgentina, 'local_pickup', [
+      'woocommerce_local_pickup_title' => 'Local pickup custom name',
+      'woocommerce_local_pickup_tax_status' => 'taxable',
+      'woocommerce_local_pickup_cost' => '10',
+    ]);
+
+    $shippingZoneBrazil = $this->createShippingZone('Brazil', 'BR');
+
+    $this->addShippingMethodToZone($shippingZoneBrazil, 'free_shipping', [
+      'woocommerce_free_shipping_title' => 'Free shipping custom name',
+      'woocommerce_free_shipping_requires' => '',
+      'woocommerce_free_shipping_min_amount' => '0',
+    ]);
+  }
+
+  protected function createShippingZone($zoneName, $countryName): \WC_Shipping_Zone {
+    $shippingZone = new \WC_Shipping_Zone();
+    $shippingZone->set_zone_name($zoneName);
+    $shippingZone->add_location($countryName, 'country');
+    $shippingZone->save();
+
+    return $shippingZone;
+  }
+
+  protected function addShippingMethodToZone($shippingZone, $shippingMethodType, $shippingMethodData) {
+    $instanceId = $shippingZone->add_shipping_method($shippingMethodType);
+    $shippingMethodData['instance_id'] = $instanceId;
+
+    $shippingMethod = \WC_Shipping_Zones::get_shipping_method($instanceId);
+    $this->assertInstanceOf(\WC_Shipping_Method::class, $shippingMethod);
+    $shippingMethod->set_post_data($shippingMethodData);
+    $_REQUEST['instance_id'] = $instanceId; // workaround to make process_admin_options() save the instance data
+    $shippingMethod->process_admin_options();
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -56,19 +56,19 @@ class HelperTest extends \MailPoetTest {
 
     $expectedResult = [
       [
-        'id' => 'flat_rate:2',
+        'instanceId' => '2',
         'name' => 'Flat rate custom name (Argentina)',
       ],
       [
-        'id' => 'local_pickup:3',
+        'instanceId' => '3',
         'name' => 'Local pickup custom name (Argentina)',
       ],
       [
-        'id' => 'free_shipping:4',
+        'instanceId' => '4',
         'name' => 'Free shipping custom name (Brazil)',
       ],
       [
-        'id' => 'flat_rate:1',
+        'instanceId' => '1',
         'name' => 'Flat rate custom name (Locations not covered by your other zones)',
       ],
     ];

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -28,6 +28,7 @@
     var mailpoet_woocommerce_currency_symbol = <%= json_encode(woocommerce_currency_symbol)  %>;
     var mailpoet_woocommerce_countries = <%= json_encode(woocommerce_countries)  %>;
     var mailpoet_woocommerce_payment_methods = <%= json_encode(woocommerce_payment_methods)  %>;
+    var mailpoet_woocommerce_shipping_methods = <%= json_encode(woocommerce_shipping_methods)  %>;
     var mailpoet_signup_forms = <%= json_encode(signup_forms) %>;
   </script>
 <% endblock %>
@@ -197,6 +198,7 @@
     'segmentsActiveSubscription': __('has active subscription'),
     'woocommerceSubscriptions': _x('WooCommerce Subscriptions', 'Dynamic segment creation: User selects this to use any WooCommerce Subscriptions filters'),
     'wooUsedPaymentMethod': __('used payment method'),
+    'wooUsedShippingMethod': __('used shipping method'),
     'selectWooSubscription': __('Search subscriptions'),
     'searchLists': __('Search lists'),
     'subscriberTag': _x('tag', 'Subscriber tag'),
@@ -238,6 +240,7 @@
     'selectWooPurchasedProduct': __('Search products'),
     'selectWooCountry': __('Search countries'),
     'selectWooPaymentMethods': __('Search payment methods'),
+    'selectWooShippingMethods': __('Search shipping methods'),
     'woocommerce': _x('WooCommerce', 'Dynamic segment creation: User selects this to use any woocommerce filters'),
 
     'dynamicSegmentSizeIsCalculated': __('Calculating segment size…'),


### PR DESCRIPTION
## Description

This PR adds a new WooCommerce segment called "used shipping method".

## Code review notes

I based this new segment on the "used payment method" segment.

I noticed that when the operator "none of" is used for the "used payment method" it matches not only WooCommerce customers but all types of subscribers. I followed the same logic for this new segment but I wonder if we should limit the scope of both segments only to WooCommerce customers? (cc @NeosinneR)

## QA notes

How to test this PR:

- Place a few WooCommerce orders using different shipping methods.
- Go to the page to create a new MailPoet segment (/wp-admin/admin.php?page=mailpoet-segments#/new-segment) and try different values for the parameters of the new "used shipping method" segment.
- Verify that the number of matched subscribers matches what is expected.
- Send an email to this segment and verify that the recipients match what is expected.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4992]

## After-merge notes

_N/A_


[MAILPOET-4992]: https://mailpoet.atlassian.net/browse/MAILPOET-4992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ