### PR TITLE
Update the test SubscriptionFormCest and include the new scenario

### DIFF
--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -10,6 +10,7 @@ use MailPoet\Test\DataFactories\Settings;
 class SubscriptionFormCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;
+  const FORM_NAME = 'Subscription Acceptance Test Form';
 
   /** @var string */
   private $subscriberEmail;
@@ -29,7 +30,7 @@ class SubscriptionFormCest {
       ->withConfirmationEmailEnabled()
       ->withCaptchaType(CaptchaConstants::TYPE_DISABLED);
 
-    $formName = 'Subscription Acceptance Test Form';
+    $formName = self::FORM_NAME;
     $formFactory = new Form();
     $this->formId = $formFactory->withName($formName)->create()->getId();
 
@@ -46,6 +47,25 @@ class SubscriptionFormCest {
       ',
       'post_status' => 'publish',
     ]);
+  }
+
+  public function subscriptionNewPageConfirmation(\AcceptanceTester $i) {
+    $i->wantTo('Subscribe to a form and to see new page confirmation');
+    $formName = self::FORM_NAME;
+    $i->login();
+    $i->amOnMailpoetPage('Forms');
+    $i->clickItemRowActionByItemName($formName, 'Edit');
+    $i->waitForElement('[data-automation-id="form_title_input"]');
+    $i->click('(//div[@class="components-radio-control__option"])[2]'); // Click Go to Page option
+    $i->selectOption('.components-select-control__input', 'Sample Page');
+    $i->saveFormInEditor();
+    $i->amOnPage('/form-test');
+    $i->executeJS('window.scrollTo(0, document.body.scrollHeight);');
+    $i->switchToIframe('#mailpoet_form_iframe');
+    $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
+    $i->scrollTo('.mailpoet_submit');
+    $i->click('.mailpoet_submit');
+    $i->waitForText('Sample Page');
   }
 
   public function subscriptionFormWidget(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -30,9 +30,8 @@ class SubscriptionFormCest {
       ->withConfirmationEmailEnabled()
       ->withCaptchaType(CaptchaConstants::TYPE_DISABLED);
 
-    $formName = self::FORM_NAME;
     $formFactory = new Form();
-    $this->formId = $formFactory->withName($formName)->create()->getId();
+    $this->formId = $formFactory->withName(self::FORM_NAME)->create()->getId();
 
     $i->havePostInDatabase([
       'post_author' => 1,
@@ -47,25 +46,6 @@ class SubscriptionFormCest {
       ',
       'post_status' => 'publish',
     ]);
-  }
-
-  public function subscriptionNewPageConfirmation(\AcceptanceTester $i) {
-    $i->wantTo('Subscribe to a form and to see new page confirmation');
-    $formName = self::FORM_NAME;
-    $i->login();
-    $i->amOnMailpoetPage('Forms');
-    $i->clickItemRowActionByItemName($formName, 'Edit');
-    $i->waitForElement('[data-automation-id="form_title_input"]');
-    $i->click('(//div[@class="components-radio-control__option"])[2]'); // Click Go to Page option
-    $i->selectOption('.components-select-control__input', 'Sample Page');
-    $i->saveFormInEditor();
-    $i->amOnPage('/form-test');
-    $i->executeJS('window.scrollTo(0, document.body.scrollHeight);');
-    $i->switchToIframe('#mailpoet_form_iframe');
-    $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
-    $i->scrollTo('.mailpoet_submit');
-    $i->click('.mailpoet_submit');
-    $i->waitForText('Sample Page');
   }
 
   public function subscriptionFormWidget(\AcceptanceTester $i) {
@@ -148,5 +128,23 @@ class SubscriptionFormCest {
     $i->click('.mailpoet_submit');
     $i->waitForText("You’ve been successfully subscribed to our newsletter!", self::CONFIRMATION_MESSAGE_TIMEOUT, '.mailpoet_validate_success');
     $i->seeNoJSErrors();
+  }
+
+  public function subscriptionNewPageConfirmation(\AcceptanceTester $i) {
+    $i->wantTo('Subscribe to a form and to see new page confirmation');
+    $i->login();
+    $i->amOnMailpoetPage('Forms');
+    $i->clickItemRowActionByItemName(self::FORM_NAME, 'Edit');
+    $i->waitForElement('[data-automation-id="form_title_input"]');
+    $i->click('(//div[@class="components-radio-control__option"])[2]'); // Click Go to Page option
+    $i->selectOption('.components-select-control__input', 'Sample Page');
+    $i->saveFormInEditor();
+    $i->amOnPage('/form-test');
+    $i->executeJS('window.scrollTo(0, document.body.scrollHeight);');
+    $i->switchToIframe('#mailpoet_form_iframe');
+    $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
+    $i->scrollTo('.mailpoet_submit');
+    $i->click('.mailpoet_submit');
+    $i->waitForText('Sample Page');
   }
 }


### PR DESCRIPTION
## Description

Updating the existing test SubscriptionFormCest to include scenario of being redirected to another page after subscribing, instead seeing the confirmation on the same page.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5321]

## After-merge notes

_N/A_


[MAILPOET-5321]: https://mailpoet.atlassian.net/browse/MAILPOET-5321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ