### PR TITLE
Track specific types of engagement separately [MAILPOET-4998]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -432,6 +432,12 @@ class Hooks {
       [$this->hooksWooCommerce, 'updateSubscriberEngagement'],
       7
     );
+    // See class-wc-order.php, which says this about this action
+    // "Fires when the order progresses from a pending payment status to a paid one"
+    $this->wp->addAction(
+      'woocommerce_order_payment_status_changed',
+      [$this->hooksWooCommerce, 'updateSubscriberLastPurchase']
+    );
   }
 
   public function setupWooCommerceTracking() {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -142,6 +142,14 @@ class HooksWooCommerce {
     }
   }
 
+  public function updateSubscriberLastPurchase($orderId) {
+    try {
+      $this->subscriberEngagement->updateSubscriberLastPurchase($orderId);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Update Subscriber Last Purchase');
+    }
+  }
+
   public function declareHposCompatibility() {
     try {
       if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -159,6 +159,36 @@ class SubscriberEntity {
    * @ORM\Column(type="datetimetz", nullable=true)
    * @var DateTimeInterface|null
    */
+  private $lastSendingAt;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $lastOpenAt;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $lastClickAt;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $lastPurchaseAt;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $lastPageViewAt;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
   private $woocommerceSyncedAt;
 
   /**
@@ -528,6 +558,46 @@ class SubscriberEntity {
 
   public function setLastEngagementAt(DateTimeInterface $lastEngagementAt): void {
     $this->lastEngagementAt = $lastEngagementAt;
+  }
+
+  public function getLastSendingAt(): ?DateTimeInterface {
+    return $this->lastSendingAt;
+  }
+
+  public function setLastSendingAt(?DateTimeInterface $dateTime): void {
+    $this->lastSendingAt = $dateTime;
+  }
+
+  public function getLastOpenAt(): ?DateTimeInterface {
+    return $this->lastOpenAt;
+  }
+
+  public function setLastOpenAt(?DateTimeInterface $dateTime): void {
+    $this->lastOpenAt = $dateTime;
+  }
+
+  public function getLastClickAt(): ?DateTimeInterface {
+    return $this->lastClickAt;
+  }
+
+  public function setLastClickAt(?DateTimeInterface $dateTime): void {
+    $this->lastClickAt = $dateTime;
+  }
+
+  public function getLastPurchaseAt(): ?DateTimeInterface {
+    return $this->lastPurchaseAt;
+  }
+
+  public function setLastPurchaseAt(?DateTimeInterface $dateTime): void {
+    $this->lastPurchaseAt = $dateTime;
+  }
+
+  public function getLastPageViewAt(): ?DateTimeInterface {
+    return $this->lastPageViewAt;
+  }
+
+  public function setLastPageViewAt(?DateTimeInterface $dateTime): void {
+    $this->lastPageViewAt = $dateTime;
   }
 
   public function setWoocommerceSyncedAt(?DateTimeInterface $woocommerceSyncedAt): void {

--- a/mailpoet/lib/Migrations/Migration_20230605_174836.php
+++ b/mailpoet/lib/Migrations/Migration_20230605_174836.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\Migration;
+
+class Migration_20230605_174836 extends Migration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+    $newColumns = [
+      'last_sending_at',
+      'last_open_at',
+      'last_click_at',
+      'last_purchase_at',
+      'last_page_view_at',
+    ];
+    foreach ($newColumns as $column) {
+      if ($this->columnExists($subscribersTable, $column)) {
+        continue;
+      }
+
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$subscribersTable}`
+          ADD COLUMN `{$column}` TIMESTAMP NULL DEFAULT NULL,
+          ADD INDEX `{$column}` (`{$column}`)"
+      );
+    }
+  }
+}

--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -117,7 +117,7 @@ class Clicks {
       // track open event
       $this->opens->track($data, $displayImage = false);
       // Update engagement date
-      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
+      $this->subscribersRepository->maybeUpdateLastClickAt($subscriber);
     }
     $url = $this->processUrl($link->getUrl(), $newsletter, $subscriber, $queue, $wpUserPreview);
     $this->redirectToUrl($url);

--- a/mailpoet/lib/Statistics/Track/Opens.php
+++ b/mailpoet/lib/Statistics/Track/Opens.php
@@ -63,7 +63,7 @@ class Opens {
             $this->statisticsOpensRepository->flush();
           }
         }
-        $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
+        $this->subscribersRepository->maybeUpdateLastOpenAt($subscriber);
         return $this->returnResponse($displayImage);
       }
       $statistics = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
@@ -74,7 +74,7 @@ class Opens {
       }
       $this->statisticsOpensRepository->persist($statistics);
       $this->statisticsOpensRepository->flush();
-      $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
+      $this->subscribersRepository->maybeUpdateLastOpenAt($subscriber);
       $this->statisticsOpensRepository->recalculateSubscriberScore($subscriber);
     }
     return $this->returnResponse($displayImage);

--- a/mailpoet/lib/Statistics/Track/SubscriberActivityTracker.php
+++ b/mailpoet/lib/Statistics/Track/SubscriberActivityTracker.php
@@ -92,7 +92,7 @@ class SubscriberActivityTracker {
   }
 
   private function processTracking(SubscriberEntity $subscriber): void {
-    $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
+    $this->subscribersRepository->maybeUpdateLastPageViewAt($subscriber);
     $this->pageViewCookie->setPageViewTimestamp($this->wp->currentTime('timestamp'));
     foreach ($this->callbacks as $callback) {
       $callback($subscriber);

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Subscribers;
 
+use DateTimeInterface;
 use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\SegmentEntity;
@@ -284,6 +285,21 @@ class SubscribersRepository extends Repository {
 
     $this->changesNotifier->subscribersUpdated($ids);
     $this->invalidateTotalSubscribersCache();
+    return count($ids);
+  }
+
+  public function bulkUpdateLastSendingAt(array $ids, DateTimeInterface $dateTime): int {
+    if (empty($ids)) {
+      return 0;
+    }
+    $this->entityManager->createQueryBuilder()
+      ->update(SubscriberEntity::class, 's')
+      ->set('s.lastSendingAt', ':lastSendingAt')
+      ->where('s.id IN (:ids)')
+      ->setParameter('lastSendingAt', $dateTime)
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
     return count($ids);
   }
 

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -340,12 +340,56 @@ class SubscribersRepository extends Repository {
   }
 
   public function maybeUpdateLastEngagement(SubscriberEntity $subscriberEntity): void {
-    $now = CarbonImmutable::createFromTimestamp((int)$this->wp->currentTime('timestamp'));
+    $now = $this->getCurrentDateTime();
     // Do not update engagement if was recently updated to avoid unnecessary updates in DB
     if ($subscriberEntity->getLastEngagementAt() && $subscriberEntity->getLastEngagementAt() > $now->subMinute()) {
       return;
     }
     // Update last engagement
+    $subscriberEntity->setLastEngagementAt($now);
+    $this->flush();
+  }
+
+  public function maybeUpdateLastOpenAt(SubscriberEntity $subscriberEntity): void {
+    $now = $this->getCurrentDateTime();
+    // Avoid unnecessary DB calls
+    if ($subscriberEntity->getLastOpenAt() && $subscriberEntity->getLastOpenAt() > $now->subMinute()) {
+      return;
+    }
+    $subscriberEntity->setLastOpenAt($now);
+    $subscriberEntity->setLastEngagementAt($now);
+    $this->flush();
+  }
+
+  public function maybeUpdateLastClickAt(SubscriberEntity $subscriberEntity): void {
+    $now = $this->getCurrentDateTime();
+    // Avoid unnecessary DB calls
+    if ($subscriberEntity->getLastClickAt() && $subscriberEntity->getLastClickAt() > $now->subMinute()) {
+      return;
+    }
+    $subscriberEntity->setLastClickAt($now);
+    $subscriberEntity->setLastEngagementAt($now);
+    $this->flush();
+  }
+
+  public function maybeUpdateLastPurchaseAt(SubscriberEntity $subscriberEntity): void {
+    $now = $this->getCurrentDateTime();
+    // Avoid unnecessary DB calls
+    if ($subscriberEntity->getLastPurchaseAt() && $subscriberEntity->getLastPurchaseAt() > $now->subMinute()) {
+      return;
+    }
+    $subscriberEntity->setLastPurchaseAt($now);
+    $subscriberEntity->setLastEngagementAt($now);
+    $this->flush();
+  }
+
+  public function maybeUpdateLastPageViewAt(SubscriberEntity $subscriberEntity): void {
+    $now = $this->getCurrentDateTime();
+    // Avoid unnecessary DB calls
+    if ($subscriberEntity->getLastPageViewAt() && $subscriberEntity->getLastPageViewAt() > $now->subMinute()) {
+      return;
+    }
+    $subscriberEntity->setLastPageViewAt($now);
     $subscriberEntity->setLastEngagementAt($now);
     $this->flush();
   }
@@ -500,5 +544,9 @@ class SubscribersRepository extends Repository {
     });
 
     return count($subscribers);
+  }
+
+  private function getCurrentDateTime(): CarbonImmutable {
+    return CarbonImmutable::createFromTimestamp((int)$this->wp->currentTime('timestamp'));
   }
 }

--- a/mailpoet/lib/WooCommerce/SubscriberEngagement.php
+++ b/mailpoet/lib/WooCommerce/SubscriberEngagement.php
@@ -35,4 +35,18 @@ class SubscriberEngagement {
 
     $this->subscribersRepository->maybeUpdateLastEngagement($subscriber);
   }
+
+  public function updateSubscriberLastPurchase($orderId): void {
+    $order = $this->woocommerceHelper->wcGetOrder($orderId);
+    if (!$order instanceof WC_Order) {
+      return;
+    }
+
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $order->get_billing_email()]);
+    if (!$subscriber instanceof SubscriberEntity) {
+      return;
+    }
+
+    $this->subscribersRepository->maybeUpdateLastPurchaseAt($subscriber);
+  }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -413,7 +413,10 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       )
     );
+    expect($this->subscriber->getLastSendingAt())->null();
     $sendingQueueWorker->process();
+    $this->subscribersRepository->refresh($this->subscriber);
+    expect($this->subscriber->getLastSendingAt())->notNull();
 
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
@@ -538,7 +541,10 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       )
     );
+    expect($this->subscriber->getLastSendingAt())->null();
     $sendingQueueWorker->process();
+    $this->subscribersRepository->refresh($this->subscriber);
+    expect($this->subscriber->getLastSendingAt())->notNull();
 
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
@@ -1000,6 +1006,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
     $this->sendingQueuesRepository->refresh($sendingQueue);
     expect($sendingQueue->getCountTotal())->equals($expectSending ? 1 : 0);
+    // Transactional emails shouldn't update last sending at
+    $this->subscribersRepository->refresh($subscriber);
+    expect($subscriber->getLastSendingAt())->null();
   }
 
   public function dataForTestItSendsTransactionalEmails(): array {

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -499,7 +499,7 @@ class ClicksTest extends \MailPoetTest {
     expect($link)->equals('http://example.com/?email=test@example.com&newsletter_subject=Subject');
   }
 
-  public function testItUpdatesSubscriberEngagementForHumanAgent() {
+  public function testItUpdatesSubscriberTimestampsForHumanAgent() {
     $now = Carbon::now();
     $wpMock = $this->createMock(WPFunctions::class);
     $wpMock->expects($this->any())
@@ -531,8 +531,11 @@ class ClicksTest extends \MailPoetTest {
     ], $this);
     $clicks->track($data);
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
+    $savedClickTime = $this->subscriber->getLastClickAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
+    $this->assertInstanceOf(\DateTimeInterface::class, $savedClickTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
+    expect($savedClickTime->getTimestamp())->equals($now->getTimestamp());
   }
 
   public function testItUpdatesSubscriberEngagementForUnknownAgent() {
@@ -566,8 +569,11 @@ class ClicksTest extends \MailPoetTest {
     ], $this);
     $clicks->track($data);
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
+    $savedClickTime = $this->subscriber->getLastClickAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
+    $this->assertInstanceOf(\DateTimeInterface::class, $savedClickTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
+    expect($savedClickTime->getTimestamp())->equals($now->getTimestamp());
   }
 
   public function testItUpdatesSubscriberEngagementForMachineAgent() {
@@ -601,14 +607,17 @@ class ClicksTest extends \MailPoetTest {
     ], $this);
     $clicks->track($data);
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
+    $savedClickTime = $this->subscriber->getLastClickAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
+    $this->assertInstanceOf(\DateTimeInterface::class, $savedClickTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
+    expect($savedClickTime->getTimestamp())->equals($now->getTimestamp());
   }
 
   public function testItWontUpdateSubscriberThatWasRecentlyUpdated() {
-    $lastEngagement = Carbon::now()->subSeconds(10);
+    $lastClickTime = Carbon::now()->subSeconds(10);
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
-    $this->subscriber->setLastEngagementAt($lastEngagement);
+    $this->subscriber->setLastClickAt($lastClickTime);
     $data = $this->trackData;
     $data->userAgent = UserAgentEntity::MACHINE_USER_AGENTS[0];
     $clicks = Stub::construct($this->clicks, [
@@ -625,6 +634,6 @@ class ClicksTest extends \MailPoetTest {
       'redirectToUrl' => null,
     ], $this);
     $clicks->track($data);
-    expect($this->subscriber->getLastEngagementAt())->equals($lastEngagement);
+    expect($this->subscriber->getLastClickAt())->equals($lastClickTime);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -374,8 +374,11 @@ class OpensTest extends \MailPoetTest {
 
     $opens->track($this->trackData);
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
+    $savedOpenTime = $this->subscriber->getLastOpenAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
+    $this->assertInstanceOf(\DateTimeInterface::class, $savedOpenTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
+    expect($savedOpenTime->getTimestamp())->equals($now->getTimestamp());
   }
 
   public function testItUpdatesSubscriberEngagementForUnknownAgent() {
@@ -395,11 +398,14 @@ class OpensTest extends \MailPoetTest {
 
     $opens->track($this->trackData);
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
+    $savedOpenTime = $this->subscriber->getLastOpenAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
+    $this->assertInstanceOf(\DateTimeInterface::class, $savedOpenTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
+    expect($savedOpenTime->getTimestamp())->equals($now->getTimestamp());
   }
 
-  public function testItUpdatesSubscriberEngagementForMachineAgent() {
+  public function testItUpdatesSubscriberTimestampsForMachineAgent() {
     $now = Carbon::now();
     $wpMock = $this->createMock(WPFunctions::class);
     $wpMock->expects($this->once())
@@ -416,7 +422,10 @@ class OpensTest extends \MailPoetTest {
 
     $opens->track($this->trackData);
     $savedEngagementTime = $this->subscriber->getLastEngagementAt();
+    $savedOpenTime = $this->subscriber->getLastOpenAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
+    $this->assertInstanceOf(\DateTimeInterface::class, $savedOpenTime);
     expect($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
+    expect($savedOpenTime->getTimestamp())->equals($now->getTimestamp());
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
@@ -106,6 +106,8 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     expect($subscriber->getLastEngagementAt())->greaterThan(Carbon::now()->subMinute());
     expect($subscriber->getLastEngagementAt())->lessThan(Carbon::now()->addMinute());
+    expect($subscriber->getLastPageViewAt())->greaterThan(Carbon::now()->subMinute());
+    expect($subscriber->getLastPageViewAt())->lessThan(Carbon::now()->addMinute());
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds 5 new columns to the subscribers table, and we'll now track these different types of engagement separately:

- last_sending_at
- last_open_at
- last_click_at
- last_purchase_at
- last_page_view_at

We will still update `last_engagement_at` when any of these specific values are updated **except** for `last_sending_at`.

## Code review notes

I'm not sure if I'm using the best approach for the `last_sending_at` updates. I do think we'll want to perform bulk updates so we're not adding an extra query for every individual send, I just don't know if the spot I chose in the sending queue processing is the best.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4998](https://mailpoet.atlassian.net/browse/MAILPOET-4998)

## After-merge notes

_N/A_


[MAILPOET-4998]: https://mailpoet.atlassian.net/browse/MAILPOET-4998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ