### PR TITLE
Fix this.activateMode is not a function [MAILPOET-5380]

### DIFF
--- a/mailpoet/assets/js/src/newsletter_editor/behaviors/MediaManagerBehavior.js
+++ b/mailpoet/assets/js/src/newsletter_editor/behaviors/MediaManagerBehavior.js
@@ -63,6 +63,7 @@ BL.MediaManagerBehavior = Marionette.Behavior.extend({
 
     MediaManager = window.wp.media.view.MediaFrame.Select.extend({
       initialize: function () {
+        window._ = _; // make sure underscore is available on window – it's required by media manager
         window.wp.media.view.MediaFrame.prototype.initialize.apply(
           this,
           arguments,


### PR DESCRIPTION
## Description

We need to make sure that the global _ is always "underscore". In certain themes, Lodash's global _ is overriding the Underscore.js global of the same name, so while this segment of code was written targeting Underscore, it's in-fact using Lodash:

https://github.com/WordPress/wordpress-develop/blob/6e7053a6dfb2f5657151c4e327e06269c40c9e26/src/wp-includes/js/media/views/frame.js\#L76-L78

Unlike Underscore.js's each method, Lodash's equivalent does not support the third context argument. Since the above code is dependent upon the context being provided for this to be bound correctly in the call to this.activeMode, it otherwise fails.


## QA notes

How to replicate the issue:

- Use the theme betheme (included in the attachments of the original Jira)
- Open the email editor
- Insert an image into a newsletter
- *Bug:* You cannot attach any image
- In the console, there is an error: this.activateMode is not a function


## Linked tickets

Fixes: #4708
[MAILPOET-5380]




[MAILPOET-5380]: https://mailpoet.atlassian.net/browse/MAILPOET-5380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ