### PR TITLE
Prevent page to break when iframe fails to load [MAILPOET-5381]

### DIFF
--- a/mailpoet/assets/js/src/common/thumbnail.ts
+++ b/mailpoet/assets/js/src/common/thumbnail.ts
@@ -37,9 +37,9 @@ export const fromUrl = (url) =>
     iframe.style.opacity = '0';
     iframe.scrolling = 'no';
     iframe.onload = async () => {
-      const container = iframe.contentDocument.documentElement;
-      container.style.padding = '10px 20px';
       try {
+        const container = iframe.contentDocument.documentElement;
+        container.style.padding = '10px 20px';
         const image = await fromDom(container);
         document.body.removeChild(iframe);
         resolve(image);


### PR DESCRIPTION
## Description

Make sure we catch any errors that can happen during the iframe loading.

## QA notes

This is difficult to replicate. That is why the code worked for years, but it has failed for one customer. The customer reporting the issue is sending the header `X-Frame-Options: DENY` on their server, and that breaks the last step of the sending page. We advised the customer to fix their headers, however, loading the page shouldn't break it.

## Linked tickets

[MAILPOET-5381]


[MAILPOET-5381]: https://mailpoet.atlassian.net/browse/MAILPOET-5381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ