### PR TITLE
Make sure the doctrine parameters are unique in export [MAILPOET-5382]

### DIFF
--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -253,7 +253,7 @@ class ImportExportRepository {
     $customFields = $customFields->fetchAll();
 
     foreach ($customFields as $customField) {
-      $customFieldId = "customFieldId{$customField['id']}";
+      $customFieldId = "customFieldId{$customField['id']}export";
       $qb->addSelect("MAX(CASE WHEN {$customFieldsTable}.id = :{$customFieldId} THEN {$subscriberCustomFieldTable}.value END) AS :{$customFieldId}")
         ->setParameter($customFieldId, $customField['id']);
     }


### PR DESCRIPTION
## Description

Previously there was a mismatch between the parameters from the dynamic segment and the parameters from the export controller.

## QA notes

How to replicate:

- Create a new text custom field with the text value with name “Paper”
- Go to the list of subscribers and set the value of “Paper” as “Yes” to a subscriber
- Create a new dynamic segment and add set it to “MailPoet custom field”, “Paper”, “equals”, “Yes”
- You should see the message “This segment has 1 subscribers.”, this is the sign the segment is working.
- Go to the list of subscribers and “Recalculate now” the segments so that you get the dynamic segment to the list
- Open the export and export all the subscribers to this list.
- **Bug:** No subscriber is exported.

## Linked tickets

[MAILPOET-5382]

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5382]: https://mailpoet.atlassian.net/browse/MAILPOET-5382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ