### PR TITLE
Order fields [MAILPOET-5169]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/SubjectTransformerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/SubjectTransformerHandler.php
@@ -54,6 +54,7 @@ class SubjectTransformerHandler {
         }
       }
     }
+    sort($all);
     return $all;
   }
 

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -6,6 +6,7 @@ use DateTimeZone;
 use WP_Comment;
 use WP_Error;
 use WP_Locale;
+use WP_Post;
 use WP_Term;
 use WP_User;
 use wpdb;
@@ -54,6 +55,11 @@ class WordPress {
   public function getWpLocale(): WP_Locale {
     global $wp_locale;
     return $wp_locale;
+  }
+
+  /** @return WP_Post[]|int[] */
+  public function getPosts(array $args = null): array {
+    return get_posts($args);
   }
 
   /**

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -29,7 +29,7 @@ class SubscriberAutomationFieldsFactory {
       'options' => array_map(function (Automation $automation) {
         return [
           'id' => $automation->getId(),
-          'name' => $automation->getName() . " [{$automation->getId()}]",
+          'name' => $automation->getName() . " (#{$automation->getId()})",
         ];
       }, $automations),
     ];

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactory.php
@@ -71,12 +71,15 @@ class CustomerFieldsFactory {
         ),
         new Field(
           'woocommerce:customer:billing-country',
-          Field::TYPE_STRING,
+          Field::TYPE_ENUM,
           __('Billing country', 'mailpoet'),
           function (CustomerPayload $payload) {
             $customer = $payload->getCustomer();
             return $customer ? $customer->get_billing_country() : null;
-          }
+          },
+          [
+            'options' => $this->getBillingCountryOptions(),
+          ]
         ),
         new Field(
           'woocommerce:customer:shipping-company',
@@ -125,16 +128,35 @@ class CustomerFieldsFactory {
         ),
         new Field(
           'woocommerce:customer:shipping-country',
-          Field::TYPE_STRING,
+          Field::TYPE_ENUM,
           __('Shipping country', 'mailpoet'),
           function (CustomerPayload $payload) {
             $customer = $payload->getCustomer();
             return $customer ? $customer->get_shipping_country() : null;
-          }
+          },
+          [
+            'options' => $this->getShippingCountryOptions(),
+          ]
         ),
       ],
       $this->customerOrderFieldsFactory->getFields(),
       $this->customerReviewFieldsFactory->getFields()
     );
+  }
+
+  private function getBillingCountryOptions(): array {
+    $options = [];
+    foreach (WC()->countries->get_allowed_countries() as $code => $name) {
+      $options[] = ['id' => $code, 'name' => $name];
+    }
+    return $options;
+  }
+
+  private function getShippingCountryOptions(): array {
+    $options = [];
+    foreach (WC()->countries->get_shipping_countries() as $code => $name) {
+      $options[] = ['id' => $code, 'name' => $name];
+    }
+    return $options;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -95,7 +95,7 @@ class CustomerOrderFieldsFactory {
           return $customer ? $this->getOrderProductTermIds($customer, 'product_cat') : [];
         },
         [
-          'options' => $this->termOptionsBuilder->getCategoryOptions(),
+          'options' => $this->termOptionsBuilder->getTermOptions('product_cat'),
         ]
       ),
       new Field(
@@ -107,7 +107,7 @@ class CustomerOrderFieldsFactory {
           return $customer ? $this->getOrderProductTermIds($customer, 'product_tag') : [];
         },
         [
-          'options' => $this->termOptionsBuilder->getTagOptions(),
+          'options' => $this->termOptionsBuilder->getTermOptions('product_tag'),
         ]
       ),
     ];

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -12,6 +12,9 @@ use WC_Payment_Gateway;
 use WP_Post;
 
 class OrderFieldsFactory {
+  /** @var TermOptionsBuilder */
+  private $termOptionsBuilder;
+
   /** @var WordPress */
   private $wordPress;
 
@@ -19,9 +22,11 @@ class OrderFieldsFactory {
   private $wooCommerce;
 
   public function __construct(
+    TermOptionsBuilder $termOptionsBuilder,
     WordPress $wordPress,
     WooCommerce $wooCommerce
   ) {
+    $this->termOptionsBuilder = $termOptionsBuilder;
     $this->wordPress = $wordPress;
     $this->wooCommerce = $wooCommerce;
   }
@@ -199,6 +204,23 @@ class OrderFieldsFactory {
             $order = $payload->getOrder();
             return !$this->previousOrderExists($order);
           }
+        ),
+        new Field(
+          'woocommerce:order:categories',
+          Field::TYPE_ENUM_ARRAY,
+          __('Categories', 'mailpoet'),
+          function (OrderPayload $payload) {
+            $products = $this->getProducts($payload->getOrder());
+            $categoryIds = [];
+            foreach ($products as $product) {
+              $categoryIds = array_merge($categoryIds, $product->get_category_ids());
+            }
+            sort($categoryIds);
+            return array_unique($categoryIds);
+          },
+          [
+            'options' => $this->termOptionsBuilder->getCategoryOptions(),
+          ]
         ),
       ]
     );

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -296,7 +296,10 @@ class OrderFieldsFactory {
     $statuses = $this->wooCommerce->wcGetOrderStatuses();
     $options = [];
     foreach ($statuses as $id => $name) {
-      $options[] = ['id' => $id, 'name' => $name];
+      $options[] = [
+        'id' => substr($id, 0, 3) === 'wc-' ? substr($id, 3) : $id,
+        'name' => $name,
+      ];
     }
     return $options;
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -227,7 +227,7 @@ class OrderFieldsFactory {
             return array_unique($categoryIds);
           },
           [
-            'options' => $this->termOptionsBuilder->getCategoryOptions(),
+            'options' => $this->termOptionsBuilder->getTermOptions('product_cat'),
           ]
         ),
         new Field(
@@ -244,7 +244,7 @@ class OrderFieldsFactory {
             return array_unique($tagIds);
           },
           [
-            'options' => $this->termOptionsBuilder->getTagOptions(),
+            'options' => $this->termOptionsBuilder->getTermOptions('product_tag'),
           ]
         ),
         new Field(

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -58,6 +58,54 @@ class OrderFieldsFactory {
             return $payload->getOrder()->get_billing_country();
           }
         ),
+        new Field(
+          'woocommerce:order:shipping-company',
+          Field::TYPE_STRING,
+          __('Shipping company', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_shipping_company();
+          }
+        ),
+        new Field(
+          'woocommerce:order:shipping-phone',
+          Field::TYPE_STRING,
+          __('Shipping phone', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_shipping_phone();
+          }
+        ),
+        new Field(
+          'woocommerce:order:shipping-city',
+          Field::TYPE_STRING,
+          __('Shipping city', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_shipping_city();
+          }
+        ),
+        new Field(
+          'woocommerce:order:shipping-postcode',
+          Field::TYPE_STRING,
+          __('Shipping postcode', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_shipping_postcode();
+          }
+        ),
+        new Field(
+          'woocommerce:order:shipping-state',
+          Field::TYPE_STRING,
+          __('Shipping state/county', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_shipping_state();
+          }
+        ),
+        new Field(
+          'woocommerce:order:shipping-country',
+          Field::TYPE_STRING,
+          __('Shipping country', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_shipping_country();
+          }
+        ),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\Fields;
+
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
+
+class OrderFieldsFactory {
+  /** @return Field[] */
+  public function getFields(): array {
+    return array_merge(
+      [
+        new Field(
+          'woocommerce:order:billing-company',
+          Field::TYPE_STRING,
+          __('Billing company', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_billing_company();
+          }
+        ),
+        new Field(
+          'woocommerce:order:billing-phone',
+          Field::TYPE_STRING,
+          __('Billing phone', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_billing_phone();
+          }
+        ),
+        new Field(
+          'woocommerce:order:billing-city',
+          Field::TYPE_STRING,
+          __('Billing city', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_billing_city();
+          }
+        ),
+        new Field(
+          'woocommerce:order:billing-postcode',
+          Field::TYPE_STRING,
+          __('Billing postcode', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_billing_postcode();
+          }
+        ),
+        new Field(
+          'woocommerce:order:billing-state',
+          Field::TYPE_STRING,
+          __('Billing state/county', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_billing_state();
+          }
+        ),
+        new Field(
+          'woocommerce:order:billing-country',
+          Field::TYPE_STRING,
+          __('Billing country', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_billing_country();
+          }
+        ),
+      ]
+    );
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -122,6 +122,14 @@ class OrderFieldsFactory {
             return $payload->getOrder()->get_date_paid();
           }
         ),
+        new Field(
+          'woocommerce:order:customer-note',
+          Field::TYPE_STRING,
+          __('Customer provided note', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_customer_note();
+          }
+        ),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -106,6 +106,14 @@ class OrderFieldsFactory {
             return $payload->getOrder()->get_shipping_country();
           }
         ),
+        new Field(
+          'woocommerce:order:created-date',
+          Field::TYPE_DATETIME,
+          __('Created date', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_date_created();
+          }
+        ),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -163,6 +163,14 @@ class OrderFieldsFactory {
             'options' => $this->getOrderStatusOptions(),
           ]
         ),
+        new Field(
+          'woocommerce:order:total',
+          Field::TYPE_NUMBER,
+          __('Total', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return (float)$payload->getOrder()->get_total();
+          }
+        ),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -114,6 +114,14 @@ class OrderFieldsFactory {
             return $payload->getOrder()->get_date_created();
           }
         ),
+        new Field(
+          'woocommerce:order:paid-date',
+          Field::TYPE_DATETIME,
+          __('Paid date', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_date_paid();
+          }
+        ),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -222,6 +222,23 @@ class OrderFieldsFactory {
             'options' => $this->termOptionsBuilder->getCategoryOptions(),
           ]
         ),
+        new Field(
+          'woocommerce:order:tags',
+          Field::TYPE_ENUM_ARRAY,
+          __('Tags', 'mailpoet'),
+          function (OrderPayload $payload) {
+            $products = $this->getProducts($payload->getOrder());
+            $tagIds = [];
+            foreach ($products as $product) {
+              $tagIds = array_merge($tagIds, $product->get_tag_ids());
+            }
+            sort($tagIds);
+            return array_unique($tagIds);
+          },
+          [
+            'options' => $this->termOptionsBuilder->getTagOptions(),
+          ]
+        ),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -314,7 +314,7 @@ class OrderFieldsFactory {
     foreach ($coupons as $coupon) {
       if ($coupon instanceof WP_Post) {
         // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-        $options[] = ['id' => $coupon->post_title, 'name' => $coupon->post_name];
+        $options[] = ['id' => $coupon->post_title, 'name' => $coupon->post_title];
       }
     }
     return $options;

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -79,11 +79,14 @@ class OrderFieldsFactory {
         ),
         new Field(
           'woocommerce:order:billing-country',
-          Field::TYPE_STRING,
+          Field::TYPE_ENUM,
           __('Billing country', 'mailpoet'),
           function (OrderPayload $payload) {
             return $payload->getOrder()->get_billing_country();
-          }
+          },
+          [
+            'options' => $this->getBillingCountryOptions(),
+          ]
         ),
         new Field(
           'woocommerce:order:shipping-company',
@@ -127,11 +130,14 @@ class OrderFieldsFactory {
         ),
         new Field(
           'woocommerce:order:shipping-country',
-          Field::TYPE_STRING,
+          Field::TYPE_ENUM,
           __('Shipping country', 'mailpoet'),
           function (OrderPayload $payload) {
             return $payload->getOrder()->get_shipping_country();
-          }
+          },
+          [
+            'options' => $this->getShippingCountryOptions(),
+          ]
         ),
         new Field(
           'woocommerce:order:created-date',
@@ -257,6 +263,22 @@ class OrderFieldsFactory {
         ),
       ]
     );
+  }
+
+  private function getBillingCountryOptions(): array {
+    $options = [];
+    foreach (WC()->countries->get_allowed_countries() as $code => $name) {
+      $options[] = ['id' => $code, 'name' => $name];
+    }
+    return $options;
+  }
+
+  private function getShippingCountryOptions(): array {
+    $options = [];
+    foreach (WC()->countries->get_shipping_countries() as $code => $name) {
+      $options[] = ['id' => $code, 'name' => $name];
+    }
+    return $options;
   }
 
   private function getOrderPaymentOptions(): array {

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermOptionsBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermOptionsBuilder.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\Fields;
+
+use MailPoet\Automation\Engine\WordPress;
+use WP_Error;
+use WP_Term;
+
+class TermOptionsBuilder {
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WordPress $wordPress
+  ) {
+    $this->wordPress = $wordPress;
+  }
+
+  /** @return array<array{id: int, name: string}> */
+  public function getCategoryOptions(): array {
+    return $this->getTermOptions('product_cat');
+  }
+
+  /** @return array<array{id: int, name: string}> */
+  public function getTagOptions(): array {
+    return $this->getTermOptions('product_tag');
+  }
+
+  /** @return array<array{id: int, name: string}> */
+  private function getTermOptions(string $taxonomy): array {
+    $terms = $this->wordPress->getTerms(['taxonomy' => $taxonomy, 'hide_empty' => false]);
+    if ($terms instanceof WP_Error) {
+      return [];
+    }
+    return $this->buildTermsList((array)$terms);
+  }
+
+  /** @return array<array{id: int, name: string}> */
+  private function buildTermsList(array $terms, int $parentId = 0): array {
+    $parents = array_filter($terms, function ($term) use ($parentId) {
+      return $term instanceof WP_Term && $term->parent === $parentId;
+    });
+
+    usort($parents, function (WP_Term $a, WP_Term $b) {
+      return $a->name <=> $b->name;
+    });
+
+    $list = [];
+    foreach ($parents as $term) {
+      $id = $term->term_id; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $list[] = ['id' => (int)$id, 'name' => $term->name];
+      foreach ($this->buildTermsList($terms, $id) as $child) {
+        $list[] = ['id' => (int)$child['id'], 'name' => "$term->name | {$child['name']}"];
+      }
+    }
+    return $list;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermOptionsBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermOptionsBuilder.php
@@ -17,17 +17,7 @@ class TermOptionsBuilder {
   }
 
   /** @return array<array{id: int, name: string}> */
-  public function getCategoryOptions(): array {
-    return $this->getTermOptions('product_cat');
-  }
-
-  /** @return array<array{id: int, name: string}> */
-  public function getTagOptions(): array {
-    return $this->getTermOptions('product_tag');
-  }
-
-  /** @return array<array{id: int, name: string}> */
-  private function getTermOptions(string $taxonomy): array {
+  public function getTermOptions(string $taxonomy): array {
     $terms = $this->wordPress->getTerms(['taxonomy' => $taxonomy, 'hide_empty' => false]);
     if ($terms instanceof WP_Error) {
       return [];

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/OrderSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/OrderSubject.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Integrations\WooCommerce\Subjects;
 use MailPoet\Automation\Engine\Data\Subject as SubjectData;
 use MailPoet\Automation\Engine\Integration\Payload;
 use MailPoet\Automation\Engine\Integration\Subject;
+use MailPoet\Automation\Integrations\WooCommerce\Fields\OrderFieldsFactory;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
 use MailPoet\NotFoundException;
 use MailPoet\Validator\Builder;
@@ -20,10 +21,15 @@ class OrderSubject implements Subject {
 
   private $woocommerce;
 
+  /** @var OrderFieldsFactory */
+  private $orderFieldsFactory;
+
   public function __construct(
-    Helper $woocommerce
+    Helper $woocommerce,
+    OrderFieldsFactory $orderFieldsFactory
   ) {
     $this->woocommerce = $woocommerce;
+    $this->orderFieldsFactory = $orderFieldsFactory;
   }
 
   public function getName(): string {
@@ -51,6 +57,6 @@ class OrderSubject implements Subject {
   }
 
   public function getFields(): array {
-    return [];
+    return $this->orderFieldsFactory->getFields();
   }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerce.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerce.php
@@ -3,6 +3,8 @@
 namespace MailPoet\Automation\Integrations\WooCommerce;
 
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use stdClass;
+use WC_Order;
 
 class WooCommerce {
   public function isWooCommerceActive(): bool {
@@ -17,6 +19,11 @@ class WooCommerce {
     return $this->isWooCommerceActive()
       && method_exists(OrderUtil::class, 'custom_orders_table_usage_is_enabled')
       && OrderUtil::custom_orders_table_usage_is_enabled();
+  }
+
+  /** @return WC_Order[]|stdClass */
+  public function wcGetOrders(array $args = []) {
+    return wc_get_orders($args);
   }
 
   public function wcGetOrderStatuses(): array {

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerce.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerce.php
@@ -18,4 +18,8 @@ class WooCommerce {
       && method_exists(OrderUtil::class, 'custom_orders_table_usage_is_enabled')
       && OrderUtil::custom_orders_table_usage_is_enabled();
   }
+
+  public function wcGetOrderStatuses(): array {
+    return wc_get_order_statuses();
+  }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -186,6 +186,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerOrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerReviewFieldsFactory::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\OrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\TermOptionsBuilder::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\OrderStatusChangedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject::class)->setPublic(true)->setShared(false);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -186,6 +186,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerOrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerReviewFieldsFactory::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\TermOptionsBuilder::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\OrderStatusChangedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderStatusChangeSubject::class)->setPublic(true)->setShared(false);

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -214,7 +214,7 @@ class Helper {
   public function getLatestCoupon(): ?string {
     $coupons = $this->wp->getPosts([
       'numberposts' => 1,
-      'orderby' => 'name',
+      'orderby' => 'date_created',
       'order' => 'desc',
       'post_type' => 'shop_coupon',
       'post_status' => 'publish',

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -170,14 +170,14 @@ class IntegrationTester extends \Codeception\Actor {
   }
 
   public function createWooCommerceCoupon(array $data): void {
-    $coupon1 = new WC_Coupon();
+    $coupon = new WC_Coupon();
 
     if (isset($data['code'])) {
-      $coupon1->set_code($data['code']);
+      $coupon->set_code($data['code']);
     }
 
-    $coupon1->save();
-    $this->wooCouponIds[] = $coupon1->get_id();
+    $coupon->save();
+    $this->wooCouponIds[] = $coupon->get_id();
   }
 
   public function updateWooOrderStats(int $orderId): void {
@@ -229,7 +229,7 @@ class IntegrationTester extends \Codeception\Actor {
   public function deleteTestWooCoupons(): void {
     foreach ($this->wooCouponIds as $couponId) {
       $coupon = new WC_Coupon($couponId);
-      if (!$coupon->get_id() > 0) {
+      if ($coupon->get_id() > 0) {
         $coupon->delete(true);
       }
     }

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -53,6 +53,8 @@ class IntegrationTester extends \Codeception\Actor {
 
   private $wooOrderIds = [];
 
+  private $wooCouponIds = [];
+
   private $createdUsers = [];
 
   public function __construct(
@@ -169,6 +171,17 @@ class IntegrationTester extends \Codeception\Actor {
     return $order;
   }
 
+  public function createWooCommerceCoupon(array $data): void {
+    $coupon1 = new WC_Coupon();
+
+    if (isset($data['code'])) {
+      $coupon1->set_code($data['code']);
+    }
+
+    $coupon1->save();
+    $this->wooCouponIds[] = $coupon1->get_id();
+  }
+
   public function updateWooOrderStats(int $orderId): void {
     if (!class_exists('Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore')) {
       return;
@@ -213,6 +226,16 @@ class IntegrationTester extends \Codeception\Actor {
       }
     }
     $this->wooOrderIds = [];
+  }
+
+  public function deleteTestWooCoupons(): void {
+    foreach ($this->wooCouponIds as $couponId) {
+      $coupon = new WC_Coupon($couponId);
+      if (!$coupon->get_id() > 0) {
+        $coupon->delete(true);
+      }
+    }
+    $this->wooCouponIds = [];
   }
 
   public function uniqueId($length = 10): string {
@@ -321,5 +344,6 @@ class IntegrationTester extends \Codeception\Actor {
     $this->deleteCreatedUsers();
     $this->deleteTestWooProducts();
     $this->deleteTestWooOrders();
+    $this->deleteTestWooCoupons();
   }
 }

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -150,12 +150,10 @@ class IntegrationTester extends \Codeception\Actor {
     $helper = ContainerWrapper::getInstance()->get(Helper::class);
     $order = $helper->wcCreateOrder($data);
 
+    $order->set_billing_email($data['billing_email'] ?? md5($this->uniqueId()) . '@example.com');
+
     if (isset($data['date_created'])) {
       $order->set_date_created($data['date_created']);
-    }
-
-    if (isset($data['billing_email'])) {
-      $order->set_billing_email($data['billing_email']);
     }
 
     if (isset($data['total'])) {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -35,9 +35,9 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
       $this->assertSame($name, $field->getName());
       $this->assertSame('enum_array', $field->getType());
       $this->assertSame(['options' => [
-        ['id' => $deactivating->getId(), 'name' => "Deactivating [{$deactivating->getId()}]"],
-        ['id' => $active->getId(), 'name' => "Active [{$active->getId()}]"],
-        ['id' => $draft->getId(), 'name' => "Draft [{$draft->getId()}]"],
+        ['id' => $deactivating->getId(), 'name' => "Deactivating (#{$deactivating->getId()})"],
+        ['id' => $active->getId(), 'name' => "Active (#{$active->getId()})"],
+        ['id' => $draft->getId(), 'name' => "Draft (#{$draft->getId()})"],
       ]], $field->getArgs());
     }
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -76,13 +76,12 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
     $orderChangeTrigger->registerHooks();
 
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation));
-    $order = new \WC_Order();
-
     $billingAddress = md5(uniqid()) . '@example.com';
-    $order->set_billing_email($billingAddress);
-    $order->set_customer_id(1);
-    $order->set_status('pending');
-    $order->save();
+    $order = $this->tester->createWooCommerceOrder([
+      'customer_id' => 1,
+      'status' => 'pending',
+      'billing_email' => $billingAddress,
+    ]);
 
     // Lets make a status change.
     $order->set_status('completed');

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactoryTest.php
@@ -5,6 +5,7 @@ namespace integration\Automation\Integrations\WooCommerce\Fields;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\CustomerPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\WP\Functions as WPFunctions;
 use WC_Customer;
 
 /**
@@ -12,6 +13,11 @@ use WC_Customer;
  */
 class CustomerFieldsFactoryTest extends \MailPoetTest {
   public function testBillingInfo(): void {
+    // set specific countries
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('woocommerce_allowed_countries', 'specific');
+    $wp->updateOption('woocommerce_specific_allowed_countries', ['CZ', 'DE']);
+
     $fields = $this->getFieldsMap();
 
     // check definitions
@@ -42,8 +48,13 @@ class CustomerFieldsFactoryTest extends \MailPoetTest {
 
     $countryField = $fields['woocommerce:customer:billing-country'];
     $this->assertSame('Billing country', $countryField->getName());
-    $this->assertSame('string', $countryField->getType());
-    $this->assertSame([], $countryField->getArgs());
+    $this->assertSame('enum', $countryField->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => 'CZ', 'name' => 'Czech Republic'],
+        ['id' => 'DE', 'name' => 'Germany'],
+      ],
+    ], $countryField->getArgs());
 
     // check values (guest)
     $payload = new CustomerPayload();
@@ -61,7 +72,7 @@ class CustomerFieldsFactoryTest extends \MailPoetTest {
     $customer->set_billing_city('Test billing city');
     $customer->set_billing_postcode('12345');
     $customer->set_billing_state('Test billing state');
-    $customer->set_billing_country('Test billing country');
+    $customer->set_billing_country('DE');
 
     $payload = new CustomerPayload($customer);
     $this->assertSame('Test billing company', $companyField->getValue($payload));
@@ -69,10 +80,15 @@ class CustomerFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('Test billing city', $cityField->getValue($payload));
     $this->assertSame('12345', $postcodeField->getValue($payload));
     $this->assertSame('Test billing state', $stateField->getValue($payload));
-    $this->assertSame('Test billing country', $countryField->getValue($payload));
+    $this->assertSame('DE', $countryField->getValue($payload));
   }
 
   public function testShippingInfo(): void {
+    // set specific countries
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('woocommerce_ship_to_countries', 'specific');
+    $wp->updateOption('woocommerce_specific_ship_to_countries', ['GR', 'SK']);
+
     $fields = $this->getFieldsMap();
 
     // check definitions
@@ -103,8 +119,13 @@ class CustomerFieldsFactoryTest extends \MailPoetTest {
 
     $countryField = $fields['woocommerce:customer:shipping-country'];
     $this->assertSame('Shipping country', $countryField->getName());
-    $this->assertSame('string', $countryField->getType());
-    $this->assertSame([], $countryField->getArgs());
+    $this->assertSame('enum', $countryField->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => 'GR', 'name' => 'Greece'],
+        ['id' => 'SK', 'name' => 'Slovakia'],
+      ],
+    ], $countryField->getArgs());
 
     // check values (guest)
     $payload = new CustomerPayload();
@@ -122,7 +143,7 @@ class CustomerFieldsFactoryTest extends \MailPoetTest {
     $customer->set_shipping_city('Test shipping city');
     $customer->set_shipping_postcode('12345');
     $customer->set_shipping_state('Test shipping state');
-    $customer->set_shipping_country('Test shipping country');
+    $customer->set_shipping_country('SK');
 
     $payload = new CustomerPayload($customer);
     $this->assertSame('Test shipping company', $companyField->getValue($payload));
@@ -130,7 +151,7 @@ class CustomerFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('Test shipping city', $cityField->getValue($payload));
     $this->assertSame('12345', $postcodeField->getValue($payload));
     $this->assertSame('Test shipping state', $stateField->getValue($payload));
-    $this->assertSame('Test shipping country', $countryField->getValue($payload));
+    $this->assertSame('SK', $countryField->getValue($payload));
   }
 
   /** @return array<string, Field> */

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
@@ -9,8 +9,6 @@ use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
 use MailPoet\InvalidStateException;
 use WC_Customer;
 use WC_Order;
-use WC_Product;
-use WC_Product_Simple;
 use WC_Product_Variable;
 use WC_Product_Variation;
 use WP_Error;
@@ -121,11 +119,11 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     ], $purchasedCategories->getArgs());
 
     // create products
-    $p1 = $this->createProduct('Product 1'); // uncategorized
-    $p2 = $this->createProduct('Product 2', [$cat1Id]);
-    $p3 = $this->createProduct('Product 3', [$cat1Id, $cat2Id]);
-    $p4 = $this->createProduct('Product 4', [$subCat1]);
-    $p5 = $this->createProduct('Product 5', [$cat3Id, $subCat2]);
+    $p1 = $this->tester->createWooCommerceProduct(['name' => 'Product 1']); // uncategorized
+    $p2 = $this->tester->createWooCommerceProduct(['name' => 'Product 2', 'category_ids' => [$cat1Id]]);
+    $p3 = $this->tester->createWooCommerceProduct(['name' => 'Product 3', 'category_ids' => [$cat1Id, $cat2Id]]);
+    $p4 = $this->tester->createWooCommerceProduct(['name' => 'Product 4', 'category_ids' => [$subCat1]]);
+    $p5 = $this->tester->createWooCommerceProduct(['name' => 'Product 5', 'category_ids' => [$cat3Id, $subCat2]]);
 
     // check values (guest)
     $o1 = $this->createOrder(0, 123);
@@ -185,10 +183,10 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     ], $purchasedTags->getArgs());
 
     // create products
-    $p1 = $this->createProduct('Product 1'); // no tags
-    $p2 = $this->createProduct('Product 2', [], [$tag1Id, $tag2Id]);
-    $p3 = $this->createProduct('Product 3', [], [$tag2Id]);
-    $p4 = $this->createProduct('Product 4', [], [$tag3Id]);
+    $p1 = $this->tester->createWooCommerceProduct(['name' => 'Product 1']); // no tags
+    $p2 = $this->tester->createWooCommerceProduct(['name' => 'Product 2', 'tag_ids' => [$tag1Id, $tag2Id]]);
+    $p3 = $this->tester->createWooCommerceProduct(['name' => 'Product 3', 'tag_ids' => [$tag2Id]]);
+    $p4 = $this->tester->createWooCommerceProduct(['name' => 'Product 4', 'tag_ids' => [$tag3Id]]);
 
     // check values (guest)
     $o1 = $this->createOrder(0, 123);
@@ -270,15 +268,6 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
       throw new InvalidStateException('Failed to create term');
     }
     return $term['term_id'];
-  }
-
-  private function createProduct(string $name, array $categoryIds = [], array $tagIds = []): WC_Product {
-    $product = new WC_Product_Simple();
-    $product->set_name($name);
-    $product->set_category_ids($categoryIds);
-    $product->set_tag_ids($tagIds);
-    $product->save();
-    return $product;
   }
 
   private function createOrder(int $customerId, float $total, string $date = '2023-06-01 14:03:27'): WC_Order {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Automation\Integrations\WooCommerce\Fields;
+
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use WC_Order;
+
+/**
+ * @group woo
+ */
+class OrderFieldsFactoryTest extends \MailPoetTest {
+  public function testBillingInfo(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $companyField = $fields['woocommerce:order:billing-company'];
+    $this->assertSame('Billing company', $companyField->getName());
+    $this->assertSame('string', $companyField->getType());
+    $this->assertSame([], $companyField->getArgs());
+
+    $phoneField = $fields['woocommerce:order:billing-phone'];
+    $this->assertSame('Billing phone', $phoneField->getName());
+    $this->assertSame('string', $phoneField->getType());
+    $this->assertSame([], $phoneField->getArgs());
+
+    $cityField = $fields['woocommerce:order:billing-city'];
+    $this->assertSame('Billing city', $cityField->getName());
+    $this->assertSame('string', $cityField->getType());
+    $this->assertSame([], $cityField->getArgs());
+
+    $postcodeField = $fields['woocommerce:order:billing-postcode'];
+    $this->assertSame('Billing postcode', $postcodeField->getName());
+    $this->assertSame('string', $postcodeField->getType());
+    $this->assertSame([], $postcodeField->getArgs());
+
+    $stateField = $fields['woocommerce:order:billing-state'];
+    $this->assertSame('Billing state/county', $stateField->getName());
+    $this->assertSame('string', $stateField->getType());
+    $this->assertSame([], $stateField->getArgs());
+
+    $countryField = $fields['woocommerce:order:billing-country'];
+    $this->assertSame('Billing country', $countryField->getName());
+    $this->assertSame('string', $countryField->getType());
+    $this->assertSame([], $countryField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_billing_company('Test billing company');
+    $order->set_billing_phone('123456789');
+    $order->set_billing_city('Test billing city');
+    $order->set_billing_postcode('12345');
+    $order->set_billing_state('Test billing state');
+    $order->set_billing_country('Test billing country');
+
+    $payload = new OrderPayload($order);
+    $this->assertSame('Test billing company', $companyField->getValue($payload));
+    $this->assertSame('123456789', $phoneField->getValue($payload));
+    $this->assertSame('Test billing city', $cityField->getValue($payload));
+    $this->assertSame('12345', $postcodeField->getValue($payload));
+    $this->assertSame('Test billing state', $stateField->getValue($payload));
+    $this->assertSame('Test billing country', $countryField->getValue($payload));
+  }
+
+  /** @return array<string, Field> */
+  private function getFieldsMap(): array {
+    $factory = $this->diContainer->get(OrderSubject::class);
+    $fields = [];
+    foreach ($factory->getFields() as $field) {
+      $fields[$field->getKey()] = $field;
+    }
+    return $fields;
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -7,7 +7,6 @@ use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
 use MailPoet\WP\Functions as WPFunctions;
-use WC_Coupon;
 use WC_Order;
 use WP_Term;
 
@@ -242,17 +241,9 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
   }
 
   public function testCouponsField(): void {
-    $coupon1 = new WC_Coupon();
-    $coupon1->set_code('coupon-1');
-    $coupon1->save();
-
-    $coupon2 = new WC_Coupon();
-    $coupon2->set_code('coupon-2');
-    $coupon2->save();
-
-    $coupon3 = new WC_Coupon();
-    $coupon3->set_code('coupon-3');
-    $coupon3->save();
+    $this->tester->createWooCommerceCoupon(['code' => 'coupon-1']);
+    $this->tester->createWooCommerceCoupon(['code' => 'coupon-2']);
+    $this->tester->createWooCommerceCoupon(['code' => 'coupon-3']);
 
     $fields = $this->getFieldsMap();
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -6,11 +6,9 @@ use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
-use MailPoet\InvalidStateException;
 use MailPoet\WP\Functions as WPFunctions;
 use WC_Coupon;
 use WC_Order;
-use WP_Error;
 use WP_Term;
 
 /**
@@ -302,11 +300,11 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     // categories
     $uncategorized = get_term_by('slug', 'uncategorized', 'product_cat');
     $uncategorizedId = $uncategorized instanceof WP_Term ? $uncategorized->term_id : null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    $cat1Id = $this->createTerm('Cat 1', 'product_cat', ['slug' => 'cat-1']);
-    $cat2Id = $this->createTerm('Cat 2', 'product_cat', ['slug' => 'cat-2']);
-    $cat3Id = $this->createTerm('Cat 3', 'product_cat', ['slug' => 'cat-3']);
-    $subCat1 = $this->createTerm('Subcat 1', 'product_cat', ['slug' => 'subcat-1', 'parent' => $cat1Id]);
-    $subCat2 = $this->createTerm('Subcat 2', 'product_cat', ['slug' => 'subcat-2', 'parent' => $cat1Id]);
+    $cat1Id = $this->tester->createWordPressTerm('Cat 1', 'product_cat', ['slug' => 'cat-1']);
+    $cat2Id = $this->tester->createWordPressTerm('Cat 2', 'product_cat', ['slug' => 'cat-2']);
+    $cat3Id = $this->tester->createWordPressTerm('Cat 3', 'product_cat', ['slug' => 'cat-3']);
+    $subCat1 = $this->tester->createWordPressTerm('Subcat 1', 'product_cat', ['slug' => 'subcat-1', 'parent' => $cat1Id]);
+    $subCat2 = $this->tester->createWordPressTerm('Subcat 2', 'product_cat', ['slug' => 'subcat-2', 'parent' => $cat1Id]);
 
     // check definitions
     $fields = $this->getFieldsMap();
@@ -344,9 +342,9 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
 
   public function testTagsField(): void {
     // tags
-    $tag1Id = $this->createTerm('Tag 1', 'product_tag', ['slug' => 'tag-1']);
-    $tag2Id = $this->createTerm('Tag 2', 'product_tag', ['slug' => 'tag-2']);
-    $tag3Id = $this->createTerm('Tag 3', 'product_tag', ['slug' => 'tag-3']);
+    $tag1Id = $this->tester->createWordPressTerm('Tag 1', 'product_tag', ['slug' => 'tag-1']);
+    $tag2Id = $this->tester->createWordPressTerm('Tag 2', 'product_tag', ['slug' => 'tag-2']);
+    $tag3Id = $this->tester->createWordPressTerm('Tag 3', 'product_tag', ['slug' => 'tag-3']);
 
     // check definitions
     $fields = $this->getFieldsMap();
@@ -418,13 +416,5 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
       $fields[$field->getKey()] = $field;
     }
     return $fields;
-  }
-
-  private function createTerm(string $term, string $taxonomy, array $args = []): int {
-    $term = wp_insert_term($term, $taxonomy, $args);
-    if ($term instanceof WP_Error) {
-      throw new InvalidStateException('Failed to create term');
-    }
-    return $term['term_id'];
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -150,6 +150,23 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertEquals(new DateTimeImmutable('2020-01-01 00:00:00'), $paidDateField->getValue($payload));
   }
 
+  public function testCustomerNoteField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $customerNoteField = $fields['woocommerce:order:customer-note'];
+    $this->assertSame('Customer provided note', $customerNoteField->getName());
+    $this->assertSame('string', $customerNoteField->getType());
+    $this->assertSame([], $customerNoteField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_customer_note('Test customer note');
+
+    $payload = new OrderPayload($order);
+    $this->assertSame('Test customer note', $customerNoteField->getValue($payload));
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -260,7 +260,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     ], $couponsField->getArgs());
 
     // check values
-    $order = new WC_Order();
+    $order = $this->tester->createWooCommerceOrder();
     $order->apply_coupon('coupon-1');
     $order->apply_coupon('coupon-2');
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -222,6 +222,23 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('processing', $statusField->getValue($payload));
   }
 
+  public function testTotalField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $totalField = $fields['woocommerce:order:total'];
+    $this->assertSame('Total', $totalField->getName());
+    $this->assertSame('number', $totalField->getType());
+    $this->assertSame([], $totalField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_total('123.45');
+
+    $payload = new OrderPayload($order);
+    $this->assertSame(123.45, $totalField->getValue($payload));
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -15,6 +15,11 @@ use WP_Term;
  */
 class OrderFieldsFactoryTest extends \MailPoetTest {
   public function testBillingInfo(): void {
+    // set specific countries
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('woocommerce_allowed_countries', 'specific');
+    $wp->updateOption('woocommerce_specific_allowed_countries', ['CZ', 'DE']);
+
     $fields = $this->getFieldsMap();
 
     // check definitions
@@ -45,8 +50,13 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
 
     $countryField = $fields['woocommerce:order:billing-country'];
     $this->assertSame('Billing country', $countryField->getName());
-    $this->assertSame('string', $countryField->getType());
-    $this->assertSame([], $countryField->getArgs());
+    $this->assertSame('enum', $countryField->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => 'CZ', 'name' => 'Czech Republic'],
+        ['id' => 'DE', 'name' => 'Germany'],
+      ],
+    ], $countryField->getArgs());
 
     // check values
     $order = new WC_Order();
@@ -55,7 +65,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $order->set_billing_city('Test billing city');
     $order->set_billing_postcode('12345');
     $order->set_billing_state('Test billing state');
-    $order->set_billing_country('Test billing country');
+    $order->set_billing_country('CZ');
 
     $payload = new OrderPayload($order);
     $this->assertSame('Test billing company', $companyField->getValue($payload));
@@ -63,10 +73,15 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('Test billing city', $cityField->getValue($payload));
     $this->assertSame('12345', $postcodeField->getValue($payload));
     $this->assertSame('Test billing state', $stateField->getValue($payload));
-    $this->assertSame('Test billing country', $countryField->getValue($payload));
+    $this->assertSame('CZ', $countryField->getValue($payload));
   }
 
   public function testShippingInfo(): void {
+    // set specific countries
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('woocommerce_ship_to_countries', 'specific');
+    $wp->updateOption('woocommerce_specific_ship_to_countries', ['GR', 'SK']);
+
     $fields = $this->getFieldsMap();
 
     // check definitions
@@ -97,8 +112,13 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
 
     $countryField = $fields['woocommerce:order:shipping-country'];
     $this->assertSame('Shipping country', $countryField->getName());
-    $this->assertSame('string', $countryField->getType());
-    $this->assertSame([], $countryField->getArgs());
+    $this->assertSame('enum', $countryField->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => 'GR', 'name' => 'Greece'],
+        ['id' => 'SK', 'name' => 'Slovakia'],
+      ],
+    ], $countryField->getArgs());
 
     // check values
     $order = new WC_Order();
@@ -107,7 +127,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $order->set_shipping_city('Test shipping city');
     $order->set_shipping_postcode('12345');
     $order->set_shipping_state('Test shipping state');
-    $order->set_shipping_country('Test shipping country');
+    $order->set_shipping_country('GR');
 
     $payload = new OrderPayload($order);
     $this->assertSame('Test shipping company', $companyField->getValue($payload));
@@ -115,7 +135,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('Test shipping city', $cityField->getValue($payload));
     $this->assertSame('12345', $postcodeField->getValue($payload));
     $this->assertSame('Test shipping state', $stateField->getValue($payload));
-    $this->assertSame('Test shipping country', $countryField->getValue($payload));
+    $this->assertSame('GR', $countryField->getValue($payload));
   }
 
   public function testCreatedDateField(): void {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace integration\Automation\Integrations\WooCommerce\Fields;
 
+use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
@@ -113,6 +114,23 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('12345', $postcodeField->getValue($payload));
     $this->assertSame('Test shipping state', $stateField->getValue($payload));
     $this->assertSame('Test shipping country', $countryField->getValue($payload));
+  }
+
+  public function testCreatedDateField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $createdDateField = $fields['woocommerce:order:created-date'];
+    $this->assertSame('Created date', $createdDateField->getName());
+    $this->assertSame('datetime', $createdDateField->getType());
+    $this->assertSame([], $createdDateField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_date_created('2020-01-01 00:00:00');
+
+    $payload = new OrderPayload($order);
+    $this->assertEquals(new DateTimeImmutable('2020-01-01 00:00:00'), $createdDateField->getValue($payload));
   }
 
   /** @return array<string, Field> */

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -63,6 +63,58 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('Test billing country', $countryField->getValue($payload));
   }
 
+  public function testShippingInfo(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $companyField = $fields['woocommerce:order:shipping-company'];
+    $this->assertSame('Shipping company', $companyField->getName());
+    $this->assertSame('string', $companyField->getType());
+    $this->assertSame([], $companyField->getArgs());
+
+    $phoneField = $fields['woocommerce:order:shipping-phone'];
+    $this->assertSame('Shipping phone', $phoneField->getName());
+    $this->assertSame('string', $phoneField->getType());
+    $this->assertSame([], $phoneField->getArgs());
+
+    $cityField = $fields['woocommerce:order:shipping-city'];
+    $this->assertSame('Shipping city', $cityField->getName());
+    $this->assertSame('string', $cityField->getType());
+    $this->assertSame([], $cityField->getArgs());
+
+    $postcodeField = $fields['woocommerce:order:shipping-postcode'];
+    $this->assertSame('Shipping postcode', $postcodeField->getName());
+    $this->assertSame('string', $postcodeField->getType());
+    $this->assertSame([], $postcodeField->getArgs());
+
+    $stateField = $fields['woocommerce:order:shipping-state'];
+    $this->assertSame('Shipping state/county', $stateField->getName());
+    $this->assertSame('string', $stateField->getType());
+    $this->assertSame([], $stateField->getArgs());
+
+    $countryField = $fields['woocommerce:order:shipping-country'];
+    $this->assertSame('Shipping country', $countryField->getName());
+    $this->assertSame('string', $countryField->getType());
+    $this->assertSame([], $countryField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_shipping_company('Test shipping company');
+    $order->set_shipping_phone('123456789');
+    $order->set_shipping_city('Test shipping city');
+    $order->set_shipping_postcode('12345');
+    $order->set_shipping_state('Test shipping state');
+    $order->set_shipping_country('Test shipping country');
+
+    $payload = new OrderPayload($order);
+    $this->assertSame('Test shipping company', $companyField->getValue($payload));
+    $this->assertSame('123456789', $phoneField->getValue($payload));
+    $this->assertSame('Test shipping city', $cityField->getValue($payload));
+    $this->assertSame('12345', $postcodeField->getValue($payload));
+    $this->assertSame('Test shipping state', $stateField->getValue($payload));
+    $this->assertSame('Test shipping country', $countryField->getValue($payload));
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -344,6 +344,40 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertNotContains($subCat2, $value);
   }
 
+  public function testTagsField(): void {
+    // tags
+    $tag1Id = $this->createTerm('Tag 1', 'product_tag', ['slug' => 'tag-1']);
+    $tag2Id = $this->createTerm('Tag 2', 'product_tag', ['slug' => 'tag-2']);
+    $tag3Id = $this->createTerm('Tag 3', 'product_tag', ['slug' => 'tag-3']);
+
+    // check definitions
+    $fields = $this->getFieldsMap();
+    $purchasedTags = $fields['woocommerce:order:tags'];
+    $this->assertSame('Tags', $purchasedTags->getName());
+    $this->assertSame('enum_array', $purchasedTags->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => $tag1Id, 'name' => 'Tag 1'],
+        ['id' => $tag2Id, 'name' => 'Tag 2'],
+        ['id' => $tag3Id, 'name' => 'Tag 3'],
+      ],
+    ], $purchasedTags->getArgs());
+
+    // check values
+    $product = $this->createProduct('Test product', [], [$tag1Id, $tag2Id]);
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($product);
+
+    $orderPayload = new OrderPayload($order);
+    $value = $purchasedTags->getValue($orderPayload);
+
+    $this->assertIsArray($value);
+    $this->assertCount(2, $value);
+    $this->assertContains($tag1Id, $value);
+    $this->assertContains($tag2Id, $value);
+    $this->assertNotContains($tag3Id, $value);
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -194,6 +194,34 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('Test payment method', $paymentMethodField->getValue($payload));
   }
 
+  public function testStatusField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $statusField = $fields['woocommerce:order:status'];
+    $this->assertSame('Status', $statusField->getName());
+    $this->assertSame('enum', $statusField->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => 'wc-pending', 'name' => 'Pending payment'],
+        ['id' => 'wc-processing', 'name' => 'Processing'],
+        ['id' => 'wc-on-hold', 'name' => 'On hold'],
+        ['id' => 'wc-completed', 'name' => 'Completed'],
+        ['id' => 'wc-cancelled', 'name' => 'Cancelled'],
+        ['id' => 'wc-refunded', 'name' => 'Refunded'],
+        ['id' => 'wc-failed', 'name' => 'Failed'],
+        ['id' => 'wc-checkout-draft', 'name' => 'Draft'],
+      ],
+    ], $statusField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_status('wc-processing');
+
+    $payload = new OrderPayload($order);
+    $this->assertSame('processing', $statusField->getValue($payload));
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -224,14 +224,14 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('enum', $statusField->getType());
     $this->assertSame([
       'options' => [
-        ['id' => 'wc-pending', 'name' => 'Pending payment'],
-        ['id' => 'wc-processing', 'name' => 'Processing'],
-        ['id' => 'wc-on-hold', 'name' => 'On hold'],
-        ['id' => 'wc-completed', 'name' => 'Completed'],
-        ['id' => 'wc-cancelled', 'name' => 'Cancelled'],
-        ['id' => 'wc-refunded', 'name' => 'Refunded'],
-        ['id' => 'wc-failed', 'name' => 'Failed'],
-        ['id' => 'wc-checkout-draft', 'name' => 'Draft'],
+        ['id' => 'pending', 'name' => 'Pending payment'],
+        ['id' => 'processing', 'name' => 'Processing'],
+        ['id' => 'on-hold', 'name' => 'On hold'],
+        ['id' => 'completed', 'name' => 'Completed'],
+        ['id' => 'cancelled', 'name' => 'Cancelled'],
+        ['id' => 'refunded', 'name' => 'Refunded'],
+        ['id' => 'failed', 'name' => 'Failed'],
+        ['id' => 'checkout-draft', 'name' => 'Draft'],
       ],
     ], $statusField->getArgs());
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -133,6 +133,23 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertEquals(new DateTimeImmutable('2020-01-01 00:00:00'), $createdDateField->getValue($payload));
   }
 
+  public function testPaidDateField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $paidDateField = $fields['woocommerce:order:paid-date'];
+    $this->assertSame('Paid date', $paidDateField->getName());
+    $this->assertSame('datetime', $paidDateField->getType());
+    $this->assertSame([], $paidDateField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_date_paid('2020-01-01 00:00:00');
+
+    $payload = new OrderPayload($order);
+    $this->assertEquals(new DateTimeImmutable('2020-01-01 00:00:00'), $paidDateField->getValue($payload));
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -378,6 +378,40 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertNotContains($tag3Id, $value);
   }
 
+  public function testProductsField(): void {
+    // products
+    $product1 = $this->createProduct('Product 1');
+    $product2 = $this->createProduct('Product 2');
+    $product3 = $this->createProduct('Product 3');
+
+    // check definitions
+    $fields = $this->getFieldsMap();
+    $purchasedProducts = $fields['woocommerce:order:products'];
+    $this->assertSame('Products', $purchasedProducts->getName());
+    $this->assertSame('enum_array', $purchasedProducts->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => $product1->get_id(), 'name' => "Product 1 (#{$product1->get_id()})"],
+        ['id' => $product2->get_id(), 'name' => "Product 2 (#{$product2->get_id()})"],
+        ['id' => $product3->get_id(), 'name' => "Product 3 (#{$product3->get_id()})"],
+      ],
+    ], $purchasedProducts->getArgs());
+
+    // check values
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($product1);
+    $order->add_product($product2);
+
+    $orderPayload = new OrderPayload($order);
+    $value = $purchasedProducts->getValue($orderPayload);
+
+    $this->assertIsArray($value);
+    $this->assertCount(2, $value);
+    $this->assertContains($product1->get_id(), $value);
+    $this->assertContains($product2->get_id(), $value);
+    $this->assertNotContains($product3->get_id(), $value);
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -10,8 +10,6 @@ use MailPoet\InvalidStateException;
 use MailPoet\WP\Functions as WPFunctions;
 use WC_Coupon;
 use WC_Order;
-use WC_Product;
-use WC_Product_Simple;
 use WP_Error;
 use WP_Term;
 
@@ -327,7 +325,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     ], $purchasedCategories->getArgs());
 
     // check values
-    $product = $this->createProduct('Test product', [$cat1Id, $cat2Id, $subCat1]);
+    $product = $this->tester->createWooCommerceProduct(['name' => 'Test product', 'category_ids' => [$cat1Id, $cat2Id, $subCat1]]);
     $order = $this->tester->createWooCommerceOrder();
     $order->add_product($product);
 
@@ -364,7 +362,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     ], $purchasedTags->getArgs());
 
     // check values
-    $product = $this->createProduct('Test product', [], [$tag1Id, $tag2Id]);
+    $product = $this->tester->createWooCommerceProduct(['name' => 'Test product', 'tag_ids' => [$tag1Id, $tag2Id]]);
     $order = $this->tester->createWooCommerceOrder();
     $order->add_product($product);
 
@@ -380,9 +378,9 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
 
   public function testProductsField(): void {
     // products
-    $product1 = $this->createProduct('Product 1');
-    $product2 = $this->createProduct('Product 2');
-    $product3 = $this->createProduct('Product 3');
+    $product1 = $this->tester->createWooCommerceProduct(['name' => 'Product 1']);
+    $product2 = $this->tester->createWooCommerceProduct(['name' => 'Product 2']);
+    $product3 = $this->tester->createWooCommerceProduct(['name' => 'Product 3']);
 
     // check definitions
     $fields = $this->getFieldsMap();
@@ -428,14 +426,5 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
       throw new InvalidStateException('Failed to create term');
     }
     return $term['term_id'];
-  }
-
-  private function createProduct(string $name, array $categoryIds = [], array $tagIds = []): WC_Product {
-    $product = new WC_Product_Simple();
-    $product->set_name($name);
-    $product->set_category_ids($categoryIds);
-    $product->set_tag_ids($tagIds);
-    $product->save();
-    return $product;
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -276,6 +276,25 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame(['coupon-1', 'coupon-2'], $couponsField->getValue($payload));
   }
 
+  public function testIsFirstOrderField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $isFirstOrderField = $fields['woocommerce:order:is-first-order'];
+    $this->assertSame('Is first order', $isFirstOrderField->getName());
+    $this->assertSame('boolean', $isFirstOrderField->getType());
+    $this->assertSame([], $isFirstOrderField->getArgs());
+
+    // check values
+    $order1 = $this->tester->createWooCommerceOrder(['customer_id' => 123]);
+    $payload = new OrderPayload($order1);
+    $this->assertTrue($isFirstOrderField->getValue($payload));
+
+    $order2 = $this->tester->createWooCommerceOrder(['customer_id' => 123]);
+    $payload = new OrderPayload($order2);
+    $this->assertFalse($isFirstOrderField->getValue($payload));
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);


### PR DESCRIPTION
## Description

Adds WooCommerce Order fields to automations.

## Code review notes

Woo order fields + some additional small fixes.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5169]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5169]: https://mailpoet.atlassian.net/browse/MAILPOET-5169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ