### PR TITLE
Prevent PHP notices [MAILPOET-5383]

### DIFF
--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -181,7 +181,7 @@ class Menu {
 
     // Welcome wizard page
     $this->wp->addSubmenuPage(
-      null,
+      '',
       $this->setPageTitle(__('Welcome Wizard', 'mailpoet')),
       esc_html__('Welcome Wizard', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -194,7 +194,7 @@ class Menu {
 
     // Landingpage
     $this->wp->addSubmenuPage(
-      null,
+      '',
       $this->setPageTitle(__('MailPoet', 'mailpoet')),
       esc_html__('MailPoet', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -448,7 +448,7 @@ class Menu {
 
     // WooCommerce Setup
     $this->wp->addSubmenuPage(
-      null,
+      '',
       $this->setPageTitle(__('WooCommerce Setup', 'mailpoet')),
       esc_html__('WooCommerce Setup', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -712,7 +712,7 @@ class Menu {
       return false;
     }
     WPFunctions::get()->addSubmenuPage(
-      null,
+      '',
       'MailPoet',
       'MailPoet',
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -174,7 +174,7 @@ class Menu {
       'MailPoet',
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
       self::MAIN_PAGE_SLUG,
-      null,
+      '',
       self::ICON_BASE64_SVG,
       30
     );

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -484,7 +484,7 @@ class Menu {
     $parentSlug = self::MAIN_PAGE_SLUG;
     // Automations menu is hidden when the subscription is part of a bundle and AutomateWoo is active but pages can be accessed directly
     if ($this->wp->isPluginActive('automatewoo/automatewoo.php') && $this->servicesChecker->isBundledSubscription()) {
-      $parentSlug = null;
+      $parentSlug = '';
     }
 
     $automationPage = $this->wp->addSubmenuPage(

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -72,12 +72,23 @@ class Functions {
     return add_image_size($name, $width, $height, $crop);
   }
 
-  public function addMenuPage($pageTitle, $menuTitle, $capability, $menuSlug, callable $function = null, $iconUrl = '', $position = null) {
-    if (is_null($function)) {
-      $function = function () {
+  /**
+   * @param string $pageTitle
+   * @param string $menuTitle
+   * @param string $capability
+   * @param string $menuSlug
+   * @param callable $callback|null
+   * @param string $iconUrl
+   * @param int $position
+   * @return string The resulting page's hook_suffix.
+   * @return string
+   */
+  public function addMenuPage($pageTitle, $menuTitle, $capability, $menuSlug, callable $callback = null, $iconUrl = '', $position = null) {
+    if (is_null($callback)) {
+      $callback = function () {
       };
     }
-    return add_menu_page($pageTitle, $menuTitle, $capability, $menuSlug, $function, $iconUrl, $position);
+    return add_menu_page($pageTitle, $menuTitle, $capability, $menuSlug, $callback, $iconUrl, $position);
   }
 
   public function addQueryArg($key, $value = false, $url = false) {
@@ -92,8 +103,18 @@ class Functions {
     return add_shortcode($tag, $callback);
   }
 
-  public function addSubmenuPage($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, callable $function) {
-    return add_submenu_page($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, $function);
+  /**
+   * @param string $parentSlug
+   * @param string $pageTitle
+   * @param string $menuTitle
+   * @param string $capability
+   * @param string $menuSlug
+   * @param callable $function
+   * @param int $position
+   * @return string|false
+   */
+  public function addSubmenuPage($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, callable $function, $position = null) {
+    return add_submenu_page($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, $function, $position);
   }
 
   public function adminUrl($path = '', $scheme = 'admin') {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -77,17 +77,12 @@ class Functions {
    * @param string $menuTitle
    * @param string $capability
    * @param string $menuSlug
-   * @param callable $callback|null
+   * @param callable|'' $callback
    * @param string $iconUrl
    * @param int $position
-   * @return string The resulting page's hook_suffix.
    * @return string
    */
-  public function addMenuPage($pageTitle, $menuTitle, $capability, $menuSlug, callable $callback = null, $iconUrl = '', $position = null) {
-    if (is_null($callback)) {
-      $callback = function () {
-      };
-    }
+  public function addMenuPage($pageTitle, $menuTitle, $capability, $menuSlug, $callback = '', $iconUrl = '', $position = null) {
     return add_menu_page($pageTitle, $menuTitle, $capability, $menuSlug, $callback, $iconUrl, $position);
   }
 
@@ -109,12 +104,12 @@ class Functions {
    * @param string $menuTitle
    * @param string $capability
    * @param string $menuSlug
-   * @param callable $function
+   * @param callable|'' $callback
    * @param int $position
    * @return string|false
    */
-  public function addSubmenuPage($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, callable $function, $position = null) {
-    return add_submenu_page($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, $function, $position);
+  public function addSubmenuPage($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, $callback = '', $position = null) {
+    return add_submenu_page($parentSlug, $pageTitle, $menuTitle, $capability, $menuSlug, $callback, $position);
   }
 
   public function adminUrl($path = '', $scheme = 'admin') {

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -96,6 +96,11 @@ parameters:
       message: "#^Cannot cast string|void to string\\.$#"
       count: 2
       path: ../../lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+    -
+      # WP annotates parameter as callable, but passes empty string as a default.
+      message: '/function add_(sub)?menu_page expects callable\(\): mixed, ''''\|\(callable\(\): mixed\) given/'
+      count: 2
+      path: ../../lib/WP/Functions.php
 
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:


### PR DESCRIPTION
## Description

Fix deprecation notices in Menu, from: https://github.com/mailpoet/mailpoet/pull/4982

Thanks, [Drivingralle](https://github.com/Drivingralle)!

Fixes: https://github.com/mailpoet/mailpoet/issues/4981
Closes: https://github.com/mailpoet/mailpoet/pull/4982

## Linked tickets

[MAILPOET-5383](https://mailpoet.atlassian.net/browse/MAILPOET-5383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5383]: https://mailpoet.atlassian.net/browse/MAILPOET-5383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ