### PR TITLE
Update tests and add new helper method

### DIFF
--- a/mailpoet/assets/js/src/form_editor/blocks/input_styles_settings.tsx
+++ b/mailpoet/assets/js/src/form_editor/blocks/input_styles_settings.tsx
@@ -131,6 +131,7 @@ function InputStylesSettings({ styles, onChange }: InputStylesSettingsProps) {
                 max={40}
                 allowReset
                 onChange={partial(updateStyles, 'borderRadius')}
+                className="mailpoet-automation-styles-border-radius-size"
               />
             </>
           ) : null}

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -650,6 +650,18 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   /**
+   * Select the panel color in the form editor
+   * Selectable colors are: Black [1], Gray [2], White [3], Pink [4], Red [5], Orange [6],
+   * Yellow [7], Turquoise [8], Green [9], Cyan [10], Blue [11] and Purple [12].
+   * Please select colors by providing [number] as string.
+   * @param string $colorOrder
+   */
+  public function selectPanelColor($colorOrder) {
+    $i = $this;
+    $i->click('(//div[@class="components-circular-option-picker__option-wrapper"])' . $colorOrder);
+  }
+
+  /**
    * Checks that email was received by looking for a subject in inbox.
    * In case it was not found reloads the inbox and check once more.
    * Emails are sent via cron and might not be sent immediately.

--- a/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
@@ -41,8 +41,8 @@ class EditorButtonStylesCest {
     $i->fillField('.mailpoet-automation-styles-border-size input[type="number"]', 10); // Set border size
 
     $i->wantTo('Check element has styles');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'border-width: 10px;');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'font-weight: bold;');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'font-weight', '700');
 
     $i->wantTo('Save form');
     $i->saveFormInEditor();
@@ -50,20 +50,20 @@ class EditorButtonStylesCest {
     $i->wantTo('Reload page and check data were saved');
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'border-width: 10px;');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'font-weight: bold;');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'color: rgb(255, 105, 0);');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'border-color: rgb(252, 185, 0);');
-    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'background-color: rgb(142, 209, 252);');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'font-weight', '700');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-color', 'rgb(252, 185, 0)');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'background-color', 'rgba(255, 105, 0, 1)');
 
     $i->wantTo('Check styles are applied on frontend page');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'font-weight', '700');
-    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'color', 'rgba(255, 105, 0, 1)');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'color', 'rgba(142, 209, 252, 1)');
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'background-color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'background-color', 'rgba(255, 105, 0, 1)');
     $i->seeInField('[data-automation-id="subscribe-submit-button"]', 'Join Now');
   }
 }

--- a/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
@@ -27,6 +27,15 @@ class EditorButtonStylesCest {
     $i->click('.mailpoet-automation-input-styles-panel');
     $i->waitForElement('[data-automation-id="input_styles_settings"]');
     $i->click('.mailpoet-automation-inherit-theme-toggle input'); // Display custom settings
+    $i->click('(//button[@class="components-button block-editor-panel-color-gradient-settings__dropdown"])[1]'); // Click Background color
+    $i->selectPanelColor('[6]'); // Select Vivid orange
+    $i->click('[data-automation-id="editor_submit_input"]');
+    $i->click('Font');
+    $i->selectPanelColor('[10]'); // Select Cyan blue
+    $i->click('[data-automation-id="editor_submit_input"]');
+    $i->click('Border');
+    $i->selectPanelColor('[7]'); // Select Vivid amber
+    $i->click('[data-automation-id="editor_submit_input"]');
     $i->click('.mailpoet-automation-styles-bold-toggle input'); // Toggle bold on
     $i->clearFormField('.mailpoet-automation-styles-border-size input[type="number"]');
     $i->fillField('.mailpoet-automation-styles-border-size input[type="number"]', 10); // Set border size
@@ -43,12 +52,18 @@ class EditorButtonStylesCest {
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'border-width: 10px;');
     $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'font-weight: bold;');
+    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'color: rgb(255, 105, 0);');
+    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'border-color: rgb(252, 185, 0);');
+    $i->assertAttributeContains('[data-automation-id="editor_submit_input"]', 'style', 'background-color: rgb(142, 209, 252);');
 
     $i->wantTo('Check styles are applied on frontend page');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'font-weight', '700');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'color', 'rgba(255, 105, 0, 1)');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-color', 'rgb(252, 185, 0)');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'background-color', 'rgba(142, 209, 252, 1)');
     $i->seeInField('[data-automation-id="subscribe-submit-button"]', 'Join Now');
   }
 }

--- a/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
@@ -80,10 +80,10 @@ class EditorTextInputStylesCest {
     $i->assertCssProperty('[data-automation-id="editor_first_name_label"]', 'font-weight', '700');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-radius', '40px');
-    $i->assertAttributeContains('[data-automation-id="editor_first_name_input"]', 'style', 'border-color: rgb(252, 185, 0);');
-    $i->assertAttributeContains('[data-automation-id="editor_first_name_input"]', 'style', 'background-color: rgb(142, 209, 252);');
-    $i->assertAttributeContains('[data-automation-id="editor_email_input"]', 'style', 'border-color: rgb(252, 185, 0);');
-    $i->assertAttributeContains('[data-automation-id="editor_email_input"]', 'style', 'background-color: rgb(142, 209, 252);');
+    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-color', 'rgb(252, 185, 0)');
+    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'background-color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-color', 'rgb(252, 185, 0)');
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'background-color', 'rgba(142, 209, 252, 1)');
     $i->see('Heading Lorem');
     $i->see('Paragraph ipsum dolor');
 

--- a/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
@@ -28,9 +28,27 @@ class EditorTextInputStylesCest {
     $i->click('.mailpoet-automation-input-styles-panel');
     $i->waitForElement('[data-automation-id="input_styles_settings"]');
     $i->click('.mailpoet-automation-inherit-theme-toggle input'); // Display custom settings
+    $i->click('Font');
+    $i->selectPanelColor('[6]'); // Select Vivid orange
+    $i->click('[data-automation-id="editor_first_name_input"]');
+    $i->click('(//button[@class="components-button block-editor-panel-color-gradient-settings__dropdown"])[2]'); // Click Background color
+    $i->selectPanelColor('[10]'); // Select Cyan blue
+    $i->click('[data-automation-id="editor_first_name_input"]');
+    $i->click('Border');
+    $i->selectPanelColor('[7]'); // Select Vivid amber
+    $i->click('[data-automation-id="editor_first_name_input"]');
     $i->click('.mailpoet-automation-styles-bold-toggle input'); // Toggle bold on
     $i->clearFormField('.mailpoet-automation-styles-border-size input[type="number"]');
-    $i->fillField('.mailpoet-automation-styles-border-size input[type="number"]', 10); // Set border size
+    $i->fillField('.mailpoet-automation-styles-border-size input[type="number"]', 10); // Set border width size
+    $i->clearFormField('.mailpoet-automation-styles-border-radius-size input[type="number"]');
+    $i->fillField('.mailpoet-automation-styles-border-radius-size input[type="number"]', 40); // Set border radius size
+    
+    $i->wantTo('Check that reset button resets the value');
+    $i->click('Reset');
+    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-width', '1px');
+    $i->seeInField('.mailpoet-automation-styles-border-size input[type="number"]', '1');
+    $i->clearFormField('.mailpoet-automation-styles-border-size input[type="number"]');
+    $i->fillField('.mailpoet-automation-styles-border-size input[type="number"]', 10); // Set border width size
 
     $i->wantTo('Check element has styles');
     $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-width', '10px');
@@ -50,24 +68,40 @@ class EditorTextInputStylesCest {
     $i->see('Paragraph ipsum dolor');
 
     $i->wantTo('Check email block has styles too and save the form');
-    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-radius', '40px');
     $i->saveFormInEditor();
 
     $i->wantTo('Reload page and check data were saved');
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-radius', '40px');
     $i->assertCssProperty('[data-automation-id="editor_first_name_label"]', 'font-weight', '700');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-radius', '40px');
+    $i->assertAttributeContains('[data-automation-id="editor_first_name_input"]', 'style', 'border-color: rgb(252, 185, 0);');
+    $i->assertAttributeContains('[data-automation-id="editor_first_name_input"]', 'style', 'background-color: rgb(142, 209, 252);');
+    $i->assertAttributeContains('[data-automation-id="editor_email_input"]', 'style', 'border-color: rgb(252, 185, 0);');
+    $i->assertAttributeContains('[data-automation-id="editor_email_input"]', 'style', 'background-color: rgb(142, 209, 252);');
     $i->see('Heading Lorem');
     $i->see('Paragraph ipsum dolor');
 
     $i->wantTo('Check styles are applied on frontend page');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
+    $i->fillField('[data-automation-id="form_first_name"]', 'John Doe');
     $i->assertCssProperty('[data-automation-id="form_first_name"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'border-radius', '40px');
     $i->assertCssProperty('[data-automation-id="form_first_name_label"]', 'font-weight', '700');
     $i->assertCssProperty('[data-automation-id="form_email"]', 'border-width', '10px');
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'border-radius', '40px');
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'color', 'rgba(255, 105, 0, 1)');
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'border-color', 'rgb(252, 185, 0)');
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'background-color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'color', 'rgba(255, 105, 0, 1)');
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'border-color', 'rgb(252, 185, 0)');
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'background-color', 'rgba(142, 209, 252, 1)');
     $i->see('Heading Lorem');
     $i->see('Paragraph ipsum dolor');
   }

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateMandatoryFieldsCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateMandatoryFieldsCest.php
@@ -7,6 +7,8 @@ use MailPoet\Test\DataFactories\Segment;
 
 class EditorUpdateMandatoryFieldsCest {
   public function updateEmailAndSubmit(\AcceptanceTester $i) {
+    $i->wantTo('Update form mandatory fields');
+
     $segmentFactory = new Segment();
     $formName = 'Mandatory fields test';
     $formFactory = new Form();
@@ -14,14 +16,15 @@ class EditorUpdateMandatoryFieldsCest {
       ->withSegments([$segmentFactory->withName('Fancy List')->create()])
       ->withName($formName)
       ->create();
-    $i->wantTo('Update form mandatory fields');
+
     $i->login();
-    // Open form for editation
+
     $i->amOnMailPoetPage('Forms');
     $i->waitForText($formName);
     $i->clickItemRowActionByItemName($formName, 'Edit');
     $i->waitForElement('[data-automation-id="form_title_input"]');
-    // Change email label
+
+    $i->wantTo('Change email label');
     $blockEmailInput = '[data-automation-id="editor_email_input"]';
     $i->click($blockEmailInput);
     $blockSettingsEmailLabelInput = '[data-automation-id="settings_email_label_input"]';
@@ -30,7 +33,8 @@ class EditorUpdateMandatoryFieldsCest {
     $i->fillField($blockSettingsEmailLabelInput, $updatedEmailLabel);
     $i->see($updatedEmailLabel, '[data-automation-id="editor_email_label"]');
     $i->seeNoJSErrors();
-    // Change submit label
+
+    $i->wantTo('Change submit label');
     $blockSubmitInput = '[data-automation-id="editor_submit_input"]';
     $i->click($blockSubmitInput);
     $blockSettingsSubmitLabelInput = '[data-automation-id="settings_submit_label_input"]';
@@ -39,9 +43,10 @@ class EditorUpdateMandatoryFieldsCest {
     $i->fillField($blockSettingsSubmitLabelInput, $updatedSubmitLabel);
     $i->assertAttributeContains($blockSubmitInput, 'value', $updatedSubmitLabel);
     $i->seeNoJSErrors();
-    // Save changes
+
     $i->saveFormInEditor();
-    // Reload page and check data were saved
+
+    $i->wantTo('Reload page and check data were saved');
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->assertAttributeContains($blockSubmitInput, 'value', $updatedSubmitLabel);

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
@@ -42,7 +42,6 @@ class EditorUpdateNewFormCest {
 
     $i->amOnMailPoetPage('Forms');
 
-    // Create a new form
     $formName = 'My awesome form';
     $updatedFormName = 'My updated awesome form';
     $i->click('[data-automation-id="create_new_form"]');
@@ -52,47 +51,46 @@ class EditorUpdateNewFormCest {
     $i->clearField('[data-automation-id="form_title_input"]'); // Clear field due to flakiness
     $i->fillField('[data-automation-id="form_title_input"]', $formName);
 
-    // Try saving form without selected list
+    $i->wantTo('Try saving form without selected list');
     $i->click('[data-automation-id="form_save_button"]');
     $i->waitForText('Please select a list', 10, '.automation-dismissible-notices');
     $i->seeNoJSErrors();
 
-    // Select list and save form
+    $i->wantTo('Select list and save form');
     $i->selectOptionInSelect2($segmentName);
     $i->saveFormInEditor();
 
-    // Reload page and check data were saved
+    $i->wantTo('Reload page and check data were saved');
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->seeInField('[data-automation-id="form_title_input"]', $formName);
     $i->seeSelectedInSelect2($segmentName);
     $i->seeNoJSErrors();
 
-    // Update form name and confirmation message
+    $i->wantTo('Update form name and confirmation message');
     $i->fillField('[data-automation-id="form_title_input"]', $updatedFormName);
     $i->fillField('.components-textarea-control__input', $newConfMessage);
 
-    // Update success and error message colors
+    $i->wantTo('Update success and error message colors');
     $i->click('[data-automation-id="mailpoet_form_settings_tab"]');
     $i->click('Styles');
     $i->click('Success');
-    $i->click('.components-color-palette__custom-color');
-    $i->click('(//div[@class="components-circular-option-picker__option-wrapper"])[10]'); // Select Cyan blue
+    $i->selectPanelColor('[10]'); // Select Cyan blue
     $i->click('[data-automation-id="mailpoet_form_settings_tab"]');
     $i->click('Error');
-    $i->click('(//div[@class="components-circular-option-picker__option-wrapper"])[12]'); // Select Vivid purple
+    $i->selectPanelColor('[12]'); // Select Vivid purple
     $i->click('[data-automation-id="mailpoet_form_settings_tab"]');
     
     $i->saveFormInEditor();
 
-    // Reload page and check data were saved
+    $i->wantTo('Reload page and check data were saved');
     $i->reloadPage();
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->seeInField('[data-automation-id="form_title_input"]', $updatedFormName);
     $i->seeInField('.components-textarea-control__input', $newConfMessage);
     $i->seeNoJSErrors();
 
-    // Verify new form name in Forms list page and also new conf message and colors on the front end
+    $i->wantTo('Verify new form name in Forms list page and also new conf message and colors on the front end');
     $i->amOnMailpoetPage('Forms');
     $i->waitForText('Forms');
     $i->waitForText($updatedFormName);


### PR DESCRIPTION
## Description

In this PR, I updated tests to include checks for selecting colors of the font, background and border. Covered also selecting border radius size, but also testing the reset button.

Added a new helper method to select panel colors, there's explanation in the commented area how to use the method.

Updated comments with `wantTo()`.

I also updated where we used `assertAttributeContains` for verifying the CSS thing in editor, but that doesn't work, so instead we should use `assertCssProperty` which is more appropriate assertiong of the CSS. This means, with previously used `assertAttributeContains` it would be green/passed even if it would be wrong color (I just realised that while making this test). We should never use `assertAttributeContains` for asserting CSS.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5318] & [MAILPOET-5319]

## After-merge notes

_N/A_


[MAILPOET-5318]: https://mailpoet.atlassian.net/browse/MAILPOET-5318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5319]: https://mailpoet.atlassian.net/browse/MAILPOET-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ