### PR TITLE
Email volume and subscriber limits number format [MAILPOET-5388]

### DIFF
--- a/mailpoet/assets/js/src/notices/email_volume_limit_notice.tsx
+++ b/mailpoet/assets/js/src/notices/email_volume_limit_notice.tsx
@@ -14,11 +14,11 @@ function EmailVolumeLimitNotice(): JSX.Element {
   if (MailPoet.emailVolumeLimit) {
     title = MailPoet.I18n.t('emailVolumeLimitNoticeTitle').replace(
       '[emailVolumeLimit]',
-      MailPoet.emailVolumeLimit,
+      MailPoet.emailVolumeLimit.toLocaleString(),
     );
     youReachedEmailVolumeLimit = MailPoet.I18n.t(
       'youReachedEmailVolumeLimit',
-    ).replace('[emailVolumeLimit]', MailPoet.emailVolumeLimit);
+    ).replace('[emailVolumeLimit]', MailPoet.emailVolumeLimit.toLocaleString());
   }
 
   const upgradeLink = MailPoet.MailPoetComUrlFactory.getUpgradeUrl(

--- a/mailpoet/assets/js/src/notices/subscribers_limit_notice.tsx
+++ b/mailpoet/assets/js/src/notices/subscribers_limit_notice.tsx
@@ -5,7 +5,7 @@ import { Notice } from 'notices/notice';
 function SubscribersLimitNotice(): JSX.Element {
   if (!MailPoet.subscribersLimitReached) return null;
   const hasValidApiKey = MailPoet.hasValidApiKey;
-  const subscribersLimit = MailPoet.subscribersLimit.toString();
+  const subscribersLimit = MailPoet.subscribersLimit.toLocaleString();
   let title = MailPoet.I18n.t('subscribersLimitNoticeTitleUnknownLimit');
   let youReachedTheLimit = '';
   if (MailPoet.subscribersLimit) {

--- a/mailpoet/tests/acceptance/Misc/ExceededLimitsErrorNoticesCest.php
+++ b/mailpoet/tests/acceptance/Misc/ExceededLimitsErrorNoticesCest.php
@@ -23,7 +23,8 @@ class ExceededLimitsErrorNoticesCest {
     $settings->withSendingMethodMailpoetWithRestrictedAccess(Bridge::KEY_ACCESS_EMAIL_VOLUME_LIMIT, 5000);
 
     $i->amOnMailpoetPage('Homepage');
-    $i->waitForText('Congratulations, you sent more than 5000 emails this month!');
+    $i->waitForText('Congratulations, you sent more than 5,000 emails this month!');
+    $i->waitForText('your MailPoet plan includes (5,000)');
     $i->dontSee($mailerErrorMessage);
 
     $i->wantTo('Check the alternative message without limit info is displayed when the limit info is not available');

--- a/mailpoet/tests/acceptance/Misc/ExceededLimitsErrorNoticesCest.php
+++ b/mailpoet/tests/acceptance/Misc/ExceededLimitsErrorNoticesCest.php
@@ -50,7 +50,8 @@ class ExceededLimitsErrorNoticesCest {
     $settings->withSendingMethodMailpoetWithRestrictedAccess(Bridge::KEY_ACCESS_SUBSCRIBERS_LIMIT, 5000);
 
     $i->amOnMailpoetPage('Homepage');
-    $i->waitForText('Congratulations, you now have more than 5000 subscribers!');
+    $i->waitForText('Congratulations, you now have more than 5,000 subscribers!');
+    $i->waitForText('Your plan is limited to 5,000 subscribers');
     $i->dontSee($mailerErrorMessage);
 
     $i->wantTo('Check the alternative message without limit info is displayed when the limit info is not available');


### PR DESCRIPTION
## Description

Added number formatting in notices when limits are reached.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5388]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5388]: https://mailpoet.atlassian.net/browse/MAILPOET-5388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ