### PR TITLE
Segment filters for entered/exited automations [MAILPOET-5003]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/automation_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/automation_options.ts
@@ -1,0 +1,20 @@
+import { MailPoet } from 'mailpoet';
+import { SegmentTypes } from '../types';
+
+export enum AutomationsActionTypes {
+  ENTERED_AUTOMATION = 'enteredAutomation',
+  EXITED_AUTOMATION = 'exitedAutomation',
+}
+
+export const AutomationsOptions = [
+  {
+    value: AutomationsActionTypes.ENTERED_AUTOMATION,
+    label: MailPoet.I18n.t('automationsEnteredAutomation'),
+    group: SegmentTypes.Automations,
+  },
+  {
+    value: AutomationsActionTypes.EXITED_AUTOMATION,
+    label: MailPoet.I18n.t('automationsExitedAutomation'),
+    group: SegmentTypes.Automations,
+  },
+];

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/automations.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/automations.tsx
@@ -1,0 +1,34 @@
+import { useSelect } from '@wordpress/data';
+import { FilterProps, AutomationsFormItem } from '../types';
+import { storeName } from '../store';
+import { AutomationsActionTypes } from './automation_options';
+import {
+  GeneralAutomationsFields,
+  validateAutomationsFields,
+} from './fields/automations/general_automations_fields';
+
+export function validateAutomations(formItems: AutomationsFormItem): boolean {
+  if (
+    !Object.values(AutomationsActionTypes).some((v) => v === formItems.action)
+  ) {
+    return false;
+  }
+  if (formItems.action === AutomationsActionTypes.ENTERED_AUTOMATION) {
+    return validateAutomationsFields(formItems);
+  }
+  return true;
+}
+
+const componentsMap = {
+  [AutomationsActionTypes.ENTERED_AUTOMATION]: GeneralAutomationsFields,
+  [AutomationsActionTypes.EXITED_AUTOMATION]: GeneralAutomationsFields,
+};
+
+export function AutomationsFields({ filterIndex }: FilterProps): JSX.Element {
+  const segment: AutomationsFormItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const Component = componentsMap[segment.action];
+  return <Component filterIndex={filterIndex} />;
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/automations/general_automations_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/automations/general_automations_fields.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+import { MailPoet } from 'mailpoet';
+import { Select } from 'common/form/select/select';
+import { Grid } from 'common/grid';
+import { ReactSelect } from 'common/form/react_select/react_select';
+
+import {
+  AnyValueTypes,
+  Automation,
+  AutomationsFormItem,
+  FilterProps,
+  SelectOption,
+} from '../../../types';
+import { storeName } from '../../../store';
+
+export function validateAutomationsFields(
+  formItems: AutomationsFormItem,
+): boolean {
+  return (
+    (formItems.operator === AnyValueTypes.ANY ||
+      formItems.operator === AnyValueTypes.NONE ||
+      formItems.operator === AnyValueTypes.ALL) &&
+    Array.isArray(formItems.automation_ids) &&
+    formItems.automation_ids.length > 0
+  );
+}
+
+export function GeneralAutomationsFields({
+  filterIndex,
+}: FilterProps): JSX.Element {
+  const segment: AutomationsFormItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const automations: Automation[] = useSelect(
+    (select) => select(storeName).getAutomations(),
+    [],
+  );
+
+  const { updateSegmentFilter, updateSegmentFilterFromEvent } =
+    useDispatch(storeName);
+  useEffect(() => {
+    if (
+      segment.operator !== AnyValueTypes.ANY &&
+      segment.operator !== AnyValueTypes.ALL &&
+      segment.operator !== AnyValueTypes.NONE
+    ) {
+      void updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
+  const options = automations.map((automation) => ({
+    value: automation.id,
+    label: automation.name,
+  }));
+
+  return (
+    <>
+      <Grid.CenteredRow>
+        <Select
+          key="select"
+          isFullWidth
+          value={segment.operator}
+          onChange={(e) => {
+            void updateSegmentFilterFromEvent('operator', filterIndex, e);
+          }}
+        >
+          <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+          <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+          <option value={AnyValueTypes.NONE}>
+            {MailPoet.I18n.t('noneOf')}
+          </option>
+        </Select>
+      </Grid.CenteredRow>
+      <Grid.CenteredRow>
+        <ReactSelect
+          dimension="small"
+          isFullWidth
+          isMulti
+          placeholder={MailPoet.I18n.t('searchAutomations')}
+          options={options}
+          value={options.filter((option) => {
+            if (!segment.automation_ids) {
+              return undefined;
+            }
+            const automationId = option.value;
+            return segment.automation_ids.indexOf(automationId) !== -1;
+          })}
+          onChange={(selectOptions: SelectOption[]): void => {
+            void updateSegmentFilter(
+              { automation_ids: selectOptions.map((option) => option.value) },
+              filterIndex,
+            );
+          }}
+        />
+      </Grid.CenteredRow>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/form_filter_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/form_filter_fields.tsx
@@ -5,11 +5,13 @@ import { FilterProps, SegmentTypes, WordpressRoleFormItem } from './types';
 import { EmailFields } from './dynamic_segments_filters/email';
 import { SubscriberFields } from './dynamic_segments_filters/subscriber';
 import { WooCommerceFields } from './dynamic_segments_filters/woocommerce';
+import { AutomationsFields } from './dynamic_segments_filters/automations';
 import { WooCommerceMembershipFields } from './dynamic_segments_filters/fields/woocommerce/woocommerce_membership';
 import { WooCommerceSubscriptionFields } from './dynamic_segments_filters/fields/woocommerce/woocommerce_subscription';
 import { storeName } from './store';
 
 const filterFieldsMap = {
+  [SegmentTypes.Automations]: AutomationsFields,
   [SegmentTypes.Email]: EmailFields,
   [SegmentTypes.WooCommerce]: WooCommerceFields,
   [SegmentTypes.WordPressRole]: SubscriberFields,

--- a/mailpoet/assets/js/src/segments/dynamic/store/all_available_filters.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/all_available_filters.ts
@@ -1,6 +1,7 @@
 import { MailPoet } from 'mailpoet';
 
 import { GroupFilterValue } from '../types';
+import { AutomationsOptions } from '../dynamic_segments_filters/automation_options';
 import { EmailSegmentOptions } from '../dynamic_segments_filters/email_options';
 import { SubscriberSegmentOptions } from '../dynamic_segments_filters/subscriber_options';
 import {
@@ -14,6 +15,10 @@ export function getAvailableFilters(
   canUseWooMembership: boolean,
 ): GroupFilterValue[] {
   const filters: GroupFilterValue[] = [
+    {
+      label: MailPoet.I18n.t('automations'),
+      options: AutomationsOptions,
+    },
     {
       label: MailPoet.I18n.t('email'),
       options: EmailSegmentOptions,

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial_state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial_state.ts
@@ -10,6 +10,7 @@ import {
 declare let window: SegmentFormDataWindow;
 
 export const getInitialState = (): StateType => ({
+  automations: window.mailpoet_automations,
   products: window.mailpoet_products,
   staticSegmentsList: window.mailpoet_static_segments_list,
   membershipPlans: window.mailpoet_membership_plans,

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -1,5 +1,6 @@
 import {
   AnyFormItem,
+  Automation,
   FilterRow,
   FilterValue,
   GroupFilterValue,
@@ -55,6 +56,8 @@ export const getPaymentMethods = (state: StateType): WooPaymentMethod[] =>
   state.wooPaymentMethods;
 export const getShippingMethods = (state: StateType): WooShippingMethod[] =>
   state.wooShippingMethods;
+export const getAutomations = (state: StateType): Automation[] =>
+  state.automations;
 export const getSegmentFilter = (
   state: StateType,
   index: number,

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -1,4 +1,5 @@
 export enum SegmentTypes {
+  Automations = 'automations',
   Email = 'email',
   WordPressRole = 'userRole',
   SubscribedDate = 'subscribedDate',
@@ -111,6 +112,11 @@ export interface WooCommerceFormItem extends FormItem {
   used_shipping_method_days?: string;
 }
 
+export interface AutomationsFormItem extends FormItem {
+  operator?: string;
+  automation_ids?: string[];
+}
+
 export interface WooCommerceMembershipFormItem extends FormItem {
   plan_ids?: string[];
   operator?: AnyValueTypes;
@@ -139,6 +145,7 @@ export type Segment = {
 };
 
 export type AnyFormItem =
+  | AutomationsFormItem
   | DateFormItem
   | WordpressRoleFormItem
   | WooCommerceFormItem
@@ -223,6 +230,7 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_static_segments_list: StaticSegment[];
   mailpoet_tags: Tag[];
   mailpoet_signup_forms: SignupForm[];
+  mailpoet_automations: Automation[];
 }
 
 export interface StateType {
@@ -246,6 +254,7 @@ export interface StateType {
   staticSegmentsList: StaticSegment[];
   tags: Tag[];
   signupForms: SignupForm[];
+  automations: Automation[];
 }
 
 export enum Actions {
@@ -299,6 +308,11 @@ export type SignupForm = {
 };
 
 export type WooPaymentMethod = {
+  id: string;
+  name: string;
+};
+
+export type Automation = {
   id: string;
   name: string;
 };

--- a/mailpoet/assets/js/src/segments/dynamic/validator.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/validator.ts
@@ -1,4 +1,5 @@
 import { AnyFormItem, SegmentTypes } from './types';
+import { validateAutomations } from './dynamic_segments_filters/automations';
 import { validateEmail } from './dynamic_segments_filters/email';
 import { validateWooCommerce } from './dynamic_segments_filters/woocommerce';
 import { validateSubscriber } from './dynamic_segments_filters/subscriber';
@@ -6,6 +7,7 @@ import { validateWooCommerceMembership } from './dynamic_segments_filters/fields
 import { validateWooCommerceSubscription } from './dynamic_segments_filters/fields/woocommerce/woocommerce_subscription';
 
 const validationMap = {
+  [SegmentTypes.Automations]: validateAutomations,
   [SegmentTypes.Email]: validateEmail,
   [SegmentTypes.WooCommerce]: validateWooCommerce,
   [SegmentTypes.WordPressRole]: validateSubscriber,

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -162,7 +162,7 @@ class Segments {
     }
     $data['automations'] = array_map(function(Automation $automation) {
       return [
-        'id' => $automation->getId(),
+        'id' => (string)$automation->getId(),
         'name' => $automation->getName(),
       ];
     }, $this->automationStorage->getAutomations());

--- a/mailpoet/lib/AdminPages/Pages/Segments.php
+++ b/mailpoet/lib/AdminPages/Pages/Segments.php
@@ -4,6 +4,8 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\API\JSON\ResponseBuilders\CustomFieldsResponseBuilder;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\FormEntity;
@@ -52,6 +54,9 @@ class Segments {
   /** @var FormsRepository */
   private $formsRepository;
 
+  /** @var AutomationStorage */
+  private $automationStorage;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
@@ -63,7 +68,8 @@ class Segments {
     SegmentDependencyValidator $segmentDependencyValidator,
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
-    FormsRepository $formsRepository
+    FormsRepository $formsRepository,
+    AutomationStorage $automationStorage
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
@@ -76,6 +82,7 @@ class Segments {
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
     $this->formsRepository = $formsRepository;
+    $this->automationStorage = $automationStorage;
   }
 
   public function render() {
@@ -153,7 +160,12 @@ class Segments {
 
       $data['woocommerce_shipping_methods'] = $this->woocommerceHelper->getShippingMethodInstancesData();
     }
-
+    $data['automations'] = array_map(function(Automation $automation) {
+      return [
+        'id' => $automation->getId(),
+        'name' => $automation->getName(),
+      ];
+    }, $this->automationStorage->getAutomations());
     $this->pageRenderer->displayPage('segments.html', $data);
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -421,6 +421,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\AutomationsEvents::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\DateFilterHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny::class)->setPublic(true);

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -10,6 +10,7 @@ use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
  * @ORM\Embeddable()
  */
 class DynamicSegmentFilterData {
+  const TYPE_AUTOMATIONS = 'automations';
   const TYPE_USER_ROLE = 'userRole';
   const TYPE_EMAIL = 'email';
   const TYPE_WOOCOMMERCE = 'woocommerce';

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -5,6 +5,7 @@ namespace MailPoet\Segments\DynamicSegments;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Segments\DynamicSegments\Filters\AutomationsEvents;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
 use MailPoet\Segments\DynamicSegments\Filters\EmailActionClickAny;
 use MailPoet\Segments\DynamicSegments\Filters\EmailOpensAbsoluteCountAction;
@@ -104,6 +105,9 @@ class FilterFactory {
   /** @var WooCommerceCustomerTextField */
   private $wooCommerceCustomerTextField;
 
+  /** @var AutomationsEvents */
+  private $automationsEvents;
+
   public function __construct(
     EmailAction $emailAction,
     EmailActionClickAny $emailActionClickAny,
@@ -128,7 +132,8 @@ class FilterFactory {
     WooCommerceAverageSpent $wooCommerceAverageSpent,
     WooCommerceUsedPaymentMethod $wooCommerceUsedPaymentMethod,
     WooCommerceUsedShippingMethod $wooCommerceUsedShippingMethod,
-    SubscriberTextField $subscriberTextField
+    SubscriberTextField $subscriberTextField,
+    AutomationsEvents $automationsEvents
   ) {
     $this->emailAction = $emailAction;
     $this->userRole = $userRole;
@@ -154,6 +159,7 @@ class FilterFactory {
     $this->wooCommerceUsedPaymentMethod = $wooCommerceUsedPaymentMethod;
     $this->wooCommerceUsedShippingMethod = $wooCommerceUsedShippingMethod;
     $this->wooCommerceCustomerTextField = $wooCommerceCustomerTextField;
+    $this->automationsEvents = $automationsEvents;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -161,6 +167,8 @@ class FilterFactory {
     $filterType = $filterData->getFilterType();
     $action = $filterData->getAction();
     switch ($filterType) {
+      case DynamicSegmentFilterData::TYPE_AUTOMATIONS:
+        return $this->automationsEvents;
       case DynamicSegmentFilterData::TYPE_USER_ROLE:
         return $this->userRole($action);
       case DynamicSegmentFilterData::TYPE_EMAIL:

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/AutomationsEvents.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/AutomationsEvents.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class AutomationsEvents implements Filter {
+
+  const SUPPORTED_ACTIONS = [
+    self::ENTERED_ACTION,
+    self::EXITED_ACTION,
+  ];
+
+  const ENTERED_ACTION = 'enteredAutomation';
+  const EXITED_ACTION = 'exitedAutomation';
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  public function __construct(
+    FilterHelper $filterHelper
+  ) {
+    $this->filterHelper = $filterHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $action = $filterData->getParam('action');
+    $operator = $filterData->getParam('operator');
+    $automationIds = $filterData->getParam('automation_ids');
+
+    switch ($operator) {
+      case DynamicSegmentFilterData::OPERATOR_ANY:
+        $this->applyForAnyOperator($queryBuilder, $action, $automationIds);
+        break;
+      case DynamicSegmentFilterData::OPERATOR_ALL:
+        $this->applyForAllOperator($queryBuilder, $action, $automationIds);
+        break;
+      case DynamicSegmentFilterData::OPERATOR_NONE:
+        $subscribersTable = $this->filterHelper->getSubscribersTable();
+        $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+        $this->applyForAnyOperator($subQuery, $action, $automationIds);
+        $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
+        break;
+    }
+    return $queryBuilder;
+  }
+
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, $action, $automationIds) {
+    $subscribersTable = $this->filterHelper->getSubscribersTable();
+    $automationsTable = $this->filterHelper->getPrefixedTable('mailpoet_automations');
+    $automationRunsTable = $this->filterHelper->getPrefixedTable('mailpoet_automation_runs');
+    $automationRunSubjectsTable = $this->filterHelper->getPrefixedTable('mailpoet_automation_run_subjects');
+    $automationIdsParam = $this->filterHelper->getUniqueParameterName('automationIds');
+
+    $queryBuilder
+      ->innerJoin(
+        $subscribersTable,
+        $automationRunSubjectsTable,
+        'subjects',
+        "subjects.key = 'mailpoet:subscriber' AND subjects.args = CONCAT('{\"subscriber_id\":', $subscribersTable.id, '}')")
+      ->innerJoin(
+        'subjects',
+        $automationRunsTable,
+        'runs',
+        'subjects.automation_run_id = runs.id')
+      ->innerJoin(
+        'runs',
+        $automationsTable,
+        'automations',
+        'automations.id = runs.automation_id')
+      ->andWhere("automations.id IN (:$automationIdsParam)")
+      ->setParameter($automationIdsParam, $automationIds, Connection::PARAM_STR_ARRAY);
+
+    if ($action === self::EXITED_ACTION) {
+      $statusParam = $this->filterHelper->getUniqueParameterName('status');
+      $queryBuilder
+        ->andWhere("runs.status != :$statusParam")
+        ->setParameter($statusParam, AutomationRun::STATUS_RUNNING);
+    }
+  }
+
+  private function applyForAllOperator(QueryBuilder $queryBuilder, $action, $automationIds) {
+    $this->applyForAnyOperator($queryBuilder, $action, $automationIds);
+    $queryBuilder
+      ->groupBy('inner_subscriber_id')
+      ->having("COUNT(DISTINCT automations.id) = " . count($automationIds));
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/AutomationsEventsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/AutomationsEventsTest.php
@@ -1,0 +1,249 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\Filters\AutomationsEvents;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class AutomationsEventsTest extends \MailPoetTest {
+
+  /** @var AutomationsEvents */
+  private $filter;
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  /** @var SegmentEntity */
+  private $triggerSegment;
+
+  public function _before(): void {
+    $this->filter = $this->diContainer->get(AutomationsEvents::class);
+    $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $this->triggerSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->withName('test segment')->create();
+  }
+
+  public function testEnteredWorksWithAnyOperator(): void {
+    $s1 = (new Subscriber())->withEmail('1@e.com')->create();
+    $s2 = (new Subscriber())->withEmail('2@e.com')->create();
+    $s3 = (new Subscriber())->withEmail('3@e.com')->create();
+    $s4 = (new Subscriber())->withEmail('4@e.com')->create();
+    $s5 = (new Subscriber())->withEmail('5@e.com')->create();
+    $s6 = (new Subscriber())->withEmail('6@e.com')->create();
+    $s7 = (new Subscriber())->withEmail('7@e.com')->create();
+    $s8 = (new Subscriber())->withEmail('8@e.com')->create();
+
+    $automation1 = $this->createAutomation();
+    $automation2 = $this->createAutomation();
+
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s2, $automation1, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s3, $automation1, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s4, $automation1, AutomationRun::STATUS_FAILED);
+
+    $this->addSubscriberToAutomation($s5, $automation2, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s6, $automation2, AutomationRun::STATUS_COMPLETE);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'any', [$automation1->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'any', [$automation2->getId()], ['5@e.com', '6@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'any', [$automation1->getId(), $automation2->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com', '5@e.com', '6@e.com']);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'any', [$automation1->getId()], ['2@e.com', '3@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'any', [$automation2->getId()], ['6@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'any', [$automation1->getId(), $automation2->getId()], ['2@e.com', '3@e.com', '4@e.com', '6@e.com']);
+  }
+
+  public function testStatusesWorkAsExpectedForAllOperator(): void {
+    $s1 = (new Subscriber())->withEmail('1@e.com')->create();
+    $s2 = (new Subscriber())->withEmail('2@e.com')->create();
+    $s3 = (new Subscriber())->withEmail('3@e.com')->create();
+    $s4 = (new Subscriber())->withEmail('4@e.com')->create();
+    $s5 = (new Subscriber())->withEmail('5@e.com')->create();
+    $s6 = (new Subscriber())->withEmail('6@e.com')->create();
+    $s7 = (new Subscriber())->withEmail('7@e.com')->create();
+    $s8 = (new Subscriber())->withEmail('8@e.com')->create();
+    $s9 = (new Subscriber())->withEmail('9@e.com')->create();
+    $s10 = (new Subscriber())->withEmail('10@e.com')->create();
+    $s11 = (new Subscriber())->withEmail('11@e.com')->create();
+    $s12 = (new Subscriber())->withEmail('12@e.com')->create();
+
+    $automation1 = $this->createAutomation();
+    $automation2 = $this->createAutomation();
+    $automation3 = $this->createAutomation();
+
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s2, $automation1, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s3, $automation1, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s4, $automation1, AutomationRun::STATUS_FAILED);
+
+    $this->addSubscriberToAutomation($s5, $automation2, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s6, $automation2, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s7, $automation2, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s8, $automation2, AutomationRun::STATUS_FAILED);
+
+    $this->addSubscriberToAutomation($s9, $automation3, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s10, $automation3, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s11, $automation3, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s12, $automation3, AutomationRun::STATUS_FAILED);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation1->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation2->getId()], ['5@e.com', '6@e.com', '7@e.com', '8@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation3->getId()], ['9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'all', [$automation1->getId()], ['2@e.com', '3@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'all', [$automation2->getId()], ['6@e.com', '7@e.com', '8@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'all', [$automation3->getId()], ['10@e.com', '11@e.com', '12@e.com']);
+  }
+
+  public function testCombinationsWorkAsExpectedWithAllOperator(): void {
+    $automation1 = $this->createAutomation();
+    $automation2 = $this->createAutomation();
+    $automation3 = $this->createAutomation();
+    $automation4 = $this->createAutomation();
+
+    $s1 = (new Subscriber())->withEmail('1@e.com')->create();
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s1, $automation2, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s1, $automation3, AutomationRun::STATUS_COMPLETE);
+
+    $s2 = (new Subscriber())->withEmail('2@e.com')->create();
+    $this->addSubscriberToAutomation($s2, $automation2, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s2, $automation3, AutomationRun::STATUS_COMPLETE);
+
+    $s3 = (new Subscriber())->withEmail('3@e.com')->create();
+    $this->addSubscriberToAutomation($s3, $automation3, AutomationRun::STATUS_COMPLETE);
+
+    $s4 = (new Subscriber())->withEmail('4@e.com')->create();
+    $this->addSubscriberToAutomation($s4, $automation1, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s4, $automation3, AutomationRun::STATUS_COMPLETE);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation1->getId(), $automation2->getId(), $automation3->getId()], ['1@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation1->getId(), $automation2->getId(), $automation3->getId(), $automation4->getId()], []);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation2->getId(), $automation3->getId()], ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation2->getId(), $automation3->getId(), $automation4->getId()], []);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation3->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation3->getId(), $automation4->getId()], []);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation1->getId(), $automation3->getId()], ['1@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation1->getId(), $automation3->getId(), $automation4->getId()], []);
+  }
+
+  public function testItWorksWithNoneOperator(): void {
+    $s1 = (new Subscriber())->withEmail('1@e.com')->create();
+    $s2 = (new Subscriber())->withEmail('2@e.com')->create();
+    $s3 = (new Subscriber())->withEmail('3@e.com')->create();
+    $s4 = (new Subscriber())->withEmail('4@e.com')->create();
+    $s5 = (new Subscriber())->withEmail('5@e.com')->create();
+    $s6 = (new Subscriber())->withEmail('6@e.com')->create();
+    $s7 = (new Subscriber())->withEmail('7@e.com')->create();
+    $s8 = (new Subscriber())->withEmail('8@e.com')->create();
+    $s9 = (new Subscriber())->withEmail('9@e.com')->create();
+    $s10 = (new Subscriber())->withEmail('10@e.com')->create();
+    $s11 = (new Subscriber())->withEmail('11@e.com')->create();
+    $s12 = (new Subscriber())->withEmail('12@e.com')->create();
+
+    $automation1 = $this->createAutomation();
+    $automation2 = $this->createAutomation();
+    $automation3 = $this->createAutomation();
+
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s2, $automation1, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s3, $automation1, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s4, $automation1, AutomationRun::STATUS_FAILED);
+
+    $this->addSubscriberToAutomation($s5, $automation2, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s6, $automation2, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s7, $automation2, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s8, $automation2, AutomationRun::STATUS_FAILED);
+
+    $this->addSubscriberToAutomation($s9, $automation3, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s10, $automation3, AutomationRun::STATUS_COMPLETE);
+    $this->addSubscriberToAutomation($s11, $automation3, AutomationRun::STATUS_CANCELLED);
+    $this->addSubscriberToAutomation($s12, $automation3, AutomationRun::STATUS_FAILED);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation1->getId()], ['5@e.com', '6@e.com', '7@e.com', '8@e.com', '9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation2->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com', '9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation3->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com', '5@e.com', '6@e.com', '7@e.com', '8@e.com']);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation1->getId(), $automation2->getId()], ['9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation2->getId(), $automation3->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation1->getId(), $automation3->getId()], ['5@e.com', '6@e.com', '7@e.com', '8@e.com']);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation1->getId(), $automation2->getId(), $automation3->getId()], []);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation1->getId()], ['1@e.com', '5@e.com', '6@e.com', '7@e.com', '8@e.com', '9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation2->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com', '5@e.com', '9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation3->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com', '5@e.com', '6@e.com', '7@e.com', '8@e.com', '9@e.com']);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation1->getId(), $automation2->getId()], ['1@e.com', '5@e.com', '9@e.com', '10@e.com', '11@e.com', '12@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation2->getId(), $automation3->getId()], ['1@e.com', '2@e.com', '3@e.com', '4@e.com', '5@e.com', '9@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation1->getId(), $automation3->getId()], ['1@e.com', '5@e.com', '6@e.com', '7@e.com', '8@e.com', '9@e.com']);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation1->getId(), $automation2->getId(), $automation3->getId()], ['1@e.com', '5@e.com', '9@e.com']);
+  }
+
+  public function testNoneOfReturnsSubscribersNotAssociatedWithAutomations(): void {
+    $automation1 = $this->createAutomation();
+    $s1 = (new Subscriber())->withEmail('1@e.com')->create();
+    $s2 = (new Subscriber())->withEmail('2@e.com')->create();
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_COMPLETE);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation1->getId()], ['2@e.com']);
+  }
+
+  public function testItWorksWithSubscribersWhoHaveMultipleRunsForTheSameAutomation(): void {
+    $automation1 = $this->createAutomation();
+
+    $s1 = (new Subscriber())->withEmail('1@e.com')->create();
+
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_RUNNING);
+    $this->addSubscriberToAutomation($s1, $automation1, AutomationRun::STATUS_COMPLETE);
+
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'any', [$automation1->getId()], ['1@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'any', [$automation1->getId()], ['1@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'all', [$automation1->getId()], ['1@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'all', [$automation1->getId()], ['1@e.com']);
+    $this->assertFilterReturnsEmails(AutomationsEvents::ENTERED_ACTION, 'none', [$automation1->getId()], []);
+    $this->assertFilterReturnsEmails(AutomationsEvents::EXITED_ACTION, 'none', [$automation1->getId()], []);
+  }
+
+  private function assertFilterReturnsEmails(string $action, string $operator, array $automationIds, array $expectedEmails): void {
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_AUTOMATIONS, $action, [
+      'action' => $action,
+      'operator' => $operator,
+      'automation_ids' => $automationIds,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  private function createAutomation(): Automation {
+    return (new AutomationFactory())
+      ->withName('test automation')
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+  }
+
+  private function addSubscriberToAutomation(SubscriberEntity $subscriberEntity, Automation $automation, string $status) {
+    $subscriberSubject = new Subject('mailpoet:subscriber', ['subscriber_id' => $subscriberEntity->getId()]);
+    $segmentSubject = new Subject('mailpoet:segment', ['segment_id' => $this->triggerSegment->getId()]);
+    $automationRun = new AutomationRun(
+      $automation->getId(),
+      $automation->getVersionId(),
+      'mailpoet:someone-subscribes',
+      [$subscriberSubject, $segmentSubject]
+    );
+    $id = $this->automationRunStorage->createAutomationRun($automationRun);
+    if ($status !== AutomationRun::STATUS_RUNNING) {
+      $this->automationRunStorage->updateStatus($id, $status);
+    }
+  }
+}

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -807,4 +807,95 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'operator' => 'not a valid operator',
     ]]]);
   }
+
+  public function testItMapsEnteredAutomation() {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_AUTOMATIONS,
+      'action' => 'enteredAutomation',
+      'operator' => 'any',
+      'automation_ids' => ['1', '2'],
+    ]]];
+    $filters = $this->mapper->map($data);
+    expect($filters)->array();
+    expect($filters)->count(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    expect($filter)->isInstanceOf(DynamicSegmentFilterData::class);
+    expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_AUTOMATIONS);
+    expect($filter->getAction())->equals('enteredAutomation');
+    expect($filter->getData())->equals([
+      'action' => 'enteredAutomation',
+      'operator' => 'any',
+      'automation_ids' => ['1', '2'],
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+    ]);
+  }
+
+  public function testItMapsExitedAutomation() {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_AUTOMATIONS,
+      'action' => 'exitedAutomation',
+      'operator' => 'all',
+      'automation_ids' => ['1', '2'],
+    ]]];
+    $filters = $this->mapper->map($data);
+    expect($filters)->array();
+    expect($filters)->count(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    expect($filter)->isInstanceOf(DynamicSegmentFilterData::class);
+    expect($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_AUTOMATIONS);
+    expect($filter->getAction())->equals('exitedAutomation');
+    expect($filter->getData())->equals([
+      'action' => 'exitedAutomation',
+      'operator' => 'all',
+      'automation_ids' => ['1', '2'],
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+    ]);
+  }
+
+  public function testItThrowsExceptionIfAutomationIdsMissing() {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    $this->expectExceptionMessage('Missing automation IDs');
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_AUTOMATIONS,
+      'action' => 'enteredAutomation',
+      'operator' => 'none',
+    ]]]);
+  }
+
+  public function testItThrowsExceptionIfAutomationsOperatorIsInvalid(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_OPERATOR);
+    $this->expectExceptionMessage('Missing operator');
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_AUTOMATIONS,
+      'action' => 'enteredAutomation',
+      'operator' => 'not a valid operator',
+    ]]]);
+  }
+
+  public function testItThrowsExceptionIfInvalidAutomationsAction(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
+    $this->expectExceptionMessage('Unknown automations action');
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_AUTOMATIONS,
+      'action' => 'didSomethingUnsupportedWithAutomation',
+      'operator' => 'any',
+      'automation_ids' => ['1', '2'],
+    ]]]);
+  }
+
+  public function testItThrowsExceptionIfAutomationActionIsMissing(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_ACTION);
+    $this->expectExceptionMessage('Missing automations filter action');
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_AUTOMATIONS,
+      'operator' => 'any',
+      'automation_ids' => ['1', '2'],
+    ]]]);
+  }
 }

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -30,6 +30,7 @@
     var mailpoet_woocommerce_payment_methods = <%= json_encode(woocommerce_payment_methods)  %>;
     var mailpoet_woocommerce_shipping_methods = <%= json_encode(woocommerce_shipping_methods)  %>;
     var mailpoet_signup_forms = <%= json_encode(signup_forms) %>;
+    var mailpoet_automations = <%= json_encode(automations) %>;
   </script>
 <% endblock %>
 
@@ -215,6 +216,11 @@
     'multipleDynamicSegmentsRestored': __('%1$d segments have been restored from the Trash.'),
     'multipleDynamicSegmentsDeleted': __('%1$d segments were permanently deleted.'),
     'oneDynamicSegmentDeleted': __('1 segment was permanently deleted.'),
+
+    'automations': __('Automations'),
+    'automationsEnteredAutomation': __('entered automation'),
+    'automationsExitedAutomation': __('exited automation'),
+    'searchAutomations': __('Search automations'),
 
     'wooNumberOfOrders': __('number of orders'),
     'moreThan': __('more than'),


### PR DESCRIPTION
## Description

This PR adds two new dynamic segment filters for subscriber entered/exited automation(s).

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs
_N/A_

## Linked tickets

[MAILPOET-5003](https://mailpoet.atlassian.net/browse/MAILPOET-5003)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5003]: https://mailpoet.atlassian.net/browse/MAILPOET-5003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ