### PR TITLE
Fix translation string typo

### DIFF
--- a/mailpoet/views/woo_system_info.html
+++ b/mailpoet/views/woo_system_info.html
@@ -11,7 +11,7 @@
   <tr>
     <td data-export-label="Sending Method"><%= __("Sending Method:") %></td>
     <td class="help">
-      <span class="woocommerce-help-tip" data-tip="<%= __("What method is used to sent out newsletters?")|escape('html_attr') %>"></span>
+      <span class="woocommerce-help-tip" data-tip="<%= __("What method is used to send out newsletters?")|escape('html_attr') %>"></span>
     </td>
     <td><%= system_info.sending_method %></td>
   </tr>


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

No Jira ticket, reported in p1686554178405109-slack-C01HUN2F7EH

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes