### PR TITLE
New filters for city and postal code [MAILPOET-4990]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/text_field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/text_field.tsx
@@ -4,8 +4,8 @@ import { Grid } from 'common/grid';
 import { Select } from 'common/form/select/select';
 import { Input } from 'common/form/input/input';
 import { MailPoet } from 'mailpoet';
-import { FilterProps, WordpressRoleFormItem } from '../../../types';
-import { storeName } from '../../../store';
+import { FilterProps, TextFormItem } from '../../types';
+import { storeName } from '../../store';
 
 const validOperators = [
   'is',
@@ -18,17 +18,15 @@ const validOperators = [
   'notEndsWith',
 ];
 
-export function validateSubscriberTextField(
-  formItems: WordpressRoleFormItem,
-): boolean {
+export function validateTextField(formItems: TextFormItem): boolean {
   if (!validOperators.includes(formItems.operator)) {
     return false;
   }
   return typeof formItems.value === 'string' && formItems.value.length > 0;
 }
 
-export function SubscriberTextField({ filterIndex }: FilterProps): JSX.Element {
-  const segment: WordpressRoleFormItem = useSelect(
+export function TextField({ filterIndex }: FilterProps): JSX.Element {
+  const segment: TextFormItem = useSelect(
     (select) => select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/subscriber.tsx
@@ -28,10 +28,7 @@ import {
   SubscriberTag,
   validateSubscriberTag,
 } from './fields/subscriber/subscriber_tag';
-import {
-  SubscriberTextField,
-  validateSubscriberTextField,
-} from './fields/subscriber/subscriber_text_field';
+import { TextField, validateTextField } from './fields/text_field';
 import {
   SubscribedViaForm,
   validateSubscribedViaForm,
@@ -66,7 +63,7 @@ export function validateSubscriber(formItems: WordpressRoleFormItem): boolean {
       SubscriberActionTypes.SUBSCRIBER_EMAIL,
     ].includes(formItems.action as SubscriberActionTypes)
   ) {
-    return validateSubscriberTextField(formItems);
+    return validateTextField(formItems);
   }
   if (formItems.action === SubscriberActionTypes.SUBSCRIBED_VIA_FORM) {
     return validateSubscribedViaForm(formItems);
@@ -89,9 +86,9 @@ const componentsMap = {
   [SubscriberActionTypes.MAILPOET_CUSTOM_FIELD]: MailPoetCustomFields,
   [SubscriberActionTypes.SUBSCRIBED_TO_LIST]: SubscribedToList,
   [SubscriberActionTypes.SUBSCRIBER_TAG]: SubscriberTag,
-  [SubscriberActionTypes.SUBSCRIBER_FIRST_NAME]: SubscriberTextField,
-  [SubscriberActionTypes.SUBSCRIBER_LAST_NAME]: SubscriberTextField,
-  [SubscriberActionTypes.SUBSCRIBER_EMAIL]: SubscriberTextField,
+  [SubscriberActionTypes.SUBSCRIBER_FIRST_NAME]: TextField,
+  [SubscriberActionTypes.SUBSCRIBER_LAST_NAME]: TextField,
+  [SubscriberActionTypes.SUBSCRIBER_EMAIL]: TextField,
   [SubscriberActionTypes.SUBSCRIBED_VIA_FORM]: SubscribedViaForm,
 };
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -1,5 +1,5 @@
 import { useSelect } from '@wordpress/data';
-import { WooCommerceFormItem, FilterProps } from '../types';
+import { FilterProps, WooCommerceFormItem } from '../types';
 import { DateFields, validateDateField } from './fields/date_fields';
 import { storeName } from '../store';
 import { WooCommerceActionTypes } from './woocommerce_options';
@@ -35,6 +35,7 @@ import {
   UsedPaymentMethodFields,
   validateUsedPaymentMethod,
 } from './fields/woocommerce/used_payment_method';
+import { TextField, validateTextField } from './fields/text_field';
 
 export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (
@@ -69,11 +70,21 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (formItems.action === WooCommerceActionTypes.PURCHASE_DATE) {
     return validateDateField(formItems);
   }
+  if (
+    [
+      WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE,
+      WooCommerceActionTypes.CUSTOMER_IN_CITY,
+    ].includes(formItems.action as WooCommerceActionTypes)
+  ) {
+    return validateTextField(formItems);
+  }
   return true;
 }
 
 const componentsMap = {
   [WooCommerceActionTypes.CUSTOMER_IN_COUNTRY]: CustomerInCountryFields,
+  [WooCommerceActionTypes.CUSTOMER_IN_CITY]: TextField,
+  [WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE]: TextField,
   [WooCommerceActionTypes.NUMBER_OF_ORDERS]: NumberOfOrdersFields,
   [WooCommerceActionTypes.PURCHASE_DATE]: DateFields,
   [WooCommerceActionTypes.PURCHASED_PRODUCT]: PurchasedProductFields,

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
@@ -10,6 +10,8 @@ export enum WooCommerceActionTypes {
   TOTAL_SPENT = 'totalSpent',
   AVERAGE_SPENT = 'averageSpent',
   CUSTOMER_IN_COUNTRY = 'customerInCountry',
+  CUSTOMER_IN_CITY = 'customerInCity',
+  CUSTOMER_IN_POSTAL_CODE = 'customerInPostalCode',
   SINGLE_ORDER_VALUE = 'singleOrderValue',
   USED_PAYMENT_METHOD = 'usedPaymentMethod',
 }
@@ -21,6 +23,11 @@ export const WooCommerceOptions = [
     group: SegmentTypes.WooCommerce,
   },
   {
+    value: WooCommerceActionTypes.CUSTOMER_IN_CITY,
+    label: MailPoet.I18n.t('wooCustomerInCity'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
     value: WooCommerceActionTypes.CUSTOMER_IN_COUNTRY,
     label: MailPoet.I18n.t('wooCustomerInCountry'),
     group: SegmentTypes.WooCommerce,
@@ -28,6 +35,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.NUMBER_OF_ORDERS,
     label: MailPoet.I18n.t('wooNumberOfOrders'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE,
+    label: MailPoet.I18n.t('wooCustomerInPostalCode'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -71,6 +71,11 @@ export interface DateFormItem extends FormItem {
   value?: string;
 }
 
+export interface TextFormItem extends FormItem {
+  operator?: string;
+  value?: string;
+}
+
 export interface WordpressRoleFormItem extends FormItem {
   wordpressRole?: string[];
   operator?: string;

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -437,6 +437,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCustomerTextField::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -23,6 +23,25 @@ class DynamicSegmentFilterData {
   public const OPERATOR_ANY = 'any';
   public const OPERATOR_NONE = 'none';
 
+  public const OPERATOR_STARTS_WITH = 'startsWith';
+  public const OPERATOR_NOT_ENDS_WITH = 'notEndsWith';
+  public const OPERATOR_IS = 'is';
+  public const OPERATOR_CONTAINS = 'contains';
+  public const OPERATOR_NOT_CONTAINS = 'notContains';
+  public const OPERATOR_NOT_STARTS_WITH = 'notStartsWith';
+  public const OPERATOR_IS_NOT = 'isNot';
+  public const OPERATOR_ENDS_WITH = 'endsWith';
+  public const TEXT_FIELD_OPERATORS = [
+    DynamicSegmentFilterData::OPERATOR_IS,
+    DynamicSegmentFilterData::OPERATOR_IS_NOT,
+    DynamicSegmentFilterData::OPERATOR_CONTAINS,
+    DynamicSegmentFilterData::OPERATOR_NOT_CONTAINS,
+    DynamicSegmentFilterData::OPERATOR_STARTS_WITH,
+    DynamicSegmentFilterData::OPERATOR_NOT_STARTS_WITH,
+    DynamicSegmentFilterData::OPERATOR_ENDS_WITH,
+    DynamicSegmentFilterData::OPERATOR_NOT_ENDS_WITH,
+  ];
+
   /**
    * @ORM\Column(type="serialized_array")
    * @var array|null

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -95,7 +95,9 @@ class FilterDataMapper {
       $data['action'] = DynamicSegmentFilterData::TYPE_USER_ROLE;
     }
     if ($data['action'] === SubscriberSubscribedDate::TYPE) {
-      if (empty($data['value'])) throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['value'])) {
+        throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+      }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'value' => $data['value'],
         'operator' => $data['operator'] ?? DateFilterHelper::BEFORE,
@@ -103,7 +105,9 @@ class FilterDataMapper {
       ]);
     }
     if ($data['action'] === SubscriberScore::TYPE) {
-      if (!isset($data['value'])) throw new InvalidFilterException('Missing engagement score value', InvalidFilterException::MISSING_VALUE);
+      if (!isset($data['value'])) {
+        throw new InvalidFilterException('Missing engagement score value', InvalidFilterException::MISSING_VALUE);
+      }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'value' => $data['value'],
         'operator' => $data['operator'] ?? SubscriberScore::HIGHER_THAN,
@@ -111,7 +115,9 @@ class FilterDataMapper {
       ]);
     }
     if ($data['action'] === SubscriberSegment::TYPE) {
-      if (empty($data['segments'])) throw new InvalidFilterException('Missing segments', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['segments'])) {
+        throw new InvalidFilterException('Missing segments', InvalidFilterException::MISSING_VALUE);
+      }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'segments' => array_map(function ($segmentId) {
           return intval($segmentId);
@@ -121,21 +127,33 @@ class FilterDataMapper {
       ]);
     }
     if ($data['action'] === MailPoetCustomFields::TYPE) {
-      if (empty($data['custom_field_id'])) throw new InvalidFilterException('Missing custom field id', InvalidFilterException::MISSING_VALUE);
-      if (empty($data['custom_field_type'])) throw new InvalidFilterException('Missing custom field type', InvalidFilterException::MISSING_VALUE);
-      if (!isset($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['custom_field_id'])) {
+        throw new InvalidFilterException('Missing custom field id', InvalidFilterException::MISSING_VALUE);
+      }
+      if (empty($data['custom_field_type'])) {
+        throw new InvalidFilterException('Missing custom field type', InvalidFilterException::MISSING_VALUE);
+      }
+      if (!isset($data['value'])) {
+        throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
+      }
       $filterData = [
         'value' => $data['value'],
         'custom_field_id' => $data['custom_field_id'],
         'custom_field_type' => $data['custom_field_type'],
         'connect' => $data['connect'],
       ];
-      if (!empty($data['date_type'])) $filterData['date_type'] = $data['date_type'];
-      if (!empty($data['operator'])) $filterData['operator'] = $data['operator'];
+      if (!empty($data['date_type'])) {
+        $filterData['date_type'] = $data['date_type'];
+      }
+      if (!empty($data['operator'])) {
+        $filterData['operator'] = $data['operator'];
+      }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], $filterData);
     }
     if ($data['action'] === SubscriberTag::TYPE) {
-      if (empty($data['tags'])) throw new InvalidFilterException('Missing tags', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['tags'])) {
+        throw new InvalidFilterException('Missing tags', InvalidFilterException::MISSING_VALUE);
+      }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'tags' => array_map(function ($tagId) {
           return intval($tagId);
@@ -160,8 +178,12 @@ class FilterDataMapper {
       ]);
     }
     if (in_array($data['action'], SubscriberTextField::TYPES)) {
-      if (empty($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
-      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (empty($data['value'])) {
+        throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
+      }
+      if (empty($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       if (!in_array($data['operator'], DynamicSegmentFilterData::TEXT_FIELD_OPERATORS)) {
         throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
       }
@@ -172,7 +194,9 @@ class FilterDataMapper {
         'connect' => $data['connect'],
       ]);
     }
-    if (empty($data['wordpressRole'])) throw new InvalidFilterException('Missing role', InvalidFilterException::MISSING_ROLE);
+    if (empty($data['wordpressRole'])) {
+      throw new InvalidFilterException('Missing role', InvalidFilterException::MISSING_ROLE);
+    }
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
       'wordpressRole' => $data['wordpressRole'],
       'operator' => $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY,
@@ -184,8 +208,12 @@ class FilterDataMapper {
    * @throws InvalidFilterException
    */
   private function createEmail(array $data): DynamicSegmentFilterData {
-    if (empty($data['action'])) throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
-    if (!in_array($data['action'], EmailAction::ALLOWED_ACTIONS)) throw new InvalidFilterException('Invalid email action', InvalidFilterException::INVALID_EMAIL_ACTION);
+    if (empty($data['action'])) {
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    }
+    if (!in_array($data['action'], EmailAction::ALLOWED_ACTIONS)) {
+      throw new InvalidFilterException('Invalid email action', InvalidFilterException::INVALID_EMAIL_ACTION);
+    }
     if (
       ($data['action'] === EmailOpensAbsoluteCountAction::TYPE)
       || ($data['action'] === EmailOpensAbsoluteCountAction::MACHINE_TYPE)
@@ -193,9 +221,9 @@ class FilterDataMapper {
       return $this->createEmailOpensAbsoluteCount($data);
     }
     if ($data['action'] === EmailActionClickAny::TYPE) {
-        return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $data['action'], [
-          'connect' => $data['connect'],
-        ]);
+      return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $data['action'], [
+        'connect' => $data['connect'],
+      ]);
     }
 
     $filterData = [
@@ -204,10 +232,14 @@ class FilterDataMapper {
     ];
 
     if (($data['action'] === EmailAction::ACTION_CLICKED)) {
-      if (empty($data['newsletter_id'])) throw new InvalidFilterException('Missing newsletter id', InvalidFilterException::MISSING_NEWSLETTER_ID);
+      if (empty($data['newsletter_id'])) {
+        throw new InvalidFilterException('Missing newsletter id', InvalidFilterException::MISSING_NEWSLETTER_ID);
+      }
       $filterData['newsletter_id'] = $data['newsletter_id'];
     } else {
-      if (empty($data['newsletters']) || !is_array($data['newsletters'])) throw new InvalidFilterException('Missing newsletter', InvalidFilterException::MISSING_NEWSLETTER_ID);
+      if (empty($data['newsletters']) || !is_array($data['newsletters'])) {
+        throw new InvalidFilterException('Missing newsletter', InvalidFilterException::MISSING_NEWSLETTER_ID);
+      }
       $filterData['newsletters'] = array_map(function ($segmentId) {
         return intval($segmentId);
       }, $data['newsletters']);
@@ -217,7 +249,9 @@ class FilterDataMapper {
     $action = $data['action'];
     if (isset($data['link_ids']) && is_array($data['link_ids'])) {
       $filterData['link_ids'] = array_map('intval', $data['link_ids']);
-      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (!isset($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       $filterData['operator'] = $data['operator'];
     }
     return new DynamicSegmentFilterData($filterType, $action, $filterData);
@@ -227,8 +261,12 @@ class FilterDataMapper {
    * @throws InvalidFilterException
    */
   private function createEmailOpensAbsoluteCount(array $data): DynamicSegmentFilterData {
-    if (!isset($data['opens'])) throw new InvalidFilterException('Missing number of opens', InvalidFilterException::MISSING_VALUE);
-    if (empty($data['days'])) throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+    if (!isset($data['opens'])) {
+      throw new InvalidFilterException('Missing number of opens', InvalidFilterException::MISSING_VALUE);
+    }
+    if (empty($data['days'])) {
+      throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+    }
     $filterData = [
       'opens' => $data['opens'],
       'days' => $data['days'],
@@ -244,24 +282,36 @@ class FilterDataMapper {
    * @throws InvalidFilterException
    */
   private function createWooCommerce(array $data): DynamicSegmentFilterData {
-    if (empty($data['action'])) throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    if (empty($data['action'])) {
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    }
     $filterData = [
       'connect' => $data['connect'],
     ];
     $filterType = DynamicSegmentFilterData::TYPE_WOOCOMMERCE;
     $action = $data['action'];
     if ($data['action'] === WooCommerceCategory::ACTION_CATEGORY) {
-      if (!isset($data['category_ids'])) throw new InvalidFilterException('Missing category', InvalidFilterException::MISSING_CATEGORY_ID);
-      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (!isset($data['category_ids'])) {
+        throw new InvalidFilterException('Missing category', InvalidFilterException::MISSING_CATEGORY_ID);
+      }
+      if (!isset($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       $filterData['operator'] = $data['operator'];
       $filterData['category_ids'] = $data['category_ids'];
     } elseif ($data['action'] === WooCommerceProduct::ACTION_PRODUCT) {
-      if (!isset($data['product_ids'])) throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
-      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (!isset($data['product_ids'])) {
+        throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
+      }
+      if (!isset($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       $filterData['operator'] = $data['operator'];
       $filterData['product_ids'] = $data['product_ids'];
     } elseif ($data['action'] === WooCommerceCountry::ACTION_CUSTOMER_COUNTRY) {
-      if (!isset($data['country_code'])) throw new InvalidFilterException('Missing country', InvalidFilterException::MISSING_COUNTRY);
+      if (!isset($data['country_code'])) {
+        throw new InvalidFilterException('Missing country', InvalidFilterException::MISSING_COUNTRY);
+      }
       $filterData['country_code'] = $data['country_code'];
       $filterData['operator'] = $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY;
     } elseif ($data['action'] === WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS) {
@@ -325,8 +375,12 @@ class FilterDataMapper {
       $filterData['payment_methods'] = $data['payment_methods'];
       $filterData['used_payment_method_days'] = intval($data['used_payment_method_days']);
     } elseif (in_array($data['action'], WooCommerceCustomerTextField::ACTIONS)) {
-      if (empty($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
-      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (empty($data['value'])) {
+        throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
+      }
+      if (empty($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       if (!in_array($data['operator'], DynamicSegmentFilterData::TEXT_FIELD_OPERATORS)) {
         throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
       }
@@ -343,15 +397,21 @@ class FilterDataMapper {
    * @throws InvalidFilterException
    */
   private function createWooCommerceMembership(array $data): DynamicSegmentFilterData {
-    if (empty($data['action'])) throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    if (empty($data['action'])) {
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    }
     $filterData = [
       'connect' => $data['connect'],
     ];
     $filterType = DynamicSegmentFilterData::TYPE_WOOCOMMERCE_MEMBERSHIP;
     $action = $data['action'];
     if ($data['action'] === WooCommerceMembership::ACTION_MEMBER_OF) {
-      if (!isset($data['plan_ids']) || !is_array($data['plan_ids'])) throw new InvalidFilterException('Missing plan', InvalidFilterException::MISSING_PLAN_ID);
-      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (!isset($data['plan_ids']) || !is_array($data['plan_ids'])) {
+        throw new InvalidFilterException('Missing plan', InvalidFilterException::MISSING_PLAN_ID);
+      }
+      if (!isset($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       $filterData['operator'] = $data['operator'];
       $filterData['plan_ids'] = $data['plan_ids'];
     } else {
@@ -364,15 +424,21 @@ class FilterDataMapper {
    * @throws InvalidFilterException
    */
   private function createWooCommerceSubscription(array $data): DynamicSegmentFilterData {
-    if (empty($data['action'])) throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    if (empty($data['action'])) {
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
+    }
     $filterData = [
       'connect' => $data['connect'],
     ];
     $filterType = DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION;
     $action = $data['action'];
     if ($data['action'] === WooCommerceSubscription::ACTION_HAS_ACTIVE) {
-      if (!isset($data['product_ids']) || !is_array($data['product_ids'])) throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
-      if (!isset($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      if (!isset($data['product_ids']) || !is_array($data['product_ids'])) {
+        throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);
+      }
+      if (!isset($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
       $filterData['operator'] = $data['operator'];
       $filterData['product_ids'] = $data['product_ids'];
     } else {

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -18,6 +18,7 @@ use MailPoet\Segments\DynamicSegments\Filters\SubscriberTextField;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCustomerTextField;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
@@ -323,6 +324,15 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['payment_methods'] = $data['payment_methods'];
       $filterData['used_payment_method_days'] = intval($data['used_payment_method_days']);
+    } elseif (in_array($data['action'], WooCommerceCustomerTextField::ACTIONS)) {
+      if (empty($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
+      if (!in_array($data['operator'], DynamicSegmentFilterData::TEXT_FIELD_OPERATORS)) {
+        throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_VALUE);
+      }
+      $filterData['value'] = $data['value'];
+      $filterData['operator'] = $data['operator'];
+      $filterData['action'] = $data['action'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -161,7 +161,7 @@ class FilterDataMapper {
     if (in_array($data['action'], SubscriberTextField::TYPES)) {
       if (empty($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
       if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
-      if (!in_array($data['operator'], SubscriberTextField::OPERATORS)) {
+      if (!in_array($data['operator'], DynamicSegmentFilterData::TEXT_FIELD_OPERATORS)) {
         throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_VALUE);
       }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -161,9 +161,9 @@ class FilterDataMapper {
     }
     if (in_array($data['action'], SubscriberTextField::TYPES)) {
       if (empty($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
-      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
       if (!in_array($data['operator'], DynamicSegmentFilterData::TEXT_FIELD_OPERATORS)) {
-        throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_VALUE);
+        throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
       }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'value' => $data['value'],
@@ -326,9 +326,9 @@ class FilterDataMapper {
       $filterData['used_payment_method_days'] = intval($data['used_payment_method_days']);
     } elseif (in_array($data['action'], WooCommerceCustomerTextField::ACTIONS)) {
       if (empty($data['value'])) throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
-      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
+      if (empty($data['operator'])) throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
       if (!in_array($data['operator'], DynamicSegmentFilterData::TEXT_FIELD_OPERATORS)) {
-        throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_VALUE);
+        throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
       }
       $filterData['value'] = $data['value'];
       $filterData['operator'] = $data['operator'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -20,6 +20,7 @@ use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCustomerTextField;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
@@ -96,6 +97,9 @@ class FilterFactory {
   /** @var WooCommerceUsedPaymentMethod */
   private $wooCommerceUsedPaymentMethod;
 
+  /** @var WooCommerceCustomerTextField */
+  private $wooCommerceCustomerTextField;
+
   public function __construct(
     EmailAction $emailAction,
     EmailActionClickAny $emailActionClickAny,
@@ -104,6 +108,7 @@ class FilterFactory {
     WooCommerceProduct $wooCommerceProduct,
     WooCommerceCategory $wooCommerceCategory,
     WooCommerceCountry $wooCommerceCountry,
+    WooCommerceCustomerTextField $wooCommerceCustomerTextField,
     EmailOpensAbsoluteCountAction $emailOpensAbsoluteCount,
     WooCommerceNumberOfOrders $wooCommerceNumberOfOrders,
     WooCommerceTotalSpent $wooCommerceTotalSpent,
@@ -142,6 +147,7 @@ class FilterFactory {
     $this->subscribedViaForm = $subscribedViaForm;
     $this->wooCommerceAverageSpent = $wooCommerceAverageSpent;
     $this->wooCommerceUsedPaymentMethod = $wooCommerceUsedPaymentMethod;
+    $this->wooCommerceCustomerTextField = $wooCommerceCustomerTextField;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -231,6 +237,8 @@ class FilterFactory {
       return $this->wooCommerceAverageSpent;
     } elseif ($action === WooCommerceUsedPaymentMethod::ACTION) {
       return $this->wooCommerceUsedPaymentMethod;
+    } elseif (in_array($action, WooCommerceCustomerTextField::ACTIONS)) {
+      return $this->wooCommerceCustomerTextField;
     }
     return $this->wooCommerceCategory;
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTextField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTextField.php
@@ -1,38 +1,19 @@
-<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class SubscriberTextField implements Filter {
-  const IS = 'is';
-  const IS_NOT = 'isNot';
-  const CONTAINS = 'contains';
-  const NOT_CONTAINS = 'notContains';
-  const STARTS_WITH = 'startsWith';
-  const NOT_STARTS_WITH = 'notStartsWith';
-  const ENDS_WITH = 'endsWith';
-  const NOT_ENDS_WITH = 'notEndsWith';
-
   const FIRST_NAME = 'subscriberFirstName';
   const LAST_NAME = 'subscriberLastName';
   const EMAIL = 'subscriberEmail';
 
   const TYPES = [self::FIRST_NAME, self::LAST_NAME, self::EMAIL];
-
-  const OPERATORS = [
-    self::IS,
-    self::IS_NOT,
-    self::CONTAINS,
-    self::NOT_CONTAINS,
-    self::STARTS_WITH,
-    self::NOT_STARTS_WITH,
-    self::ENDS_WITH,
-    self::NOT_ENDS_WITH,
-  ];
 
   /** @var FilterHelper */
   private $filterHelper;
@@ -65,33 +46,33 @@ class SubscriberTextField implements Filter {
     $parameter = $this->filterHelper->getUniqueParameterName('subscriberText');
 
     switch ($operator) {
-      case self::IS:
+      case DynamicSegmentFilterData::OPERATOR_IS:
         $queryBuilder->andWhere("$columnName = :$parameter");
         break;
-      case self::IS_NOT:
+      case DynamicSegmentFilterData::OPERATOR_IS_NOT:
         $queryBuilder->andWhere("$columnName != :$parameter");
         break;
-      case self::CONTAINS:
+      case DynamicSegmentFilterData::OPERATOR_CONTAINS:
         $queryBuilder->andWhere($queryBuilder->expr()->like($columnName, ":$parameter"));
         $value = '%' . Helpers::escapeSearch($value) . '%';
         break;
-      case self::NOT_CONTAINS:
+      case DynamicSegmentFilterData::OPERATOR_NOT_CONTAINS:
         $queryBuilder->andWhere($queryBuilder->expr()->notLike($columnName, ":$parameter"));
         $value = '%' . Helpers::escapeSearch($value) . '%';
         break;
-      case self::STARTS_WITH:
+      case DynamicSegmentFilterData::OPERATOR_STARTS_WITH:
         $queryBuilder->andWhere($queryBuilder->expr()->like($columnName, ":$parameter"));
         $value = Helpers::escapeSearch($value) . '%';
         break;
-      case self::NOT_STARTS_WITH:
+      case DynamicSegmentFilterData::OPERATOR_NOT_STARTS_WITH:
         $queryBuilder->andWhere($queryBuilder->expr()->notLike($columnName, ":$parameter"));
         $value = Helpers::escapeSearch($value) . '%';
         break;
-      case self::ENDS_WITH:
+      case DynamicSegmentFilterData::OPERATOR_ENDS_WITH:
         $queryBuilder->andWhere($queryBuilder->expr()->like($columnName, ":$parameter"));
         $value = '%' . Helpers::escapeSearch($value);
         break;
-      case self::NOT_ENDS_WITH:
+      case DynamicSegmentFilterData::OPERATOR_NOT_ENDS_WITH:
         $queryBuilder->andWhere($queryBuilder->expr()->notLike($columnName, ":$parameter"));
         $value = '%' . Helpers::escapeSearch($value);
         break;

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTextField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTextField.php
@@ -31,7 +31,7 @@ class SubscriberTextField implements Filter {
     $operator = $filterData->getParam('operator');
 
     if (!is_string($action)) {
-      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_VALUE);
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
     }
 
     if (!is_string($value)) {
@@ -39,7 +39,7 @@ class SubscriberTextField implements Filter {
     }
 
     if (!is_string($operator)) {
-      throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
+      throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
     }
 
     $columnName = $this->getColumnNameForAction($action);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCustomerTextField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCustomerTextField.php
@@ -35,7 +35,7 @@ class WooCommerceCustomerTextField implements Filter {
     $operator = $filterData->getParam('operator');
 
     if (!is_string($action)) {
-      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_VALUE);
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
     }
 
     if (!is_string($value)) {
@@ -43,7 +43,7 @@ class WooCommerceCustomerTextField implements Filter {
     }
 
     if (!is_string($operator)) {
-      throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
+      throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
     }
 
     $customerLookupAlias = $this->wooFilterHelper->applyCustomerLookupJoin($queryBuilder);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCustomerTextField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCustomerTextField.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Util\Helpers;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooCommerceCustomerTextField implements Filter {
+  const CITY = 'customerInCity';
+  const POSTAL_CODE = 'customerInPostalCode';
+
+  const ACTIONS = [self::CITY, self::POSTAL_CODE];
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
+  public function __construct(
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper
+  ) {
+    $this->filterHelper = $filterHelper;
+    $this->wooFilterHelper = $wooFilterHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $action = $filterData->getParam('action');
+    $value = $filterData->getParam('value');
+    $operator = $filterData->getParam('operator');
+
+    if (!is_string($action)) {
+      throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_VALUE);
+    }
+
+    if (!is_string($value)) {
+      throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);
+    }
+
+    if (!is_string($operator)) {
+      throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_VALUE);
+    }
+
+    $customerLookupAlias = $this->wooFilterHelper->applyCustomerLookupJoin($queryBuilder);
+    $column = sprintf("%s.%s", $customerLookupAlias, $this->getColumnNameForAction($action));
+    $parameter = $this->filterHelper->getUniqueParameterName('customerTextField');
+
+    switch ($operator) {
+      case DynamicSegmentFilterData::OPERATOR_IS:
+        $queryBuilder->andWhere("$column = :$parameter");
+        break;
+      case DynamicSegmentFilterData::OPERATOR_IS_NOT:
+        $queryBuilder->andWhere("$column != :$parameter");
+        break;
+      case DynamicSegmentFilterData::OPERATOR_CONTAINS:
+        $queryBuilder->andWhere($queryBuilder->expr()->like($column, ":$parameter"));
+        $value = '%' . Helpers::escapeSearch($value) . '%';
+        break;
+      case DynamicSegmentFilterData::OPERATOR_NOT_CONTAINS:
+        $queryBuilder->andWhere($queryBuilder->expr()->notLike($column, ":$parameter"));
+        $value = '%' . Helpers::escapeSearch($value) . '%';
+        break;
+      case DynamicSegmentFilterData::OPERATOR_STARTS_WITH:
+        $queryBuilder->andWhere($queryBuilder->expr()->like($column, ":$parameter"));
+        $value = Helpers::escapeSearch($value) . '%';
+        break;
+      case DynamicSegmentFilterData::OPERATOR_NOT_STARTS_WITH:
+        $queryBuilder->andWhere($queryBuilder->expr()->notLike($column, ":$parameter"));
+        $value = Helpers::escapeSearch($value) . '%';
+        break;
+      case DynamicSegmentFilterData::OPERATOR_ENDS_WITH:
+        $queryBuilder->andWhere($queryBuilder->expr()->like($column, ":$parameter"));
+        $value = '%' . Helpers::escapeSearch($value);
+        break;
+      case DynamicSegmentFilterData::OPERATOR_NOT_ENDS_WITH:
+        $queryBuilder->andWhere($queryBuilder->expr()->notLike($column, ":$parameter"));
+        $value = '%' . Helpers::escapeSearch($value);
+        break;
+      default:
+        throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
+    }
+
+    $queryBuilder->setParameter($parameter, $value);
+
+    return $queryBuilder;
+  }
+
+  private function getColumnNameForAction(string $field): string {
+    switch ($field) {
+      case self::CITY:
+        return 'city';
+      case self::POSTAL_CODE:
+        return 'postcode';
+    }
+
+    throw new InvalidFilterException('Invalid action');
+  }
+}

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -156,6 +156,14 @@ class IntegrationTester extends \Codeception\Actor {
       $order->set_date_created($data['date_created']);
     }
 
+    if (isset($data['billing_postcode'])) {
+      $order->set_billing_postcode($data['billing_postcode']);
+    }
+
+    if (isset($data['billing_city'])) {
+      $order->set_billing_city($data['billing_city']);
+    }
+
     if (isset($data['total'])) {
       $order->set_total($data['total']);
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCustomerTextFieldTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCustomerTextFieldTest.php
@@ -1,0 +1,208 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCustomerTextField;
+
+/**
+ * @group woo
+ */
+class WooCommerceCustomerTextFieldTest extends \MailPoetTest {
+
+  /** @var WooCommerceCustomerTextField */
+  private $filter;
+
+  public function _before(): void {
+    $this->filter = $this->diContainer->get(WooCommerceCustomerTextField::class);
+  }
+
+  public function testEquals(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'is', 'Minneapolis', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'is', 'Anchorage', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'is', 'eapolis', []);
+    $this->assertFilterReturnsEmails('customerInCity', 'is', 'Anchorag', []);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'is', '55111', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'is', '99540', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'is', '9954', []);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'is', '9540', []);
+  }
+
+  public function testNotEquals(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'isNot', 'Minneapolis', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'isNot', 'Anchorage', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'isNot', 'eapolis', ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'isNot', 'Anchorag', ['1@e.com', '2@e.com']);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'isNot', '55111', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'isNot', '99540', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'isNot', '9540', ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'isNot', '9954', ['1@e.com', '2@e.com']);
+  }
+
+  public function testStartsWith() {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'startsWith', 'Minneapolis', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'startsWith', 'Minn', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'startsWith', 'Anchorage', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'startsWith', 'A', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'startsWith', 'Anchoragee', []);
+    $this->assertFilterReturnsEmails('customerInCity', 'startsWith', 'inneapolis', []);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'startsWith', '55111', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'startsWith', '5', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'startsWith', '99540', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'startsWith', '9954', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'startsWith', '6', []);
+  }
+
+  public function testDoesNotStartWith(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'notStartsWith', 'Minneapolis', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notStartsWith', 'Minn', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notStartsWith', 'Anchorage', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notStartsWith', 'A', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notStartsWith', 'Anchoragee', ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notStartsWith', 'inneapolis', ['1@e.com', '2@e.com']);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notStartsWith', '55111', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notStartsWith', '5', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notStartsWith', '99540', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notStartsWith', '9954', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notStartsWith', '6', ['1@e.com', '2@e.com']);
+  }
+
+  public function testEndsWith(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'Minneapolis', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'lis', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'Minn', []);
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'Anchorage', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'age', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'A', []);
+    $this->assertFilterReturnsEmails('customerInCity', 'endsWith', 'liss', []);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'endsWith', '55111', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'endsWith', '1', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'endsWith', '99540', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'endsWith', '40', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'endsWith', '2', []);
+  }
+
+  public function testDoesNotEndWith(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'notEndsWith', 'Minneapolis', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notEndsWith', 'lis', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notEndsWith', 'Anchorage', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notEndsWith', 'e', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notEndsWith', 'q', ['1@e.com', '2@e.com']);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notEndsWith', '55111', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notEndsWith', '1', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notEndsWith', '99540', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notEndsWith', '40', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notEndsWith', '6', ['1@e.com', '2@e.com']);
+  }
+
+  public function testContains(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'Minneapolis', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'lis', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'Min', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'eapo', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'Anchorage', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'age', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'Anc', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'hora', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'q', []);
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', 'e', ['1@e.com', '2@e.com']);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '55111', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '55', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '111', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '51', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '99540', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '99', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '40', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '954', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '6', []);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'contains', '5', ['1@e.com', '2@e.com']);
+  }
+
+  public function testNotContains(): void {
+    $this->createCustomer('1@e.com', 'Minneapolis', '55111');
+    $this->createCustomer('2@e.com', 'Anchorage', '99540');
+
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'Minneapolis', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'lis', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'Min', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'eapo', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'Anchorage', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'age', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'Anc', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'hora', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'q', ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails('customerInCity', 'notContains', 'e', []);
+
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '55111', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '55', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '111', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '51', ['2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '99540', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '99', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '40', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '954', ['1@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '6', ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails('customerInPostalCode', 'notContains', '5', []);
+  }
+
+  public function testContainsDoesNotBreakIfItIncludesPercentSymbol(): void {
+    $this->createCustomer('1@e.com', 'Minn%eapolis', '55111');
+    $this->assertFilterReturnsEmails('customerInCity', 'contains', '%', ['1@e.com']);
+  }
+
+  private function assertFilterReturnsEmails(string $action, string $operator, string $value, array $expectedEmails): void {
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, $action, [
+      'operator' => $operator,
+      'value' => $value,
+      'action' => $action,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  private function createCustomer(string $email, string $city, string $postalCode): void {
+    $this->tester->createCustomer($email);
+    $order = $this->tester->createWooCommerceOrder([
+      'billing_email' => $email,
+      'billing_postcode' => $postalCode,
+      'billing_city' => $city,
+      'status' => 'wc-complete',
+    ]);
+    $order->save();
+  }
+
+  public function _after() {
+    parent::_after();
+    global $wpdb;
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+  }
+}

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -229,7 +229,7 @@
     'wooPurchaseDate': __('purchase date'),
     'wooPurchasedProduct': __('purchased product'),
     'wooTotalSpent': __('total spent'),
-    'wooCustomerInCountry': __('is in country'),
+    'wooCustomerInCountry': __('country'),
     'wooCustomerInCity': __('city'),
     'wooCustomerInPostalCode': __('postal code'),
     'wooSingleOrderValue': __('single order value'),

--- a/mailpoet/views/segments.html
+++ b/mailpoet/views/segments.html
@@ -230,6 +230,8 @@
     'wooPurchasedProduct': __('purchased product'),
     'wooTotalSpent': __('total spent'),
     'wooCustomerInCountry': __('is in country'),
+    'wooCustomerInCity': __('city'),
+    'wooCustomerInPostalCode': __('postal code'),
     'wooSingleOrderValue': __('single order value'),
     'wooSpentAmount': __('amount'),
     'selectWooPurchasedCategory': __('Search categories'),


### PR DESCRIPTION
## Description

This PR adds new dynamic segment filters for WooCommerce customers' city and postal codes. It also renames the `is in country` filter to simply `country`.

These filters work very similarly to the subscriber filters for first name, last name, and email address.

## Code review notes

_N/A_

## QA notes

I did some minor refactoring to allow re-use of some of the subscriber text field code, so it would be great if you could double check the first name, last name, and email filters.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4990](https://mailpoet.atlassian.net/browse/MAILPOET-4990)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4990]: https://mailpoet.atlassian.net/browse/MAILPOET-4990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ