### PR TITLE
Convert Segments code to TSX [MAILPOET-5407]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -1,12 +1,42 @@
 import { Link, withRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import ReactStringReplace from 'react-string-replace';
 
 import { MailPoet } from 'mailpoet';
 import { Listing } from 'listing/listing.jsx';
 import { escapeHTML } from '@wordpress/escape-html';
+import { SegmentResponse } from 'segments/types';
 
-const columns = [
+type ColumnType = {
+  name: string;
+  label: string;
+  sortable: boolean;
+};
+
+type DynamicSegmentItem = {
+  id: number;
+  name: string;
+  description: string;
+  count_all: string;
+  count_subscribed: string;
+  created_at: string;
+  is_plugin_missing: boolean;
+  subscribers_url: string;
+  missing_plugin_message?: {
+    message: string;
+    link?: string;
+  };
+};
+
+type DynamicSegmentListComponentProps = {
+  location: {
+    pathname: string;
+  };
+  match: {
+    params;
+  };
+};
+
+const columns: ColumnType[] = [
   {
     name: 'name',
     label: MailPoet.I18n.t('nameColumn'),
@@ -85,10 +115,10 @@ const itemActions = [
   {
     name: 'edit',
     className: 'mailpoet-hide-on-mobile',
-    link: (item) => (
+    link: (item: DynamicSegmentItem) => (
       <Link to={`/edit-segment/${item.id}`}>{MailPoet.I18n.t('edit')}</Link>
     ),
-    display: (item) => !item.is_plugin_missing,
+    display: (item: DynamicSegmentItem) => !item.is_plugin_missing,
   },
   {
     name: 'duplicate_segment',
@@ -103,13 +133,13 @@ const itemActions = [
           id: item.id,
         },
       })
-        .done((response) => {
+        .done((response: SegmentResponse) => {
           MailPoet.Notice.success(
             MailPoet.I18n.t('segmentDuplicated').replace(
               '%1$s',
               escapeHTML(response.data.name),
-              { scroll: true },
             ),
+            { scroll: true },
           );
           refresh();
         })
@@ -123,10 +153,10 @@ const itemActions = [
   {
     name: 'edit_disabled',
     className: 'mailpoet-hide-on-mobile mailpoet-disabled',
-    link: (item) => (
+    link: (item: DynamicSegmentItem) => (
       <Link to={`/edit-segment/${item.id}`}>{MailPoet.I18n.t('edit')}</Link>
     ),
-    display: (item) => item.is_plugin_missing,
+    display: (item: DynamicSegmentItem) => item.is_plugin_missing,
   },
   {
     name: 'view_subscribers',
@@ -148,7 +178,7 @@ const bulkActions = [
   },
 ];
 
-function renderItem(item, actions) {
+function renderItem(item: DynamicSegmentItem, actions) {
   return (
     <>
       <td
@@ -163,7 +193,7 @@ function renderItem(item, actions) {
       </td>
       {item.is_plugin_missing ? (
         <td
-          colSpan="2"
+          colSpan={2}
           className="column mailpoet-hide-on-mobile"
           data-colname={MailPoet.I18n.t('missingPluginMessageColumn')}
         >
@@ -185,7 +215,7 @@ function renderItem(item, actions) {
                   </a>
                 ),
               )
-            : item.missing_plugin_message}
+            : item.missing_plugin_message.message}
         </td>
       ) : (
         <>
@@ -215,7 +245,9 @@ function renderItem(item, actions) {
   );
 }
 
-function DynamicSegmentListComponent(props) {
+function DynamicSegmentListComponent(
+  props: DynamicSegmentListComponentProps,
+): JSX.Element {
   return (
     <>
       <Listing
@@ -248,14 +280,5 @@ function DynamicSegmentListComponent(props) {
     </>
   );
 }
-
-DynamicSegmentListComponent.propTypes = {
-  location: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  match: PropTypes.shape({
-    params: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  }).isRequired,
-};
-
-DynamicSegmentListComponent.displayName = 'DynamicSegmentList';
 
 export const DynamicSegmentList = withRouter(DynamicSegmentListComponent);

--- a/mailpoet/assets/js/src/segments/form.tsx
+++ b/mailpoet/assets/js/src/segments/form.tsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import { Background } from 'common/background/background';
 import { Form } from 'form/form.jsx';
 import { Heading } from 'common/typography/heading/heading';
@@ -42,7 +41,15 @@ const messages = {
   },
 };
 
-function SegmentForm(props) {
+type SegmentFormPropType = {
+  match: {
+    params: {
+      id: string;
+    };
+  };
+};
+
+function SegmentForm({ match }: SegmentFormPropType) {
   return (
     <div>
       <Background color="#fff" />
@@ -63,20 +70,12 @@ function SegmentForm(props) {
       <Form
         endpoint="segments"
         fields={fields}
-        params={props.match.params}
+        params={match.params}
         messages={messages}
       />
     </div>
   );
 }
-
-SegmentForm.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-    }).isRequired,
-  }).isRequired,
-};
 
 SegmentForm.displayName = 'SegmentForm';
 

--- a/mailpoet/assets/js/src/segments/heading.tsx
+++ b/mailpoet/assets/js/src/segments/heading.tsx
@@ -6,7 +6,7 @@ import { SubscribersInPlan } from 'common/subscribers_in_plan';
 import { MssAccessNotices } from 'notices/mss_access_notices';
 import { SubscribersCacheMessage } from 'common/subscribers_cache_message';
 
-function ListHeading() {
+function ListHeading(): JSX.Element {
   return (
     <>
       <TopBarWithBeamer>

--- a/mailpoet/assets/js/src/segments/list.tsx
+++ b/mailpoet/assets/js/src/segments/list.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { escapeHTML, escapeAttribute } from '@wordpress/escape-html';
 
 import { Listing } from 'listing/listing.jsx';
+import { SegmentResponse } from 'segments/types';
 import { ListingsEngagementScore } from '../subscribers/listings_engagement_score';
 
 type Segment = {
@@ -22,18 +23,6 @@ type Segment = {
   };
   created_at: string;
   subscribers_url: string;
-};
-
-type SegmentResponse = {
-  meta: {
-    count: string;
-  };
-  data: {
-    name: string;
-  };
-  errors: {
-    message: string;
-  }[];
 };
 
 const isWPUsersSegment = (segment: Segment) => segment.type === 'wp_users';

--- a/mailpoet/assets/js/src/segments/segments.jsx
+++ b/mailpoet/assets/js/src/segments/segments.jsx
@@ -6,12 +6,12 @@ import { RoutedTabs } from 'common/tabs/routed_tabs';
 import { Tab } from 'common/tabs/tab';
 import { SegmentList } from 'segments/list.jsx';
 import { SegmentForm } from 'segments/form.tsx';
+import { ListHeading } from 'segments/heading.tsx';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { registerTranslations, withBoundary } from 'common';
 import { Editor } from './dynamic/editor';
 import { DynamicSegmentList } from './dynamic/list.jsx';
-import { ListHeading } from './heading';
 
 const container = document.getElementById('segments_container');
 

--- a/mailpoet/assets/js/src/segments/segments.jsx
+++ b/mailpoet/assets/js/src/segments/segments.jsx
@@ -4,7 +4,7 @@ import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { MailPoet } from 'mailpoet';
 import { RoutedTabs } from 'common/tabs/routed_tabs';
 import { Tab } from 'common/tabs/tab';
-import { SegmentList } from 'segments/list.jsx';
+import { SegmentList } from 'segments/list.tsx';
 import { SegmentForm } from 'segments/form.tsx';
 import { ListHeading } from 'segments/heading.tsx';
 import { GlobalContext, useGlobalContextValue } from 'context';

--- a/mailpoet/assets/js/src/segments/segments.jsx
+++ b/mailpoet/assets/js/src/segments/segments.jsx
@@ -11,7 +11,7 @@ import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { registerTranslations, withBoundary } from 'common';
 import { Editor } from './dynamic/editor';
-import { DynamicSegmentList } from './dynamic/list.jsx';
+import { DynamicSegmentList } from './dynamic/list.tsx';
 
 const container = document.getElementById('segments_container');
 

--- a/mailpoet/assets/js/src/segments/segments.jsx
+++ b/mailpoet/assets/js/src/segments/segments.jsx
@@ -5,7 +5,7 @@ import { MailPoet } from 'mailpoet';
 import { RoutedTabs } from 'common/tabs/routed_tabs';
 import { Tab } from 'common/tabs/tab';
 import { SegmentList } from 'segments/list.jsx';
-import { SegmentForm } from 'segments/form.jsx';
+import { SegmentForm } from 'segments/form.tsx';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { registerTranslations, withBoundary } from 'common';

--- a/mailpoet/assets/js/src/segments/segments.tsx
+++ b/mailpoet/assets/js/src/segments/segments.tsx
@@ -4,18 +4,18 @@ import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { MailPoet } from 'mailpoet';
 import { RoutedTabs } from 'common/tabs/routed_tabs';
 import { Tab } from 'common/tabs/tab';
-import { SegmentList } from 'segments/list.tsx';
-import { SegmentForm } from 'segments/form.tsx';
-import { ListHeading } from 'segments/heading.tsx';
+import { SegmentList } from 'segments/list';
+import { SegmentForm } from 'segments/form';
+import { ListHeading } from 'segments/heading';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { registerTranslations, withBoundary } from 'common';
 import { Editor } from './dynamic/editor';
-import { DynamicSegmentList } from './dynamic/list.tsx';
+import { DynamicSegmentList } from './dynamic/list';
 
 const container = document.getElementById('segments_container');
 
-function Tabs() {
+function Tabs(): JSX.Element {
   return (
     <>
       <ListHeading />
@@ -42,19 +42,19 @@ function Tabs() {
 
 Tabs.displayName = 'SegmentTabs';
 
-function App() {
+function App(): JSX.Element {
   return (
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <HashRouter>
         <Notices />
         <Switch>
           <Route exact path="/" render={() => <Redirect to="/lists" />} />
-          <Route path="/new" render={withBoundary(SegmentForm)} />
-          <Route path="/edit/:id" render={withBoundary(SegmentForm)} />
-          <Route path="/new-segment" render={withBoundary(Editor)} />
-          <Route path="/edit-segment/:id" render={withBoundary(Editor)} />
-          <Route path="/segments/(.*)?" render={withBoundary(Tabs)} />
-          <Route path="/lists/(.*)?" render={withBoundary(Tabs)} />
+          <Route path="/new" component={withBoundary(SegmentForm)} />
+          <Route path="/edit/:id" component={withBoundary(SegmentForm)} />
+          <Route path="/new-segment" component={withBoundary(Editor)} />
+          <Route path="/edit-segment/:id" component={withBoundary(Editor)} />
+          <Route path="/segments/(.*)?" component={withBoundary(Tabs)} />
+          <Route path="/lists/(.*)?" component={withBoundary(Tabs)} />
         </Switch>
       </HashRouter>
     </GlobalContext.Provider>

--- a/mailpoet/assets/js/src/segments/types.ts
+++ b/mailpoet/assets/js/src/segments/types.ts
@@ -1,1 +1,13 @@
 export * from './dynamic/types';
+
+export type SegmentResponse = {
+  meta: {
+    count: string;
+  };
+  data: {
+    name: string;
+  };
+  errors: {
+    message: string;
+  }[];
+};

--- a/mailpoet/assets/js/src/webpack_admin_index.tsx
+++ b/mailpoet/assets/js/src/webpack_admin_index.tsx
@@ -7,7 +7,7 @@
 import 'homepage/homepage'; // side effect - renders ReactDOM to document
 import 'subscribers/subscribers.jsx'; // side effect - renders ReactDOM to document
 import 'newsletters/newsletters.jsx'; // side effect - renders ReactDOM to window
-import 'segments/segments.jsx'; // side effect - renders ReactDOM to document
+import 'segments/segments'; // side effect - renders ReactDOM to document
 import 'forms/forms.jsx'; // side effect - renders ReactDOM to document
 import 'help/help.jsx'; // side effect - renders ReactDOM to document
 import 'subscribers/importExport/import.jsx'; // side effect - executes on doc ready, adds events

--- a/mailpoet/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/DynamicSegmentsResponseBuilder.php
@@ -82,13 +82,19 @@ class DynamicSegmentsResponseBuilder {
     if ($missingPlugins) {
       $missingPlugin = reset($missingPlugins);
       $data['is_plugin_missing'] = true;
-      $data['missing_plugin_message'] = $this->segmentDependencyValidator->getCustomErrorMessage($missingPlugin)
-        ?:
-        sprintf(
-          // translators: %s is the name of the missing plugin.
-          __('Activate the %s plugin to see the number of subscribers and enable the editing of this segment.', 'mailpoet'),
-          $missingPlugin
-        );
+
+      $missingPluginMessage = $this->segmentDependencyValidator->getCustomErrorMessage($missingPlugin);
+
+      if ($missingPluginMessage) {
+        $data['missing_plugin_message'] = $missingPluginMessage;
+      } else {
+        $data['missing_plugin_message']['message'] =
+          sprintf(
+            // translators: %s is the name of the missing plugin.
+            __('Activate the %s plugin to see the number of subscribers and enable the editing of this segment.', 'mailpoet'),
+            $missingPlugin
+          );
+      }
     } else {
       $data['is_plugin_missing'] = false;
       $data['missing_plugin_message'] = null;


### PR DESCRIPTION
## Description

This PR converts JSX code in `assets/js/src/segments/` to TSX. This is part of https://mailpoet.atlassian.net/browse/MAILPOET-5392. I decided to do it in a separate ticket to avoid creating a big PR.

## Code review notes

Please note that I'm still not very great with TS, so I might be missing something here. Any feedback is welcome.

The performance tests are failing but it doesn't seem to be related to the changes proposed here. I tried rerunning a few times but they continued failing.

## QA notes

This PR should not affect the behavior of the plugin, but it changes several files related to the lists and dynamic segments interface. If possible, please test anything related to those features that are not tested by our test suite.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5407]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5407]: https://mailpoet.atlassian.net/browse/MAILPOET-5407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ