### PR TITLE
Add scenario to cover additional WC list and opt-in message

### DIFF
--- a/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
@@ -2,7 +2,10 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\WooCommerceProduct;
 
 /**
  * @group woo
@@ -15,11 +18,58 @@ class WooCommerceSettingsTabCest {
   /** @var Settings */
   private $settingsFactory;
 
+  /** @var array WooCommerce Product data*/
+  private $product;
+  private $segmentName;
+
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();
+    $this->product = (new WooCommerceProduct($i))->create();
     $this->settingsFactory = new Settings();
     $this->settingsFactory->withCookieRevenueTrackingDisabled();
     $this->settingsFactory->withWooCommerceListImportPageDisplayed(true);
+    $this->segmentName = 'Additional WC List';
+    $segmentFactory = new Segment();
+    $segmentFactory->withName($this->segmentName)->create();
+  }
+
+  public function checkWooCommerceOptInMessage(\AcceptanceTester $i) {
+    $i->wantTo('Check WooCommerce Opt-in message');
+
+    $i->login();
+    $i->amOnMailpoetPage('Settings');
+    $i->waitForText('WooCommerce');
+    $i->click('[data-automation-id="woocommerce_settings_tab"]');
+    $i->waitForText('Opt-in on checkout');
+    $i->seeInField('[data-automation-id="mailpoet_wc_checkout_optin_message"]', 'I would like to receive exclusive emails with discounts and product information');
+
+    $i->wantTo('Change the opt-in message and verify on the front-end');
+
+    $i->fillField('[data-automation-id="mailpoet_wc_checkout_optin_message"]', 'I want to opt-in with the custom message.');
+    $i->click('Save settings');
+    $i->waitForText('Settings saved');
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->see('I want to opt-in with the custom message.');
+  }
+
+  public function checkWooCommerceAdditionalLists(\AcceptanceTester $i) {
+    $i->wantTo('Check adding additional lists to subscribe beside WooCommerce Customers');
+
+    $customerEmail = 'woo_customer@example.com';
+
+    $i->login();
+    $i->amOnMailpoetPage('Settings');
+    $i->waitForText('WooCommerce');
+    $i->click('[data-automation-id="woocommerce_settings_tab"]');
+    $i->waitForText('Opt-in on checkout');
+    $i->selectOptionInReactSelect($this->segmentName, '#mailpoet_wc_checkout_optin_segments');
+    $i->click('Save settings');
+    $i->waitForText('Settings saved');
+    $i->logOut();
+    $i->orderProduct($this->product, $customerEmail, false, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers', $this->segmentName]);
   }
 
   public function checkWooCommerceTabExists(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
@@ -20,6 +20,8 @@ class WooCommerceSettingsTabCest {
 
   /** @var array WooCommerce Product data*/
   private $product;
+  
+  /** @var string */
   private $segmentName;
 
   public function _before(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Improving the existing test case WooCommerceSettingsTabCest to include scenarios for testing the opt-in message and additional list to subscribe.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5324]

## After-merge notes

_N/A_

## Tasks

- N/A I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- N/A I added sufficient test coverage
- N/A I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5324]: https://mailpoet.atlassian.net/browse/MAILPOET-5324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ