### PR TITLE
Update k6 nightly tests with proper locator and increase max duration

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -53,7 +53,7 @@ let scenarios = {
   nightlytests: {
     executor: 'per-vu-iterations',
     vus: 1,
-    iterations: 1,
+    iterations: 3,
     maxDuration: '30m',
     exec: 'nightly',
   },

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -47,14 +47,14 @@ let scenarios = {
     executor: 'per-vu-iterations',
     vus: 1,
     iterations: 1,
-    maxDuration: '5m',
+    maxDuration: '10m',
     exec: 'pullRequests',
   },
   nightlytests: {
     executor: 'per-vu-iterations',
     vus: 1,
-    iterations: 3,
-    maxDuration: '15m',
+    iterations: 1,
+    maxDuration: '30m',
     exec: 'nightly',
   },
 };

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -141,14 +141,19 @@ export async function listsComplexSegment() {
   await page.waitForSelector('[data-automation-id="filters_all"]', {
     state: 'visible',
   });
+  const locator =
+    "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
   describe(listsPageTitle, () => {
     describe('should be able to see Segment Updated message', () => {
-      expect(page.locator('div.notice').innerText()).to.contain(
-        'Segment successfully updated!',
-      );
+      expect(page.locator(locator)).to.exist;
     });
   });
   await page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + 'Lists_Complex_Segment_05.png',
+    fullPage: fullPageSet,
+  });
 
   // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -95,12 +95,12 @@ export async function newsletterSending() {
   });
 
   // Wait for the success notice message and confirm it
+  const locator =
+    "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
   await page.waitForSelector('#mailpoet_notices');
   describe(emailsPageTitle, () => {
     describe('should be able to see Newsletter Sent message', () => {
-      expect(page.locator('div > .notice-success').innerText()).to.contain(
-        'The newsletter is being sent...',
-      );
+      expect(page.locator(locator)).to.exist;
     });
   });
   await page.waitForLoadState('networkidle');

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -56,12 +56,17 @@ export async function settingsBasic() {
   await page.waitForLoadState('networkidle');
 
   // Check if there's notice about saved settings
+  const locator =
+    "//div[@class='notice-success'].//p[starts-with(text(),'Settings saved')]";
   describe(settingsPageTitle, () => {
     describe('should be able to see Settings Saved message', () => {
-      expect(page.locator('div.notice').innerText()).to.contain(
-        'Settings saved',
-      );
+      expect(page.locator(locator)).to.exist;
     });
+  });
+
+  await page.screenshot({
+    path: screenshotPath + 'Settings_Basic_02.png',
+    fullPage: fullPageSet,
   });
 
   // Thinking time and closing

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -67,11 +67,11 @@ export async function subscribersAdding() {
   await page.locator('input[name="last_name"]').type(lastName);
   selectInSelect2(page, defaultListName);
   await page.locator('button[type="submit"]').click();
+  await page.waitForLoadState('networkidle');
 
   // Verify you see the success message and the filter is visible
   const locator =
     "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
-  await page.waitForSelector(locator);
   describe(subscribersPageTitle, () => {
     describe('should be able to see Subscriber Added message', () => {
       expect(page.locator(locator)).to.exist;

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -74,6 +74,11 @@ export async function subscribersTrashingRestoring() {
     });
   });
 
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Trashing_Restoring_02.png',
+    fullPage: fullPageSet,
+  });
+
   // Restore from trash all the trashed subscribers
   await page.locator('[data-automation-id="filters_trash"]').click();
   await page.waitForSelector('[data-automation-id="empty_trash"]');
@@ -86,6 +91,11 @@ export async function subscribersTrashingRestoring() {
   await page.waitForSelector('.notice-success');
   waitForSelectorToBeVisible(page, '.colspanchange');
   waitForSelectorToBeVisible(page, '[data-automation-id="filters_subscribed"]');
+
+  await page.screenshot({
+    path: screenshotPath + 'Subscribers_Trashing_Restoring_03.png',
+    fullPage: fullPageSet,
+  });
 
   // Thinking time and closing
   sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));


### PR DESCRIPTION
## Description

Updating nightly tests to have proper locator for the notice-success message. Unable to locate the message due to June Sales banner which is using the notice-success class as well.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5411]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5411]: https://mailpoet.atlassian.net/browse/MAILPOET-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ