### PR TITLE
Automation templates [MAILPOET-5372]

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -16,6 +16,8 @@ ul.mailpoet-automation-templates {
 }
 
 .mailpoet-automation-template-list-item {
+  min-height: 220px;
+
   button.components-button {
     align-content: baseline;
     align-items: flex-start;

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -26,9 +26,9 @@ ul.mailpoet-automation-templates {
     border-radius: 4px;
     cursor: pointer;
     display: grid;
-    grid-template-rows: 40px auto auto;
+    grid-template-rows: 40px;
     height: 100%;
-    padding: 24px 24px 26px;
+    padding: 24px;
     text-align: left;
     width: 100%;
 

--- a/mailpoet/lib/AdminPages/Pages/Automation.php
+++ b/mailpoet/lib/AdminPages/Pages/Automation.php
@@ -4,8 +4,8 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
+use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
-use MailPoet\Automation\Engine\Storage\AutomationTemplateStorage;
 use MailPoet\Form\AssetsController;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -22,21 +22,21 @@ class Automation {
   /** @var AutomationStorage */
   private $automationStorage;
 
-  /** @var AutomationTemplateStorage  */
-  private $templateStorage;
+  /** @var Registry  */
+  private $registry;
 
   public function __construct(
     AssetsController $assetsController,
     PageRenderer $pageRenderer,
     WPFunctions $wp,
     AutomationStorage $automationStorage,
-    AutomationTemplateStorage $templateStorage
+    Registry $registry
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
     $this->wp = $wp;
     $this->automationStorage = $automationStorage;
-    $this->templateStorage = $templateStorage;
+    $this->registry = $registry;
   }
 
   public function render() {
@@ -52,7 +52,7 @@ class Automation {
         function(AutomationTemplate $template): array {
           return $template->toArray();
         },
-        $this->templateStorage->getTemplates()
+        array_values($this->registry->getTemplates())
       ),
     ]);
   }

--- a/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
@@ -4,7 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
-use MailPoet\Automation\Engine\Storage\AutomationTemplateStorage;
+use MailPoet\Automation\Engine\Registry;
 use MailPoet\Form\AssetsController;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -15,8 +15,8 @@ class AutomationTemplates {
   /** @var PageRenderer */
   private $pageRenderer;
 
-  /** @var AutomationTemplateStorage  */
-  private $templateStorage;
+  /** @var Registry  */
+  private $registry;
 
   /** @var WPFunctions */
   private $wp;
@@ -24,12 +24,12 @@ class AutomationTemplates {
   public function __construct(
     AssetsController $assetsController,
     PageRenderer $pageRenderer,
-    AutomationTemplateStorage $templateStorage,
+    Registry $registry,
     WPFunctions $wp
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
-    $this->templateStorage = $templateStorage;
+    $this->registry = $registry;
     $this->wp = $wp;
   }
 
@@ -48,7 +48,7 @@ class AutomationTemplates {
           function(AutomationTemplate $template): array {
             return $template->toArray();
           },
-          $this->templateStorage->getTemplates()
+          array_values($this->registry->getTemplates())
         ),
       ]
     );

--- a/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
@@ -35,7 +35,7 @@ class CreateAutomationFromTemplateController {
       throw Exceptions::automationTemplateNotFound($slug);
     }
 
-    $automation = $template->getAutomation();
+    $automation = $template->createAutomation();
     $this->automationValidator->validate($automation);
     $automationId = $this->storage->createAutomation($automation);
     $savedAutomation = $this->storage->getAutomation($automationId);

--- a/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
@@ -5,32 +5,32 @@ namespace MailPoet\Automation\Engine\Builder;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
-use MailPoet\Automation\Engine\Storage\AutomationTemplateStorage;
 use MailPoet\Automation\Engine\Validation\AutomationValidator;
 
 class CreateAutomationFromTemplateController {
   /** @var AutomationStorage */
   private $storage;
 
-  /** @var AutomationTemplateStorage  */
-  private $templateStorage;
-
   /** @var AutomationValidator */
   private $automationValidator;
 
+  /** @var Registry */
+  private $registry;
+
   public function __construct(
     AutomationStorage $storage,
-    AutomationTemplateStorage $templateStorage,
-    AutomationValidator $automationValidator
+    AutomationValidator $automationValidator,
+    Registry $registry
   ) {
     $this->storage = $storage;
-    $this->templateStorage = $templateStorage;
     $this->automationValidator = $automationValidator;
+    $this->registry = $registry;
   }
 
   public function createAutomation(string $slug): Automation {
-    $template = $this->templateStorage->getTemplateBySlug($slug);
+    $template = $this->registry->getTemplate($slug);
     if (!$template) {
       throw Exceptions::automationTemplateNotFound($slug);
     }

--- a/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
@@ -5,16 +5,16 @@ namespace MailPoet\Automation\Engine\Data;
 use MailPoet\RuntimeException;
 
 class AutomationTemplate {
-
   public const TYPE_DEFAULT = 'default';
   public const TYPE_FREE_ONLY = 'free-only';
   public const TYPE_PREMIUM = 'premium';
   public const TYPE_COMING_SOON = 'coming-soon';
 
-  public const CATEGORY_WELCOME = 1;
-  public const CATEGORY_ABANDONED_CART = 2;
-  public const CATEGORY_REENGAGEMENT = 3;
-  public const CATEGORY_WOOCOMMERCE = 4;
+  public const CATEGORY_WELCOME = 'welcome';
+  public const CATEGORY_ABANDONED_CART = 'abandoned-cart';
+  public const CATEGORY_REENGAGEMENT = 'reengagement';
+  public const CATEGORY_WOOCOMMERCE = 'woocommerce';
+
   public const ALL_CATEGORIES = [
     self::CATEGORY_WELCOME,
     self::CATEGORY_ABANDONED_CART,
@@ -25,7 +25,7 @@ class AutomationTemplate {
   /** @var string */
   private $slug;
 
-  /** @var int */
+  /** @var string */
   private $category;
 
   /** @var string */
@@ -43,7 +43,7 @@ class AutomationTemplate {
   /** @param callable(): Automation $automationFactory */
   public function __construct(
     string $slug,
-    int $category,
+    string $category,
     string $name,
     string $description,
     callable $automationFactory,
@@ -68,7 +68,7 @@ class AutomationTemplate {
     return $this->name;
   }
 
-  public function getCategory(): int {
+  public function getCategory(): string {
     return $this->category;
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
@@ -29,19 +29,24 @@ class AutomationTemplate {
   private $category;
 
   /** @var string */
-  private $type;
+  private $name;
 
   /** @var string */
   private $description;
 
-  /** @var Automation */
-  private $automation;
+  /** @var callable(): Automation */
+  private $automationFactory;
 
+  /** @var string */
+  private $type;
+
+  /** @param callable(): Automation $automationFactory */
   public function __construct(
     string $slug,
     int $category,
+    string $name,
     string $description,
-    Automation $automation,
+    callable $automationFactory,
     string $type = self::TYPE_DEFAULT
   ) {
     if (!in_array($category, self::ALL_CATEGORIES)) {
@@ -49,8 +54,9 @@ class AutomationTemplate {
     }
     $this->slug = $slug;
     $this->category = $category;
+    $this->name = $name;
     $this->description = $description;
-    $this->automation = $automation;
+    $this->automationFactory = $automationFactory;
     $this->type = $type;
   }
 
@@ -59,7 +65,7 @@ class AutomationTemplate {
   }
 
   public function getName(): string {
-    return $this->automation->getName();
+    return $this->name;
   }
 
   public function getCategory(): int {
@@ -74,8 +80,8 @@ class AutomationTemplate {
     return $this->description;
   }
 
-  public function getAutomation(): Automation {
-    return $this->automation;
+  public function createAutomation(): Automation {
+    return ($this->automationFactory)();
   }
 
   public function toArray(): array {
@@ -85,7 +91,7 @@ class AutomationTemplate {
       'category' => $this->getCategory(),
       'type' => $this->getType(),
       'description' => $this->getDescription(),
-      'automation' => $this->getAutomation()->toArray(),
+      'automation' => $this->createAutomation()->toArray(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
@@ -91,7 +91,6 @@ class AutomationTemplate {
       'category' => $this->getCategory(),
       'type' => $this->getType(),
       'description' => $this->getDescription(),
-      'automation' => $this->createAutomation()->toArray(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
@@ -20,7 +20,8 @@ class AutomationTemplatesGetEndpoint extends Endpoint {
   }
 
   public function handle(Request $request): Response {
-    $templates = array_values($this->registry->getTemplates((int)$request->getParam('category')));
+    $category = $request->getParam('category');
+    $templates = array_values($this->registry->getTemplates($category ? strval($category) : null));
     return new Response(array_map(function (AutomationTemplate $automation) {
       return $automation->toArray();
     }, $templates));
@@ -28,7 +29,7 @@ class AutomationTemplatesGetEndpoint extends Endpoint {
 
   public static function getRequestSchema(): array {
     return [
-      'category' => Builder::integer()->nullable(),
+      'category' => Builder::string(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
@@ -6,22 +6,21 @@ use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
-use MailPoet\Automation\Engine\Storage\AutomationTemplateStorage;
+use MailPoet\Automation\Engine\Registry;
 use MailPoet\Validator\Builder;
 
 class AutomationTemplatesGetEndpoint extends Endpoint {
-
-
-  private $storage;
+  /** @var Registry */
+  private $registry;
 
   public function __construct(
-    AutomationTemplateStorage $storage
+    Registry $registry
   ) {
-    $this->storage = $storage;
+    $this->registry = $registry;
   }
 
   public function handle(Request $request): Response {
-    $templates = $this->storage->getTemplates((int)$request->getParam('category'));
+    $templates = array_values($this->registry->getTemplates((int)$request->getParam('category')));
     return new Response(array_map(function (AutomationTemplate $automation) {
       return $automation->toArray();
     }, $templates));

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -31,8 +31,6 @@ class Hooks {
 
   public const AUTOMATION_RUN_CREATE = 'mailpoet/automation/run/create';
 
-  public const AUTOMATION_TEMPLATES = 'mailpoet/automation/templates';
-
   public function doAutomationBeforeSave(Automation $automation): void {
     $this->wordPress->doAction(self::AUTOMATION_BEFORE_SAVE, $automation);
   }

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -61,7 +61,7 @@ class Registry {
   }
 
   /** @return array<string, AutomationTemplate> */
-  public function getTemplates(int $category = null): array {
+  public function getTemplates(string $category = null): array {
     $templates = (array)$this->wordPress->applyFilters(Hooks::AUTOMATION_TEMPLATES, $this->templates);
     foreach ($templates as $template) {
       if (!$template instanceof AutomationTemplate) {

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -62,22 +62,18 @@ class Registry {
 
   /** @return array<string, AutomationTemplate> */
   public function getTemplates(string $category = null): array {
-    $templates = (array)$this->wordPress->applyFilters(Hooks::AUTOMATION_TEMPLATES, $this->templates);
-    foreach ($templates as $template) {
-      if (!$template instanceof AutomationTemplate) {
-        throw new \Exception(); // TODO
-      }
-    }
-
-    /** @var AutomationTemplate[] $templates -- the array was checked at this point, let PHPStan know */
     return $category
       ? array_filter(
-          $templates,
+          $this->templates,
           function(AutomationTemplate $template) use ($category): bool {
             return $template->getCategory() === $category;
           }
         )
-      : $templates;
+      : $this->templates;
+  }
+
+  public function removeTemplate(string $slug): void {
+    unset($this->templates[$slug]);
   }
 
   /** @param Subject<Payload> $subject */

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\Control\RootStep;
+use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Engine\Integration\Action;
 use MailPoet\Automation\Engine\Integration\Filter;
@@ -13,6 +14,9 @@ use MailPoet\Automation\Engine\Integration\SubjectTransformer;
 use MailPoet\Automation\Engine\Integration\Trigger;
 
 class Registry {
+  /** @var array<string, AutomationTemplate> */
+  private $templates;
+
   /** @var array<string, Step> */
   private $steps = [];
 
@@ -46,6 +50,26 @@ class Registry {
   ) {
     $this->wordPress = $wordPress;
     $this->steps[$rootStep->getKey()] = $rootStep;
+  }
+
+  public function addTemplate(AutomationTemplate $template): void {
+    $this->templates[$template->getSlug()] = $template;
+  }
+
+  public function getTemplate(string $slug): ?AutomationTemplate {
+    return $this->templates[$slug] ?? null;
+  }
+
+  /** @return array<string, AutomationTemplate> */
+  public function getTemplates(int $category = null): array {
+    return $category
+      ? array_filter(
+          $this->templates,
+          function(AutomationTemplate $template) use ($category): bool {
+            return $template->getCategory() === $category;
+          }
+        )
+      : $this->templates;
   }
 
   /** @param Subject<Payload> $subject */

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -57,19 +57,27 @@ class Registry {
   }
 
   public function getTemplate(string $slug): ?AutomationTemplate {
-    return $this->templates[$slug] ?? null;
+    return $this->getTemplates()[$slug] ?? null;
   }
 
   /** @return array<string, AutomationTemplate> */
   public function getTemplates(int $category = null): array {
+    $templates = (array)$this->wordPress->applyFilters(Hooks::AUTOMATION_TEMPLATES, $this->templates);
+    foreach ($templates as $template) {
+      if (!$template instanceof AutomationTemplate) {
+        throw new \Exception(); // TODO
+      }
+    }
+
+    /** @var AutomationTemplate[] $templates -- the array was checked at this point, let PHPStan know */
     return $category
       ? array_filter(
-          $this->templates,
+          $templates,
           function(AutomationTemplate $template) use ($category): bool {
             return $template->getCategory() === $category;
           }
         )
-      : $this->templates;
+      : $templates;
   }
 
   /** @param Subject<Payload> $subject */

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -4,12 +4,10 @@ namespace MailPoet\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Hooks;
-use MailPoet\Automation\Integrations\MailPoet\Templates\AutomationBuilder;
+use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\WP\Functions as WPFunctions;
 
 class AutomationTemplateStorage {
-
-
   /** @var AutomationTemplate[]  */
   private $templates = [];
 

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -137,9 +137,38 @@ class AutomationTemplateStorage {
       ),
       $this->builder->createFromSequence(
         __('Celebrate first-time buyers', 'mailpoet'),
-        []
+        [
+          [
+            'key' => 'woocommerce:order-status-changed',
+            'args' => [
+              'from' => 'any',
+              'to' => 'wc-completed',
+            ],
+            'filters' => [
+              'operator' => 'and',
+              'groups' => [
+                [
+                  'operator' => 'and',
+                  'filters' => [
+                    ['field' => 'woocommerce:order:is-first-order', 'condition' => 'is', 'value' => true],
+                  ],
+                ],
+              ],
+            ],
+          ],
+          [
+            'key' => 'mailpoet:send-email',
+            'args' => [
+              'name' => __('Thank you', 'mailpoet'),
+              'subject' => __('Thank You for Choosing Us!', 'mailpoet'),
+            ],
+          ],
+        ],
+        [
+          'mailpoet:run-once-per-subscriber' => true,
+        ]
       ),
-      AutomationTemplate::TYPE_COMING_SOON
+      AutomationTemplate::TYPE_DEFAULT
     );
 
     $loyalCustomers = new AutomationTemplate(

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -189,17 +189,24 @@ class AutomationTemplateStorage {
       'abandoned-cart',
       AutomationTemplate::CATEGORY_ABANDONED_CART,
       __(
-        "Nudge your shoppers to complete the purchase after they added a product to the cart but haven't completed the order. Offer a coupon code as a last resort to convert them to customers.",
+        "Nudge your shoppers to complete the purchase after they have added a product to the cart but haven't completed the order.",
         'mailpoet'
       ),
       $this->builder->createFromSequence(
         __('Abandoned cart reminder', 'mailpoet'),
-        []
+        [
+          ['key' => 'woocommerce:abandoned-cart'],
+          [
+            'key' => 'mailpoet:send-email',
+            'args' => [
+              'name' => 'Abandoned cart',
+              'subject' => 'Looks like you forgot something',
+            ],
+          ],
+        ]
       ),
-      AutomationTemplate::TYPE_COMING_SOON
+      AutomationTemplate::TYPE_DEFAULT
     );
-
-
 
     $templates = $this->wp->applyFilters(Hooks::AUTOMATION_TEMPLATES, [
       $subscriberWelcomeEmail,

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -68,17 +68,9 @@ class AutomationTemplateStorage {
       $this->builder->createFromSequence(
         __('Welcome new subscribers', 'mailpoet'),
         [
-          'mailpoet:someone-subscribes',
-          'core:delay',
-          'mailpoet:send-email',
-        ],
-        [
-          [],
-          [
-            'delay' => 1,
-            'delay_type' => 'MINUTES',
-          ],
-          [],
+          ['key' => 'mailpoet:someone-subscribes'],
+          ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
+          ['key' => 'mailpoet:send-email'],
         ],
         [
           'mailpoet:run-once-per-subscriber' => true,
@@ -97,17 +89,9 @@ class AutomationTemplateStorage {
       $this->builder->createFromSequence(
         __('Welcome new WordPress users', 'mailpoet'),
         [
-          'mailpoet:wp-user-registered',
-          'core:delay',
-          'mailpoet:send-email',
-        ],
-        [
-          [],
-          [
-            'delay' => 1,
-            'delay_type' => 'MINUTES',
-          ],
-          [],
+          ['key' => 'mailpoet:wp-user-registered'],
+          ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
+          ['key' => 'mailpoet:send-email'],
         ],
         [
           'mailpoet:run-once-per-subscriber' => true,

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationTemplateStorage.php
@@ -208,6 +208,20 @@ class AutomationTemplateStorage {
       AutomationTemplate::TYPE_DEFAULT
     );
 
+    $abandonedCartCampaign = new AutomationTemplate(
+      'abandoned-cart',
+      AutomationTemplate::CATEGORY_ABANDONED_CART,
+      __(
+        "Encourage your potential customers to finalize their purchase when they have added items to their cart but haven't finished the order yet. Offer a coupon code as a last resort to convert them to customers.",
+        'mailpoet'
+      ),
+      $this->builder->createFromSequence(
+        __('Abandoned cart campaign', 'mailpoet'),
+        []
+      ),
+      AutomationTemplate::TYPE_COMING_SOON
+    );
+
     $templates = $this->wp->applyFilters(Hooks::AUTOMATION_TEMPLATES, [
       $subscriberWelcomeEmail,
       $userWelcomeEmail,
@@ -216,6 +230,7 @@ class AutomationTemplateStorage {
       $firstPurchase,
       $loyalCustomers,
       $abandonedCart,
+      $abandonedCartCampaign,
     ]);
     return is_array($templates) ? $templates : [];
   }

--- a/mailpoet/lib/Automation/Engine/Templates/AutomationBuilder.php
+++ b/mailpoet/lib/Automation/Engine/Templates/AutomationBuilder.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Integrations\MailPoet\Templates;
+namespace MailPoet\Automation\Engine\Templates;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\Filter;
@@ -15,7 +15,6 @@ use MailPoet\Util\Security;
 use MailPoet\Validator\Schema\ObjectSchema;
 
 class AutomationBuilder {
-
   /** @var Registry */
   private $registry;
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
@@ -13,6 +13,7 @@ use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\OrderSubjectToSegmentSubjectTransformer;
 use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\OrderSubjectToSubscriberSubjectTransformer;
 use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\SubscriberSubjectToWordPressUserSubjectTransformer;
+use MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\UserRegistrationTrigger;
 
@@ -50,6 +51,9 @@ class MailPoetIntegration implements Integration {
   /** @var SubscriberSubjectToWordPressUserSubjectTransformer */
   private $subscriberToWordPressUserTransformer;
 
+  /** @var TemplatesFactory */
+  private $templatesFactory;
+
   /** @var Analytics */
   private $registerAnalytics;
 
@@ -65,6 +69,7 @@ class MailPoetIntegration implements Integration {
     SendEmailAction $sendEmailAction,
     AutomationEditorLoadingHooks $automationEditorLoadingHooks,
     CreateAutomationRunHook $createAutomationRunHook,
+    TemplatesFactory $templatesFactory,
     Analytics $registerAnalytics
   ) {
     $this->contextFactory = $contextFactory;
@@ -78,6 +83,7 @@ class MailPoetIntegration implements Integration {
     $this->sendEmailAction = $sendEmailAction;
     $this->automationEditorLoadingHooks = $automationEditorLoadingHooks;
     $this->createAutomationRunHook = $createAutomationRunHook;
+    $this->templatesFactory = $templatesFactory;
     $this->registerAnalytics = $registerAnalytics;
   }
 
@@ -94,6 +100,10 @@ class MailPoetIntegration implements Integration {
     $registry->addSubjectTransformer($this->orderToSubscriberTransformer);
     $registry->addSubjectTransformer($this->orderToSegmentTransformer);
     $registry->addSubjectTransformer($this->subscriberToWordPressUserTransformer);
+
+    foreach ($this->templatesFactory->createTemplates() as $template) {
+      $registry->addTemplate($template);
+    }
 
     // sync step args (subject, preheader, etc.) to email settings
     $registry->onBeforeAutomationStepSave(

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/AutomationBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/AutomationBuilder.php
@@ -21,15 +21,27 @@ class AutomationBuilder {
     $this->registry = $registry;
   }
 
-  public function createFromSequence(string $name, array $sequence, array $sequenceArgs = [], array $meta = []): Automation {
+  /**
+   * @param string $name
+   * @param array<
+   *   array{
+   *     key: string,
+   *     args?: array<string, mixed>,
+   *   }
+   * > $sequence
+   * @param array<string, mixed> $meta
+   * @return Automation
+   */
+  public function createFromSequence(string $name, array $sequence, array $meta = []): Automation {
     $steps = [];
     $nextSteps = [];
-    foreach (array_reverse($sequence) as $index => $stepKey) {
+    foreach (array_reverse($sequence) as $data) {
+      $stepKey = $data['key'];
       $automationStep = $this->registry->getStep($stepKey);
       if (!$automationStep) {
         continue;
       }
-      $args = array_merge($this->getDefaultArgs($automationStep->getArgsSchema()), array_reverse($sequenceArgs)[$index] ?? []);
+      $args = array_merge($this->getDefaultArgs($automationStep->getArgsSchema()), $data['args'] ?? []);
       $step = new Step(
         $this->uniqueId(),
         in_array(Trigger::class, (array)class_implements($automationStep)) ? Step::TYPE_TRIGGER : Step::TYPE_ACTION,

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
+use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
@@ -40,21 +41,24 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'subscriber-welcome-email',
       AutomationTemplate::CATEGORY_WELCOME,
+      __('Welcome new subscribers', 'mailpoet'),
       __(
         "Send a welcome email when someone subscribes to your list. Optionally, you can choose to send this email after a specified period.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Welcome new subscribers', 'mailpoet'),
-        [
-          ['key' => 'mailpoet:someone-subscribes'],
-          ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
-          ['key' => 'mailpoet:send-email'],
-        ],
-        [
-          'mailpoet:run-once-per-subscriber' => true,
-        ]
-      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Welcome new subscribers', 'mailpoet'),
+          [
+            ['key' => 'mailpoet:someone-subscribes'],
+            ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
+            ['key' => 'mailpoet:send-email'],
+          ],
+          [
+            'mailpoet:run-once-per-subscriber' => true,
+          ]
+        );
+      },
       AutomationTemplate::TYPE_FREE_ONLY
     );
   }
@@ -63,21 +67,24 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'user-welcome-email',
       AutomationTemplate::CATEGORY_WELCOME,
+      __('Welcome new WordPress users', 'mailpoet'),
       __(
         "Send a welcome email when a new WordPress user registers to your website. Optionally, you can choose to send this email after a specified period.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Welcome new WordPress users', 'mailpoet'),
-        [
-          ['key' => 'mailpoet:wp-user-registered'],
-          ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
-          ['key' => 'mailpoet:send-email'],
-        ],
-        [
-          'mailpoet:run-once-per-subscriber' => true,
-        ]
-      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Welcome new WordPress users', 'mailpoet'),
+          [
+            ['key' => 'mailpoet:wp-user-registered'],
+            ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
+            ['key' => 'mailpoet:send-email'],
+          ],
+          [
+            'mailpoet:run-once-per-subscriber' => true,
+          ]
+        );
+      },
       AutomationTemplate::TYPE_FREE_ONLY
     );
   }
@@ -86,14 +93,17 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'subscriber-welcome-series',
       AutomationTemplate::CATEGORY_WELCOME,
+      __('Welcome series for new subscribers', 'mailpoet'),
       __(
         "Welcome new subscribers and start building a relationship with them. Send an email immediately after someone subscribes to your list to introduce your brand and a follow-up two days later to keep the conversation going.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Welcome series for new subscribers', 'mailpoet'),
-        []
-      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Welcome series for new subscribers', 'mailpoet'),
+          []
+        );
+      },
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -102,14 +112,17 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'user-welcome-series',
       AutomationTemplate::CATEGORY_WELCOME,
+      __('Welcome series for new WordPress users', 'mailpoet'),
       __(
         "Welcome new WordPress users to your site. Send an email immediately after a WordPress user registers. Send a follow-up email two days later with more in-depth information.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Welcome series for new WordPress users', 'mailpoet'),
-        []
-      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Welcome series for new WordPress users', 'mailpoet'),
+          []
+        );
+      },
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -118,43 +131,46 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'first-purchase',
       AutomationTemplate::CATEGORY_WOOCOMMERCE,
+      __('Celebrate first-time buyers', 'mailpoet'),
       __(
         "Welcome your first-time customers by sending an email with a special offer for their next purchase. Make them feel appreciated within your brand.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Celebrate first-time buyers', 'mailpoet'),
-        [
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Celebrate first-time buyers', 'mailpoet'),
           [
-            'key' => 'woocommerce:order-status-changed',
-            'args' => [
-              'from' => 'any',
-              'to' => 'wc-completed',
-            ],
-            'filters' => [
-              'operator' => 'and',
-              'groups' => [
-                [
-                  'operator' => 'and',
-                  'filters' => [
-                    ['field' => 'woocommerce:order:is-first-order', 'condition' => 'is', 'value' => true],
+            [
+              'key' => 'woocommerce:order-status-changed',
+              'args' => [
+                'from' => 'any',
+                'to' => 'wc-completed',
+              ],
+              'filters' => [
+                'operator' => 'and',
+                'groups' => [
+                  [
+                    'operator' => 'and',
+                    'filters' => [
+                      ['field' => 'woocommerce:order:is-first-order', 'condition' => 'is', 'value' => true],
+                    ],
                   ],
                 ],
               ],
             ],
-          ],
-          [
-            'key' => 'mailpoet:send-email',
-            'args' => [
-              'name' => __('Thank you', 'mailpoet'),
-              'subject' => __('Thank You for Choosing Us!', 'mailpoet'),
+            [
+              'key' => 'mailpoet:send-email',
+              'args' => [
+                'name' => __('Thank you', 'mailpoet'),
+                'subject' => __('Thank You for Choosing Us!', 'mailpoet'),
+              ],
             ],
           ],
-        ],
-        [
-          'mailpoet:run-once-per-subscriber' => true,
-        ]
-      ),
+          [
+            'mailpoet:run-once-per-subscriber' => true,
+          ]
+        );
+      },
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -163,14 +179,17 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'loyal-customers',
       AutomationTemplate::CATEGORY_WOOCOMMERCE,
+      __('Thank loyal customers', 'mailpoet'),
       __(
         "These are your most important customers. Make them feel special by sending a thank you note for supporting your brand.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Thank loyal customers', 'mailpoet'),
-        []
-      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Thank loyal customers', 'mailpoet'),
+          []
+        );
+      },
       AutomationTemplate::TYPE_COMING_SOON
     );
   }
@@ -179,23 +198,26 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'abandoned-cart',
       AutomationTemplate::CATEGORY_ABANDONED_CART,
+      __('Abandoned cart reminder', 'mailpoet'),
       __(
         "Nudge your shoppers to complete the purchase after they have added a product to the cart but haven't completed the order.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Abandoned cart reminder', 'mailpoet'),
-        [
-          ['key' => 'woocommerce:abandoned-cart'],
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Abandoned cart reminder', 'mailpoet'),
           [
-            'key' => 'mailpoet:send-email',
-            'args' => [
-              'name' => 'Abandoned cart',
-              'subject' => 'Looks like you forgot something',
+            ['key' => 'woocommerce:abandoned-cart'],
+            [
+              'key' => 'mailpoet:send-email',
+              'args' => [
+                'name' => 'Abandoned cart',
+                'subject' => 'Looks like you forgot something',
+              ],
             ],
-          ],
-        ]
-      ),
+          ]
+        );
+      },
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -204,14 +226,17 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'abandoned-cart-campaign',
       AutomationTemplate::CATEGORY_ABANDONED_CART,
+      __('Abandoned cart campaign', 'mailpoet'),
       __(
         "Encourage your potential customers to finalize their purchase when they have added items to their cart but haven't finished the order yet. Offer a coupon code as a last resort to convert them to customers.",
         'mailpoet'
       ),
-      $this->builder->createFromSequence(
-        __('Abandoned cart campaign', 'mailpoet'),
-        []
-      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Abandoned cart campaign', 'mailpoet'),
+          []
+        );
+      },
       AutomationTemplate::TYPE_COMING_SOON
     );
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -4,27 +4,20 @@ namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
-use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
-use MailPoet\Automation\Engine\WordPress;
 
 class TemplatesFactory {
   /** @var AutomationBuilder */
   private $builder;
 
-  /** @var WordPress */
-  private $wp;
-
   public function __construct(
-    AutomationBuilder $builder,
-    WordPress $wp
+    AutomationBuilder $builder
   ) {
     $this->builder = $builder;
-    $this->wp = $wp;
   }
 
   public function createTemplates(): array {
-    $templates = $this->wp->applyFilters(Hooks::AUTOMATION_TEMPLATES, [
+    return [
       $this->createSubscriberWelcomeEmailTemplate(),
       $this->createUserWelcomeEmailTemplate(),
       $this->createSubscriberWelcomeSeriesTemplate(),
@@ -33,8 +26,7 @@ class TemplatesFactory {
       $this->createLoyalCustomersTemplate(),
       $this->createAbandonedCartTemplate(),
       $this->createAbandonedCartCampaignTemplate(),
-    ]);
-    return is_array($templates) ? $templates : [];
+    ];
   }
 
   private function createSubscriberWelcomeEmailTemplate(): AutomationTemplate {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -23,7 +23,21 @@ class TemplatesFactory {
   }
 
   public function createTemplates(): array {
-    $subscriberWelcomeEmail = new AutomationTemplate(
+    $templates = $this->wp->applyFilters(Hooks::AUTOMATION_TEMPLATES, [
+      $this->createSubscriberWelcomeEmailTemplate(),
+      $this->createUserWelcomeEmailTemplate(),
+      $this->createSubscriberWelcomeSeriesTemplate(),
+      $this->createUserWelcomeSeriesTemplate(),
+      $this->createFirstPurchaseTemplate(),
+      $this->createLoyalCustomersTemplate(),
+      $this->createAbandonedCartTemplate(),
+      $this->createAbandonedCartCampaignTemplate(),
+    ]);
+    return is_array($templates) ? $templates : [];
+  }
+
+  private function createSubscriberWelcomeEmailTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'subscriber-welcome-email',
       AutomationTemplate::CATEGORY_WELCOME,
       __(
@@ -43,8 +57,10 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_FREE_ONLY
     );
+  }
 
-    $userWelcomeEmail = new AutomationTemplate(
+  private function createUserWelcomeEmailTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'user-welcome-email',
       AutomationTemplate::CATEGORY_WELCOME,
       __(
@@ -64,8 +80,10 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_FREE_ONLY
     );
+  }
 
-    $subscriberWelcomeSeries = new AutomationTemplate(
+  private function createSubscriberWelcomeSeriesTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'subscriber-welcome-series',
       AutomationTemplate::CATEGORY_WELCOME,
       __(
@@ -78,8 +96,10 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_PREMIUM
     );
+  }
 
-    $userWelcomeSeries = new AutomationTemplate(
+  private function createUserWelcomeSeriesTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'user-welcome-series',
       AutomationTemplate::CATEGORY_WELCOME,
       __(
@@ -92,8 +112,10 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_PREMIUM
     );
+  }
 
-    $firstPurchase = new AutomationTemplate(
+  private function createFirstPurchaseTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'first-purchase',
       AutomationTemplate::CATEGORY_WOOCOMMERCE,
       __(
@@ -135,8 +157,10 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_DEFAULT
     );
+  }
 
-    $loyalCustomers = new AutomationTemplate(
+  private function createLoyalCustomersTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'loyal-customers',
       AutomationTemplate::CATEGORY_WOOCOMMERCE,
       __(
@@ -149,8 +173,10 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_COMING_SOON
     );
+  }
 
-    $abandonedCart = new AutomationTemplate(
+  private function createAbandonedCartTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
       'abandoned-cart',
       AutomationTemplate::CATEGORY_ABANDONED_CART,
       __(
@@ -172,9 +198,11 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_DEFAULT
     );
+  }
 
-    $abandonedCartCampaign = new AutomationTemplate(
-      'abandoned-cart',
+  private function createAbandonedCartCampaignTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'abandoned-cart-campaign',
       AutomationTemplate::CATEGORY_ABANDONED_CART,
       __(
         "Encourage your potential customers to finalize their purchase when they have added items to their cart but haven't finished the order yet. Offer a coupon code as a last resort to convert them to customers.",
@@ -186,17 +214,5 @@ class TemplatesFactory {
       ),
       AutomationTemplate::TYPE_COMING_SOON
     );
-
-    $templates = $this->wp->applyFilters(Hooks::AUTOMATION_TEMPLATES, [
-      $subscriberWelcomeEmail,
-      $userWelcomeEmail,
-      $subscriberWelcomeSeries,
-      $userWelcomeSeries,
-      $firstPurchase,
-      $loyalCustomers,
-      $abandonedCart,
-      $abandonedCartCampaign,
-    ]);
-    return is_array($templates) ? $templates : [];
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -1,61 +1,28 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Automation\Engine\Storage;
+namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
-use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\Automation\Engine\WordPress;
 
-class AutomationTemplateStorage {
-  /** @var AutomationTemplate[]  */
-  private $templates = [];
-
-  /** @var AutomationBuilder  */
+class TemplatesFactory {
+  /** @var AutomationBuilder */
   private $builder;
 
-  /** @var WPFunctions  */
+  /** @var WordPress */
   private $wp;
 
   public function __construct(
     AutomationBuilder $builder,
-    WPFunctions $wp
+    WordPress $wp
   ) {
     $this->builder = $builder;
     $this->wp = $wp;
   }
 
-  public function getTemplateBySlug(string $slug): ?AutomationTemplate {
-    if (!$this->templates) {
-      $this->templates = $this->createTemplates();
-    }
-    foreach ($this->templates as $template) {
-      if ($template->getSlug() === $slug) {
-        return $template;
-      }
-    }
-    return null;
-  }
-
-  /** @return AutomationTemplate[] */
-  public function getTemplates(int $category = null): array {
-    if (!$this->templates) {
-      $this->templates = $this->createTemplates();
-    }
-    if (!$category) {
-      return $this->templates;
-    }
-    return array_values(
-      array_filter(
-        $this->templates,
-        function(AutomationTemplate $template) use ($category): bool {
-            return $template->getCategory() === $category;
-        }
-    )
-    );
-  }
-
-  private function createTemplates(): array {
+  public function createTemplates(): array {
     $subscriberWelcomeEmail = new AutomationTemplate(
       'subscriber-welcome-email',
       AutomationTemplate::CATEGORY_WELCOME,

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -135,7 +135,6 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationRunStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationRunLogStorage::class)->setPublic(true);
-    $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Templates\AutomationBuilder::class)->setPublic(true)->setShared(false);
@@ -178,6 +177,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\OrderSubjectToSubscriberSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\OrderSubjectToSegmentSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\SubscriberSubjectToWordPressUserSubjectTransformer::class)->setPublic(true)->setShared(false);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory::class)->setPublic(true)->setShared(false);
 
     // Automation - WooCommerce integration
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\WooCommerce::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -138,6 +138,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationTemplateStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationStorage::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Templates\AutomationBuilder::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationWalker::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\UnknownStepRule::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepArgsRule::class)->setPublic(true);
@@ -171,7 +172,6 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Subjects\AbandonedCartSubject::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Triggers\UserRegistrationTrigger::class)->setPublic(true)->setShared(false);
-    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\AutomationBuilder::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Hooks\AutomationEditorLoadingHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Hooks\CreateAutomationRunHook::class)->setPublic(true);

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -9,10 +9,6 @@ parameters:
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Automation/Integrations/MailPoet/Analytics/Endpoints/OverviewEndpoint.php
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: ../../lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
 
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -9,10 +9,6 @@ parameters:
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Automation/Integrations/MailPoet/Analytics/Endpoints/OverviewEndpoint.php
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: ../../lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
 
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -4,10 +4,6 @@ parameters:
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: ../../lib/Automation/Engine/Endpoints/Automations/AutomationsCreateFromTemplateEndpoint.php
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: ../../lib/Automation/Engine/Endpoints/Automations/AutomationTemplatesGetEndpoint.php
 
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -13,7 +13,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(7, $result['data']);
+    $this->assertCount(8, $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -21,7 +21,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(7, $data['data']);
+    $this->assertCount(8, $data['data']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -42,13 +42,14 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
         'category' => AutomationTemplate::CATEGORY_WELCOME,
       ],
     ]);
+
     $this->assertCount(4, $result['data']);
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
         'category' => AutomationTemplate::CATEGORY_ABANDONED_CART,
       ],
     ]);
-    $this->assertCount(1, $result['data']);
+    $this->assertCount(2, $result['data']);
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
         'category' => AutomationTemplate::CATEGORY_WOOCOMMERCE,


### PR DESCRIPTION
## Description

Adds new automation templates and refactors the template registration code.

## Code review notes

The PR is opened against https://github.com/mailpoet/mailpoet/pull/4984, which needs to be merged first.

## QA notes

Please check that all templates work, including the existing ones.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/736

## Linked tickets

[MAILPOET-5372]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5169]: https://mailpoet.atlassian.net/browse/MAILPOET-5169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-5372]: https://mailpoet.atlassian.net/browse/MAILPOET-5372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ