### PR TITLE
Fix missing baseline definition for PHPStan with PHP 8.1 [MAILPOET-5414]

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -4,6 +4,10 @@ parameters:
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: ../../lib/Automation/Engine/Endpoints/Automations/AutomationsCreateFromTemplateEndpoint.php
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: ../../lib/Automation/Integrations/MailPoet/Analytics/Endpoints/OverviewEndpoint.php
 
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5414]

## After-merge notes

_N/A_


[MAILPOET-5414]: https://mailpoet.atlassian.net/browse/MAILPOET-5414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ