### PR TITLE
Improved 3 test cases about managing Confirmation pages in Settings

### DIFF
--- a/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
@@ -2,9 +2,59 @@
 
  namespace MailPoet\Test\Acceptance;
 
+ use Codeception\Util\Locator;
+ use MailPoet\Subscription\Captcha\CaptchaConstants;
+ use MailPoet\Test\DataFactories\Form;
+ use MailPoet\Test\DataFactories\Settings;
+
 class ConfirmConfirmationPageCest {
+  
+    const CONFIRMATION_MESSAGE_TIMEOUT = 20;
+    const FORM_NAME = 'Subscription Acceptance Test Form';
+
+  /** @var string */
+  private $subscriberEmail;
+
+  /** @var int|null */
+  private $formId;
+
+  public function __construct() {
+    $this->subscriberEmail = 'test-form@example.com';
+  }
+
+  public function _before(\AcceptanceTester $i) {
+    $settings = new Settings();
+    $settings
+      ->withConfirmationEmailSubject()
+      ->withConfirmationEmailBody()
+      ->withConfirmationEmailEnabled()
+      ->withCaptchaType(CaptchaConstants::TYPE_DISABLED);
+
+    $formFactory = new Form();
+    $this->formId = $formFactory->withName(self::FORM_NAME)->create()->getId();
+
+    $i->havePostInDatabase([
+      'post_author' => 1,
+      'post_type' => 'page',
+      'post_name' => 'form-test',
+      'post_title' => 'Form Test',
+      'post_content' => '
+        Regular form:
+          [mailpoet_form id="' . $this->formId . '"]
+        Iframe form:
+          <iframe class="mailpoet_form_iframe" id="mailpoet_form_iframe" tabindex="0" src="http://test.local?mailpoet_form_iframe=1" width="100%" height="100%" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+      ',
+      'post_status' => 'publish',
+    ]);
+  }
+
   public function confirmDefaultConfirmationPage(\AcceptanceTester $i) {
     $i->wantTo('Confirm link to default confirmation page works correctly');
+
+    $siteTitle = get_bloginfo('name', 'raw');
+    $pageTitle = 'MailPoetConfirmationPage';
+    $postContent = 'BobsYourUncle';
+
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="signup_settings_tab"]');
@@ -12,18 +62,31 @@ class ConfirmConfirmationPageCest {
     $i->waitForText('MailPoet Page');
     $i->click('[data-automation-id="preview_page_link"]');
     $i->switchToNextTab();
-    $siteTitle = get_bloginfo('name', 'raw');
     $i->see("You have subscribed to $siteTitle");
-    $pageTitle = 'MailPoetConfirmationPage';
-    $postContent = 'BobsYourUncle';
+
+    $i->wantTo('See the new confirmation page shows up');
     $i->cli(['post', 'create', '--post_type=page', '--post_status=publish', "--post_title=$pageTitle", "--post_content=$postContent"]);
+
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="signup_settings_tab"]');
     $i->waitForText('Enable sign-up confirmation');
     $i->waitForText('MailPoet Page');
     $i->selectOption('[data-automation-id="page_selection"]', $pageTitle);
-    $i->click('[data-automation-id="preview_page_link"]');
+    $i->click('Save settings');
+    $i->waitForText('Settings saved');
+
+    $i->amOnPage('/form-test');
+    $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
+    $i->scrollTo('.mailpoet_submit');
+    $i->click('.mailpoet_submit');
+    $i->waitForText('Check your inbox or spam folder to confirm your subscription.', self::CONFIRMATION_MESSAGE_TIMEOUT, '.mailpoet_validate_success');
+    $i->checkEmailWasReceived('Confirm your subscription');
+    $i->click(Locator::contains('span.subject', 'Confirm your subscription'));
+    $i->switchToIframe('#preview-html');
+    $i->click('Click here to confirm your subscription');
+
     $i->switchToNextTab();
     $i->waitForText($postContent);
+    $i->seeNoJSErrors();
   }
 }

--- a/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
@@ -2,9 +2,13 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Codeception\Util\Locator;
+use MailPoet\Test\DataFactories\Subscriber;
+
 class SubscriptionPageCest {
   public function previewDefaultSubscriptionPage(\AcceptanceTester $i) {
     $i->wantTo('Preview default MailPoet page from MP Settings page');
+
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="preview_manage_subscription_page_link"]');
@@ -13,19 +17,51 @@ class SubscriptionPageCest {
   }
 
   public function createNewSubscriptionPage(\AcceptanceTester $i) {
-    $i->wantTo('Make a custom subscription page');
+    $i->wantTo('Make and set a custom manage subscription page');
+
     $pageTitle = 'CustomSubscriptionPage';
-    $pageContent = 'This is custom manage subscription page [mailpoet_manage_subscription]';
-    $i->cli(['post', 'create', '--post_status=publish', '--post_type=page', "--post_title='$pageTitle'", "--post_content='$pageContent'"]);
+    $pageContent = 'This is custom manage subscription page';
+    $emailContent = 'Click <a href="[link:subscription_manage_url]">Manage Subscription</a> to see the subscription page.';
+    $emailAddress = 'subscriber@example.com';
+    $confirmationEmailName = 'Confirm your subscription';
+    $subscriberFactory = new Subscriber();
+    $subscriberFactory->withEmail($emailAddress)
+      ->withStatus('unconfirmed')
+      ->withCountConfirmations(0)
+      ->create();
+
+    $i->cli(['post', 'create', '--post_status=publish', '--post_type=page', "--post_title='$pageTitle'", "--post_content='$pageContent [mailpoet_manage_subscription]'"]);
+
     $i->login();
+
     $i->amOnMailPoetPage('Settings');
     $i->click(['css' => '[data-automation-id="subscription-manage-page-selection"]']);
     $i->selectOption('[data-automation-id="subscription-manage-page-selection"]', $pageTitle);
-    //save settings and then verify the page
     $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForNoticeAndClose('Settings saved');
+
+    $i->wantTo('Click the manage subscription link and verify it');
+
+    // Making a shortcut in this scenario by providing required url in the conf email
+    $i->click('[data-automation-id="signup_settings_tab"]');
+    $i->checkOption('[data-automation-id="mailpoet_confirmation_email_customizer"]');
+    $i->clearField('[data-automation-id="signup_confirmation_email_body"]');
+    $i->fillField('[data-automation-id="signup_confirmation_email_body"]', $emailContent);
+    $i->click('Save settings');
     $i->waitForText('Settings saved');
-    $i->click('[data-automation-id="preview_manage_subscription_page_link"]');
+
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForText($emailAddress);
+    $i->clickItemRowActionByItemName($emailAddress, 'Resend confirmation email');
+    $i->waitForText('1 confirmation email has been sent.');
+
+    $i->amOnMailboxAppPage();
+    $i->checkEmailWasReceived($confirmationEmailName);
+    $i->click(Locator::contains('span.subject', $confirmationEmailName));
+    $i->switchToIframe('#preview-html');
+    $i->click('Manage Subscription');
     $i->switchToNextTab();
-    $i->waitForText('This is custom manage subscription page');
+    $i->waitForText($pageTitle);
+    $i->waitForText($pageContent);
   }
 }

--- a/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
@@ -2,9 +2,39 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Codeception\Util\Locator;
+use MailPoet\Test\DataFactories\Subscriber;
+
 class UnsubscribePageCest {
+
+  /** @var string */
+  private $emailAddress;
+  private $pageTitleConfirmation;
+  private $pageTitleSuccess;
+  private $pageContent;
+  private $emailContent;
+  private $confirmationEmailName;
+
+  public function _before(\AcceptanceTester $i) {
+    $this->emailAddress = 'subscriber@example.com';
+    $this->pageTitleConfirmation = 'Custom Unsubscribe Confirmation Page';
+    $this->pageTitleSuccess = 'Custom Unsubscribe Success Page';
+    $this->pageContent = 'This is custom unsubscribe page';
+    $this->emailContent = 'Click <a href="[link:subscription_unsubscribe_url]">Unsubscribe</a> to get unsubscribed.';
+    $this->confirmationEmailName = 'Confirm your subscription';
+    $subscriberFactory = new Subscriber();
+    $subscriberFactory->withEmail($this->emailAddress)
+      ->withStatus('unconfirmed')
+      ->withCountConfirmations(0)
+      ->create();
+
+    $i->cli(['post', 'create', '--post_status=publish', '--post_type=page', "--post_title='$this->pageTitleConfirmation'", "--post_content='$this->pageContent [mailpoet_page]'"]);
+    $i->cli(['post', 'create', '--post_status=publish', '--post_type=page', "--post_title='$this->pageTitleSuccess'", "--post_content='$this->pageContent [mailpoet_page]'"]);
+  }
+
   public function previewDefaultUnsubscribePage(\AcceptanceTester $i) {
     $i->wantTo('Preview default MailPoet Unsubscribe page from MP Settings page');
+
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="unsubscribe_page_preview_link"]');
@@ -14,39 +44,74 @@ class UnsubscribePageCest {
 
   public function createNewUnsubscribeConfirmationPage(\AcceptanceTester $i) {
     $i->wantTo('Make a custom unsubscribe confirmation page');
-    $pageTitle = 'Custom Unsubscribe Confirmation';
-    $pageContent = 'This is custom unsubscribe confirmation page [mailpoet_page]';
-    $i->cli(['post', 'create', '--post_status=publish', '--post_type=page', "--post_title='$pageTitle'", "--post_content='$pageContent'"]);
+
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->scrollTo('[data-automation-id="subscription-manage-page-selection"]');
     $i->click(['css' => '[data-automation-id="unsubscribe-confirmation-page-selection"]']);
-    $i->selectOption('[data-automation-id="unsubscribe-confirmation-page-selection"]', $pageTitle);
-    //save settings and then verify the page
+    $i->selectOption('[data-automation-id="unsubscribe-confirmation-page-selection"]', $this->pageTitleConfirmation);
     $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForNoticeAndClose('Settings saved');
+
+    $i->wantTo('Click the Unsubscribe link and verify the Confirmation page');
+    
+    // Making a shortcut in this scenario by providing required url in the conf email
+    $i->click('[data-automation-id="signup_settings_tab"]');
+    $i->checkOption('[data-automation-id="mailpoet_confirmation_email_customizer"]');
+    $i->clearField('[data-automation-id="signup_confirmation_email_body"]');
+    $i->fillField('[data-automation-id="signup_confirmation_email_body"]', $this->emailContent);
+    $i->click('Save settings');
     $i->waitForText('Settings saved');
-    $i->click('[data-automation-id="unsubscribe_page_preview_link_confirmation"]');
+
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForText($this->emailAddress);
+    $i->clickItemRowActionByItemName($this->emailAddress, 'Resend confirmation email');
+    $i->waitForText('1 confirmation email has been sent.');
+
+    $i->amOnMailboxAppPage();
+    $i->checkEmailWasReceived($this->confirmationEmailName);
+    $i->click(Locator::contains('span.subject', $this->confirmationEmailName));
+    $i->switchToIframe('#preview-html');
+    $i->click('Unsubscribe');
     $i->switchToNextTab();
-    $i->waitForText('This is custom unsubscribe confirmation page');
-    $i->waitForText('Simply click on this link to stop receiving emails from us.');
-    $i->waitForText('Yes, unsubscribe me');
+    $i->waitForText($this->pageTitleConfirmation);
+    $i->waitForText($this->pageContent);
   }
 
   public function createNewUnsubscribeSuccessPage(\AcceptanceTester $i) {
     $i->wantTo('Make a custom unsubscribe success page');
-    $pageTitle = 'Custom Unsubscribe Success';
-    $pageContent = 'This is custom unsubscribe success page [mailpoet_page]';
-    $i->cli(['post', 'create', '--post_status=publish', '--post_type=page', "--post_title='$pageTitle'", "--post_content='$pageContent'"]);
+
     $i->login();
     $i->amOnMailPoetPage('Settings');
     $i->scrollTo('[data-automation-id="subscription-manage-page-selection"]');
     $i->click(['css' => '[data-automation-id="unsubscribe-success-page-selection"]']);
-    $i->selectOption('[data-automation-id="unsubscribe-success-page-selection"]', $pageTitle);
-    //save settings and then verify the page
+    $i->selectOption('[data-automation-id="unsubscribe-success-page-selection"]', $this->pageTitleSuccess);
     $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForNoticeAndClose('Settings saved');
+
+    $i->wantTo('Click the Unsubscribe link and verify the Success page');
+
+    // Making a shortcut in this scenario by providing required url in the conf email
+    $i->click('[data-automation-id="signup_settings_tab"]');
+    $i->checkOption('[data-automation-id="mailpoet_confirmation_email_customizer"]');
+    $i->clearField('[data-automation-id="signup_confirmation_email_body"]');
+    $i->fillField('[data-automation-id="signup_confirmation_email_body"]', $this->emailContent);
+    $i->click('Save settings');
     $i->waitForText('Settings saved');
-    $i->click('[data-automation-id="unsubscribe_page_preview_link"]');
+
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForText($this->emailAddress);
+    $i->clickItemRowActionByItemName($this->emailAddress, 'Resend confirmation email');
+    $i->waitForText('1 confirmation email has been sent.');
+
+    $i->amOnMailboxAppPage();
+    $i->checkEmailWasReceived($this->confirmationEmailName);
+    $i->click(Locator::contains('span.subject', $this->confirmationEmailName));
+    $i->switchToIframe('#preview-html');
+    $i->click('Unsubscribe');
     $i->switchToNextTab();
-    $i->waitForText('This is custom unsubscribe success page');
+    $i->waitForText('Yes, unsubscribe me');
+    $i->click('Yes, unsubscribe me');
+    $i->waitForText($this->pageTitleSuccess);
   }
 }


### PR DESCRIPTION
## Description

In this PR, there are 3 improved test cases.
- TC ConfirmConfirmationPageCest
- TC SubscriptionPageCest
- TC UnsubscribePageCest

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5325], [MAILPOET-5326], [MAILPOET-5327]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5325]: https://mailpoet.atlassian.net/browse/MAILPOET-5325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5326]: https://mailpoet.atlassian.net/browse/MAILPOET-5326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5327]: https://mailpoet.atlassian.net/browse/MAILPOET-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ