### PR TITLE
Automation filter improvements [MAILPOET-5415][MAILPOET-5418][MAILPOET-5426]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_filters.scss
@@ -41,7 +41,13 @@ button.components-button.mailpoet-automation-filters-panel-add-filter {
   display: grid;
   grid-template-columns: 1fr auto;
 
+  &.mailpoet-automation-filters-list-item-has-error {
+    background: #fcf0f1;
+    color: #8a2424;
+  }
+
   .mailpoet-automation-filters-list-item-content {
+    color: inherit;
     display: block;
     height: auto;
     line-height: inherit;
@@ -58,6 +64,12 @@ button.components-button.mailpoet-automation-filters-panel-add-filter {
     margin: 4px;
     padding: 0;
   }
+}
+
+.mailpoet-automation-filters-list-item-error {
+  color: #8a2424;
+  font-size: 12px;
+  margin-top: 4px;
 }
 
 .mailpoet-automation-filters-list-item-field,

--- a/mailpoet/assets/css/src/components-automation-editor/_filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_filters.scss
@@ -76,3 +76,13 @@ button.components-button.mailpoet-automation-filters-panel-add-filter {
 .mailpoet-automation-filters-list-item-value {
   font-weight: 600;
 }
+
+.mailpoet-automation-filters-list-item-value-missing {
+  color: #757575;
+  display: inline-block;
+  vertical-align: middle;
+
+  svg {
+    margin: -2px 0;
+  }
+}

--- a/mailpoet/assets/css/src/components-automation-editor/_filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_filters.scss
@@ -42,7 +42,15 @@ button.components-button.mailpoet-automation-filters-panel-add-filter {
   grid-template-columns: 1fr auto;
 
   .mailpoet-automation-filters-list-item-content {
+    display: block;
+    height: auto;
+    line-height: inherit;
     padding: 8px 12px;
+    text-align: left;
+
+    &:disabled {
+      opacity: 1;
+    }
   }
 
   .mailpoet-automation-filters-list-item-remove {

--- a/mailpoet/assets/css/src/components-automation-editor/_step-filters.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_step-filters.scss
@@ -1,6 +1,7 @@
 .mailpoet-automation-editor-step-filters {
   display: grid;
   gap: 8px;
+  max-height: 400px;
   padding: 8px;
   width: 300px;
 }

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-filters.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-filters.tsx
@@ -1,18 +1,44 @@
+import { useMemo } from 'react';
 import { Dropdown } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Step } from './types';
 import { Chip } from '../chip';
 import { FiltersList } from '../filters';
+import { storeName } from '../../store';
 
 type Props = {
-  filterCount: number;
+  step: Step;
 };
 
-export function StepFilters({ filterCount }: Props): JSX.Element {
+export function StepFilters({ step }: Props): JSX.Element | null {
+  const { errors } = useSelect(
+    (select) => ({
+      errors: select(storeName).getStepError(step.id),
+    }),
+    [],
+  );
+
+  const groups = step.filters?.groups;
+  const filterCount = useMemo(
+    () => (groups ?? []).reduce((sum, group) => sum + group.filters.length, 0),
+    [groups],
+  );
+
+  if (filterCount === 0) {
+    return null;
+  }
+
   return (
     <Dropdown
       popoverProps={{ offset: 6 }}
       renderToggle={({ onToggle, isOpen }) => (
-        <Chip size="small" onClick={onToggle} ariaExpanded={isOpen}>
+        <Chip
+          variant={errors ? 'danger' : 'default'}
+          size="small"
+          onClick={onToggle}
+          ariaExpanded={isOpen}
+        >
           {__(`Filters: ${filterCount}`, 'mailpoet')}
         </Chip>
       )}

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
@@ -57,11 +57,6 @@ export function Step({ step, isSelected }: Props): JSX.Element {
 
   const compositeItemId = `step-${step.id}`;
   const stepTypeData = stepType ?? getUnknownStepType(step);
-  const filterCount =
-    step.filters?.groups.reduce(
-      (sum, group) => sum + group.filters.length,
-      0,
-    ) ?? 0;
 
   return (
     <div className="mailpoet-automation-editor-step-wrapper">
@@ -109,7 +104,7 @@ export function Step({ step, isSelected }: Props): JSX.Element {
           </div>
         </div>
         <div className="mailpoet-automation-editor-step-footer">
-          {filterCount > 0 && <StepFilters filterCount={filterCount} />}
+          <StepFilters step={step} />
           {error && (
             <div className="mailpoet-automation-editor-step-error">
               <Chip variant="danger" size="small">

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -84,6 +84,7 @@ export type StepErrors = {
   step_id: string;
   message: string;
   fields: Record<string, string>;
+  filters: Record<string, string>;
 };
 
 export type Errors = {

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -53,7 +53,6 @@ export type Registry = {
     {
       field_type: string;
       conditions: { key: string; label: string }[];
-      args_schema: Record<string, unknown>;
     }
   >;
 };

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -3,7 +3,7 @@
  * filters.
  */
 
-import { Dispatch, SetStateAction } from 'react';
+import { ComponentType, Dispatch, ReactNode, SetStateAction } from 'react';
 import { DropdownMenu } from '@wordpress/components';
 import { Item } from '../editor/components/inserter/item';
 import { Filter, Step } from '../editor/components/automation/types';
@@ -57,12 +57,17 @@ export type OrderStatusOptions = Map<
 // mailpoet.automation.filters.panel.content
 export type FiltersPanelContentType = (step: Step) => JSX.Element;
 
-// mailpoet.automation.filters.delete_step_filter_callback
-export type DeleteStepFilterType = (stepId: string, filter: Filter) => void;
-
 // mailpoet.automation.filters.group_operator_change_callback
 export type FilterGroupOperatorChangeType = (
   stepId: string,
   groupId: string,
   operator: 'and' | 'or',
 ) => void;
+
+// mailpoet.automation.filters.filter_wrapper
+export type FilterWrapperType = ComponentType<{
+  step: Step;
+  filter: Filter;
+  editable: boolean;
+  children: ReactNode;
+}>;

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -139,7 +139,6 @@ class AutomationEditor {
       $filters[$fieldType] = [
         'field_type' => $filter->getFieldType(),
         'conditions' => $conditions,
-        'args_schema' => $filter->getArgsSchema()->toArray(),
       ];
     }
 

--- a/mailpoet/lib/Automation/Engine/Integration/Filter.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Filter.php
@@ -11,7 +11,7 @@ interface Filter {
   /** @return array<string, string> */
   public function getConditions(): array;
 
-  public function getArgsSchema(): ObjectSchema;
+  public function getArgsSchema(string $condition): ObjectSchema;
 
   /** @param mixed $value */
   public function matches(FilterData $data, $value): bool;

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
@@ -35,7 +35,7 @@ class ValidStepFiltersRule implements AutomationNodeVisitor {
         if (!$registryFilter) {
           continue;
         }
-        $this->validator->validate($registryFilter->getArgsSchema(), $filter->getArgs());
+        $this->validator->validate($registryFilter->getArgsSchema($filter->getCondition()), $filter->getArgs());
       }
     }
   }

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRule.php
@@ -6,6 +6,7 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationNode;
 use MailPoet\Automation\Engine\Validation\AutomationGraph\AutomationNodeVisitor;
+use MailPoet\Validator\ValidationException;
 use MailPoet\Validator\Validator;
 
 class ValidStepFiltersRule implements AutomationNodeVisitor {
@@ -29,14 +30,27 @@ class ValidStepFiltersRule implements AutomationNodeVisitor {
   public function visitNode(Automation $automation, AutomationNode $node): void {
     $filters = $node->getStep()->getFilters();
     $groups = $filters ? $filters->getGroups() : [];
+    $errors = [];
     foreach ($groups as $group) {
       foreach ($group->getFilters() as $filter) {
         $registryFilter = $this->registry->getFilter($filter->getFieldType());
         if (!$registryFilter) {
           continue;
         }
-        $this->validator->validate($registryFilter->getArgsSchema($filter->getCondition()), $filter->getArgs());
+        try {
+          $this->validator->validate($registryFilter->getArgsSchema($filter->getCondition()), $filter->getArgs());
+        } catch (ValidationException $e) {
+          $errors[$filter->getId()] = $e->getWpError()->get_error_code();
+        }
       }
+    }
+
+    if ($errors) {
+      $throwable = ValidationException::create()->withMessage('invalid-automation-filters');
+      foreach ($errors as $errorKey => $errorMsg) {
+        $throwable->withError((string)$errorKey, (string)$errorMsg);
+      }
+      throw $throwable;
     }
   }
 

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepRule.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationRules/ValidStepRule.php
@@ -45,7 +45,7 @@ class ValidStepRule implements AutomationNodeVisitor {
         $rule->visitNode($automation, $node);
       } catch (UnexpectedValueException $e) {
         if (!isset($this->errors[$stepId])) {
-          $this->errors[$stepId] = ['step_id' => $stepId, 'message' => $e->getMessage(), 'fields' => []];
+          $this->errors[$stepId] = ['step_id' => $stepId, 'message' => $e->getMessage(), 'fields' => [], 'filters' => []];
         }
         $this->errors[$stepId]['fields'] = array_merge(
           $this->mapErrorCodesToErrorMessages($e->getErrors()),
@@ -53,15 +53,17 @@ class ValidStepRule implements AutomationNodeVisitor {
         );
       } catch (ValidationException $e) {
         if (!isset($this->errors[$stepId])) {
-          $this->errors[$stepId] = ['step_id' => $stepId, 'message' => $e->getMessage(), 'fields' => []];
+          $this->errors[$stepId] = ['step_id' => $stepId, 'message' => $e->getMessage(), 'fields' => [], 'filters' => []];
         }
-        $this->errors[$stepId]['fields'] = array_merge(
+
+        $key = $rule instanceof ValidStepFiltersRule ? 'filters' : 'fields';
+        $this->errors[$stepId][$key] = array_merge(
           $this->mapErrorCodesToErrorMessages($e->getErrors()),
-          $this->errors[$stepId]['fields']
+          $this->errors[$stepId][$key]
         );
       } catch (Throwable $e) {
         if (!isset($this->errors[$stepId])) {
-          $this->errors[$stepId] = ['step_id' => $stepId, 'message' => __('Unknown error.', 'mailpoet'), 'fields' => []];
+          $this->errors[$stepId] = ['step_id' => $stepId, 'message' => __('Unknown error.', 'mailpoet'), 'fields' => [], 'filters' => []];
         }
       }
     }

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/BooleanFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/BooleanFilter.php
@@ -21,7 +21,7 @@ class BooleanFilter implements Filter {
     ];
   }
 
-  public function getArgsSchema(): ObjectSchema {
+  public function getArgsSchema(string $condition): ObjectSchema {
     return Builder::object([
       'value' => Builder::boolean()->required(),
     ]);

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -25,7 +25,7 @@ class EnumArrayFilter implements Filter {
     ];
   }
 
-  public function getArgsSchema(): ObjectSchema {
+  public function getArgsSchema(string $condition): ObjectSchema {
     return Builder::object([
       'value' => Builder::oneOf([
         Builder::array(Builder::string())->minItems(1),

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
@@ -23,7 +23,7 @@ class EnumFilter implements Filter {
     ];
   }
 
-  public function getArgsSchema(): ObjectSchema {
+  public function getArgsSchema(string $condition): ObjectSchema {
     return Builder::object([
       'value' => Builder::oneOf([
         Builder::array(Builder::string())->minItems(1),

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
@@ -12,13 +12,19 @@ class IntegerFilter extends NumberFilter {
     return Field::TYPE_INTEGER;
   }
 
-  public function getArgsSchema(): ObjectSchema {
-    return Builder::object([
-      'value' => Builder::oneOf([
-        Builder::integer()->required(),
-        Builder::array(Builder::integer())->minItems(2)->maxItems(2)->required(),
-      ]),
-    ]);
+  public function getArgsSchema(string $condition): ObjectSchema {
+    switch ($condition) {
+      case self::CONDITION_BETWEEN:
+      case self::CONDITION_NOT_BETWEEN:
+        return Builder::object([
+          'value' => Builder::array(Builder::integer())->minItems(2)->maxItems(2)->required(),
+        ]);
+      case self::CONDITION_IS_SET:
+      case self::CONDITION_IS_NOT_SET:
+        return Builder::object([]);
+      default:
+        return Builder::object(['value' => Builder::integer()->required()]);
+    }
   }
 
   public function matches(FilterData $data, $value): bool {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
@@ -39,13 +39,19 @@ class NumberFilter implements Filter {
     ];
   }
 
-  public function getArgsSchema(): ObjectSchema {
-    return Builder::object([
-      'value' => Builder::oneOf([
-        Builder::number()->required(),
-        Builder::array(Builder::number())->minItems(2)->maxItems(2)->required(),
-      ]),
-    ]);
+  public function getArgsSchema(string $condition): ObjectSchema {
+    switch ($condition) {
+      case self::CONDITION_BETWEEN:
+      case self::CONDITION_NOT_BETWEEN:
+        return Builder::object([
+          'value' => Builder::array(Builder::number())->minItems(2)->maxItems(2)->required(),
+        ]);
+      case self::CONDITION_IS_SET:
+      case self::CONDITION_IS_NOT_SET:
+        return Builder::object([]);
+      default:
+        return Builder::object(['value' => Builder::number()->required()]);
+    }
   }
 
   public function matches(FilterData $data, $value): bool {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/StringFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/StringFilter.php
@@ -38,10 +38,14 @@ class StringFilter implements Filter {
     ];
   }
 
-  public function getArgsSchema(): ObjectSchema {
-    return Builder::object([
-      'value' => Builder::string()->required(),
-    ]);
+  public function getArgsSchema(string $condition): ObjectSchema {
+    switch ($condition) {
+      case self::CONDITION_IS_BLANK:
+      case self::CONDITION_IS_NOT_BLANK:
+        return Builder::object([]);
+      default:
+        return Builder::object(['value' => Builder::string()->required()]);
+    }
   }
 
   public function matches(FilterData $data, $value): bool {

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -279,7 +279,7 @@ class FilterHandlerTest extends MailPoetUnitTest {
         return [];
       }
 
-      public function getArgsSchema(): ObjectSchema {
+      public function getArgsSchema(string $condition): ObjectSchema {
         return Builder::object();
       }
 

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
@@ -68,7 +68,7 @@ class ValidStepFiltersRuleTest extends AutomationRuleTest {
         return [];
       }
 
-      public function getArgsSchema(): ObjectSchema {
+      public function getArgsSchema(string $condition): ObjectSchema {
         return Builder::object();
       }
 

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepRuleTest.php
@@ -49,6 +49,7 @@ class ValidStepRuleTest extends AutomationRuleTest {
             'step_id' => 'root',
             'message' => 'Test error',
             'fields' => [],
+            'filters' => [],
           ],
         ],
         $e->getErrors()
@@ -79,6 +80,7 @@ class ValidStepRuleTest extends AutomationRuleTest {
             'step_id' => 'root',
             'message' => 'Unknown error.',
             'fields' => [],
+            'filters' => [],
           ],
         ],
         $e->getErrors()

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/BooleanFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/BooleanFilterTest.php
@@ -21,7 +21,7 @@ class BooleanFilterTest extends MailPoetUnitTest {
           'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+    ], $filter->getArgsSchema('is')->toArray());
   }
 
   public function testInvalidValues(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/DateTimeFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/DateTimeFilterTest.php
@@ -34,47 +34,61 @@ class DateTimeFilterTest extends MailPoetUnitTest {
       'on-the-days-of-the-week' => 'on the day(s) of the week',
     ], $filter->getConditions());
 
-    $this->assertSame([
+    $datetimeValueSchema = [
+      'type' => 'string',
+      'pattern' => '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$',
+      'required' => true,
+    ];
+
+    $dateValueSchema = [
+      'type' => 'string',
+      'pattern' => '^\d{4}-\d{2}-\d{2}$',
+      'required' => true,
+    ];
+
+    $relativeValueSchema = [
       'type' => 'object',
       'properties' => [
-        'value' => [
-          'oneOf' => [
-            [
-              'type' => 'string',
-              'pattern' => '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$',
-            ],
-            [
-              'type' => 'string',
-              'pattern' => '^\d{4}-\d{2}-\d{2}$',
-            ],
-            [
-              'type' => 'array',
-              'items' => [
-                'type' => 'integer',
-                'minimum' => 0,
-                'maximum' => 6,
-              ],
-              'minItems' => 1,
-            ],
-            [
-              'type' => 'object',
-              'properties' => [
-                'number' => [
-                  'type' => 'integer',
-                  'minimum' => 1,
-                  'required' => true,
-                ],
-                'unit' => [
-                  'type' => 'string',
-                  'pattern' => '^days|weeks|months$',
-                  'required' => true,
-                ],
-              ],
-            ],
-          ],
+        'number' => [
+          'type' => 'integer',
+          'minimum' => 1,
+          'required' => true,
+        ],
+        'unit' => [
+          'type' => 'string',
+          'pattern' => '^days|weeks|months$',
+          'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+      'required' => true,
+    ];
+
+    $daysOfWeekSchema = [
+      'type' => 'array',
+      'items' => [
+        'type' => 'integer',
+        'minimum' => 0,
+        'maximum' => 6,
+      ],
+      'minItems' => 1,
+      'required' => true,
+    ];
+
+    $dateTimeArgsSchema = ['type' => 'object', 'properties' => ['value' => $datetimeValueSchema]];
+    $dateArgsSchema = ['type' => 'object', 'properties' => ['value' => $dateValueSchema]];
+    $relativeArgsSchema = ['type' => 'object', 'properties' => ['value' => $relativeValueSchema]];
+    $daysOfWeekArgsSchema = ['type' => 'object', 'properties' => ['value' => $daysOfWeekSchema]];
+    $emptyArgsSchema = ['type' => 'object', 'properties' => []];
+
+    $this->assertSame($dateTimeArgsSchema, $filter->getArgsSchema('before')->toArray());
+    $this->assertSame($dateTimeArgsSchema, $filter->getArgsSchema('after')->toArray());
+    $this->assertSame($dateArgsSchema, $filter->getArgsSchema('on')->toArray());
+    $this->assertSame($dateArgsSchema, $filter->getArgsSchema('not-on')->toArray());
+    $this->assertSame($relativeArgsSchema, $filter->getArgsSchema('in-the-last')->toArray());
+    $this->assertSame($relativeArgsSchema, $filter->getArgsSchema('not-in-the-last')->toArray());
+    $this->assertSame($daysOfWeekArgsSchema, $filter->getArgsSchema('on-the-days-of-the-week')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-set')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-not-set')->toArray());
   }
 
   public function testInvalidValues(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
@@ -18,7 +18,7 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
       'matches-none-of' => 'matches none of',
     ], $filter->getConditions());
 
-    $this->assertSame([
+    $argsSchema = [
       'type' => 'object',
       'properties' => [
         'value' => [
@@ -29,7 +29,11 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
           'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+    ];
+
+    $this->assertSame($argsSchema, $filter->getArgsSchema('matches-any-of')->toArray());
+    $this->assertSame($argsSchema, $filter->getArgsSchema('matches-all-of')->toArray());
+    $this->assertSame($argsSchema, $filter->getArgsSchema('matches-none-of')->toArray());
   }
 
   public function testInvalidValues(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumFilterTest.php
@@ -17,7 +17,7 @@ class EnumFilterTest extends MailPoetUnitTest {
       'is-none-of' => 'is none of',
     ], $filter->getConditions());
 
-    $this->assertSame([
+    $argsSchema = [
       'type' => 'object',
       'properties' => [
         'value' => [
@@ -28,7 +28,10 @@ class EnumFilterTest extends MailPoetUnitTest {
           'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+    ];
+
+    $this->assertSame($argsSchema, $filter->getArgsSchema('is-any-of')->toArray());
+    $this->assertSame($argsSchema, $filter->getArgsSchema('is-none-of')->toArray());
   }
 
   public function testInvalidValues(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/IntegerFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/IntegerFilterTest.php
@@ -24,28 +24,41 @@ class IntegerFilterTest extends MailPoetUnitTest {
       'is-not-set' => 'is not set',
     ], $filter->getConditions());
 
-    $this->assertSame([
+    $singleValueArgsSchema = [
       'type' => 'object',
       'properties' => [
         'value' => [
-          'oneOf' => [
-            [
-              'type' => 'integer',
-              'required' => true,
-            ],
-            [
-              'type' => 'array',
-              'items' => [
-                'type' => 'integer',
-              ],
-              'minItems' => 2,
-              'maxItems' => 2,
-              'required' => true,
-            ],
-          ],
+          'type' => 'integer',
+          'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+    ];
+
+    $rangeValueArgsSchema = [
+      'type' => 'object',
+      'properties' => [
+        'value' => [
+          'type' => 'array',
+          'items' => ['type' => 'integer'],
+          'minItems' => 2,
+          'maxItems' => 2,
+          'required' => true,
+        ],
+      ],
+    ];
+
+    $emptyArgsSchema = ['type' => 'object', 'properties' => []];
+
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('equals')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('not-equals')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('greater-than')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('less-than')->toArray());
+    $this->assertSame($rangeValueArgsSchema, $filter->getArgsSchema('between')->toArray());
+    $this->assertSame($rangeValueArgsSchema, $filter->getArgsSchema('not-between')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('is-multiple-of')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('is-not-multiple-of')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-set')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-not-set')->toArray());
   }
 
   public function testInvalidValues(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/NumberFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/NumberFilterTest.php
@@ -24,28 +24,41 @@ class NumberFilterTest extends MailPoetUnitTest {
       'is-not-set' => 'is not set',
     ], $filter->getConditions());
 
-    $this->assertSame([
+    $singleValueArgsSchema = [
       'type' => 'object',
       'properties' => [
         'value' => [
-          'oneOf' => [
-            [
-              'type' => 'number',
-              'required' => true,
-            ],
-            [
-              'type' => 'array',
-              'items' => [
-                'type' => 'number',
-              ],
-              'minItems' => 2,
-              'maxItems' => 2,
-              'required' => true,
-            ],
-          ],
+          'type' => 'number',
+          'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+    ];
+
+    $rangeValueArgsSchema = [
+      'type' => 'object',
+      'properties' => [
+        'value' => [
+          'type' => 'array',
+          'items' => ['type' => 'number'],
+          'minItems' => 2,
+          'maxItems' => 2,
+          'required' => true,
+        ],
+      ],
+    ];
+
+    $emptyArgsSchema = ['type' => 'object', 'properties' => []];
+
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('equals')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('not-equals')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('greater-than')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('less-than')->toArray());
+    $this->assertSame($rangeValueArgsSchema, $filter->getArgsSchema('between')->toArray());
+    $this->assertSame($rangeValueArgsSchema, $filter->getArgsSchema('not-between')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('is-multiple-of')->toArray());
+    $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('is-not-multiple-of')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-set')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-not-set')->toArray());
   }
 
   public function testInvalidValues(): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/StringFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/StringFilterTest.php
@@ -24,7 +24,7 @@ class StringFilterTest extends MailPoetUnitTest {
       'matches-regex' => 'matches regex',
     ], $filter->getConditions());
 
-    $this->assertSame([
+    $stringValueArgsSchema = [
       'type' => 'object',
       'properties' => [
         'value' => [
@@ -32,7 +32,19 @@ class StringFilterTest extends MailPoetUnitTest {
           'required' => true,
         ],
       ],
-    ], $filter->getArgsSchema()->toArray());
+    ];
+
+    $emptyArgsSchema = ['type' => 'object', 'properties' => []];
+
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('is')->toArray());
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('is-not')->toArray());
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('contains')->toArray());
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('does-not-contain')->toArray());
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('starts-with')->toArray());
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('ends-with')->toArray());
+    $this->assertSame($stringValueArgsSchema, $filter->getArgsSchema('matches-regex')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-blank')->toArray());
+    $this->assertSame($emptyArgsSchema, $filter->getArgsSchema('is-not-blank')->toArray());
   }
 
   public function testInvalidValues(): void {


### PR DESCRIPTION
## Description

This fixes and improves various automation issues:
1. Fix can't save `is-blank` and `is-not-blank` filters.
2. Refactor filter validation to work per-condition (`is-blank` expects a different value than `matches regex`, etc.).
3. Make filters editable so that we can prefill them only partly in some templates (e.g. "purchased product ...").
4. Mark filter errors, so users know which ones are not fully set.
5. Avoid calling automation run query on every request (fetch fields lazily).

## Code review notes

The solution for 5 may not be the ultimate one, but it's a quick one. We can think through a more robust approach to executing minimum automation code on every request. I was also considering creating field args via a callback (we can always add that as well).

## QA notes

Please, do a smoke test of automation filters.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/739

## Linked tickets

[MAILPOET-5415]
[MAILPOET-5418]
[MAILPOET-5426]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5415]: https://mailpoet.atlassian.net/browse/MAILPOET-5415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5418]: https://mailpoet.atlassian.net/browse/MAILPOET-5418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5426]: https://mailpoet.atlassian.net/browse/MAILPOET-5426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ