### PR TITLE
Improve the test SettingsArchivePageCest to properly test the archive shortcode

### DIFF
--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -51,22 +51,36 @@ class SettingsArchivePageCest {
     $i->waitForText('SentNewsletter');
     $i->dontSee('DraftNewsletter');
     $i->dontSee('ScheduledNewsletter');
+
+    // Create 2 additional sent newsletters
     $newsletterFactory = new Newsletter();
-    $newsletterFactory->withSubject('SentNewsletter2')->withDraftStatus()->withSendingQueue()->withSegments([$segment3])->create();
+    $newsletterFactory->withSubject('SentNewsletter2')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
     $newsletterFactory = new Newsletter();
-    $newsletterFactory->withSubject('SentNewsletter3')->withDraftStatus()->withSendingQueue()->withSegments([$segment3])->create();
+    $newsletterFactory->withSubject('SentNewsletter3')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
+
+    $i->wantTo('See the newly created sent newsletters are present on the page');
     $i->reloadPage();
     $i->waitForText('SentNewsletter');
     $i->waitForText('SentNewsletter2');
     $i->waitForText('SentNewsletter3');
+
+    $i->wantTo('Move both sent newsletters to the trash and delete only one');
     $i->amOnMailpoetPage('Emails');
-    $i->waitForText('SentNewsletter3');
+    $i->waitForText('SentNewsletter2');
+    $i->clickItemRowActionByItemName('SentNewsletter2', 'Move to trash');
+    $i->waitForNoticeAndClose('1 email was moved to the trash.');
     $i->clickItemRowActionByItemName('SentNewsletter3', 'Move to trash');
-    $i->waitForText('1 email was moved to the trash.');
+    $i->waitForNoticeAndClose('1 email was moved to the trash.');
+    $i->click('[data-automation-id="filters_trash"]');
+    $i->waitForElement('[data-automation-id="empty_trash"]');
+    $i->waitForText('SentNewsletter3');
+    $i->clickItemRowActionByItemName('SentNewsletter3', 'Delete permanently');
+    $i->waitForText('1 email was permanently deleted.');
+
     $i->amOnUrl($postUrl);
     $i->waitForText($pageTitle3);
     $i->waitForText('SentNewsletter');
-    $i->waitForText('SentNewsletter2');
+    $i->dontSee('SentNewsletter2');
     $i->dontSee('SentNewsletter3');
   }
 }

--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -8,11 +8,13 @@ use MailPoet\Test\DataFactories\Segment;
 class SettingsArchivePageCest {
   public function createArchivePageNoSentNewsletters(\AcceptanceTester $i) {
     $i->wantTo('Create page with MP archive shortcode, showing no sent newsletters');
+
     $segmentFactory = new Segment();
     $segment = $segmentFactory->withName('Empty Send')->create();
     $pageTitle = 'EmptyNewsletterArchive';
     $pageContent = "[mailpoet_archive segments=\"{$segment->getId()}\"]";
     $postUrl = $i->createPost($pageTitle, $pageContent);
+
     $i->login();
     $i->amOnUrl($postUrl);
     $i->waitForText($pageTitle);
@@ -21,6 +23,7 @@ class SettingsArchivePageCest {
 
   public function createArchivePageWithSentNewsletters(\AcceptanceTester $i) {
     $i->wantTo('Create page with MP archive shortcode, showing sent newsletters');
+
     $segmentFactory = new Segment();
     $segment2 = $segmentFactory->withName('SentNewsletters')->create();
     $newsletterFactory = new Newsletter();
@@ -28,6 +31,7 @@ class SettingsArchivePageCest {
     $pageTitle2 = 'SentNewsletterArchive';
     $pageContent2 = "[mailpoet_archive segments=\"{$segment2->getId()}\"]";
     $postUrl = $i->createPost($pageTitle2, $pageContent2);
+
     $i->login();
     $i->amOnUrl($postUrl);
     $i->waitForText($pageTitle2);
@@ -36,8 +40,11 @@ class SettingsArchivePageCest {
 
   public function createArchivePageWithVariousStatusNewsletters(\AcceptanceTester $i) {
     $i->wantTo('Create page with MP archive shortcode, showing only sent newsletters but having various in database');
+
     $segmentFactory = new Segment();
     $segment3 = $segmentFactory->withName('SentNewsletters')->create();
+    $segmentFactory = new Segment();
+    $segment4 = $segmentFactory->withName('SentNewsletters2')->create();
     $newsletterFactory = new Newsletter();
     $newsletterFactory->withSubject('SentNewsletter')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
     $newsletterFactory->withSubject('DraftNewsletter')->withDraftStatus()->withScheduledQueue()->withSegments([$segment3])->create();
@@ -45,6 +52,7 @@ class SettingsArchivePageCest {
     $pageTitle3 = 'SentNewsletterArchive';
     $pageContent3 = "[mailpoet_archive segments=\"{$segment3->getId()}\"]";
     $postUrl = $i->createPost($pageTitle3, $pageContent3);
+
     $i->login();
     $i->amOnUrl($postUrl);
     $i->waitForText($pageTitle3);
@@ -57,6 +65,8 @@ class SettingsArchivePageCest {
     $newsletterFactory->withSubject('SentNewsletter2')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
     $newsletterFactory = new Newsletter();
     $newsletterFactory->withSubject('SentNewsletter3')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
+    $newsletterFactory = new Newsletter();
+    $newsletterFactory->withSubject('SentNewsletter4')->withSentStatus()->withSendingQueue()->withSegments([$segment4])->create();
 
     $i->wantTo('See the newly created sent newsletters are present on the page');
     $i->reloadPage();
@@ -82,5 +92,6 @@ class SettingsArchivePageCest {
     $i->waitForText('SentNewsletter');
     $i->dontSee('SentNewsletter2');
     $i->dontSee('SentNewsletter3');
+    $i->dontSee('SentNewsletter4');
   }
 }

--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -93,5 +93,17 @@ class SettingsArchivePageCest {
     $i->dontSee('SentNewsletter2');
     $i->dontSee('SentNewsletter3');
     $i->dontSee('SentNewsletter4');
+    
+    $pageTitle4 = 'SentNewsletterArchive';
+    $pageContent4 = "[mailpoet_archive segments=\"{$segment3->getId()},{$segment4->getId()}\"]";
+    $postUrl2 = $i->createPost($pageTitle4, $pageContent4);
+
+    $i->wantTo('Create another page containing archive shortcode with multiple lists');
+    $i->amOnUrl($postUrl2);
+    $i->waitForText($pageTitle4);
+    $i->waitForText('SentNewsletter');
+    $i->dontSee('SentNewsletter2');
+    $i->dontSee('SentNewsletter3');
+    $i->waitForText('SentNewsletter4');
   }
 }


### PR DESCRIPTION
## Description

Improving the existing test case SettingsArchivePageCest and adding new scenario to it.

I realised that this test was improperly written and it didn't test what it should. It was made to always pass the test. Now, properly testing the archive page shortcode in various scenarios.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5322]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5322]: https://mailpoet.atlassian.net/browse/MAILPOET-5322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ