### PR TITLE
Refactor Sending::getSubscribers() and Sending::setSubscribers() to use Doctrine instead of Paris [MAILPOET-4368]

### DIFF
--- a/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
@@ -120,6 +120,21 @@ class ScheduledTaskSubscriberEntity {
     return $this->subscriber;
   }
 
+  /**
+   * Get the ID of the subscriber without querying wp_mailpoet_subscribers.
+   * $this->getSubscriber->getId() queries wp_mailpoet_subscribers because of
+   * the way the SafeToOneAssociationLoadTrait works.
+   *
+   * @return int|null
+   */
+  public function getSubscriberId() {
+    if ($this->subscriber instanceof SubscriberEntity) {
+      return $this->subscriber->getId();
+    }
+
+    return null;
+  }
+
   public function setSubscriber(SubscriberEntity $subscriber) {
     $this->subscriber = $subscriber;
   }

--- a/mailpoet/lib/Models/ScheduledTaskSubscriber.php
+++ b/mailpoet/lib/Models/ScheduledTaskSubscriber.php
@@ -41,7 +41,11 @@ class ScheduledTaskSubscriber extends Model {
     ]);
   }
 
+  /**
+   * @deprecated This method can be removed after 2024-01-04.
+   */
   public static function setSubscribers($taskId, array $subscriberIds) {
+    self::deprecationError(__METHOD__);
     static::clearSubscribers($taskId);
     return static::addSubscribers($taskId, $subscriberIds);
   }
@@ -76,5 +80,12 @@ class ScheduledTaskSubscriber extends Model {
       $orm->where('processed', $processed);
     }
     return $orm->count();
+  }
+
+  private static function deprecationError($methodName) {
+    trigger_error(
+      'Calling ' . esc_html($methodName) . ' is deprecated and will be removed. Use \MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository and \MailPoet\Entities\ScheduledTaskSubscriberEntity instead.',
+      E_USER_DEPRECATED
+    );
   }
 }

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -125,6 +125,17 @@ class ScheduledTaskSubscribersRepository extends Repository {
       ->execute();
   }
 
+  public function setSubscribers(ScheduledTaskEntity $task, array $subscriberIds): void {
+    $this->deleteByScheduledTask($task);
+
+    foreach ($subscriberIds as $subscriberId) {
+      $this->createOrUpdate([
+        'task_id' => $task->getId(),
+        'subscriber_id' => $subscriberId,
+      ]);
+    }
+  }
+
   private function checkCompleted(ScheduledTaskEntity $task): void {
     $count = $this->countBy(['task' => $task, 'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED]);
     if ($count === 0) {

--- a/mailpoet/lib/Tasks/Subscribers.php
+++ b/mailpoet/lib/Tasks/Subscribers.php
@@ -14,10 +14,6 @@ class Subscribers {
     $this->task = $task;
   }
 
-  public function setSubscribers(array $subscriberIds) {
-    ScheduledTaskSubscriber::setSubscribers($this->task->id, $subscriberIds);
-  }
-
   public function getSubscribers() {
     return ScheduledTaskSubscriber::where('task_id', $this->task->id);
   }

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as TaskSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class ScheduledTaskSubscribersRepositoryTest extends \MailPoetTest {
+  /** @var ScheduledTaskSubscribersRepository */
+  private $repository;
+
+  /** @var SubscriberFactory */
+  private $subscriberFactory;
+
+  /** @var ScheduledTaskEntity */
+  private $scheduledTask1;
+
+  /** @var ScheduledTaskEntity */
+  private $scheduledTask2;
+
+  /** @var SubscriberEntity */
+  private $subscriberUnprocessed;
+
+  /** @var SubscriberEntity */
+  private $subscriberProcessed;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $scheduledTaskFactory = new ScheduledTaskFactory();
+    $this->subscriberFactory = new SubscriberFactory();
+    $taskSubscriberFactory = new TaskSubscriberFactory();
+
+    $this->subscriberUnprocessed = $this->subscriberFactory->withEmail('subscriberUprocessed@email.com')->create();
+    $this->subscriberProcessed = $this->subscriberFactory->withEmail('subscriberProcessed@email.com')->create();
+    $subscriberFailed = $this->subscriberFactory->withEmail('subscriberFailed@email.com')->create();
+    $this->subscriberFactory->withEmail('subscriberNotIncluded@email.com')->create();
+
+    $this->scheduledTask1 = $scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay());
+    $this->scheduledTask2 = $scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay());
+
+    $taskSubscriberFactory->createUnprocessed($this->scheduledTask1, $this->subscriberUnprocessed);
+    $taskSubscriberFactory->createProcessed($this->scheduledTask1, $this->subscriberProcessed);
+    $taskSubscriberFactory->createFailed($this->scheduledTask1, $subscriberFailed, 'Error Message');
+
+    $taskSubscriberFactory->createUnprocessed($this->scheduledTask2, $this->subscriberUnprocessed);
+    $taskSubscriberFactory->createProcessed($this->scheduledTask2, $this->subscriberProcessed);
+  }
+
+  public function testItSetsSubscribers() {
+    $subscriber = $this->subscriberFactory->withEmail('newsubscriber@email.com')->create();
+
+    $this->assertCount(3, $this->repository->findBy(['task' => $this->scheduledTask1]));
+    $this->repository->setSubscribers($this->scheduledTask1, [$subscriber->getId()]);
+    $task1Subscribers = $this->repository->findBy(['task' => $this->scheduledTask1]);
+    $this->assertCount(1, $task1Subscribers);
+    $this->assertInstanceOf(SubscriberEntity::class, $task1Subscribers[0]->getSubscriber());
+    $this->assertEquals($subscriber->getId(), $task1Subscribers[0]->getSubscriber()->getId());
+
+    // check that setSubscribers() does not delete subscribers from other tasks
+    $task2Subscribers = $this->repository->findBy(['task' => $this->scheduledTask2]);
+    $this->assertCount(2, $task2Subscribers);
+    $this->assertInstanceOf(SubscriberEntity::class, $task2Subscribers[0]->getSubscriber());
+    $this->assertInstanceOf(SubscriberEntity::class, $task2Subscribers[1]->getSubscriber());
+    $this->assertEquals($this->subscriberUnprocessed->getId(), $task2Subscribers[0]->getSubscriber()->getId());
+    $this->assertEquals($this->subscriberProcessed->getId(), $task2Subscribers[1]->getSubscriber()->getId());
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -4,11 +4,13 @@ namespace MailPoet\Newsletter\ViewInBrowser;
 
 use Codeception\Stub\Expected;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
 use MailPoet\Router\Router;
@@ -127,6 +129,10 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     $queue->setSubscribers([$subscriber->getId()]);
     $this->sendingTask = $queue->save();
     $this->newsletterRepository->refresh($newsletter);
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $scheduledTask = $scheduledTasksRepository->findOneById($this->sendingTask->task()->id);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $scheduledTasksRepository->refresh($scheduledTask);
     $this->newsletter = $newsletter;
 
     // create newsletter link associations

--- a/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -2,8 +2,10 @@
 
 namespace MailPoet\Test\Statistics\Track;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Tasks\Sending as SendingTask;
@@ -43,6 +45,11 @@ class UnsubscribesTest extends \MailPoetTest {
     $queue->setSubscribers([$this->subscriber->getId()]);
     $queue->updateProcessedSubscribers([$this->subscriber->getId()]);
     $this->queue = $queue->save();
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $scheduledTask = $scheduledTasksRepository->findOneById($this->queue->task()->id);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $scheduledTasksRepository->refresh($scheduledTask);
+
     // instantiate class
     $this->unsubscribes = $this->diContainer->get(Unsubscribes::class);
     $this->statisticsUnsubscribesRepository = $this->diContainer->get(StatisticsUnsubscribesRepository::class);

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -128,7 +128,19 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItGetsSubscribers() {
-    verify($this->sending->getSubscribers())->equals([123, 456]);
+    verify($this->sending->getSubscribers())->same(['1', '2']);
+  }
+
+  public function testItGetsOnlyProcessedSubscribers() {
+    $this->sending->updateProcessedSubscribers([1]);
+
+    verify($this->sending->getSubscribers(true))->same(['1']);
+  }
+
+  public function testItGetsOnlyUnprocessedSubscribers() {
+    $this->sending->updateProcessedSubscribers([1]);
+
+    verify($this->sending->getSubscribers(false))->same(['2']);
   }
 
   public function testItSetsSubscribers() {
@@ -139,9 +151,9 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItRemovesSubscribers() {
-    $subscriberIds = [456];
+    $subscriberIds = [2];
     $this->sending->removeSubscribers($subscriberIds);
-    verify($this->sending->getSubscribers())->equals([123]);
+    verify($this->sending->getSubscribers())->equals([1]);
     verify($this->sending->count_total)->equals(1);
   }
 
@@ -152,7 +164,7 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItUpdatesProcessedSubscribers() {
-    $subscriberId = 456;
+    $subscriberId = 2;
     $taskSubscriber = $this->getTaskSubscriber($this->task->id, $subscriberId);
     verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
 
@@ -276,7 +288,7 @@ class SendingTest extends \MailPoetTest {
     $status = isset($args['status']) ? $args['status'] : null;
 
     $sending = SendingTask::create($task, $queue);
-    $sending->setSubscribers([123, 456]); // random IDs
+    $sending->setSubscribers([1, 2]); // random IDs
     $sending->status = $status;
     $sending->scheduledAt = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->subHours(1);
     return $sending->save();

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -3,10 +3,11 @@
 namespace MailPoet\Test\Tasks;
 
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Tasks\Subscribers;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
@@ -25,6 +26,9 @@ class SendingTest extends \MailPoetTest {
   /** @var NewsletterFactory */
   private $newsletterFactory;
 
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   public function _before() {
     parent::_before();
     $this->newsletterFactory = new NewsletterFactory();
@@ -40,6 +44,7 @@ class SendingTest extends \MailPoetTest {
       'queue' => $this->queue,
     ]);
     $this->scheduledTaskRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
   }
 
   public function testItCanBeConstructed() {
@@ -119,7 +124,7 @@ class SendingTest extends \MailPoetTest {
     $this->sending->delete();
     verify(ScheduledTask::findOne($this->task->id))->equals(false);
     verify(SendingQueue::findOne($this->queue->id))->equals(false);
-    verify(ScheduledTaskSubscriber::where('task_id', $this->task->id)->findMany())->empty();
+    verify($this->scheduledTaskSubscribersRepository->findBy(['task' => $this->task->id]))->empty();
   }
 
   public function testItGetsSubscribers() {
@@ -149,7 +154,7 @@ class SendingTest extends \MailPoetTest {
   public function testItUpdatesProcessedSubscribers() {
     $subscriberId = 456;
     $taskSubscriber = $this->getTaskSubscriber($this->task->id, $subscriberId);
-    verify($taskSubscriber->processed)->equals(ScheduledTaskSubscriber::STATUS_UNPROCESSED);
+    verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
 
     verify($this->sending->count_to_process)->equals(2);
     verify($this->sending->count_processed)->equals(0);
@@ -159,7 +164,7 @@ class SendingTest extends \MailPoetTest {
     verify($this->sending->count_processed)->equals(1);
 
     $taskSubscriber = $this->getTaskSubscriber($this->task->id, $subscriberId);
-    verify($taskSubscriber->processed)->equals(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
   }
 
   public function testItGetsScheduledQueues() {
@@ -277,7 +282,11 @@ class SendingTest extends \MailPoetTest {
     return $sending->save();
   }
 
-  private function getTaskSubscriber($taskId, $subscriberId) {
-    return ScheduledTaskSubscriber::where(['task_id' => $taskId, 'subscriber_id' => $subscriberId])->findOne();
+  private function getTaskSubscriber($taskId, $subscriberId): ScheduledTaskSubscriberEntity {
+    $scheduledTaskSubscriber = $this->scheduledTaskSubscribersRepository->findOneBy(['task' => $taskId, 'subscriber' => $subscriberId]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscriber);
+    $this->scheduledTaskSubscribersRepository->refresh($scheduledTaskSubscriber);
+
+    return $scheduledTaskSubscriber;
   }
 }

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -37,13 +37,16 @@ class SendingTest extends \MailPoetTest {
   /** SubscriberEntity */
   private $subscriber2;
 
+  /** @var SubscriberFactory */
+  private $subscriberFactory;
+
   public function _before() {
     parent::_before();
     $this->newsletterFactory = new NewsletterFactory();
     $this->newsletter = $this->newsletterFactory->create();
-    $subscriberFactory = new SubscriberFactory();
-    $this->subscriber1 = $subscriberFactory->withEmail('subscriber1@test.com')->create();
-    $this->subscriber2 = $subscriberFactory->withEmail('subscriber2@test.com')->create();
+    $this->subscriberFactory = new SubscriberFactory();
+    $this->subscriber1 = $this->subscriberFactory->withEmail('subscriber1@test.com')->create();
+    $this->subscriber2 = $this->subscriberFactory->withEmail('subscriber2@test.com')->create();
     $this->task = $this->createNewScheduledTask();
     $this->queue = $this->createNewSendingQueue([
       'newsletter' => $this->newsletter,
@@ -155,10 +158,17 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItSetsSubscribers() {
-    $subscriberIds = [$this->subscriber1->getId(), $this->subscriber2->getId()];
+    $subscriber3 = $this->subscriberFactory->withEmail('subscriber3@test.com')->create();
+    $subscriber4 = $this->subscriberFactory->withEmail('subscriber4@test.com')->create();
+    $subscriber5 = $this->subscriberFactory->withEmail('subscriber5@test.com')->create();
+
+    $subscriberIds = [$subscriber3->getId(), $subscriber4->getId(), $subscriber5->getId()];
     $this->sending->setSubscribers($subscriberIds);
+
     verify($this->sending->getSubscribers())->equals($subscriberIds);
     verify($this->sending->count_total)->equals(count($subscriberIds));
+    verify($this->sending->count_processed)->equals(0);
+    verify($this->sending->count_to_process)->equals(3);
   }
 
   public function testItRemovesSubscribers() {

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -3,13 +3,13 @@
 namespace MailPoet\Test\Tasks;
 
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Models\Newsletter;
 use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Tasks\Subscribers;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -22,9 +22,13 @@ class SendingTest extends \MailPoetTest {
   /** @var ScheduledTasksRepository */
   private $scheduledTaskRepository;
 
+  /** @var NewsletterFactory */
+  private $newsletterFactory;
+
   public function _before() {
     parent::_before();
-    $this->newsletter = $this->createNewNewsletter();
+    $this->newsletterFactory = new NewsletterFactory();
+    $this->newsletter = $this->newsletterFactory->create();
     $this->task = $this->createNewScheduledTask();
     $this->queue = $this->createNewSendingQueue([
       'newsletter' => $this->newsletter,
@@ -85,7 +89,7 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function testItCanBeInitializedByNewsletterId() {
-    $sending = SendingTask::getByNewsletterId($this->newsletter->id);
+    $sending = SendingTask::getByNewsletterId($this->newsletter->getId());
     $queue = $sending->queue();
     $task = $sending->task();
     verify($task->id)->equals($queue->taskId);
@@ -245,12 +249,6 @@ class SendingTest extends \MailPoetTest {
     verify($tasks[2]->getId())->equals($sending2->taskId);
   }
 
-  public function createNewNewsletter() {
-    $newsletter = Newsletter::create();
-    $newsletter->type = Newsletter::TYPE_STANDARD;
-    return $newsletter->save();
-  }
-
   public function createNewScheduledTask() {
     $task = ScheduledTask::create();
     $task->type = SendingTask::TASK_TYPE;
@@ -258,11 +256,11 @@ class SendingTest extends \MailPoetTest {
   }
 
   public function createNewSendingQueue($args = []) {
-    $newsletter = isset($args['newsletter']) ? $args['newsletter'] : $this->createNewNewsletter();
+    $newsletter = isset($args['newsletter']) ? $args['newsletter'] : $this->newsletterFactory->create();
     $task = isset($args['task']) ? $args['task'] : $this->createNewScheduledTask();
 
     $queue = SendingQueue::create();
-    $queue->newsletterId = $newsletter->id;
+    $queue->newsletterId = $newsletter->getId();
     $queue->taskId = $task->id;
     return $queue->save();
   }


### PR DESCRIPTION
## Description

This PR refactors the methods Sending::getSubscribers() and Sending::setSubscribers() to use Doctrine instead of Paris. The remaining subscriber related methods that exist in Sending will be refactored in another PR. 

## Code review notes

See one inline comment for a specific part that I wanted to highlight. 

## QA notes

This PR should not change any functionality, but it touches sending emails which is a core part of MailPoet. It would be nice to test anything sending related that is not covered by automated tests. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4368]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4368]: https://mailpoet.atlassian.net/browse/MAILPOET-4368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ