### PR TITLE
Fix Redirecting to MailPoet Homepage after activating other plugins - MAILPOET-5417

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -360,10 +360,10 @@ class Initializer {
     $activatedByWpAdmin = !empty(strpos($currentUrl, 'plugins.php')) && isset($_GET['activate']) && (bool)$_GET['activate'];
     if (!$activatedByWpAdmin) return; // not activated by wp. Do not redirect e.g WooCommerce NUX
 
-    $this->changelog->redirectToLandingPage();
-
-    // done with afterPluginActivation actions
+    // done with afterPluginActivation actions. Delete before redirect
     $this->wpFunctions->deleteOption(self::PLUGIN_ACTIVATED);
+
+    $this->changelog->redirectToLandingPage();
   }
 
   public function maybeDbUpdate() {


### PR DESCRIPTION

## Description

Fix Redirecting to MailPoet Homepage after activating other plugins.

## Code review notes

_N/A_

## QA notes

Testing steps:
On an Old site (site with MailPoet already installed)
* Set `version` to NULL on `mailpoet-settings` table (from the Database) 
<details>
<summary>SQL query</summary>
<p>

```sql

 UPDATE `wp_mailpoet_settings` SET
`value` = NULL,
`updated_at` = now()
WHERE `name` = 'version';

```
</p>
</details>

On a new Site
* Install the MailPoet plugin and another plugin e.g WooCommerce Smooth Generator or MailPoet Debug
* Do not activate both plugins
* Activate the MailPoet plugin. You should be redirected to the Landing page
* Visit the plugins page and activate the second plugin
* You should **not** be redirected.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5417](https://mailpoet.atlassian.net/browse/MAILPOET-5417)

Fixes #5014 

## After-merge notes

_N/A_

## Tasks

- [ ] ~I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations~
- [ ] ~I added sufficient test coverage~
- [ ] ~I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes~

Thanks @filipecsweb  👏🏾

[MAILPOET-5417]: https://mailpoet.atlassian.net/browse/MAILPOET-5417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ