### PR TITLE
Fix acceptance test failure by reverting to WooCommerce 7.8.0 [MAILPOET-5438]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip latest
+            ./do download:woo-commerce-zip 7.8.0
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2


### PR DESCRIPTION
## Description

WooCommerce 7.8.1 seems to have added some code to the checkout process that requires email verification in certain cases.

I believe the code that's causing the failure is this: https://github.com/Automattic/testwoo/blame/404585847345ee8b1c768879c19421937b21451c/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php#L303-L307

This PR forces the use of WooCommerce 7.8.0 instead of `latest` to avoid the issue for now.

## Code review notes

This is a bandaid fix to get pipelines passing again while I figure out a better fix.

## QA notes

No QA required.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5438](https://mailpoet.atlassian.net/browse/MAILPOET-5438)

## After-merge notes

_N/A_

## Tasks

- [ ] ~I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations~
- [ ] ~I added sufficient test coverage~
- [ ] ~I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes~

[MAILPOET-5438]: https://mailpoet.atlassian.net/browse/MAILPOET-5438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ