### PR TITLE
Return cached item for homepage stats [MAILPOET-5439]

### DIFF
--- a/mailpoet/lib/Subscribers/SubscribersCountsController.php
+++ b/mailpoet/lib/Subscribers/SubscribersCountsController.php
@@ -92,7 +92,7 @@ class SubscribersCountsController {
   }
 
   public function getHomepageStatistics(): array {
-    $result = $this->getCacheItem(TransientCache::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY, 0) ?? [];
+    $result = $this->getCacheItem(TransientCache::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY, 0)['item'] ?? [];
     if (!$result) {
       $result = $this->recalculateHomepageStatisticsCache();
     }


### PR DESCRIPTION
## Description

Make sure we return the `'item'` of a cached homepage stats result.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
