### PR TITLE
Improve the test subscribers count shortcode

### DIFF
--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -30,7 +30,7 @@ class SubscriberCountShortcodeCest {
     $segment = $segmentFactory->withName(self::SUBSCRIBER_LIST_NAME)->create();
     $subscriberFactory = new Subscriber();
     $subscriberFactory->withSegments([$segment])->create();
-    $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count segments=\"{$segment->getId()}\"]";
+    $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count segments={$segment->getId()}]";
     $postUrl = $i->createPost(self::PAGE_TITLE, $pageContent);
 
     $i->login();
@@ -46,7 +46,7 @@ class SubscriberCountShortcodeCest {
     $segmentFactory = new Segment();
     $this->segment1 = $segmentFactory->withName(self::SUBSCRIBERS_LIST_NAME_ONE)->create();
     $this->segment2 = $segmentFactory->withName(self::SUBSCRIBERS_LIST_NAME_TWO)->create();
-    $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count] segments=\"{$this->segment1->getId()},{$this->segment2->getId()}\"]";
+    $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count] segments={$this->segment1->getId()},{$this->segment2->getId()}]";
     $postUrl = $i->createPost(self::PAGE_TITLE, $pageContent);
 
     $this->prepareSubscribersData($this->segment1, $this->segment2);

--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -19,10 +19,6 @@ class SubscriberCountShortcodeCest {
   const PAGE_TITLE = 'Subscribers Shortcode Page';
   const PAGE_TEXT = 'Your subscriber count is';
 
-  /** @var SegmentEntity */
-  private $segment1;
-  private $segment2;
-
   public function verifySubscribersShortcodeWithSegments(\AcceptanceTester $i) {
     $i->wantTo('Create page with shortcode of one subscriber and segment');
 
@@ -44,12 +40,12 @@ class SubscriberCountShortcodeCest {
     $i->wantTo('Create page with shortcode of all subscribers but different statuses');
 
     $segmentFactory = new Segment();
-    $this->segment1 = $segmentFactory->withName(self::SUBSCRIBERS_LIST_NAME_ONE)->create();
-    $this->segment2 = $segmentFactory->withName(self::SUBSCRIBERS_LIST_NAME_TWO)->create();
-    $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count] segments={$this->segment1->getId()},{$this->segment2->getId()}]";
+    $segment1 = $segmentFactory->withName(self::SUBSCRIBERS_LIST_NAME_ONE)->create();
+    $segment2 = $segmentFactory->withName(self::SUBSCRIBERS_LIST_NAME_TWO)->create();
+    $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count segments={$segment1->getId()},{$segment2->getId()}]";
     $postUrl = $i->createPost(self::PAGE_TITLE, $pageContent);
 
-    $this->prepareSubscribersData($this->segment1, $this->segment2);
+    $this->prepareSubscribersData($segment1, $segment2);
 
     $i->login();
 

--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -49,7 +49,7 @@ class SubscriberCountShortcodeCest {
     $pageContent = self::PAGE_TEXT . " [mailpoet_subscribers_count] segments=\"{$this->segment1->getId()},{$this->segment2->getId()}\"]";
     $postUrl = $i->createPost(self::PAGE_TITLE, $pageContent);
 
-    $this->prepareSubscribersData();
+    $this->prepareSubscribersData($this->segment1, $this->segment2);
 
     $i->login();
 
@@ -76,27 +76,27 @@ class SubscriberCountShortcodeCest {
     $i->waitForText(self::PAGE_TEXT . " 5");
   }
 
-  private function prepareSubscribersData() {
+  private function prepareSubscribersData(SegmentEntity $segment1, SegmentEntity $segment2) {
     for ($i = 0; $i < self::ACTIVE_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withSegments([$this->segment1])->create();
+      (new Subscriber())->withSegments([$segment1])->create();
     }
     for ($i = 0; $i < self::INACTIVE_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withStatus('inactive')->withSegments([$this->segment1])->create();
+      (new Subscriber())->withStatus('inactive')->withSegments([$segment1])->create();
     }
     for ($i = 0; $i < self::UNCONFIRMED_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withStatus('unconfirmed')->withSegments([$this->segment1])->create();
+      (new Subscriber())->withStatus('unconfirmed')->withSegments([$segment1])->create();
     }
     for ($i = 0; $i < self::UNSUBSCRIBED_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withStatus('unsubscribed')->withSegments([$this->segment1])->create();
+      (new Subscriber())->withStatus('unsubscribed')->withSegments([$segment1])->create();
     }
     for ($i = 0; $i < self::BOUNCED_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withStatus('bounced')->withSegments([$this->segment1])->create();
+      (new Subscriber())->withStatus('bounced')->withSegments([$segment1])->create();
     }
     for ($i = 0; $i < self::ACTIVE_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withSegments([$this->segment2])->create();
+      (new Subscriber())->withSegments([$segment2])->create();
     }
     for ($i = 0; $i < self::UNSUBSCRIBED_SUBSCRIBERS_COUNT; $i++) {
-      (new Subscriber())->withStatus('unsubscribed')->withSegments([$this->segment2])->create();
+      (new Subscriber())->withStatus('unsubscribed')->withSegments([$segment2])->create();
     }
   }
 }


### PR DESCRIPTION
## Description

Improve the existing test case `SubscriberCountShortcodeCest` to check for multiple lists, bounced subscribers and deleted subscribers.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5323]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5323]: https://mailpoet.atlassian.net/browse/MAILPOET-5323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ