### PR TITLE
Fix failing nightly tests [MAILPOET-5449]

### DIFF
--- a/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Acceptance;
 use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Settings;
 
 class EditorCreateCustomFieldCest {
   private function prepareTheForm(\AcceptanceTester $i) {
@@ -32,6 +33,8 @@ class EditorCreateCustomFieldCest {
     $this->openFormInEditor($i);
     // Insert create custom field block
     $i->addFromBlockInEditor('Create Custom Field');
+    $settings = new Settings();
+    $settings->withConfirmationEmailEnabled();
   }
 
   public function createCustomSelect(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -27,12 +27,13 @@ class WooCheckoutAutomateWooSubscriptionsCest {
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();
     $i->activateAutomateWoo();
+    $i->login();
+    $i->amOnPage('/wp-admin/');
     $this->product = (new WooCommerceProduct($i))->create();
     $this->settingsFactory = new Settings();
     $this->settingsFactory->withWooCommerceListImportPageDisplayed(true);
     $this->settingsFactory->withCookieRevenueTrackingDisabled();
     // Let AutomateWoo settings to be applied
-    $i->login();
     $i->amOnPage('/wp-admin/admin.php?page=automatewoo-settings');
     $i->seeCheckboxIsChecked('#automatewoo_enable_checkout_optin');
     $i->logout();


### PR DESCRIPTION
## Description

This makes a small change to our automatewoo tests to force the creation of tables by visiting the admin. I believe this won't be necessary when https://github.com/woocommerce/automatewoo/pull/1483 is merged, which will make AW create tables when it's installed via WP CLI.

These tests started failing with AutomateWoo version 5.8.1, which made a change to the AbandonedCarts Job, which apparently made it start running that job during our tests even though the tables didn't exist.

This doesn't fully resolve the failing tests because I'm still not sure how to get all our tests passing with WooCommerce 7.8.1, but that will have to be saved for a different PR.

It also ensures that confirmation emails are enabled for tests that assume they are.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
