### PR TITLE
Add tags bulk actions for subscribers [MAILPOET-5454]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -253,4 +253,11 @@ interface Window {
   mailpoet_brand_styles?: {
     available: boolean;
   };
+  mailpoet_max_confirmation_emails: number;
+  mailpoet_segments: Array<{
+    id: string;
+    name: string;
+    subscribers: string;
+    type: 'default' | 'wp_users' | 'woocommerce_users' | 'dynamic';
+  }>;
 }

--- a/mailpoet/assets/js/src/subscribers/list.jsx
+++ b/mailpoet/assets/js/src/subscribers/list.jsx
@@ -305,6 +305,36 @@ const bulkActions = [
       );
     },
   },
+  {
+    name: 'removeTag',
+    label: MailPoet.I18n.t('removeTag'),
+    onSelect: function onSelect(submitModal, closeModal) {
+      const field = {
+        id: 'remove_tag',
+        name: 'remove_tag',
+        endpoint: 'tags',
+      };
+
+      return createModal(
+        submitModal,
+        closeModal,
+        field,
+        MailPoet.I18n.t('removeTag'),
+      );
+    },
+    getData: function getData() {
+      return {
+        tag_id: Number(jQuery('#remove_tag').val()),
+      };
+    },
+    onSuccess: function onSuccess(response) {
+      MailPoet.Notice.success(
+        MailPoet.I18n.t('tagRemovedFromMultipleSubscribers')
+          .replace('%1$s', response.meta.tag)
+          .replace('%2$d', Number(response.meta.count).toLocaleString()),
+      );
+    },
+  },
 ];
 
 const itemActions = [

--- a/mailpoet/assets/js/src/subscribers/list.jsx
+++ b/mailpoet/assets/js/src/subscribers/list.jsx
@@ -275,6 +275,36 @@ const bulkActions = [
       );
     },
   },
+  {
+    name: 'addTag',
+    label: MailPoet.I18n.t('addTag'),
+    onSelect: function onSelect(submitModal, closeModal) {
+      const field = {
+        id: 'add_tag',
+        name: 'add_tag',
+        endpoint: 'tags',
+      };
+
+      return createModal(
+        submitModal,
+        closeModal,
+        field,
+        MailPoet.I18n.t('addTag'),
+      );
+    },
+    getData: function getData() {
+      return {
+        tag_id: Number(jQuery('#add_tag').val()),
+      };
+    },
+    onSuccess: function onSuccess(response) {
+      MailPoet.Notice.success(
+        MailPoet.I18n.t('tagAddedToMultipleSubscribers')
+          .replace('%1$s', response.meta.tag)
+          .replace('%2$d', Number(response.meta.count).toLocaleString()),
+      );
+    },
+  },
 ];
 
 const itemActions = [

--- a/mailpoet/assets/js/src/subscribers/subscribers.jsx
+++ b/mailpoet/assets/js/src/subscribers/subscribers.jsx
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 
-import { SubscriberList } from 'subscribers/list.jsx';
+import { SubscriberList } from 'subscribers/list.tsx';
 import { SubscriberForm } from 'subscribers/form.jsx';
 import { SubscriberStats } from 'subscribers/stats';
 import { GlobalContext, useGlobalContextValue } from 'context';

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -293,6 +293,8 @@ class Subscribers extends APIEndpoint {
       $count = $this->subscribersRepository->bulkUnsubscribe($ids);
     } elseif ($data['action'] === 'addTag' && $tag instanceof TagEntity) {
       $count = $this->subscribersRepository->bulkAddTag($tag, $ids);
+    } elseif ($data['action'] === 'removeTag' && $tag instanceof TagEntity) {
+      $count = $this->subscribersRepository->bulkRemoveTag($tag, $ids);
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -13,6 +13,7 @@ use MailPoet\ConflictException;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\TagEntity;
 use MailPoet\Exception;
 use MailPoet\Listing;
 use MailPoet\Segments\SegmentsRepository;
@@ -22,6 +23,7 @@ use MailPoet\Subscribers\SubscriberListingRepository;
 use MailPoet\Subscribers\SubscriberSaveController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\SubscriberSubscribeController;
+use MailPoet\Tags\TagRepository;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\Helpers;
 
@@ -51,6 +53,9 @@ class Subscribers extends APIEndpoint {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var TagRepository */
+  private $tagRepository;
+
   /** @var SubscriberSaveController */
   private $saveController;
 
@@ -67,6 +72,7 @@ class Subscribers extends APIEndpoint {
     SubscribersResponseBuilder $subscribersResponseBuilder,
     SubscriberListingRepository $subscriberListingRepository,
     SegmentsRepository $segmentsRepository,
+    TagRepository $tagRepository,
     SubscriberSaveController $saveController,
     SubscriberSubscribeController $subscribeController,
     SettingsController $settings
@@ -77,6 +83,7 @@ class Subscribers extends APIEndpoint {
     $this->subscribersResponseBuilder = $subscribersResponseBuilder;
     $this->subscriberListingRepository = $subscriberListingRepository;
     $this->segmentsRepository = $segmentsRepository;
+    $this->tagRepository = $tagRepository;
     $this->saveController = $saveController;
     $this->subscribeController = $subscribeController;
     $this->settings = $settings;
@@ -258,6 +265,16 @@ class Subscribers extends APIEndpoint {
       }
     }
 
+    $tag = null;
+    if (isset($data['tag_id'])) {
+      $tag = $this->getTag($data);
+      if (!$tag) {
+        return $this->errorResponse([
+          APIError::NOT_FOUND => __('This tag does not exist.', 'mailpoet'),
+        ]);
+      }
+    }
+
     if ($data['action'] === 'trash') {
       $count = $this->subscribersRepository->bulkTrash($ids);
     } elseif ($data['action'] === 'restore') {
@@ -274,6 +291,8 @@ class Subscribers extends APIEndpoint {
       $count = $this->subscribersRepository->bulkMoveToSegment($segment, $ids);
     } elseif ($data['action'] === 'unsubscribe') {
       $count = $this->subscribersRepository->bulkUnsubscribe($ids);
+    } elseif ($data['action'] === 'addTag' && $tag instanceof TagEntity) {
+      $count = $this->subscribersRepository->bulkAddTag($tag, $ids);
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
@@ -284,6 +303,9 @@ class Subscribers extends APIEndpoint {
 
     if ($segment) {
       $meta['segment'] = $segment->getName();
+    }
+    if ($tag) {
+      $meta['tag'] = $tag->getName();
     }
     return $this->successResponse(null, $meta);
   }
@@ -301,6 +323,12 @@ class Subscribers extends APIEndpoint {
   private function getSegment(array $data): ?SegmentEntity {
     return isset($data['segment_id'])
       ? $this->segmentsRepository->findOneById((int)$data['segment_id'])
+      : null;
+  }
+
+  private function getTag(array $data): ?TagEntity {
+    return isset($data['tag_id'])
+      ? $this->tagRepository->findOneById((int)$data['tag_id'])
       : null;
   }
 

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -156,6 +156,8 @@
     'recalculateNow': __('Recalculate now'),
     'tags': __('Tags'),
     'addNewTag': __('Add new tag'),
+    'tagAddedToMultipleSubscribers': __('Tag <strong>%1$s</strong> was added to %2$d subscribers.'),
+    'addTag': __('Add tag...'),
   }) %>
 <% endblock %>
 

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -157,7 +157,9 @@
     'tags': __('Tags'),
     'addNewTag': __('Add new tag'),
     'tagAddedToMultipleSubscribers': __('Tag <strong>%1$s</strong> was added to %2$d subscribers.'),
+    'tagRemovedFromMultipleSubscribers': __('Tag <strong>%1$s</strong> was removed from %2$d subscribers.'),
     'addTag': __('Add tag...'),
+    'removeTag': __('Remove tag...'),
   }) %>
 <% endblock %>
 


### PR DESCRIPTION
## Description

This PR adds two new bulk actions to subscribers' listings. The first is for adding a new tag to selected subscribers, and the second is removing a tag from selected subscribers.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5454]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5454]: https://mailpoet.atlassian.net/browse/MAILPOET-5454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ