### PR TITLE
Fix acceptance tests with WC latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 7.8.0
+            ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -580,7 +580,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $i = $this;
     $i->waitForText('Place order');
     $i->click('Place order');
-    $i->waitForText('Your order has been received');
+    $i->waitForText('Order received');
   }
 
   /**


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I am only checking that the order was received, we don't need to see the order details.
This is what WC also does [here](https://github.com/woocommerce/woocommerce/compare/7.8.0...7.8.1#diff-724523f01d5fc4d96d861d48684efc49d04658878cdd6a2d1163737ec7af426fR272)
I don't know why the login screen is displayed on CI, it does not happen locally or when testing manually.
I think this change is enough for now.

## QA notes

No need for QA

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5449]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations - NA
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes -NA


[MAILPOET-5449]: https://mailpoet.atlassian.net/browse/MAILPOET-5449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ