### PR TITLE
Fix script loading by escaping the date

### DIFF
--- a/mailpoet/assets/js/src/form/fields/selection.jsx
+++ b/mailpoet/assets/js/src/form/fields/selection.jsx
@@ -185,10 +185,13 @@ class Selection extends Component {
       this.props.field.getCount !== undefined ||
       this.props.field.getTag !== undefined
     ) {
-      const items = this.getItems(this.props.field);
+      let items = this.getItems(this.props.field) ?? [];
       let selectedValues = this.getSelectedValues() || [];
       if (!Array.isArray(selectedValues)) {
         selectedValues = [selectedValues];
+      }
+      if (!Array.isArray(items)) {
+        items = [items];
       }
       const data = items.map((item) => {
         const id = this.getValue(item);
@@ -312,7 +315,10 @@ class Selection extends Component {
   };
 
   render() {
-    const items = this.getItems(this.props.field);
+    let items = this.getItems(this.props.field) ?? [];
+    if (!Array.isArray(items)) {
+      items = [items];
+    }
     const selectedValues = this.getSelectedValues();
     const options = items.map((item) => {
       const label = this.getLabel(item);

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -19,7 +19,7 @@
       var mailpoet_current_time = <%= json_encode(current_time) %>;
       var mailpoet_current_date_time = <%= json_encode(current_date_time) %>;
       var mailpoet_schedule_time_of_day = <%= json_encode(schedule_time_of_day) %>;
-      var mailpoet_date_display_format = "<%= wp_date_format() %>";
+      var mailpoet_date_display_format = "<%= wp_datetime_format()|escape('js') %>";
       var mailpoet_date_storage_format = "Y-m-d";
       var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
       var mailpoet_products = <%= json_encode(products) %>;


### PR DESCRIPTION
## Description

Fixes an error on the send page when the date format breaks the script loading.

To test, select a custom date format on wp-admin > Settings > General and add double quotes somewhere in the middle.
Edit a newsletter, click on next and you will see the error.

This PR escapes the date, same as we do in other scripts and also adds some checks to prevent the error if the data is not present.

## Code review notes
@costasovo I am assigning this to you because I am not that familiar with the Twig functions and I see that you made similar changes in the selection.jsx file.

I didn't have time to convert to TS or add tests (this area of the code does not have any)
I can create a separate ticket or leave this PR open until I get another maintenance window. Let me know what you think.
It is not an urgent fix as there is a workaround by using a standard date format.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5457]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations NA
- [ ] I added sufficient test coverage (See note above)
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes (See note above)


[MAILPOET-5457]: https://mailpoet.atlassian.net/browse/MAILPOET-5457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ