### PR TITLE
Refactor code to create a component for the `in the last X days` part of some dynamic segments

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/email.tsx
@@ -11,6 +11,7 @@ import { storeName } from '../store';
 import { EmailOpenStatisticsFields } from './fields/email/email_statistics_opens';
 import { EmailClickStatisticsFields } from './fields/email/email_statistics_clicks';
 import { EmailOpensAbsoluteCountFields } from './fields/email/email_opens_absolute_count';
+import { validateDaysPeriod } from './fields/days_period_field';
 
 export function validateEmail(formItems: EmailFormItem): boolean {
   // check if the action has the right type
@@ -35,7 +36,9 @@ export function validateEmail(formItems: EmailFormItem): boolean {
     );
   }
 
-  return !!formItems.days && !!formItems.opens && !!formItems.operator;
+  return (
+    validateDaysPeriod(formItems) && !!formItems.opens && !!formItems.operator
+  );
 }
 
 const componentsMap = {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
@@ -1,0 +1,52 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Input } from 'common';
+import { MailPoet } from 'mailpoet';
+import { DaysPeriodItem, FilterProps } from 'segments/dynamic/types';
+import { storeName } from 'segments/dynamic/store';
+
+function replaceElementsInDaysSentence(
+  fn: (value) => JSX.Element,
+): JSX.Element[] {
+  return MailPoet.I18n.t('emailActionOpensDaysSentence')
+    .split(/({days})/gim)
+    .map(fn);
+}
+
+export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
+  const segment: DaysPeriodItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const { updateSegmentFilterFromEvent } = useDispatch(storeName);
+
+  return (
+    <>
+      {replaceElementsInDaysSentence((match) => {
+        if (match === '{days}') {
+          return (
+            <Input
+              key="input"
+              type="number"
+              value={segment.days || ''}
+              data-automation-id="segment-number-of-days"
+              onChange={(e) => {
+                void updateSegmentFilterFromEvent('days', filterIndex, e);
+              }}
+              min={1}
+              step={1}
+              placeholder={MailPoet.I18n.t('daysPlaceholder')}
+            />
+          );
+        }
+        if (typeof match === 'string' && match.trim().length > 1) {
+          return <div key={match}>{match}</div>;
+        }
+        return null;
+      })}
+    </>
+  );
+}
+
+export function validateDaysPeriod(formItems: DaysPeriodItem): boolean {
+  return !!formItems.days;
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/email/email_opens_absolute_count.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/email/email_opens_absolute_count.tsx
@@ -8,14 +8,7 @@ import { MailPoet } from 'mailpoet';
 
 import { EmailFormItem, FilterProps } from '../../../types';
 import { storeName } from '../../../store';
-
-function replaceElementsInDaysSentence(
-  fn: (value) => JSX.Element,
-): JSX.Element[] {
-  return MailPoet.I18n.t('emailActionOpensDaysSentence')
-    .split(/({days})/gim)
-    .map(fn);
-}
+import { DaysPeriodField } from '../days_period_field';
 
 function replaceEmailActionOpensSentence(
   fn: (value) => JSX.Element,
@@ -85,27 +78,7 @@ export function EmailOpensAbsoluteCountFields({
         })}
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        {replaceElementsInDaysSentence((match) => {
-          if (match === '{days}') {
-            return (
-              <Input
-                key="input"
-                type="number"
-                value={segment.days || ''}
-                data-automation-id="segment-number-of-days"
-                onChange={(e) => {
-                  void updateSegmentFilterFromEvent('days', filterIndex, e);
-                }}
-                min="0"
-                placeholder={MailPoet.I18n.t('emailActionDays')}
-              />
-            );
-          }
-          if (typeof match === 'string' && match.trim().length > 1) {
-            return <div key={match}>{match}</div>;
-          }
-          return null;
-        })}
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/average_spent.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/average_spent.tsx
@@ -5,12 +5,13 @@ import { Input, Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { storeName } from '../../../store';
 import { WooCommerceFormItem, FilterProps } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days_period_field';
 
 export function validateAverageSpent(formItems: WooCommerceFormItem): boolean {
   const averageSpentIsInvalid =
     !formItems.average_spent_amount ||
     !formItems.average_spent_type ||
-    !formItems.average_spent_days;
+    !validateDaysPeriod(formItems);
 
   return !averageSpentIsInvalid;
 }
@@ -72,23 +73,7 @@ export function AverageSpentFields({ filterIndex }: FilterProps): JSX.Element {
         <div>{wooCurrencySymbol}</div>
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        <div>{MailPoet.I18n.t('inTheLast')}</div>
-        <Input
-          data-automation-id="input-average-spent-days"
-          type="number"
-          min={1}
-          step={1}
-          value={segment.average_spent_days || ''}
-          placeholder={MailPoet.I18n.t('daysPlaceholder')}
-          onChange={(e): void => {
-            void updateSegmentFilterFromEvent(
-              'average_spent_days',
-              filterIndex,
-              e,
-            );
-          }}
-        />
-        <div>{MailPoet.I18n.t('days')}</div>
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_orders.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_orders.tsx
@@ -5,13 +5,14 @@ import { Input, Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { storeName } from '../../../store';
 import { WooCommerceFormItem, FilterProps } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days_period_field';
 
 export function validateNumberOfOrders(
   formItems: WooCommerceFormItem,
 ): boolean {
   const numberOfOrdersIsInvalid =
     !formItems.number_of_orders_count ||
-    !formItems.number_of_orders_days ||
+    !validateDaysPeriod(formItems) ||
     !formItems.number_of_orders_type;
 
   return !numberOfOrdersIsInvalid;
@@ -70,22 +71,7 @@ export function NumberOfOrdersFields({
         <div>{MailPoet.I18n.t('wooNumberOfOrdersOrders')}</div>
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        <div>{MailPoet.I18n.t('inTheLast')}</div>
-        <Input
-          data-automation-id="input-number-of-orders-days"
-          type="number"
-          min={1}
-          value={segment.number_of_orders_days || ''}
-          placeholder={MailPoet.I18n.t('daysPlaceholder')}
-          onChange={(e): void => {
-            void updateSegmentFilterFromEvent(
-              'number_of_orders_days',
-              filterIndex,
-              e,
-            );
-          }}
-        />
-        <div>{MailPoet.I18n.t('days')}</div>
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/single_order_value.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/single_order_value.tsx
@@ -5,13 +5,14 @@ import { Input, Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { WooCommerceFormItem, FilterProps } from '../../../types';
 import { storeName } from '../../../store';
+import { DaysPeriodField, validateDaysPeriod } from '../days_period_field';
 
 export function validateSingleOrderValue(
   formItems: WooCommerceFormItem,
 ): boolean {
   const singleOrderValueIsInvalid =
     !formItems.single_order_value_amount ||
-    !formItems.single_order_value_days ||
+    !validateDaysPeriod(formItems) ||
     !formItems.single_order_value_type;
 
   return !singleOrderValueIsInvalid;
@@ -75,22 +76,7 @@ export function SingleOrderValueFields({
         <div>{wooCurrencySymbol}</div>
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        <div>{MailPoet.I18n.t('inTheLast')}</div>
-        <Input
-          data-automation-id="input-single-order-value-days"
-          type="number"
-          min={1}
-          value={segment.single_order_value_days || ''}
-          placeholder={MailPoet.I18n.t('daysPlaceholder')}
-          onChange={(e): void => {
-            void updateSegmentFilterFromEvent(
-              'single_order_value_days',
-              filterIndex,
-              e,
-            );
-          }}
-        />
-        <div>{MailPoet.I18n.t('days')}</div>
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/total_spent.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/total_spent.tsx
@@ -5,11 +5,12 @@ import { Input, Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { WooCommerceFormItem, FilterProps } from '../../../types';
 import { storeName } from '../../../store';
+import { DaysPeriodField, validateDaysPeriod } from '../days_period_field';
 
 export function validateTotalSpent(formItems: WooCommerceFormItem): boolean {
   const totalSpentIsInvalid =
     !formItems.total_spent_amount ||
-    !formItems.total_spent_days ||
+    !validateDaysPeriod(formItems) ||
     !formItems.total_spent_type;
 
   return !totalSpentIsInvalid;
@@ -69,22 +70,7 @@ export function TotalSpentFields({ filterIndex }: FilterProps): JSX.Element {
         <div>{wooCurrencySymbol}</div>
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        <div>{MailPoet.I18n.t('inTheLast')}</div>
-        <Input
-          data-automation-id="input-total-spent-days"
-          type="number"
-          min={1}
-          value={segment.total_spent_days || ''}
-          placeholder={MailPoet.I18n.t('daysPlaceholder')}
-          onChange={(e): void => {
-            void updateSegmentFilterFromEvent(
-              'total_spent_days',
-              filterIndex,
-              e,
-            );
-          }}
-        />
-        <div>{MailPoet.I18n.t('days')}</div>
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -101,11 +101,9 @@ export interface WooCommerceFormItem extends FormItem {
   number_of_orders_count?: number;
   total_spent_type?: string;
   total_spent_amount?: number;
-  total_spent_days?: number;
   country_code?: string[];
   single_order_value_type?: string;
   single_order_value_amount?: number;
-  single_order_value_days?: number;
   average_spent_type?: string;
   average_spent_amount?: string;
   payment_methods?: string[];

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -99,7 +99,6 @@ export interface WooCommerceFormItem extends FormItem {
   operator?: string;
   number_of_orders_type?: string;
   number_of_orders_count?: number;
-  number_of_orders_days?: number;
   total_spent_type?: string;
   total_spent_amount?: number;
   total_spent_days?: number;
@@ -109,7 +108,6 @@ export interface WooCommerceFormItem extends FormItem {
   single_order_value_days?: number;
   average_spent_type?: string;
   average_spent_amount?: string;
-  average_spent_days?: string;
   payment_methods?: string[];
   used_payment_method_days?: string;
   shipping_methods?: string[];

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -72,6 +72,10 @@ export interface DateFormItem extends FormItem {
   value?: string;
 }
 
+export interface DaysPeriodItem extends FormItem {
+  days?: string;
+}
+
 export interface TextFormItem extends FormItem {
   operator?: string;
   value?: string;
@@ -133,7 +137,6 @@ export interface EmailFormItem extends FormItem {
   link_ids?: string[];
   operator?: string;
   opens?: string;
-  days?: string;
 }
 
 export type Segment = {

--- a/mailpoet/lib/Migrations/Migration_20230712_180341.php
+++ b/mailpoet/lib/Migrations/Migration_20230712_180341.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Migrator\Migration;
+use MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
+
+class Migration_20230712_180341 extends Migration {
+  public function run(): void {
+    $dynamicSegmentFilterRepository = $this->container->get(DynamicSegmentFilterRepository::class);
+    $filters = $dynamicSegmentFilterRepository->findBy(
+      [
+        'filterData.action' => [
+          WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS,
+          WooCommerceTotalSpent::ACTION_TOTAL_SPENT,
+          WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE,
+          WooCommerceAverageSpent::ACTION,
+        ],
+      ]
+    );
+
+    foreach ($filters as $filter) {
+      $filterData = $filter->getFilterData();
+      $data = $filter->getFilterData()->getData();
+
+      if (isset($data['number_of_orders_days'])) {
+        $days = $data['number_of_orders_days'];
+      } else if (isset($data['total_spent_days'])) {
+        $days = $data['total_spent_days'];
+      } else if (isset($data['single_order_value_days'])) {
+        $days = $data['single_order_value_days'];
+      } else if (isset($data['average_spent_days'])) {
+        $days = $data['average_spent_days'];
+      }
+
+      $filterType = $filterData->getFilterType();
+      $filterAction = $filterData->getAction();
+
+      if (isset($days) && is_string($filterType) && is_string($filterAction)) {
+        $data['days'] = $days;
+        $newFilterData = new DynamicSegmentFilterData($filterType, $filterAction, $data);
+        $filter->setFilterData($newFilterData);
+        $this->entityManager->persist($filter);
+        $this->entityManager->flush();
+      }
+    }
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -366,24 +366,24 @@ class FilterDataMapper {
       if (
         !isset($data['total_spent_type'])
         || !isset($data['total_spent_amount']) || $data['total_spent_amount'] < 0
-        || !isset($data['total_spent_days']) || $data['total_spent_days'] < 1
+        || !isset($data['days']) || $data['days'] < 1
       ) {
         throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_TOTAL_SPENT_FIELDS);
       }
       $filterData['total_spent_type'] = $data['total_spent_type'];
       $filterData['total_spent_amount'] = $data['total_spent_amount'];
-      $filterData['total_spent_days'] = $data['total_spent_days'];
+      $filterData['days'] = $data['days'];
     } elseif ($data['action'] === WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE) {
       if (
         !isset($data['single_order_value_type'])
         || !isset($data['single_order_value_amount']) || $data['single_order_value_amount'] < 0
-        || !isset($data['single_order_value_days']) || $data['single_order_value_days'] < 1
+        || !isset($data['days']) || $data['days'] < 1
       ) {
         throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_SINGLE_ORDER_VALUE_FIELDS);
       }
       $filterData['single_order_value_type'] = $data['single_order_value_type'];
       $filterData['single_order_value_amount'] = $data['single_order_value_amount'];
-      $filterData['single_order_value_days'] = $data['single_order_value_days'];
+      $filterData['days'] = $data['days'];
     } elseif ($data['action'] === WooCommercePurchaseDate::ACTION) {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -355,13 +355,13 @@ class FilterDataMapper {
       if (
         !isset($data['number_of_orders_type'])
         || !isset($data['number_of_orders_count']) || $data['number_of_orders_count'] < 0
-        || !isset($data['number_of_orders_days']) || $data['number_of_orders_days'] < 1
+        || !isset($data['days']) || $data['days'] < 1
       ) {
         throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_NUMBER_OF_ORDERS_FIELDS);
       }
       $filterData['number_of_orders_type'] = $data['number_of_orders_type'];
       $filterData['number_of_orders_count'] = $data['number_of_orders_count'];
-      $filterData['number_of_orders_days'] = $data['number_of_orders_days'];
+      $filterData['days'] = $data['days'];
     } elseif ($data['action'] === WooCommerceTotalSpent::ACTION_TOTAL_SPENT) {
       if (
         !isset($data['total_spent_type'])
@@ -391,11 +391,11 @@ class FilterDataMapper {
       if (
         !isset($data['average_spent_type'])
         || !isset($data['average_spent_amount']) || $data['average_spent_amount'] < 0
-        || !isset($data['average_spent_days']) || $data['average_spent_days'] < 1
+        || !isset($data['days']) || $data['days'] < 1
       ) {
         throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_AVERAGE_SPENT_FIELDS);
       }
-      $filterData['average_spent_days'] = $data['average_spent_days'];
+      $filterData['days'] = $data['days'];
       $filterData['average_spent_amount'] = $data['average_spent_amount'];
       $filterData['average_spent_type'] = $data['average_spent_type'];
     } elseif ($data['action'] === WooCommerceUsedPaymentMethod::ACTION) {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -27,7 +27,7 @@ class WooCommerceAverageSpent implements Filter {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('average_spent_type');
     $amount = $filterData->getParam('average_spent_amount');
-    $days = intval($filterData->getParam('average_spent_days'));
+    $days = intval($filterData->getParam('days'));
 
     $date = Carbon::now()->subDays($days);
     $dateParam = $this->filterHelper->getUniqueParameterName('date');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -39,7 +39,7 @@ class WooCommerceNumberOfOrders implements Filter {
     $filterData = $filter->getFilterData();
     $type = strval($filterData->getParam('number_of_orders_type'));
     $count = intval($filterData->getParam('number_of_orders_count'));
-    $days = $filterData->getParam('number_of_orders_days');
+    $days = $filterData->getParam('days');
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $collation = $this->collationChecker->getCollateIfNeeded(
       $subscribersTable,

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
@@ -23,7 +23,7 @@ class WooCommerceSingleOrderValue implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('single_order_value_type');
     $amount = $filterData->getParam('single_order_value_amount');
-    $days = $filterData->getParam('single_order_value_days');
+    $days = $filterData->getParam('days');
 
     if (!is_string($days)) {
       $days = '1'; // Default to last day

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -23,7 +23,7 @@ class WooCommerceTotalSpent implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('total_spent_type');
     $amount = $filterData->getParam('total_spent_amount');
-    $days = $filterData->getParam('total_spent_days');
+    $days = $filterData->getParam('days');
 
     $date = Carbon::now()->subDays($days);
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();

--- a/mailpoet/tests/DataFactories/DynamicSegment.php
+++ b/mailpoet/tests/DataFactories/DynamicSegment.php
@@ -48,7 +48,7 @@ class DynamicSegment extends Segment {
     $this->filterData['action'] = 'numberOfOrders';
     $this->filterData['number_of_orders_type'] = '=';
     $this->filterData['number_of_orders_count'] = '1';
-    $this->filterData['number_of_orders_days'] = '1';
+    $this->filterData['days'] = '1';
     return $this;
   }
 

--- a/mailpoet/tests/DataFactories/DynamicSegment.php
+++ b/mailpoet/tests/DataFactories/DynamicSegment.php
@@ -57,7 +57,7 @@ class DynamicSegment extends Segment {
     $this->filterData['action'] = 'totalSpent';
     $this->filterData['total_spent_type'] = '>';
     $this->filterData['total_spent_amount'] = $amount;
-    $this->filterData['total_spent_days'] = $days;
+    $this->filterData['days'] = $days;
     return $this;
   }
 
@@ -66,7 +66,7 @@ class DynamicSegment extends Segment {
     $this->filterData['action'] = 'singleOrderValue';
     $this->filterData['single_order_value_type'] = '>';
     $this->filterData['single_order_value_amount'] = $amount;
-    $this->filterData['single_order_value_days'] = $days;
+    $this->filterData['days'] = $days;
     return $this;
   }
 

--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -148,7 +148,7 @@ class ManageWooCommerceSegmentsCest {
     $actionSelectElement = '[data-automation-id="select-segment-action"]';
     $numberOfOrdersTypeElement = '[data-automation-id="select-number-of-orders-type"]';
     $numberOfOrdersCountElement = '[data-automation-id="input-number-of-orders-count"]';
-    $numberOfOrdersDaysElement = '[data-automation-id="input-number-of-orders-days"]';
+    $numberOfOrdersDaysElement = '[data-automation-id="segment-number-of-days"]';
 
     $i->wantTo('Create a new WooCommerce Number of Orders segment');
     $segmentTitle = 'Segment Woo Number of Orders Test';

--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -215,7 +215,7 @@ class ManageWooCommerceSegmentsCest {
     $actionSelectElement = '[data-automation-id="select-segment-action"]';
     $totalSpentTypeElement = '[data-automation-id="select-total-spent-type"]';
     $totalSpentAmountElement = '[data-automation-id="input-total-spent-amount"]';
-    $totalSpentDaysElement = '[data-automation-id="input-total-spent-days"]';
+    $totalSpentDaysElement = '[data-automation-id="segment-number-of-days"]';
 
     $i->wantTo('Create a new WooCommerce Total Spent segment');
     $segmentTitle = 'Segment Woo Total Spent Test';
@@ -284,7 +284,7 @@ class ManageWooCommerceSegmentsCest {
     $actionSelectElement = '[data-automation-id="select-segment-action"]';
     $singleOrderValueTypeElement = '[data-automation-id="select-single-order-value-type"]';
     $singleOrderValueAmountElement = '[data-automation-id="input-single-order-value-amount"]';
-    $singleOrderValueDaysElement = '[data-automation-id="input-single-order-value-days"]';
+    $singleOrderValueDaysElement = '[data-automation-id="segment-number-of-days"]';
 
     $i->wantTo('Create a new WooCommerce Single Order Value segment');
     $segmentTitle = 'Segment Single Order Value Test';

--- a/mailpoet/tests/integration/Migrations/Migration_20230712_180341_Test.php
+++ b/mailpoet/tests/integration/Migrations/Migration_20230712_180341_Test.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Migrations;
+
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Migrations\Migration_20230712_180341;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceAverageSpent;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20230712_180341_Test extends \MailPoetTest {
+  /** @var Migration_20230712_180341 */
+  private $migration;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20230712_180341($this->diContainer);
+  }
+
+  public function testItMigratesWooCommerceNumberOfOrdersFilterCorrectly() {
+    $oldFilterData = [
+      'connect' => 'and',
+      'number_of_orders_type' => '=',
+      'number_of_orders_count' => '1',
+      'number_of_orders_days' => '300',
+    ];
+
+    $this->testGivenFilterActionMigratesCorrectly(WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, $oldFilterData, 'number_of_orders_days');
+  }
+
+  public function testItMigratesWooCommerceTotalSpentFilterCorrectly() {
+    $oldFilterData = [
+      'connect' => 'and',
+      'total_spent_type' => '=',
+      'total_spent_amount' => '10',
+      'total_spent_days' => '20',
+    ];
+
+    $this->testGivenFilterActionMigratesCorrectly(WooCommerceTotalSpent::ACTION_TOTAL_SPENT, $oldFilterData, 'total_spent_days');
+  }
+
+  public function testItMigratesWooCommerceSingleOrderValueFilterCorrectly() {
+    $oldFilterData = [
+      'connect' => 'and',
+      'single_order_value_type' => '=',
+      'single_order_value_amount' => '10',
+      'single_order_value_days' => '20',
+    ];
+
+    $this->testGivenFilterActionMigratesCorrectly(WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE, $oldFilterData, 'single_order_value_days');
+  }
+
+  public function testItMigratesWooCommerceAverageSpentFilterCorrectly() {
+    $oldFilterData = [
+      'connect' => 'and',
+      'average_spent_type' => '=',
+      'average_spent_amount' => '10',
+      'average_spent_days' => '20',
+    ];
+
+    $this->testGivenFilterActionMigratesCorrectly(WooCommerceAverageSpent::ACTION, $oldFilterData, 'average_spent_days');
+  }
+
+  private function testGivenFilterActionMigratesCorrectly(string $filterAction, array $oldFilterData, string $keyToBeMigrated): void {
+    $migratedFilterData = $oldFilterData;
+    $migratedFilterData['days'] = $oldFilterData[$keyToBeMigrated];
+
+    $id = $this->createSegmentFilter($filterAction, $oldFilterData, 'any_type');
+
+    $this->migration->run();
+
+    $this->entityManager->clear();
+    $filter = $this->entityManager->find(DynamicSegmentFilterEntity::class, $id);
+    $this->assertInstanceOf(DynamicSegmentFilterEntity::class, $filter);
+    $this->assertSame($filterAction, $filter->getFilterData()->getAction());
+    $this->assertSame($migratedFilterData, $filter->getFilterData()->getData());
+  }
+
+  private function createSegmentFilter(string $action, array $data, string $type, $segmentId = 1): int {
+    $filterTable = $this->entityManager->getClassMetadata(DynamicSegmentFilterEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeQuery(
+      "INSERT into $filterTable (segment_id, filter_data, action, filter_type)
+     VALUES (:segment, :filter_data, :action, :filter_type)",
+      [
+        'segment' => $segmentId,
+        'action' => $action,
+        'filter_data' => serialize($data),
+        'filter_type' => $type,
+      ]
+    );
+    return (int)$this->entityManager->getConnection()->lastInsertId();
+  }
+}

--- a/mailpoet/tests/integration/Migrations/Migration_20230712_180341_Test.php
+++ b/mailpoet/tests/integration/Migrations/Migration_20230712_180341_Test.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace integration\Migrations;
+namespace MailPoet\Migrations;
 
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Migrations\Migration_20230712_180341;

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -135,7 +135,7 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
       'average_spent_type' => $operator,
       'average_spent_amount' => $amount,
-      'average_spent_days' => $days,
+      'days' => $days,
     ]);
 
     return $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->averageSpentFilter);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -72,7 +72,7 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
       'number_of_orders_type' => $comparisonType,
       'number_of_orders_count' => $ordersCount,
-      'number_of_orders_days' => $days,
+      'days' => $days,
     ]);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
@@ -67,7 +67,7 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE, [
       'single_order_value_type' => $type,
       'single_order_value_amount' => $amount,
-      'single_order_value_days' => $days,
+      'days' => $days,
     ]);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -74,7 +74,7 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT, [
       'total_spent_type' => $type,
       'total_spent_amount' => $amount,
-      'total_spent_days' => $days,
+      'days' => $days,
     ]);
   }
 

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -448,7 +448,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'action' => WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE,
       'single_order_value_type' => '=',
       'single_order_value_amount' => 20,
-      'single_order_value_days' => 7,
+      'days' => 7,
       'some_mess' => 'mess',
     ]]];
 

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -411,7 +411,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'action' => WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS,
       'number_of_orders_type' => '=',
       'number_of_orders_count' => 2,
-      'number_of_orders_days' => 1,
+      'days' => 1,
       'some_mess' => 'mess',
     ]]];
 

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -106,7 +106,6 @@
   'emailActionOpensAbsoluteCount': __('number of opens'),
   'emailActionMachineOpensAbsoluteCount': __('number of machine-opens'),
   'emailActionOpens': __('opens'),
-  'emailActionDays': __('days'),
   'emailActionOpensSentence': _x('{condition} {opens} opens', 'The result will be "more than 20 opens"'),
   'emailActionOpensDaysSentence': _x('in the last {days} days', 'The result will be "in the last 5 days"'),
   'moreThan': __('more than'),


### PR DESCRIPTION
## Description

As a first step to implementing changes to the `in the last X days` part of some dynamic segments (see [MAILPOET-4991]), in this PR, I refactored the code so that all the applicable dynamic segments use the same component for `in the last X days` part.

The affected dynamic segments are:

- `# of opens`
- `# of machine opens`
- `average order value`
- `# of orders`
- `single order value`
- `total spent`

## Code review notes

_N/A_

## QA notes

This PR should not change any user-facing behavior. It is probably a good idea to check that the functionality not covered by automated tests of the dynamic segments mentioned above remains the same.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4991]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4991]: https://mailpoet.atlassian.net/browse/MAILPOET-4991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4991]: https://mailpoet.atlassian.net/browse/MAILPOET-4991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ