### PR TITLE
Add progress indicator to Import [MAILPOET-5174]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_legacy-modal.scss
+++ b/mailpoet/assets/css/src/components-plugin/_legacy-modal.scss
@@ -257,3 +257,42 @@ body.mailpoet_modal_opened {
   90% { background-color: $color-secondary-light; }
   50% { background-color: $color-secondary; }
 }
+
+.mailpoet_modal_progress {
+  background-color: $color-secondary-light;
+  border-radius: 21px;
+  display: flex;
+  flex-direction: row;
+  height: 32px;
+  overflow: hidden;
+  position: relative;
+  width: 200px;
+}
+
+.mailpoet_modal_progress_bar {
+  animation-direction: linear;
+  animation-duration: 3s;
+  animation-iteration-count: infinite;
+  animation-name: bounce_mailpoet_modal_progress;
+  background-color: $color-secondary;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, .5) inset;
+  height: 100%;
+  line-height: inherit;
+  position: absolute;
+  transition: width .4s ease-in-out;
+}
+
+@keyframes bounce_mailpoet_modal_progress {
+  50% { background-color: $color-secondary-middle; }
+  100% { background-color: $color-secondary; }
+}
+
+.mailpoet_modal_progress_text {
+  color: $color-black;
+  display: inline-block;
+  margin: 5px 0 0;
+  position: absolute;
+  text-align: center;
+  text-shadow: $color-secondary-light 1px 0 1px;
+  width: 100%;
+}

--- a/mailpoet/assets/js/src/modal.js
+++ b/mailpoet/assets/js/src/modal.js
@@ -100,6 +100,11 @@ export const MailPoetModal = {
       '<div id="mailpoet_modal_loading_2" class="mailpoet_modal_loading mailpoet_modal_loading_2"></div>' +
       '<div id="mailpoet_modal_loading_3" class="mailpoet_modal_loading mailpoet_modal_loading_3"></div>' +
       '</div>',
+    progress:
+      '<div id="mailpoet_modal_progress" class="mailpoet_modal_progress" style="display:none;">' +
+      '<div class="mailpoet_modal_progress_bar" style="width: 0%"></div>' +
+      '<div class="mailpoet_modal_progress_text">0%</div>' +
+      '</div>',
     panel:
       '<div id="mailpoet_panel" class="mailpoet_panel">' +
       '<a href="javascript:;" id="mailpoet_modal_close" class="mailpoet_modal_close">' +
@@ -198,6 +203,8 @@ export const MailPoetModal = {
       jQuery('body').append(this.templates.overlay);
       // insert loading indicator into overlay
       jQuery('#mailpoet_modal_overlay').append(this.templates.loading);
+      // insert progress indicator into overlay
+      jQuery('#mailpoet_modal_overlay').append(this.templates.progress);
     }
     return this;
   },
@@ -574,6 +581,43 @@ export const MailPoetModal = {
 
     // remove loading class from overlay
     jQuery('#mailpoet_modal_overlay').removeClass('mailpoet_overlay_loading');
+
+    return this;
+  },
+  progress: function (toggle) {
+    // make sure the overlay is initialized and that it's visible
+    this.initOverlay(true);
+
+    if (toggle === true) {
+      this.showProgress();
+    } else {
+      this.hideProgress();
+    }
+
+    return this;
+  },
+  showProgress: function () {
+    this.setProgress(0);
+    jQuery('#mailpoet_modal_progress').show();
+
+    // add loading class to overlay
+    jQuery('#mailpoet_modal_overlay').addClass('mailpoet_overlay_loading');
+
+    return this;
+  },
+  hideProgress: function () {
+    jQuery('#mailpoet_modal_progress').hide();
+
+    // remove loading class from overlay
+    jQuery('#mailpoet_modal_overlay').removeClass('mailpoet_overlay_loading');
+
+    return this;
+  },
+  setProgress: function (percent) {
+    var value = Math.max(0, Math.min(percent, 100));
+    var $progress = jQuery('#mailpoet_modal_progress');
+    $progress.find('.mailpoet_modal_progress_bar').css({ width: value + '%' });
+    $progress.find('.mailpoet_modal_progress_text').text(value + '%');
 
     return this;
   },

--- a/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/do_import.jsx
+++ b/mailpoet/assets/js/src/subscribers/importExport/import/step_data_manipulation/do_import.jsx
@@ -25,7 +25,10 @@ export const doImport = (
     tags: [],
   };
 
-  MailPoet.Modal.loading(true);
+  const calcProgress = (result, subs) =>
+    Math.floor(((result.created + result.updated) / subs.length) * 100);
+
+  MailPoet.Modal.progress(true);
   const splitSubscribers = (localSubscribers, size) =>
     localSubscribers.reduce((res, item, index) => {
       if (index % size === 0) {
@@ -72,10 +75,13 @@ export const doImport = (
           importResult.updated += response.data.updated;
           importResult.segments = response.data.segments;
           importResult.added_to_segment_with_welcome_notification = added;
+          MailPoet.Modal.setProgress(
+            calcProgress(importResult, subscribersToImport),
+          );
           addQueue.run();
         })
         .fail((response) => {
-          MailPoet.Modal.loading(false);
+          MailPoet.Modal.progress(false);
           if (response.errors.length > 0) {
             MailPoet.Notice.error(
               response.errors.map((error) => error.message),
@@ -90,7 +96,7 @@ export const doImport = (
   queue.run();
 
   queue.onComplete(() => {
-    MailPoet.Modal.loading(false);
+    MailPoet.Modal.progress(false);
     if (
       importResult.errors.length > 0 &&
       !importResult.updated &&


### PR DESCRIPTION
## Description

I did it in the old modals code because import works outside React, using jQuery, and replacing an old loading modal this way was the most natural.

## Code review notes

_N/A_

## QA notes

You can use [this test CSV](https://mailpoet.atlassian.net/browse/MAILPOET-5174?focusedCommentId=24136) to test the progress indicator during import. 
Please make sure old modals in other places work as before: loading - e.g. in stats, segments sync; popups - e.g. newsletter editor preview; newsletter editor panels.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5174]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5174]: https://mailpoet.atlassian.net/browse/MAILPOET-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ