### PR TITLE
Improve the test WooCommerce Subscriptions segment

### DIFF
--- a/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -67,7 +67,7 @@ class WooCommerceSubscriptionsSegmentCest {
     $segmentTitle = 'Woo Active Subscriptions';
 
     $i->login();
-    $i->amOnMailpoetPage('Lists');
+    $i->amOnMailpoetPage('Segments');
     $i->click('[data-automation-id="new-segment"]');
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], 'Desc ' . $segmentTitle);
@@ -99,9 +99,8 @@ class WooCommerceSubscriptionsSegmentCest {
 
     $i->wantTo('Check that MailPoet plugin works when admin disables WooCommerce Subscriptions');
     $i->deactivateWooCommerceSubscriptions();
-    $i->amOnMailpoetPage('Lists');
-    $i->waitForElement('[data-automation-id="dynamic-segments-tab"]');
-    $i->click('[data-automation-id="dynamic-segments-tab"]');
+    $i->amOnMailpoetPage('Segments');
+    $i->waitForElement('[data-automation-id="new-segment"]');
     $i->waitForText($segmentTitle);
     $i->canSee('Activate the WooCommerce Subscriptions plugin to see the number of subscribers and enable the editing of this segment.');
 

--- a/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceSubscriptionsSegmentCest.php
@@ -25,7 +25,17 @@ class WooCommerceSubscriptionsSegmentCest {
   }
 
   public function createSubscriptionSegmentForActiveSubscriptions(\AcceptanceTester $i) {
+    $i->wantTo('Create dynamic segment for subscriptions');
     $i->activateWooCommerceSubscriptions();
+
+    $userFactory = new User();
+    $subscriber1 = $userFactory->createUser('Sub Scriber1', 'subscriber', 'subscriber1@example.com');
+    $subscriber2 = $userFactory->createUser('Sub Scriber2', 'subscriber', 'subscriber2@example.com');
+    $subscriber3 = $userFactory->createUser('Sub Scriber3', 'subscriber', 'subscriber3@example.com');
+    $subscriber4 = $userFactory->createUser('Sub Scriber4', 'subscriber', 'subscriber4@example.com');
+    $subscriber5 = $userFactory->createUser('Sub Scriber5', 'subscriber', 'subscriber5@example.com');
+    $subscriber6 = $userFactory->createUser('Sub Scriber6', 'subscriber', 'subscriber6@example.com');
+
     $productFactory = new WooCommerceProduct($i);
     $subscriptionProduct1 = $productFactory
       ->withName('Subscription 1')
@@ -43,23 +53,21 @@ class WooCommerceSubscriptionsSegmentCest {
       ->withPrice(20)
       ->create();
 
-    $userFactory = new User();
-    $subscriber1 = $userFactory->createUser('Sub Scriber1', 'subscriber', 'subscriber1@example.com');
-    $subscriber2 = $userFactory->createUser('Sub Scriber2', 'subscriber', 'subscriber2@example.com');
-    $userFactory->createUser('Sub Scriber3', 'subscriber', 'subscriber3@example.com');
-    $userFactory->createUser('Sub Scriber4', 'subscriber', 'subscriber4@example.com');
-
     $subscriptionFactory = new WooCommerceSubscription();
     $subscriptionFactory->createSubscription($subscriber1->ID, $subscriptionProduct1['id']);
     $subscriptionFactory->createSubscription($subscriber2->ID, $subscriptionProduct1['id']);
     $subscriptionFactory->createSubscription($subscriber2->ID, $subscriptionProduct2['id']);
+    $subscriptionFactory->createSubscription($subscriber3->ID, $subscriptionProduct1['id'], 'expired');
+    $subscriptionFactory->createSubscription($subscriber4->ID, $subscriptionProduct2['id'], 'cancelled');
+    $subscriptionFactory->createSubscription($subscriber5->ID, $subscriptionProduct1['id'], 'expired');
+    $subscriptionFactory->createSubscription($subscriber6->ID, $subscriptionProduct2['id'], 'cancelled');
 
     $segmentActionSelectElement = '[data-automation-id="select-segment-action"]';
     $operatorSelectElement = '[data-automation-id="select-operator"]';
     $segmentTitle = 'Woo Active Subscriptions';
-    $i->wantTo('Create dynamic segment for subscriptions');
+
     $i->login();
-    $i->amOnMailpoetPage('Segments');
+    $i->amOnMailpoetPage('Lists');
     $i->click('[data-automation-id="new-segment"]');
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], 'Desc ' . $segmentTitle);
@@ -70,16 +78,18 @@ class WooCommerceSubscriptionsSegmentCest {
 
     // Check for none of
     $i->selectOption($operatorSelectElement, 'none of');
-    $i->waitForText('This segment has 3 subscribers.'); // subscriber3@example.com, subscriber4@example.com, and admin user
+    $i->waitForText('This segment has 5 subscribers.'); // subscriber3, subscriber4, subscriber5, subscriber6 and admin user
     // Check for all of
     $i->selectOption($operatorSelectElement, 'all of');
-    $i->waitForText('This segment has 1 subscribers.'); // subscriber2@example.com
+    $i->waitForText('This segment has 1 subscribers.'); // subscriber2
     // Check for any of
-    $i->selectOption($operatorSelectElement, 'any of'); // subscriber2@example.com and subscriber1@example.com
+    $i->selectOption($operatorSelectElement, 'any of'); // subscriber2 and subscriber1
     $i->waitForText('This segment has 2 subscribers.');
 
     $i->seeNoJSErrors();
+
     $i->click('Save');
+
     $i->wantTo('Check that segment contains correct subscribers');
     $i->waitForElement('[data-automation-id="filters_all"]');
     $i->waitForText($segmentTitle);
@@ -89,7 +99,9 @@ class WooCommerceSubscriptionsSegmentCest {
 
     $i->wantTo('Check that MailPoet plugin works when admin disables WooCommerce Subscriptions');
     $i->deactivateWooCommerceSubscriptions();
-    $i->amOnMailpoetPage('Segments');
+    $i->amOnMailpoetPage('Lists');
+    $i->waitForElement('[data-automation-id="dynamic-segments-tab"]');
+    $i->click('[data-automation-id="dynamic-segments-tab"]');
     $i->waitForText($segmentTitle);
     $i->canSee('Activate the WooCommerce Subscriptions plugin to see the number of subscribers and enable the editing of this segment.');
 


### PR DESCRIPTION
## Description

Improved the existing test case by adding expired and cancelled subscriptions to the test.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5330]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5330]: https://mailpoet.atlassian.net/browse/MAILPOET-5330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ