### PR TITLE
On or (after|before) segment filters [MAILPOET-5012]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/date_fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/date_fields.tsx
@@ -15,6 +15,8 @@ export enum DateOperator {
   BEFORE = 'before',
   AFTER = 'after',
   ON = 'on',
+  ON_OR_BEFORE = 'onOrBefore',
+  ON_OR_AFTER = 'onOrAfter',
   NOT_ON = 'notOn',
   IN_THE_LAST = 'inTheLast',
   NOT_IN_THE_LAST = 'notInTheLast',
@@ -24,6 +26,8 @@ const availableOperators = [
   DateOperator.BEFORE,
   DateOperator.AFTER,
   DateOperator.ON,
+  DateOperator.ON_OR_AFTER,
+  DateOperator.ON_OR_BEFORE,
   DateOperator.NOT_ON,
   DateOperator.IN_THE_LAST,
   DateOperator.NOT_IN_THE_LAST,
@@ -66,6 +70,8 @@ export function DateFields({ filterIndex }: FilterProps): JSX.Element {
       (segment.operator === DateOperator.BEFORE ||
         segment.operator === DateOperator.AFTER ||
         segment.operator === DateOperator.ON ||
+        segment.operator === DateOperator.ON_OR_AFTER ||
+        segment.operator === DateOperator.ON_OR_BEFORE ||
         segment.operator === DateOperator.NOT_ON) &&
       (parseDate(segment.value) === undefined ||
         !/^\d+-\d+-\d+$/.test(segment.value))
@@ -95,9 +101,15 @@ export function DateFields({ filterIndex }: FilterProps): JSX.Element {
         }}
       >
         <option value={DateOperator.BEFORE}>{MailPoet.I18n.t('before')}</option>
-        <option value={DateOperator.AFTER}>{MailPoet.I18n.t('after')}</option>
+        <option value={DateOperator.ON_OR_BEFORE}>
+          {MailPoet.I18n.t('onOrBefore')}
+        </option>
         <option value={DateOperator.ON}>{MailPoet.I18n.t('on')}</option>
         <option value={DateOperator.NOT_ON}>{MailPoet.I18n.t('notOn')}</option>
+        <option value={DateOperator.ON_OR_AFTER}>
+          {MailPoet.I18n.t('onOrAfter')}
+        </option>
+        <option value={DateOperator.AFTER}>{MailPoet.I18n.t('after')}</option>
         <option value={DateOperator.IN_THE_LAST}>
           {MailPoet.I18n.t('inTheLast')}
         </option>
@@ -108,6 +120,8 @@ export function DateFields({ filterIndex }: FilterProps): JSX.Element {
       {(segment.operator === DateOperator.BEFORE ||
         segment.operator === DateOperator.AFTER ||
         segment.operator === DateOperator.ON ||
+        segment.operator === DateOperator.ON_OR_AFTER ||
+        segment.operator === DateOperator.ON_OR_BEFORE ||
         segment.operator === DateOperator.NOT_ON) && (
         <Datepicker
           dateFormat="MMM d, yyyy"
@@ -151,6 +165,8 @@ export function validateDateField(formItems: DateFormItem): boolean {
       DateOperator.AFTER,
       DateOperator.ON,
       DateOperator.NOT_ON,
+      DateOperator.ON_OR_BEFORE,
+      DateOperator.ON_OR_AFTER,
     ].includes(formItems.operator as DateOperator)
   ) {
     const re = /^\d+-\d+-\d+$/;

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
@@ -10,6 +10,8 @@ class DateFilterHelper {
   const BEFORE = 'before';
   const AFTER = 'after';
   const ON = 'on';
+  const ON_OR_BEFORE = 'onOrBefore';
+  const ON_OR_AFTER = 'onOrAfter';
   const NOT_ON = 'notOn';
   const IN_THE_LAST = 'inTheLast';
   const NOT_IN_THE_LAST = 'notInTheLast';
@@ -26,6 +28,8 @@ class DateFilterHelper {
       self::BEFORE,
       self::AFTER,
       self::ON,
+      self::ON_OR_BEFORE,
+      self::ON_OR_AFTER,
       self::NOT_ON,
     ];
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedDate.php
@@ -26,20 +26,29 @@ class SubscriberSubscribedDate implements Filter {
     $parameter = 'date' . $parameterSuffix;
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $value);
 
-    if ($operator === DateFilterHelper::BEFORE) {
-      $queryBuilder->andWhere("DATE(last_subscribed_at) < :$parameter");
-    } elseif ($operator === DateFilterHelper::AFTER) {
-      $queryBuilder->andWhere("DATE(last_subscribed_at) > :$parameter");
-    } elseif ($operator === DateFilterHelper::ON) {
-      $queryBuilder->andWhere("DATE(last_subscribed_at) = :$parameter");
-    } elseif ($operator === DateFilterHelper::NOT_ON) {
-      $queryBuilder->andWhere("DATE(last_subscribed_at) != :$parameter");
-    } elseif ($operator === DateFilterHelper::IN_THE_LAST) {
-      $queryBuilder->andWhere("DATE(last_subscribed_at) >= :$parameter");
-    } elseif ($operator === DateFilterHelper::NOT_IN_THE_LAST) {
-      $queryBuilder->andWhere("DATE(last_subscribed_at) < :$parameter");
-    } else {
-      throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
+    switch ($operator) {
+      case DateFilterHelper::BEFORE:
+      case DateFilterHelper::NOT_IN_THE_LAST:
+        $queryBuilder->andWhere("DATE(last_subscribed_at) < :$parameter");
+        break;
+      case DateFilterHelper::AFTER:
+        $queryBuilder->andWhere("DATE(last_subscribed_at) > :$parameter");
+        break;
+      case DateFilterHelper::ON:
+        $queryBuilder->andWhere("DATE(last_subscribed_at) = :$parameter");
+        break;
+      case DateFilterHelper::ON_OR_BEFORE:
+        $queryBuilder->andWhere("DATE(last_subscribed_at) <= :$parameter");
+        break;
+      case DateFilterHelper::NOT_ON:
+        $queryBuilder->andWhere("DATE(last_subscribed_at) != :$parameter");
+        break;
+      case DateFilterHelper::IN_THE_LAST:
+      case DateFilterHelper::ON_OR_AFTER:
+        $queryBuilder->andWhere("DATE(last_subscribed_at) >= :$parameter");
+        break;
+      default:
+        throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }
     $queryBuilder->setParameter($parameter, $date);
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -58,11 +58,15 @@ class WooCommercePurchaseDate implements Filter {
         break;
       case DateFilterHelper::IN_THE_LAST:
       case DateFilterHelper::NOT_IN_THE_LAST:
+      case DateFilterHelper::ON_OR_AFTER:
         $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) >= :$dateParam");
         break;
       case DateFilterHelper::ON:
       case DateFilterHelper::NOT_ON:
         $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) = :$dateParam");
+        break;
+      case DateFilterHelper::ON_OR_BEFORE:
+        $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) <= :$dateParam");
         break;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedDateTest.php
@@ -59,6 +59,18 @@ class SubscriberSubscribedDateTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['e123@example.com'], $emails);
   }
 
+  public function testGetOnOrBefore(): void {
+    $segmentFilterData = $this->getSegmentFilterData('onOrBefore', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e123@example.com', 'e1234@example.com', 'e12345@example.com'], $emails);
+  }
+
+  public function testGetOnOrAfter(): void {
+    $segmentFilterData = $this->getSegmentFilterData('onOrAfter', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['e1@example.com', 'e12@example.com', 'e123@example.com'], $emails);
+  }
+
   public function testGetNotOn(): void {
     $segmentFilterData = $this->getSegmentFilterData('notOn', CarbonImmutable::now()->subDays(2)->format('Y-m-d'));
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -86,6 +86,30 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
     expect($emails)->equals(['c2@example.com']);
   }
 
+  public function testOnOrAfterDate(): void {
+    $customerId1 = $this->tester->createCustomer('c1@example.com');
+    $customerId2 = $this->tester->createCustomer('c2@example.com');
+    $customerId3 = $this->tester->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-01-01'));
+    $this->createOrder($customerId2, new Carbon('2023-01-02'));
+    $this->createOrder($customerId3, new Carbon('2023-01-03'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('onOrAfter', '2023-01-02');
+    expect(count($emails))->equals(2);
+    expect($emails)->equals(['c2@example.com', 'c3@example.com']);
+  }
+
+  public function testOnOrBeforeDate(): void {
+    $customerId1 = $this->tester->createCustomer('c1@example.com');
+    $customerId2 = $this->tester->createCustomer('c2@example.com');
+    $customerId3 = $this->tester->createCustomer('c3@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-01-01'));
+    $this->createOrder($customerId2, new Carbon('2023-01-02'));
+    $this->createOrder($customerId3, new Carbon('2023-01-03'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('onOrBefore', '2023-01-02');
+    expect(count($emails))->equals(2);
+    expect($emails)->equals(['c1@example.com', 'c2@example.com']);
+  }
+
   public function testNotOn(): void {
     $customerId1 = $this->tester->createCustomer('c1@example.com');
     $customerId2 = $this->tester->createCustomer('c2@example.com');

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -137,7 +137,8 @@
   'after': _x('after', 'Meaning: "Subscriber subscribed after April'),
   'onOrBefore': __('on or before'),
   'on': _x('on', 'Meaning: "Subscriber subscribed on a given date"'),
-  'onOrAfter': __('on or after'),  'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
+  'onOrAfter': __('on or after'),
+  'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
   'inTheLast': _x('in the last', 'Meaning: "Subscriber subscribed in the last 3 days"'),
   'notInTheLast': _x('not in the last', 'Meaning: "Subscriber subscribed not in the last 3 days"'),
 

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -135,8 +135,9 @@
 
   'before': _x('before', 'Meaning: "Subscriber subscribed before April"'),
   'after': _x('after', 'Meaning: "Subscriber subscribed after April'),
+  'onOrBefore': __('on or before'),
   'on': _x('on', 'Meaning: "Subscriber subscribed on a given date"'),
-  'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
+  'onOrAfter': __('on or after'),  'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
   'inTheLast': _x('in the last', 'Meaning: "Subscriber subscribed in the last 3 days"'),
   'notInTheLast': _x('not in the last', 'Meaning: "Subscriber subscribed not in the last 3 days"'),
 


### PR DESCRIPTION
## Description

This PR adds two new options, `on or before` and `on or after`, to the existing date based filters, Subscribed Date and Purchase Date.

## Code review notes

For the new translations, I didn't use `_x` like the other similar translations because my understanding is that isn't a best practice. I'm wondering if I should convert the existing `_x` translations to `__` or if I should just leave them as is (which is what I did) to avoid having to re-translate them.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5012

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
