### PR TITLE
Add support default value for subscriber's custom fields shortcode [MAILPOET-5463]

### DIFF
--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -64,7 +64,9 @@ class Subscriber implements CategoryInterface {
             'subscriber' => $subscriber,
             'customField' => $customField[1],
           ]);
-          return ($customField instanceof SubscriberCustomFieldEntity) ? $customField->getValue() : null;
+          return ($customField instanceof SubscriberCustomFieldEntity && !empty($customField->getValue()))
+            ? htmlspecialchars($customField->getValue())
+            : $defaultValue;
         }
         return null;
     }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -258,7 +258,11 @@ class ShortcodesTest extends \MailPoetTest {
     $result = $shortcodesObject->process(
       ['[subscriber:cf_' . $customField->getId() . ']']
     );
-    expect($result[0])->null();
+    expect($result[0])->equals('');
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ' | default:custom field value]']
+    );
+    expect($result[0])->equals('custom field value');
     $subscriberCustomField = new SubscriberCustomFieldEntity($subscriber, $customField, 'custom_field_value');
     $this->entityManager->persist($subscriberCustomField);
     $this->entityManager->flush();


### PR DESCRIPTION
## Description

This pull request adds the default value support to the subscriber custom field shortcode because we want to unify the behavior of all subscriber shortcodes.

## Code review notes

_N/A_

## QA notes

1. Create a subscriber custom field
2. Add shortcode `[subscriber:cf_x | default:some value]` to a newsletter (`x` is id of the custom field)
3. Send the newsletter to two different subscribers
  a. Subscriber with filled custom field
  b. Subscriber without a custom field
4. Check received emails
  a. The first email should contain rendered custom field value
  b. The second email should contain rendered `some value`

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5463]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5463]: https://mailpoet.atlassian.net/browse/MAILPOET-5463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ