### PR TITLE
Improve the test switching language

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -4,12 +4,55 @@ namespace MailPoet\Test\Acceptance;
 
 use AcceptanceTester;
 use Codeception\Exception\ElementNotFound;
+use MailPoet\Test\DataFactories\Automation;
+use MailPoet\Test\DataFactories\Form;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
 use Throwable;
 
 class SwitchingLanguagesCest {
+  public function _before(\AcceptanceTester $i) {
+    $i->wantToTest('Prepare data for testing');
+
+    $segmentFactory = new Segment();
+    $segment = $segmentFactory
+      ->withName('Simple segment')
+      ->create();
+
+    $emailSubject = 'Simple newsletter';
+    $newsletter = new Newsletter();
+    $newsletter
+      ->withSendingQueue()
+      ->withSubject($emailSubject)
+      ->withSegments([$segment])
+      ->withSentStatus()
+      ->create();
+
+    $automation = new Automation();
+    $automation
+      ->withName('Simple automation')
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withMeta('mailpoet:run-once-per-subscriber', false)
+      ->withStatusActive()
+      ->create();
+
+    $form = new Form();
+    $form->withName('Simple form')
+      ->withDisplayBelowPosts()
+      ->create();
+
+    $subscriber = new Subscriber();
+    $subscriber
+      ->withEmail('test@example.com')
+      ->withStatus('unconfirmed')
+      ->create();
+  }
+
   public function switchLanguage(AcceptanceTester $i): void {
     // We don't want to run the test on release branch because in our release process
-    // the language packs are not prepared at the time we crate the branch
+    // the language packs are not prepared at the time we create the branch
     if (getenv('CIRCLE_BRANCH') === 'release') {
       return;
     }
@@ -24,9 +67,9 @@ class SwitchingLanguagesCest {
     $i->wantTo('Update translations to make sure strings are downloaded');
 
     // translations may not be scheduled for update yet, retry multiple times in that case
-    for ($attemtps = 0; $attemtps < 5; $attemtps++) {
+    for ($attempts = 0; $attempts < 5; $attempts++) {
       try {
-        $i->wait($attemtps);
+        $i->wait($attempts);
         $i->amOnAdminPage('update-core.php');
         $i->waitForText('WordPress-Aktualisierungen');
         // Wait before clicking the update button to prevent triggering too many requests too translate.wordpress.com within one second
@@ -50,18 +93,73 @@ class SwitchingLanguagesCest {
     $i->waitForText('Listen');
     $i->waitForText('Einstellungen');
     $i->waitForText('Hilfe');
+    $i->waitForText('Neue E-Mail');
 
-    $i->wantTo('Check email listing strings (translated with MailPoet.i18n)');
+    $i->wantTo('Check Emails filter strings');
+    $i->waitForText('Alle');
+    $i->waitForText('Entwurf');
+    $i->waitForText('Geplant');
+    $i->waitForText('Senden');
+    $i->waitForText('Gesendet');
+
+    $i->wantTo('Check Emails listing strings (translated with MailPoet.i18n)');
+    $i->waitForText('Geklickt, Geöffnet');
     $i->waitForText('Newsletter');
     $i->waitForText('Willkommens-E-Mail');
-    $i->waitForText('Benachrichtigung über neueste Beiträge');
+    $i->waitForText('Beitrags-Benachrichtigungen');
     $i->waitForText('Wiederaufnahme-E-Mails');
 
-    $i->wantTo('Check automation templates strings (translated with @wordpress/i18n)');
-    $i->amOnMailpoetPage('automation-templates');
-    $i->waitForText('Wähle dein Automatisierungstemplate');
-    $i->waitForText('Von Grund');
-    $i->waitForText('Von Grund auf neu erstellen');
+    $i->wantTo('Check Automation listing strings (translated with @wordpress/i18n)');
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Erstelle deine eigenen Automatisierungen');
+    $i->waitForText('Neue Automatisierung');
+    $i->waitForText('Wesentliche Dinge erforschen');
+    $i->waitForText('Bearbeiten');
+    $i->waitForText('Eingetragen');
+    $i->waitForText('Aktiv');
+
+    $i->wantTo('Check some Forms page strings');
+    $i->amOnMailpoetPage('forms');
+    $i->waitForText('Neues Formular');
+    $i->waitForText('Unterhalb der Seiten');
+    $i->waitForText('Registrierungen');
+    $i->waitForText('Änderungsdatum');
+
+    $i->wantTo('Check Subscribers filter strings and button');
+    $i->amOnMailpoetPage('subscribers');
+    $i->waitForText('Neu hinzufügen');
+    $i->waitForText('Alle');
+    $i->waitForText('Eingetragen');
+    $i->waitForText('Unbestätigt');
+    $i->waitForText('Ausgetragen');
+    $i->waitForText('Inaktiv');
+    $i->waitForText('Bounced');
+
+    $i->wantTo('Check Subscribers listing strings');
+    $i->waitForText('Jetzt neu berechnen');
+    $i->waitForText('Abonnent');
+    $i->waitForText('Unbestätigt');
+    $i->waitForText('Schlagwörter');
+    $i->waitForText('Unbekannt');
+
+    $i->wantTo('Check some Lists strings');
+    $i->amOnMailpoetPage('lists');
+    $i->waitForText('Abonnenten in deinem Tarif');
+    $i->waitForText('Listen-Bewertung');
+    $i->waitForText('Neue Liste');
+    $i->waitForText('Ausgetragen');
+
+    $i->wantTo('Check Settings tabs strings');
+    $i->amOnMailpoetPage('settings');
+    $i->waitForText('Grundlagen');
+    $i->waitForText('Registrierungsbestätigung');
+    $i->waitForText('Senden mit ...');
+    $i->waitForText('Fortgeschritten');
+    $i->waitForText('Schlüssel-Aktivierung');
+
+    $i->wantTo('Check some Settings strings');
+    $i->waitForText('Standardabsender');
+    $i->waitForText('Einstellungen speichern');
   }
 
   public function _after(AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Improved the existing test for switching language to Deutsch.
This is now more closer and detailed way of verifying the new language, but in the same time not too much to avoid over-testing.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5331]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5331]: https://mailpoet.atlassian.net/browse/MAILPOET-5331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ