### PR TITLE
Add lifetime option to last days component [MAILPOET-4991]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
@@ -8,6 +8,7 @@ import {
   Timeframes,
 } from 'segments/dynamic/types';
 import { storeName } from 'segments/dynamic/store';
+import { useEffect } from 'react';
 import { isInEnum } from '../../../../utils';
 
 function replaceElementsInDaysSentence(
@@ -26,12 +27,14 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
   const { updateSegmentFilterFromEvent, updateSegmentFilter } =
     useDispatch(storeName);
 
-  if (!isInEnum(segment.timeframe, Timeframes)) {
-    void updateSegmentFilter(
-      { timeframe: Timeframes.IN_THE_LAST },
-      filterIndex,
-    );
-  }
+  useEffect(() => {
+    if (!isInEnum(segment.timeframe, Timeframes)) {
+      void updateSegmentFilter(
+        { timeframe: Timeframes.IN_THE_LAST },
+        filterIndex,
+      );
+    }
+  }, [segment, updateSegmentFilter, filterIndex]);
 
   const isInTheLast = segment.timeframe === Timeframes.IN_THE_LAST;
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
@@ -2,8 +2,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Input } from 'common';
 import { MailPoet } from 'mailpoet';
 import { Select } from 'common/form/select/select';
-import { DaysPeriodItem, FilterProps } from 'segments/dynamic/types';
+import {
+  DaysPeriodItem,
+  FilterProps,
+  Timeframes,
+} from 'segments/dynamic/types';
 import { storeName } from 'segments/dynamic/store';
+import { isInEnum } from '../../../../utils';
 
 function replaceElementsInDaysSentence(
   fn: (value) => JSX.Element,
@@ -21,11 +26,14 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
   const { updateSegmentFilterFromEvent, updateSegmentFilter } =
     useDispatch(storeName);
 
-  if (!['inTheLast', 'allTime'].includes(segment.timeframe)) {
-    void updateSegmentFilter({ timeframe: 'inTheLast' }, filterIndex);
+  if (!isInEnum(segment.timeframe, Timeframes)) {
+    void updateSegmentFilter(
+      { timeframe: Timeframes.IN_THE_LAST },
+      filterIndex,
+    );
   }
 
-  const isInTheLast = segment.timeframe === 'inTheLast';
+  const isInTheLast = segment.timeframe === Timeframes.IN_THE_LAST;
 
   return (
     <>
@@ -74,7 +82,7 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
 }
 
 export function validateDaysPeriod(formItems: DaysPeriodItem): boolean {
-  if (formItems.timeframe === 'allTime') {
+  if (isInEnum(formItems.timeframe, Timeframes)) {
     return true;
   }
   return !!formItems.days;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -80,6 +80,7 @@ export interface DateFormItem extends FormItem {
 
 export interface DaysPeriodItem extends FormItem {
   days?: string;
+  timeframe?: string;
 }
 
 export interface TextFormItem extends FormItem {
@@ -156,7 +157,8 @@ export type AnyFormItem =
   | WooCommerceFormItem
   | WooCommerceSubscriptionFormItem
   | WooCommerceMembershipFormItem
-  | EmailFormItem;
+  | EmailFormItem
+  | DaysPeriodItem;
 
 export interface SubscriberCount {
   count?: number;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -83,6 +83,11 @@ export interface DaysPeriodItem extends FormItem {
   timeframe?: string;
 }
 
+export enum Timeframes {
+  ALL_TIME = 'allTime',
+  IN_THE_LAST = 'inTheLast',
+}
+
 export interface TextFormItem extends FormItem {
   operator?: string;
   value?: string;

--- a/mailpoet/assets/js/src/utils.tsx
+++ b/mailpoet/assets/js/src/utils.tsx
@@ -1,0 +1,3 @@
+export function isInEnum<T>(value: unknown, enumObj: T): value is T[keyof T] {
+  return Object.values(enumObj).includes(value as T[keyof T]);
+}

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -43,6 +43,9 @@ class DynamicSegmentFilterData {
     DynamicSegmentFilterData::OPERATOR_NOT_ENDS_WITH,
   ];
 
+  public const TIMEFRAME_ALL_TIME = 'allTime';
+  public const TIMEFRAME_IN_THE_LAST = 'inTheLast';
+
   /**
    * @ORM\Column(type="serialized_array")
    * @var array|null

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -69,7 +69,7 @@ class FilterDataMapper {
   private function createFilter(array $filterData): DynamicSegmentFilterData {
     if (isset($filterData['days']) && !isset($filterData['timeframe'])) {
       // Backwards compatibility for filters created before time period component had "over all time" option
-      $filterData['timeframe'] = 'inTheLast';
+      $filterData['timeframe'] = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST;
     }
     switch ($this->getSegmentType($filterData)) {
       case DynamicSegmentFilterData::TYPE_AUTOMATIONS:
@@ -318,7 +318,7 @@ class FilterDataMapper {
       'opens' => $data['opens'],
       'days' => $data['days'] ?? 0,
       'operator' => $data['operator'] ?? 'more',
-      'timeframe' => $data['timeframe'] ?? 'inTheLast', // backwards compatibility
+      'timeframe' => $data['timeframe'] ?? DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, // backwards compatibility
       'connect' => $data['connect'],
     ];
     $filterType = DynamicSegmentFilterData::TYPE_EMAIL;
@@ -513,11 +513,11 @@ class FilterDataMapper {
   }
 
   private function validateDaysPeriodData(array $data): void {
-    if (!isset($data['timeframe']) || !in_array($data['timeframe'], ['allTime', 'inTheLast'], true)) {
+    if (!isset($data['timeframe']) || !in_array($data['timeframe'], [DynamicSegmentFilterData::TIMEFRAME_ALL_TIME, DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST], true)) {
       throw new InvalidFilterException('Missing timeframe type', InvalidFilterException::MISSING_VALUE);
     }
 
-    if ($data['timeframe'] === 'allTime') {
+    if ($data['timeframe'] === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
       return;
     }
 

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -316,7 +316,7 @@ class FilterDataMapper {
     $this->validateDaysPeriodData($data);
     $filterData = [
       'opens' => $data['opens'],
-      'days' => $data['days'],
+      'days' => $data['days'] ?? 0,
       'operator' => $data['operator'] ?? 'more',
       'timeframe' => $data['timeframe'] ?? 'inTheLast', // backwards compatibility
       'connect' => $data['connect'],
@@ -372,7 +372,7 @@ class FilterDataMapper {
       }
       $filterData['number_of_orders_type'] = $data['number_of_orders_type'];
       $filterData['number_of_orders_count'] = $data['number_of_orders_count'];
-      $filterData['days'] = $data['days'];
+      $filterData['days'] = $data['days'] ?? 0;
       $filterData['timeframe'] = $data['timeframe'];
     } elseif ($data['action'] === WooCommerceTotalSpent::ACTION_TOTAL_SPENT) {
       $this->validateDaysPeriodData($data);
@@ -384,7 +384,7 @@ class FilterDataMapper {
       }
       $filterData['total_spent_type'] = $data['total_spent_type'];
       $filterData['total_spent_amount'] = $data['total_spent_amount'];
-      $filterData['days'] = $data['days'];
+      $filterData['days'] = $data['days'] ?? 0;
       $filterData['timeframe'] = $data['timeframe'];
     } elseif ($data['action'] === WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE) {
       $this->validateDaysPeriodData($data);
@@ -396,7 +396,7 @@ class FilterDataMapper {
       }
       $filterData['single_order_value_type'] = $data['single_order_value_type'];
       $filterData['single_order_value_amount'] = $data['single_order_value_amount'];
-      $filterData['days'] = $data['days'];
+      $filterData['days'] = $data['days'] ?? 0;
       $filterData['timeframe'] = $data['timeframe'];
     } elseif ($data['action'] === WooCommercePurchaseDate::ACTION) {
       $filterData['operator'] = $data['operator'];
@@ -409,7 +409,7 @@ class FilterDataMapper {
       ) {
         throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_AVERAGE_SPENT_FIELDS);
       }
-      $filterData['days'] = $data['days'];
+      $filterData['days'] = $data['days'] ?? 0;
       $filterData['timeframe'] = $data['timeframe'];
       $filterData['average_spent_amount'] = $data['average_spent_amount'];
       $filterData['average_spent_type'] = $data['average_spent_type'];

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -34,7 +35,7 @@ class EmailOpensAbsoluteCountAction implements Filter {
     $statsTable = $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
 
-    if ($timeframe === 'allTime') {
+    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
       $queryBuilder->leftJoin(
         $subscribersTable,
         $statsTable,

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -27,15 +27,20 @@ class WooCommerceAverageSpent implements Filter {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('average_spent_type');
     $amount = $filterData->getParam('average_spent_amount');
-    $days = intval($filterData->getParam('days'));
+    $timeframe = $filterData->getParam('timeframe');
 
-    $date = Carbon::now()->subDays($days);
-    $dateParam = $this->filterHelper->getUniqueParameterName('date');
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
 
-    $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-      ->setParameter($dateParam, $date->toDateTimeString())
-      ->groupBy('inner_subscriber_id');
+    if ($timeframe !== 'allTime') {
+      $days = intval($filterData->getParam('days'));
+      $date = Carbon::now()->subDays($days);
+      $dateParam = $this->filterHelper->getUniqueParameterName('date');
+      $queryBuilder
+        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
+        ->setParameter($dateParam, $date->toDateTimeString());
+    }
+
+    $queryBuilder->groupBy('inner_subscriber_id');
 
     $amountParam = $this->filterHelper->getUniqueParameterName('amount');
     if ($operator === '=') {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -31,7 +32,7 @@ class WooCommerceAverageSpent implements Filter {
 
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
 
-    if ($timeframe !== 'allTime') {
+    if ($timeframe !== DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
       $days = intval($filterData->getParam('days'));
       $date = Carbon::now()->subDays($days);
       $dateParam = $this->filterHelper->getUniqueParameterName('date');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Util\DBCollationChecker;
@@ -39,7 +40,7 @@ class WooCommerceNumberOfOrders implements Filter {
     $filterData = $filter->getFilterData();
     $type = strval($filterData->getParam('number_of_orders_type'));
     $count = intval($filterData->getParam('number_of_orders_count'));
-    $isAllTime = $filterData->getParam('timeframe') === 'allTime';
+    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $collation = $this->collationChecker->getCollateIfNeeded(
       $subscribersTable,

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
@@ -23,7 +24,7 @@ class WooCommerceSingleOrderValue implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('single_order_value_type');
     $amount = $filterData->getParam('single_order_value_amount');
-    $isAllTime = $filterData->getParam('timeframe') === 'allTime';
+    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
 
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
@@ -23,18 +23,22 @@ class WooCommerceSingleOrderValue implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('single_order_value_type');
     $amount = $filterData->getParam('single_order_value_amount');
-    $days = $filterData->getParam('days');
-
-    if (!is_string($days)) {
-      $days = '1'; // Default to last day
-    }
-
-    $date = Carbon::now()->subDays((int)$days);
+    $isAllTime = $filterData->getParam('timeframe') === 'allTime';
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
-    $dateParam = "date_$parameterSuffix";
+
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-    $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-      ->setParameter($dateParam, $date->toDateTimeString());
+
+    if (!$isAllTime) {
+      $days = $filterData->getParam('days');
+      if (!is_string($days)) {
+        $days = '1'; // Default to last day
+      }
+      $date = Carbon::now()->subDays((int)$days);
+      $dateParam = "date_$parameterSuffix";
+      $queryBuilder
+        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
+        ->setParameter($dateParam, $date->toDateTimeString());
+    }
 
     if ($type === '=') {
       $queryBuilder->andWhere("$orderStatsAlias.total_sales = :amount" . $parameterSuffix);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
@@ -23,7 +24,7 @@ class WooCommerceTotalSpent implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('total_spent_type');
     $amount = $filterData->getParam('total_spent_amount');
-    $isAllTime = $filterData->getParam('timeframe') === 'allTime';
+    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
 
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -93,7 +93,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   }
 
   public function testGetMachineOpened(): void {
-    $segmentFilterData = $this->getSegmentFilterData(1, 'more', 5, 'inTheLast', EmailOpensAbsoluteCountAction::MACHINE_TYPE);
+    $segmentFilterData = $this->getSegmentFilterData(1, 'more', 5, DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, EmailOpensAbsoluteCountAction::MACHINE_TYPE);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
     $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com'], $emails);
   }
@@ -135,7 +135,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   }
 
   public function testOverAllTime() {
-    $segmentFilterData = $this->getSegmentFilterData(1000000, 'less', 0, 'allTime');
+    $segmentFilterData = $this->getSegmentFilterData(1000000, 'less', 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
     $this->assertEqualsCanonicalizing([
       'opened-3-newsletters@example.com',
@@ -145,7 +145,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     ], $emails);
   }
 
-  private function getSegmentFilterData(int $opens, string $operator, int $days, string $timeframe = 'inTheLast', string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {
+  private function getSegmentFilterData(int $opens, string $operator, int $days, string $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'operator' => $operator,
       'opens' => $opens,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -93,7 +93,7 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
   }
 
   public function testGetMachineOpened(): void {
-    $segmentFilterData = $this->getSegmentFilterData(1, 'more', 5, EmailOpensAbsoluteCountAction::MACHINE_TYPE);
+    $segmentFilterData = $this->getSegmentFilterData(1, 'more', 5, 'inTheLast', EmailOpensAbsoluteCountAction::MACHINE_TYPE);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
     $this->assertEqualsCanonicalizing(['opened-3-newsletters@example.com'], $emails);
   }
@@ -134,11 +134,23 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['opened-old-opens@example.com', 'opened-no-opens@example.com'], $emails);
   }
 
-  private function getSegmentFilterData(int $opens, string $operator, int $days, string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {
+  public function testOverAllTime() {
+    $segmentFilterData = $this->getSegmentFilterData(1000000, 'less', 0, 'allTime');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->action);
+    $this->assertEqualsCanonicalizing([
+      'opened-3-newsletters@example.com',
+      'opened-less-opens@example.com',
+      'opened-no-opens@example.com',
+      'opened-old-opens@example.com',
+    ], $emails);
+  }
+
+  private function getSegmentFilterData(int $opens, string $operator, int $days, string $timeframe = 'inTheLast', string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'operator' => $operator,
       'opens' => $opens,
       'days' => $days,
+      'timeframe' => $timeframe,
     ]);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -136,11 +136,11 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
     $this->createOrder($id1, 100, 3);
     $id1 = $this->tester->createCustomer('2@e.com');
     $this->createOrder($id1, 100, 30000);
-    $matchingEmails = $this->getMatchingEmails('>=', 50, 0, 'allTime');
+    $matchingEmails = $this->getMatchingEmails('>=', 50, 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com'], $matchingEmails);
   }
 
-  private function getMatchingEmails(string $operator, float $amount, int $days = 365, string $timeframe = 'inTheLast'): array {
+  private function getMatchingEmails(string $operator, float $amount, int $days = 365, string $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): array {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
       'average_spent_type' => $operator,
       'average_spent_amount' => $amount,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -131,11 +131,21 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
   }
 
-  private function getMatchingEmails(string $operator, float $amount, int $days = 365): array {
+  public function testItWorksWithAllTimeOption(): void {
+    $id1 = $this->tester->createCustomer('1@e.com');
+    $this->createOrder($id1, 100, 3);
+    $id1 = $this->tester->createCustomer('2@e.com');
+    $this->createOrder($id1, 100, 30000);
+    $matchingEmails = $this->getMatchingEmails('>=', 50, 0, 'allTime');
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com'], $matchingEmails);
+  }
+
+  private function getMatchingEmails(string $operator, float $amount, int $days = 365, string $timeframe = 'inTheLast'): array {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
       'average_spent_type' => $operator,
       'average_spent_amount' => $amount,
       'days' => $days,
+      'timeframe' => $timeframe,
     ]);
 
     return $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->averageSpentFilter);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -69,7 +69,7 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
   }
 
   public function testItWorksWithAllTimeTimeframe(): void {
-    $segmentFilterData = $this->getSegmentFilterData('>', 0, 0, 'allTime');
+    $segmentFilterData = $this->getSegmentFilterData('>', 0, 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
     $this->assertEqualsCanonicalizing([
       'customer1@example.com',
@@ -78,7 +78,7 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     ], $emails);
   }
 
-  private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days, $timeframe = 'inTheLast'): DynamicSegmentFilterData {
+  private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days, $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
       'number_of_orders_type' => $comparisonType,
       'number_of_orders_count' => $ordersCount,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -68,11 +68,22 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing([$createdSub->getEmail()], $emails);
   }
 
-  private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days): DynamicSegmentFilterData {
+  public function testItWorksWithAllTimeTimeframe(): void {
+    $segmentFilterData = $this->getSegmentFilterData('>', 0, 0, 'allTime');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing([
+      'customer1@example.com',
+      'customer2@example.com',
+      'customer3@example.com',
+    ], $emails);
+  }
+
+  private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days, $timeframe = 'inTheLast'): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
       'number_of_orders_type' => $comparisonType,
       'number_of_orders_count' => $ordersCount,
       'days' => $days,
+      'timeframe' => $timeframe,
     ]);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -48,7 +48,7 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
     $this->createOrder($customerId1, Carbon::now()->subDays(3));
     $this->createOrder($customerId2, Carbon::now()->subDays(4));
     $this->createOrder($customerId3, Carbon::now()->subDays(5));
-    $emails = $this->getSubscriberEmailsMatchingFilter('inTheLast', '5');
+    $emails = $this->getSubscriberEmailsMatchingFilter(DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, '5');
     expect(count($emails))->equals(2);
     $this->assertEqualsCanonicalizing(['c1@example.com', 'c2@example.com'], $emails);
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
@@ -63,11 +63,18 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['customer2@example.com', 'customer3@example.com'], $emails);
   }
 
-  private function getSegmentFilterData(string $type, float $amount, int $days): DynamicSegmentFilterData {
+  public function testItWorksWithLifetimeOption(): void {
+    $segmentFilterData = $this->getSegmentFilterData('<', 1000000000, 0, 'allTime');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->singleOrderValue);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
+  }
+
+  private function getSegmentFilterData(string $type, float $amount, int $days, $timeframe = 'inTheLast'): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE, [
       'single_order_value_type' => $type,
       'single_order_value_amount' => $amount,
       'days' => $days,
+      'timeframe' => $timeframe,
     ]);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
@@ -64,12 +64,12 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
   }
 
   public function testItWorksWithLifetimeOption(): void {
-    $segmentFilterData = $this->getSegmentFilterData('<', 1000000000, 0, 'allTime');
+    $segmentFilterData = $this->getSegmentFilterData('<', 1000000000, 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->singleOrderValue);
     $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
   }
 
-  private function getSegmentFilterData(string $type, float $amount, int $days, $timeframe = 'inTheLast'): DynamicSegmentFilterData {
+  private function getSegmentFilterData(string $type, float $amount, int $days, $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE, [
       'single_order_value_type' => $type,
       'single_order_value_amount' => $amount,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -71,12 +71,12 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
   }
 
   public function testItWorksWithAllTimeOption(): void {
-    $segmentFilterData = $this->getSegmentFilterData('<', 100000000000, 0, 'allTime');
+    $segmentFilterData = $this->getSegmentFilterData('<', 100000000000, 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
     $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
   }
 
-  private function getSegmentFilterData(string $type, float $amount, int $days, $timeframe = 'inTheLast'): DynamicSegmentFilterData {
+  private function getSegmentFilterData(string $type, float $amount, int $days, $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT, [
       'total_spent_type' => $type,
       'total_spent_amount' => $amount,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -70,10 +70,17 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
   }
 
-  private function getSegmentFilterData(string $type, float $amount, int $days): DynamicSegmentFilterData {
+  public function testItWorksWithAllTimeOption(): void {
+    $segmentFilterData = $this->getSegmentFilterData('<', 100000000000, 0, 'allTime');
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
+  }
+
+  private function getSegmentFilterData(string $type, float $amount, int $days, $timeframe = 'inTheLast'): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT, [
       'total_spent_type' => $type,
       'total_spent_amount' => $amount,
+      'timeframe' => $timeframe,
       'days' => $days,
     ]);
   }

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -314,7 +314,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getData())->equals([
       'opens' => 5,
       'days' => 3,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
       'operator' => 'more',
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
@@ -358,7 +358,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getData())->equals([
       'opens' => 5,
       'days' => 3,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
       'operator' => 'less',
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
@@ -369,7 +369,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailOpensAbsoluteCountAction::TYPE,
       'days' => 3,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
     ]]];
     $this->expectException(InvalidFilterException::class);
     $this->mapper->map($data);
@@ -392,7 +392,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'number_of_orders_type' => '=',
       'number_of_orders_count' => 2,
       'days' => 1,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
       'some_mess' => 'mess',
     ]]];
 
@@ -420,7 +420,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
       'days' => 2,
     ]]]);
   }
@@ -432,7 +432,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'single_order_value_type' => '=',
       'single_order_value_amount' => 20,
       'days' => 7,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
       'some_mess' => 'mess',
     ]]];
 
@@ -461,7 +461,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE,
       'days' => 2,
-      'timeframe' => 'inTheLast',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
     ]]]);
   }
 

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -314,6 +314,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getData())->equals([
       'opens' => 5,
       'days' => 3,
+      'timeframe' => 'inTheLast',
       'operator' => 'more',
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
@@ -357,6 +358,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getData())->equals([
       'opens' => 5,
       'days' => 3,
+      'timeframe' => 'inTheLast',
       'operator' => 'less',
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
@@ -367,6 +369,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
       'action' => EmailOpensAbsoluteCountAction::TYPE,
       'days' => 3,
+      'timeframe' => 'inTheLast',
     ]]];
     $this->expectException(InvalidFilterException::class);
     $this->mapper->map($data);
@@ -389,6 +392,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'number_of_orders_type' => '=',
       'number_of_orders_count' => 2,
       'days' => 1,
+      'timeframe' => 'inTheLast',
       'some_mess' => 'mess',
     ]]];
 
@@ -416,6 +420,8 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS,
+      'timeframe' => 'inTheLast',
+      'days' => 2,
     ]]]);
   }
 
@@ -426,6 +432,7 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
       'single_order_value_type' => '=',
       'single_order_value_amount' => 20,
       'days' => 7,
+      'timeframe' => 'inTheLast',
       'some_mess' => 'mess',
     ]]];
 
@@ -453,6 +460,8 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE,
+      'days' => 2,
+      'timeframe' => 'inTheLast',
     ]]]);
   }
 

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -107,7 +107,7 @@
   'emailActionMachineOpensAbsoluteCount': __('number of machine-opens'),
   'emailActionOpens': __('opens'),
   'emailActionOpensSentence': _x('{condition} {opens} opens', 'The result will be "more than 20 opens"'),
-  'emailActionOpensDaysSentence': _x('in the last {days} days', 'The result will be "in the last 5 days"'),
+  'emailActionOpensDaysSentence': _x('{timeframe} {days} days', 'The result will be "in the last 5 days"'),
   'moreThan': __('more than'),
   'lessThan': __('less than'),
   'higherThan': __('higher than'),
@@ -147,6 +147,7 @@
   'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
   'inTheLast': _x('in the last', 'Meaning: "Subscriber subscribed in the last 3 days"'),
   'notInTheLast': _x('not in the last', 'Meaning: "Subscriber subscribed not in the last 3 days"'),
+  'overAllTime': __('over all time'),
 
   'emailActionNotOpened': _x('not opened', 'Dynamic segment creation: when newsletter was not opened'),
   'emailActionClicked': _x('clicked', 'Dynamic segment creation: when a newsletter link was clicked'),


### PR DESCRIPTION
## Description

This PR changes the dynamic segment filter text  `in the last` for all filters that use the 'in the last X days' component to a select that allows a user to select either `in the last` or `over all time`. If `over all time` is selected, the days input disappears, and the filter should include subscribers regardless of the dates involved.

This affects the following filters:

- number of opens
- number of machine opens
- average order value
- number of orders
- single order value
- total spent

## Code review notes

_N/A_

## QA notes

It's very important that this change doesn't affect any current filters. It should be fully backwards compatible, so please make sure that filters created prior to installing this version of the plugin continue to work exactly as they did before.

## Linked PRs

~This is based on the branch https://github.com/mailpoet/mailpoet/pull/5045 and should not be merged until after that one.~

Update: the blocker PR has been merged.

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-4991

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
