### PR TITLE
Fix missing translations [MAILPOET-5468]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/subscriber/custom_fields/date.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/subscriber/custom_fields/date.tsx
@@ -1,9 +1,9 @@
+import { __, _x } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { assign, range } from 'lodash/fp';
 import { format, getYear, isValid, parseISO } from 'date-fns';
 import { useSelect, useDispatch } from '@wordpress/data';
 
-import { MailPoet } from 'mailpoet';
 import { Select } from 'common/form/select/select';
 import { Grid } from 'common/grid';
 import { Datepicker } from 'common/datepicker/datepicker';
@@ -32,20 +32,18 @@ function DateMonth({ onChange, item, filterIndex }: ComponentProps) {
         onChange(assign(item, { value: e.target.value }), filterIndex);
       }}
     >
-      <option value="2017-01-01 00:00:00">{MailPoet.I18n.t('january')}</option>
-      <option value="2017-02-01 00:00:00">{MailPoet.I18n.t('february')}</option>
-      <option value="2017-03-01 00:00:00">{MailPoet.I18n.t('march')}</option>
-      <option value="2017-04-01 00:00:00">{MailPoet.I18n.t('april')}</option>
-      <option value="2017-05-01 00:00:00">{MailPoet.I18n.t('may')}</option>
-      <option value="2017-06-01 00:00:00">{MailPoet.I18n.t('june')}</option>
-      <option value="2017-07-01 00:00:00">{MailPoet.I18n.t('july')}</option>
-      <option value="2017-08-01 00:00:00">{MailPoet.I18n.t('august')}</option>
-      <option value="2017-09-01 00:00:00">
-        {MailPoet.I18n.t('september')}
-      </option>
-      <option value="2017-10-01 00:00:00">{MailPoet.I18n.t('october')}</option>
-      <option value="2017-11-01 00:00:00">{MailPoet.I18n.t('november')}</option>
-      <option value="2017-12-01 00:00:00">{MailPoet.I18n.t('december')}</option>
+      <option value="2017-01-01 00:00:00">{__('january', 'mailpoet')}</option>
+      <option value="2017-02-01 00:00:00">{__('february', 'mailpoet')}</option>
+      <option value="2017-03-01 00:00:00">{__('march', 'mailpoet')}</option>
+      <option value="2017-04-01 00:00:00">{__('april', 'mailpoet')}</option>
+      <option value="2017-05-01 00:00:00">{__('may', 'mailpoet')}</option>
+      <option value="2017-06-01 00:00:00">{__('june', 'mailpoet')}</option>
+      <option value="2017-07-01 00:00:00">{__('july', 'mailpoet')}</option>
+      <option value="2017-08-01 00:00:00">{__('august', 'mailpoet')}</option>
+      <option value="2017-09-01 00:00:00">{__('september', 'mailpoet')}</option>
+      <option value="2017-10-01 00:00:00">{__('october', 'mailpoet')}</option>
+      <option value="2017-11-01 00:00:00">{__('november', 'mailpoet')}</option>
+      <option value="2017-12-01 00:00:00">{__('december', 'mailpoet')}</option>
     </Select>
   );
 }
@@ -73,9 +71,21 @@ function DateYear({ onChange, item, filterIndex }: ComponentProps) {
           onChange(assign(item, { operator: e.target.value }), filterIndex);
         }}
       >
-        <option value="equals">{MailPoet.I18n.t('equals')}</option>
-        <option value="before">{MailPoet.I18n.t('before')}</option>
-        <option value="after">{MailPoet.I18n.t('after')}</option>
+        <option value="equals">{__('equals', 'mailpoet')}</option>
+        <option value="before">
+          {_x(
+            'before',
+            'Meaning: "Subscriber subscribed before April"',
+            'mailpoet',
+          )}
+        </option>
+        <option value="after">
+          {_x(
+            'after',
+            'Meaning: "Subscriber subscribed after April',
+            'mailpoet',
+          )}
+        </option>
       </Select>
       <Select
         key="select-year"
@@ -139,9 +149,21 @@ function DateFullDate({ onChange, item, filterIndex }: ComponentProps) {
           onChange(assign(item, { operator: e.target.value }), filterIndex);
         }}
       >
-        <option value="equals">{MailPoet.I18n.t('equals')}</option>
-        <option value="before">{MailPoet.I18n.t('before')}</option>
-        <option value="after">{MailPoet.I18n.t('after')}</option>
+        <option value="equals">{__('equals', 'mailpoet')}</option>
+        <option value="before">
+          {_x(
+            'before',
+            'Meaning: "Subscriber subscribed before April"',
+            'mailpoet',
+          )}
+        </option>
+        <option value="after">
+          {_x(
+            'after',
+            'Meaning: "Subscriber subscribed after April',
+            'mailpoet',
+          )}
+        </option>
       </Select>
       <Datepicker
         dateFormat="MMM d, yyyy"
@@ -179,9 +201,21 @@ function DateMonthYear({ onChange, item, filterIndex }: ComponentProps) {
           onChange(assign(item, { operator: e.target.value }), filterIndex);
         }}
       >
-        <option value="equals">{MailPoet.I18n.t('equals')}</option>
-        <option value="before">{MailPoet.I18n.t('before')}</option>
-        <option value="after">{MailPoet.I18n.t('after')}</option>
+        <option value="equals">{__('equals', 'mailpoet')}</option>
+        <option value="before">
+          {_x(
+            'before',
+            'Meaning: "Subscriber subscribed before April"',
+            'mailpoet',
+          )}
+        </option>
+        <option value="after">
+          {_x(
+            'after',
+            'Meaning: "Subscriber subscribed after April',
+            'mailpoet',
+          )}
+        </option>{' '}
       </Select>
       <Datepicker
         onChange={(value): void =>


### PR DESCRIPTION
## Description

Currently translations are missing for month names for dynamic segment custom fields that use the "month" format of the date field. I'm guessing this isn't a very common type of custom field.

## Code review notes

I opted to migrate all the translations in this file to `@wordpress/i18n`, but I'm not sure if we should be gradually doing that or if there's a plan to tackle everything at once at some point. If it would be better to stick to `MailPoet.I18n` for now I'm happy to revise this.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
https://mailpoet.atlassian.net/browse/MAILPOET-5468

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
