### PR TITLE
Add notice when premium features for key are available [MAILPOET-5429]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -260,4 +260,5 @@ interface Window {
     subscribers: string;
     type: 'default' | 'wp_users' | 'woocommerce_users' | 'dynamic';
   }>;
+  mailpoet_admin_plugins_url: string;
 }

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -83,6 +83,7 @@ export const MailPoet = {
     window.mailpoet_transactional_emails_opt_in_notice_dismissed,
   mailFunctionEnabled: window.mailpoet_mail_function_enabled,
   corrupt_newsletters: window.corrupt_newsletters ?? [],
+  adminPluginsUrl: window.mailpoet_admin_plugins_url,
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/page.tsx
@@ -14,7 +14,7 @@ import { ErrorBoundary } from 'common';
 import { NewsletterGeneralStats } from './newsletter_general_stats';
 import { NewsletterType } from './newsletter_type';
 import { NewsletterStatsInfo } from './newsletter_stats_info';
-import { PremiumBanner } from './premium_banner.jsx';
+import { PremiumBanner } from './premium_banner';
 
 type Props = {
   match: {

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.jsx
@@ -5,33 +5,69 @@ import { PremiumRequired } from 'common/premium_required/premium_required';
 import { withBoundary } from '../../common';
 
 function SkipDisplayingDetailedStats() {
-  const ctaButton = (
-    <Button
-      href={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
-        MailPoet.subscribersCount,
-        MailPoet.currentWpUserEmail,
-        'starter',
-        { utm_medium: 'stats', utm_campaign: 'signup' },
-      )}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {__('Upgrade', 'mailpoet')}
-    </Button>
-  );
+  let ctaButton;
+  let description;
 
-  const description = (
-    <p>
-      {__(
-        'Learn more about your subscribers and optimize your campaigns. See who opened your emails, which links they clicked, and then use the data to make your emails even better. And if you run a WooCommerce store, you’ll also see the revenue earned per email. All starting $10 per month.',
-        'mailpoet',
-      )}{' '}
-      <a href="admin.php?page=mailpoet-upgrade">
-        {__('Learn more', 'mailpoet')}
-      </a>
-      .
-    </p>
-  );
+  if (
+    MailPoet.hasValidPremiumKey &&
+    (!MailPoet.isPremiumPluginInstalled || !MailPoet.premiumActive)
+  ) {
+    description = (
+      <p>
+        {__(
+          'Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.',
+          'mailpoet',
+        )}
+      </p>
+    );
+    ctaButton = (
+      <Button
+        href={MailPoet.premiumPluginActivationUrl}
+        rel="noopener noreferrer"
+      >
+        {__('Activate MailPoet Premium plugin', 'mailpoet')}
+      </Button>
+    );
+    // If the premium plugin is not installed, we need to provide a download link
+    if (!MailPoet.isPremiumPluginInstalled) {
+      ctaButton = (
+        <Button
+          href={MailPoet.premiumPluginDownloadUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {__('Download MailPoet Premium plugin', 'mailpoet')}
+        </Button>
+      );
+    }
+  } else {
+    description = (
+      <p>
+        {__(
+          'Learn more about your subscribers and optimize your campaigns. See who opened your emails, which links they clicked, and then use the data to make your emails even better. And if you run a WooCommerce store, you’ll also see the revenue earned per email. All starting $10 per month.',
+          'mailpoet',
+        )}{' '}
+        <a href="admin.php?page=mailpoet-upgrade">
+          {__('Learn more', 'mailpoet')}
+        </a>
+        .
+      </p>
+    );
+    ctaButton = (
+      <Button
+        href={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
+          MailPoet.subscribersCount,
+          MailPoet.currentWpUserEmail,
+          'starter',
+          { utm_medium: 'stats', utm_campaign: 'signup' },
+        )}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {__('Upgrade', 'mailpoet')}
+      </Button>
+    );
+  }
 
   return (
     <div className="mailpoet-stats-premium-required">

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
@@ -96,8 +96,8 @@ function PremiumBanner() {
           'Congratulations, you now have [subscribersCount] subscribers! Our free version is limited to [subscribersLimit] subscribers. You need to upgrade now to be able to continue using MailPoet.',
           'mailpoet',
         )
-          .replace('[subscribersLimit]', window.mailpoet_subscribers_limit)
-          .replace('[subscribersCount]', window.mailpoet_subscribers_count);
+          .replace('[subscribersLimit]', MailPoet.subscribersLimit.toString())
+          .replace('[subscribersCount]', MailPoet.subscribersCount.toString());
     const upgradeLink = hasValidApiKey
       ? MailPoet.MailPoetComUrlFactory.getUpgradeUrl(MailPoet.pluginPartialKey)
       : MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
@@ -2,112 +2,41 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common/button/button';
 import { PremiumRequired } from 'common/premium_required/premium_required';
-import { useState } from 'react';
-import jQuery from 'jquery';
-import ReactStringReplace from 'react-string-replace';
 import { withBoundary } from '../../common';
+import { PremiumBannerWithUpgrade } from '../../common/premium_banner_with_upgrade/premium_banner_with_upgrade';
 
 function SkipDisplayingDetailedStats() {
-  let ctaButton;
-  let description;
+  const ctaButton = (
+    <Button
+      href={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
+        MailPoet.subscribersCount,
+        MailPoet.currentWpUserEmail,
+        'starter',
+        { utm_medium: 'stats', utm_campaign: 'signup' },
+      )}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {__('Upgrade', 'mailpoet')}
+    </Button>
+  );
 
-  const [loading, setLoading] = useState(false);
-
-  if (
-    MailPoet.hasValidPremiumKey &&
-    (!MailPoet.isPremiumPluginInstalled || !MailPoet.premiumActive)
-  ) {
-    description = (
-      <p>
-        {__(
-          'Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.',
-          'mailpoet',
-        )}
-      </p>
-    );
-    ctaButton = (
-      <Button
-        withSpinner={loading}
-        href={MailPoet.premiumPluginActivationUrl}
-        rel="noopener noreferrer"
-        onClick={(e) => {
-          e.preventDefault();
-          setLoading(true);
-
-          jQuery
-            .get(MailPoet.premiumPluginActivationUrl)
-            .then((response) => {
-              if (response.includes('Plugin activated')) {
-                window.location.reload();
-              }
-            })
-            .catch(() => {
-              setLoading(false);
-              MailPoet.Notice.error(
-                ReactStringReplace(
-                  __(
-                    'We were unable to activate the premium plugin, please try visiting the [link]plugin page link[/link] to activate it manually.',
-                    'mailpoet',
-                  ),
-                  /\[link\](.*?)\[\/link\]/g,
-                  (match) =>
-                    `<a rel="noreferrer" href=${MailPoet.adminPluginsUrl}>${match}</a>`,
-                ).join(''),
-                { isDismissible: false },
-              );
-            });
-        }}
-      >
-        {loading
-          ? __('Activating MailPoet premium...', 'mailpoet')
-          : __('Activate MailPoet Premium plugin', 'mailpoet')}
-      </Button>
-    );
-    // If the premium plugin is not installed, we need to provide a download link
-    if (!MailPoet.isPremiumPluginInstalled) {
-      ctaButton = (
-        <Button
-          href={MailPoet.premiumPluginDownloadUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {__('Download MailPoet Premium plugin', 'mailpoet')}
-        </Button>
-      );
-    }
-  } else {
-    description = (
-      <p>
-        {__(
-          'Learn more about your subscribers and optimize your campaigns. See who opened your emails, which links they clicked, and then use the data to make your emails even better. And if you run a WooCommerce store, you’ll also see the revenue earned per email. All starting $10 per month.',
-          'mailpoet',
-        )}{' '}
-        <a href="admin.php?page=mailpoet-upgrade">
-          {__('Learn more', 'mailpoet')}
-        </a>
-        .
-      </p>
-    );
-    ctaButton = (
-      <Button
-        href={MailPoet.MailPoetComUrlFactory.getPurchasePlanUrl(
-          MailPoet.subscribersCount,
-          MailPoet.currentWpUserEmail,
-          'starter',
-          { utm_medium: 'stats', utm_campaign: 'signup' },
-        )}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {__('Upgrade', 'mailpoet')}
-      </Button>
-    );
-  }
+  const description = (
+    <p>
+      {__(
+        'Learn more about your subscribers and optimize your campaigns. See who opened your emails, which links they clicked, and then use the data to make your emails even better. And if you run a WooCommerce store, you’ll also see the revenue earned per email. All starting $10 per month.',
+        'mailpoet',
+      )}{' '}
+      <a href="admin.php?page=mailpoet-upgrade">
+        {__('Learn more', 'mailpoet')}
+      </a>
+      .
+    </p>
+  );
 
   return (
     <div className="mailpoet-stats-premium-required">
-      <PremiumRequired
-        title={__('This is a Premium feature', 'mailpoet')}
+      <PremiumBannerWithUpgrade
         message={description}
         actionButton={ctaButton}
       />

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
@@ -4,6 +4,7 @@ import { Button } from 'common/button/button';
 import { PremiumRequired } from 'common/premium_required/premium_required';
 import { useState } from 'react';
 import jQuery from 'jquery';
+import ReactStringReplace from 'react-string-replace';
 import { withBoundary } from '../../common';
 
 function SkipDisplayingDetailedStats() {
@@ -42,6 +43,18 @@ function SkipDisplayingDetailedStats() {
             })
             .catch(() => {
               setLoading(false);
+              MailPoet.Notice.error(
+                ReactStringReplace(
+                  __(
+                    'We were unable to activate the premium plugin, please try visiting the [link]plugin page link[/link] to activate it manually.',
+                    'mailpoet',
+                  ),
+                  /\[link\](.*?)\[\/link\]/g,
+                  (match) =>
+                    `<a rel="noreferrer" href=${MailPoet.adminPluginsUrl}>${match}</a>`,
+                ).join(''),
+                { isDismissible: false },
+              );
             });
         }}
       >

--- a/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign_stats/premium_banner.tsx
@@ -2,11 +2,15 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common/button/button';
 import { PremiumRequired } from 'common/premium_required/premium_required';
+import { useState } from 'react';
+import jQuery from 'jquery';
 import { withBoundary } from '../../common';
 
 function SkipDisplayingDetailedStats() {
   let ctaButton;
   let description;
+
+  const [loading, setLoading] = useState(false);
 
   if (
     MailPoet.hasValidPremiumKey &&
@@ -22,10 +26,28 @@ function SkipDisplayingDetailedStats() {
     );
     ctaButton = (
       <Button
+        withSpinner={loading}
         href={MailPoet.premiumPluginActivationUrl}
         rel="noopener noreferrer"
+        onClick={(e) => {
+          e.preventDefault();
+          setLoading(true);
+
+          jQuery
+            .get(MailPoet.premiumPluginActivationUrl)
+            .then((response) => {
+              if (response.includes('Plugin activated')) {
+                window.location.reload();
+              }
+            })
+            .catch(() => {
+              setLoading(false);
+            });
+        }}
       >
-        {__('Activate MailPoet Premium plugin', 'mailpoet')}
+        {loading
+          ? __('Activating MailPoet premium...', 'mailpoet')
+          : __('Activate MailPoet Premium plugin', 'mailpoet')}
       </Button>
     );
     // If the premium plugin is not installed, we need to provide a download link

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -159,6 +159,7 @@ class PageRenderer {
       'transactional_emails_opt_in_notice_dismissed' => (bool)$this->userFlags->get('transactional_emails_opt_in_notice_dismissed'),
       'track_wizard_loaded_via_woocommerce' => (bool)$this->settings->get(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME),
       'mail_function_enabled' => function_exists('mail') && is_callable('mail'),
+      'admin_plugins_url' => WPFunctions::get()->adminUrl('plugins.php'),
 
       // Premium & plan upgrade info
       'current_wp_user_email' => $this->wp->wpGetCurrentUser()->user_email,

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -5,7 +5,6 @@ namespace MailPoet\AdminPages\Pages;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
-use MailPoet\Config\Installer;
 use MailPoet\Config\Menu;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Listing\PageLimit;
@@ -15,6 +14,7 @@ use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\AutocompletePostListLoader as WPPostListLoader;
 use MailPoet\WP\DateTime;
@@ -54,6 +54,9 @@ class Newsletters {
   /** @var AuthorizedSenderDomainController */
   private $senderDomainController;
 
+  /** @var SubscribersFeature */
+  private $subscribersFeature;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
@@ -65,7 +68,8 @@ class Newsletters {
     SegmentsSimpleListRepository $segmentsListRepository,
     NewslettersRepository $newslettersRepository,
     Bridge $bridge,
-    AuthorizedSenderDomainController $senderDomainController
+    AuthorizedSenderDomainController $senderDomainController,
+    SubscribersFeature $subscribersFeature
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
@@ -78,6 +82,7 @@ class Newsletters {
     $this->newslettersRepository = $newslettersRepository;
     $this->bridge = $bridge;
     $this->senderDomainController = $senderDomainController;
+    $this->subscribersFeature = $subscribersFeature;
   }
 
   public function render() {
@@ -116,7 +121,7 @@ class Newsletters {
 
     $data['sent_newsletters_count'] = $this->newslettersRepository->countBy(['status' => NewsletterEntity::STATUS_SENT]);
     $data['woocommerce_transactional_email_id'] = $this->settings->get(TransactionalEmails::SETTING_EMAIL_ID);
-    $data['display_detailed_stats'] = Installer::getPremiumStatus()['premium_plugin_initialized'];
+    $data['display_detailed_stats'] = $this->subscribersFeature->hasValidPremiumKey() && !$this->subscribersFeature->check();
     $data['newsletters_templates_recently_sent_count'] = $this->newsletterTemplatesRepository->getRecentlySentCount();
 
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Util\Notices;
 
 use MailPoet\Config\Menu;
+use MailPoet\Config\ServicesChecker;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
@@ -54,12 +55,16 @@ class PermanentNotices {
   /** @var WooCommerceVersionWarning */
   private $woocommerceVersionWarning;
 
+  /** @var PremiumFeaturesAvailableNotice */
+  private $premiumFeaturesAvailableNotice;
+
   public function __construct(
     WPFunctions $wp,
     TrackingConfig $trackingConfig,
     SubscribersRepository $subscribersRepository,
     SettingsController $settings,
     SubscribersFeature $subscribersFeature,
+    ServicesChecker $serviceChecker,
     MailerFactory $mailerFactory
   ) {
     $this->wp = $wp;
@@ -76,6 +81,7 @@ class PermanentNotices {
     $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature, $mailerFactory);
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
+    $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);
   }
 
   public function init() {
@@ -129,6 +135,9 @@ class PermanentNotices {
     $this->woocommerceVersionWarning->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
+    $this->premiumFeaturesAvailableNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
   }
 
   public function ajaxDismissNoticeHandler() {
@@ -160,6 +169,9 @@ class PermanentNotices {
         break;
       case (WooCommerceVersionWarning::OPTION_NAME):
         $this->woocommerceVersionWarning->disable();
+        break;
+      case (PremiumFeaturesAvailableNotice::OPTION_NAME):
+        $this->premiumFeaturesAvailableNotice->disable();
         break;
     }
   }

--- a/mailpoet/lib/Util/Notices/PremiumFeaturesAvailableNotice.php
+++ b/mailpoet/lib/Util/Notices/PremiumFeaturesAvailableNotice.php
@@ -67,7 +67,7 @@ class PremiumFeaturesAvailableNotice {
     $noticeString = Helpers::replaceLinkTags($noticeString, $link, $attributes);
     $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
 
-    return Notice::displayInfo($noticeString, $extraClasses, self::OPTION_NAME);
+    return Notice::displaySuccess($noticeString, $extraClasses, self::OPTION_NAME);
   }
 
   public function disable(): void {

--- a/mailpoet/lib/Util/Notices/PremiumFeaturesAvailableNotice.php
+++ b/mailpoet/lib/Util/Notices/PremiumFeaturesAvailableNotice.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Config\Installer;
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Util\Helpers;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class PremiumFeaturesAvailableNotice {
+
+  /** @var SubscribersFeature */
+  private $subscribersFeature;
+
+  /** @var ServicesChecker */
+  private $servicesChecker;
+
+  /** @var Installer */
+  private $premiumInstaller;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  const DISMISS_NOTICE_TIMEOUT_SECONDS = 2592000; // 30 days
+  const OPTION_NAME = 'dismissed-premium-features-available-notice';
+
+  public function __construct(
+    SubscribersFeature $subscribersFeature,
+    ServicesChecker $servicesChecker,
+    WPFunctions $wp
+  ) {
+    $this->subscribersFeature = $subscribersFeature;
+    $this->servicesChecker = $servicesChecker;
+    $this->premiumInstaller = new Installer(Installer::PREMIUM_PLUGIN_PATH);
+    $this->wp = $wp;
+  }
+
+  public function init($shouldDisplay): ?Notice {
+    if (
+      $shouldDisplay
+      && !$this->wp->getTransient(self::OPTION_NAME)
+      && $this->subscribersFeature->hasValidPremiumKey()
+      && (!Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG) || !$this->servicesChecker->isPremiumPluginActive())
+    ) {
+      return $this->display();
+    }
+
+    return null;
+  }
+
+  public function display(): Notice {
+    $noticeString = __('Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.', 'mailpoet');
+
+    // We reuse already existing translations from premium_messages.tsx
+    if (!Installer::isPluginInstalled(Installer::PREMIUM_PLUGIN_SLUG)) {
+      $noticeString .= ' [link]' . __('Download MailPoet Premium plugin', 'mailpoet') . '[/link]';
+      $link = $this->premiumInstaller->generatePluginDownloadUrl();
+      $attributes = ['target' => '_blank']; // Only download link should be opened in a new tab
+    } else {
+      $noticeString .= ' [link]' . __('Activate MailPoet Premium plugin', 'mailpoet') . '[/link]';
+      $link = $this->premiumInstaller->generatePluginActivationUrl(Installer::PREMIUM_PLUGIN_PATH);
+      $attributes = [];
+    }
+
+    $noticeString = Helpers::replaceLinkTags($noticeString, $link, $attributes);
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+
+    return Notice::displayInfo($noticeString, $extraClasses, self::OPTION_NAME);
+  }
+
+  public function disable(): void {
+    WPFunctions::get()->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+  }
+}

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -71,6 +71,7 @@
   var mailpoet_woocommerce_version = <%= json_encode(get_woocommerce_version()) %>;
   var mailpoet_track_wizard_loaded_via_woocommerce = <%= json_encode(track_wizard_loaded_via_woocommerce) %>;
   var mailpoet_mail_function_enabled = '<%= mail_function_enabled %>';
+  var mailpoet_admin_plugins_url = '<%= admin_plugins_url %>';
 
   var mailpoet_site_name = '<%= site_name %>';
   var mailpoet_site_url = "<%= site_url %>";


### PR DESCRIPTION
## Description

To improve our user experience, this pull request adds a new notice that should be displayed only when the customer's key supports the premium feature and the premium plugin is not installed or downloaded.

## Code review notes

_N/A_

## QA notes

1. Set a key supporting premium features
  a. Check if the new notice is visible when the premium plugin is not installed. The message should contain a download link. As a part of it, the exact text should be visible in the premium banner, which is visible on the newsletter stats page.
  b. Check if the new notice is visible when the premium plugin is not activated. The message should contain an activation link. As a part of it, the exact text should be visible in the premium banner, which is visible on the newsletter stats page.
2. Use a key without premium features; the new notices shouldn't be visible

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5429]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5429]: https://mailpoet.atlassian.net/browse/MAILPOET-5429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ