### PR TITLE
Update form template header and add footer [MAILPOET-5376]

### DIFF
--- a/mailpoet/assets/css/src/components-form-editor/_template-selection.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_template-selection.scss
@@ -40,3 +40,10 @@ $mailpoet-form-template-thumbnail-height: 316px;
   grid-column: 1/-1;
   justify-content: space-between;
 }
+
+.mailpoet-form-template-selection-footer {
+  border-top: 1px solid $color-tertiary-light;
+  grid-column: 1/-1;
+  margin-top: $grid-gap-medium;
+  text-align: center;
+}

--- a/mailpoet/assets/css/src/components-form-editor/_template-selection.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_template-selection.scss
@@ -31,14 +31,8 @@ $mailpoet-form-template-thumbnail-height: 316px;
   }
 }
 
-/**
- The header uses grid to position heading in center (second column) and a new form button on right (third column)
- */
 .mailpoet-form-template-selection-header {
-  display: flex;
-  flex-direction: row;
   grid-column: 1/-1;
-  justify-content: space-between;
 }
 
 .mailpoet-form-template-selection-footer {

--- a/mailpoet/assets/css/src/components-form-editor/_template-selection.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_template-selection.scss
@@ -10,10 +10,9 @@ $mailpoet-form-template-thumbnail-height: 316px;
   justify-content: center;
 }
 
-.mailpoet-templates {
+.mailpoet-form-templates {
   @include formTemplatesGrid;
   padding-bottom: math.div($mailpoet-form-template-thumbnail-height, 3);
-  padding-top: $grid-gap-large;
 
   .mailpoet-categories {
     grid-column: 1 / -1;
@@ -32,37 +31,12 @@ $mailpoet-form-template-thumbnail-height: 316px;
   }
 }
 
-$templates-one-column-breakpoint: 2 * ($mailpoet-form-template-thumbnail-width + $grid-gap-half) + $grid-gap + 160;
 /**
  The header uses grid to position heading in center (second column) and a new form button on right (third column)
  */
-.mailpoet-template-selection-header {
-  @include formTemplatesGrid;
-  background: $color-input-background;
-  border-bottom: 1px solid $color-tertiary-light;
-  grid-row-gap: 0;
-  justify-items: center;
-  padding: $grid-gap 0;
-  position: relative;
-
-  @include breakpoint-min-width($templates-one-column-breakpoint) {
-    justify-items: right;
-  }
-
-  .mailpoet-h4 {
-    // Keep heading centered when we are sure there are 2 or more columns
-
-    @include breakpoint-min-width($templates-one-column-breakpoint) {
-      left: 50%;
-      margin-top: 0;
-      position: absolute;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
-  }
-
-  .mailpoet-button {
-    align-self: center;
-    grid-column-end: -1;
-  }
+.mailpoet-form-template-selection-header {
+  display: flex;
+  flex-direction: row;
+  grid-column: 1/-1;
+  justify-content: space-between;
 }

--- a/mailpoet/assets/js/src/form_editor/templates/selection.tsx
+++ b/mailpoet/assets/js/src/form_editor/templates/selection.tsx
@@ -1,5 +1,5 @@
 import { __, _x } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, Flex } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Categories } from 'common/categories/categories';
 import { Background } from 'common/background/background';
@@ -104,7 +104,7 @@ export function Selection(): JSX.Element {
       <div data-automation-id="template_selection_list">
         <Background color="#fff" />
         <div className="mailpoet-form-templates">
-          <div className="mailpoet-form-template-selection-header">
+          <Flex className="mailpoet-form-template-selection-header">
             <h1 className="wp-heading-inline">
               {__('Start with a template', 'mailpoet')}
             </h1>
@@ -117,7 +117,7 @@ export function Selection(): JSX.Element {
             >
               {__('Or, start with a blank form', 'mailpoet')}
             </Button>
-          </div>
+          </Flex>
           <Categories
             categories={categories}
             active={selectedCategory}

--- a/mailpoet/assets/js/src/form_editor/templates/selection.tsx
+++ b/mailpoet/assets/js/src/form_editor/templates/selection.tsx
@@ -1,11 +1,12 @@
+import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Categories } from 'common/categories/categories';
 import { Background } from 'common/background/background';
 import { Loading } from 'common/loading';
 import { TemplateBox } from 'common/template_box/template_box';
-import { Heading } from 'common/typography/heading/heading';
-import { Button } from 'common';
+import { TopBarWithBeamer } from 'common/top_bar/top_bar';
 import { Notice } from 'notices/notice';
 import { TemplateData } from './store/types';
 import { storeName } from './store/constants';
@@ -70,17 +71,7 @@ export function Selection(): JSX.Element {
             ),
         ),
       )}
-      <div className="mailpoet-template-selection-header">
-        <Heading level={4}>{MailPoet.I18n.t('selectTemplate')}</Heading>
-        <Button
-          automationId="create_blank_form"
-          onClick={(): void => {
-            void selectTemplate('initial_form', 'Blank template');
-          }}
-        >
-          {MailPoet.I18n.t('createBlankTemplate')}
-        </Button>
-      </div>
+      <TopBarWithBeamer />
       {selectTemplateFailed && (
         <Notice type="error" scroll renderInPlace>
           <p>{MailPoet.I18n.t('createFormError')}</p>
@@ -88,7 +79,21 @@ export function Selection(): JSX.Element {
       )}
       <div data-automation-id="template_selection_list">
         <Background color="#fff" />
-        <div className="mailpoet-templates">
+        <div className="mailpoet-form-templates">
+          <div className="mailpoet-form-template-selection-header">
+            <h1 className="wp-heading-inline">
+              {__('Start with a template', 'mailpoet')}
+            </h1>
+            <Button
+              data-automation-id="create_blank_form"
+              variant="secondary"
+              onClick={(): void => {
+                void selectTemplate('initial_form', 'Blank template');
+              }}
+            >
+              {__('Or, start with a blank form', 'mailpoet')}
+            </Button>
+          </div>
           <Categories
             categories={categories}
             active={selectedCategory}

--- a/mailpoet/assets/js/src/form_editor/templates/selection.tsx
+++ b/mailpoet/assets/js/src/form_editor/templates/selection.tsx
@@ -144,6 +144,19 @@ export function Selection(): JSX.Element {
               </div>
             </TemplateBox>
           ))}
+          <div className="mailpoet-form-template-selection-footer">
+            <p>
+              {__('Can’t find a template that suits your needs?', 'mailpoet')}
+            </p>
+            <Button
+              variant="link"
+              onClick={(): void => {
+                void selectTemplate('initial_form', 'Blank template');
+              }}
+            >
+              {__('Start with a blank form', 'mailpoet')}
+            </Button>
+          </div>
         </div>
       </div>
       {loading && <Loading />}

--- a/mailpoet/assets/js/src/form_editor/templates/selection.tsx
+++ b/mailpoet/assets/js/src/form_editor/templates/selection.tsx
@@ -1,5 +1,4 @@
-import { __ } from '@wordpress/i18n';
-import { MailPoet } from 'mailpoet';
+import { __, _x } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Categories } from 'common/categories/categories';
@@ -15,23 +14,43 @@ export function Selection(): JSX.Element {
   const categories = [
     {
       name: 'popup',
-      label: MailPoet.I18n.t('popupCategory'),
+      label: _x(
+        'Pop-up',
+        'This is a text on a widget that leads to settings for form placement - form type is pop-up, it will be displayed on page in a small modal window',
+        'mailpoet',
+      ),
     },
     {
       name: 'slide_in',
-      label: MailPoet.I18n.t('slideInCategory'),
+      label: _x(
+        'Slide–in',
+        'This is a text on a widget that leads to settings for form placement - form type is slide in',
+        'mailpoet',
+      ),
     },
     {
       name: 'fixed_bar',
-      label: MailPoet.I18n.t('fixedBarCategory'),
+      label: _x(
+        'Fixed bar',
+        'This is a text on a widget that leads to settings for form placement - form type is fixed bar',
+        'mailpoet',
+      ),
     },
     {
       name: 'below_posts',
-      label: MailPoet.I18n.t('belowPagesCategory'),
+      label: _x(
+        'Below pages',
+        'This is a text on a widget that leads to settings for form placement',
+        'mailpoet',
+      ),
     },
     {
       name: 'others',
-      label: MailPoet.I18n.t('othersCategory'),
+      label: _x(
+        'Others (widget)',
+        'Placement of the form using theme widget',
+        'mailpoet',
+      ),
     },
   ];
 
@@ -74,7 +93,12 @@ export function Selection(): JSX.Element {
       <TopBarWithBeamer />
       {selectTemplateFailed && (
         <Notice type="error" scroll renderInPlace>
-          <p>{MailPoet.I18n.t('createFormError')}</p>
+          <p>
+            {__(
+              'Sorry, there was an error, please try again later.',
+              'mailpoet',
+            )}
+          </p>
         </Notice>
       )}
       <div data-automation-id="template_selection_list">

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -324,14 +324,6 @@ class Menu {
       ]
     );
 
-    // add body class for form editor page
-    $this->wp->addAction('load-' . $formTemplateSelectionEditorPage, function() {
-      $this->wp->addFilter('admin_body_class', function ($classes) {
-        return ltrim($classes . ' block-editor-page');
-      });
-    });
-
-
     // Subscribers page
     $subscribersPage = $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,

--- a/mailpoet/views/form/template_selection.html
+++ b/mailpoet/views/form/template_selection.html
@@ -29,19 +29,6 @@
 <style id="mailpoet-form-editor-form-styles"></style>
 <% endblock %>
 
-<% block translations %>
-<%= localize({
-  'fixedBarCategory': _x('Fixed bar', 'This is a text on a widget that leads to settings for form placement - form type is fixed bar'),
-  'slideInCategory': _x('Slide–in', 'This is a text on a widget that leads to settings for form placement - form type is slide in'),
-  'popupCategory': _x('Pop-up', 'This is a text on a widget that leads to settings for form placement - form type is pop-up, it will be displayed on page in a small modal window'),
-  'belowPagesCategory': _x('Below pages', 'This is a text on a widget that leads to settings for form placement'),
-  'othersCategory': _x('Others (widget)', 'Placement of the form using theme widget'),
-  'select': _x('Select', 'Verb'),
-  'selectTemplate': _x('Select a template', 'Form template selection heading'),
-  'createFormError': __('Sorry, there was an error, please try again later.'),
-}) %>
-<% endblock %>
-
 <% block after_javascript %>
 <%= javascript('form_editor.js')%>
 <% endblock %>

--- a/mailpoet/views/form/template_selection.html
+++ b/mailpoet/views/form/template_selection.html
@@ -4,7 +4,7 @@
 <%= stylesheet('mailpoet-form-editor.css') %>
 <% endblock %>
 
-<% block container %>
+<% block content %>
 
 <script type="text/javascript">
   var mailpoet_beacon_articles = [
@@ -31,8 +31,6 @@
 
 <% block translations %>
 <%= localize({
-  'heading': __('Select form template'),
-  'createBlankTemplate': _x('Skip, start with a blank form', 'a button for skipping form template selection'),
   'fixedBarCategory': _x('Fixed bar', 'This is a text on a widget that leads to settings for form placement - form type is fixed bar'),
   'slideInCategory': _x('Slide–in', 'This is a text on a widget that leads to settings for form placement - form type is slide in'),
   'popupCategory': _x('Pop-up', 'This is a text on a widget that leads to settings for form placement - form type is pop-up, it will be displayed on page in a small modal window'),


### PR DESCRIPTION
## Description

This PR updates the header in the form template selection.

## Code review notes

Compared with the Figma design, I decided not to use the left chevron icon in the heading for better consistency with other headings. Also, spacing should be more consistent with Automation.

## QA notes

Check the new header and footer in the form template selection.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5376]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5376]: https://mailpoet.atlassian.net/browse/MAILPOET-5376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ