### PR TITLE
Fix date format related errors when scheduling newsletter [MAILPOET-5472]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -126,7 +126,7 @@ interface Window {
   mailpoet_api_version: string;
   mailpoet_email_regex: RegExp;
   mailpoet_wp_segment_state: string;
-  mailpoet_wp_week_starts_on: number;
+  mailpoet_wp_week_starts_on: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   mailpoet_subscribers_counts_cache_created_at: string;
   mailpoet_shortcode_links: string[];
   mailpoet_tracking_config: Partial<{

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -147,7 +147,6 @@ interface Window {
   mailpoet_current_date?: string;
   mailpoet_tomorrow_date?: string;
   mailpoet_schedule_time_of_day?: string;
-  mailpoet_date_display_format?: string;
   mailpoet_date_storage_format?: string;
   mailpoet_current_date_time?: string;
   mailpoet_urls: Record<string, string>;

--- a/mailpoet/assets/js/src/newsletters/send/date_text.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/date_text.jsx
@@ -101,6 +101,8 @@ class DateText extends Component {
     return convertedFormat
       .replace(/D/g, 'd')
       .replace(/Y/g, 'y')
+      .replace(/A/g, 'a')
+      .replace(/o/g, 'Y') // MailPoet.Date.convertFormat converts 'S' to 'o'
       .replace(/\[/g, '')
       .replace(/\]/g, '');
   };

--- a/mailpoet/assets/js/src/newsletters/send/date_text.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date_text.tsx
@@ -1,12 +1,12 @@
-import { Component } from 'react';
+import { Component, SyntheticEvent } from 'react';
 import { __, _x } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { registerLocale } from 'react-datepicker';
 import locale from 'date-fns/locale/en-US';
 import buildLocalizeFn from 'date-fns/locale/_lib/buildLocalizeFn';
 
-import { Datepicker } from 'common/datepicker/datepicker.tsx';
+import { Datepicker } from 'common/datepicker/datepicker';
 import { MailPoet } from 'mailpoet';
+import { DateOptions } from 'date';
 
 const monthValues = {
   abbreviated: [
@@ -82,9 +82,33 @@ locale.options.weekStartsOn =
 
 registerLocale('mailpoet', locale);
 
-class DateText extends Component {
-  onChange = (value, event) => {
-    const changeEvent = event;
+type DateTextEvent = SyntheticEvent<HTMLInputElement> & {
+  target: EventTarget & {
+    name?: string;
+    value?: string;
+  };
+};
+
+type DateTextProps = {
+  displayFormat: string;
+  onChange: (date: DateTextEvent) => void;
+  storageFormat: string;
+  value: string;
+  disabled: boolean;
+  validation: {
+    'data-parsley-required': boolean;
+    'data-parsley-required-message': string;
+    'data-parsley-type': string;
+    'data-parsley-errors-container': string;
+    maxLength: number;
+  };
+  maxDate: Date;
+  name?: string;
+};
+
+class DateText extends Component<DateTextProps> {
+  onChange = (value: Date, event) => {
+    const changeEvent: DateTextEvent = event;
     // Swap display format to storage format
     const storageDate = this.getStorageDate(value);
 
@@ -95,7 +119,7 @@ class DateText extends Component {
 
   getFieldName = () => this.props.name || 'date';
 
-  getDisplayDateFormat = (format) => {
+  getDisplayDateFormat = (format: string) => {
     const convertedFormat = MailPoet.Date.convertFormat(format);
     // Convert moment format to date-fns, see: https://git.io/fxCyr
     return convertedFormat
@@ -107,14 +131,14 @@ class DateText extends Component {
       .replace(/\]/g, '');
   };
 
-  getDate = (date) => {
+  getDate = (date: string) => {
     const formatting = {
       parseFormat: this.props.storageFormat,
-    };
+    } as DateOptions;
     return MailPoet.Date.toDate(date, formatting);
   };
 
-  getStorageDate = (date) => {
+  getStorageDate = (date: Date) => {
     const formatting = {
       format: this.props.storageFormat,
     };
@@ -138,26 +162,4 @@ class DateText extends Component {
   }
 }
 
-DateText.propTypes = {
-  displayFormat: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  name: PropTypes.string,
-  storageFormat: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  disabled: PropTypes.bool.isRequired,
-  validation: PropTypes.shape({
-    'data-parsley-required': PropTypes.bool,
-    'data-parsley-required-message': PropTypes.string,
-    'data-parsley-type': PropTypes.string,
-    'data-parsley-errors-container': PropTypes.string,
-    maxLength: PropTypes.number,
-  }).isRequired,
-  maxDate: PropTypes.instanceOf(Date),
-};
-
-DateText.defaultProps = {
-  name: 'date',
-  maxDate: null,
-};
-DateText.displayName = 'DateText';
 export { DateText };

--- a/mailpoet/assets/js/src/newsletters/send/date_time.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/date_time.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { Grid } from 'common/grid';
-import { DateText } from 'newsletters/send/date_text.jsx';
+import { DateText } from 'newsletters/send/date_text';
 import { TimeSelect } from 'newsletters/send/time_select.jsx';
 import { ErrorBoundary } from '../../common';
 

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -15,7 +15,7 @@ import { Field } from '../../form/types';
 const currentTime = window.mailpoet_current_time || '00:00';
 const tomorrowDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
 const timeOfDayItems = window.mailpoet_schedule_time_of_day;
-const dateDisplayFormat = window.mailpoet_date_display_format;
+const dateDisplayFormat = window.mailpoet_date_format;
 const dateStorageFormat = window.mailpoet_date_storage_format;
 
 type StandardSchedulingProps = {

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -19,7 +19,6 @@
       var mailpoet_current_time = <%= json_encode(current_time) %>;
       var mailpoet_current_date_time = <%= json_encode(current_date_time) %>;
       var mailpoet_schedule_time_of_day = <%= json_encode(schedule_time_of_day) %>;
-      var mailpoet_date_display_format = "<%= wp_datetime_format()|escape('js') %>";
       var mailpoet_date_storage_format = "Y-m-d";
       var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
       var mailpoet_products = <%= json_encode(products) %>;


### PR DESCRIPTION
## Description

This PR fixes a JS error that appears on the newsletter send page when a user attempts to schedule a newsletter.

## Code review notes

I described the change in commit messages.

## QA notes

1) Go to WordPress General settings and set the Time Format to `g:i A`
2) Create a new newsletter and try to schedule it. 
3) Observe the issue.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5472]

## After-merge notes

_N/A_

## Tasks

- [X] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] 🚫I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes. 



[MAILPOET-5472]: https://mailpoet.atlassian.net/browse/MAILPOET-5472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ