### PR TITLE
Number of reviews filter [MAILPOET-5413]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
@@ -2,11 +2,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Input } from 'common';
 import { MailPoet } from 'mailpoet';
 import { Select } from 'common/form/select/select';
-import {
-  DaysPeriodItem,
-  FilterProps,
-  Timeframes,
-} from 'segments/dynamic/types';
+import { DaysPeriodItem, FilterProps, Timeframe } from 'segments/dynamic/types';
 import { storeName } from 'segments/dynamic/store';
 import { useEffect } from 'react';
 import { isInEnum } from '../../../../utils';
@@ -28,15 +24,15 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
     useDispatch(storeName);
 
   useEffect(() => {
-    if (!isInEnum(segment.timeframe, Timeframes)) {
+    if (!isInEnum(segment.timeframe, Timeframe)) {
       void updateSegmentFilter(
-        { timeframe: Timeframes.IN_THE_LAST },
+        { timeframe: Timeframe.IN_THE_LAST },
         filterIndex,
       );
     }
   }, [segment, updateSegmentFilter, filterIndex]);
 
-  const isInTheLast = segment.timeframe === Timeframes.IN_THE_LAST;
+  const isInTheLast = segment.timeframe === Timeframe.IN_THE_LAST;
 
   return (
     <>
@@ -85,7 +81,7 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
 }
 
 export function validateDaysPeriod(formItems: DaysPeriodItem): boolean {
-  if (formItems.timeframe === Timeframes.ALL_TIME) {
+  if (formItems.timeframe === Timeframe.ALL_TIME) {
     return true;
   }
   return !!formItems.days;

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/days_period_field.tsx
@@ -85,7 +85,7 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
 }
 
 export function validateDaysPeriod(formItems: DaysPeriodItem): boolean {
-  if (isInEnum(formItems.timeframe, Timeframes)) {
+  if (formItems.timeframe === Timeframes.ALL_TIME) {
     return true;
   }
   return !!formItems.days;

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
@@ -8,7 +8,7 @@ import {
   WooCommerceFormItem,
   FilterProps,
   DaysPeriodItem,
-  Timeframes,
+  Timeframe,
   ReviewRating,
   CountType,
 } from '../../../types';
@@ -44,9 +44,9 @@ export function NumberOfReviewsFields({
     if (!isInEnum(segment.rating, ReviewRating)) {
       void updateSegmentFilter({ rating: ReviewRating.ANY }, filterIndex);
     }
-    if (!isInEnum(segment.timeframe, Timeframes)) {
+    if (!isInEnum(segment.timeframe, Timeframe)) {
       void updateSegmentFilter(
-        { timeframe: Timeframes.IN_THE_LAST },
+        { timeframe: Timeframe.IN_THE_LAST },
         filterIndex,
       );
     }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
@@ -1,0 +1,93 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { Grid } from 'common/grid';
+import { Input, Select } from 'common';
+import { MailPoet } from 'mailpoet';
+import { storeName } from '../../../store';
+import {
+  WooCommerceFormItem,
+  FilterProps,
+  DaysPeriodItem,
+} from '../../../types';
+import { validateDaysPeriod, DaysPeriodField } from '../days_period_field';
+
+export function validateNumberOfReviews(
+  formItems: WooCommerceFormItem,
+): boolean {
+  const numberOfOrdersIsInvalid =
+    !formItems.count ||
+    !formItems.count_type ||
+    !formItems.rating ||
+    !validateDaysPeriod(formItems);
+
+  return !numberOfOrdersIsInvalid;
+}
+
+export function NumberOfReviewsFields({
+  filterIndex,
+}: FilterProps): JSX.Element {
+  const segment: WooCommerceFormItem & DaysPeriodItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const { updateSegmentFilter, updateSegmentFilterFromEvent } =
+    useDispatch(storeName);
+
+  useEffect(() => {
+    if (segment.count_type === undefined) {
+      void updateSegmentFilter({ count_type: '=' }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
+
+  if (!['inTheLast', 'allTime'].includes(segment.timeframe)) {
+    void updateSegmentFilter({ timeframe: 'inTheLast' }, filterIndex);
+  }
+
+  return (
+    <>
+      <Grid.CenteredRow>
+        <Select
+          key="rating-select"
+          value={segment.rating}
+          onChange={(e): void => {
+            void updateSegmentFilterFromEvent('rating', filterIndex, e);
+          }}
+        >
+          <option value="any">{MailPoet.I18n.t('wooAnyStarRating')}</option>
+          <option value="1">{MailPoet.I18n.t('wooOneStarRating')}</option>
+          <option value="2">{MailPoet.I18n.t('wooTwoStarRating')}</option>
+          <option value="3">{MailPoet.I18n.t('wooThreeStarRating')}</option>
+          <option value="4">{MailPoet.I18n.t('wooFourStarRating')}</option>
+          <option value="5">{MailPoet.I18n.t('wooFiveStarRating')}</option>
+        </Select>
+        <Select
+          key="select"
+          value={segment.count_type}
+          onChange={(e): void => {
+            void updateSegmentFilterFromEvent('count_type', filterIndex, e);
+          }}
+          automationId="select-number-of-reviews-type"
+        >
+          <option value="=">{MailPoet.I18n.t('equals')}</option>
+          <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
+          <option value=">">{MailPoet.I18n.t('moreThan')}</option>
+          <option value="<">{MailPoet.I18n.t('lessThan')}</option>
+        </Select>
+        <Input
+          data-automation-id="input-number-of-reviews-count"
+          type="number"
+          min={0}
+          value={segment.count || ''}
+          placeholder={MailPoet.I18n.t('wooNumberOfOrdersCount')}
+          onChange={(e): void => {
+            void updateSegmentFilterFromEvent('count', filterIndex, e);
+          }}
+        />
+        <div>{MailPoet.I18n.t('wooNumberOfReviewsReviews')}</div>
+      </Grid.CenteredRow>
+      <Grid.CenteredRow>
+        <DaysPeriodField filterIndex={filterIndex} />
+      </Grid.CenteredRow>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
@@ -9,6 +9,8 @@ import {
   FilterProps,
   DaysPeriodItem,
   Timeframes,
+  ReviewRating,
+  CountType,
 } from '../../../types';
 import { validateDaysPeriod, DaysPeriodField } from '../days_period_field';
 import { isInEnum } from '../../../../../utils';
@@ -36,17 +38,19 @@ export function NumberOfReviewsFields({
     useDispatch(storeName);
 
   useEffect(() => {
-    if (segment.count_type === undefined) {
-      void updateSegmentFilter({ count_type: '=' }, filterIndex);
+    if (!isInEnum(segment.count_type, CountType)) {
+      void updateSegmentFilter({ count_type: CountType.EQUALS }, filterIndex);
+    }
+    if (!isInEnum(segment.rating, ReviewRating)) {
+      void updateSegmentFilter({ rating: ReviewRating.ANY }, filterIndex);
+    }
+    if (!isInEnum(segment.timeframe, Timeframes)) {
+      void updateSegmentFilter(
+        { timeframe: Timeframes.IN_THE_LAST },
+        filterIndex,
+      );
     }
   }, [updateSegmentFilter, segment, filterIndex]);
-
-  if (!isInEnum(segment.timeframe, Timeframes)) {
-    void updateSegmentFilter(
-      { timeframe: Timeframes.IN_THE_LAST },
-      filterIndex,
-    );
-  }
 
   return (
     <>
@@ -58,12 +62,24 @@ export function NumberOfReviewsFields({
             void updateSegmentFilterFromEvent('rating', filterIndex, e);
           }}
         >
-          <option value="any">{MailPoet.I18n.t('wooAnyStarRating')}</option>
-          <option value="1">{MailPoet.I18n.t('wooOneStarRating')}</option>
-          <option value="2">{MailPoet.I18n.t('wooTwoStarRating')}</option>
-          <option value="3">{MailPoet.I18n.t('wooThreeStarRating')}</option>
-          <option value="4">{MailPoet.I18n.t('wooFourStarRating')}</option>
-          <option value="5">{MailPoet.I18n.t('wooFiveStarRating')}</option>
+          <option value={ReviewRating.ANY}>
+            {MailPoet.I18n.t('wooAnyStarRating')}
+          </option>
+          <option value={ReviewRating.ONE}>
+            {MailPoet.I18n.t('wooOneStarRating')}
+          </option>
+          <option value={ReviewRating.TWO}>
+            {MailPoet.I18n.t('wooTwoStarRating')}
+          </option>
+          <option value={ReviewRating.THREE}>
+            {MailPoet.I18n.t('wooThreeStarRating')}
+          </option>
+          <option value={ReviewRating.FOUR}>
+            {MailPoet.I18n.t('wooFourStarRating')}
+          </option>
+          <option value={ReviewRating.FIVE}>
+            {MailPoet.I18n.t('wooFiveStarRating')}
+          </option>
         </Select>
         <Select
           key="select"
@@ -73,10 +89,16 @@ export function NumberOfReviewsFields({
           }}
           automationId="select-number-of-reviews-type"
         >
-          <option value="=">{MailPoet.I18n.t('equals')}</option>
-          <option value="!=">{MailPoet.I18n.t('notEquals')}</option>
-          <option value=">">{MailPoet.I18n.t('moreThan')}</option>
-          <option value="<">{MailPoet.I18n.t('lessThan')}</option>
+          <option value={CountType.EQUALS}>{MailPoet.I18n.t('equals')}</option>
+          <option value={CountType.NOT_EQUALS}>
+            {MailPoet.I18n.t('notEquals')}
+          </option>
+          <option value={CountType.MORE_THAN}>
+            {MailPoet.I18n.t('moreThan')}
+          </option>
+          <option value={CountType.LESS_THAN}>
+            {MailPoet.I18n.t('lessThan')}
+          </option>
         </Select>
         <Input
           data-automation-id="input-number-of-reviews-count"

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/number_of_reviews.tsx
@@ -8,8 +8,10 @@ import {
   WooCommerceFormItem,
   FilterProps,
   DaysPeriodItem,
+  Timeframes,
 } from '../../../types';
 import { validateDaysPeriod, DaysPeriodField } from '../days_period_field';
+import { isInEnum } from '../../../../../utils';
 
 export function validateNumberOfReviews(
   formItems: WooCommerceFormItem,
@@ -39,8 +41,11 @@ export function NumberOfReviewsFields({
     }
   }, [updateSegmentFilter, segment, filterIndex]);
 
-  if (!['inTheLast', 'allTime'].includes(segment.timeframe)) {
-    void updateSegmentFilter({ timeframe: 'inTheLast' }, filterIndex);
+  if (!isInEnum(segment.timeframe, Timeframes)) {
+    void updateSegmentFilter(
+      { timeframe: Timeframes.IN_THE_LAST },
+      filterIndex,
+    );
   }
 
   return (

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce.tsx
@@ -43,6 +43,10 @@ import {
   validateUsedShippingMethod,
 } from './fields/woocommerce/used_shipping_method';
 import { TextField, validateTextField } from './fields/text_field';
+import {
+  NumberOfReviewsFields,
+  validateNumberOfReviews,
+} from './fields/woocommerce/number_of_reviews';
 
 export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (
@@ -80,6 +84,9 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (formItems.action === WooCommerceActionTypes.PURCHASE_DATE) {
     return validateDateField(formItems);
   }
+  if (formItems.action === WooCommerceActionTypes.NUMBER_OF_REVIEWS) {
+    return validateNumberOfReviews(formItems);
+  }
   if (
     [
       WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE,
@@ -96,6 +103,7 @@ const componentsMap = {
   [WooCommerceActionTypes.CUSTOMER_IN_CITY]: TextField,
   [WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE]: TextField,
   [WooCommerceActionTypes.NUMBER_OF_ORDERS]: NumberOfOrdersFields,
+  [WooCommerceActionTypes.NUMBER_OF_REVIEWS]: NumberOfReviewsFields,
   [WooCommerceActionTypes.PURCHASE_DATE]: DateFieldsDefaultBefore,
   [WooCommerceActionTypes.PURCHASED_PRODUCT]: PurchasedProductFields,
   [WooCommerceActionTypes.PURCHASED_CATEGORY]: PurchasedCategoryFields,

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/woocommerce_options.ts
@@ -4,6 +4,7 @@ import { SegmentTypes } from '../types';
 // WooCommerce
 export enum WooCommerceActionTypes {
   NUMBER_OF_ORDERS = 'numberOfOrders',
+  NUMBER_OF_REVIEWS = 'numberOfReviews',
   PURCHASED_CATEGORY = 'purchasedCategory',
   PURCHASE_DATE = 'purchaseDate',
   PURCHASED_PRODUCT = 'purchasedProduct',
@@ -36,6 +37,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.NUMBER_OF_ORDERS,
     label: MailPoet.I18n.t('wooNumberOfOrders'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.NUMBER_OF_REVIEWS,
+    label: MailPoet.I18n.t('wooNumberOfReviews'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -122,6 +122,10 @@ export interface WooCommerceFormItem extends FormItem {
   used_payment_method_days?: string;
   shipping_methods?: string[];
   used_shipping_method_days?: string;
+  rating?: string;
+  count_type?: string;
+  count?: string;
+  days?: string;
 }
 
 export interface AutomationsFormItem extends FormItem {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -80,7 +80,7 @@ export interface DateFormItem extends FormItem {
 
 export interface DaysPeriodItem extends FormItem {
   days?: string;
-  timeframe?: string;
+  timeframe?: Timeframes;
 }
 
 export enum Timeframes {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -80,10 +80,10 @@ export interface DateFormItem extends FormItem {
 
 export interface DaysPeriodItem extends FormItem {
   days?: string;
-  timeframe?: Timeframes;
+  timeframe?: Timeframe;
 }
 
-export enum Timeframes {
+export enum Timeframe {
   ALL_TIME = 'allTime',
   IN_THE_LAST = 'inTheLast',
 }

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -105,6 +105,22 @@ export interface WordpressRoleFormItem extends FormItem {
   form_ids?: string[];
 }
 
+export enum ReviewRating {
+  ANY = 'any',
+  ONE = '1',
+  TWO = '2',
+  THREE = '3',
+  FOUR = '4',
+  FIVE = '5',
+}
+
+export enum CountType {
+  EQUALS = '=',
+  NOT_EQUALS = '!=',
+  MORE_THAN = '>',
+  LESS_THAN = '<',
+}
+
 export interface WooCommerceFormItem extends FormItem {
   category_ids?: string[];
   product_ids?: string[];
@@ -122,8 +138,8 @@ export interface WooCommerceFormItem extends FormItem {
   used_payment_method_days?: string;
   shipping_methods?: string[];
   used_shipping_method_days?: string;
-  rating?: string;
-  count_type?: string;
+  rating?: ReviewRating;
+  count_type?: CountType;
   count?: string;
   days?: string;
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -454,6 +454,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceCustomerTextField::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -24,6 +24,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCustomerTextField;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
@@ -108,6 +109,9 @@ class FilterFactory {
   /** @var AutomationsEvents */
   private $automationsEvents;
 
+  /** @var WooCommerceNumberOfReviews */
+  private $wooCommerceNumberOfReviews;
+
   public function __construct(
     EmailAction $emailAction,
     EmailActionClickAny $emailActionClickAny,
@@ -119,6 +123,7 @@ class FilterFactory {
     WooCommerceCustomerTextField $wooCommerceCustomerTextField,
     EmailOpensAbsoluteCountAction $emailOpensAbsoluteCount,
     WooCommerceNumberOfOrders $wooCommerceNumberOfOrders,
+    WooCommerceNumberOfReviews $wooCommerceNumberOfReviews,
     WooCommerceTotalSpent $wooCommerceTotalSpent,
     WooCommerceMembership $wooCommerceMembership,
     WooCommercePurchaseDate $wooCommercePurchaseDate,
@@ -141,6 +146,7 @@ class FilterFactory {
     $this->wooCommerceCategory = $wooCommerceCategory;
     $this->wooCommerceCountry = $wooCommerceCountry;
     $this->wooCommerceNumberOfOrders = $wooCommerceNumberOfOrders;
+    $this->wooCommerceNumberOfReviews = $wooCommerceNumberOfReviews;
     $this->wooCommerceMembership = $wooCommerceMembership;
     $this->wooCommercePurchaseDate = $wooCommercePurchaseDate;
     $this->wooCommerceSubscription = $wooCommerceSubscription;
@@ -253,6 +259,8 @@ class FilterFactory {
       return $this->wooCommerceUsedPaymentMethod;
     } elseif ($action === WooCommerceUsedShippingMethod::ACTION) {
       return $this->wooCommerceUsedShippingMethod;
+    } elseif ($action === WooCommerceNumberOfReviews::ACTION) {
+      return $this->wooCommerceNumberOfReviews;
     } elseif (in_array($action, WooCommerceCustomerTextField::ACTIONS)) {
       return $this->wooCommerceCustomerTextField;
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -2,13 +2,15 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\Security;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class FilterHelper {
-    /** @var EntityManager */
+  /** @var EntityManager */
   private $entityManager;
 
   public function __construct(
@@ -59,5 +61,21 @@ class FilterHelper {
   public function getUniqueParameterName(string $parameter): string {
     $suffix = Security::generateRandomString();
     return sprintf("%s_%s", $parameter, $suffix);
+  }
+
+  public function validateDaysPeriodData(array $data): void {
+    if (!isset($data['timeframe']) || !in_array($data['timeframe'], [DynamicSegmentFilterData::TIMEFRAME_ALL_TIME, DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST], true)) {
+      throw new InvalidFilterException('Missing timeframe type', InvalidFilterException::MISSING_VALUE);
+    }
+
+    if ($data['timeframe'] === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
+      return;
+    }
+
+    $days = intval($data['days'] ?? null);
+
+    if ($days < 1) {
+      throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+    }
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Util\DBCollationChecker;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooCommerceNumberOfReviews implements Filter {
+  const ACTION = 'numberOfReviews';
+
+  /** @var DBCollationChecker */
+  private $collationChecker;
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  public function __construct(
+    DBCollationChecker $collationChecker,
+    FilterHelper $filterHelper
+  ) {
+    $this->collationChecker = $collationChecker;
+    $this->filterHelper = $filterHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $commentsTable = $this->filterHelper->getPrefixedTable('comments');
+    $commentMetaTable = $this->filterHelper->getPrefixedTable('commentmeta');
+    $filterData = $filter->getFilterData();
+    $this->validateFilterData((array)$filterData->getData());
+    $type = strval($filterData->getParam('count_type'));
+    $rating = strval($filterData->getParam('rating'));
+    $days = intval($filterData->getParam('days'));
+    $count = intval($filterData->getParam('count'));
+
+    $subscribersTable = $this->filterHelper->getSubscribersTable();
+    $collation = $this->collationChecker->getCollateIfNeeded(
+      $subscribersTable,
+      'email',
+      $commentsTable,
+      'comment_author_email'
+    );
+
+    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
+    $joinCondition = "$subscribersTable.email = comments.comment_author_email $collation
+      AND comments.comment_type = 'review'";
+
+    if (!$isAllTime) {
+      $date = Carbon::now()->subDays($days);
+      $dateParam = $this->filterHelper->getUniqueParameterName('date');
+      $joinCondition .= " AND comments.comment_date >= :$dateParam";
+      $queryBuilder->setParameter($dateParam, $date->toDateTimeString());
+    }
+
+    $commentMetaJoinCondition = "comments.comment_ID = commentmeta.comment_id AND commentmeta.meta_key = 'rating'";
+
+    if ($rating !== 'any') {
+      $ratingParam = $this->filterHelper->getUniqueParameterName('rating');
+      $commentMetaJoinCondition .= "AND commentmeta.meta_value = :$ratingParam";
+      $queryBuilder->setParameter($ratingParam, $rating);
+    }
+
+    $queryBuilder
+      ->leftJoin(
+        $subscribersTable,
+        $commentsTable,
+        'comments',
+        $joinCondition
+      )->leftJoin(
+        'comments',
+        $commentMetaTable,
+        'commentmeta',
+        $commentMetaJoinCondition
+      );
+
+    $queryBuilder->groupBy('inner_subscriber_id');
+
+    $countParam = $this->filterHelper->getUniqueParameterName('count');
+
+    switch ($type) {
+      case '=':
+        $queryBuilder->having("COUNT(commentmeta.meta_value) = :$countParam");
+        break;
+      case '!=':
+        $queryBuilder->having("COUNT(commentmeta.meta_value) != :$countParam");
+        break;
+      case '>':
+        $queryBuilder->having("COUNT(commentmeta.meta_value) > :$countParam");
+        break;
+      case '<':
+        $queryBuilder->having("COUNT(commentmeta.meta_value) < :$countParam");
+        break;
+    }
+
+    $queryBuilder->setParameter($countParam, $count, 'integer');
+    return $queryBuilder;
+  }
+
+  public function validateFilterData(array $data): void {
+    if (!isset($data['rating'])) {
+      throw new InvalidFilterException('Missing rating', InvalidFilterException::MISSING_VALUE);
+    }
+    $validRatings = ['1', '2', '3', '4', '5', 'any'];
+    if (!in_array($data['rating'], $validRatings, true)) {
+      throw new InvalidFilterException('Invalid rating', InvalidFilterException::MISSING_VALUE);
+    }
+    if (!isset($data['count_type'])) {
+      throw new InvalidFilterException('Missing count type', InvalidFilterException::MISSING_VALUE);
+    }
+    $type = $data['count_type'];
+    $validTypes = [
+      '=',
+      '!=',
+      '>',
+      '<',
+    ];
+    if (!in_array($type, $validTypes, true)) {
+      throw new InvalidFilterException('Invalid count type', InvalidFilterException::INVALID_TYPE);
+    }
+
+    if (!isset($data['count'])) {
+      throw new InvalidFilterException('Missing review count', InvalidFilterException::MISSING_VALUE);
+    }
+    $this->filterHelper->validateDaysPeriodData($data);
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviewsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviewsTest.php
@@ -1,0 +1,239 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * @group woo
+ */
+class WooCommerceNumberOfReviewsTest extends \MailPoetTest {
+  /** @var WooCommerceNumberOfReviews */
+  private $filter;
+
+  /** @var int */
+  private $productId;
+
+  public function _before(): void {
+    $this->filter = $this->diContainer->get(WooCommerceNumberOfReviews::class);
+    $this->productId = $this->tester->createWooCommerceProduct(['name' => 'Some really fantastic product'])->get_id();
+  }
+
+  public function testAnyRatingOnlyReturnsSubscribersWithRating(): void {
+    $customerId = $this->tester->createCustomer('1@e.com');
+    $this->tester->createCustomer('noreview@e.com');
+    $this->tester->createWooProductReview($customerId, '1@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $this->assertFilterReturnsEmails('any', '>', 0, 200, 'inTheLast', ['1@e.com']);
+  }
+
+  public function testItWorksWithOverAllTimeOption(): void {
+    $customerId = $this->tester->createCustomer('1@e.com');
+    $this->tester->createWooProductReview($customerId, '1@e.com', $this->productId, 1, Carbon::now()->subDays(20));
+    $this->assertFilterReturnsEmails('any', '>', 0, 2, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', '>', 0, 2, 'allTime', ['1@e.com']);
+  }
+
+  public function testItHandlesExactNumberOfReviews(): void {
+    $customerId = $this->tester->createCustomer('test1@e.com');
+    $this->tester->createWooProductReview($customerId, 'test1@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $this->tester->createWooProductReview($customerId, 'test1@e.com', $this->productId, 2, Carbon::now()->subDay());
+    $this->assertFilterReturnsEmails('any', '=', 2, 200, 'inTheLast', ['test1@e.com']);
+  }
+
+  public function testItHandlesGreaterThan(): void {
+    $customerId = $this->tester->createCustomer('greaterThanTest@e.com');
+    $this->tester->createWooProductReview($customerId, 'greaterthantest@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $this->tester->createWooProductReview($customerId, 'greaterthantest@e.com', $this->productId, 2, Carbon::now()->subDay());
+    $customerId = $this->tester->createCustomer('oneReviewTest@e.com');
+    $this->tester->createWooProductReview($customerId, 'onereviewtest@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $this->assertFilterReturnsEmails('any', '>', 1, 200, 'inTheLast', ['greaterthantest@e.com']);
+  }
+
+  public function testItHandlesLessThan(): void {
+    $this->tester->createCustomer('lessthantest@e.com');
+    $customerId = $this->tester->createCustomer('onereviewtest@e.com');
+    $this->tester->createWooProductReview($customerId, 'onereviewtest@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $customerId2 = $this->tester->createCustomer('tworeviews@e.com');
+    $this->tester->createWooProductReview($customerId, 'tworeviews@e.com', $this->productId, 2, Carbon::now()->subDay());
+    $this->tester->createWooProductReview($customerId, 'tworeviews@e.com', $this->productId, 2, Carbon::now()->subDay());
+    $this->assertFilterReturnsEmails('any', '<', 1, 200, 'inTheLast', ['lessthantest@e.com']);
+    $this->assertFilterReturnsEmails('any', '<', 2, 200, 'inTheLast', ['lessthantest@e.com', 'onereviewtest@e.com']);
+  }
+
+  public function testItHandlesNotEquals(): void {
+    $this->tester->createCustomer('notequalstest@e.com');
+    $customerId = $this->tester->createCustomer('onereviewtest@e.com');
+    $this->tester->createWooProductReview($customerId, 'onereviewtest@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $customerId = $this->tester->createCustomer('tworeviewstest@e.com');
+    $this->tester->createWooProductReview($customerId, 'tworeviewstest@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $this->tester->createWooProductReview($customerId, 'tworeviewstest@e.com', $this->productId, 2, Carbon::now()->subDay());
+
+    $this->assertFilterReturnsEmails('any', '!=', 1, 200, 'inTheLast', ['notequalstest@e.com', 'tworeviewstest@e.com']);
+  }
+
+  public function testItHandlesCustomerWithNoReviews(): void {
+    $this->tester->createCustomer('test2@e.com');
+    $this->assertFilterReturnsEmails('any', '>', 0, 200, 'inTheLast', []);
+  }
+
+  public function testItIncludesCustomersWithNoReviewsWhenUsingLessThan(): void {
+    $this->tester->createCustomer('test1@e.com');
+    $customerId = $this->tester->createCustomer('test2@e.com');
+    $this->tester->createWooProductReview($customerId, 'test2@e.com', $this->productId, 1, Carbon::now()->subDay());
+    $this->assertFilterReturnsEmails('any', '<', 1, 200, 'inTheLast', ['test1@e.com']);
+  }
+
+  public function testFiltersByDifferentRatings(): void {
+    $customerOneId = $this->tester->createCustomer('customer-one@test.com');
+    $this->tester->createWooProductReview($customerOneId, 'customer-one@test.com', $this->productId, 5);
+    $this->tester->createWooProductReview($customerOneId, 'customer-one@test.com', $this->productId, 5);
+    $this->tester->createWooProductReview($customerOneId, 'customer-one@test.com', $this->productId, 3);
+
+    $customerTwoId = $this->tester->createCustomer('customer-two@test.com');
+    $this->tester->createWooProductReview($customerTwoId, 'customer-two@test.com', $this->productId, 4);
+    $this->tester->createWooProductReview($customerTwoId, 'customer-two@test.com', $this->productId, 4);
+    $this->tester->createWooProductReview($customerTwoId, 'customer-two@test.com', $this->productId, 4);
+
+    $customerThreeId = $this->tester->createCustomer('customer-three@test.com');
+    $this->tester->createWooProductReview($customerThreeId, 'customer-three@test.com', $this->productId, 2);
+    $this->tester->createWooProductReview($customerThreeId, 'customer-three@test.com', $this->productId, 5);
+
+    $this->assertFilterReturnsEmails('5', '>', 1, 200, 'inTheLast', ['customer-one@test.com']);
+    $this->assertFilterReturnsEmails('4', '=', 3, 200, 'inTheLast', ['customer-two@test.com']);
+    $this->assertFilterReturnsEmails('2', '=', 1, 200, 'inTheLast', ['customer-three@test.com']);
+  }
+
+  public function testFiltersByDifferentDates(): void {
+    $customerFourId = $this->tester->createCustomer('1@e.com');
+    $this->tester->createWooProductReview($customerFourId, '1@e.com', $this->productId, 5, Carbon::now()->subDays(6));
+
+    $customerFiveId = $this->tester->createCustomer('2@e.com');
+    $this->tester->createWooProductReview($customerFiveId, '2@e.com', $this->productId, 5, Carbon::now()->subWeeks(3));
+
+    $customerSixId = $this->tester->createCustomer('3@e.com');
+    $this->tester->createWooProductReview($customerSixId, '3@e.com', $this->productId, 4, Carbon::now()->subWeeks(6));
+
+    $this->assertFilterReturnsEmails('5', '=', 1, 7, 'inTheLast', ['1@e.com']);
+    $this->assertFilterReturnsEmails('5', '=', 1, 30, 'inTheLast', ['1@e.com', '2@e.com']);
+    $this->assertFilterReturnsEmails('4', '=', 1, 50, 'inTheLast', ['3@e.com']);
+  }
+
+  public function testItValidatesRatingPresence(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    $this->expectExceptionMessage('Missing rating');
+    $this->filter->validateFilterData([
+      'action' => 'numberOfReviews',
+      'count_type' => '!=',
+      'days' => '10',
+      'count' => '3',
+      'timeframe' => 'inTheLast',
+    ]);
+  }
+
+  /**
+   * @dataProvider ratingDataProvider
+   */
+  public function testItValidatesRatingValue(string $rating, bool $shouldFail): void {
+    $data = [
+      'action' => 'numberOfReviews',
+      'rating' => $rating,
+      'days' => '10',
+      'count' => '2',
+      'count_type' => '!=',
+      'timeframe' => 'inTheLast',
+    ];
+
+    if ($shouldFail) {
+      $this->expectException(InvalidFilterException::class);
+      $this->expectExceptionMessage('Invalid rating');
+      $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    }
+
+    $this->filter->validateFilterData($data);
+  }
+
+  public function ratingDataProvider(): array {
+    return [
+      'Invalid rating value' => ['6', true],
+      'Valid rating value 1' => ['1', false],
+      'Valid rating value 2' => ['2', false],
+      'Valid rating value 3' => ['3', false],
+      'Valid rating value 4' => ['4', false],
+      'Valid rating value 5' => ['5', false],
+      'Valid rating value any' => ['any', false],
+    ];
+  }
+
+  public function testItValidatesCountType(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    $this->expectExceptionMessage('Missing count type');
+    $this->filter->validateFilterData([
+      'action' => 'numberOfReviews',
+      'rating' => '3',
+      'days' => '10',
+      'count' => '3',
+      'timeframe' => 'inTheLast',
+    ]);
+  }
+
+  public function testItValidatesCountTypeOptions(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_TYPE);
+    $this->expectExceptionMessage('Invalid count type');
+    $this->filter->validateFilterData([
+      'action' => 'numberOfReviews',
+      'rating' => '3',
+      'days' => '10',
+      'count' => '3',
+      'count_type' => 'invalid',
+      'timeframe' => 'inTheLast',
+    ]);
+  }
+
+  public function testItValidatesCount(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    $this->expectExceptionMessage('Missing review count');
+    $this->filter->validateFilterData([
+      'action' => 'numberOfReviews',
+      'count_type' => '!=',
+      'rating' => '3',
+      'days' => '10',
+      'timeframe' => 'inTheLast',
+    ]);
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->cleanUp();
+  }
+
+  private function assertFilterReturnsEmails(string $rating, string $countType, int $count, int $days, string $timeframe, array $expectedEmails): void {
+    $data = new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceNumberOfReviews::ACTION,
+      [
+        'days' => $days,
+        'count_type' => $countType,
+        'count' => $count,
+        'timeframe' => $timeframe,
+        'rating' => $rating,
+      ]
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($data, $this->filter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  private function cleanUp(): void {
+    global $wpdb;
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}comments");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}commentmeta");
+  }
+}

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -195,6 +195,14 @@
   'searchAutomations': __('Search automations'),
 
   'wooNumberOfOrders': __('number of orders'),
+  'wooNumberOfReviews': __('number of reviews'),
+  'wooAnyStarRating': __('any'),
+  'wooOneStarRating': __('1 star'),
+  'wooTwoStarRating': __('2 star'),
+  'wooThreeStarRating': __('3 star'),
+  'wooFourStarRating': __('4 star'),
+  'wooFiveStarRating': __('5 star'),
+
   'moreThan': __('more than'),
   'moreThanOrEqual': __('more than or equal'),
   'lessThan': __('less than'),
@@ -205,6 +213,7 @@
   'inTheLast': _x('in the last', 'Appears together with `days` when creating a new WooCommerce segment based on the number of orders.'),
   'wooAverageSpent': __('average order value'),
   'wooNumberOfOrdersOrders': __('orders'),
+  'wooNumberOfReviewsReviews': __('reviews'),
   'wooPurchasedCategory': __('purchased in category'),
   'wooPurchaseDate': __('purchase date'),
   'wooPurchasedProduct': __('purchased product'),


### PR DESCRIPTION
## Description

WooCommerce number of reviews filter for dynamic segments.

## Code review notes

_N/A_

## QA notes

This includes a fix for the validation for the number of days field, which is used in a number of filters. I mistakenly broke that logic in this commit: https://github.com/mailpoet/mailpoet/commit/8ab1df5ffa56199a1f4380dcbed9655710ef8235
Without this fix, filters will appear valid if they're set to "in the last" even if there isn't a number of days specified.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5413](https://mailpoet.atlassian.net/browse/MAILPOET-5413)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5413]: https://mailpoet.atlassian.net/browse/MAILPOET-5413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ