### PR TITLE
Add Acceptance tests for Analytics [MAILPOET-5405]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
@@ -80,7 +80,8 @@ function getWooCommerceDelta(type: 'revenue' | 'orders'): number | undefined {
     return 0;
   }
 
-  return (newValue / previous) * 100;
+  const delta = (newValue / previous) * 100;
+  return current > previous ? delta : delta * -1;
 }
 
 export function Overview(): JSX.Element | null {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
@@ -31,8 +31,7 @@ function getEmailPercentage(
     return 0;
   }
 
-  const percentage = (data[period] * 100) / sent[period] / 100;
-  return percentage;
+  return (data[period] * 100) / sent[period] / 100;
 }
 
 function getEmailDelta(type: 'opened' | 'clicked'): number | undefined {
@@ -46,9 +45,8 @@ function getEmailDelta(type: 'opened' | 'clicked'): number | undefined {
     return 0;
   }
 
-  const newValue = current > previous ? current - previous : previous - current;
-  const delta = (newValue / previous) * 100;
-  return current > previous ? delta : delta * -1;
+  const newValue = current - previous;
+  return (newValue / previous) * 100;
 }
 
 function getWooCommerceTotal(
@@ -75,13 +73,11 @@ function getWooCommerceDelta(type: 'revenue' | 'orders'): number | undefined {
   if (current === undefined || previous === undefined) {
     return undefined;
   }
-  const newValue = current > previous ? current - previous : previous - current;
+  const newValue = current - previous;
   if (newValue === 0 || previous === 0) {
     return 0;
   }
-
-  const delta = (newValue / previous) * 100;
-  return current > previous ? delta : delta * -1;
+  return (newValue / previous) * 100;
 }
 
 export function Overview(): JSX.Element | null {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
@@ -39,7 +39,7 @@ function getEmailDelta(type: 'opened' | 'clicked'): number | undefined {
   const current = getEmailPercentage(type, 'current');
   const previous = getEmailPercentage(type, 'previous');
   if (current === undefined || previous === undefined) {
-    return undefined;
+    return 0;
   }
 
   if (previous === 0) {
@@ -47,7 +47,8 @@ function getEmailDelta(type: 'opened' | 'clicked'): number | undefined {
   }
 
   const newValue = current > previous ? current - previous : previous - current;
-  return (newValue / previous) * 100;
+  const delta = (newValue / previous) * 100;
+  return current > previous ? delta : delta * -1;
 }
 
 function getWooCommerceTotal(

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation_flow/statistic_separator.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation_flow/statistic_separator.tsx
@@ -34,7 +34,9 @@ export function StatisticSeparator({
       notation: 'compact',
     }).format(data.step_data.total);
     return (
-      <div className="mailpoet-automation-editor-separator mailpoet-automation-analytics-separator">
+      <div
+        className={`mailpoet-automation-editor-separator mailpoet-automation-analytics-separator mailpoet-automation-analytics-separator-${previousStepId}`}
+      >
         <p>
           <span className="mailpoet-automation-analytics-separator-values">
             {formattedValue}
@@ -64,7 +66,9 @@ export function StatisticSeparator({
   }).format(percent / 100);
 
   return (
-    <div className="mailpoet-automation-editor-separator mailpoet-automation-analytics-separator">
+    <div
+      className={`mailpoet-automation-editor-separator mailpoet-automation-analytics-separator  mailpoet-automation-analytics-separator-${previousStepId}`}
+    >
       <p>
         <span className="mailpoet-automation-analytics-separator-values">
           {formattedPercent} ({formattedValue})

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation_flow/steps/send_email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation_flow/steps/send_email/index.tsx
@@ -8,6 +8,7 @@ import { locale } from '../../../../../config';
 import { formattedPrice } from '../../../../../formatter';
 import { openTab } from '../../../../../navigation/open_tab';
 import { Badge } from '../../../../email_click_badge';
+import { MailPoet } from '../../../../../../../../../mailpoet';
 
 type SendEmailPanelSectionProps = {
   label: string;
@@ -89,33 +90,37 @@ export function SendEmailPanel({ step }: SendEmailPanelProps): JSX.Element {
         value={<Badge email={email} property="clicked" />}
         isLoading={isLoading}
       />
-      <hr />
-      <SendEmailPanelSection
-        label={__('Orders', 'mailpoet')}
-        value={
-          <Tooltip text={__('View orders', 'mailpoet')}>
-            <a
-              href={addQueryArgs(window.location.href, {
-                tab: 'automation-orders',
-              })}
-              onClick={(e) => {
-                e.preventDefault();
-                openTab('orders', { filters: { emails: [`${email.id}`] } });
-              }}
-            >
-              {Intl.NumberFormat(locale.toString(), {
-                notation: 'compact',
-              }).format(email?.orders ?? 0)}
-            </a>
-          </Tooltip>
-        }
-        isLoading={isLoading}
-      />
-      <SendEmailPanelSection
-        label={__('Revenue', 'mailpoet')}
-        value={formattedPrice(email?.revenue ?? 0)}
-        isLoading={isLoading}
-      />
+      {MailPoet.isWoocommerceActive && (
+        <>
+          <hr />
+          <SendEmailPanelSection
+            label={__('Orders', 'mailpoet')}
+            value={
+              <Tooltip text={__('View orders', 'mailpoet')}>
+                <a
+                  href={addQueryArgs(window.location.href, {
+                    tab: 'automation-orders',
+                  })}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    openTab('orders', { filters: { emails: [`${email.id}`] } });
+                  }}
+                >
+                  {Intl.NumberFormat(locale.toString(), {
+                    notation: 'compact',
+                  }).format(email?.orders ?? 0)}
+                </a>
+              </Tooltip>
+            }
+            isLoading={isLoading}
+          />
+          <SendEmailPanelSection
+            label={__('Revenue', 'mailpoet')}
+            value={formattedPrice(email?.revenue ?? 0)}
+            isLoading={isLoading}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { calculateSummary } from './summary';
 import { transformEmailsToRows } from './rows';
 import { EmailStats, OverviewSection, storeName } from '../../../store';
+import { MailPoet } from '../../../../../../../mailpoet';
 
 const headers = [
   {
@@ -29,18 +30,26 @@ const headers = [
     isLeftAligned: false,
     isNumeric: true,
   },
-  {
-    key: 'orders',
-    label: __('Orders', 'mailpoet'),
-    isLeftAligned: false,
-    isNumeric: true,
-  },
-  {
-    key: 'revenue',
-    label: __('Revenue', 'mailpoet'),
-    isLeftAligned: false,
-    isNumeric: true,
-  },
+];
+
+if (MailPoet.isWoocommerceActive) {
+  headers.push(
+    {
+      key: 'orders',
+      label: __('Orders', 'mailpoet'),
+      isLeftAligned: false,
+      isNumeric: true,
+    },
+    {
+      key: 'revenue',
+      label: __('Revenue', 'mailpoet'),
+      isLeftAligned: false,
+      isNumeric: true,
+    },
+  );
+}
+
+headers.push(
   {
     key: 'unsubscribed',
     label: __('Unsubscribed', 'mailpoet'),
@@ -51,7 +60,7 @@ const headers = [
     key: 'actions',
     label: '',
   },
-];
+);
 
 export function Emails(): JSX.Element {
   const { overview } = useSelect((s) => ({

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
@@ -9,6 +9,7 @@ import { formattedPrice } from '../../../formatter';
 import { openTab } from '../../../navigation/open_tab';
 import { calculatePercentage } from '../../../formatter/calculate_percentage';
 import { Badge } from '../../email_click_badge';
+import { MailPoet } from '../../../../../../../mailpoet';
 
 const percentageFormatter = Intl.NumberFormat(locale.toString(), {
   style: 'percent',
@@ -23,7 +24,7 @@ export function transformEmailsToRows(emails: EmailStats[]) {
       email.sent.current,
     );
 
-    return [
+    const rows = [
       {
         display: (
           <Cell
@@ -89,32 +90,42 @@ export function transformEmailsToRows(emails: EmailStats[]) {
         ),
         value: email.clicked,
       },
-      {
-        display: (
-          <Cell
-            value={
-              <Tooltip text={__('View orders', 'mailpoet')}>
-                <a
-                  href={addQueryArgs(window.location.href, {
-                    tab: 'automation-orders',
-                  })}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    openTab('orders', { filters: { emails: [`${email.id}`] } });
-                  }}
-                >
-                  {`${email.orders}`}
-                </a>
-              </Tooltip>
-            }
-          />
-        ),
-        value: email.orders,
-      },
-      {
-        display: <Cell value={formattedPrice(email.revenue)} />,
-        value: email.revenue,
-      },
+    ];
+
+    if (MailPoet.isWoocommerceActive) {
+      rows.push(
+        {
+          display: (
+            <Cell
+              value={
+                <Tooltip text={__('View orders', 'mailpoet')}>
+                  <a
+                    href={addQueryArgs(window.location.href, {
+                      tab: 'automation-orders',
+                    })}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openTab('orders', {
+                        filters: { emails: [`${email.id}`] },
+                      });
+                    }}
+                  >
+                    {`${email.orders}`}
+                  </a>
+                </Tooltip>
+              }
+            />
+          ),
+          value: email.orders,
+        },
+        {
+          display: <Cell value={formattedPrice(email.revenue)} />,
+          value: email.revenue,
+        },
+      );
+    }
+
+    return rows.concat([
       {
         display: <Cell value={email.unsubscribed} />,
         value: email.unsubscribed,
@@ -123,6 +134,6 @@ export function transformEmailsToRows(emails: EmailStats[]) {
         display: <Actions id={email.id} previewUrl={email.previewUrl} />,
         value: null,
       },
-    ];
+    ]);
   });
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/summary.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/summary.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { locale } from '../../../../../../config';
 import { EmailStats } from '../../../store';
 import { formattedPrice } from '../../../formatter';
+import { MailPoet } from '../../../../../../../mailpoet';
 
 export function calculateSummary(rows: EmailStats[]) {
   if (rows.length === 0) {
@@ -43,16 +44,20 @@ export function calculateSummary(rows: EmailStats[]) {
       label: __('clicked', 'mailpoet'),
       value: compactFormatter.format(data.clicked),
     },
-    {
-      label: __('orders', 'mailpoet'),
-      value: compactFormatter.format(data.orders),
-    },
-    { label: __('revenue', 'mailpoet'), value: formattedPrice(data.revenue) },
-    {
-      label: __('unsubscribed', 'mailpoet'),
-      value: compactFormatter.format(data.unsubscribed),
-    },
   ];
+  if (MailPoet.isWoocommerceActive) {
+    summary.push(
+      {
+        label: __('orders', 'mailpoet'),
+        value: compactFormatter.format(data.orders),
+      },
+      { label: __('revenue', 'mailpoet'), value: formattedPrice(data.revenue) },
+    );
+  }
+  summary.push({
+    label: __('unsubscribed', 'mailpoet'),
+    value: compactFormatter.format(data.unsubscribed),
+  });
 
   return summary;
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/index.tsx
@@ -9,6 +9,7 @@ import { Emails } from './emails';
 import { Orders } from './orders';
 import { Subscribers } from './subscribers';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
+import { MailPoet } from '../../../../../../mailpoet';
 
 export function Tabs(): JSX.Element {
   const history = useHistory();
@@ -34,17 +35,19 @@ export function Tabs(): JSX.Element {
       className: 'mailpoet-analytics-tab-emails',
       title: __('Emails', 'mailpoet'),
     });
-    tabs.push({
-      name: 'automation-orders',
-      className: 'mailpoet-analytics-tab-orders',
-      // title is defined as string but allows for JSX.Element
-      title: (
-        <>
-          {_x('Orders', 'WooCommerce orders', 'mailpoet')}{' '}
-          <Icon icon={lockSmall} />
-        </>
-      ) as unknown as string,
-    });
+    if (MailPoet.isWoocommerceActive) {
+      tabs.push({
+        name: 'automation-orders',
+        className: 'mailpoet-analytics-tab-orders',
+        // title is defined as string but allows for JSX.Element
+        title: (
+          <>
+            {_x('Orders', 'WooCommerce orders', 'mailpoet')}{' '}
+            <Icon icon={lockSmall} />
+          </>
+        ) as unknown as string,
+      });
+    }
     tabs.push({
       name: 'automation-subscribers',
       className: 'mailpoet-analytics-tab-subscribers',

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial_state.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial_state.ts
@@ -1,74 +1,80 @@
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { State } from './types';
+import { Section, State } from './types';
 import { storeName as editorStoreName } from '../../../../editor/store';
+import { MailPoet } from '../../../../../mailpoet';
 
-export const getInitialState = (): State => ({
-  sections: {
-    automation_flow: {
-      id: 'automation_flow',
-      name: __('Automation flow', 'mailpoet'),
-      data: undefined,
-      withPreviousData: false,
-      endpoint: '/automation/analytics/automation_flow',
-      updateCallback: (data): void => {
-        if (!data || !data?.automation) {
-          return;
-        }
-        const { automation } = data;
-        dispatch(editorStoreName).updateAutomation(automation);
-      },
-    },
-    overview: {
-      id: 'overview',
-      name: __('Overview', 'mailpoet'),
-      data: undefined,
-      withPreviousData: true,
-      endpoint: '/automation/analytics/overview',
-    },
-    orders: {
-      id: 'orders',
-      name: __('Orders', 'mailpoet'),
-      data: undefined,
-      currentView: {
-        filters: {
-          emails: [],
-        },
-      },
-      customQuery: {
-        order: 'asc',
-        order_by: 'created_at',
-        limit: 25,
-        page: 1,
-        filter: undefined,
-        search: undefined,
-      },
-      withPreviousData: false,
-      endpoint: '/automation/analytics/orders',
-    },
-    subscribers: {
-      id: 'subscribers',
-      name: __('Subscribers', 'mailpoet'),
-      data: undefined,
-      currentView: {
-        search: '',
-        filters: {
-          step: [],
-          status: [],
-        },
-      },
-      customQuery: {
-        order: 'asc',
-        order_by: 'updated_at',
-        limit: 25,
-        page: 1,
-        filter: undefined,
-        search: undefined,
-      },
-      withPreviousData: false,
-      endpoint: '/automation/analytics/subscribers',
+const sections: Record<string, Section> = {
+  automation_flow: {
+    id: 'automation_flow',
+    name: __('Automation flow', 'mailpoet'),
+    data: undefined,
+    withPreviousData: false,
+    endpoint: '/automation/analytics/automation_flow',
+    updateCallback: (data): void => {
+      if (!data || !data?.automation) {
+        return;
+      }
+      const { automation } = data;
+      dispatch(editorStoreName).updateAutomation(automation);
     },
   },
+  overview: {
+    id: 'overview',
+    name: __('Overview', 'mailpoet'),
+    data: undefined,
+    withPreviousData: true,
+    endpoint: '/automation/analytics/overview',
+  },
+  subscribers: {
+    id: 'subscribers',
+    name: __('Subscribers', 'mailpoet'),
+    data: undefined,
+    currentView: {
+      search: '',
+      filters: {
+        step: [],
+        status: [],
+      },
+    },
+    customQuery: {
+      order: 'asc',
+      order_by: 'updated_at',
+      limit: 25,
+      page: 1,
+      filter: undefined,
+      search: undefined,
+    },
+    withPreviousData: false,
+    endpoint: '/automation/analytics/subscribers',
+  },
+};
+
+if (MailPoet.isWoocommerceActive) {
+  sections.orders = {
+    id: 'orders',
+    name: __('Orders', 'mailpoet'),
+    data: undefined,
+    currentView: {
+      filters: {
+        emails: [],
+      },
+    },
+    customQuery: {
+      order: 'asc',
+      order_by: 'created_at',
+      limit: 25,
+      page: 1,
+      filter: undefined,
+      search: undefined,
+    },
+    withPreviousData: false,
+    endpoint: '/automation/analytics/orders',
+  };
+}
+
+export const getInitialState = (): State => ({
+  sections,
   query: {
     compare: 'previous_period',
     period: 'quarter',

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -106,6 +106,10 @@ class Automation {
     return $this->createdAt;
   }
 
+  public function setCreatedAt(DateTimeImmutable $createdAt): void {
+    $this->createdAt = $createdAt;
+  }
+
   public function getAuthor(): \WP_User {
     return $this->author;
   }

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -54,6 +54,15 @@ class AutomationRunStorage {
     return $automationRunId;
   }
 
+  public function deleteAutomationRun(AutomationRun $automationRun): bool {
+    $success = $this->wpdb->delete($this->table, ['id' => $automationRun->getId()]);
+    if ($success === false) {
+      return false;
+    }
+    $success = $this->wpdb->delete($this->subjectTable, ['automation_run_id' => $automationRun->getId()]);
+    return $success !== false;
+  }
+
   public function getAutomationRun(int $id): ?AutomationRun {
     $table = esc_sql($this->table);
     $subjectTable = esc_sql($this->subjectTable);

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -54,15 +54,6 @@ class AutomationRunStorage {
     return $automationRunId;
   }
 
-  public function deleteAutomationRun(AutomationRun $automationRun): bool {
-    $success = $this->wpdb->delete($this->table, ['id' => $automationRun->getId()]);
-    if ($success === false) {
-      return false;
-    }
-    $success = $this->wpdb->delete($this->subjectTable, ['automation_run_id' => $automationRun->getId()]);
-    return $success !== false;
-  }
-
   public function getAutomationRun(int $id): ?AutomationRun {
     $table = esc_sql($this->table);
     $subjectTable = esc_sql($this->subjectTable);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/FreeOrderController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/FreeOrderController.php
@@ -101,12 +101,15 @@ class FreeOrderController implements OrderController {
         'avatar' => $this->wp->getAvatarUrl($subscriber->getEmail(), ['size' => 20]),
       ],
       'details' => [
-        'id' => $currentOrder ? $currentOrder->get_id() : null,
+        'id' => $currentOrder ? $currentOrder->get_id() : 0,
         'status' => $currentOrder ? [
           'id' => $currentOrder->get_status(),
           'name' => $this->woocommerce->wcGetOrderStatusName($currentOrder->get_status()),
-          ] : null,
-        'total' => $currentOrder ? (float)$currentOrder->get_total() : null,
+          ] : [
+          'id' => 'completed',
+          'name' => $this->woocommerce->wcGetOrderStatusName('completed'),
+        ],
+        'total' => $currentOrder ? (float)$currentOrder->get_total() : 0,
         'products' => $products,
       ],
         'email' => [

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/FreeOrderController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/FreeOrderController.php
@@ -44,6 +44,13 @@ class FreeOrderController implements OrderController {
 
   public function getOrdersForAutomation(Automation $automation, Query $query): array {
     $allEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getAfter(), $query->getBefore());
+    if (!$allEmails) {
+      return [
+        'results' => 0,
+        'items' => [],
+        'emails' => [],
+      ];
+    }
     $items = [
       $this->addItem($automation, $query),
       $this->addItem($automation, $query),

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/FreeSubscriberController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/FreeSubscriberController.php
@@ -50,7 +50,6 @@ class FreeSubscriberController implements SubscriberController {
 
     $subscriber = $this->getRandomSubscriber();
 
-    $step = $this->getRandomStep($automation);
     return [
       'date' => $this->findRandomDateBetween($query->getAfter(), $query->getBefore())->format(\DateTimeImmutable::W3C),
       'subscriber' => [

--- a/mailpoet/tests/DataFactories/Automation.php
+++ b/mailpoet/tests/DataFactories/Automation.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterEntity;
 
 class Automation {
 
@@ -41,7 +42,7 @@ class Automation {
     return $this;
   }
 
-  public function withSteps(Step ...$steps) {
+  public function withSteps(Step ...$steps): self {
     $sortedSteps = [];
     foreach ($steps as $step) {
       $sortedSteps[$step->getId()] = $step;
@@ -50,7 +51,7 @@ class Automation {
     return $this;
   }
 
-  public function addStep(Step $step) {
+  public function addStep(Step $step): self {
     $steps = $this->automation->getSteps();
     $lastStep = end($steps);
     if (!$lastStep) {
@@ -61,7 +62,7 @@ class Automation {
     return $this->withSteps(...array_values($steps));
   }
 
-  public function withDelayAction() {
+  public function withDelayAction(): self {
     $step = new Step(
       uniqid(),
       Step::TYPE_ACTION,
@@ -75,7 +76,23 @@ class Automation {
     return $this->addStep($step);
   }
 
-  public function withSomeoneSubscribesTrigger() {
+  public function withSendEmailStep(NewsletterEntity $newsletter): self {
+    $step = new Step(
+      uniqid(),
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      [
+        'email_id' => $newsletter->getId(),
+        'subject' => $newsletter->getSubject(),
+        'sender_name' => $newsletter->getSenderName(),
+        'sender_address' => $newsletter->getSenderAddress(),
+      ],
+      []
+    );
+    return $this->addStep($step);
+  }
+
+  public function withSomeoneSubscribesTrigger(): self {
     $step = new Step(
       uniqid(),
       Step::TYPE_TRIGGER,
@@ -86,22 +103,22 @@ class Automation {
     return $this->addStep($step);
   }
 
-  public function withMeta($key, $value) {
+  public function withMeta($key, $value): self {
     $this->automation->setMeta($key, $value);
     return $this;
   }
 
-  public function withStatus($status) {
+  public function withStatus($status): self {
     $this->automation->setStatus($status);
     return $this;
   }
 
-  public function withStatusActive() {
+  public function withStatusActive(): self {
     $this->automation->setStatus(Entity::STATUS_ACTIVE);
     return $this;
   }
 
-  public function create() {
+  public function create(): \MailPoet\Automation\Engine\Data\Automation {
     $id = $this->storage->createAutomation($this->automation);
     $automation = $this->storage->getAutomation($id);
     if (!$automation) {

--- a/mailpoet/tests/DataFactories/Automation.php
+++ b/mailpoet/tests/DataFactories/Automation.php
@@ -118,6 +118,11 @@ class Automation {
     return $this;
   }
 
+  public function withCreatedAt(\DateTimeImmutable $createdAt): self {
+    $this->automation->setCreatedAt($createdAt);
+    return $this;
+  }
+
   public function create(): \MailPoet\Automation\Engine\Data\Automation {
     $id = $this->storage->createAutomation($this->automation);
     $automation = $this->storage->getAutomation($id);

--- a/mailpoet/tests/DataFactories/AutomationRun.php
+++ b/mailpoet/tests/DataFactories/AutomationRun.php
@@ -89,28 +89,20 @@ class AutomationRun {
   }
 
   public function create(): Entity {
+    $now = new DateTimeImmutable();
+    $automationRun = Entity::fromArray([
+      'id' => 0,
+      'automation_id' => $this->automation->getId(),
+      'version_id' => $this->automation->getVersionId(),
+      'trigger_key' => $this->triggerKey,
+      'status' => $this->status,
+      'created_at' => ($this->createdAt ?? $now)->format(DateTimeImmutable::W3C),
+      'updated_at' => ($this->updatedAt ?? $now)->format(DateTimeImmutable::W3C),
+      'subjects' => array_map(function (Subject $subject) {
+        return $subject->toArray();
+      }, $this->subjects),
+    ]);
 
-    $automationRun = new Entity(
-      $this->automation->getId(),
-      $this->automation->getVersionId(),
-      $this->triggerKey,
-      $this->subjects
-    );
-
-    $id = $this->storage->createAutomationRun($automationRun);
-    $automationRun = $this->storage->getAutomationRun($id);
-    $this->storage->deleteAutomationRun($automationRun);
-
-    $array = $automationRun->toArray();
-    $array['id'] = $automationRun->getId();
-    $array['status'] = $this->status;
-    if ($this->createdAt) {
-      $array['created_at'] = $this->createdAt->format(DateTimeImmutable::W3C);
-    }
-    if ($this->updatedAt) {
-      $array['updated_at'] = $this->updatedAt->format(DateTimeImmutable::W3C);
-    }
-    $automationRun = Entity::fromArray($array);
     $id = $this->storage->createAutomationRun($automationRun);
     $this->storage->updateNextStep($id, $this->nextStep);
     $this->automationRun = $this->storage->getAutomationRun($id);

--- a/mailpoet/tests/DataFactories/AutomationRun.php
+++ b/mailpoet/tests/DataFactories/AutomationRun.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use DateTimeImmutable;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun as Entity;
+use MailPoet\Automation\Engine\Data\AutomationRunLog;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\DI\ContainerWrapper;
+
+class AutomationRun {
+
+
+  /** @var ?Entity */
+  private $automationRun = null;
+
+  /** @var Automation  */
+  private $automation;
+
+  /** @var array Subject[] */
+  private $subjects = [];
+
+  /** @var string  */
+  private $triggerKey = '';
+
+  /** @var \DateTimeImmutable | null */
+  private $createdAt;
+
+  /** @var \DateTimeImmutable | null */
+  private $updatedAt;
+
+  /** @var string  */
+  private $status = Entity::STATUS_COMPLETE;
+
+  /** @var ?string */
+  private $nextStep = null;
+
+  private $storage;
+
+  public function __construct() {
+    $this->storage = ContainerWrapper::getInstance(WP_DEBUG)->get(AutomationRunStorage::class);
+  }
+
+  public function withAutomation(Automation $automation): self {
+    $this->automation = $automation;
+    return $this;
+  }
+
+  public function withSubject(Subject $subject): self {
+    $this->subjects[] = $subject;
+    return $this;
+  }
+
+  public function withTriggerKey(string $triggeKey): self {
+    $this->triggerKey = $triggeKey;
+    return $this;
+  }
+
+  public function withCreatedAt(DateTimeImmutable $createdAt): self {
+    $this->createdAt = $createdAt;
+    if (!$this->updatedAt) {
+      return $this->withUpdatedAt($createdAt);
+    }
+    return $this;
+  }
+
+  public function withUpdatedAt(DateTimeImmutable $updatedAt): self {
+    $this->updatedAt = $updatedAt;
+    if (!$this->createdAt) {
+      return $this->withCreatedAt($updatedAt);
+    }
+    return $this;
+  }
+
+  public function withStatus(string $status): self {
+    $this->status = $status;
+    return $this;
+  }
+
+  public function withNextStep(string $nextStep = null): self {
+    $this->nextStep = $nextStep;
+    return $this;
+  }
+
+  public function create(): Entity {
+
+    $automationRun = new Entity(
+      $this->automation->getId(),
+      $this->automation->getVersionId(),
+      $this->triggerKey,
+      $this->subjects
+    );
+
+    $id = $this->storage->createAutomationRun($automationRun);
+    $automationRun = $this->storage->getAutomationRun($id);
+    $this->storage->deleteAutomationRun($automationRun);
+
+    $array = $automationRun->toArray();
+    $array['id'] = $automationRun->getId();
+    $array['status'] = $this->status;
+    if ($this->createdAt) {
+      $array['created_at'] = $this->createdAt->format(DateTimeImmutable::W3C);
+    }
+    if ($this->updatedAt) {
+      $array['updated_at'] = $this->updatedAt->format(DateTimeImmutable::W3C);
+    }
+    $automationRun = Entity::fromArray($array);
+    $id = $this->storage->createAutomationRun($automationRun);
+    $this->storage->updateNextStep($id, $this->nextStep);
+    $this->automationRun = $this->storage->getAutomationRun($id);
+    return $this->automationRun;
+  }
+
+  public function generateLogs(Entity $run, string $lastStep) {
+    $automation = ContainerWrapper::getInstance(WP_DEBUG)->get(AutomationStorage::class)->getAutomation($run->getAutomationId());
+    $steps = $this->findPathToStep($automation, $lastStep);
+
+    $logStorage = ContainerWrapper::getInstance(WP_DEBUG)->get(AutomationRunLogStorage::class);
+    foreach ($steps as $step) {
+      $log = new AutomationRunLog($run->getId(), $step);
+      $log->markCompletedSuccessfully();
+      $logStorage->createAutomationRunLog($log);
+    }
+  }
+
+  private function findPathToStep(Automation $automation, $lastStep): array {
+
+    $steps = $automation->getSteps();
+    if (in_array($steps[$lastStep]->getType(), [Step::TYPE_ROOT, Step::TYPE_TRIGGER], true)) {
+      return [];
+    }
+    $steps = [];
+    foreach ($automation->getSteps() as $step) {
+      $nextStepIds = array_map(
+        function(NextStep $next): string { return $next->getId();
+        },
+        $step->getNextSteps()
+      );
+      if (!in_array($lastStep, $nextStepIds, true)) {
+        continue;
+      }
+
+      $steps = array_merge($this->findPathToStep($automation, $step->getId()), [$step->getId()]);
+    }
+
+    return array_unique(array_merge($steps, [$lastStep]));
+
+  }
+}

--- a/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
+++ b/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
@@ -1,0 +1,302 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class AnalyticsCest {
+
+
+  /** @var Automation */
+  private $automation;
+
+  /** @var NewsletterEntity */
+  private $newsletter1;
+
+  /** @var NewsletterEntity */
+  private $newsletter2;
+
+  public function _before() {
+    $this->newsletter1 = $this->createNewsletter("Email 1");
+    $this->newsletter2 = $this->createNewsletter("Email 2");
+    $createdAt = (new \DateTimeImmutable())->modify('-2 years');
+    $this->automation = (new DataFactories\Automation())
+      ->withName('Someone Subscribed Automation')
+      ->withSomeoneSubscribesTrigger()
+      ->withSendEmailStep($this->newsletter1)
+      ->withDelayAction()
+      ->withSendEmailStep($this->newsletter2)
+      ->withStatusActive()
+      ->withCreatedAt($createdAt)
+      ->create();
+
+    //We need to alter the created_at date of the versions, so we can do historical comparisons.
+    global $wpdb;
+    $sql = 'update ' . $wpdb->prefix . 'mailpoet_automation_versions set created_at = %s where automation_id=%d';
+    $wpdb->query($wpdb->prepare($sql, $createdAt->format(\DateTimeImmutable::W3C), $this->automation->getId()));
+  }
+
+  public function testOverviewOpens(\AcceptanceTester $i) {
+
+    $i->wantTo('I want to check the overview opens and clicks');
+    $i->login();
+
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId() . "&tab=automation-emails");
+    $i->see('Overview');
+    $i->waitForText('Opened');
+    $i->see('Opened', '.woocommerce-summary > .woocommerce-summary__item-container');
+    $i->see('0%', '.woocommerce-summary > .woocommerce-summary__item-container');
+    $i->see('Clicked', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
+    $i->see('0%', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
+
+    $firstEmailSentCell = 'tbody > tr:nth-child(2n) > td:nth-child(2n) ';
+    $firstEmailOpenCell = 'tbody > tr:nth-child(2n) > td:nth-child(3n) ';
+    $firstEmailClickCell = 'tbody > tr:nth-child(2n) > td:nth-child(4n) ';
+    $secondEmailSentCell = 'tbody > tr:nth-child(3n) > td:nth-child(2n) ';
+    $secondEmailOpenCell = 'tbody > tr:nth-child(3n) > td:nth-child(3n) ';
+    $secondEmailClickCell = 'tbody > tr:nth-child(3n) > td:nth-child(4n) ';
+
+    $i->see('100', $firstEmailSentCell . '.mailpoet-analytics-main-value');
+    $i->see('900%', $firstEmailSentCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('100', $secondEmailSentCell . '.mailpoet-analytics-main-value');
+    $i->see('900%', $secondEmailSentCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0%', $firstEmailSentCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0%', $secondEmailSentCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0', $firstEmailOpenCell . '.mailpoet-analytics-main-value');
+    $i->see('0', $secondEmailOpenCell . '.mailpoet-analytics-main-value');
+    $i->see('0%', $firstEmailOpenCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0%', $secondEmailOpenCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0', $firstEmailClickCell . '.mailpoet-analytics-main-value');
+    $i->see('0', $secondEmailClickCell . '.mailpoet-analytics-main-value');
+    $i->see('0%', $firstEmailClickCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0%', $secondEmailClickCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('200sent', '.woocommerce-table__summary');
+    $i->see('0opened', '.woocommerce-table__summary');
+    $i->see('0clicked', '.woocommerce-table__summary');
+
+    $subscriber1 = $this->createSubscriber();
+    $subscriber2 = $this->createSubscriber();
+    $this->createRunForSubscriber($subscriber1);
+    $this->createRunForSubscriber($subscriber2);
+    $open1 = $this->createOpenForNewsletter($this->newsletter1, $subscriber1);
+    $open2 = $this->createOpenForNewsletter($this->newsletter1, $subscriber2);
+    $open3 = $this->createOpenForNewsletter($this->newsletter2, $subscriber2);
+    $click1 = $this->createClickForNewsletter($this->newsletter1, $subscriber1);
+    $click2 = $this->createClickForNewsletter($this->newsletter1, $subscriber2);
+
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId() . "&tab=automation-emails");
+    $i->waitForText('Opened');
+    $i->see('Opened', '.woocommerce-summary > .woocommerce-summary__item-container');
+    $i->see('1.5%', '.woocommerce-summary > .woocommerce-summary__item-container');
+    $i->see('Clicked', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
+    $i->see('1%', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
+
+
+    $i->see('100', $firstEmailSentCell . '.mailpoet-analytics-main-value');
+    $i->see('100', $secondEmailSentCell . '.mailpoet-analytics-main-value');
+    $i->see('900%', $firstEmailSentCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('900%', $secondEmailSentCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('2', $firstEmailOpenCell . '.mailpoet-analytics-main-value');
+    $i->see('1', $secondEmailOpenCell . '.mailpoet-analytics-main-value');
+    $i->see('2%', $firstEmailOpenCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('1%', $secondEmailOpenCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('2', $firstEmailClickCell . '.mailpoet-analytics-main-value');
+    $i->see('0', $secondEmailClickCell . '.mailpoet-analytics-main-value');
+    $i->see('2%', $firstEmailClickCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0%', $secondEmailClickCell . '.mailpoet-automation-analytics-table-subvalue');
+
+    $i->see('200sent', '.woocommerce-table__summary');
+    $i->see('3opened', '.woocommerce-table__summary');
+    $i->see('2clicked', '.woocommerce-table__summary');
+
+    $i->wantTo("Compare historical data");
+    $date = (new \DateTimeImmutable())->modify('-3 months');
+    $this->alterCreateDateForClick($click1, $date);
+    $this->alterCreateDateForOpen($open2, $date);
+
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId() . "&tab=automation-emails");
+    $i->waitForText('Opened');
+
+    $i->see('Opened', '.woocommerce-summary > .woocommerce-summary__item-container:first-child');
+    $i->see('1%', '.woocommerce-summary > .woocommerce-summary__item-container:first-child .woocommerce-summary__item-value');
+    $i->see('-80%', '.woocommerce-summary > .woocommerce-summary__item-container:first-child .woocommerce-summary__item-delta');
+
+    $i->see('Clicked', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
+    $i->see('0.5%', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n) .woocommerce-summary__item-value');
+    $i->see('-90%', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n) .woocommerce-summary__item-delta');
+
+    $i->see('1', $firstEmailOpenCell . '.mailpoet-analytics-main-value');
+    $i->see('1%', $firstEmailOpenCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('1', $firstEmailClickCell . '.mailpoet-analytics-main-value');
+    $i->see('0', $secondEmailClickCell . '.mailpoet-analytics-main-value');
+    $i->see('1%', $firstEmailClickCell . '.mailpoet-automation-analytics-table-subvalue');
+    $i->see('0%', $secondEmailClickCell . '.mailpoet-automation-analytics-table-subvalue');
+
+  }
+
+  public function automationFlowView(\AcceptanceTester $i) {
+
+    $i->wantTo('See how many people wait in the automation flow');
+    $i->login();
+
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId());
+    $i->see('Overview');
+    $i->waitForText('Opened');
+    $i->see('0%');
+    $i->dontSee('An unknown error occurred.');
+
+    //Two subscribers have finished the run
+    $this->createRunForSubscriber($this->createSubscriber());
+    $this->createRunForSubscriber($this->createSubscriber());
+
+    $automationSteps = $this->automation->getSteps();
+    $delayStep = null;
+    $firstEmailStep = null;
+    $secondEmailStep = null;
+    foreach ($automationSteps as $step) {
+      if ($step->getKey() === 'core:delay') {
+        $delayStep = $step->getId();
+      }
+      if ($step->getKey() === 'mailpoet:send-email' && $step->getArgs()['email_id'] === $this->newsletter1->getId()) {
+        $firstEmailStep = $step->getId();
+      }
+      if ($step->getKey() === 'mailpoet:send-email' && $step->getArgs()['email_id'] === $this->newsletter2->getId()) {
+        $secondEmailStep = $step->getId();
+      }
+    }
+    // 1 subscriber is waiting at core:delay
+    $this->createRunForSubscriber($this->createSubscriber(), $delayStep, AutomationRun::STATUS_RUNNING);
+
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId());
+    $i->waitForText('Opened');
+    $i->see('3 entered');
+
+    $i->scrollTo('.mailpoet-automation-analytics-separator-' . $firstEmailStep);
+    $i->see('0% (0) waiting', '#step-' . $firstEmailStep);
+    $i->see('100% (3) completed', '.mailpoet-automation-analytics-separator-' . $firstEmailStep);
+
+    $i->scrollTo('.mailpoet-automation-analytics-separator-' . $delayStep);
+    $i->see('33% (1) waiting', '#step-' . $delayStep);
+    $i->see('67% (2) completed', '.mailpoet-automation-analytics-separator-' . $delayStep);
+
+    $i->scrollTo('.mailpoet-automation-editor-automation-end');
+    $i->see('0% (0) waiting', '#step-' . $secondEmailStep);
+    $i->see('67% (2) completed', '.mailpoet-automation-analytics-separator-' . $secondEmailStep);
+
+    $i->wantTo("See that in the free version I see the sample data text");
+    $i->click('button.mailpoet-analytics-tab-subscribers');
+    $i->see("You're viewing sample data.");
+  }
+
+  /**
+   * This method assumes the last element of the steps is the last step of the automation.
+   * This is only true, if they have been added in a serial sequence. In our case, they have
+   * been added that way.
+   */
+  private function getLastStepOfAutomation(): string {
+    $steps = $this->automation->getSteps();
+    $stepIds = array_keys($steps);
+    $lastStep = end($stepIds);
+    return (string)$lastStep;
+  }
+
+  private function createSubscriber(): SubscriberEntity {
+    $subscriber = (new DataFactories\Subscriber())
+      ->create();
+
+    return $subscriber;
+  }
+
+  private function createRunForSubscriber(SubscriberEntity $subscriber, string $nextStep = null, string $status = AutomationRun::STATUS_COMPLETE) {
+    $run = (new DataFactories\AutomationRun())
+      ->withAutomation($this->automation)
+      ->withStatus($nextStep ? $status : AutomationRun::STATUS_COMPLETE)
+      ->withNextStep($nextStep)
+      ->withSubject(new Subject('mailpoet:subscriber', ['subscriber_id' => $subscriber->getId()]))
+      ->create();
+
+    if (!$nextStep) {
+      (new DataFactories\AutomationRun())
+        ->generateLogs($run, $this->getLastStepOfAutomation());
+        return;
+    }
+    $steps = $this->automation->getSteps();
+    foreach ($steps as $step) {
+      if (
+        !in_array($nextStep, array_map(function(NextStep $nextStep): string { return $nextStep->getId();
+        }, $step->getNextSteps()), true)
+      ) {
+        continue;
+      }
+
+      (new DataFactories\AutomationRun())
+        ->generateLogs($run, $step->getId());
+      return;
+    }
+  }
+
+  private function createNewsletter($newsletterTitle) {
+
+    $date = (new \DateTimeImmutable())->modify('-3 months');
+    return (new Newsletter())
+      ->withSubject($newsletterTitle)
+      ->loadBodyFrom('newsletterWithText.json')
+      ->withSentStatus()
+      ->withActiveStatus()
+      ->withSendingQueue([
+        'count_processed' => 100,
+        'count_total' => 100,
+      ])
+      ->withSendingQueue([
+        'count_processed' => 10,
+        'count_total' => 10,
+        'created_at' => $date,
+        'updated_at' => $date,
+      ])
+      ->create();
+  }
+
+  private function createClickForNewsletter(NewsletterEntity $email, SubscriberEntity $subscriber): StatisticsClickEntity {
+    $link = (new DataFactories\NewsletterLink($email))->create();
+    return (new DataFactories\StatisticsClicks($link, $subscriber))->create();
+  }
+
+  private function alterCreateDateForClick(StatisticsClickEntity $click, \DateTimeImmutable $created) {
+    $em = ContainerWrapper::getInstance()->get(EntityManager::class);
+
+    $em->createQueryBuilder()->update(StatisticsClickEntity::class, 'c')
+      ->set('c.createdAt', ':createdAt')
+      ->set('c.updatedAt', ':updatedAt')
+      ->where('c.id = :id')
+      ->setParameter('createdAt', $created)
+      ->setParameter('updatedAt', $created)
+      ->setParameter('id', $click->getId())
+      ->getQuery()->execute();
+  }
+
+  private function alterCreateDateForOpen(StatisticsOpenEntity $open, \DateTimeImmutable $created) {
+    $em = ContainerWrapper::getInstance()->get(EntityManager::class);
+
+    $em->createQueryBuilder()->update(StatisticsOpenEntity::class, 'c')
+      ->set('c.createdAt', ':createdAt')
+      ->where('c.id = :id')
+      ->setParameter('createdAt', $created)
+      ->setParameter('id', $open->getId())
+      ->getQuery()->execute();
+  }
+
+  private function createOpenForNewsletter(NewsletterEntity $email, SubscriberEntity $subscriber): StatisticsOpenEntity {
+    return (new DataFactories\StatisticsOpens($email, $subscriber))->create();
+  }
+}

--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -45,10 +45,9 @@ class SettingsArchivePageCest {
     $segment3 = $segmentFactory->withName('SentNewsletters')->create();
     $segmentFactory = new Segment();
     $segment4 = $segmentFactory->withName('SentNewsletters2')->create();
-    $newsletterFactory = new Newsletter();
-    $newsletterFactory->withSubject('SentNewsletter')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
-    $newsletterFactory->withSubject('DraftNewsletter')->withDraftStatus()->withScheduledQueue()->withSegments([$segment3])->create();
-    $newsletterFactory->withSubject('ScheduledNewsletter')->withScheduledStatus()->withScheduledQueue()->withSegments([$segment3])->create();
+    (new Newsletter())->withSubject('SentNewsletter')->withSentStatus()->withSendingQueue()->withSegments([$segment3])->create();
+    (new Newsletter())->withSubject('DraftNewsletter')->withDraftStatus()->withScheduledQueue()->withSegments([$segment3])->create();
+    (new Newsletter())->withSubject('ScheduledNewsletter')->withScheduledStatus()->withScheduledQueue()->withSegments([$segment3])->create();
     $pageTitle3 = 'SentNewsletterArchive';
     $pageContent3 = "[mailpoet_archive segments=\"{$segment3->getId()}\"]";
     $postUrl = $i->createPost($pageTitle3, $pageContent3);
@@ -93,7 +92,7 @@ class SettingsArchivePageCest {
     $i->dontSee('SentNewsletter2');
     $i->dontSee('SentNewsletter3');
     $i->dontSee('SentNewsletter4');
-    
+
     $pageTitle4 = 'SentNewsletterArchive';
     $pageContent4 = "[mailpoet_archive segments=\"{$segment3->getId()},{$segment4->getId()}\"]";
     $postUrl2 = $i->createPost($pageTitle4, $pageContent4);


### PR DESCRIPTION
## Description
Adds the tests and smaller bugfixes.

Bugfixes:
- Show order related stuff only when WC is active
- When the open rate/click rate/revenue etc in the previous period was higher, we need to show `-x%` instead of `x%` in the Overview Panel

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/752

## Linked tickets

[MAILPOET-5405]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5405]: https://mailpoet.atlassian.net/browse/MAILPOET-5405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ