### PR TITLE
Improve ManageSubscribers test and update SubscribersListing

### DIFF
--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -12,37 +12,44 @@ class ManageSubscribersCest {
   const ACTIVE_SUBSCRIBERS_COUNT = 3;
   const INACTIVE_SUBSCRIBERS_COUNT = 4;
   const INACTIVE_LIST_NAME = 'Inactivity';
+  const SINGLE_SEGMENT_NAME = 'Subscriber Management Test List';
+  const MULTIPLE_SEGMENT_NAME_COOKING = 'Cooking';
+  const MULTIPLE_SEGMENT_NAME_CAMPING = 'Camping';
+  const SUBSCRIBER_UPDATED_NOTICE = 'Subscriber was updated successfully!';
 
   /** @var SegmentEntity */
   private $segment;
 
   public function _before() {
     $segmentFactory = new Segment();
-    $this->segment = $segmentFactory->withName('Subscriber Management Test List')->create();
+    $this->segment = $segmentFactory->withName(self::SINGLE_SEGMENT_NAME)->create();
   }
 
   private function generateWPUsersList(\AcceptanceTester $i) {
     $i->wantTo('Create some subscribers');
+
     $i->cli(['user', 'import-csv', '/wp-core/wp-content/plugins/mailpoet/tests/_data/users.csv']);
+
     $i->login();
     $i->amOnMailPoetPage ('Subscribers');
     $i->seeNoJSErrors();
   }
 
-  private function generateSingleSubscriber($newSubscriberEmail, $subscriberFirstName, $subscriberLastName) {
+  private function generateSingleSubscriber($newSubscriberEmail, $subscriberFirstName, $subscriberLastName, $segment) {
     $subscriberFactory = new Subscriber();
     return $subscriberFactory
       ->withEmail($newSubscriberEmail)
       ->withFirstName($subscriberFirstName)
       ->withLastName($subscriberLastName)
+      ->withSegments([$segment])
       ->create();
   }
 
   private function generateMultipleLists() {
     $segmentFactory1 = new Segment();
-    $segmentFactory1->withName('Cooking')->create();
+    $segmentFactory1->withName(self::MULTIPLE_SEGMENT_NAME_COOKING)->create();
     $segmentFactory2 = new Segment();
-    $segmentFactory2->withName('Camping')->create();
+    $segmentFactory2->withName(self::MULTIPLE_SEGMENT_NAME_CAMPING)->create();
   }
 
   private function prepareInactiveSubscribersData() {
@@ -57,7 +64,9 @@ class ManageSubscribersCest {
 
   public function viewSubscriberList(\AcceptanceTester $i) {
     $i->wantTo('View list of subscribers');
+
     $this->generateWPUsersList($i);
+
     $i->searchFor('Alec Saunders');
     $i->waitForText('Alec Saunders');
     $i->seeNoJSErrors();
@@ -65,6 +74,7 @@ class ManageSubscribersCest {
 
   public function addGlobalSubscriber(\AcceptanceTester $i) {
     $i->wantTo('Add a user to global subscribers list');
+
     $i->login();
     $i->amOnMailPoetPage ('Subscribers');
     $i->click('[data-automation-id="add-new-subscribers-button"]');
@@ -72,7 +82,7 @@ class ManageSubscribersCest {
     $i->fillField(['name' => 'first_name'], 'New');
     $i->fillField(['name' => 'last_name'], 'GlobalUser');
     $i->selectOptionInSelect2($this->segment->getName());
-    $i->click('[data-automation-id="subscriber_edit_form"] [type="submit"]');
+    $i->click('Save');
     $i->amOnMailPoetPage ('Subscribers');
     $i->searchFor('newglobaluser99@fakemail.fake');
     $i->waitForText('newglobaluser99@fakemail.fake');
@@ -81,8 +91,11 @@ class ManageSubscribersCest {
 
   public function deleteGlobalSubscriber(\AcceptanceTester $i) {
     $i->wantTo('Delete a user from global subscribers list');
+
     $newSubscriberEmail = 'deleteglobaluser99@fakemail.fake';
-    $this->generateSingleSubscriber('deleteglobaluser99@fakemail.fake', 'Delete', 'ThisGlobalUser');
+
+    $this->generateSingleSubscriber('deleteglobaluser99@fakemail.fake', 'Delete', 'ThisGlobalUser', $this->segment);
+
     $i->login();
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForListingItemsToLoad();
@@ -97,10 +110,13 @@ class ManageSubscribersCest {
 
   public function deleteGlobalSubscriberForever(\AcceptanceTester $i) {
     $i->wantTo('Delete a subscriber forever');
+
     $newSubscriberEmail = 'deletesubscriberforever@fakemail.fake';
     $newSubscriberEmail2 = 'deletesubscriberforever2@fakemail.fake';
-    $this->generateSingleSubscriber($newSubscriberEmail, 'Delete', 'ThisGlobalUser');
-    $this->generateSingleSubscriber($newSubscriberEmail2, 'Keep', 'ThisSubscriber');
+
+    $this->generateSingleSubscriber($newSubscriberEmail, 'Delete', 'ThisGlobalUser', $this->segment);
+    $this->generateSingleSubscriber($newSubscriberEmail2, 'Keep', 'ThisSubscriber', $this->segment);
+
     $i->login();
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForListingItemsToLoad();
@@ -122,10 +138,13 @@ class ManageSubscribersCest {
 
   public function emptyTrash(\AcceptanceTester $i) {
     $i->wantTo('Delete a subscriber forever');
+
     $newSubscriberEmail = 'deletesubscriberforever@fakemail.fake';
     $newSubscriberEmail2 = 'deletesubscriberforever2@fakemail.fake';
-    $this->generateSingleSubscriber($newSubscriberEmail, 'Delete', 'ThisGlobalUser');
-    $this->generateSingleSubscriber($newSubscriberEmail2, 'Keep', 'ThisSubscriber');
+
+    $this->generateSingleSubscriber($newSubscriberEmail, 'Delete', 'ThisGlobalUser', $this->segment);
+    $this->generateSingleSubscriber($newSubscriberEmail2, 'Keep', 'ThisSubscriber', $this->segment);
+
     $i->login();
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForListingItemsToLoad();
@@ -146,43 +165,94 @@ class ManageSubscribersCest {
 
   public function addSubscriberToList(\AcceptanceTester $i) {
     $i->wantTo('Add a subscriber to a list');
+
     $newSubscriberEmail = 'addtolistuser99@fakemail.fake';
+
     $this->generateMultipleLists();
-    $this->generateSingleSubscriber('addtolistuser99@fakemail.fake', 'Add', 'ToAList');
+    $this->generateSingleSubscriber('addtolistuser99@fakemail.fake', 'Add', 'ToAList', $this->segment);
+
     $i->login();
     $i->amOnMailPoetPage ('Subscribers');
     $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
     $i->waitForText('Subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
-    $i->selectOptionInSelect2('Cooking');
-    $i->click('[data-automation-id="subscriber_edit_form"] [type="submit"]');
+    $i->selectOptionInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
     $i->seeNoJSErrors();
+    $i->click('Save');
+    $i->waitForText(self::SUBSCRIBER_UPDATED_NOTICE);
+    $i->waitForText($newSubscriberEmail);
+    $i->see(self::MULTIPLE_SEGMENT_NAME_COOKING);
+
+    $i->wantTo('Add a subscriber to a list from the listing page');
+    $i->click("[data-automation-id='listing-row-checkbox-2']");
+    $i->click('[data-automation-id="action-addToList"]');
+    $i->selectOption('#add_to_segment', self::MULTIPLE_SEGMENT_NAME_CAMPING);
+    $i->click('.mailpoet-modal-content > button');
+    $i->waitForText('1 subscribers were added to list ' . self::MULTIPLE_SEGMENT_NAME_CAMPING . '.');
+    $i->waitForListingItemsToLoad();
+    $i->waitForText($newSubscriberEmail);
+    $i->see(self::MULTIPLE_SEGMENT_NAME_CAMPING);
+
+    $i->wantTo('Check subscriber edit page and the attached lists');
+    $i->waitForText('Subscriber');
+    $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
+    $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_CAMPING);
   }
 
   public function deleteSubscriberFromList(\AcceptanceTester $i) {
     $i->wantTo('Delete a subscriber from a list');
+
     $newSubscriberEmail = 'deletefromlistuser99@fakemail.fake';
+
     $this->generateMultipleLists();
-    $this->generateSingleSubscriber('deletefromlistuser99@fakemail.fake', 'Delete', 'FromAList');
+    $this->generateSingleSubscriber('deletefromlistuser99@fakemail.fake', 'Delete', 'FromAList', $this->segment);
+
     $i->login();
     $i->amOnMailPoetPage ('Subscribers');
     $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
     $i->waitForText('Subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
-    $i->selectOptionInSelect2('Cooking');
+    $i->waitForText(self::SINGLE_SEGMENT_NAME);
     $i->click('.select2-selection__choice__remove');
-    $i->click('[data-automation-id="subscriber_edit_form"] [type="submit"]');
-    $i->waitForText('Subscriber was updated');
+    $i->seeSelectedInSelect2('');
+    $i->click('Save');
+    $i->waitForText(self::SUBSCRIBER_UPDATED_NOTICE);
+    $i->waitForListingItemsToLoad();
+    $i->waitForText($newSubscriberEmail);
+    $i->dontSee(self::SINGLE_SEGMENT_NAME, '.mailpoet-tags');
+
+    $i->wantTo('Remove subscriber from list from the listing page');
+    $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
+    $i->waitForText('Subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->selectOptionInSelect2(self::SINGLE_SEGMENT_NAME);
+    $i->click('Save');
+    $i->waitForText(self::SUBSCRIBER_UPDATED_NOTICE);
+    $i->waitForListingItemsToLoad();
+    $i->waitForText($newSubscriberEmail);
+    $i->click("[data-automation-id='listing-row-checkbox-2']");
+    $i->click('[data-automation-id="action-removeFromList"]');
+    $i->selectOption('#remove_from_segment', self::SINGLE_SEGMENT_NAME);
+    $i->click('.mailpoet-modal-content > button');
+    $i->waitForNoticeAndClose('1 subscribers were removed from list ' . self::SINGLE_SEGMENT_NAME);
+    $i->waitForListingItemsToLoad();
+    $i->waitForText($newSubscriberEmail);
+    $i->dontSee(self::SINGLE_SEGMENT_NAME, '.mailpoet-tags');
   }
 
   public function editSubscriber(\AcceptanceTester $i) {
     $i->wantTo('Edit a subscriber');
+
     $newSubscriberEmail = 'editglobaluser99@fakemail.fake';
     $unsubscribedMessage = ['xpath' => '//*[@class="description"]'];
+
     $this->generateMultipleLists();
-    $this->generateSingleSubscriber('editglobaluser99@fakemail.fake', 'Edit', 'ThisGlobalUser');
+    $this->generateSingleSubscriber('editglobaluser99@fakemail.fake', 'Edit', 'ThisGlobalUser', $this->segment);
+
     $i->login();
     $i->amOnMailPoetPage ('Subscribers');
     $i->waitForListingItemsToLoad();
@@ -191,39 +261,56 @@ class ManageSubscribersCest {
     $i->fillField(['name' => 'first_name'], 'EditedNew');
     $i->fillField(['name' => 'last_name'], 'EditedGlobalUser');
     $i->selectOption('[data-automation-id="subscriber-status"]', 'Unsubscribed');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     // we cannot use data-automation attribute because this input is based on guttenberg component
-    $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag,'); // the comma separates the tag
+    $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag 1,'); // the comma separates the tag
+    $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag 2,');
+    $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag 3,');
+    $i->selectOption('[data-automation-id="subscriber-status"]', 'Unsubscribed');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->click('Save');
     $i->waitForElementVisible('[data-automation-id="listing_item_1"]');
+    $i->waitForNoticeAndClose(self::SUBSCRIBER_UPDATED_NOTICE);
+    $i->see('My tag 1');
+    $i->see('My tag 2');
+    $i->see('My tag 3');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
     $i->waitForText('Subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->seeOptionIsSelected('[data-automation-id="subscriber-status"]', 'Unsubscribed');
     $i->see('Unsubscribed at', $unsubscribedMessage);
-    // tag is visible
-    $i->see('My tag');
-    $i->selectOptionInSelect2('Cooking');
-    $i->selectOptionInSelect2('Camping');
+    // tags are visible
+    $i->see('My tag 1');
+    $i->see('My tag 2');
+    $i->see('My tag 3');
+    $i->selectOptionInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
+    $i->selectOptionInSelect2(self::MULTIPLE_SEGMENT_NAME_CAMPING);
     $i->waitForElementClickable('[data-automation-id="subscriber-status"]');
     $i->selectOption('[data-automation-id="subscriber-status"]', 'Subscribed');
-    // remove tag
+    // remove the first tag
     $i->click(Locator::firstElement('.mailpoet-form-field-tags button[aria-label="Remove item"]'));
     $i->click('Save');
     $i->waitForElementVisible('[data-automation-id="listing_item_1"]');
+    $i->waitForNoticeAndClose(self::SUBSCRIBER_UPDATED_NOTICE);
+    $i->see(self::MULTIPLE_SEGMENT_NAME_COOKING);
+    $i->see(self::MULTIPLE_SEGMENT_NAME_CAMPING);
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
     $i->waitForText('Subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
-    $i->seeSelectedInSelect2('Cooking');
-    $i->seeSelectedInSelect2('Camping');
+    $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
+    $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_CAMPING);
     $i->seeOptionIsSelected('[data-automation-id="subscriber-status"]', 'Subscribed');
-    // check that tag is removed
-    $i->seeInField('.mailpoet-form-field-tags input[type="text"]', '');
-    $i->dontSee('My tag');
+    // check that tags are present and one is removed by looking in the hidden data input inside input field
+    $i->dontSee('My tag 1');
+    $i->see('My tag 2 (1 of 2)');
+    $i->see('My tag 3 (2 of 2)');
   }
 
   public function inactiveSubscribers(\AcceptanceTester $i) {
     $i->wantTo('Check inactive subscribers');
+
     $this->prepareInactiveSubscribersData();
+
     $i->login();
     $i->amOnMailPoetPage ('Subscribers');
 

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -10,20 +10,28 @@ class SubscribersListingCest {
   public function subscribersListing(\AcceptanceTester $i) {
     $i->wantTo('Open subscribers listings page');
 
-    $tag = (new Tag())
-      ->withName('My Tag')
+    $tag1 = (new Tag())
+      ->withName('My Tag 1')
+      ->create();
+    $tag2 = (new Tag())
+      ->withName('My Tag 2')
+      ->create();
+    $tag3 = (new Tag())
+      ->withName('My Tag 3')
       ->create();
 
     (new Subscriber())
       ->withEmail('wp@example.com')
-      ->withTags([$tag])
+      ->withTags([$tag1, $tag2, $tag3])
       ->create();
 
     $i->login();
     $i->amOnMailpoetPage('Subscribers');
     $i->searchFor('wp@example.com');
     $i->waitForText('wp@example.com');
-    $i->waitForText('My Tag');
+    $i->waitForText('My Tag 1');
+    $i->waitForText('My Tag 2');
+    $i->waitForText('My Tag 3');
   }
 
   public function useTagFilter(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Improved the existing test `ManageSubscribersCest` and slightly updated `SubscribersListingCest`.

Now, with this change, we're verifying the functionality more rigorously and properly. For example adding a subscriber to a list, before this change, we only looked at whether it can pick a list in the subscriber edit page, but not saving and testing on the listing page, and then also checking adding to a list from the listing page. The same applies for deleting subscriber from a list and more.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5332]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5332]: https://mailpoet.atlassian.net/browse/MAILPOET-5332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ