### PR TITLE
Symlink premium on atomic and expand the use of the premium modal

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/orders/upgrade.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/orders/upgrade.tsx
@@ -26,10 +26,13 @@ const getCta = (state: State, upgradeInfo: UpgradeInfo): string => {
 };
 
 export function Upgrade(): JSX.Element {
-  const upgradeInfo = useUpgradeInfo({
-    utm_medium: 'upsell_modal',
-    utm_campaign: 'automation-analytics',
-  });
+  const upgradeInfo = useUpgradeInfo(
+    {},
+    {
+      utm_medium: 'upsell_modal',
+      utm_campaign: 'automation-analytics',
+    },
+  );
 
   const [state, setState] = useState<State>();
 

--- a/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
@@ -5,6 +5,7 @@ import { PremiumStatus } from 'settings/store/types';
 import { Button } from 'common/button/button';
 import { PremiumModal } from 'common/premium_modal';
 import { useState } from 'react';
+import { Data } from '../../premium_modal/upgrade_info';
 
 type ActiveMessageProps = { canUseSuccessClass: boolean };
 
@@ -21,6 +22,7 @@ function ActiveMessage(props: ActiveMessageProps) {
 }
 
 type PremiumMessageProps = {
+  data?: Data;
   message?: string;
   buttonText: string;
 };
@@ -45,6 +47,7 @@ function PremiumMessageWithModal(props: PremiumMessageProps) {
       </Button>
       {showPremiumModal && (
         <PremiumModal
+          data={props.data}
           onRequestClose={() => {
             setShowPremiumModal(false);
           }}
@@ -87,6 +90,12 @@ function PremiumMessages(props: Props) {
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_INSTALLED:
       return (
         <PremiumMessageWithModal
+          data={{
+            premiumInstalled: false,
+            premiumActive: false,
+            hasValidApiKey: true,
+            hasValidPremiumKey: true,
+          }}
           message={__('MailPoet Premium is not installed.', 'mailpoet')}
           buttonText={__('Download MailPoet Premium plugin', 'mailpoet')}
         />
@@ -94,6 +103,12 @@ function PremiumMessages(props: Props) {
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_ACTIVE:
       return (
         <PremiumMessageWithModal
+          data={{
+            premiumInstalled: true,
+            premiumActive: false,
+            hasValidApiKey: true,
+            hasValidPremiumKey: true,
+          }}
           message={__(
             'MailPoet Premium is installed but not activated.',
             'mailpoet',

--- a/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
@@ -21,19 +21,26 @@ function ActiveMessage(props: ActiveMessageProps) {
 }
 
 type PremiumMessageProps = {
-  message: string;
+  message?: string;
   buttonText: string;
 };
 
-function PremiumMessage(props: PremiumMessageProps) {
+function PremiumMessageWithModal(props: PremiumMessageProps) {
   const [showPremiumModal, setShowPremiumModal] = useState(false);
 
   return (
     <>
-      <div className="mailpoet_error mailpoet_install_premium_message">
-        {props.message}
-      </div>
-      <Button onClick={() => setShowPremiumModal(true)}>
+      {props.message && (
+        <div className="mailpoet_error mailpoet_install_premium_message">
+          {props.message}
+        </div>
+      )}
+      <Button
+        onClick={(e) => {
+          e.preventDefault();
+          setShowPremiumModal(true);
+        }}
+      >
         {props.buttonText}
       </Button>
       {showPremiumModal && (
@@ -71,7 +78,7 @@ type Props = {
   canUseSuccessClass: boolean;
 };
 
-export function PremiumMessages(props: Props) {
+function PremiumMessages(props: Props) {
   const { premiumStatus: status } = useSelector('getKeyActivationState')();
 
   switch (status) {
@@ -79,14 +86,14 @@ export function PremiumMessages(props: Props) {
       return <ActiveMessage canUseSuccessClass={props.canUseSuccessClass} />;
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_INSTALLED:
       return (
-        <PremiumMessage
+        <PremiumMessageWithModal
           message={__('MailPoet Premium is not installed.', 'mailpoet')}
           buttonText={__('Download MailPoet Premium plugin', 'mailpoet')}
         />
       );
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_ACTIVE:
       return (
-        <PremiumMessage
+        <PremiumMessageWithModal
           message={__(
             'MailPoet Premium is installed but not activated.',
             'mailpoet',
@@ -104,3 +111,5 @@ export function PremiumMessages(props: Props) {
 PremiumMessages.defaultProps = {
   keyMessage: '',
 };
+
+export { PremiumMessages, PremiumMessageWithModal };

--- a/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
+++ b/mailpoet/assets/js/src/common/premium_key/key_messages/premium_messages.tsx
@@ -3,6 +3,8 @@ import { __ } from '@wordpress/i18n';
 import { useSelector } from 'settings/store/hooks';
 import { PremiumStatus } from 'settings/store/types';
 import { Button } from 'common/button/button';
+import { PremiumModal } from 'common/premium_modal';
+import { useState } from 'react';
 
 type ActiveMessageProps = { canUseSuccessClass: boolean };
 
@@ -18,35 +20,33 @@ function ActiveMessage(props: ActiveMessageProps) {
   );
 }
 
-type PremiumNotActiveMessageProps = {
-  url?: string;
+type PremiumMessageProps = {
+  message: string;
+  buttonText: string;
 };
 
-function PremiumNotActiveMessage(props: PremiumNotActiveMessageProps) {
-  return (
-    <>
-      <div className="mailpoet_error mailpoet_install_premium_message">
-        {__('MailPoet Premium is installed but not activated.', 'mailpoet')}
-      </div>
-      {props.url && (
-        <Button href={props.url}>
-          {__('Activate MailPoet Premium plugin', 'mailpoet')}
-        </Button>
-      )}
-    </>
-  );
-}
+function PremiumMessage(props: PremiumMessageProps) {
+  const [showPremiumModal, setShowPremiumModal] = useState(false);
 
-function PremiumNotInstalledMessage(props: PremiumNotActiveMessageProps) {
   return (
     <>
       <div className="mailpoet_error mailpoet_install_premium_message">
-        {__('MailPoet Premium is not installed.', 'mailpoet')}
+        {props.message}
       </div>
-      {props.url && (
-        <Button href={props.url}>
-          {__('Download MailPoet Premium plugin', 'mailpoet')}
-        </Button>
+      <Button onClick={() => setShowPremiumModal(true)}>
+        {props.buttonText}
+      </Button>
+      {showPremiumModal && (
+        <PremiumModal
+          onRequestClose={() => {
+            setShowPremiumModal(false);
+          }}
+        >
+          {__(
+            'Your current MailPoet plan includes advanced features, but they require the MailPoet Premium plugin to be installed and activated.',
+            'mailpoet',
+          )}
+        </PremiumModal>
       )}
     </>
   );
@@ -72,19 +72,28 @@ type Props = {
 };
 
 export function PremiumMessages(props: Props) {
-  const {
-    premiumStatus: status,
-    downloadUrl,
-    activationUrl,
-  } = useSelector('getKeyActivationState')();
+  const { premiumStatus: status } = useSelector('getKeyActivationState')();
 
   switch (status) {
     case PremiumStatus.VALID_PREMIUM_PLUGIN_ACTIVE:
       return <ActiveMessage canUseSuccessClass={props.canUseSuccessClass} />;
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_INSTALLED:
-      return <PremiumNotInstalledMessage url={downloadUrl} />;
+      return (
+        <PremiumMessage
+          message={__('MailPoet Premium is not installed.', 'mailpoet')}
+          buttonText={__('Download MailPoet Premium plugin', 'mailpoet')}
+        />
+      );
     case PremiumStatus.VALID_PREMIUM_PLUGIN_NOT_ACTIVE:
-      return <PremiumNotActiveMessage url={activationUrl} />;
+      return (
+        <PremiumMessage
+          message={__(
+            'MailPoet Premium is installed but not activated.',
+            'mailpoet',
+          )}
+          buttonText={__('Activate MailPoet Premium plugin', 'mailpoet')}
+        />
+      );
     case PremiumStatus.INVALID:
       return <NotValidMessage message={props.keyMessage} />;
     default:

--- a/mailpoet/assets/js/src/common/premium_modal/index.tsx
+++ b/mailpoet/assets/js/src/common/premium_modal/index.tsx
@@ -17,6 +17,7 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import {
+  Data,
   premiumFeaturesEnabled,
   UpgradeInfo,
   useUpgradeInfo,
@@ -28,11 +29,15 @@ import { withBoundary } from '../error_boundary';
 export const premiumValidAndActive =
   premiumFeaturesEnabled && MailPoet.premiumActive;
 
-type Props = Omit<ComponentProps<typeof Modal>, 'title' | 'onRequestClose'> & {
+type Props = Omit<
+  ComponentProps<typeof Modal>,
+  'data' | 'title' | 'onRequestClose'
+> & {
   // Fix type from "@types/wordpress__components" where it is defined as a union of event
   // handlers, resulting in a function requiring intersection of all of the event types.
   onRequestClose: EventHandler<KeyboardEvent | MouseEvent | FocusEvent>;
 } & {
+  data?: Data;
   tracking?: UtmParams;
 };
 
@@ -52,9 +57,14 @@ const getCta = (state: State, upgradeInfo: UpgradeInfo): string => {
   return cta;
 };
 
-function PremiumModal({ children, tracking, ...props }: Props): JSX.Element {
+function PremiumModal({
+  data = {},
+  children,
+  tracking,
+  ...props
+}: Props): JSX.Element {
   const [state, setState] = useState<State>();
-  const upgradeInfo = useUpgradeInfo(tracking);
+  const upgradeInfo = useUpgradeInfo(data, tracking);
 
   //
   useEffect(() => {

--- a/mailpoet/lib/API/JSON/v1/Premium.php
+++ b/mailpoet/lib/API/JSON/v1/Premium.php
@@ -55,11 +55,15 @@ class Premium extends APIEndpoint {
     $pluginInfo = (array)$pluginInfo;
 
     // If we are in Dotcom platform, we try to symlink the plugin instead of downloading it
-    if ($this->dotcomHelperFunctions->isDotcom()) {
-      $result = symlink(self::SIMLINK_PATH, WP_PLUGIN_DIR . '/' . self::PREMIUM_PLUGIN_SLUG);
-      if ($result === true) {
-        return $this->successResponse();
+    try {
+      if ($this->dotcomHelperFunctions->isDotcom()) {
+        $result = symlink(self::SIMLINK_PATH, WP_PLUGIN_DIR . '/' . self::PREMIUM_PLUGIN_SLUG);
+        if ($result === true) {
+          return $this->successResponse();
+        }
       }
+    } catch (\Exception $e) {
+      // Do nothing and continue with a regular installation
     }
 
     $result = $this->wp->installPlugin($pluginInfo['download_link']);

--- a/mailpoet/lib/API/JSON/v1/Premium.php
+++ b/mailpoet/lib/API/JSON/v1/Premium.php
@@ -13,7 +13,8 @@ use WP_Error;
 class Premium extends APIEndpoint {
   const PREMIUM_PLUGIN_SLUG = 'mailpoet-premium';
   const PREMIUM_PLUGIN_PATH = 'mailpoet-premium/mailpoet-premium.php';
-  const SIMLINK_PATH = '../../../../wordpress/plugins/mailpoet-premium/latest';
+  // This is the path to the managed plugin on Dotcom platform. It is relative to WP_PLUGIN_DIR.
+  const DOTCOM_SYMLINK_PATH = '../../../../wordpress/plugins/mailpoet-premium/latest';
 
   public $permissions = [
     'global' => AccessControl::PERMISSION_MANAGE_SETTINGS,
@@ -57,7 +58,7 @@ class Premium extends APIEndpoint {
     // If we are in Dotcom platform, we try to symlink the plugin instead of downloading it
     try {
       if ($this->dotcomHelperFunctions->isDotcom()) {
-        $result = symlink(self::SIMLINK_PATH, WP_PLUGIN_DIR . '/' . self::PREMIUM_PLUGIN_SLUG);
+        $result = symlink(self::DOTCOM_SYMLINK_PATH, WP_PLUGIN_DIR . '/' . self::PREMIUM_PLUGIN_SLUG);
         if ($result === true) {
           return $this->successResponse();
         }

--- a/mailpoet/tests/unit/API/JSON/PremiumTest.php
+++ b/mailpoet/tests/unit/API/JSON/PremiumTest.php
@@ -8,6 +8,7 @@ use MailPoet\API\JSON\SuccessResponse;
 use MailPoet\API\JSON\v1\Premium;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 class PremiumTest extends \MailPoetUnitTest {
   public function testItInstallsPlugin() {
@@ -22,7 +23,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'installPlugin' => Expected::once(true),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions());
     $response = $premium->installPlugin();
     expect($response)->isInstanceOf(SuccessResponse::class);
   }
@@ -37,7 +38,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'installPlugin' => Expected::never(),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions());
     $response = $premium->installPlugin();
     expect($response)->isInstanceOf(ErrorResponse::class);
     expect($response->getData()['errors'][0])->same([
@@ -56,7 +57,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'installPlugin' => Expected::never(),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions());
     $response = $premium->installPlugin();
     expect($response)->isInstanceOf(ErrorResponse::class);
     expect($response->getData()['errors'][0])->same([
@@ -77,7 +78,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'installPlugin' => Expected::once(false),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions());
     $response = $premium->installPlugin();
     expect($response)->isInstanceOf(ErrorResponse::class);
     expect($response->getData()['errors'][0])->same([
@@ -95,7 +96,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'activatePlugin' => Expected::once(null),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions());
     $response = $premium->activatePlugin();
     expect($response)->isInstanceOf(SuccessResponse::class);
   }
@@ -105,7 +106,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'isPremiumKeyValid' => Expected::once(false),
     ]);
 
-    $premium = new Premium($servicesChecker, new WPFunctions());
+    $premium = new Premium($servicesChecker, new WPFunctions(), new DotcomHelperFunctions());
     $response = $premium->activatePlugin();
     expect($response)->isInstanceOf(ErrorResponse::class);
     expect($response->getData()['errors'][0])->same([
@@ -123,7 +124,7 @@ class PremiumTest extends \MailPoetUnitTest {
       'activatePlugin' => Expected::once('error'),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions());
     $response = $premium->activatePlugin();
     expect($response)->isInstanceOf(ErrorResponse::class);
     expect($response->getData()['errors'][0])->same([


### PR DESCRIPTION
## Description

This PR replaces the download and activate premium links on the key verification screens and on the upgrade premium banner with the modal to install and activate the premium plugin

It also changes the installation of the premium plugin to use the symlinked version if the plugin is in the Dotcom platform

## Code review notes

_N/A_

## QA notes

To test:
- Get a key that gives premium features
- Install the plugin on a new site
- Go through the wizard, and check that the key verification works as expected
- Delete the premium plugin
- Go to Settings > Key activation. Replace the key with an invalid key and click on verify.
- Reload the page
- Add the valid key, click on verify
- Check that you see the button to download the plugin
- Click on the button, check that you see the modal with a button to download and not to purchase
- Click on download, check that the modal changes to Activate
- Click on activate, reload the page
- Check that premium is installed and active
- Deactivate or delete the plugin
- Go to Automations > click on one of the premium features, check that the modal still works

To test on Dotcom:
- Unzip the build, change the name of the plugin folder and zip it back (this is required or the plugin will be replaced with the .org version)
- Install the modified zip on a Dotcom business site (make sure it is using the build and not the managed version)
- Use a key with premium features and follow any path that will show the modal to download the premium plugin
- Click on download
- Click on activate
- Go to plugins, check that MailPoet premium is active and managed by Host

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5435]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5435]: https://mailpoet.atlassian.net/browse/MAILPOET-5435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ