### PR TITLE
Fix create custom select cest [MAILPOET-5480]

### DIFF
--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -79,7 +79,10 @@ class CleanupExtension extends Extension {
 
     // cleanup EntityManager for data factories that are using it
     ContainerWrapper::getInstance()->get(EntityManager::class)->clear();
-    
+
+    // reset settings controller cache
+    ContainerWrapper::getInstance()->get(\MailPoet\Settings\SettingsController::class)->resetCache();
+
     // Without clearing the cache WordPress will think data exist that doesn't, e.g. users created in previous tests
     global $wp_object_cache;
     if ($wp_object_cache) {

--- a/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
@@ -27,14 +27,15 @@ class EditorCreateCustomFieldCest {
   }
 
   public function _before(\AcceptanceTester $i) {
+    // Make sure the confirmation is enabled to have correct message
+    $settings = new Settings();
+    $settings->withConfirmationEmailEnabled();
     // Prepare the form for testing
     $this->prepareTheForm($i);
     // Go and edit the form
     $this->openFormInEditor($i);
     // Insert create custom field block
     $i->addFromBlockInEditor('Create Custom Field');
-    $settings = new Settings();
-    $settings->withConfirmationEmailEnabled();
   }
 
   public function createCustomSelect(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Fixes flaky createCustomSelect test. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5480]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5480]: https://mailpoet.atlassian.net/browse/MAILPOET-5480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ