### PR TITLE
Improve the test Manage Subscription Link and add new scenario

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -55,6 +55,7 @@ class AcceptanceTester extends \Codeception\Actor {
   const WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN = 'woocommerce-subscriptions';
   const AUTOMATE_WOO_PLUGIN = 'automatewoo';
   const MAILHOG_DATA_PATH = '/mailhog-data';
+  const ADMIN_EMAIL = 'test@test.com';
 
   /**
    * Define custom actions here

--- a/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
@@ -85,7 +85,7 @@ class BasicsPageCest {
     $i->clickItemRowActionByItemName('Newsletter mailing list', 'View Subscribers');
     $i->waitForText('Subscribers');
     $i->changeGroupInListingFilter('unconfirmed');
-    $i->waitForText('test@test.com');
+    $i->waitForText(\AcceptanceTester::ADMIN_EMAIL);
     //clear checkbox to hide Select2 from next test
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="subscribe-on_comment-checkbox"]');

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -93,6 +93,25 @@ class ManageSubscriptionLinkCest {
     $this->verifyUnsubscribeLinks($i);
   }
 
+  public function unsubscribeUrlWithoutToken(\AcceptanceTester $i) {
+    $i->wantTo('Check if as a logged in user cannot unsubscribe using url without token');
+    $i->login();
+    // Make sure the admin is subscribed
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForText(\AcceptanceTester::ADMIN_EMAIL);
+    $i->clickItemRowActionByItemName(\AcceptanceTester::ADMIN_EMAIL, 'Edit');
+    $i->waitForText('Subscriber');
+    $i->waitForElement('[data-automation-id="subscriber_edit_form"]');
+    $i->selectOption('[data-automation-id="subscriber-status"]', 'Subscribed');
+    $i->click('Save');
+    $i->waitForText('Subscriber was updated successfully!');
+    $i->amOnUrl(\AcceptanceTester::WP_URL . '/?mailpoet_page=subscriptions&mailpoet_router&endpoint=subscription&action=unsubscribe&data=');
+    $i->waitForText("Hmmm... we don't have a record of you.");
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForText(\AcceptanceTester::ADMIN_EMAIL);
+    $i->see('Subscribed');
+  }
+
   private function verifyUnsubscribeLinks(\AcceptanceTester $i) {
     $this->sendEmail($i);
     $formStatusElement = '[data-automation-id="form_status"]';


### PR DESCRIPTION
## Description

In the existing testcase ManageSubscriptionLinkCest, added new scenario to cover the issue we had in the past [MAILPOET-4184]. Also improved the existing scenario to cover multiple lists.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5334]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4184]: https://mailpoet.atlassian.net/browse/MAILPOET-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5334]: https://mailpoet.atlassian.net/browse/MAILPOET-5334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ