### PR TITLE
Fix logCurlInformation causing error when called with one parameter [MAILPOET-5493]

### DIFF
--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -117,7 +117,11 @@ class API {
     return ['code' => $code, 'data' => $body, 'error_message' => $errorMessage];
   }
 
-  public function logCurlInformation($headers, $info) {
+  /**
+   * This method logs data from 'requests-curl.after_request' hook.
+   * The hook is mostly called with two parameters but sometimes only with one.
+   */
+  public function logCurlInformation($headers, $info = null) {
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_MSS)->info(
       'requests-curl.after_request',
       ['headers' => $headers, 'curl_info' => $info]


### PR DESCRIPTION
## Description

The method BridgeApi::logCurlInformation is hooked to `requests-curl.after_request` action. The action is mostly called with two parameters, but there is also [a case when it is called with one parameter](https://github.com/search?q=repo%3AWordPress%2FWordPress%20curl.after_request&type=code). This PR fixes the error when the method is called with one parameter by making the second parameter optional.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5493]

## After-merge notes

_N/A_

## Tasks

- [X] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [] I added sufficient test coverage -I haven't added test because this is hard to test
- [X] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5493]: https://mailpoet.atlassian.net/browse/MAILPOET-5493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ