### PR TITLE
Inactive subscriber calculation tweaks [MAILPOET-5410]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -7,7 +7,7 @@
 .mailpoet-subscriber-stats-summary-grid {
   display: grid;
   grid-gap: $grid-gap;
-  grid-template-columns: auto auto 1fr;
+  grid-template-columns: auto auto auto 1fr;
 
   .mailpoet-listing .mailpoet-listing-table {
     border: 0;

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -4,7 +4,7 @@ import { MailPoet } from 'mailpoet';
 import { Loading } from 'common/loading';
 import { useGlobalContextValue } from 'context';
 
-import { Heading } from 'common/typography/heading/heading';
+import { Heading } from 'common';
 import { StatsHeading } from './stats/heading';
 import { Summary } from './stats/summary';
 import { WoocommerceRevenues } from './stats/woocommerce_revenues';

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -4,7 +4,8 @@ import { MailPoet } from 'mailpoet';
 import { Loading } from 'common/loading';
 import { useGlobalContextValue } from 'context';
 
-import { StatsHeading as Heading } from './stats/heading';
+import { Heading } from 'common/typography/heading/heading';
+import { StatsHeading } from './stats/heading';
 import { Summary } from './stats/summary';
 import { WoocommerceRevenues } from './stats/woocommerce_revenues';
 import { OpenedEmailsStats } from './stats/opened_email_stats';
@@ -68,7 +69,8 @@ export function SubscriberStats(): JSX.Element {
 
   return (
     <div className="mailpoet-subscriber-stats">
-      <Heading email={stats.email} />
+      <StatsHeading email={stats.email} />
+      <Heading level={4}>{MailPoet.I18n.t('engagementPeriodHeading')}</Heading>
       <p>
         {MailPoet.I18n.t('lastEngagement')}
         {': '}

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -9,6 +9,7 @@ import { StatsHeading } from './stats/heading';
 import { Summary } from './stats/summary';
 import { WoocommerceRevenues } from './stats/woocommerce_revenues';
 import { OpenedEmailsStats } from './stats/opened_email_stats';
+import { EngagementSummary } from './stats/engagement_summary';
 
 export type StatsType = {
   email: string;
@@ -18,6 +19,11 @@ export type StatsType = {
   click: number;
   engagement_score: number;
   last_engagement?: string;
+  last_click?: string;
+  last_open?: string;
+  last_sending?: string;
+  last_page_view?: string;
+  last_purchase?: string;
   woocommerce: {
     currency: string;
     value: number;
@@ -71,13 +77,6 @@ export function SubscriberStats(): JSX.Element {
     <div className="mailpoet-subscriber-stats">
       <StatsHeading email={stats.email} />
       <Heading level={4}>{MailPoet.I18n.t('engagementPeriodHeading')}</Heading>
-      <p>
-        {MailPoet.I18n.t('lastEngagement')}
-        {': '}
-        {stats.last_engagement
-          ? MailPoet.Date.format(stats.last_engagement)
-          : MailPoet.I18n.t('never')}
-      </p>
       <div className="mailpoet-subscriber-stats-summary-grid">
         <Summary
           click={stats.click}
@@ -88,6 +87,15 @@ export function SubscriberStats(): JSX.Element {
             id: Number(match.params.id),
             engagement_score: stats.engagement_score,
           }}
+        />
+        <EngagementSummary
+          lastClick={stats.last_click}
+          lastEngagement={stats.last_engagement}
+          lastOpen={stats.last_open}
+          lastPageView={stats.last_page_view}
+          lastPurchase={stats.last_purchase}
+          lastSending={stats.last_sending}
+          wooCommerceActive={!!stats.woocommerce}
         />
         {stats.woocommerce && (
           <WoocommerceRevenues

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useRouteMatch, useLocation } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { MailPoet } from 'mailpoet';
 import { Loading } from 'common/loading';
 import { useGlobalContextValue } from 'context';
@@ -10,28 +10,7 @@ import { Summary } from './stats/summary';
 import { WoocommerceRevenues } from './stats/woocommerce_revenues';
 import { OpenedEmailsStats } from './stats/opened_email_stats';
 import { EngagementSummary } from './stats/engagement_summary';
-
-export type StatsType = {
-  email: string;
-  total_sent: number;
-  open: number;
-  machine_open: number;
-  click: number;
-  engagement_score: number;
-  last_engagement?: string;
-  last_click?: string;
-  last_open?: string;
-  last_sending?: string;
-  last_page_view?: string;
-  last_purchase?: string;
-  woocommerce: {
-    currency: string;
-    value: number;
-    count: number;
-    formatted: string;
-    formatted_average: string;
-  };
-};
+import { StatsType } from './types';
 
 export function SubscriberStats(): JSX.Element {
   const match = useRouteMatch<{ id: string }>();
@@ -88,15 +67,7 @@ export function SubscriberStats(): JSX.Element {
             engagement_score: stats.engagement_score,
           }}
         />
-        <EngagementSummary
-          lastClick={stats.last_click}
-          lastEngagement={stats.last_engagement}
-          lastOpen={stats.last_open}
-          lastPageView={stats.last_page_view}
-          lastPurchase={stats.last_purchase}
-          lastSending={stats.last_sending}
-          wooCommerceActive={!!stats.woocommerce}
-        />
+        <EngagementSummary stats={stats} />
         {stats.woocommerce && (
           <WoocommerceRevenues
             averageRevenueValue={stats.woocommerce.formatted_average}

--- a/mailpoet/assets/js/src/subscribers/stats/engagement_summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/engagement_summary.tsx
@@ -1,14 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { MailPoet } from '../../mailpoet';
+import { StatsType } from '../types';
 
 export type PropTypes = {
-  lastClick?: string;
-  lastEngagement?: string;
-  lastOpen?: string;
-  lastPageView?: string;
-  lastPurchase?: string;
-  lastSending?: string;
-  wooCommerceActive: boolean;
+  stats: StatsType;
 };
 
 function dateOrNever(date?: string): string {
@@ -18,28 +13,38 @@ function dateOrNever(date?: string): string {
   return __('never', 'mailpoet');
 }
 
-export function EngagementSummary({
-  lastClick,
-  lastEngagement,
-  lastOpen,
-  lastPageView,
-  lastPurchase,
-  lastSending,
-  wooCommerceActive,
-}: PropTypes): JSX.Element {
-  const stats = [
-    { label: __('Last click', 'mailpoet'), date: lastClick },
-    { label: __('Last engagement', 'mailpoet'), date: lastEngagement },
-    { label: __('Last open', 'mailpoet'), date: lastOpen },
-    { label: __('Last page view', 'mailpoet'), date: lastPageView },
-    { label: __('Last sending', 'mailpoet'), date: lastSending },
+export function EngagementSummary({ stats }: PropTypes): JSX.Element {
+  const engagementData = [
+    {
+      label: __('Last click', 'mailpoet'),
+      date: stats.last_click || null,
+    },
+    {
+      label: __('Last engagement', 'mailpoet'),
+      date: stats.last_engagement || null,
+    },
+    {
+      label: __('Last open', 'mailpoet'),
+      date: stats.last_open || null,
+    },
+    {
+      label: __('Last page view', 'mailpoet'),
+      date: stats.last_page_view || null,
+    },
+    {
+      label: __('Last sending', 'mailpoet'),
+      date: stats.last_sending || null,
+    },
   ];
 
-  if (wooCommerceActive) {
-    stats.push({ label: __('Last purchase', 'mailpoet'), date: lastPurchase });
+  if (stats.woocommerce) {
+    engagementData.push({
+      label: __('Last purchase', 'mailpoet'),
+      date: stats.last_purchase || null,
+    });
   }
 
-  stats.sort((a, b) => {
+  engagementData.sort((a, b) => {
     if (a.date === b.date) {
       return 0;
     }
@@ -57,7 +62,7 @@ export function EngagementSummary({
       <div className="mailpoet-listing">
         <table className="mailpoet-listing-table">
           <tbody>
-            {stats.map(({ label, date }) => (
+            {engagementData.map(({ label, date }) => (
               <tr key={label}>
                 <td>{label}</td>
                 <td>

--- a/mailpoet/assets/js/src/subscribers/stats/engagement_summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/engagement_summary.tsx
@@ -1,0 +1,73 @@
+import { __ } from '@wordpress/i18n';
+import { MailPoet } from '../../mailpoet';
+
+export type PropTypes = {
+  lastClick?: string;
+  lastEngagement?: string;
+  lastOpen?: string;
+  lastPageView?: string;
+  lastPurchase?: string;
+  lastSending?: string;
+  wooCommerceActive: boolean;
+};
+
+function dateOrNever(date?: string): string {
+  if (typeof date === 'string') {
+    return MailPoet.Date.format(date);
+  }
+  return __('never', 'mailpoet');
+}
+
+export function EngagementSummary({
+  lastClick,
+  lastEngagement,
+  lastOpen,
+  lastPageView,
+  lastPurchase,
+  lastSending,
+  wooCommerceActive,
+}: PropTypes): JSX.Element {
+  const stats = [
+    { label: __('Last click', 'mailpoet'), date: lastClick },
+    { label: __('Last engagement', 'mailpoet'), date: lastEngagement },
+    { label: __('Last open', 'mailpoet'), date: lastOpen },
+    { label: __('Last page view', 'mailpoet'), date: lastPageView },
+    { label: __('Last sending', 'mailpoet'), date: lastSending },
+  ];
+
+  if (wooCommerceActive) {
+    stats.push({ label: __('Last purchase', 'mailpoet'), date: lastPurchase });
+  }
+
+  stats.sort((a, b) => {
+    if (a.date === b.date) {
+      return 0;
+    }
+    if (!a.date) {
+      return 1;
+    }
+    if (!b.date) {
+      return -1;
+    }
+    return b.date.localeCompare(a.date);
+  });
+
+  return (
+    <div className="mailpoet-tab-content mailpoet-subscriber-stats-summary">
+      <div className="mailpoet-listing">
+        <table className="mailpoet-listing-table">
+          <tbody>
+            {stats.map(({ label, date }) => (
+              <tr key={label}>
+                <td>{label}</td>
+                <td>
+                  <b>{dateOrNever(date)}</b>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/types.tsx
+++ b/mailpoet/assets/js/src/subscribers/types.tsx
@@ -1,0 +1,21 @@
+export type StatsType = {
+  email: string;
+  total_sent: number;
+  open: number;
+  machine_open: number;
+  click: number;
+  engagement_score: number;
+  last_engagement?: string;
+  last_click?: string;
+  last_open?: string;
+  last_sending?: string;
+  last_page_view?: string;
+  last_purchase?: string;
+  woocommerce?: {
+    currency: string;
+    value: number;
+    count: number;
+    formatted: string;
+    formatted_average: string;
+  };
+};

--- a/mailpoet/lib/API/JSON/v1/SubscriberStats.php
+++ b/mailpoet/lib/API/JSON/v1/SubscriberStats.php
@@ -47,9 +47,30 @@ class SubscriberStats extends APIEndpoint {
       'click' => $statistics->getClickCount(),
       'engagement_score' => $subscriber->getEngagementScore(),
     ];
+    $dateFormat = 'Y-m-d H:i:s';
     $lastEngagement = $subscriber->getLastEngagementAt();
     if ($lastEngagement instanceof \DateTimeInterface) {
-      $response['last_engagement'] = $lastEngagement->format('Y-m-d H:i:s');
+      $response['last_engagement'] = $lastEngagement->format($dateFormat);
+    }
+    $lastClick = $subscriber->getLastClickAt();
+    if ($lastClick instanceof \DateTimeInterface) {
+      $response['last_click'] = $lastClick->format($dateFormat);
+    }
+    $lastOpen = $subscriber->getLastOpenAt();
+    if ($lastOpen instanceof \DateTimeInterface) {
+      $response['last_open'] = $lastOpen->format($dateFormat);
+    }
+    $lastPageView = $subscriber->getLastPageViewAt();
+    if ($lastPageView instanceof \DateTimeInterface) {
+      $response['last_page_view'] = $lastPageView->format($dateFormat);
+    }
+    $lastPurchase = $subscriber->getLastPurchaseAt();
+    if ($lastPurchase instanceof \DateTimeInterface) {
+      $response['last_purchase'] = $lastPurchase->format($dateFormat);
+    }
+    $lastSending = $subscriber->getLastSendingAt();
+    if ($lastSending instanceof \DateTimeInterface) {
+      $response['last_sending'] = $lastSending->format($dateFormat);
     }
     $woocommerce = $statistics->getWooCommerceRevenue();
     if ($woocommerce instanceof WooCommerceRevenue) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -274,6 +274,8 @@ class SendingQueue {
         if (!$isTransactional) {
           $now = Carbon::createFromTimestamp((int)current_time('timestamp'));
           $this->subscribersRepository->bulkUpdateLastSendingAt($foundSubscribersIds, $now);
+          // We're nullifying this value so these subscribers' engagement score will be recalculated the next time the cron runs
+          $this->subscribersRepository->bulkUpdateEngagementScoreUpdatedAt($foundSubscribersIds, null);
         }
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
           'after queue chunk processing',

--- a/mailpoet/lib/Statistics/StatisticsOpensRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsOpensRepository.php
@@ -33,6 +33,7 @@ class StatisticsOpensRepository extends Repository {
       ->getQuery()
       ->getSingleScalarResult();
     if ($newslettersSentCount < 3) {
+      $subscriber->setEngagementScore(null);
       $this->entityManager->flush();
       return;
     }

--- a/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
+++ b/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
@@ -101,14 +101,18 @@ class SubscriberStatisticsRepository extends Repository {
       return null;
     }
 
+    $dateTime = (new Carbon())->subYear();
+
     $currency = $this->wcHelper->getWoocommerceCurrency();
     $purchases = $this->entityManager->createQueryBuilder()
       ->select('stats.orderPriceTotal')
       ->from(StatisticsWooCommercePurchaseEntity::class, 'stats')
       ->where('stats.subscriber = :subscriber')
       ->andWhere('stats.orderCurrency = :currency')
+      ->andWhere('stats.createdAt > :dateTime')
       ->setParameter('subscriber', $subscriber)
       ->setParameter('currency', $currency)
+      ->setParameter('dateTime', $dateTime)
       ->groupBy('stats.orderId, stats.orderPriceTotal')
       ->getQuery()
       ->getResult();

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -304,9 +304,9 @@ class SubscribersRepository extends Repository {
     return count($ids);
   }
 
-  public function bulkUpdateEngagementScoreUpdatedAt(array $ids, ?DateTimeInterface $dateTime): int {
+  public function bulkUpdateEngagementScoreUpdatedAt(array $ids, ?DateTimeInterface $dateTime): void {
     if (empty($ids)) {
-      return 0;
+      return;
     }
     $this->entityManager->createQueryBuilder()
       ->update(SubscriberEntity::class, 's')
@@ -316,7 +316,6 @@ class SubscribersRepository extends Repository {
       ->setParameter('ids', $ids)
       ->getQuery()
       ->execute();
-    return count($ids);
   }
 
   public function findWpUserIdAndEmailByEmails(array $emails): array {

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -304,6 +304,21 @@ class SubscribersRepository extends Repository {
     return count($ids);
   }
 
+  public function bulkUpdateEngagementScoreUpdatedAt(array $ids, ?DateTimeInterface $dateTime): int {
+    if (empty($ids)) {
+      return 0;
+    }
+    $this->entityManager->createQueryBuilder()
+      ->update(SubscriberEntity::class, 's')
+      ->set('s.engagementScoreUpdatedAt', ':dateTime')
+      ->where('s.id IN (:ids)')
+      ->setParameter('dateTime', $dateTime)
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+    return count($ids);
+  }
+
   public function findWpUserIdAndEmailByEmails(array $emails): array {
     return $this->entityManager->createQueryBuilder()
       ->select('s.wpUserId AS wp_user_id, LOWER(s.email) AS email')

--- a/mailpoet/tests/DataFactories/StatisticsNewsletters.php
+++ b/mailpoet/tests/DataFactories/StatisticsNewsletters.php
@@ -28,6 +28,16 @@ class StatisticsNewsletters {
     $this->subscriber = $subscriber;
   }
 
+  /**
+   * @param \DateTimeInterface $date
+   *
+   * @return $this
+   */
+  public function withSentAt(\DateTimeInterface $date) {
+    $this->data['sentAt'] = $date;
+    return $this;
+  }
+
   public function create(): StatisticsNewsletterEntity {
     $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
     $queue = $this->newsletter->getLatestQueue();
@@ -37,6 +47,9 @@ class StatisticsNewsletters {
       $queue,
       $this->subscriber
     );
+    if (isset($this->data['sentAt'])) {
+      $entity->setSentAt($this->data['sentAt']);
+    }
     $entityManager->persist($entity);
     $entityManager->flush();
     return $entity;

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -12,6 +12,7 @@ use MailPoet\Test\DataFactories\StatisticsNewsletters as StatisticsNewslettersFa
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFacctory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetTest;
+use MailPoetVendor\Carbon\Carbon;
 
 class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
   public function testItCreatesSentCountField(): void {
@@ -22,8 +23,8 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     $newsletter2 = (new NewsletterFactory())->withSendingQueue()->create();
     (new NewsletterFactory())->withSendingQueue()->create();
 
-    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->create();
-    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->create();
+    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->withSentAt(Carbon::now())->create();
+    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->withSentAt(Carbon::now())->create();
 
     // check definitions
     $field = $fields['mailpoet:subscriber:email-sent-count'];

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -212,7 +212,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->scheduledTasksRepository,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
     try {
       $sendingQueueWorker->process();
@@ -247,7 +248,8 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       ),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
     $sendingQueueWorker->sendNewsletters(
       $this->queue,
@@ -293,7 +295,8 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       ),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
     $sendingQueueWorker->sendNewsletters(
       $queue,
@@ -333,7 +336,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->scheduledTasksRepository,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
     $sendingQueueWorker->process();
   }
@@ -413,10 +417,15 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       )
     );
+    $this->subscriber->setEngagementScoreUpdatedAt(Carbon::now()->subDays(5));
+    $this->entityManager->flush();
+    $this->entityManager->refresh($this->subscriber);
     expect($this->subscriber->getLastSendingAt())->null();
+    expect($this->subscriber->getEngagementScoreUpdatedAt())->notNull();
     $sendingQueueWorker->process();
     $this->subscribersRepository->refresh($this->subscriber);
     expect($this->subscriber->getLastSendingAt())->notNull();
+    expect($this->subscriber->getEngagementScoreUpdatedAt())->null();
 
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
@@ -666,7 +675,8 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       ),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
 
     $sendingQueueWorker->sendNewsletters(
@@ -1113,7 +1123,8 @@ class SendingQueueTest extends \MailPoetTest {
         ]
       ),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
     try {
       $sendingQueueWorker->sendNewsletters(
@@ -1421,7 +1432,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->scheduledTasksRepository,
       $mailerMock ?? $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
-      $this->sendingQueuesRepository
+      $this->sendingQueuesRepository,
+      $this->entityManager
     );
   }
 

--- a/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
@@ -78,6 +78,19 @@ class StatisticsOpensRepositoryTest extends \MailPoetTest {
     expect($averageScoreUpdatedAt->isAfter((new CarbonImmutable())->subMinutes(5)))->true();
   }
 
+  public function testItResetsSubscriberScoreIfNotEnoughNewsletters() {
+    $subscriber = $this->createSubscriber();
+    $segment = $this->createSegment();
+    $this->createSubscriberSegment($subscriber, $segment);
+    $subscriber->setEngagementScore(5);
+    $this->entityManager->flush();
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getEngagementScore())->equals(5);
+    $this->repository->recalculateSubscriberScore($subscriber);
+    $this->entityManager->refresh($subscriber);
+    expect($subscriber->getEngagementScore())->null();
+  }
+
   public function testItUpdatesScore() {
     $subscriber = $this->createSubscriber();
     $segment = $this->createSegment();

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -152,7 +152,7 @@ class SubscribersRepositoryTest extends \MailPoetTest {
 
     $idsToUpdate = [
       $subscriberOne->getId(),
-      $subscriberTwo->getId(),
+      $subscriberThree->getId(),
     ];
     $this->repository->bulkUpdateEngagementScoreUpdatedAt($idsToUpdate, null);
 

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -42,6 +42,7 @@
     'deletePermanently': __('Delete Permanently'),
     'showMoreDetails': __('Show more details'),
     'lastEngagement': __('Last engagement'),
+    'engagementPeriodHeading': __('Engagement over the last 12 months'),
     'never': _x('never', 'when was the last time the subscriber engaged with the website?'),
 
     'previousPage': __('Previous page'),


### PR DESCRIPTION
## Description

This PR makes some significant changes to the way engagement scores are calculated and updated.
- Sending a newsletter to a subscriber marks them as being due for an engagement score recalculation the next time the cron runs.
- if a subscriber currently has an engagement score but hasn't received a newsletter in the last year, their engagement score will be reset to "unknown" instead of simply remaining the same.
- We're no longer counting machine opens as opens for the engagement score calculation.
- All of the individual stats on a subscriber's statistics page are now based on data from the last year, not all time. The UI has been updated with text to make this clear.
- The WC revenues stats also now include data just for the last year.
- Individual stats pages now include a new section displaying dates of last engagement of different types (click, open, page view, etc).

## Code review notes

_N/A_

## QA notes

If possible, could you please benchmark a larger send before and after this change? It would be good to know if the additional query is going to have a noticeable affect on performance.

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5410

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
