### PR TITLE
Use admin_email as default sender.

### DIFF
--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -231,9 +231,11 @@ class Populator {
     // parse current user name if an email is used
     $senderName = explode('@', $currentUserName);
     $senderName = reset($senderName);
+    // If current user is not set, default to admin email
+    $senderAddress = $currentUser->user_email ?: $this->wp->getOption('admin_email'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $defaultSender = [
       'name' => $senderName,
-      'address' => $currentUser->user_email ?: '', // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      'address' => $senderAddress ?: '',
     ];
     $savedSender = $this->settings->fetch('sender', []);
 


### PR DESCRIPTION
## Description

When the populator runs and there is no current user set, for example when the plugin is installed via CLI without setting the user, we set the sender address to an empty string.
During the wizard, if someone skips setting the sender address we use admin_email as the default.

In this PR we set the default sender to admin_email when the populator runs and there is no user set.

This will be useful for Woo Express or when the plugin is installed via Dotcom marketplace. In those cases, we want to pre-fill the settings as much as possible.

## Code review notes

_N/A_

## QA notes
Follow the steps [here](https://github.com/mailpoet/mailpoet/pull/3941) with the [build](https://output.circle-artifacts.com/output/job/08b62392-ae1b-49dd-ba14-3cb1880bd7e5/artifacts/0/home/circleci/mailpoet/mailpoet/mailpoet.zip)

Or if you want to test on a Jurassic ninja site:
Create a [Jurassic ninja](https://jurassic.ninja/) site
Connect via SFTP and upload [the zip file](https://output.circle-artifacts.com/output/job/08b62392-ae1b-49dd-ba14-3cb1880bd7e5/artifacts/0/home/circleci/mailpoet/mailpoet/mailpoet.zip) to the plugins folder
Connect via SSH and unzip the file
Run `wp plugin activate mailpoet`
Go to the wizard and check the sender address is prefilled with the admin address.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5497]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5498]: https://mailpoet.atlassian.net/browse/MAILPOET-5498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-5497]: https://mailpoet.atlassian.net/browse/MAILPOET-5497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ