### PR TITLE
Add action to existing subscribedDate filters [MAILPOET-5500]

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20230802_174831_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230802_174831_App.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Migrator\AppMigration;
+
+class Migration_20230802_174831_App extends AppMigration {
+  public function run(): void {
+    $subscribedDateFilters = $this->entityManager->createQueryBuilder()
+      ->select('dsf')
+      ->from(DynamicSegmentFilterEntity::class, 'dsf')
+      ->where('dsf.filterData.filterType = :filterType')
+      ->andWhere('dsf.filterData.action = :action')
+      ->setParameter('filterType', 'userRole')
+      ->setParameter('action', 'subscribedDate')
+      ->getQuery()
+      ->getResult();
+
+    /** @var DynamicSegmentFilterEntity $subscribedDateFilter */
+    foreach ($subscribedDateFilters as $subscribedDateFilter) {
+      $filterData = $subscribedDateFilter->getFilterData();
+      $data = $filterData->getData();
+      if (isset($data['action']) && $data['action'] === 'subscribedDate') {
+        continue;
+      }
+      $data['action'] = 'subscribedDate';
+      if (!is_string($filterData->getFilterType()) || !is_string($filterData->getAction())) {
+        continue;
+      }
+      $newFilterData = new DynamicSegmentFilterData(
+        $filterData->getFilterType(),
+        $filterData->getAction(),
+        $data
+      );
+      $subscribedDateFilter->setFilterData($newFilterData);
+      $this->entityManager->persist($subscribedDateFilter);
+    }
+
+    $this->entityManager->flush();
+  }
+}


### PR DESCRIPTION
## Description

After MAILPOET-4989, the subscribedDate filter needs an 'action'. This happens automatically when the data is first run through the FilterDataMapper, but that mapper doesn't get invoked when doing things like recalculating subscriber counts. This adds a migration to update existing filter data to include the proper action.

## Code review notes

_N/A_

## QA notes

Steps to reproduce the bug:
1. Using MailPoet 4.22.0, create a dynamic segment with the "Subscribed Date" filter.
2. Switch to MailPoet 4.22.1.
3. Visit the segments listing page
4. Observe the `An unknown error occurred.` error showing up multiple times.

The bug may not occur if the segment count has been cached, so you may need to clear this cached item to see the error: https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Subscribers/SubscribersCountsController.php#L83-L83

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5500](https://mailpoet.atlassian.net/browse/MAILPOET-5500)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5500]: https://mailpoet.atlassian.net/browse/MAILPOET-5500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ