### PR TITLE
Fetch action directly from filter data [MAILPOET-5500]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -239,7 +239,6 @@ class FilterDataMapper {
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
         'value' => $data['value'],
         'operator' => $data['operator'],
-        'action' => $data['action'],
         'connect' => $data['connect'],
       ]);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
@@ -43,7 +43,7 @@ class SubscriberDateField implements Filter {
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $operator = $this->dateFilterHelper->getOperatorFromFilter($filter);
-    $action = $filter->getFilterData()->getParam('action');
+    $action = $filter->getFilterData()->getAction();
     $value = $this->dateFilterHelper->getDateValueFromFilter($filter);
     $parameter = $this->filterHelper->getUniqueParameterName('date');
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $value);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberDateFieldTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberDateFieldTest.php
@@ -197,7 +197,6 @@ class SubscriberDateFieldTest extends \MailPoetTest {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $action, [
       'operator' => $operator,
       'value' => $value,
-      'action' => $action,
     ]);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);

--- a/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/unit/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -906,7 +906,6 @@ class FilterDataMapperTest extends \MailPoetUnitTest {
     expect($filter->getData())->equals([
       'value' => '2023-07-01',
       'operator' => 'on',
-      'action' => $action,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }


### PR DESCRIPTION
## Description

This fixes an issue where pre-existing subscribedDate filters were causing errors because they didn't have an `action` stored in their serialized data.

It was never necessary to store the action redundantly in the serialized  filter data in the first place, so we're now fetching the action directly from the filter data entity itself.

## Code review notes

_N/A_

## QA notes

Steps to reproduce the bug:

1. Using MailPoet 4.22.0, create a dynamic segment with the "Subscribed Date" filter.
2. Switch to MailPoet 4.22.1.
3. Visit the segments listing page
4. Observe the An unknown error occurred. error showing up multiple times.

The bug may not occur if the segment count has been cached, so you may need to clear this cached item to see the error: https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Subscribers/SubscribersCountsController.php#L83-L83

## Linked PRs

I closed https://github.com/mailpoet/mailpoet/pull/5084 in favor of this PR.

## Linked tickets

[MAILPOET-5500](https://mailpoet.atlassian.net/browse/MAILPOET-5500)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5500]: https://mailpoet.atlassian.net/browse/MAILPOET-5500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ