### PR TITLE
MAILPOET-5496/update-used-shipping-and-payment-methods-timespan

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_payment_method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_payment_method.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { Grid } from 'common/grid';
-import { Input, Select } from 'common';
+import { Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { ReactSelect } from 'common/form/react_select/react_select';
 import { filter } from 'lodash/fp';
@@ -13,6 +13,7 @@ import {
   SelectOption,
 } from '../../../types';
 import { storeName } from '../../../store';
+import { DaysPeriodField, validateDaysPeriod } from '../days_period_field';
 
 export function validateUsedPaymentMethod(
   formItems: WooCommerceFormItem,
@@ -21,8 +22,7 @@ export function validateUsedPaymentMethod(
     !formItems.payment_methods ||
     formItems.payment_methods.length < 1 ||
     !formItems.operator ||
-    !formItems.used_payment_method_days ||
-    parseInt(formItems.used_payment_method_days, 10) < 1;
+    !validateDaysPeriod(formItems);
 
   return !usedPaymentMethodIsInvalid;
 }
@@ -34,8 +34,7 @@ export function UsedPaymentMethodFields({
     (select) => select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],
   );
-  const { updateSegmentFilter, updateSegmentFilterFromEvent } =
-    useDispatch(storeName);
+  const { updateSegmentFilter } = useDispatch(storeName);
   const paymentMethods: WooPaymentMethod[] = useSelect(
     (select) => select(storeName).getPaymentMethods(),
     [],
@@ -97,22 +96,7 @@ export function UsedPaymentMethodFields({
         />
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        <div>{MailPoet.I18n.t('inTheLast')}</div>
-        <Input
-          data-automation-id="input-used-payment-days"
-          type="number"
-          min={1}
-          value={segment.used_payment_method_days || ''}
-          placeholder={MailPoet.I18n.t('daysPlaceholder')}
-          onChange={(e): void => {
-            void updateSegmentFilterFromEvent(
-              'used_payment_method_days',
-              filterIndex,
-              e,
-            );
-          }}
-        />
-        <div>{MailPoet.I18n.t('days')}</div>
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_shipping_method.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { Grid } from 'common/grid';
-import { Input, Select } from 'common';
+import { Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { ReactSelect } from 'common/form/react_select/react_select';
 import { filter } from 'lodash/fp';
@@ -13,6 +13,7 @@ import {
   SelectOption,
 } from '../../../types';
 import { storeName } from '../../../store';
+import { DaysPeriodField, validateDaysPeriod } from '../days_period_field';
 
 export function validateUsedShippingMethod(
   formItems: WooCommerceFormItem,
@@ -21,8 +22,7 @@ export function validateUsedShippingMethod(
     !formItems.shipping_methods ||
     formItems.shipping_methods.length < 1 ||
     !formItems.operator ||
-    !formItems.used_shipping_method_days ||
-    parseInt(formItems.used_shipping_method_days, 10) < 1;
+    !validateDaysPeriod(formItems);
 
   return !usedShippingMethodIsInvalid;
 }
@@ -34,8 +34,7 @@ export function UsedShippingMethodFields({
     (select) => select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],
   );
-  const { updateSegmentFilter, updateSegmentFilterFromEvent } =
-    useDispatch(storeName);
+  const { updateSegmentFilter } = useDispatch(storeName);
   const shippingMethods: WooShippingMethod[] = useSelect(
     (select) => select(storeName).getShippingMethods(),
     [],
@@ -97,22 +96,7 @@ export function UsedShippingMethodFields({
         />
       </Grid.CenteredRow>
       <Grid.CenteredRow>
-        <div>{MailPoet.I18n.t('inTheLast')}</div>
-        <Input
-          data-automation-id="input-used-shipping-days"
-          type="number"
-          min={1}
-          value={segment.used_shipping_method_days || ''}
-          placeholder={MailPoet.I18n.t('daysPlaceholder')}
-          onChange={(e): void => {
-            void updateSegmentFilterFromEvent(
-              'used_shipping_method_days',
-              filterIndex,
-              e,
-            );
-          }}
-        />
-        <div>{MailPoet.I18n.t('days')}</div>
+        <DaysPeriodField filterIndex={filterIndex} />
       </Grid.CenteredRow>
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -144,9 +144,7 @@ export interface WooCommerceFormItem extends FormItem {
   average_spent_type?: string;
   average_spent_amount?: string;
   payment_methods?: string[];
-  used_payment_method_days?: string;
   shipping_methods?: string[];
-  used_shipping_method_days?: string;
   rating?: ReviewRating;
   count_type?: CountType;
   count?: string;

--- a/mailpoet/lib/Migrations/App/Migration_20230803_200413_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230803_200413_App.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
+
+class Migration_20230803_200413_App extends AppMigration {
+  public function run(): void {
+    $dynamicSegmentFilterRepository = $this->container->get(DynamicSegmentFilterRepository::class);
+    $filters = $dynamicSegmentFilterRepository->findBy(
+      [
+        'filterData.action' => [
+          WooCommerceUsedPaymentMethod::ACTION,
+          WooCommerceUsedShippingMethod::ACTION,
+        ],
+      ]
+    );
+
+    /** @var DynamicSegmentFilterEntity $filter */
+    foreach ($filters as $filter) {
+      $filterData = $filter->getFilterData();
+      $data = $filter->getFilterData()->getData();
+
+      if (isset($data['used_payment_method_days'])) {
+        $days = $data['used_payment_method_days'];
+      } elseif (isset($data['used_shipping_method_days'])) {
+        $days = $data['used_shipping_method_days'];
+      }
+
+      $filterType = $filterData->getFilterType();
+      $filterAction = $filterData->getAction();
+
+      if (isset($days) && is_string($filterType) && is_string($filterAction)) {
+        $data['days'] = $days;
+        $newFilterData = new DynamicSegmentFilterData($filterType, $filterAction, $data);
+        $filter->setFilterData($newFilterData);
+        $this->entityManager->persist($filter);
+        $this->entityManager->flush();
+      }
+    }
+  }
+}

--- a/mailpoet/lib/Migrations/App/Migration_20230803_200413_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230803_200413_App.php
@@ -37,6 +37,7 @@ class Migration_20230803_200413_App extends AppMigration {
 
       if (isset($days) && is_string($filterType) && is_string($filterAction)) {
         $data['days'] = $days;
+        $data['timeframe'] = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST;
         $newFilterData = new DynamicSegmentFilterData($filterType, $filterAction, $data);
         $filter->setFilterData($newFilterData);
         $this->entityManager->persist($filter);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -444,12 +444,11 @@ class FilterDataMapper {
       if (!isset($data['payment_methods']) || !is_array($data['payment_methods']) || empty($data['payment_methods'])) {
         throw new InvalidFilterException('Missing payment gateways', InvalidFilterException::MISSING_VALUE);
       }
-      if (!isset($data['used_payment_method_days']) || intval($data['used_payment_method_days']) < 1) {
-        throw new InvalidFilterException('Missing days', InvalidFilterException::MISSING_VALUE);
-      }
+      $this->filterHelper->validateDaysPeriodData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['payment_methods'] = $data['payment_methods'];
-      $filterData['used_payment_method_days'] = intval($data['used_payment_method_days']);
+      $filterData['days'] = intval($data['days'] ?? 0);
+      $filterData['timeframe'] = $data['timeframe'];
     } elseif ($data['action'] === WooCommerceUsedShippingMethod::ACTION) {
       if (!isset($data['operator']) || !in_array($data['operator'], WooCommerceUsedShippingMethod::VALID_OPERATORS, true)) {
         throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
@@ -457,12 +456,11 @@ class FilterDataMapper {
       if (!isset($data['shipping_methods']) || !is_array($data['shipping_methods']) || empty($data['shipping_methods'])) {
         throw new InvalidFilterException('Missing shipping methods', InvalidFilterException::MISSING_VALUE);
       }
-      if (!isset($data['used_shipping_method_days']) || intval($data['used_shipping_method_days']) < 1) {
-        throw new InvalidFilterException('Missing days', InvalidFilterException::MISSING_VALUE);
-      }
+      $this->filterHelper->validateDaysPeriodData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['shipping_methods'] = $data['shipping_methods'];
-      $filterData['used_shipping_method_days'] = intval($data['used_shipping_method_days']);
+      $filterData['days'] = intval($data['days'] ?? 0);
+      $filterData['timeframe'] = $data['timeframe'];
     } elseif (in_array($data['action'], WooCommerceCustomerTextField::ACTIONS)) {
       if (empty($data['value'])) {
         throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -54,10 +54,6 @@ class WooCommerceUsedPaymentMethod implements Filter {
     }
 
     $data = $filterData->getData();
-    // Backwards compatibility for filters saved before timeframe was added
-    if (!isset($data['timeframe'])) {
-      $data['timeframe'] = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST;
-    }
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
     $includedStatuses = array_keys($this->wooHelper->getOrderStatuses());

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -55,10 +55,6 @@ class WooCommerceUsedShippingMethod implements Filter {
     }
 
     $data = $filterData->getData();
-    // Backwards compatibility for filters saved before timeframe was added
-    if (!isset($data['timeframe'])) {
-      $data['timeframe'] = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST;
-    }
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
     $includedStatuses = array_keys($this->wooHelper->getOrderStatuses());

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -274,7 +274,7 @@ class Helper {
 
     foreach ($shippingMethods as $shippingMethod) {
       $formattedShippingMethods[] = [
-        'instanceId' => $shippingMethod->instance_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        'instanceId' => (string)$shippingMethod->instance_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         'name' => "{$shippingMethod->title} ({$shippingZoneName})",
       ];
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethodTest.php
@@ -29,9 +29,9 @@ class WooCommerceUsedPaymentMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'cheque');
     $this->createOrder($customerId3, Carbon::now(), 'paypal');
 
-    $this->assertFilterReturnsEmails('any', ['paypal'], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', ['cheque'], 1, ['c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', ['doge'], 1000, []);
+    $this->assertFilterReturnsEmails('any', ['paypal'], 1, 'inTheLast', ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', ['cheque'], 1, 'inTheLast', ['c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', ['doge'], 1000, 'inTheLast', []);
   }
 
   public function testItWorksWithAllOperator(): void {
@@ -46,10 +46,10 @@ class WooCommerceUsedPaymentMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'cheque');
     $this->createOrder($customerId3, Carbon::now(), 'paypal');
 
-    $this->assertfilterreturnsemails('all', ['paypal'], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['cheque'], 1, ['c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['cheque', 'paypal'], 1, ['c3@e.com']);
-    $this->assertFilterReturnsEmails('all', ['doge'], 1000, []);
+    $this->assertfilterreturnsemails('all', ['paypal'], 1, 'inTheLast', ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['cheque'], 1, 'inTheLast', ['c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['cheque', 'paypal'], 1, 'inTheLast', ['c3@e.com']);
+    $this->assertFilterReturnsEmails('all', ['doge'], 1000, 'inTheLast', []);
   }
 
   public function testItWorksWithNoneOperator(): void {
@@ -66,10 +66,10 @@ class WooCommerceUsedPaymentMethodTest extends \MailPoetTest {
 
     (new Subscriber)->withEmail('sub@e.com')->create();
 
-    $this->assertFilterReturnsEmails('none', ['paypal'], 1, ['sub@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['cheque'], 1, ['sub@e.com', 'c1@e.com']);
-    $this->assertFilterReturnsEmails('none', ['doge'], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('none', ['paypal', 'cheque'], 1, ['sub@e.com']);
+    $this->assertFilterReturnsEmails('none', ['paypal'], 1, 'inTheLast', ['sub@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['cheque'], 1, 'inTheLast', ['sub@e.com', 'c1@e.com']);
+    $this->assertFilterReturnsEmails('none', ['doge'], 1000, 'inTheLast', ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('none', ['paypal', 'cheque'], 1, 'inTheLast', ['sub@e.com']);
   }
 
   public function testItWorksWithDateRanges(): void {
@@ -79,30 +79,49 @@ class WooCommerceUsedPaymentMethodTest extends \MailPoetTest {
 
     $customerId2 = $this->tester->createCustomer('c2@e.com');
     $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'cash');
-    $this->assertFilterReturnsEmails('any', ['paypal'], 1, []);
-    $this->assertFilterReturnsEmails('any', ['paypal'], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', ['cheque'], 4, []);
-    $this->assertFilterReturnsEmails('any', ['cheque'], 5, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', ['cash'], 99, []);
-    $this->assertFilterReturnsEmails('any', ['cash'], 100, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', ['cash', 'paypal'], 100, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('any', ['paypal'], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', ['paypal'], 2, 'inTheLast', ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', ['cheque'], 4, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', ['cheque'], 5, 'inTheLast', ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', ['cash'], 99, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', ['cash'], 100, 'inTheLast', ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', ['cash', 'paypal'], 100, 'inTheLast', ['c1@e.com', 'c2@e.com']);
 
-    $this->assertFilterReturnsEmails('all', ['paypal'], 1, []);
-    $this->assertFilterReturnsEmails('all', ['paypal'], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('all', ['paypal', 'cheque'], 2, []);
-    $this->assertFilterReturnsEmails('all', ['paypal', 'cheque'], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', ['paypal'], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('all', ['paypal'], 2, 'inTheLast', ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', ['paypal', 'cheque'], 2, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('all', ['paypal', 'cheque'], 5, 'inTheLast', ['c1@e.com']);
 
-    $this->assertFilterReturnsEmails('none', ['paypal'], 1, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['paypal'], 2, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['cheque'], 2, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', ['cheque'], 5, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['paypal'], 1, 'inTheLast', ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['paypal'], 2, 'inTheLast', ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['cheque'], 2, 'inTheLast', ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['cheque'], 5, 'inTheLast', ['c2@e.com']);
   }
 
-  private function assertFilterReturnsEmails(string $operator, array $paymentMethods, int $days, array $expectedEmails): void {
+  public function testItWorksWithAllTime(): void {
+    $customerId1 = $this->tester->createCustomer('c1@e.com');
+    $this->createOrder($customerId1, Carbon::now()->subDays(2)->addMinute(), 'paypal');
+    $this->createOrder($customerId1, Carbon::now()->subDays(5)->addMinute(), 'cheque');
+
+    $customerId2 = $this->tester->createCustomer('c2@e.com');
+    $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'cash');
+
+    $this->assertFilterReturnsEmails('any', ['cash', 'paypal'], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', ['cash', 'paypal'], 1, 'allTime', ['c1@e.com', 'c2@e.com']);
+
+    $this->assertFilterReturnsEmails('all', ['cash'], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('all', ['cash'], 1, 'allTime', ['c2@e.com']);
+
+    $this->assertFilterReturnsEmails('none', ['cash', 'paypal'], 1, 'inTheLast', ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', ['cash', 'paypal'], 1, 'allTime', []);
+  }
+
+  private function assertFilterReturnsEmails(string $operator, array $paymentMethods, int $days, string $timeframe, array $expectedEmails): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedPaymentMethod::ACTION, [
       'operator' => $operator,
       'payment_methods' => $paymentMethods,
-      'used_payment_method_days' => $days,
+      'days' => $days,
+      'timeframe' => $timeframe,
     ]);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
@@ -32,10 +32,10 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 3);
     $this->createOrder($customerId4, Carbon::now(), 'flat_rate', 4);
 
-    $this->assertFilterReturnsEmails('any', [1], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', [2], 1, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', [2, 1], 1, ['c1@e.com', 'c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('any', [8], 1000, []); // non-existing shipping method
+    $this->assertFilterReturnsEmails('any', [1], 1, 'inTheLast', ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', [2], 1, 'inTheLast', ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', [2, 1], 1, 'inTheLast', ['c1@e.com', 'c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('any', [8], 1000, 'inTheLast', []); // non-existing shipping method
   }
 
   public function testItWorksWithAllOperator(): void {
@@ -50,10 +50,10 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 2);
     $this->createOrder($customerId3, Carbon::now(), 'flat_rate', 1);
 
-    $this->assertfilterreturnsemails('all', [1], 1, ['c1@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', [2], 1, ['c2@e.com', 'c3@e.com']);
-    $this->assertFilterReturnsEmails('all', [2, 1], 1, ['c3@e.com']);
-    $this->assertFilterReturnsEmails('all', [8, 1], 1000, []); // includes non-existing shipping method
+    $this->assertfilterreturnsemails('all', [1], 1, 'inTheLast', ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [2], 1, 'inTheLast', ['c2@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [2, 1], 1, 'inTheLast', ['c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [8, 1], 1000, 'inTheLast', []); // includes non-existing shipping method
   }
 
   public function testItWorksWithNoneOperator(): void {
@@ -70,10 +70,10 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
 
     (new Subscriber)->withEmail('sub@e.com')->create();
 
-    $this->assertFilterReturnsEmails('none', [1], 1, ['sub@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', [2], 1, ['sub@e.com', 'c1@e.com']);
-    $this->assertFilterReturnsEmails('none', [8], 1000, ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']); // non-existing shipping method
-    $this->assertFilterReturnsEmails('none', [1, 2], 1, ['sub@e.com']);
+    $this->assertFilterReturnsEmails('none', [1], 1, 'inTheLast', ['sub@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 1, 'inTheLast', ['sub@e.com', 'c1@e.com']);
+    $this->assertFilterReturnsEmails('none', [8], 1000, 'inTheLast', ['sub@e.com', 'c1@e.com', 'c2@e.com', 'c3@e.com']); // non-existing shipping method
+    $this->assertFilterReturnsEmails('none', [1, 2], 1, 'inTheLast', ['sub@e.com']);
   }
 
   public function testItWorksWithDateRanges(): void {
@@ -83,30 +83,49 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
 
     $customerId2 = $this->tester->createCustomer('c2@e.com');
     $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'local_pickup', 3);
-    $this->assertFilterReturnsEmails('any', [1], 1, []);
-    $this->assertFilterReturnsEmails('any', [1], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', [2], 4, []);
-    $this->assertFilterReturnsEmails('any', [2], 5, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('any', [3], 99, []);
-    $this->assertFilterReturnsEmails('any', [3], 100, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('any', [3, 1], 100, ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('any', [1], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', [1], 2, 'inTheLast', ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', [2], 4, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', [2], 5, 'inTheLast', ['c1@e.com']);
+    $this->assertFilterReturnsEmails('any', [3], 99, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', [3], 100, 'inTheLast', ['c2@e.com']);
+    $this->assertFilterReturnsEmails('any', [3, 1], 100, 'inTheLast', ['c1@e.com', 'c2@e.com']);
 
-    $this->assertFilterReturnsEmails('all', [1], 1, []);
-    $this->assertFilterReturnsEmails('all', [1], 2, ['c1@e.com']);
-    $this->assertFilterReturnsEmails('all', [1, 2], 2, []);
-    $this->assertFilterReturnsEmails('all', [1, 2], 5, ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', [1], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('all', [1], 2, 'inTheLast', ['c1@e.com']);
+    $this->assertFilterReturnsEmails('all', [1, 2], 2, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('all', [1, 2], 5, 'inTheLast', ['c1@e.com']);
 
-    $this->assertFilterReturnsEmails('none', [1], 1, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', [1], 2, ['c2@e.com']);
-    $this->assertFilterReturnsEmails('none', [2], 2, ['c1@e.com', 'c2@e.com']);
-    $this->assertFilterReturnsEmails('none', [2], 5, ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [1], 1, 'inTheLast', ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [1], 2, 'inTheLast', ['c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 2, 'inTheLast', ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 5, 'inTheLast', ['c2@e.com']);
   }
 
-  private function assertFilterReturnsEmails(string $operator, array $shippingMethodStrings, int $days, array $expectedEmails): void {
+  public function testItWorksWithAllTimeTimeframe(): void {
+    $customerId1 = $this->tester->createCustomer('c1@e.com');
+    $this->createOrder($customerId1, Carbon::now()->subDays(2)->addMinute(), 'flat_rate', 1);
+    $this->createOrder($customerId1, Carbon::now()->subDays(5)->addMinute(), 'free_shipping', 2);
+
+    $customerId2 = $this->tester->createCustomer('c2@e.com');
+    $this->createOrder($customerId2, Carbon::now()->subDays(100)->addMinute(), 'local_pickup', 3);
+
+    $this->assertFilterReturnsEmails('any', [3, 1], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('any', [3, 1], 1, 'allTime', ['c1@e.com', 'c2@e.com']);
+
+    $this->assertFilterReturnsEmails('none', [2], 1, 'inTheLast', ['c1@e.com', 'c2@e.com']);
+    $this->assertFilterReturnsEmails('none', [2], 1, 'allTime', ['c2@e.com']);
+
+    $this->assertFilterReturnsEmails('all', [2], 1, 'inTheLast', []);
+    $this->assertFilterReturnsEmails('all', [2], 1, 'allTime', ['c1@e.com']);
+  }
+
+  private function assertFilterReturnsEmails(string $operator, array $shippingMethodStrings, int $days, string $timeframe, array $expectedEmails): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
       'operator' => $operator,
       'shipping_methods' => $shippingMethodStrings,
-      'used_shipping_method_days' => $days,
+      'days' => $days,
+      'timeframe' => $timeframe,
     ]);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);


### PR DESCRIPTION
## Description

This adds the "over all time" option to the used shipping method and used payment method dynamic segment filters, which we missed when working on MAILPOET-4991 (https://github.com/mailpoet/mailpoet/pull/5057).

## Code review notes

_N/A_

## QA notes

This update changes how the data for the number of days is stored for these two filters, and it includes a migration to handle that. Please make sure that filters created before this version continue to work exactly as they did before after the update, and please also make sure that the migration ran successfully before testing (I think it should just require deactivating and reactivating the plugin).

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5057 completed this work for other fliters.
I used some of the changes introduced in https://github.com/mailpoet/mailpoet/pull/5064, so that will need to be merged before this will be ready to review (edit: that PR has been merged and this PR has been rebased)

## Linked tickets
[MAILPOET-5496](https://mailpoet.atlassian.net/browse/MAILPOET-5496)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5496]: https://mailpoet.atlassian.net/browse/MAILPOET-5496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ