### PR TITLE
Fix filterData var reference in DynamicSegmentFilterData [MAILPOET-5505]

### DIFF
--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -90,7 +90,7 @@ class DynamicSegmentFilterData {
       return $this->filterType;
     }
     // When a new column is empty, we try to get the value from serialized data
-    return $filterData['segmentType'] ?? null;
+    return $this->filterData['segmentType'] ?? null;
   }
 
   public function getAction(): ?string {

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -261,11 +261,6 @@ parameters:
 			path: ../../lib/Doctrine/Types/SerializedArrayType.php
 
 		-
-			message: "#^Variable \\$filterData on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: ../../lib/Entities/DynamicSegmentFilterData.php
-
-		-
 			message: "#^Method MailPoet\\\\Entities\\\\SegmentEntity\\:\\:getFiltersConnectOperator\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Entities/SegmentEntity.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -261,11 +261,6 @@ parameters:
 			path: ../../lib/Doctrine/Types/SerializedArrayType.php
 
 		-
-			message: "#^Variable \\$filterData on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: ../../lib/Entities/DynamicSegmentFilterData.php
-
-		-
 			message: "#^Method MailPoet\\\\Entities\\\\SegmentEntity\\:\\:getFiltersConnectOperator\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Entities/SegmentEntity.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -260,11 +260,6 @@ parameters:
 			path: ../../lib/Doctrine/Types/SerializedArrayType.php
 
 		-
-			message: "#^Variable \\$filterData on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: ../../lib/Entities/DynamicSegmentFilterData.php
-
-		-
 			message: "#^Method MailPoet\\\\Entities\\\\SegmentEntity\\:\\:getFiltersConnectOperator\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Entities/SegmentEntity.php


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5505]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5505]: https://mailpoet.atlassian.net/browse/MAILPOET-5505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ