### PR TITLE
Automation fixes [MAILPOET-5242][MAILPOET-4968][MAILPOET-5377]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_header.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_header.scss
@@ -1,0 +1,3 @@
+#mailpoet_automation_editor .interface-interface-skeleton__header {
+  border-bottom: none;
+}

--- a/mailpoet/assets/css/src/components-automation-editor/_saved-state.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_saved-state.scss
@@ -1,0 +1,22 @@
+/* See: https://github.com/WordPress/gutenberg/blob/0b4ad0072a5c3dd4832081ed00d4e27389ae88c8/packages/editor/src/components/post-saved-state/index.js */
+.mailpoet-automation-editor-saved-state {
+  align-items: center;
+  color: #757575;
+  display: flex;
+  overflow: hidden;
+  white-space: nowrap;
+
+  &.is-saving[aria-disabled='true'],
+  &.is-saving[aria-disabled='true']:hover,
+  &.is-saved[aria-disabled='true'],
+  &.is-saved[aria-disabled='true']:hover {
+    background: transparent;
+    color: #757575;
+  }
+
+  svg {
+    display: inline-block;
+    fill: currentColor;
+    flex: 0 0 auto;
+  }
+}

--- a/mailpoet/assets/css/src/components-automation-editor/editor.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/editor.scss
@@ -13,6 +13,7 @@
 @import './empty-automation';
 @import './errors';
 @import './panel';
+@import './saved-state';
 @import './separator';
 @import './status';
 @import './step';

--- a/mailpoet/assets/css/src/components-automation-editor/editor.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/editor.scss
@@ -20,5 +20,6 @@
 @import './step-filters';
 @import './step-card';
 @import './filters';
+@import './header';
 @import './notices';
 @import './deactivate-modal';

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import classnames from 'classnames';
 import {
   Button,
   NavigableMenu,
@@ -143,7 +144,13 @@ function SaveDraftButton(): JSX.Element {
   // use single Button instance for all states so that focus is not lost
   return (
     <Button
-      className={`mailpoet-automation-editor-saved-state is-${savedState}`}
+      className={classnames([
+        'mailpoet-automation-editor-saved-state',
+        `is-${savedState}`,
+        {
+          'components-animate__loading': savedState === 'saving',
+        },
+      ])}
       variant="tertiary"
       label={label}
       shortcut={isDisabled ? undefined : displayShortcut.primary('s')}

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Button,
   NavigableMenu,
@@ -6,6 +6,7 @@ import {
   Tooltip,
 } from '@wordpress/components';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { Icon, check, cloud } from '@wordpress/icons';
 import { PinnedItems } from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
 import { ErrorBoundary } from 'common';
@@ -106,11 +107,36 @@ function UpdateButton(): JSX.Element {
 }
 
 function SaveDraftButton(): JSX.Element {
+  const savedState = useSelect(
+    (select) => select(storeName).getSavedState(),
+    [],
+  );
   const { save } = useDispatch(storeName);
 
+  const label = useMemo(() => {
+    if (savedState === 'saving') {
+      return __('Saving', 'mailpoet');
+    }
+    if (savedState === 'saved') {
+      return __('Saved', 'mailpoet');
+    }
+    return __('Save draft', 'mailpoet');
+  }, [savedState]);
+
+  const isDisabled = savedState === 'saving' || savedState === 'saved';
+
+  // use single Button instance for all states so that focus is not lost
   return (
-    <Button variant="tertiary" onClick={save}>
-      {__('Save draft', 'mailpoet')}
+    <Button
+      className={`mailpoet-automation-editor-saved-state is-${savedState}`}
+      variant="tertiary"
+      label={label}
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
+      onClick={save}
+    >
+      {savedState === 'saving' && <Icon icon={cloud} />}
+      {savedState === 'saved' && <Icon icon={check} />}
     </Button>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -9,6 +9,7 @@ import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { Icon, check, cloud } from '@wordpress/icons';
 import { PinnedItems } from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
+import { displayShortcut } from '@wordpress/keycodes';
 import { ErrorBoundary } from 'common';
 import { DocumentActions } from './document_actions';
 import { Errors } from './errors';
@@ -89,6 +90,8 @@ function UpdateButton(): JSX.Element {
         variant="primary"
         className="editor-post-publish-button"
         label={label}
+        showTooltip
+        shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
         isBusy={savedState === 'saving'}
         disabled={isDisabled}
         aria-disabled={isDisabled}
@@ -143,12 +146,15 @@ function SaveDraftButton(): JSX.Element {
       className={`mailpoet-automation-editor-saved-state is-${savedState}`}
       variant="tertiary"
       label={label}
+      shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
+      showTooltip
       disabled={isDisabled}
       aria-disabled={isDisabled}
       onClick={save}
     >
       {savedState === 'saving' && <Icon icon={cloud} />}
       {savedState === 'saved' && <Icon icon={check} />}
+      {label}
     </Button>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -68,21 +68,33 @@ function ActivateButton({ label }): JSX.Element {
 function UpdateButton(): JSX.Element {
   const { save } = useDispatch(storeName);
 
-  const { automation } = useSelect(
+  const { automation, savedState } = useSelect(
     (select) => ({
       automation: select(storeName).getAutomationData(),
+      savedState: select(storeName).getSavedState(),
     }),
     [],
   );
+
+  const isDisabled = savedState === 'saving' || savedState === 'saved';
+
+  const label =
+    savedState === 'saving'
+      ? __('Updating…', 'mailpoet')
+      : __('Update', 'mailpoet');
 
   if (automation.stats.totals.in_progress === 0) {
     return (
       <Button
         variant="primary"
         className="editor-post-publish-button"
+        label={label}
+        isBusy={savedState === 'saving'}
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
         onClick={save}
       >
-        {__('Update', 'mailpoet')}
+        {label}
       </Button>
     );
   }

--- a/mailpoet/assets/js/src/automation/editor/components/keyboard-shortcuts/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/keyboard-shortcuts/index.tsx
@@ -12,12 +12,14 @@ import { stepSidebarKey, storeName, automationSidebarKey } from '../../store';
 //    https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/keyboard-shortcuts/index.js
 
 export function KeyboardShortcuts(): null {
-  const { isSidebarOpened, selectedStep } = useSelect((select) => ({
+  const { isSidebarOpened, selectedStep, savedState } = useSelect((select) => ({
     isSidebarOpened: select(storeName).isSidebarOpened,
     selectedStep: select(storeName).getSelectedStep,
+    savedState: select(storeName).getSavedState(),
   }));
 
-  const { openSidebar, closeSidebar, toggleFeature } = useDispatch(storeName);
+  const { openSidebar, closeSidebar, save, toggleFeature } =
+    useDispatch(storeName);
 
   const { registerShortcut } = useDispatch(keyboardShortcutsStore);
 
@@ -41,6 +43,16 @@ export function KeyboardShortcuts(): null {
         character: ',',
       },
     });
+
+    void registerShortcut({
+      name: 'mailpoet/automation-editor/save',
+      category: 'global',
+      description: __('Save your changes.', 'mailpoet'),
+      keyCombination: {
+        modifier: 'primary',
+        character: 's',
+      },
+    });
   }, [registerShortcut]);
 
   useShortcut('mailpoet/automation-editor/toggle-fullscreen', () => {
@@ -57,6 +69,14 @@ export function KeyboardShortcuts(): null {
         ? stepSidebarKey
         : automationSidebarKey;
       openSidebar(sidebarToOpen);
+    }
+  });
+
+  useShortcut('mailpoet/automation-editor/save', (event) => {
+    event.preventDefault();
+
+    if (savedState === 'unsaved') {
+      save();
     }
   });
 

--- a/mailpoet/assets/js/src/automation/editor/components/panel/step-name.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/panel/step-name.tsx
@@ -18,9 +18,8 @@ export function StepName({
     <Dropdown
       className="mailpoet-step-name-dropdown"
       contentClassName="mailpoet-step-name-popover"
-      position="bottom left"
       popoverProps={{
-        placement: 'bottom-start',
+        placement: 'bottom-end',
       }}
       renderToggle={({ isOpen, onToggle }) => (
         <PlainBodyTitle

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -70,7 +70,7 @@ function updatingActiveAutomationNotPossible() {
 }
 
 function onUnload(event) {
-  if (!globalSelect(storeName).getAutomationSaved()) {
+  if (globalSelect(storeName).getSavedState() !== 'saved') {
     // eslint-disable-next-line no-param-reassign
     event.returnValue = __(
       'There are unsaved changes that will be lost. Do you want to continue?',

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -89,6 +89,11 @@ export function setAutomationName(name) {
 
 export function* save() {
   const automation = select(storeName).getAutomationData();
+
+  yield {
+    type: 'SAVING',
+  };
+
   const data = yield apiFetch({
     path: `/automations/${automation.id}`,
     method: 'PUT',

--- a/mailpoet/assets/js/src/automation/editor/store/initial_state.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/initial_state.ts
@@ -3,11 +3,11 @@ import { AutomationEditorWindow, State } from './types';
 declare let window: AutomationEditorWindow;
 
 export const getInitialState = (): State => ({
+  savedState: 'saved',
   registry: { ...window.mailpoet_automation_registry },
   context: { ...window.mailpoet_automation_context },
   stepTypes: {},
   automationData: { ...window.mailpoet_automation },
-  automationSaved: true,
   selectedStep: undefined,
   inserterSidebar: {
     isOpened: false,

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -58,6 +58,11 @@ export function reducer(state: State, action): State {
         automationData: action.automation,
         savedState: 'saved',
       };
+    case 'SAVING':
+      return {
+        ...state,
+        savedState: 'saving',
+      };
     case 'REGISTER_STEP_TYPE':
       return {
         ...state,

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -32,31 +32,31 @@ export function reducer(state: State, action): State {
       return {
         ...state,
         automationData: action.automation,
-        automationSaved: false,
+        savedState: 'unsaved',
       };
     case 'SAVE':
       return {
         ...state,
         automationData: action.automation,
-        automationSaved: true,
+        savedState: 'saved',
       };
     case 'ACTIVATE':
       return {
         ...state,
         automationData: action.automation,
-        automationSaved: true,
+        savedState: 'saved',
       };
     case 'DEACTIVATE':
       return {
         ...state,
         automationData: action.automation,
-        automationSaved: true,
+        savedState: 'saved',
       };
     case 'TRASH':
       return {
         ...state,
         automationData: action.automation,
-        automationSaved: true,
+        savedState: 'saved',
       };
     case 'REGISTER_STEP_TYPE':
       return {
@@ -96,7 +96,7 @@ export function reducer(state: State, action): State {
             [action.stepId]: step,
           },
         },
-        automationSaved: false,
+        savedState: 'unsaved',
         selectedStep: step,
         errors:
           stepErrors.length > 0
@@ -119,7 +119,7 @@ export function reducer(state: State, action): State {
             [action.key]: action.value,
           },
         },
-        automationSaved: false,
+        savedState: 'unsaved',
       };
     case 'SET_ERRORS':
       return {

--- a/mailpoet/assets/js/src/automation/editor/store/selectors.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/selectors.ts
@@ -77,8 +77,8 @@ export function getAutomationData(state: State): Automation {
   return state.automationData;
 }
 
-export function getAutomationSaved(state: State): boolean {
-  return state.automationSaved;
+export function getSavedState(state: State): State['savedState'] {
+  return state.savedState;
 }
 
 export function getSelectedStep(state: State): Step | undefined {

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -92,7 +92,7 @@ export type Errors = {
 };
 
 export type State = {
-  savedState: 'unsaved' | 'saved';
+  savedState: 'unsaved' | 'saving' | 'saved';
   registry: Registry;
   context: Context;
   stepTypes: Record<string, StepType>;

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -92,11 +92,11 @@ export type Errors = {
 };
 
 export type State = {
+  savedState: 'unsaved' | 'saved';
   registry: Registry;
   context: Context;
   stepTypes: Record<string, StepType>;
   automationData: Automation;
-  automationSaved: boolean;
   selectedStep: Step | undefined;
   inserterSidebar: {
     isOpened: boolean;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/edit_newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/edit/edit_newsletter.tsx
@@ -31,11 +31,11 @@ export function EditNewsletter(): JSX.Element {
     useState(false);
   const [fetchingPreviewLink, setFetchingPreviewLink] = useState(false);
 
-  const { selectedStep, automationId, automationSaved, errors } = useSelect(
+  const { selectedStep, automationId, savedState, errors } = useSelect(
     (select) => ({
       selectedStep: select(storeName).getSelectedStep(),
       automationId: select(storeName).getAutomationData().id,
-      automationSaved: select(storeName).getAutomationSaved(),
+      savedState: select(storeName).getSavedState(),
       errors: select(storeName).getStepError(
         select(storeName).getSelectedStep().id,
       ),
@@ -77,10 +77,10 @@ export function EditNewsletter(): JSX.Element {
   // This component is rendered only when no email ID is set. Once we have the ID
   // and the automation is saved, we can safely redirect to the email design flow.
   useEffect(() => {
-    if (redirectToTemplateSelection && emailId && automationSaved) {
+    if (redirectToTemplateSelection && emailId && savedState === 'saved') {
       window.location.href = `admin.php?page=mailpoet-newsletters&context=automation#/template/${emailId}`;
     }
-  }, [emailId, automationSaved, redirectToTemplateSelection]);
+  }, [emailId, savedState, redirectToTemplateSelection]);
 
   if (!emailId || redirectToTemplateSelection) {
     return (

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send_email/index.tsx
@@ -43,8 +43,9 @@ export const step: StepType = {
           'mailpoet',
         ),
         /\[link\](.*?)\[\/link\]/g,
-        (match) => (
+        (match, i) => (
           <a
+            key={i}
             rel="noreferrer"
             href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
             target="_blank"
@@ -70,8 +71,9 @@ export const step: StepType = {
         'mailpoet',
       ),
       /\[link\](.*?)\[\/link\]/g,
-      (match) => (
+      (match, i) => (
         <a
+          key={i}
           rel="noreferrer"
           href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
           target="_blank"

--- a/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading_steps.tsx
@@ -119,7 +119,9 @@ const stepsListingHeading = (
         {' '}
       </h1>
       <div className="mailpoet-flex-grow" />
-      {emailType !== 'automation' && <TutorialIcon />}
+      {!['automation', 'automation_transactional'].includes(emailType) && (
+        <TutorialIcon />
+      )}
     </div>
   );
 };

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -17,6 +17,9 @@ class OrderFieldsFactory {
   /** @var TermOptionsBuilder */
   private $termOptionsBuilder;
 
+  /** @var TermParentsLoader */
+  private $termParentsLoader;
+
   /** @var WordPress */
   private $wordPress;
 
@@ -25,10 +28,12 @@ class OrderFieldsFactory {
 
   public function __construct(
     TermOptionsBuilder $termOptionsBuilder,
+    TermParentsLoader $termParentsLoader,
     WordPress $wordPress,
     WooCommerce $wooCommerce
   ) {
     $this->termOptionsBuilder = $termOptionsBuilder;
+    $this->termParentsLoader = $termParentsLoader;
     $this->wordPress = $wordPress;
     $this->wooCommerce = $wooCommerce;
   }
@@ -223,6 +228,7 @@ class OrderFieldsFactory {
             foreach ($products as $product) {
               $categoryIds = array_merge($categoryIds, $product->get_category_ids());
             }
+            $categoryIds = array_merge($categoryIds, $this->termParentsLoader->getParentIds($categoryIds));
             sort($categoryIds);
             return array_unique($categoryIds);
           },

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermParentsLoader.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermParentsLoader.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\Fields;
+
+use MailPoet\Automation\Engine\WordPress;
+
+class TermParentsLoader {
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WordPress $wordPress
+  ) {
+    $this->wordPress = $wordPress;
+  }
+
+  /**
+   * @param int[] $termIds
+   * @return int[]
+   */
+  public function getParentIds(array $termIds): array {
+    $idsPlaceholder = implode(',', array_fill(0, count($termIds), '%s'));
+
+    $wpdb = $this->wordPress->getWpdb();
+    $statement = (string)$wpdb->prepare("
+      SELECT DISTINCT tt.parent
+      FROM {$wpdb->term_taxonomy} AS tt
+      WHERE tt.parent != 0
+      AND tt.term_id IN ($idsPlaceholder)
+    ", $termIds);
+
+    $parentIds = array_map('intval', $wpdb->get_col($statement));
+    if (count($parentIds) === 0) {
+      return [];
+    }
+    return array_values(
+      array_unique(
+        array_merge($parentIds, $this->getParentIds($parentIds))
+      )
+    );
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -189,6 +189,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerReviewFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\OrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\TermOptionsBuilder::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\TermParentsLoader::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\OrderStatusChangedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderStatusChangeSubject::class)->setPublic(true)->setShared(false);

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -97,6 +97,10 @@ parameters:
       count: 2
       path: ../../lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
     -
+      message: "#^Cannot cast string|void to string\\.$#"
+      count: 1
+      path: ../../lib/Automation/Integrations/WooCommerce/Fields/TermParentsLoader.php
+    -
       # WP annotates parameter as callable, but passes empty string as a default.
       message: '/function add_(sub)?menu_page expects callable\(\): mixed, ''''\|\(callable\(\): mixed\) given/'
       count: 2

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -331,8 +331,9 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $cat1Id = $this->tester->createWordPressTerm('Cat 1', 'product_cat', ['slug' => 'cat-1']);
     $cat2Id = $this->tester->createWordPressTerm('Cat 2', 'product_cat', ['slug' => 'cat-2']);
     $cat3Id = $this->tester->createWordPressTerm('Cat 3', 'product_cat', ['slug' => 'cat-3']);
-    $subCat1 = $this->tester->createWordPressTerm('Subcat 1', 'product_cat', ['slug' => 'subcat-1', 'parent' => $cat1Id]);
-    $subCat2 = $this->tester->createWordPressTerm('Subcat 2', 'product_cat', ['slug' => 'subcat-2', 'parent' => $cat1Id]);
+    $subCat1Id = $this->tester->createWordPressTerm('Subcat 1', 'product_cat', ['slug' => 'subcat-1', 'parent' => $cat1Id]);
+    $subCat2Id = $this->tester->createWordPressTerm('Subcat 2', 'product_cat', ['slug' => 'subcat-2', 'parent' => $cat1Id]);
+    $subSubCat1Id = $this->tester->createWordPressTerm('Subsubcat 1', 'product_cat', ['slug' => 'subsubcat-1', 'parent' => $subCat1Id]);
 
     // check definitions
     $fields = $this->getFieldsMap();
@@ -342,8 +343,9 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame([
       'options' => [
         ['id' => $cat1Id, 'name' => 'Cat 1'],
-        ['id' => $subCat1, 'name' => 'Cat 1 | Subcat 1'],
-        ['id' => $subCat2, 'name' => 'Cat 1 | Subcat 2'],
+        ['id' => $subCat1Id, 'name' => 'Cat 1 | Subcat 1'],
+        ['id' => $subSubCat1Id, 'name' => 'Cat 1 | Subcat 1 | Subsubcat 1'],
+        ['id' => $subCat2Id, 'name' => 'Cat 1 | Subcat 2'],
         ['id' => $cat2Id, 'name' => 'Cat 2'],
         ['id' => $cat3Id, 'name' => 'Cat 3'],
         ['id' => $uncategorizedId, 'name' => 'Uncategorized'],
@@ -351,7 +353,7 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     ], $purchasedCategories->getArgs());
 
     // check values
-    $product = $this->tester->createWooCommerceProduct(['name' => 'Test product', 'category_ids' => [$cat1Id, $cat2Id, $subCat1]]);
+    $product = $this->tester->createWooCommerceProduct(['name' => 'Test product', 'category_ids' => [$cat2Id, $subSubCat1Id]]);
     $order = $this->tester->createWooCommerceOrder();
     $order->add_product($product);
 
@@ -359,13 +361,14 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $value = $purchasedCategories->getValue($orderPayload);
 
     $this->assertIsArray($value);
-    $this->assertCount(3, $value);
-    $this->assertContains($cat1Id, $value);
+    $this->assertCount(4, $value);
+    $this->assertContains($cat1Id, $value); // auto-included parent
     $this->assertContains($cat2Id, $value);
-    $this->assertContains($subCat1, $value);
+    $this->assertContains($subCat1Id, $value); // auto-included parent
+    $this->assertContains($subSubCat1Id, $value);
     $this->assertNotContains($uncategorizedId, $value);
     $this->assertNotContains($cat3Id, $value);
-    $this->assertNotContains($subCat2, $value);
+    $this->assertNotContains($subCat2Id, $value);
   }
 
   public function testTagsField(): void {


### PR DESCRIPTION
## Description

A couple of automation-related fixes:
1. Tutorial was visible in emails of type `automation_transactional` ([MAILPOET-5242]).
2. A few React warnings and popover positioning.
3. Save/update automation unified with WP post editor, added keyboard shortcut ([MAILPOET-4968]).
4. Include category parents in category fields ([MAILPOET-5377]).

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/762

## Linked tickets

[MAILPOET-5242]
[MAILPOET-4968]
[MAILPOET-5377]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5242]: https://mailpoet.atlassian.net/browse/MAILPOET-5242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4968]: https://mailpoet.atlassian.net/browse/MAILPOET-4968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5377]: https://mailpoet.atlassian.net/browse/MAILPOET-5377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5242]: https://mailpoet.atlassian.net/browse/MAILPOET-5242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4968]: https://mailpoet.atlassian.net/browse/MAILPOET-4968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5377]: https://mailpoet.atlassian.net/browse/MAILPOET-5377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ