### PR TITLE
Show subscriber stats for 3 different time periods [MAILPOET-5508]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -299,6 +299,7 @@ h1.title.mailpoet-newsletter-listing-heading {
 .mailpoet-listing-stats-tooltip-content {
   font-size: $font-size-extra-small;
   font-weight: normal;
+  text-align: left;
 
   .mailpoet-tag {
     margin-top: 3px;

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -18,6 +18,14 @@
       padding-bottom: 10px;
       padding-top: 10px;
     }
+
+    td:not(:first-child) {
+      text-align: right;
+
+      &:not(:last-child) {
+        padding-right: 25px;
+      }
+    }
   }
 }
 
@@ -37,6 +45,11 @@
 .mailpoet-subscriber-stats {
   .mailpoet-listing-table thead tr {
     box-shadow: 0 2px 4px -2px $color-tertiary-light;
+  }
+
+  thead td {
+    color: $color-wordpress-grey-dark;
+    padding-right: 8px;
   }
 
   tbody td {

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -4,7 +4,6 @@ import { MailPoet } from 'mailpoet';
 import { Loading } from 'common/loading';
 import { useGlobalContextValue } from 'context';
 
-import { Heading } from 'common';
 import { StatsHeading } from './stats/heading';
 import { Summary } from './stats/summary';
 import { WoocommerceRevenues } from './stats/woocommerce_revenues';
@@ -55,26 +54,16 @@ export function SubscriberStats(): JSX.Element {
   return (
     <div className="mailpoet-subscriber-stats">
       <StatsHeading email={stats.email} />
-      <Heading level={4}>{MailPoet.I18n.t('engagementPeriodHeading')}</Heading>
       <div className="mailpoet-subscriber-stats-summary-grid">
         <Summary
-          click={stats.click}
-          open={stats.open}
-          machineOpen={stats.machine_open}
-          totalSent={stats.total_sent}
+          stats={stats}
           subscriber={{
             id: Number(match.params.id),
             engagement_score: stats.engagement_score,
           }}
         />
         <EngagementSummary stats={stats} />
-        {stats.woocommerce && (
-          <WoocommerceRevenues
-            averageRevenueValue={stats.woocommerce.formatted_average}
-            count={stats.woocommerce.count}
-            revenueValue={stats.woocommerce.formatted}
-          />
-        )}
+        {stats.is_woo_active && <WoocommerceRevenues stats={stats} />}
       </div>
       <OpenedEmailsStats params={match.params} location={location} />
     </div>

--- a/mailpoet/assets/js/src/subscribers/stats/engagement_summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/engagement_summary.tsx
@@ -37,7 +37,7 @@ export function EngagementSummary({ stats }: PropTypes): JSX.Element {
     },
   ];
 
-  if (stats.woocommerce) {
+  if (stats.is_woo_active) {
     engagementData.push({
       label: __('Last purchase', 'mailpoet'),
       date: stats.last_purchase || null,

--- a/mailpoet/assets/js/src/subscribers/stats/summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/summary.tsx
@@ -18,7 +18,7 @@ export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
     <div className="mailpoet-tab-content mailpoet-subscriber-stats-summary">
       <div className="mailpoet-listing">
         <table className="mailpoet-listing-table">
-          <tbody>
+          <thead>
             <tr>
               <td />
               {stats.periodic_stats.map(
@@ -29,6 +29,8 @@ export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
                 ),
               )}
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td>{MailPoet.I18n.t('statsSentEmail')}</td>
               {stats.periodic_stats.map(
@@ -139,7 +141,7 @@ export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
             </tr>
             <tr>
               <td>{MailPoet.I18n.t('statisticsColumn')}</td>
-              <td>
+              <td colSpan={stats.periodic_stats.length}>
                 <div className="mailpoet-listing-stats">
                   <ListingsEngagementScore
                     id={subscriber.id}
@@ -147,7 +149,6 @@ export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
                   />
                 </div>
               </td>
-              <td />
             </tr>
           </tbody>
         </table>

--- a/mailpoet/assets/js/src/subscribers/stats/summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/summary.tsx
@@ -3,57 +3,59 @@ import { MailPoet } from 'mailpoet';
 import { Tag } from 'common/tag/tag';
 import { Tooltip } from 'help-tooltip';
 import { ListingsEngagementScore } from '../listings_engagement_score';
+import { PeriodicStats, StatsType } from '../types';
 
 export type PropTypes = {
-  totalSent: number;
-  open: number;
-  machineOpen: number;
-  click: number;
+  stats: StatsType;
   subscriber: {
     id: number;
     engagement_score?: number;
   };
 };
 
-export function Summary({
-  totalSent,
-  open,
-  machineOpen,
-  click,
-  subscriber,
-}: PropTypes): JSX.Element {
-  let openPercent = 0;
-  let machineOpenPercent = 0;
-  let clickPercent = 0;
-  let notOpenPercent = 0;
-  const notOpen = totalSent - (open + machineOpen);
-  const displayPercentages = totalSent > 0;
-  if (displayPercentages) {
-    openPercent = Math.round((open / totalSent) * 100);
-    machineOpenPercent = Math.round((machineOpen / totalSent) * 100);
-    clickPercent = Math.round((click / totalSent) * 100);
-    notOpenPercent = Math.round((notOpen / totalSent) * 100);
-  }
+export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
   return (
     <div className="mailpoet-tab-content mailpoet-subscriber-stats-summary">
       <div className="mailpoet-listing">
         <table className="mailpoet-listing-table">
           <tbody>
             <tr>
-              <td>{MailPoet.I18n.t('statsSentEmail')}</td>
-              <td>
-                <b>{totalSent.toLocaleString()}</b>
-              </td>
               <td />
+              {stats.periodic_stats.map(
+                (periodicStats: PeriodicStats): JSX.Element => (
+                  <td key={periodicStats.timeframe}>
+                    {periodicStats.timeframe}
+                  </td>
+                ),
+              )}
+            </tr>
+            <tr>
+              <td>{MailPoet.I18n.t('statsSentEmail')}</td>
+              {stats.periodic_stats.map(
+                (periodicStats: PeriodicStats): JSX.Element => (
+                  <td key={periodicStats.timeframe}>
+                    {periodicStats.total_sent}
+                  </td>
+                ),
+              )}
             </tr>
             <tr>
               <td>
                 <Tag>{MailPoet.I18n.t('statsOpened')}</Tag>
               </td>
-              <td>
-                <b>{open.toLocaleString()}</b>
-              </td>
-              <td>{displayPercentages && <>{openPercent}%</>}</td>
+              {stats.periodic_stats.map(
+                (periodicStats: PeriodicStats): JSX.Element => {
+                  const displayPercentage = periodicStats.total_sent > 0;
+                  let cell = periodicStats.open.toLocaleString();
+                  if (displayPercentage) {
+                    const percentage = Math.round(
+                      (periodicStats.open / periodicStats.total_sent) * 100,
+                    );
+                    cell += ` (${percentage}%)`;
+                  }
+                  return <td key={periodicStats.timeframe}>{cell}</td>;
+                },
+              )}
             </tr>
             <tr>
               <td>
@@ -81,26 +83,59 @@ export function Summary({
                   )}
                 />
               </td>
-              <td>
-                <b>{machineOpen.toLocaleString()}</b>
-              </td>
-              <td>{displayPercentages && <>{machineOpenPercent}%</>}</td>
+              {stats.periodic_stats.map(
+                (periodicStats: PeriodicStats): JSX.Element => {
+                  const displayPercentage = periodicStats.total_sent > 0;
+                  let cell = periodicStats.machine_open.toLocaleString();
+                  if (displayPercentage) {
+                    const percentage = Math.round(
+                      (periodicStats.machine_open / periodicStats.total_sent) *
+                        100,
+                    );
+                    cell += ` (${percentage}%)`;
+                  }
+                  return <td key={periodicStats.timeframe}>{cell}</td>;
+                },
+              )}
             </tr>
             <tr>
               <td>
                 <Tag isInverted>{MailPoet.I18n.t('statsClicked')}</Tag>
               </td>
-              <td>
-                <b>{click.toLocaleString()}</b>
-              </td>
-              <td>{displayPercentages && <>{clickPercent}%</>}</td>
+              {stats.periodic_stats.map(
+                (periodicStats: PeriodicStats): JSX.Element => {
+                  const displayPercentage = periodicStats.total_sent > 0;
+                  let cell = periodicStats.click.toLocaleString();
+                  if (displayPercentage) {
+                    const percentage = Math.round(
+                      (periodicStats.click / periodicStats.total_sent) * 100,
+                    );
+                    cell += ` (${percentage}%)`;
+                  }
+                  return <td key={periodicStats.timeframe}>{cell}</td>;
+                },
+              )}
             </tr>
             <tr>
-              <td>{MailPoet.I18n.t('statsNotClicked')}</td>
               <td>
-                <b>{notOpen.toLocaleString()}</b>
+                <Tag>{MailPoet.I18n.t('statsNotClicked')}</Tag>
               </td>
-              <td>{displayPercentages && <>{notOpenPercent}%</>}</td>
+              {stats.periodic_stats.map(
+                (periodicStats: PeriodicStats): JSX.Element => {
+                  const notOpen =
+                    periodicStats.total_sent -
+                    (periodicStats.open + periodicStats.machine_open);
+                  const displayPercentage = periodicStats.total_sent > 0;
+                  let cell = notOpen.toLocaleString();
+                  if (displayPercentage) {
+                    const percentage = Math.round(
+                      (notOpen / periodicStats.total_sent) * 100,
+                    );
+                    cell += ` (${percentage}%)`;
+                  }
+                  return <td key={periodicStats.timeframe}>{cell}</td>;
+                },
+              )}
             </tr>
             <tr>
               <td>{MailPoet.I18n.t('statisticsColumn')}</td>

--- a/mailpoet/assets/js/src/subscribers/stats/woocommerce_revenues.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/woocommerce_revenues.tsx
@@ -1,36 +1,44 @@
+import { StatsType } from '../types';
+
 export type PropTypes = {
-  count: number;
-  revenueValue: string;
-  averageRevenueValue: string;
+  stats: StatsType;
 };
 
-export function WoocommerceRevenues({
-  revenueValue,
-  count,
-  averageRevenueValue,
-}: PropTypes): JSX.Element {
+export function WoocommerceRevenues({ stats }: PropTypes): JSX.Element {
   return (
     <div className="mailpoet-tab-content mailpoet-subscriber-stats-summary">
       <div className="mailpoet-listing">
         <table className="mailpoet-listing-table">
           <tbody>
             <tr>
+              <td />
+              {stats.periodic_stats.map((periodicStats) => (
+                <td key={periodicStats.timeframe}>{periodicStats.timeframe}</td>
+              ))}
+            </tr>
+            <tr>
               <td>Orders created</td>
-              <td>
-                <b>{count.toLocaleString()}</b>
-              </td>
+              {stats.periodic_stats.map((periodicStats) => (
+                <td key={periodicStats.timeframe}>
+                  {periodicStats.woocommerce.count.toLocaleString()}
+                </td>
+              ))}
             </tr>
             <tr>
               <td>Total revenue</td>
-              <td>
-                <b>{revenueValue}</b>
-              </td>
+              {stats.periodic_stats.map((periodicStats) => (
+                <td key={periodicStats.timeframe}>
+                  {periodicStats.woocommerce.formatted}
+                </td>
+              ))}
             </tr>
             <tr>
               <td>Average revenue</td>
-              <td>
-                <b>{averageRevenueValue}</b>
-              </td>
+              {stats.periodic_stats.map((periodicStats) => (
+                <td key={periodicStats.timeframe}>
+                  {periodicStats.woocommerce.formatted_average}
+                </td>
+              ))}
             </tr>
           </tbody>
         </table>

--- a/mailpoet/assets/js/src/subscribers/stats/woocommerce_revenues.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/woocommerce_revenues.tsx
@@ -9,13 +9,15 @@ export function WoocommerceRevenues({ stats }: PropTypes): JSX.Element {
     <div className="mailpoet-tab-content mailpoet-subscriber-stats-summary">
       <div className="mailpoet-listing">
         <table className="mailpoet-listing-table">
-          <tbody>
+          <thead>
             <tr>
               <td />
               {stats.periodic_stats.map((periodicStats) => (
                 <td key={periodicStats.timeframe}>{periodicStats.timeframe}</td>
               ))}
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <td>Orders created</td>
               {stats.periodic_stats.map((periodicStats) => (

--- a/mailpoet/assets/js/src/subscribers/types.tsx
+++ b/mailpoet/assets/js/src/subscribers/types.tsx
@@ -1,9 +1,5 @@
 export type StatsType = {
   email: string;
-  total_sent: number;
-  open: number;
-  machine_open: number;
-  click: number;
   engagement_score: number;
   last_engagement?: string;
   last_click?: string;
@@ -11,6 +7,16 @@ export type StatsType = {
   last_sending?: string;
   last_page_view?: string;
   last_purchase?: string;
+  periodic_stats?: PeriodicStats[];
+  is_woo_active: boolean;
+};
+
+export type PeriodicStats = {
+  timeframe: string;
+  total_sent: number;
+  open: number;
+  machine_open: number;
+  click: number;
   woocommerce?: {
     currency: string;
     value: number;

--- a/mailpoet/lib/API/JSON/v1/SubscriberStats.php
+++ b/mailpoet/lib/API/JSON/v1/SubscriberStats.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Subscribers\Statistics\SubscriberStatisticsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoetVendor\Carbon\Carbon;
 
 class SubscriberStats extends APIEndpoint {
   public $permissions = [
@@ -38,7 +39,8 @@ class SubscriberStats extends APIEndpoint {
         APIError::NOT_FOUND => __('This subscriber does not exist.', 'mailpoet'),
       ]);
     }
-    $statistics = $this->subscribersStatisticsRepository->getStatistics($subscriber);
+    $oneYearAgo = (new Carbon())->subYear();
+    $statistics = $this->subscribersStatisticsRepository->getStatistics($subscriber, $oneYearAgo);
     $response = [
       'email' => $subscriber->getEmail(),
       'total_sent' => $statistics->getTotalSentCount(),

--- a/mailpoet/lib/API/JSON/v1/SubscriberStats.php
+++ b/mailpoet/lib/API/JSON/v1/SubscriberStats.php
@@ -6,9 +6,10 @@ use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\Config\AccessControl;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Subscribers\Statistics\SubscriberStatistics;
 use MailPoet\Subscribers\Statistics\SubscriberStatisticsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\WooCommerce\Helper;
 use MailPoetVendor\Carbon\Carbon;
 
 class SubscriberStats extends APIEndpoint {
@@ -22,12 +23,17 @@ class SubscriberStats extends APIEndpoint {
   /** @var SubscriberStatisticsRepository */
   private $subscribersStatisticsRepository;
 
+  /** @var Helper */
+  private $wooCommerceHelper;
+
   public function __construct(
     SubscribersRepository $subscribersRepository,
-    SubscriberStatisticsRepository $subscribersStatisticsRepository
+    SubscriberStatisticsRepository $subscribersStatisticsRepository,
+    Helper $wooCommerceHelper
   ) {
     $this->subscribersRepository = $subscribersRepository;
     $this->subscribersStatisticsRepository = $subscribersStatisticsRepository;
+    $this->wooCommerceHelper = $wooCommerceHelper;
   }
 
   public function get($data) {
@@ -39,16 +45,35 @@ class SubscriberStats extends APIEndpoint {
         APIError::NOT_FOUND => __('This subscriber does not exist.', 'mailpoet'),
       ]);
     }
-    $oneYearAgo = (new Carbon())->subYear();
-    $statistics = $this->subscribersStatisticsRepository->getStatistics($subscriber, $oneYearAgo);
     $response = [
       'email' => $subscriber->getEmail(),
-      'total_sent' => $statistics->getTotalSentCount(),
-      'open' => $statistics->getOpenCount(),
-      'machine_open' => $statistics->getMachineOpenCount(),
-      'click' => $statistics->getClickCount(),
       'engagement_score' => $subscriber->getEngagementScore(),
+      'is_woo_active' => $this->wooCommerceHelper->isWooCommerceActive(),
     ];
+
+    $statsMapper = function(SubscriberStatistics $statistics, string $timeframe) {
+      return [
+        'timeframe' => $timeframe,
+        'total_sent' => $statistics->getTotalSentCount(),
+        'open' => $statistics->getOpenCount(),
+        'machine_open' => $statistics->getMachineOpenCount(),
+        'click' => $statistics->getClickCount(),
+        'woocommerce' => $statistics->getWooCommerceRevenue() ? $statistics->getWooCommerceRevenue()->asArray() : null,
+      ];
+    };
+
+    $lifetimeStats = $this->subscribersStatisticsRepository->getStatistics($subscriber);
+    $oneYearStats = $this->subscribersStatisticsRepository->getStatistics($subscriber, Carbon::now()->subYear());
+    $thirtyDaysStats = $this->subscribersStatisticsRepository->getStatistics($subscriber, Carbon::now()->subDays(30));
+
+    $response['periodic_stats'] = [
+      // translators: table header meaning 30 days
+      $statsMapper($thirtyDaysStats, __('30(d)', 'mailpoet')),
+      // translators: table header meaning 12 months
+      $statsMapper($oneYearStats, __('12(m)', 'mailpoet')),
+      $statsMapper($lifetimeStats, __('Lifetime', 'mailpoet')),
+    ];
+
     $dateFormat = 'Y-m-d H:i:s';
     $lastEngagement = $subscriber->getLastEngagementAt();
     if ($lastEngagement instanceof \DateTimeInterface) {
@@ -73,10 +98,6 @@ class SubscriberStats extends APIEndpoint {
     $lastSending = $subscriber->getLastSendingAt();
     if ($lastSending instanceof \DateTimeInterface) {
       $response['last_sending'] = $lastSending->format($dateFormat);
-    }
-    $woocommerce = $statistics->getWooCommerceRevenue();
-    if ($woocommerce instanceof WooCommerceRevenue) {
-      $response['woocommerce'] = $woocommerce->asArray();
     }
     return $this->successResponse($response);
   }

--- a/mailpoet/lib/Statistics/StatisticsOpensRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsOpensRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\Statistics\SubscriberStatisticsRepository;
+use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
@@ -32,13 +33,14 @@ class StatisticsOpensRepository extends Repository {
 
   public function recalculateSubscriberScore(SubscriberEntity $subscriber): void {
     $subscriber->setEngagementScoreUpdatedAt(new \DateTimeImmutable());
-    $newslettersSentCount = $this->subscriberStatisticsRepository->getTotalSentCount($subscriber);
+    $yearAgo = Carbon::now()->subYear();
+    $newslettersSentCount = $this->subscriberStatisticsRepository->getTotalSentCount($subscriber, $yearAgo);
     if ($newslettersSentCount < 3) {
       $subscriber->setEngagementScore(null);
       $this->entityManager->flush();
       return;
     }
-    $opensCount = $this->subscriberStatisticsRepository->getStatisticsOpenCount($subscriber);
+    $opensCount = $this->subscriberStatisticsRepository->getStatisticsOpenCount($subscriber, $yearAgo);
     $score = ($opensCount / $newslettersSentCount) * 100;
     $subscriber->setEngagementScore($score);
     $this->entityManager->flush();

--- a/mailpoet/tests/DataFactories/StatisticsClicks.php
+++ b/mailpoet/tests/DataFactories/StatisticsClicks.php
@@ -26,6 +26,7 @@ class StatisticsClicks {
   ) {
     $this->data = [
       'count' => 1,
+      'createdAt' => null,
     ];
     $this->newsletterLink = $newsletterLink;
     $this->subscriber = $subscriber;
@@ -33,6 +34,11 @@ class StatisticsClicks {
 
   public function withCount($count) {
     $this->data['count'] = $count;
+    return $this;
+  }
+
+  public function withCreatedAt(\DateTimeInterface $createdAt) {
+    $this->data['createdAt'] = $createdAt;
     return $this;
   }
 
@@ -49,6 +55,9 @@ class StatisticsClicks {
       $this->newsletterLink,
       $this->data['count']
     );
+    if ($this->data['createdAt'] instanceof \DateTimeInterface) {
+      $entity->setCreatedAt($this->data['createdAt']);
+    }
     $entityManager->persist($entity);
     $entityManager->flush();
     return $entity;

--- a/mailpoet/tests/DataFactories/StatisticsOpens.php
+++ b/mailpoet/tests/DataFactories/StatisticsOpens.php
@@ -33,6 +33,11 @@ class StatisticsOpens {
     return $this;
   }
 
+  public function withCreatedAt(\DateTimeInterface $createdAt): self {
+    $this->data['createdAt'] = $createdAt;
+    return $this;
+  }
+
   public function create(): StatisticsOpenEntity {
     $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
     $queue = $this->newsletter->getLatestQueue();
@@ -43,6 +48,9 @@ class StatisticsOpens {
       $this->subscriber
     );
     $entity->setUserAgentType($this->data['userAgentType'] ?? UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    if (($this->data['createdAt'] ?? null) instanceof \DateTimeInterface) {
+      $entity->setCreatedAt($this->data['createdAt']);
+    }
     $entityManager->persist($entity);
     $entityManager->flush();
     return $entity;

--- a/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
+++ b/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
@@ -33,6 +33,11 @@ class StatisticsWooCommercePurchases {
     $this->click = $click;
   }
 
+  public function withCreatedAt(\DateTimeInterface $createdAt): self {
+    $this->data['createdAt'] = $createdAt;
+    return $this;
+  }
+
   public function create(): StatisticsWooCommercePurchaseEntity {
     $newsletter = $this->click->getNewsletter();
     Assert::assertInstanceOf(NewsletterEntity::class, $newsletter);
@@ -48,6 +53,9 @@ class StatisticsWooCommercePurchases {
       (float)$this->data['order_price_total']
     );
     $entity->setSubscriber($this->subscriber);
+    if (($this->data['createdAt'] ?? null) instanceof \DateTimeInterface) {
+      $entity->setCreatedAt($this->data['createdAt']);
+    }
 
     $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
     $entityManager->persist($entity);

--- a/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers\Statistics;
+
+use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterLink;
+use MailPoet\Test\DataFactories\StatisticsClicks;
+use MailPoet\Test\DataFactories\StatisticsNewsletters;
+use MailPoet\Test\DataFactories\StatisticsOpens;
+use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * @group woo
+ */
+class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
+  /** @var SubscriberStatisticsRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(SubscriberStatisticsRepository::class);
+  }
+
+  public function testItFetchesClickCount(): void {
+    $yearAgo = Carbon::now()->subYear();
+    $monthAgo = Carbon::now()->subMonth();
+
+    $subscriber = (new Subscriber())->create();
+
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $subscriber))
+      ->withCreatedAt($monthAgo)
+      ->create();
+
+    $newsletter2 = (new Newsletter())->withSendingQueue()->create();
+    $link2 = (new NewsletterLink($newsletter2))->create();
+    $click2 = (new StatisticsClicks($link2, $subscriber))
+      ->withCreatedAt($yearAgo)
+      ->create();
+
+
+    $newsletter3 = (new Newsletter())->withSendingQueue()->create();
+    $link3 = (new NewsletterLink($newsletter3))->create();
+    $click3 = (new StatisticsClicks($link3, $subscriber))
+      ->withCreatedAt(Carbon::now()->subYears(5))
+      ->create();
+
+    $lifetimeCount = $this->repository->getStatisticsClickCount($subscriber, null);
+    expect($lifetimeCount)->equals(3);
+
+    $yearCount = $this->repository->getStatisticsClickCount($subscriber, $yearAgo);
+    expect($yearCount)->equals(2);
+
+    $monthCount = $this->repository->getStatisticsClickCount($subscriber, $monthAgo);
+    expect($monthCount)->equals(1);
+
+    expect($this->repository->getStatisticsClickCount($subscriber, Carbon::now()->subDays(27)))->equals(0);
+  }
+
+  public function testItFetchesOpenCount(): void {
+    $subscriber = (new Subscriber())->create();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $yearAgo = Carbon::now()->subYear();
+    $open = (new StatisticsOpens($newsletter, $subscriber))->withCreatedAt($yearAgo)->create();
+
+    expect($this->repository->getStatisticsOpenCount($subscriber, null))->equals(1);
+    expect($this->repository->getStatisticsOpenCount($subscriber, $yearAgo))->equals(1);
+    expect($this->repository->getStatisticsOpenCount($subscriber, Carbon::now()->subMonth()))->equals(0);
+    expect($this->repository->getStatisticsMachineOpenCount($subscriber, null))->equals(0);
+  }
+
+  public function testItFetchesMachineOpenCount(): void {
+    $subscriber = (new Subscriber())->create();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $yearAgo = Carbon::now()->subYear();
+    $open = (new StatisticsOpens($newsletter, $subscriber))->withMachineUserAgentType()->withCreatedAt($yearAgo)->create();
+
+    expect($this->repository->getStatisticsMachineOpenCount($subscriber, null))->equals(1);
+    expect($this->repository->getStatisticsMachineOpenCount($subscriber, $yearAgo))->equals(1);
+    expect($this->repository->getStatisticsMachineOpenCount($subscriber, Carbon::now()->subMonth()))->equals(0);
+    expect($this->repository->getStatisticsOpenCount($subscriber, null))->equals(0);
+  }
+
+  public function testItFetchesTotalSentCount(): void {
+    $subscriber = (new Subscriber())->create();
+
+    $twoYearsAgo = Carbon::now()->subYears(2);
+    $yearAgo = Carbon::now()->subYear();
+    $monthAgo = Carbon::now()->subMonth();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $newsletter2 = (new Newsletter())->withSendingQueue()->create();
+    $newsletter3 = (new Newsletter())->withSendingQueue()->create();
+    $newsletterSendStat = (new StatisticsNewsletters($newsletter, $subscriber))->withSentAt($twoYearsAgo)->create();
+    $newsletterSendStat = (new StatisticsNewsletters($newsletter2, $subscriber))->withSentAt($yearAgo)->create();
+    $newsletterSendStat = (new StatisticsNewsletters($newsletter3, $subscriber))->withSentAt($monthAgo)->create();
+
+    expect($this->repository->getTotalSentCount($subscriber, $twoYearsAgo))->equals(3);
+    expect($this->repository->getTotalSentCount($subscriber, $yearAgo))->equals(2);
+    expect($this->repository->getTotalSentCount($subscriber, $monthAgo))->equals(1);
+    expect($this->repository->getTotalSentCount($subscriber, Carbon::now()->subDays(27)))->equals(0);
+  }
+
+  public function testItFetchesWooCommerceRevenueData(): void {
+    $subscriber = (new Subscriber())->create();
+    $twoYearsAgo = Carbon::now()->subYears(2);
+    $yearAgo = Carbon::now()->subYear();
+    $monthAgo = Carbon::now()->subMonth();
+
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $subscriber))
+      ->create();
+
+    (new StatisticsWooCommercePurchases($click, [
+      'id' => 1,
+      'currency' => 'USD',
+      'total' => 10.00,
+    ]))->withCreatedAt($twoYearsAgo)->create();
+    (new StatisticsWooCommercePurchases($click, [
+      'id' => 2,
+      'currency' => 'USD',
+      'total' => 20.00,
+    ]))->withCreatedAt($yearAgo)->create();
+    (new StatisticsWooCommercePurchases($click, [
+      'id' => 3,
+      'currency' => 'USD',
+      'total' => 30.00,
+    ]))->withCreatedAt($monthAgo)->create();
+
+    $twoYearsAgoResult = $this->repository->getWooCommerceRevenue($subscriber, $twoYearsAgo);
+    $this->assertInstanceOf(WooCommerceRevenue::class, $twoYearsAgoResult);
+    expect($twoYearsAgoResult->getOrdersCount())->equals(3);
+    expect($twoYearsAgoResult->getValue())->equals(60.00);
+
+    $yearAgoResult = $this->repository->getWooCommerceRevenue($subscriber, $yearAgo);
+    $this->assertInstanceOf(WooCommerceRevenue::class, $yearAgoResult);
+    expect($yearAgoResult->getOrdersCount())->equals(2);
+    expect($yearAgoResult->getValue())->equals(50.00);
+
+    $monthAgoResult = $this->repository->getWooCommerceRevenue($subscriber, $monthAgo);
+    $this->assertInstanceOf(WooCommerceRevenue::class, $monthAgoResult);
+    expect($monthAgoResult->getOrdersCount())->equals(1);
+    expect($monthAgoResult->getValue())->equals(30.00);
+
+    $daysAgoResult = $this->repository->getWooCommerceRevenue($subscriber, Carbon::now()->subDays(27));
+    $this->assertInstanceOf(WooCommerceRevenue::class, $daysAgoResult);
+    expect($daysAgoResult->getOrdersCount())->equals(0);
+    expect($daysAgoResult->getValue())->equals(0.00);
+  }
+}

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -42,7 +42,6 @@
     'deletePermanently': __('Delete Permanently'),
     'showMoreDetails': __('Show more details'),
     'lastEngagement': __('Last engagement'),
-    'engagementPeriodHeading': __('Engagement over the last 12 months'),
     'never': _x('never', 'when was the last time the subscriber engaged with the website?'),
 
     'previousPage': __('Previous page'),


### PR DESCRIPTION
## Description

In MAILPOET-5410 we changed all stats on the subscriber page to only show data for the past year (previously all the stats were lifetime data other than the engagement score). Since lifetime stats are still relevant, especially for WooCommerce data, this PR updates the stats page to include data for 3 different time periods: 30 days, 12 months, and lifetime. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

This is based on https://github.com/mailpoet/mailpoet/pull/5081, which will need to be merged before this one can be reviewed.

## Linked tickets

[MAILPOET-5508](https://mailpoet.atlassian.net/browse/MAILPOET-5508)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5508]: https://mailpoet.atlassian.net/browse/MAILPOET-5508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ