### PR TITLE
New automation templates [MAILPOET-5384]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -54,6 +54,20 @@ class Registry {
 
   public function addTemplate(AutomationTemplate $template): void {
     $this->templates[$template->getSlug()] = $template;
+
+    // keep coming soon templates at the end
+    uasort(
+      $this->templates,
+      function (AutomationTemplate $a, AutomationTemplate $b): int {
+        if ($a->getType() === AutomationTemplate::TYPE_COMING_SOON) {
+          return 1;
+        }
+        if ($b->getType() === AutomationTemplate::TYPE_COMING_SOON) {
+          return -1;
+        }
+        return 0;
+      }
+    );
   }
 
   public function getTemplate(string $slug): ?AutomationTemplate {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -5,28 +5,39 @@ namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
+use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 
 class TemplatesFactory {
   /** @var AutomationBuilder */
   private $builder;
 
+  /** @var WooCommerce */
+  private $woocommerce;
+
   public function __construct(
-    AutomationBuilder $builder
+    AutomationBuilder $builder,
+    WooCommerce $woocommerce
   ) {
     $this->builder = $builder;
+    $this->woocommerce = $woocommerce;
   }
 
   public function createTemplates(): array {
-    return [
+    $templates = [
       $this->createSubscriberWelcomeEmailTemplate(),
       $this->createUserWelcomeEmailTemplate(),
       $this->createSubscriberWelcomeSeriesTemplate(),
       $this->createUserWelcomeSeriesTemplate(),
-      $this->createFirstPurchaseTemplate(),
-      $this->createLoyalCustomersTemplate(),
-      $this->createAbandonedCartTemplate(),
-      $this->createAbandonedCartCampaignTemplate(),
     ];
+
+    if ($this->woocommerce->isWooCommerceActive()) {
+      $templates[] = $this->createFirstPurchaseTemplate();
+      $templates[] = $this->createLoyalCustomersTemplate();
+      $templates[] = $this->createAbandonedCartTemplate();
+      $templates[] = $this->createAbandonedCartCampaignTemplate();
+    }
+
+    return $templates;
   }
 
   private function createSubscriberWelcomeEmailTemplate(): AutomationTemplate {

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -7,6 +7,9 @@ use MailPoet\REST\Automation\AutomationTest;
 
 require_once __DIR__ . '/../AutomationTest.php';
 
+/**
+ * @group woo
+ */
 class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   private const ENDPOINT_PATH = '/mailpoet/v1/automation-templates';


### PR DESCRIPTION
## Description

Adds new automation templates and makes them configurable from the premium plugin.

## Code review notes

_N/A_

## QA notes

Test all the three new "Purchased..." automation templates both with and without the premium plugin (there's a small difference — in premium there is no delay step and thus the emails are transactional).

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/764

## Linked tickets

[MAILPOET-5384]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5384]: https://mailpoet.atlassian.net/browse/MAILPOET-5384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ