### PR TITLE
Fix is-first-order for guest customers [MAILPOET-5459]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -325,12 +325,19 @@ class OrderFieldsFactory {
 
   private function previousOrderExists(WC_Order $order): bool {
     $dateCreated = $order->get_date_created() ?? new DateTimeImmutable('now', $this->wordPress->wpTimezone());
-    $orderIds = (array)$this->wooCommerce->wcGetOrders([
-      'customer_id' => $order->get_customer_id(),
+    $query = [
       'date_created' => '<=' . $dateCreated->getTimestamp(),
       'limit' => 2,
       'return' => 'ids',
-    ]);
+    ];
+
+    if ($order->get_customer_id() > 0) {
+      $query['customer_id'] = $order->get_customer_id();
+    } else {
+      $query['billing_email'] = $order->get_billing_email();
+    }
+
+    $orderIds = (array)$this->wooCommerce->wcGetOrders($query);
     return count($orderIds) > 1 && min($orderIds) < $order->get_id();
   }
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -305,6 +305,23 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $order2 = $this->tester->createWooCommerceOrder(['customer_id' => 123]);
     $payload = new OrderPayload($order2);
     $this->assertFalse($isFirstOrderField->getValue($payload));
+
+    $order3 = $this->tester->createWooCommerceOrder(['customer_id' => 999]);
+    $payload = new OrderPayload($order3);
+    $this->assertTrue($isFirstOrderField->getValue($payload));
+
+    // check values for guest
+    $order1 = $this->tester->createWooCommerceOrder(['customer_id' => 0, 'billing_email' => 'guest@example.com']);
+    $payload = new OrderPayload($order1);
+    $this->assertTrue($isFirstOrderField->getValue($payload));
+
+    $order2 = $this->tester->createWooCommerceOrder(['customer_id' => 0, 'billing_email' => 'guest@example.com']);
+    $payload = new OrderPayload($order2);
+    $this->assertFalse($isFirstOrderField->getValue($payload));
+
+    $order3 = $this->tester->createWooCommerceOrder(['customer_id' => 0, 'billing_email' => 'another-guest@example.com']);
+    $payload = new OrderPayload($order3);
+    $this->assertTrue($isFirstOrderField->getValue($payload));
   }
 
   public function testCategoriesField(): void {


### PR DESCRIPTION
## Description

Just a small fix for `is-first-order` field.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5459]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5459]: https://mailpoet.atlassian.net/browse/MAILPOET-5459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ