### PR TITLE
Remove fallback to fetch any sending queue for a preview when no queue ID set [MAILPOET-5206]

### DIFF
--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -115,8 +115,6 @@ class ViewInBrowserController {
       return null;
     }
 
-    return !empty($data['queue_id'])
-      ? $this->sendingQueuesRepository->findOneById($data['queue_id'])
-      : $this->sendingQueuesRepository->findOneBy(['newsletter' => $newsletter->getId()]);
+    return isset($data['queue_id']) ? $this->sendingQueuesRepository->findOneById($data['queue_id']) : null;
   }
 }

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -53,7 +51,7 @@ class ViewInBrowserController {
     $subscriber = $this->getSubscriber($data);
 
     // if queue and subscriber exist, subscriber must have received the newsletter
-    $queue = $this->getQueue($newsletter, $data);
+    $queue = isset($data['queue_id']) ? $this->sendingQueuesRepository->findOneById($data['queue_id']) : null;
     if (!$isPreview && $queue && $subscriber->getId() && !$this->sendingQueuesRepository->isSubscriberProcessed($queue, $subscriber)) {
       throw new \InvalidArgumentException("Subscriber did not receive the newsletter yet");
     }
@@ -102,19 +100,5 @@ class ViewInBrowserController {
     }
 
     return $subscriber ?? new SubscriberEntity();
-  }
-
-  private function getQueue(NewsletterEntity $newsletter, array $data): ?SendingQueueEntity {
-    // queue is optional; try to find it if it's not defined and this is not a welcome email
-    if ($newsletter->getType() === NewsletterEntity::TYPE_WELCOME) {
-      return null;
-    }
-
-    // reset queue when automatic email is being previewed
-    if ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATIC && !empty($data['preview'])) {
-      return null;
-    }
-
-    return isset($data['queue_id']) ? $this->sendingQueuesRepository->findOneById($data['queue_id']) : null;
   }
 }

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -25,9 +25,6 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
-  /** @var NewsletterEntity */
-  private $newsletter;
-
   /** @var SubscriberEntity */
   private $subscriber;
 
@@ -59,7 +56,6 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $newsletterFactory = new Newsletter();
     $newsletter = $newsletterFactory->create();
     $newsletter->setHash(Security::generateHash());
-    $this->newsletter = $newsletter;
 
     // create subscriber
     $subscriber = new SubscriberEntity();
@@ -199,40 +195,6 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
 
     $data = $this->browserPreviewData;
     $data['queueId'] = null;
-    $viewInBrowserController->view($data);
-  }
-
-  public function testItResetsQueueForWelcomeEmails() {
-    $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
-        expect($queue)->null();
-      }),
-    ]);
-
-    $viewInBrowserController = $this->createController($viewInBrowserRenderer);
-
-    // queue will be set to null for welcome email
-    $newsletter = $this->newsletter;
-    $newsletter->setType(NewsletterEntity::TYPE_WELCOME);
-    $this->newslettersRepository->flush();
-    $viewInBrowserController->view($this->browserPreviewData);
-  }
-
-  public function testItResetsQueueForAutomaticEmailsInPreview() {
-    $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
-        expect($queue)->null();
-      }),
-    ]);
-
-    $viewInBrowserController = $this->createController($viewInBrowserRenderer);
-
-    // queue will be set to null for automatic email
-    $data = $this->browserPreviewData;
-    $data['preview'] = true;
-    $newsletter = $this->newsletter;
-    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATIC);
-    $this->newslettersRepository->flush();
     $viewInBrowserController->view($data);
   }
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

Before updating to this branch, try to reproduce the issue (with a `trunk` build or latest release build):
1. Create an automation with a send email step (e.g., "someone-subscribed" -> "send-email").
2. Trigger the automation and receive one emai.
3. Change the contents of the email, and save it.
4. Return to the email editor (from the automation step), and check the email preview. Now it's showing the old version without the edits in step 3 (= the bug).

Now update MP with the build from this branch, and the email preview should be fixed.

Please also ensure that email previews and view-in-browser links work in all other contexts.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5206]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5206]: https://mailpoet.atlassian.net/browse/MAILPOET-5206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ