### PR TITLE
Fix flaky test [MAILPOET-5526]

### DIFF
--- a/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
+++ b/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
@@ -54,7 +54,8 @@ class AnalyticsCest {
 
     $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId() . "&tab=automation-emails");
     $i->see('Overview');
-    $i->waitForText('Opened');
+
+    $i->waitForElement('.woocommerce-summary:not(.is-placeholder)');
     $i->see('Opened', '.woocommerce-summary > .woocommerce-summary__item-container');
     $i->see('0%', '.woocommerce-summary > .woocommerce-summary__item-container');
     $i->see('Clicked', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
@@ -96,7 +97,8 @@ class AnalyticsCest {
     $click2 = $this->createClickForNewsletter($this->newsletter1, $subscriber2);
 
     $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId() . "&tab=automation-emails");
-    $i->waitForText('Opened');
+
+    $i->waitForElement('.woocommerce-summary:not(.is-placeholder)');
     $i->see('Opened', '.woocommerce-summary > .woocommerce-summary__item-container');
     $i->see('1.5%', '.woocommerce-summary > .woocommerce-summary__item-container');
     $i->see('Clicked', '.woocommerce-summary > .woocommerce-summary__item-container:nth-child(2n)');
@@ -126,8 +128,8 @@ class AnalyticsCest {
     $this->alterCreateDateForOpen($open2, $date);
 
     $i->amOnPage("/wp-admin/admin.php?page=mailpoet-automation-analytics&id=" . $this->automation->getId() . "&tab=automation-emails");
-    $i->waitForText('Opened');
 
+    $i->waitForElement('.woocommerce-summary:not(.is-placeholder)');
     $i->see('Opened', '.woocommerce-summary > .woocommerce-summary__item-container:first-child');
     $i->see('1%', '.woocommerce-summary > .woocommerce-summary__item-container:first-child .woocommerce-summary__item-value');
     $i->see('-80%', '.woocommerce-summary > .woocommerce-summary__item-container:first-child .woocommerce-summary__item-delta');


### PR DESCRIPTION
## Description

'StaleElementReferenceException' seems to happen because the selector gets destroyed and created again. While the placeholder is visible the querySelector finds an element. This commit waits now until the placeholder DOM structure is removed before trying to access the values using the selectors.


## Code review notes

_N/A_

## QA notes

can be merged without QA

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5526]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5526]: https://mailpoet.atlassian.net/browse/MAILPOET-5526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ