### PR TITLE
Update wp and woo version [MAILPOET-5527]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -956,7 +956,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-6.0_php7.4_20230425.1
+          wordpress_image_version: wp-6.1_php8.0_20201122.1
           requires:
             - build
       - performance_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -948,7 +948,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 7.6.0
+          woo_core_version: 7.8.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0
@@ -986,7 +986,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 7.6.0
+          woo_core_version: 7.8.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -948,7 +948,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 7.8.0
+          woo_core_version: 7.9.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0
@@ -956,7 +956,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-6.1_php8.0_20201122.1
+          wordpress_image_version: wp-6.2_php8.0_20230425.1
           requires:
             - build
       - performance_tests:
@@ -986,7 +986,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 7.8.0
+          woo_core_version: 7.9.0
           woo_subscriptions_version: 4.3.0
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,12 +7,12 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 6.0
+ * Requires at least: 6.1
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 7.6.0
- * WC tested up to: 7.8.0
+ * WC requires at least: 7.8.0
+ * WC tested up to: 8.0.0
  *
  * @package WordPress
  * @author MailPoet
@@ -27,8 +27,8 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.0';
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '6.4';// Older versions lead to fatal errors
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.1';
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '7.8';// Older versions lead to fatal errors
 
 function mailpoet_deactivate_plugin() {
   deactivate_plugins(plugin_basename(__FILE__));

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,11 +7,11 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 6.1
+ * Requires at least: 6.2
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 7.8.0
+ * WC requires at least: 7.9.0
  * WC tested up to: 8.0.0
  *
  * @package WordPress
@@ -27,8 +27,8 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.1';
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '7.8';// Older versions lead to fatal errors
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.2';
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '7.9';// Older versions lead to fatal errors
 
 function mailpoet_deactivate_plugin() {
   deactivate_plugins(plugin_basename(__FILE__));

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,7 +1,7 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
-Requires at least: 6.1
+Requires at least: 6.2
 Tested up to: 6.3
 Stable tag: 4.24.0
 Requires PHP: 7.3

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,8 +1,8 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
-Requires at least: 6.0
-Tested up to: 6.2
+Requires at least: 6.1
+Tested up to: 6.3
 Stable tag: 4.24.0
 Requires PHP: 7.3
 License: GPLv3

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.2_php8.0_20230425.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.3_php8.0_20230811.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
## Description
Updates tested up to and minimum versions for WooCommerce and WordPress.

Minimum WP Version: 6.1
Minimum Woo Version: 7.8.0
Current WP Version: 6.2
Current Woo Version: 8.0.0

Followed the instructions PcD9cT-4b0-p2

## QA notes

> When creating the PR to update the version in the tags, check with QA if they want to do a final round of testing.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/765

## Linked tickets

[MAILPOET-5527]

[MAILPOET-5527]: https://mailpoet.atlassian.net/browse/MAILPOET-5527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ