### PR TITLE
Fix failing test [MAILPOET-5528]

### DIFF
--- a/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/PostNotificationTest.php
@@ -165,7 +165,7 @@ class PostNotificationTest extends \MailPoetTest {
     $this->postNotificationScheduler->schedulePostNotification(10);
     $currentTime = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'));
     Carbon::setTestNow($currentTime); // mock carbon to return current time
-    $nextRunDate = ($currentTime->hour < 5) ?
+    $nextRunDate = ($currentTime->hour < 5) || ($currentTime->hour === 5 && $currentTime->minute < 45) ?
       $currentTime :
       $currentTime->addDay();
     $queue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $newsletter]);


### PR DESCRIPTION
## Description
The newsletter is scheduled at 5:45, so just checking whether it is before 5 o'clock is not sufficient and the test fails between 5:00 and 5:45. This PR fixes the issue.

## Code review notes

_N/A_

## QA notes
Can be merged without QA

## Linked tickets
[MAILPOET-5528]

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5528]: https://mailpoet.atlassian.net/browse/MAILPOET-5528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ