### PR TITLE
Backend changes to support apply segment on send [MAILPOET-5509]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -163,7 +163,7 @@ class SendingQueue extends APIEndpoint {
       $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);
 
       if ($taskEntity instanceof ScheduledTaskEntity) {
-        $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments);
+        $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments, $newsletterEntity->getFilterSegmentId());
       }
 
       if (!isset($subscribersCount) || !$subscribersCount) {

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -490,6 +490,18 @@ class Populator {
         'name' => 'automationStepId',
         'newsletter_type' => NewsletterEntity::TYPE_AUTOMATION,
       ],
+      [
+        'name' => 'filterSegmentId',
+        'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
+      ],
+      [
+        'name' => 'filterSegmentId',
+        'newsletter_type' => NewsletterEntity::TYPE_RE_ENGAGEMENT,
+      ],
+      [
+        'name' => 'filterSegmentId',
+        'newsletter_type' => NewsletterEntity::TYPE_NOTIFICATION,
+      ],
     ];
 
     return [

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -13,6 +13,7 @@ use MailPoet\Cron\Workers\SubscriberLinkTokens;
 use MailPoet\Cron\Workers\SubscribersLastEngagement;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsFormEntity;
@@ -491,15 +492,15 @@ class Populator {
         'newsletter_type' => NewsletterEntity::TYPE_AUTOMATION,
       ],
       [
-        'name' => 'filterSegmentId',
+        'name' => NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID,
         'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
       ],
       [
-        'name' => 'filterSegmentId',
+        'name' => NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID,
         'newsletter_type' => NewsletterEntity::TYPE_RE_ENGAGEMENT,
       ],
       [
-        'name' => 'filterSegmentId',
+        'name' => NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID,
         'newsletter_type' => NewsletterEntity::TYPE_NOTIFICATION,
       ],
     ];

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -197,7 +197,7 @@ class Scheduler {
     $taskModel = $queue->task();
     $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);
     if ($taskEntity instanceof ScheduledTaskEntity) {
-      $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments);
+      $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments, $newsletter->getFilterSegmentId());
     }
 
     if (empty($subscribersCount)) {
@@ -318,7 +318,7 @@ class Scheduler {
     $taskEntity = $this->scheduledTasksRepository->findOneById($taskModel->id);
 
     if ($taskEntity instanceof ScheduledTaskEntity) {
-      $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments);
+      $this->subscribersFinder->addSubscribersToTaskFromSegments($taskEntity, $segments, $newsletter->getFilterSegmentId());
     }
 
     // update current queue

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -197,8 +197,15 @@ class SendingQueue {
     $this->mailerTask->configureMailer($newsletter);
     // get newsletter segments
     $newsletterSegmentsIds = $newsletterEntity->getSegmentIds();
+    $segmentIdsToCheck = $newsletterSegmentsIds;
+    $filterSegmentId = $newsletterEntity->getFilterSegmentId();
+
+    if (is_int($filterSegmentId)) {
+      $segmentIdsToCheck[] = $filterSegmentId;
+    }
+
     // Pause task in case some of related segments was deleted or trashed
-    if ($newsletterSegmentsIds && !$this->checkDeletedSegments($newsletterSegmentsIds)) {
+    if ($newsletterSegmentsIds && !$this->checkDeletedSegments($segmentIdsToCheck)) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
         'pause task in sending queue due deleted or trashed segment',
         ['task_id' => $queue->taskId]

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -237,7 +237,7 @@ class SendingQueue {
       );
       if (!empty($newsletterSegmentsIds[0])) {
         // Check that subscribers are in segments
-        $foundSubscribersIds = $this->subscribersFinder->findSubscribersInSegments($subscribersToProcessIds, $newsletterSegmentsIds);
+        $foundSubscribersIds = $this->subscribersFinder->findSubscribersInSegments($subscribersToProcessIds, $newsletterSegmentsIds, $filterSegmentId);
         $foundSubscribers = empty($foundSubscribersIds) ? [] : SubscriberModel::whereIn('id', $foundSubscribersIds)
           ->whereNull('deleted_at')
           ->findMany();

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -479,6 +479,11 @@ class NewsletterEntity {
     return $option ? $option->getValue() : null;
   }
 
+  public function getFilterSegmentId(): ?int {
+    $optionValue = $this->getOptionValue(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID);
+    return $optionValue ? (int)$optionValue : null;
+  }
+
   /**
    * @return ArrayCollection<int, SendingQueueEntity>
    */

--- a/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
@@ -32,6 +32,7 @@ class NewsletterOptionFieldEntity {
   public const NAME_WEEK_DAY = 'weekDay';
   public const NAME_AUTOMATION_ID = 'automationId';
   public const NAME_AUTOMATION_STEP_ID = 'automationStepId';
+  public const NAME_FILTER_SEGMENT_ID = 'filterSegmentId';
 
   use AutoincrementedIdTrait;
   use CreatedAtTrait;

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -36,6 +36,7 @@ class LoggerFactory {
   const TOPIC_TRACKING = 'tracking';
   const TOPIC_COUPONS = 'coupons';
   const TOPIC_PROVISIONING = 'provisioning';
+  const TOPIC_SEGMENTS = 'segments';
 
   /** @var LoggerFactory */
   private static $instance;

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -61,7 +61,7 @@ class SegmentsRepository extends Repository {
    * @return SegmentEntity[]
    */
   public function findByTypeNotIn(array $types): array {
-      return $this->doctrineRepository->createQueryBuilder('s')
+    return $this->doctrineRepository->createQueryBuilder('s')
       ->select('s')
       ->where('s.type NOT IN (:types)')
       ->setParameter('types', $types)

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -149,20 +149,20 @@ class SegmentsRepository extends Repository {
    * @return SegmentEntity
    * @throws InvalidStateException
    */
-  public function verifyFilterSegmentExists(int $id): SegmentEntity {
+  public function verifyDynamicSegmentExists(int $id): SegmentEntity {
     try {
-      $filterSegment = $this->findOneById($id);
-      if (!$filterSegment instanceof SegmentEntity) {
-        throw InvalidStateException::create()->withMessage("Filter segment with ID of $id could not be found.");
+      $dynamicSegment = $this->findOneById($id);
+      if (!$dynamicSegment instanceof SegmentEntity) {
+        throw InvalidStateException::create()->withMessage(sprintf("Could not find segment with ID %s.", $id));
       }
-      if ($filterSegment->getType() !== SegmentEntity::TYPE_DYNAMIC) {
-        throw InvalidStateException::create()->withMessage("Filter segment ID must be a dynamic segment. Type of filter with ID {$filterSegment->getId()} is {$filterSegment->getType()}.");
+      if ($dynamicSegment->getType() !== SegmentEntity::TYPE_DYNAMIC) {
+        throw InvalidStateException::create()->withMessage(sprintf("Segment with ID %s is not a dynamic segment. Its type is %s.", $id, $dynamicSegment->getType()));
       }
     } catch (InvalidStateException $exception) {
-      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_SEGMENTS)->error('Error verifying filter segment: ' . $exception->getMessage());
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_SEGMENTS)->error(sprintf("Could not verify existence of dynamic segment: %s", $exception->getMessage()));
       throw $exception;
     }
-    return $filterSegment;
+    return $dynamicSegment;
   }
 
   /**

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -48,7 +48,7 @@ class SubscribersFinder {
     }
 
     if (is_int($filterSegmentId)) {
-      $filterSegment = $this->segmentsRepository->verifyFilterSegmentExists($filterSegmentId);
+      $filterSegment = $this->segmentsRepository->verifyDynamicSegmentExists($filterSegmentId);
       $idsInFilterSegment = $this->findSubscribersInSegment($filterSegment, $subscribersToProcessIds);
       $result = array_intersect($result, $idsInFilterSegment);
     }
@@ -74,7 +74,7 @@ class SubscribersFinder {
     // Prepare subscribers on the DB side for performance reasons
     if (is_int($filterSegmentId)) {
       try {
-        $this->segmentsRepository->verifyFilterSegmentExists($filterSegmentId);
+        $this->segmentsRepository->verifyDynamicSegmentExists($filterSegmentId);
       } catch (InvalidStateException $exception) {
         return 0;
       }

--- a/mailpoet/tests/DataFactories/DynamicSegment.php
+++ b/mailpoet/tests/DataFactories/DynamicSegment.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\DataFactories;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Segments\DynamicSegments\Filters\SubscriberScore;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\SegmentSaveController;
 
@@ -24,6 +25,14 @@ class DynamicSegment extends Segment {
     $this->filterData['segmentType'] = 'userRole';
     $this->filterData['wordpressRole'] = $role;
     $this->filterData['action'] = UserRole::TYPE;
+    return $this;
+  }
+
+  public function withEngagementScoreFilter(int $score, string $operator) {
+    $this->filterData['segmentType'] = 'userRole';
+    $this->filterData['value'] = $score;
+    $this->filterData['operator'] = $operator;
+    $this->filterData['action'] = SubscriberScore::TYPE;
     return $this;
   }
 

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -295,7 +295,7 @@ class Newsletter {
    *
    * @return Newsletter
    */
-  private function withOptions(array $options) {
+  public function withOptions(array $options) {
     $this->options = $options;
     return $this;
   }

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -180,6 +180,21 @@ class NewsletterEntityTest extends \MailPoetTest {
     $this->assertSame($processedAt, $newsletter->getProcessedAt());
   }
 
+  public function testItCanRetrieveFilterSegmentIdOption(): void {
+    $optionField = $this->createOptionField(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID);
+    $newsletter = $this->createNewsletter();
+    expect($newsletter->getFilterSegmentId())->null();
+
+    $newsletterOption = new NewsletterOptionEntity($newsletter, $optionField);
+    $newsletterOption->setValue('2');
+
+    $this->entityManager->persist($newsletterOption);
+    $this->entityManager->flush();
+
+    $this->entityManager->refresh($newsletter);
+    expect($newsletter->getFilterSegmentId())->equals(2);
+  }
+
   private function createNewsletter(): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD);

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -6,13 +6,13 @@ use Codeception\Util\Stub;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
-use MailPoet\UnexpectedValueException;
 use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -214,7 +214,7 @@ class SubscribersFinderTest extends \MailPoetTest {
   }
 
   public function testFilterSegmentMustBeDynamicSegment() {
-    $this->expectException(UnexpectedValueException::class);
+    $this->expectException(InvalidStateException::class);
     $this->subscribersFinder->findSubscribersInSegments([$this->subscriber1->getId()], [$this->segment1->getId()], $this->segment2->getId());
   }
 


### PR DESCRIPTION
## Description

This PR adds the backend changes necessary to support applying a single dynamic filter to a newsletter at send time.

## Code review notes

I refactored one query to use a QueryBuilder instead of building a string because I thought this would make it cleaner to modify dynamically. I would appreciate it if you could double check that I didn't alter the existing behavior in any way.

## QA notes

Make sure to deactivate and reactivate the plugin before testing. This is necessary to create new newsletter option field rows.

You should see 3 new rows in the `mailpoet_newsletter_option_fields` table, each one with a `name` of `filterSegmentId`.

<img width="668" alt="image" src="https://github.com/mailpoet/mailpoet/assets/8656640/f2031e2b-6a27-4698-b55d-6f869dcbd548">

Note these IDs and newsletter types for later.

Since there is currently no UI for adding a "filter segment", this will require manual database changes to test.

1. Create a dynamic segment and note its `id`. Make sure there is some overlap between this segment and the list(s) you plan on sending to, otherwise there won't be any matching subscribers.
2. Create a newsletter and schedule it (you can't send right away because we need to manually add a newsletter option to the DB). Note the newsletter id.
3. In the database using a tool like adminer from the mailpoet debug plugin, add a new row to the `mailpoet_newsletter_option` table:
    `id`: auto increment
    `newsletter_id`: newsletter id from step 2
    `value`: the `id` of the segment you want to use as the filter
    `option_field_id`: One of the three IDs from the `mailpoet_newsletter_option_fields` table mentioned above. Use the id corresponding to the newsletter type you're sending. 
4. After saving that row, you can go back into the newsletter editor and send it right away and the filter segment should be applied, i.e. it should only be sent to users from the list(s) you selected AND the filter segment. It should also save data about the filter segment to the sending queue's `meta` column in the database.

Note: if premium is disabled and you choose a filter segment that has more than one filter, you will see an error message about there not being any users to send to. More graceful handling of this state will be added in a future PR.

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5509

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
