### PR TITLE
Calculate subscribers who are subscribed to a list correcty [MAILPOET-4487]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -436,9 +436,6 @@ class Settings extends APIEndpoint {
     $segments = $this->segmentsRepository->findAll();
     foreach ($segments as $segment) {
       $this->subscribersCountsController->recalculateSegmentStatisticsCache($segment);
-      if ($segment->isStatic()) {
-        $this->subscribersCountsController->recalculateSegmentGlobalStatusStatisticsCache($segment);
-      }
     }
     $this->subscribersCountsController->recalculateSubscribersWithoutSegmentStatisticsCache();
     // remove redundancies from cache

--- a/mailpoet/lib/Cache/TransientCache.php
+++ b/mailpoet/lib/Cache/TransientCache.php
@@ -7,7 +7,6 @@ use MailPoetVendor\Carbon\Carbon;
 
 class TransientCache {
   public const SUBSCRIBERS_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_cache';
-  public const SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_global_status_cache';
   public const SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY = 'mailpoet_subscribers_statistics_count_homepage_cache';
 
   private $cacheEnabled;
@@ -68,7 +67,6 @@ class TransientCache {
 
   public function invalidateAllItems(): void {
     $this->invalidateItems(self::SUBSCRIBERS_STATISTICS_COUNT_KEY);
-    $this->invalidateItems(self::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY);
     $this->invalidateItems(self::SUBSCRIBERS_HOMEPAGE_STATISTICS_COUNT_KEY);
   }
 

--- a/mailpoet/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersCountCacheRecalculation.php
@@ -62,9 +62,6 @@ class SubscribersCountCacheRecalculation extends SimpleWorker {
     if ($item === null || !isset($item['created_at']) || $now->diffInMinutes($item['created_at']) > self::EXPIRATION_IN_MINUTES) {
       if ($segment) {
         $this->subscribersCountsController->recalculateSegmentStatisticsCache($segment);
-        if ($segment->isStatic()) {
-          $this->subscribersCountsController->recalculateSegmentGlobalStatusStatisticsCache($segment);
-        }
       } else {
         $this->subscribersCountsController->recalculateSubscribersWithoutSegmentStatisticsCache();
       }

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -306,11 +306,7 @@ class SubscriberListingRepository extends ListingRepository {
     $segmentList = [];
     foreach ($queryBuilder->getQuery()->getResult() as $segment) {
       $key = $group ?: 'all';
-      if ($segment->isStatic()) {
-        $count = $this->subscribersCountsController->getSegmentGlobalStatusStatisticsCount($segment);
-      } else {
-        $count = $this->subscribersCountsController->getSegmentStatisticsCount($segment);
-      }
+      $count = $this->subscribersCountsController->getSegmentStatisticsCount($segment);
       $subscribersCount = (float)$count[$key];
       // filter segments without subscribers
       if (!$subscribersCount) {

--- a/mailpoet/lib/Subscribers/SubscribersCountsController.php
+++ b/mailpoet/lib/Subscribers/SubscribersCountsController.php
@@ -71,14 +71,6 @@ class SubscribersCountsController {
     return $result;
   }
 
-  public function getSegmentGlobalStatusStatisticsCount(SegmentEntity $segment): array {
-    $result = $this->getCacheItem(TransientCache::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY, (int)$segment->getId())['item'] ?? null;
-    if (!$result) {
-      $result = $this->recalculateSegmentGlobalStatusStatisticsCache($segment);
-    }
-    return $result;
-  }
-
   public function getSegmentStatisticsCountById(int $segmentId): array {
     $result = $this->getCacheItem(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY, $segmentId)['item'] ?? null;
     if (!$result) {
@@ -96,16 +88,6 @@ class SubscribersCountsController {
     if (!$result) {
       $result = $this->recalculateHomepageStatisticsCache();
     }
-    return $result;
-  }
-
-  public function recalculateSegmentGlobalStatusStatisticsCache(SegmentEntity $segment): array {
-    $result = $this->segmentSubscribersRepository->getSubscribersGlobalStatusStatisticsCount($segment);
-    $this->setCacheItem(
-      TransientCache::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY,
-      $result,
-      (int)$segment->getId()
-    );
     return $result;
   }
 
@@ -149,11 +131,6 @@ class SubscribersCountsController {
     foreach ($this->transientCache->getItems(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY) as $id => $item) {
       if (!in_array($id, $segmentIds)) {
         $this->transientCache->invalidateItem(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY, $id);
-      }
-    }
-    foreach ($this->transientCache->getItems(TransientCache::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY) as $id => $item) {
-      if (!in_array($id, $segmentIds)) {
-        $this->transientCache->invalidateItem(TransientCache::SUBSCRIBERS_GLOBAL_STATUS_STATISTICS_COUNT_KEY, $id);
       }
     }
   }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -756,16 +756,6 @@ parameters:
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
 		-
-			message: "#^Cannot call method isStatic\\(\\) on mixed\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\$segment of method MailPoet\\\\Subscribers\\\\SubscribersCountsController\\:\\:getSegmentGlobalStatusStatisticsCount\\(\\) expects MailPoet\\\\Entities\\\\SegmentEntity, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
 			message: "#^Parameter \\#1 \\$segment of method MailPoet\\\\Subscribers\\\\SubscribersCountsController\\:\\:getSegmentStatisticsCount\\(\\) expects MailPoet\\\\Entities\\\\SegmentEntity, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Subscribers/SubscriberListingRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -756,16 +756,6 @@ parameters:
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
 		-
-			message: "#^Cannot call method isStatic\\(\\) on mixed\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\$segment of method MailPoet\\\\Subscribers\\\\SubscribersCountsController\\:\\:getSegmentGlobalStatusStatisticsCount\\(\\) expects MailPoet\\\\Entities\\\\SegmentEntity, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
 			message: "#^Parameter \\#1 \\$segment of method MailPoet\\\\Subscribers\\\\SubscribersCountsController\\:\\:getSegmentStatisticsCount\\(\\) expects MailPoet\\\\Entities\\\\SegmentEntity, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Subscribers/SubscriberListingRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -755,16 +755,6 @@ parameters:
 			path: ../../lib/Subscribers/SubscriberListingRepository.php
 
 		-
-			message: "#^Cannot call method isStatic\\(\\) on mixed\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\$segment of method MailPoet\\\\Subscribers\\\\SubscribersCountsController\\:\\:getSegmentGlobalStatusStatisticsCount\\(\\) expects MailPoet\\\\Entities\\\\SegmentEntity, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Subscribers/SubscriberListingRepository.php
-
-		-
 			message: "#^Parameter \\#1 \\$segment of method MailPoet\\\\Subscribers\\\\SubscribersCountsController\\:\\:getSegmentStatisticsCount\\(\\) expects MailPoet\\\\Entities\\\\SegmentEntity, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Subscribers/SubscriberListingRepository.php


### PR DESCRIPTION
## Description
This PR takes into account that a user can be globally subscribed but unsubscribed to a certain segment. If you go to the subscriber listings and you selected e.g. to view only the subscribed users of a certain segment, you would see users who are unsubscribed to the specific list while globally subscribed. These users are now moved to the "Unsubscribed" tab and the numbers are calculated accordingly.

## Code review notes
Instead of changing the signature of the methods, I opted for setting a `private $definition` which gets populated on the public methods and can be used subsequently. My thinking here was that this contains the change and leaves the interface intact. I am open to changing the signatures of the methods instead. I think there are also good reasons to do so.

The main change happens in `filterGroup()`. If a static segment is used to filter the data and your group (status of the subscriber) is either `subscribed` or `unsubscribed` this PR takes now the local status of the subscription into account as well. From now on in the listing `subscribed` means you are globally subscribed _and_ subscribed to the specific segment. Unsubscribed means you are either unsubscribed from the specific segment or globally unsubscribed.

This PR gets also rid of the method `getSegmentGlobalStatusStatisticsCount()`. This was used to calculate number of bounces, subscribed, unsubscribed etc. users for a specific list and took only the global status into account. The method was solely used to calculate those numbers for the select fields in the subscriber list view, where you are able to switch between segments. The existing `getSegmentStatisticsCount()` can be used instead and produces the right numbers.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4487]

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4487]: https://mailpoet.atlassian.net/browse/MAILPOET-4487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ