### PR TITLE
Remove waiting for navigation from the k6 test forms adding

### DIFF
--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -56,7 +56,6 @@ export async function formsAdding() {
       page,
       '[data-automation-id="select_template_template_1_popup"]',
     );
-    await page.waitForNavigation();
     await page.waitForLoadState('networkidle');
 
     // Try to close the tutorial video popup


### PR DESCRIPTION
## Description

Tiny change to remove waitForNavigation method from k6 test forms-adding

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5537]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5537]: https://mailpoet.atlassian.net/browse/MAILPOET-5537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ