### PR TITLE
Close button disappears in some themes [MAILPOET-5132]

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -355,6 +355,7 @@ div.mailpoet_form_popup {
 div.mailpoet_form_fixed_bar {
   background-color: white;
   box-shadow: 0 4px 35px 0 rgba(195, 65, 2, .2);
+  box-sizing: border-box;
   display: none;
   left: 0;
   margin: 0;

--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -345,6 +345,7 @@ div.mailpoet_form_popup {
   display: block;
   height: 20px;
   margin: 0 0 0 auto;
+  padding: 0;
   position: absolute;
   right: 10px;
   top: 10px;


### PR DESCRIPTION
## Description
Applies the `padding: 0` solution to our CSS files. It seems, [this commit](abfc33002cd3e3dd766f7075f33a30522b6dfc8d) introduced the problem for some themes. For the problem with the 2023 theme, it was not the same probelm. The whole div container was wider than the screen. `box-sizing` solved that issue.

## Linked tickets
[MAILPOET-5132]



[MAILPOET-5132]: https://mailpoet.atlassian.net/browse/MAILPOET-5132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ