### PR TITLE
Do not delete revenue statistics [MAILPOET-5486]

### DIFF
--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -354,10 +354,11 @@ class NewslettersRepository extends Repository {
          WHERE s.`newsletter_id` IN (:ids)
       ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);
 
+      // Update WooCommerce statistics and remove newsletter and click id
       $statisticsPurchasesTable = $entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
       $entityManager->getConnection()->executeStatement("
-         DELETE s FROM $statisticsPurchasesTable s
-         WHERE s.`newsletter_id` IN (:ids)
+         UPDATE $statisticsPurchasesTable s
+         SET s.`newsletter_id` = 0, s.`click_id`=0 WHERE s.`newsletter_id` IN (:ids)
       ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);
 
       // Delete newsletter posts

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -56,14 +56,21 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
     $data = $this->entityManager->getConnection()->executeQuery('
       SELECT
         SUM(swp.order_price_total) AS revenue,
-        COALESCE(n.parent_id, n.id) AS campaign_id,
-        (CASE WHEN n.type = :notification_history_type THEN :notification_type ELSE n.type END) AS campaign_type,
+        COALESCE(n.parent_id, swp.newsletter_id) AS campaign_id,
+        (
+            CASE
+                WHEN n.type IS NULL THEN "unknown"
+                WHEN n.type = :notification_history_type THEN :notification_type
+                ELSE n.type
+            END
+          ) AS campaign_type,
         COUNT(order_id) as orders_count
       FROM ' . $revenueStatsTable . ' swp
-        JOIN ' . $newsletterTable . ' n ON
+      LEFT JOIN ' . $newsletterTable . ' n ON
           n.id = swp.newsletter_id
+      WHERE
+          swp.order_currency = :currency
           AND swp.click_id IN (SELECT MIN(click_id) FROM ' . $revenueStatsTable . ' ss GROUP BY order_id)
-      WHERE swp.order_currency = :currency
       GROUP BY campaign_id, n.type;
     ', [
       'notification_history_type' => NewsletterEntity::TYPE_NOTIFICATION_HISTORY,

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -208,7 +208,9 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     expect($this->entityManager->find(StatisticsNewsletterEntity::class, $statisticsNewsletter->getId()))->null();
     expect($this->entityManager->find(StatisticsOpenEntity::class, $statisticsOpen->getId()))->null();
     expect($this->entityManager->find(StatisticsClickEntity::class, $statisticsClick->getId()))->null();
-    expect($this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase->getId()))->null();
+    $statisticsPurchase = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase->getId());
+    $this->assertNotNull($statisticsPurchase);
+    expect($statisticsPurchase->getNewsletter())->null();
   }
 
   public function testItGetsArchiveNewslettersForSegments() {


### PR DESCRIPTION
## Description
When deleting a newsletter we delete all statistics. With this PR we will stop deleting revenue related statistics data, so we do not loose this data for the WooCommerce tracker. 

## Code review notes
Instead of deleting the data we update the newsletter_id to `0`. To still be accessible via the tracker, the SQL query had to be updated. Instead of `JOIN wp_mailpoet_newsletters` we do now a `LEFT JOIN` to allow for newsletters which are not found. These are marked with the campaign type `unknown`. 

The `swp.click_id IN (SELECT MIN(click_id) FROM ' . $revenueStatsTable . ' ss GROUP BY order_id)` restriction had to move from the `JOIN` clause to the `WHERE` clause to have a global effect on the rows found.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5486]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5486]: https://mailpoet.atlassian.net/browse/MAILPOET-5486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ