### PR TITLE
Add new acceptance test to cover past issue activating MailPoet redirect to WooCommerce

### DIFF
--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -21,10 +21,11 @@ class HomepageLandingAfterActivatingMailPoetCest {
 
     $i->amOnPluginsPage();
     $i->deactivatePlugin('mailpoet');
-    $i->waitForNoticeAndClose('Plugin deactivated.');
+    $i->waitForNoticeAndClose('Selected plugins deactivated.');
 
     $i->activatePlugin('mailpoet');
     $i->waitForText('Better email — without leaving WordPress');
+    $i->seeInCurrentUrl('mailpoet-landingpage');
   }
 
   public function _after(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -8,7 +8,7 @@ class HomepageLandingAfterActivatingMailPoetCest {
   }
   
   public function homepageLanding(\AcceptanceTester $i) {
-    $i->wantTo('Check that Homepage is shown after activating fresh new MailPoet plugin [MAILPOET-5020]');
+    $i->wantTo('Check that Homepage is shown after activating fresh new MailPoet plugin'); // ref: [MAILPOET-5020]
 
     $i->login();
 
@@ -17,14 +17,14 @@ class HomepageLandingAfterActivatingMailPoetCest {
     $i->click('[data-automation-id="settings-advanced-tab"]');
     $i->click('Reinstall now...');
     $i->acceptPopup();
-    $i->waitForNoticeAndClose('Better email — without leaving WordPress');
+    $i->waitForText('Better email — without leaving WordPress');
 
     $i->amOnPluginsPage();
     $i->deactivatePlugin('mailpoet');
     $i->waitForNoticeAndClose('Plugin deactivated.');
 
     $i->activatePlugin('mailpoet');
-    $i->waitForNoticeAndClose('Better email — without leaving WordPress');
+    $i->waitForText('Better email — without leaving WordPress');
   }
 
   public function _after(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -23,7 +23,7 @@ class HomepageLandingAfterActivatingMailPoetCest {
     $i->deactivatePlugin('mailpoet');
     $i->waitForNoticeAndClose('Selected plugins deactivated.');
 
-    $i->activatePlugin('mailpoet');
+    $i->click('#activate-mailpoet');
     $i->waitForText('Better email — without leaving WordPress');
     $i->seeInCurrentUrl('mailpoet-landingpage');
   }

--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+class HomepageLandingAfterActivatingMailPoetCest {
+  public function _before(\AcceptanceTester $i) {
+    $i->activateWooCommerce();
+  }
+  
+  public function homepageLanding(\AcceptanceTester $i) {
+    $i->wantTo('Check that Homepage is shown after activating fresh new MailPoet plugin [MAILPOET-5020]');
+
+    $i->login();
+
+    // Workaround to have fresh new MailPoet plugin before activation
+    $i->amOnMailpoetPage('Settings');
+    $i->click('[data-automation-id="settings-advanced-tab"]');
+    $i->click('Reinstall now...');
+    $i->acceptPopup();
+    $i->waitForNoticeAndClose('Better email — without leaving WordPress');
+
+    $i->amOnPluginsPage();
+    $i->deactivatePlugin('mailpoet');
+    $i->waitForNoticeAndClose('Plugin deactivated.');
+
+    $i->activatePlugin('mailpoet');
+    $i->waitForNoticeAndClose('Better email — without leaving WordPress');
+  }
+
+  public function _after(\AcceptanceTester $i) {
+    $i->deactivateWooCommerce();
+  }
+}


### PR DESCRIPTION
## Description

Added a new acceptance test to cover issue from the past.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5020]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5020]: https://mailpoet.atlassian.net/browse/MAILPOET-5020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ