### PR TITLE
Select latest non-deleted schedule tasks when rescheduling [MAILPOET-5543]

### DIFF
--- a/mailpoet/lib/Settings/SettingsChangeHandler.php
+++ b/mailpoet/lib/Settings/SettingsChangeHandler.php
@@ -42,7 +42,8 @@ class SettingsChangeHandler {
     $task = $this->scheduledTasksRepository->findOneBy([
       'type' => WooCommerceSync::TASK_TYPE,
       'status' => ScheduledTaskEntity::STATUS_SCHEDULED,
-    ]);
+      'deletedAt' => null,
+    ], ['createdAt' => 'DESC']);
     if (!($task instanceof ScheduledTaskEntity)) {
       $task = $this->createScheduledTask(WooCommerceSync::TASK_TYPE);
     }
@@ -56,7 +57,8 @@ class SettingsChangeHandler {
     $task = $this->scheduledTasksRepository->findOneBy([
       'type' => InactiveSubscribers::TASK_TYPE,
       'status' => ScheduledTaskEntity::STATUS_SCHEDULED,
-    ]);
+      'deletedAt' => null,
+    ], ['createdAt' => 'DESC']);
     if (!($task instanceof ScheduledTaskEntity)) {
       $task = $this->createScheduledTask(InactiveSubscribers::TASK_TYPE);
     }


### PR DESCRIPTION
## Description

`SettingsChangeHandler` reschedules any scheduled task, including a deleted one.

This can result in the inactive subscribers task being blocked in some cases.

See: https://a8c.slack.com/archives/C01GH6AED0S/p1692678767135419

## Code review notes

_N/A_

## QA notes

Ensure that counting inactive subscribers runs soon after changing the inactive subscribers settings.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5543]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5543]: https://mailpoet.atlassian.net/browse/MAILPOET-5543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ