### PR TITLE
Fix flaky FilterHandlerTest [MAILPOET-5544]

### DIFF
--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
@@ -77,7 +77,8 @@ class FilterHandlerTest extends \MailPoetTest {
       ->getConnection()
       ->createQueryBuilder()
       ->select("$subscribersTable.id")
-      ->from($subscribersTable);
+      ->from($subscribersTable)
+      ->orderBy("$subscribersTable.id", 'ASC');
   }
 
   public function _after(): void {


### PR DESCRIPTION
## Description

This test fails especially in `integration_oldest` tests on nightly builds, like [this one](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/15295/workflows/28d6343f-6ba7-4be9-9e7e-a272d4e7a397/jobs/259474).

One thing to maybe verify further, would be to check all usages of `FilterHandler::apply(...)` and check whether the `$queryBuilder` passed into them has some sort, so we don't end up with unpredictable order in the UI as well. As you're working on segments now, @johnolek, would you please help me verify these? I think the usages are:
1. [SegmentsFinder](https://github.com/mailpoet/mailpoet/blob/27a1602645e0dea545017080b6aa8c4671d8c668/mailpoet/lib/Segments/SegmentsFinder.php#L59) — seems to be missing `orderBy`, but fetches only one subscriber at a time, so I think OK ✅ 
2. [ImportExportRepository](https://github.com/mailpoet/mailpoet/blob/27a1602645e0dea545017080b6aa8c4671d8c668/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php#L211) — [looks OK](https://github.com/mailpoet/mailpoet/blob/27a1602645e0dea545017080b6aa8c4671d8c668/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php#L238) to me ✅ 
3. [SegmentSubscribersRepository](https://github.com/mailpoet/mailpoet/blob/27a1602645e0dea545017080b6aa8c4671d8c668/mailpoet/lib/Segments/SegmentSubscribersRepository.php#L399) — the call stack is a bit more complex, but I see no ordering ❗ 
4. [SubscriberListingRepository](https://github.com/mailpoet/mailpoet/blob/27a1602645e0dea545017080b6aa8c4671d8c668/mailpoet/lib/Subscribers/SubscriberListingRepository.php#L397) — this does seem to [apply some sorting](https://github.com/mailpoet/mailpoet/blob/27a1602645e0dea545017080b6aa8c4671d8c668/mailpoet/lib/Subscribers/SubscriberListingRepository.php#L187), but not sure if in all paths ❓ 

## Code review notes

No QA needed, just tests.

## QA notes

No QA needed, just tests.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5544]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5544]: https://mailpoet.atlassian.net/browse/MAILPOET-5544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ