### PR TITLE
Use WP filter default rather than explicitly checking for "isPremiumActive" [MAILPOET-5545]

### DIFF
--- a/mailpoet/assets/js/src/subscribers/stats/opened_email_stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/opened_email_stats.tsx
@@ -1,3 +1,4 @@
+import { FunctionComponent, useMemo } from 'react';
 import { Hooks } from 'hooks';
 import { Location } from 'history';
 import { MailPoet } from 'mailpoet';
@@ -12,25 +13,30 @@ type Props = {
 };
 
 export function OpenedEmailsStats({ params, location }: Props): JSX.Element {
+  const Content = useMemo(
+    () =>
+      Hooks.applyFilters(
+        'mailpoet_subscribers_opened_emails_stats',
+        () => (
+          <NoAccessInfo
+            limitReached={MailPoet.subscribersLimitReached}
+            limitValue={MailPoet.subscribersLimit}
+            subscribersCountTowardsLimit={MailPoet.subscribersCount}
+            premiumActive={MailPoet.premiumActive}
+            hasValidApiKey={MailPoet.hasValidApiKey}
+            hasPremiumSupport={MailPoet.hasPremiumSupport}
+          />
+        ),
+        params,
+        location,
+      ) as FunctionComponent,
+    [location, params],
+  );
+
   return (
     <>
       <Heading level={4}>{MailPoet.I18n.t('openedEmailsHeading')}</Heading>
-      {!MailPoet.premiumActive || MailPoet.subscribersLimitReached ? (
-        <NoAccessInfo
-          limitReached={MailPoet.subscribersLimitReached}
-          limitValue={MailPoet.subscribersLimit}
-          subscribersCountTowardsLimit={MailPoet.subscribersCount}
-          premiumActive={MailPoet.premiumActive}
-          hasValidApiKey={MailPoet.hasValidApiKey}
-          hasPremiumSupport={MailPoet.hasPremiumSupport}
-        />
-      ) : (
-        Hooks.applyFilters(
-          'mailpoet_subscribers_opened_emails_stats',
-          params,
-          location,
-        )
-      )}
+      <Content />
     </>
   );
 }


### PR DESCRIPTION
## Description

There are some places where we use code such as:

```ts
if (!MailPoet.premiumActive) {
  return <NoAccessInfo ... />;
} else {
  Hooks.applyFilters(...); // this is a slot for the premium plugin
}
```

Such code is problematic, because the premium plugin can be active, even though its code is not loaded. This occurs when the premium plugin version is not compatible with the free plugin version.

More info here: https://mailpoet.atlassian.net/browse/MAILPOET-5545

## Code review notes

_N/A_

## QA notes

First, try to replicate the issue on `trunk`:
1. Go to `admin.php?page=mailpoet-subscribers#/stats/<subscriber-id>`
2. Downgrade the premium plugin so that it's incompatible with the free plugin.
3. Refresh the page and see `Error: Objects are not valid as a React child`.

Then update to the builds from this branch (free, keep premium in an old, incompatible version). The error should disappear after page refresh.

Then, update also premium to this branch and verify the page works as usual.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/776

## Linked tickets

[MAILPOET-5545]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5545]: https://mailpoet.atlassian.net/browse/MAILPOET-5545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ