### PR TITLE
Fixed flakiness in acceptance tests

### DIFF
--- a/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
@@ -93,6 +93,8 @@ class CreateSegmentEmailAbsoluteCountCest {
 
     $i->click('Save');
     $i->waitForNoticeAndClose('Segment successfully updated!');
+    $i->waitForListingItemsToLoad();
+    $i->waitForText($segmentTitle);
 
     $i->wantTo('Check there is one subscriber on the segment');
     $i->clickItemRowActionByItemName($segmentTitle, 'View Subscribers');

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -166,12 +166,15 @@ class ManageSegmentsCest {
     $i->waitForText('No segments found');
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($segment1->getName());
+    $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName($segment1->getName(), 'Delete permanently');
     $i->waitForNoticeAndClose('1 segment was permanently deleted.');
+    $i->waitForListingItemsToLoad();
     $i->seeNoJSErrors();
     $i->waitForText($segment2->getName());
 
     $i->wantTo('Empty trash from other segments');
+    $i->waitForElementVisible('[data-automation-id="empty_trash"]');
     $i->waitForElementClickable('[data-automation-id="empty_trash"]');
     $i->click('[data-automation-id="empty_trash"]');
     $i->waitForNoticeAndClose('1 segment was permanently deleted.');

--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -78,10 +78,13 @@ class SettingsArchivePageCest {
     $i->waitForText('SentNewsletter2');
     $i->clickItemRowActionByItemName('SentNewsletter2', 'Move to trash');
     $i->waitForNoticeAndClose('1 email was moved to the trash.');
+    $i->waitForListingItemsToLoad();
+    $i->waitForText('SentNewsletter3');
     $i->clickItemRowActionByItemName('SentNewsletter3', 'Move to trash');
     $i->waitForNoticeAndClose('1 email was moved to the trash.');
     $i->click('[data-automation-id="filters_trash"]');
     $i->waitForElement('[data-automation-id="empty_trash"]');
+    $i->waitForListingItemsToLoad();
     $i->waitForText('SentNewsletter3');
     $i->clickItemRowActionByItemName('SentNewsletter3', 'Delete permanently');
     $i->waitForText('1 email was permanently deleted.');

--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -61,12 +61,15 @@ class SubscriberCountShortcodeCest {
     $i->waitForElementVisible('[data-automation-id="listing_filter_segment"]');
     $i->click('[data-automation-id="select_all"]');
     $i->click('[data-automation-id="action-trash"]');
-    $i->waitForText('11 subscribers were moved to the trash.');
+    $i->waitForListingItemsToLoad();
+    $i->waitForNoticeAndClose('11 subscribers were moved to the trash.');
+    $i->waitForText('No items found.');
     $i->waitForElement('[data-automation-id="filters_trash"]');
     $i->click('[data-automation-id="filters_trash"]');
-    $i->waitForElement('[data-automation-id="empty_trash"]');
+    $i->waitForListingItemsToLoad();
+    $i->waitForElementVisible('[data-automation-id="empty_trash"]');
     $i->click('[data-automation-id="empty_trash"]');
-    $i->waitForText('11 subscribers were permanently deleted.');
+    $i->waitForNoticeAndClose('11 subscribers were permanently deleted.');
     $i->amOnUrl($postUrl);
     $i->waitForText(self::PAGE_TITLE);
     $i->waitForText(self::PAGE_TEXT . " 5");

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -280,6 +280,10 @@ class WooCheckoutBlocksCest {
   }
 
   private function placeOrder(\AcceptanceTester $i): void {
+    // Add a note to order just to avoid flakiness due to race conditions
+    $i->click('Add a note to your order');
+    $i->fillField('.wc-block-components-textarea', 'This is a note');
+    $i->waitForText('Place Order');
     $i->waitForElementClickable(Locator::contains('button', 'Place Order'));
     $i->click(Locator::contains('button', 'Place Order'));
     $i->waitForText('Your order has been received');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -281,10 +281,10 @@ class WooCheckoutBlocksCest {
 
   private function placeOrder(\AcceptanceTester $i): void {
     // Add a note to order just to avoid flakiness due to race conditions
-    $i->click('Add a note to your order');
+    $i->click(Locator::contains('label', 'Add a note to your order'));
     $i->fillField('.wc-block-components-textarea', 'This is a note');
     $i->waitForText('Place Order');
-    $i->waitForElementClickable(Locator::contains('button', 'Place Order'));
+    $i->waitForElementClickable('.wc-block-components-checkout-place-order-button');
     $i->click(Locator::contains('button', 'Place Order'));
     $i->waitForText('Your order has been received');
   }


### PR DESCRIPTION
## Description

Fixed flaky tests. They were all about race conditions, slowing down the specific steps solves the issue.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5008]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5008]: https://mailpoet.atlassian.net/browse/MAILPOET-5008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ