### PR TITLE
Woocommerce revenue tracking improvements [MAILPOET-5485]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -12,6 +12,7 @@ use MailPoet\Subscription\Comment;
 use MailPoet\Subscription\Form;
 use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
+use MailPoet\WooCommerce\Helper;
 use MailPoet\WooCommerce\Integrations\AutomateWooHooks;
 use MailPoet\WooCommerce\WooSystemInfoController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -66,6 +67,9 @@ class Hooks {
   /** @var WooSystemInfoController */
   private $wooSystemInfoController;
 
+  /** @var Helper */
+  private $wooCommerceHelper;
+
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -82,7 +86,8 @@ class Hooks {
     WP $wpSegment,
     DotcomLicenseProvisioner $dotcomLicenseProvisioner,
     AutomateWooHooks $automateWooHooks,
-    WooSystemInfoController $wooSystemInfoController
+    WooSystemInfoController $wooSystemInfoController,
+    Helper $wooCommerceHelper
   ) {
     $this->subscriptionForm = $subscriptionForm;
     $this->subscriptionComment = $subscriptionComment;
@@ -100,6 +105,7 @@ class Hooks {
     $this->dotcomLicenseProvisioner = $dotcomLicenseProvisioner;
     $this->automateWooHooks = $automateWooHooks;
     $this->wooSystemInfoController = $wooSystemInfoController;
+    $this->wooCommerceHelper = $wooCommerceHelper;
   }
 
   public function init() {
@@ -413,12 +419,7 @@ class Hooks {
   }
 
   public function setupWooCommercePurchases() {
-    // use both 'processing' and 'completed' states since payment hook and 'processing' status
-    // may be skipped with some payment methods (cheque) or when state transitioned manually
-    $acceptedOrderStates = WPFunctions::get()->applyFilters(
-      'mailpoet_purchase_order_states',
-      ['processing', 'completed']
-    );
+    $acceptedOrderStates = $this->wooCommerceHelper->getPurchaseStates();
 
     foreach ($acceptedOrderStates as $status) {
       WPFunctions::get()->addAction(

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -12,7 +12,6 @@ use MailPoet\Subscription\Comment;
 use MailPoet\Subscription\Form;
 use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
-use MailPoet\WooCommerce\Helper;
 use MailPoet\WooCommerce\Integrations\AutomateWooHooks;
 use MailPoet\WooCommerce\WooSystemInfoController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -67,9 +66,6 @@ class Hooks {
   /** @var WooSystemInfoController */
   private $wooSystemInfoController;
 
-  /** @var Helper */
-  private $wooCommerceHelper;
-
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -86,8 +82,7 @@ class Hooks {
     WP $wpSegment,
     DotcomLicenseProvisioner $dotcomLicenseProvisioner,
     AutomateWooHooks $automateWooHooks,
-    WooSystemInfoController $wooSystemInfoController,
-    Helper $wooCommerceHelper
+    WooSystemInfoController $wooSystemInfoController
   ) {
     $this->subscriptionForm = $subscriptionForm;
     $this->subscriptionComment = $subscriptionComment;
@@ -105,7 +100,6 @@ class Hooks {
     $this->dotcomLicenseProvisioner = $dotcomLicenseProvisioner;
     $this->automateWooHooks = $automateWooHooks;
     $this->wooSystemInfoController = $wooSystemInfoController;
-    $this->wooCommerceHelper = $wooCommerceHelper;
   }
 
   public function init() {
@@ -419,16 +413,12 @@ class Hooks {
   }
 
   public function setupWooCommercePurchases() {
-    $acceptedOrderStates = $this->wooCommerceHelper->getPurchaseStates();
-
-    foreach ($acceptedOrderStates as $status) {
-      WPFunctions::get()->addAction(
-        'woocommerce_order_status_' . $status,
-        [$this->hooksWooCommerce, 'trackPurchase'],
-        10,
-        1
-      );
-    }
+    $this->wp->addAction(
+      'woocommerce_order_status_changed',
+      [$this->hooksWooCommerce, 'trackPurchase'],
+      10,
+      1
+    );
   }
 
   public function setupWooCommerceSubscriberEngagement() {

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -419,6 +419,13 @@ class Hooks {
       10,
       1
     );
+
+    $this->wp->addAction(
+      'woocommerce_order_refunded',
+      [$this->hooksWooCommerce, 'trackRefund'],
+      10,
+      1
+    );
   }
 
   public function setupWooCommerceSubscriberEngagement() {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -115,6 +115,14 @@ class HooksWooCommerce {
     }
   }
 
+  public function trackRefund($id) {
+    try {
+      $this->woocommercePurchases->trackRefund($id);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Purchases Refund');
+    }
+  }
+
   public function extendForm() {
     try {
       $this->subscriberRegistration->extendForm();

--- a/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
+++ b/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
@@ -52,7 +52,7 @@ class WooCommercePastOrders extends SimpleWorker {
     }, 10, 2);
 
     $orderIds = $this->woocommerceHelper->wcGetOrders([
-      'status' => 'completed',
+      'status' => $this->woocommerceHelper->getPurchaseStates(),
       'date_completed' => '>=' . (($createdAt = $oldestClick->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null),
       'orderby' => 'ID',
       'order' => 'ASC',

--- a/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
+++ b/mailpoet/lib/Cron/Workers/WooCommercePastOrders.php
@@ -52,7 +52,6 @@ class WooCommercePastOrders extends SimpleWorker {
     }, 10, 2);
 
     $orderIds = $this->woocommerceHelper->wcGetOrders([
-      'status' => $this->woocommerceHelper->getPurchaseStates(),
       'date_completed' => '>=' . (($createdAt = $oldestClick->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null),
       'orderby' => 'ID',
       'order' => 'ASC',

--- a/mailpoet/lib/Entities/StatisticsWooCommercePurchaseEntity.php
+++ b/mailpoet/lib/Entities/StatisticsWooCommercePurchaseEntity.php
@@ -64,13 +64,20 @@ class StatisticsWooCommercePurchaseEntity {
    */
   private $orderPriceTotal;
 
+  /**
+   * @ORM\Column(type="string")
+   * @var string
+   */
+  private $status;
+
   public function __construct(
     NewsletterEntity $newsletter,
     SendingQueueEntity $queue,
     StatisticsClickEntity $click,
     int $orderId,
     string $orderCurrency,
-    float $orderPriceTotal
+    float $orderPriceTotal,
+    string $status
   ) {
     $this->newsletter = $newsletter;
     $this->queue = $queue;
@@ -78,6 +85,7 @@ class StatisticsWooCommercePurchaseEntity {
     $this->orderId = $orderId;
     $this->orderCurrency = $orderCurrency;
     $this->orderPriceTotal = $orderPriceTotal;
+    $this->status = $status;
   }
 
   public function getNewsletter(): ?NewsletterEntity {
@@ -122,5 +130,13 @@ class StatisticsWooCommercePurchaseEntity {
 
   public function setOrderPriceTotal(float $orderPriceTotal): void {
     $this->orderPriceTotal = $orderPriceTotal;
+  }
+
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  public function setStatus(string $status): void {
+    $this->status = $status;
   }
 }

--- a/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Migrations\Db\Migration_20230824_054259_Db;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\WooCommerce\Helper;
+
+class Migration_20230825_093531_App extends AppMigration {
+  const DEFAULT_STATUS = Migration_20230824_054259_Db::DEFAULT_STATUS;
+
+  public function run(): void {
+
+    $wooCommerceHelper = $this->container->get(Helper::class);
+    $wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled() ?
+      $this->populateStatusColumnUsingHpos() : $this->populateStatusColumnUsingPost();
+  }
+
+  private function populateStatusColumnUsingHpos(): void {
+    global $wpdb;
+
+    $revenueTable = esc_sql($this->getTableName());
+    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->prefix . 'wc_orders as wc set rev.status=TRIM(Leading "wc-" FROM wc.status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
+    $wpdb->query($sql);
+  }
+
+  private function populateStatusColumnUsingPost(): void {
+    global $wpdb;
+
+    $revenueTable = esc_sql($this->getTableName());
+    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->posts . ' as wc set rev.status=TRIM(Leading "wc-" FROM wc.post_status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
+    $wpdb->query($sql);
+  }
+
+  private function getTableName(): string {
+    return $this->entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
+  }
+}

--- a/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
@@ -21,7 +21,7 @@ class Migration_20230825_093531_App extends AppMigration {
     global $wpdb;
 
     $revenueTable = esc_sql($this->getTableName());
-    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->prefix . 'wc_orders as wc set rev.status=TRIM(Leading "wc-" FROM wc.status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
+    $sql = "update " . $revenueTable . " as rev, " . $wpdb->prefix . "wc_orders as wc set rev.status=TRIM(Leading 'wc-' FROM wc.status) where wc.id = rev.order_id AND rev.status='" . self::DEFAULT_STATUS . "'";
     $wpdb->query($sql);
   }
 
@@ -29,7 +29,7 @@ class Migration_20230825_093531_App extends AppMigration {
     global $wpdb;
 
     $revenueTable = esc_sql($this->getTableName());
-    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->posts . ' as wc set rev.status=TRIM(Leading "wc-" FROM wc.post_status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
+    $sql = "update " . $revenueTable . " as rev, " . $wpdb->posts . " as wc set rev.status=TRIM(Leading 'wc-' FROM wc.post_status) where wc.id = rev.order_id AND rev.status='" . self::DEFAULT_STATUS . "'";
     $wpdb->query($sql);
   }
 

--- a/mailpoet/lib/Migrations/Db/Migration_20230824_054259_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20230824_054259_Db.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Migrator\DbMigration;
+use MailPoet\WooCommerce\Helper;
+
+class Migration_20230824_054259_Db extends DbMigration {
+
+  /** @var Helper */
+  private $wooCommerceHelper;
+
+  const DEFAULT_STATUS = 'unknown';
+
+  public function __construct(
+    ContainerWrapper $container
+  ) {
+    parent::__construct($container);
+    $this->wooCommerceHelper = $container->get(Helper::class);
+  }
+
+  public function run(): void {
+    $this->createStatusColumn();
+    $this->populateStatusColumn();
+  }
+
+  private function createStatusColumn(): void {
+    $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
+
+    if ($this->columnExists($revenueTable, 'status')) {
+      return;
+    }
+
+    $this->connection->executeQuery(
+      "ALTER TABLE `" . $revenueTable . "`
+        ADD COLUMN `status` VARCHAR(40) NOT NULL DEFAULT '" . self::DEFAULT_STATUS . "',
+        ADD INDEX `status` (`status`)"
+    );
+  }
+
+  private function populateStatusColumn(): void {
+
+    $this->wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled() ?
+      $this->populateStatusColumnUsingHpos() : $this->populateStatusColumnUsingPost();
+  }
+
+  private function populateStatusColumnUsingHpos(): void {
+    global $wpdb;
+    $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
+
+    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->prefix . 'wc_orders as wc set rev.status=TRIM(Leading "wc-" FROM wc.status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
+    $this->connection->executeQuery($sql);
+  }
+
+  private function populateStatusColumnUsingPost(): void {
+
+    global $wpdb;
+    $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
+
+    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->posts . ' as wc set rev.status=TRIM(Leading "wc-" FROM wc.post_status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
+    $this->connection->executeQuery($sql);
+  }
+}

--- a/mailpoet/lib/Migrations/Db/Migration_20230824_054259_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20230824_054259_Db.php
@@ -5,61 +5,30 @@ namespace MailPoet\Migrations\Db;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Migrator\DbMigration;
-use MailPoet\WooCommerce\Helper;
 
 class Migration_20230824_054259_Db extends DbMigration {
 
-  /** @var Helper */
-  private $wooCommerceHelper;
-
-  const DEFAULT_STATUS = 'unknown';
+  public const DEFAULT_STATUS = 'unknown';
 
   public function __construct(
     ContainerWrapper $container
   ) {
     parent::__construct($container);
-    $this->wooCommerceHelper = $container->get(Helper::class);
   }
 
   public function run(): void {
     $this->createStatusColumn();
-    $this->populateStatusColumn();
   }
 
   private function createStatusColumn(): void {
     $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
-
     if ($this->columnExists($revenueTable, 'status')) {
       return;
     }
-
     $this->connection->executeQuery(
       "ALTER TABLE `" . $revenueTable . "`
         ADD COLUMN `status` VARCHAR(40) NOT NULL DEFAULT '" . self::DEFAULT_STATUS . "',
         ADD INDEX `status` (`status`)"
     );
-  }
-
-  private function populateStatusColumn(): void {
-
-    $this->wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled() ?
-      $this->populateStatusColumnUsingHpos() : $this->populateStatusColumnUsingPost();
-  }
-
-  private function populateStatusColumnUsingHpos(): void {
-    global $wpdb;
-    $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
-
-    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->prefix . 'wc_orders as wc set rev.status=TRIM(Leading "wc-" FROM wc.status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
-    $this->connection->executeQuery($sql);
-  }
-
-  private function populateStatusColumnUsingPost(): void {
-
-    global $wpdb;
-    $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
-
-    $sql = 'update ' . $revenueTable . ' as rev, ' . $wpdb->posts . ' as wc set rev.status=TRIM(Leading "wc-" FROM wc.post_status) where wc.id = rev.order_id AND rev.status="' . self::DEFAULT_STATUS . '"';
-    $this->connection->executeQuery($sql);
   }
 }

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -263,6 +263,8 @@ class NewsletterStatisticsRepository extends Repository {
       return null;
     }
 
+    $revenueStatus = $this->wcHelper->getPurchaseStates();
+
     $currency = $this->wcHelper->getWoocommerceCurrency();
     $query = $this->entityManager
       ->createQueryBuilder()
@@ -270,8 +272,10 @@ class NewsletterStatisticsRepository extends Repository {
       ->from(StatisticsWooCommercePurchaseEntity::class, 'stats')
       ->where('stats.newsletter IN (:newsletters)')
       ->andWhere('stats.orderCurrency = :currency')
+      ->andWhere('stats.status IN (:revenue_status)')
       ->setParameter('newsletters', $newsletters)
       ->setParameter('currency', $currency)
+      ->setParameter('revenue_status', $revenueStatus)
       ->groupBy('stats.newsletter');
 
     if ($from && $to) {

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -52,13 +52,13 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
         $click,
         $order->get_id(),
         $order->get_currency(),
-        $order->get_total(),
+        (float)$order->get_remaining_refund_amount(),
         $order->get_status()
       );
       $this->persist($statistics);
     } else {
       $statistics->setOrderCurrency($order->get_currency());
-      $statistics->setOrderPriceTotal($order->get_total());
+      $statistics->setOrderPriceTotal((float)$order->get_remaining_refund_amount());
       $statistics->setStatus($order->get_status());
     }
     $statistics->setSubscriber($click->getSubscriber());

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -36,12 +36,14 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
         $click,
         $order->get_id(),
         $order->get_currency(),
-        $order->get_total()
+        $order->get_total(),
+        $order->get_status()
       );
       $this->persist($statistics);
     } else {
       $statistics->setOrderCurrency($order->get_currency());
       $statistics->setOrderPriceTotal($order->get_total());
+      $statistics->setStatus($order->get_status());
     }
     $statistics->setSubscriber($click->getSubscriber());
     $this->flush();

--- a/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
+++ b/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
@@ -92,6 +92,14 @@ class WooCommercePurchases {
     }
   }
 
+  public function trackRefund($id) {
+    $order = $this->woocommerceHelper->wcGetOrder($id);
+    if (!$order instanceof WC_Order) {
+      return;
+    }
+    $this->trackExistingStatistic($order);
+  }
+
   /**
    * Returns true when a valid purchase statistic for an order was found.
    *

--- a/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
+++ b/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
@@ -56,15 +56,9 @@ class WooCommercePurchases {
       return;
     }
 
-    // limit clicks to 'USE_CLICKS_SINCE_DAYS_AGO' range before order has been created
-    $fromDate = $order->get_date_created();
-    if (is_null($fromDate)) {
-      return;
-    }
-    $from = clone $fromDate;
-    $from->modify(-self::USE_CLICKS_SINCE_DAYS_AGO . ' days');
+    $from = $this->getFromDate($order);
     $to = $order->get_date_created();
-    if (is_null($to)) {
+    if (is_null($to) || is_null($from)) {
       return;
     }
 
@@ -95,6 +89,22 @@ class WooCommercePurchases {
       }
       $this->statisticsWooCommercePurchasesRepository->createOrUpdateByClickDataAndOrder($click, $order);
     }
+  }
+
+  /**
+   * Limit clicks to 'USE_CLICKS_SINCE_DAYS_AGO' range before order has been created.
+   *
+   * @param WC_Order $order
+   * @return \WC_DateTime|null
+   */
+  private function getFromDate(\WC_Order $order) {
+    $fromDate = $order->get_date_created();
+    if (is_null($fromDate)) {
+      return null;
+    }
+    $from = clone $fromDate;
+    $from->modify(-self::USE_CLICKS_SINCE_DAYS_AGO . ' days');
+    return $from;
   }
 
   /**

--- a/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
+++ b/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
@@ -50,8 +50,9 @@ class WooCommercePurchases {
   }
 
   public function trackPurchase($id, $useCookies = true) {
+
     $order = $this->woocommerceHelper->wcGetOrder($id);
-    if (!$order instanceof WC_Order) {
+    if (!$order instanceof WC_Order || !in_array($order->get_status(), $this->woocommerceHelper->getPurchaseStates(), true)) {
       return;
     }
 

--- a/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
+++ b/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
@@ -52,7 +52,16 @@ class WooCommercePurchases {
   public function trackPurchase($id, $useCookies = true) {
 
     $order = $this->woocommerceHelper->wcGetOrder($id);
-    if (!$order instanceof WC_Order || !in_array($order->get_status(), $this->woocommerceHelper->getPurchaseStates(), true)) {
+    if (!$order instanceof WC_Order) {
+      return;
+    }
+
+    $statistics = $this->statisticsWooCommercePurchasesRepository->findOneBy(['orderId' => $order->get_id()]);
+    if ($statistics && $statistics->getClick()) {
+      $this->statisticsWooCommercePurchasesRepository->createOrUpdateByClickDataAndOrder(
+        $statistics->getClick(),
+        $order
+      );
       return;
     }
 

--- a/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
+++ b/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
@@ -104,6 +104,7 @@ class SubscriberStatisticsRepository extends Repository {
       return null;
     }
 
+    $revenueStatus = $this->wcHelper->getPurchaseStates();
     $currency = $this->wcHelper->getWoocommerceCurrency();
     $queryBuilder = $this->entityManager->createQueryBuilder()
       ->select('stats.orderPriceTotal')
@@ -112,6 +113,10 @@ class SubscriberStatisticsRepository extends Repository {
       ->andWhere('stats.orderCurrency = :currency')
       ->setParameter('subscriber', $subscriber)
       ->setParameter('currency', $currency)
+      ->andWhere('stats.status IN (:revenue_status)')
+      ->setParameter('subscriber', $subscriber)
+      ->setParameter('currency', $currency)
+      ->setParameter('revenue_status', $revenueStatus)
       ->groupBy('stats.orderId, stats.orderPriceTotal');
     if ($startTime) {
       $queryBuilder
@@ -119,9 +124,8 @@ class SubscriberStatisticsRepository extends Repository {
         ->setParameter('dateTime', $startTime);
     }
     $purchases =
-      $queryBuilder
-      ->getQuery()
-      ->getResult();
+      $queryBuilder->getQuery()
+        ->getResult();
     $sum = array_sum(array_column($purchases, 'orderPriceTotal'));
     return new WooCommerceRevenue(
       $currency,

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -25,6 +25,16 @@ class Helper {
     return $this->isWooCommerceActive() ? get_plugin_data(WP_PLUGIN_DIR . '/woocommerce/woocommerce.php')['Version'] : null;
   }
 
+  public function getPurchaseStates(): array {
+
+    // use both 'processing' and 'completed' states since payment hook and 'processing' status
+    // may be skipped with some payment methods (cheque) or when state transitioned manually
+    return (array)$this->wp->applyFilters(
+      'mailpoet_purchase_order_states',
+      ['processing', 'completed']
+    );
+  }
+
   public function isWooCommerceBlocksActive($min_version = '') {
     if (!class_exists('\Automattic\WooCommerce\Blocks\Package')) {
       return false;

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -27,11 +27,9 @@ class Helper {
 
   public function getPurchaseStates(): array {
 
-    // use both 'processing' and 'completed' states since payment hook and 'processing' status
-    // may be skipped with some payment methods (cheque) or when state transitioned manually
     return (array)$this->wp->applyFilters(
       'mailpoet_purchase_order_states',
-      ['processing', 'completed']
+      ['completed']
     );
   }
 

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\WooCommerce;
 
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
@@ -54,10 +55,12 @@ class Tracker {
    */
   private function formatCampaignsData(array $campaignsData): array {
     return array_reduce($campaignsData, function($result, array $campaign): array {
+      $newsletter = $this->newslettersRepository->findOneById((int)$campaign['campaign_id']);
       $keyPrefix = 'campaign_' . $campaign['campaign_id'];
       $result[$keyPrefix . '_revenue'] = $campaign['revenue'];
       $result[$keyPrefix . '_orders_count'] = $campaign['orders_count'];
       $result[$keyPrefix . '_type'] = $campaign['campaign_type'];
+      $result[$keyPrefix . '_event'] = $newsletter ? (string)$newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EVENT) : '';
       return $result;
     }, []);
   }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -146,11 +146,6 @@ parameters:
 			path: ../../lib/Config/Env.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: ../../lib/Config/Hooks.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: ../../lib/Config/Populator.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -146,11 +146,6 @@ parameters:
 			path: ../../lib/Config/Env.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: ../../lib/Config/Hooks.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: ../../lib/Config/Populator.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -145,11 +145,6 @@ parameters:
 			path: ../../lib/Config/Env.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: ../../lib/Config/Hooks.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: ../../lib/Config/Populator.php

--- a/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
+++ b/mailpoet/tests/DataFactories/StatisticsWooCommercePurchases.php
@@ -28,6 +28,7 @@ class StatisticsWooCommercePurchases {
       'order_id' => $order['id'],
       'order_currency' => $order['currency'],
       'order_price_total' => $order['total'],
+      'order_status' => $order['status'] ?? 'completed',
     ];
     $this->subscriber = $click->getSubscriber();
     $this->click = $click;
@@ -50,7 +51,8 @@ class StatisticsWooCommercePurchases {
       $this->click,
       $this->data['order_id'],
       $this->data['order_currency'],
-      (float)$this->data['order_price_total']
+      (float)$this->data['order_price_total'],
+      $this->data['order_status']
     );
     $entity->setSubscriber($this->subscriber);
     if (($this->data['createdAt'] ?? null) instanceof \DateTimeInterface) {

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -559,7 +559,7 @@ class WooCommercePastRevenues implements Generator {
     $queue = $this->entityManager->getReference(SendingQueueEntity::class, $clickData['queue_id']);
     $subscriber = $this->entityManager->getReference(SubscriberEntity::class, $subscriberId);
     $click = $this->entityManager->getReference(StatisticsClickEntity::class, $clickData['click_id']);
-    $statisticsClick = new StatisticsWooCommercePurchaseEntity($newsletter, $queue, $click, $order->get_id(), $order->get_currency(), floatval($order->get_total()));
+    $statisticsClick = new StatisticsWooCommercePurchaseEntity($newsletter, $queue, $click, $order->get_id(), $order->get_currency(), floatval($order->get_total()), $order->get_status());
     $statisticsClick->setSubscriber($subscriber);
     $statisticsClick->setCreatedAt(new Carbon($order->get_date_modified()));
     $this->entityManager->persist($statisticsClick);

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -431,7 +431,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     StatisticsClickEntity $click,
     SubscriberEntity $subscriber
   ): StatisticsWooCommercePurchaseEntity {
-    $statistics = new StatisticsWooCommercePurchaseEntity($newsletter, $queue, $click, 1, 'EUR', 100);
+    $statistics = new StatisticsWooCommercePurchaseEntity($newsletter, $queue, $click, 1, 'EUR', 100, 'completed');
     $statistics->setSubscriber($subscriber);
     $this->entityManager->persist($statistics);
     $this->entityManager->flush();

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Newsletter\Statistics;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
+use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterLink;
+use MailPoet\Test\DataFactories\StatisticsClicks;
+use MailPoet\Test\DataFactories\Subscriber;
+
+/**
+ * @group woo
+ */
+
+class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
+
+  /** @var NewsletterStatisticsRepository */
+  private $testee;
+
+  /** @var StatisticsWooCommercePurchasesRepository */
+  private $revenueRepository;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+
+  /** @var \MailPoet\Entities\SubscriberEntity */
+  private $subscriber;
+
+  /** @var StatisticsClickEntity */
+  private $click1;
+
+  /** @var StatisticsClickEntity */
+  private $click2;
+
+  public function _before() {
+    $this->testee = $this->diContainer->get(NewsletterStatisticsRepository::class);
+    $this->revenueRepository = $this->diContainer->get(StatisticsWooCommercePurchasesRepository::class);
+    $this->newsletter = (new Newsletter())->withSendingQueue()->create();
+    $this->assertInstanceOf(NewsletterEntity::class, $this->newsletter);
+    $this->subscriber = (new Subscriber())->create();
+
+    $link = (new NewsletterLink($this->newsletter))->create();
+    $this->click1 = (new StatisticsClicks($link, $this->subscriber))->create();
+    $link = (new NewsletterLink($this->newsletter))->create();
+    $this->click2 = (new StatisticsClicks($link, $this->subscriber))->create();
+  }
+
+  public function testItGetsOnlyStatisticsWithTheCorrectStatus() {
+    $queue = $this->newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $toBeFound = new StatisticsWooCommercePurchaseEntity(
+      $this->newsletter,
+      $queue,
+      $this->click1,
+      1,
+      'USD',
+      10,
+      'completed'
+    );
+    $toBeFound->setSubscriber($this->subscriber);
+    $this->revenueRepository->persist($toBeFound);
+
+    $queue = $this->newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $notToBeFound = new StatisticsWooCommercePurchaseEntity(
+      $this->newsletter,
+      $queue,
+      $this->click2,
+      1,
+      'USD',
+      20,
+      'non_completed'
+    );
+    $notToBeFound->setSubscriber($this->subscriber);
+    $this->revenueRepository->persist($notToBeFound);
+    $this->revenueRepository->flush();
+
+    $revenue = $this->testee->getWooCommerceRevenue($this->newsletter);
+    $this->assertInstanceOf(WooCommerceRevenue::class, $revenue);
+    $this->assertEquals(1, $revenue->getOrdersCount());
+    $this->assertEquals(10, $revenue->getValue());
+  }
+}

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -158,7 +158,7 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     expect($click->getId())->equals($click->getId());
     expect($purchaseStats[0]->getOrderId())->equals($orderMock->get_id());
     expect($purchaseStats[0]->getOrderCurrency())->equals($orderMock->get_currency());
-    expect($purchaseStats[0]->getOrderPriceTotal())->equals($orderMock->get_total());
+    expect($purchaseStats[0]->getOrderPriceTotal())->equals($orderMock->get_remaining_refund_amount());
   }
 
   public function testItTracksPaymentForMultipleNewsletters() {
@@ -544,13 +544,13 @@ class WooCommercePurchasesTest extends \MailPoetTest {
       ->disableOriginalConstructor()
       ->disableOriginalClone()
       ->disableArgumentCloning()
-      ->setMethods(['get_id', 'get_date_created', 'get_billing_email', 'get_total', 'get_currency', 'get_status'])
+      ->setMethods(['get_id', 'get_date_created', 'get_billing_email', 'get_remaining_refund_amount', 'get_currency', 'get_status'])
       ->getMock();
 
     $mock->method('get_id')->willReturn($id);
     $mock->method('get_date_created')->willReturn($dateCreated ?? new DateTime());
     $mock->method('get_billing_email')->willReturn($email);
-    $mock->method('get_total')->willReturn((string)$totalPrice);
+    $mock->method('get_remaining_refund_amount')->willReturn((string)$totalPrice);
     $mock->method('get_currency')->willReturn('EUR');
     $mock->method('get_status')->willReturn($status);
     return $mock;

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -483,17 +483,18 @@ class WooCommercePurchasesTest extends \MailPoetTest {
   private function createWooCommerceHelperMock(MockObject $orderMock) {
     $mock = $this->createMock(WooCommerceHelper::class);
     $mock->method('wcGetOrder')->willReturn($orderMock);
+    $mock->method('getPurchaseStates')->willReturn(['completed']);
     return $mock;
   }
 
-  private function createOrderMock($email, $totalPrice = 15.0, $id = 123, $dateCreated = null) {
+  private function createOrderMock($email, $totalPrice = 15.0, $id = 123, $dateCreated = null, $status = 'completed') {
     // WC_Order class needs to be mocked without default 'disallowMockingUnknownTypes'
     // since WooCommerce may not be active (would result in error mocking undefined class)
     $mock = $this->getMockBuilder(WC_Order::class)
       ->disableOriginalConstructor()
       ->disableOriginalClone()
       ->disableArgumentCloning()
-      ->setMethods(['get_id', 'get_date_created', 'get_billing_email', 'get_total', 'get_currency'])
+      ->setMethods(['get_id', 'get_date_created', 'get_billing_email', 'get_total', 'get_currency', 'get_status'])
       ->getMock();
 
     $mock->method('get_id')->willReturn($id);
@@ -501,6 +502,7 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     $mock->method('get_billing_email')->willReturn($email);
     $mock->method('get_total')->willReturn((string)$totalPrice);
     $mock->method('get_currency')->willReturn('EUR');
+    $mock->method('get_status')->willReturn($status);
     return $mock;
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -54,6 +54,26 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     $this->cookies = new Cookies();
   }
 
+  public function testItTracksOrderStatusChanges() {
+
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email($this->subscriber->getEmail());
+    $order->set_total('10');
+    $order->set_status('processing');
+    $order->save();
+
+    $statistic = $this->statisticsWooCommercePurchasesRepository->findOneBy(['orderId' => $order->get_id()]);
+    $this->assertInstanceOf(StatisticsWooCommercePurchaseEntity::class, $statistic);
+    $this->assertEquals("processing", $statistic->getStatus());
+
+    $order->set_status('completed');
+    $order->save();
+    $this->assertEquals("completed", $statistic->getStatus());
+  }
+
   public function testItDoesNotTrackPaymentForWrongSubscriber() {
     $click = $this->createClick($this->link, $this->subscriber, 3);
 

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -54,6 +54,36 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     $this->cookies = new Cookies();
   }
 
+  public function testItTracksOrderRefunds() {
+
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email($this->subscriber->getEmail());
+    $order->set_total('10');
+    $order->set_status('completed');
+    $order->save();
+
+    $statistic = $this->statisticsWooCommercePurchasesRepository->findOneBy(['orderId' => $order->get_id()]);
+    $this->assertInstanceOf(StatisticsWooCommercePurchaseEntity::class, $statistic);
+    $this->assertEquals("completed", $statistic->getStatus());
+    $this->assertEquals(10, $statistic->getOrderPriceTotal());
+
+    wc_create_refund([
+      'order_id' => $order->get_id(),
+      'amount' => 2.5,
+    ]);
+    $this->assertEquals("completed", $statistic->getStatus());
+    $this->assertEquals(7.5, $statistic->getOrderPriceTotal());
+    wc_create_refund([
+      'order_id' => $order->get_id(),
+      'amount' => 7.5,
+    ]);
+    $this->assertEquals("refunded", $statistic->getStatus());
+    $this->assertEquals(0, $statistic->getOrderPriceTotal());
+  }
+
   public function testItTracksOrderStatusChanges() {
 
     $click = $this->createClick($this->link, $this->subscriber);


### PR DESCRIPTION
## Description

_N/A_

## Code review notes
Instead of hooking into special status changes, this PR suggest to hook into every status change. It extends the purchase entity and adds a `status` field. As soon as an order is created a purchase entity is created with the according status. When the status gets updated, the purchase entity gets updated as well.

We count as revenue only `completed`. So instead of storing just `completed` revenues, we filter the output for returning only `completed` purchase entities and counting them as "revenue". While this creates more data we store, it also opens up possibilities like tracking how many orders `failed` are `on-hold` etc. which might be interesting metrics as well.

## QA notes

We touched the revenue tracking code. Please verify order revenue is tracked and displayed in newsletter stats as expected. 
1) Create a newsletter and send it to a list
2) Make sure to click on links from a couple of received emails
3) Make a couple of orders and use emails from subscribers who clicked the links
4) Check the newsletter stats and observe that revenue was added
5) Try refunding an order and see change in stats

NOTE: For testing you will need premium from the branch same name (https://github.com/mailpoet/mailpoet-premium/pull/777)

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/777

## Linked tickets

[MAILPOET-5485]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5485]: https://mailpoet.atlassian.net/browse/MAILPOET-5485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ