### PR TITLE
Update sender name in wizard [MAILPOET-5550]

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -51,7 +51,7 @@ class WelcomeWizard {
       $this->settings->set(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME, 1);
     }
 
-    $settings = $this->settings->getAll();
+
     $premiumKeyValid = $this->servicesChecker->isPremiumKeyValid(false);
     // force MSS key check even if the method isn't active
     $mpApiKeyValid = $this->servicesChecker->isMailPoetAPIKeyValid(false, true);
@@ -61,10 +61,21 @@ class WelcomeWizard {
       'admin_email' => $this->wp->getOption('admin_email'),
       'current_wp_user' => $this->wp->wpGetCurrentUser()->to_array(),
       'show_customers_import' => $this->wooCommerceHelper->getCustomersCount() > 0,
-      'settings' => $settings,
+      'settings' => $this->getSettings(),
       'premium_key_valid' => !empty($premiumKeyValid),
       'mss_key_valid' => !empty($mpApiKeyValid),
     ];
     $this->pageRenderer->displayPage('welcome_wizard.html', $data);
+  }
+
+  private function getSettings(): array {
+    $settings = $this->settings->getAll();
+
+    $user = $this->wp->wpGetCurrentUser();
+    $settings['sender'] = [
+      'name' => $user->display_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      'address' => $user->user_email, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    ];
+    return $settings;
   }
 }


### PR DESCRIPTION
## Description
This PR populates the senders name and address field in the wizard dynamically and does not fall back to the already stored values in the settings.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5550]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5550]: https://mailpoet.atlassian.net/browse/MAILPOET-5550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ