### PR TITLE
Don't use fork-ts-checker-webpack-plugin in CI [MAILPOET-5554]

### DIFF
--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -9,6 +9,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const globalPrefix = 'MailPoetLib';
 const PRODUCTION_ENV = process.env.NODE_ENV === 'production';
+const CI_ENV = ['true', 1].includes((process.env.CI ?? '').toLowerCase());
 const manifestSeed = {};
 
 const stats = {
@@ -107,7 +108,7 @@ const baseConfig = {
       ),
     },
   },
-  plugins: PRODUCTION_ENV ? [] : [new ForkTsCheckerWebpackPlugin()],
+  plugins: PRODUCTION_ENV || CI_ENV ? [] : [new ForkTsCheckerWebpackPlugin()],
   module: {
     noParse: /node_modules\/lodash\/lodash\.js/,
     rules: [
@@ -454,7 +455,10 @@ const emailEditor = Object.assign({}, wpScriptConfig, {
     ...wpScriptConfig.resolve,
     modules: ['node_modules', 'assets/js/src'],
   },
-  plugins: [...wpScriptConfig.plugins, ...[new ForkTsCheckerWebpackPlugin()]],
+  plugins: [
+    ...wpScriptConfig.plugins,
+    ...(PRODUCTION_ENV || CI_ENV ? [] : [new ForkTsCheckerWebpackPlugin()]),
+  ],
 });
 
 const configs = [


### PR DESCRIPTION
## Description

This fixes [out-of-memory issues in the premium plugin](https://app.circleci.com/pipelines/github/mailpoet/mailpoet-premium/2657/workflows/2f982123-143d-4b70-8bfe-07ec854e0aab/jobs/19043) build.

## Code review notes

No QA needed.

## QA notes

No QA needed.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
