### PR TITLE
Add new acceptance test scenario covering MailPoet form in Gutenberg block

### DIFF
--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use Codeception\Util\Locator;
 use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
@@ -120,8 +119,13 @@ class GutenbergFormBlockCest {
     $i->amEditingPostWithId($postId);
     $i->waitForText('My Gutenberg form');
     $i->pressKey('body', WebDriverKeys::ESCAPE);
-    $i->fillField(Locator::find('p', ['aria-label' => 'Empty block']), '/MailPoet Subscription Form');
-    $i->selectOption('.mailpoet-block-create-forms-list', 'My form');
+    $i->click('.block-editor-inserter');
+    $i->fillField('.components-search-control__input', 'MailPoet Subscription Form');
+    $i->click('.editor-block-list-item-mailpoet-subscription-form-block');
+    $i->selectOption('.mailpoet-block-create-forms-list', 'Acceptance Test Block Form');
+    $i->waitForElementVisible('[data-automation-id="form_email"]');
+    $i->waitForElementVisible('[data-automation-id="form_first_name"]');
+    $i->waitForElementVisible('[data-automation-id="form_last_name"]');
     $i->click('Update');
     $i->waitForText('Page updated.');
 

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -119,7 +119,7 @@ class GutenbergFormBlockCest {
     $i->amEditingPostWithId($postId);
     $i->waitForText('My Gutenberg form');
     $i->pressKey('body', WebDriverKeys::ESCAPE);
-    $i->type('.block-editor-rich-text__editable', '/MailPoet Subscription Form');
+    $i->fillField('.block-editor-rich-text__editable', '/MailPoet Subscription Form');
     $i->selectOption('.mailpoet-block-create-forms-list', 'My form');
     $i->click('Update');
     $i->waitForText('Page updated.');

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
@@ -104,7 +105,7 @@ class GutenbergFormBlockCest {
     $i->seeNoJSErrors();
   }
 
-  public function subscriptionGutenbergBlockCSS(\AcceptanceTester $i): void {
+  public function subscriptionGutenbergBlockAddingManually(\AcceptanceTester $i): void {
     $formFactory = new Form();
     $formId = (int)$formFactory
       ->withName('Acceptance Test Block Form')
@@ -113,10 +114,11 @@ class GutenbergFormBlockCest {
       ->create()->getId();
     $postId = $this->createEmptyPost($i);
 
-    $i->wantTo('Add Gutenberg form block to the post');
+    $i->wantTo('Add Gutenberg form block to the post manually');
     $i->login();
     $i->amEditingPostWithId($postId);
     $i->waitForText('My Gutenberg form');
+    $i->pressKey('body', WebDriverKeys::ESCAPE);
     $i->type('.block-editor-rich-text__editable', '/MailPoet Subscription Form');
     $i->selectOption('.mailpoet-block-create-forms-list', 'My form');
     $i->click('Update');

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Codeception\Util\Locator;
 use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
@@ -119,7 +120,7 @@ class GutenbergFormBlockCest {
     $i->amEditingPostWithId($postId);
     $i->waitForText('My Gutenberg form');
     $i->pressKey('body', WebDriverKeys::ESCAPE);
-    $i->fillField('.block-editor-rich-text__editable', '/MailPoet Subscription Form');
+    $i->fillField(Locator::find('p', ['aria-label' => 'Empty block']), '/MailPoet Subscription Form');
     $i->selectOption('.mailpoet-block-create-forms-list', 'My form');
     $i->click('Update');
     $i->waitForText('Page updated.');

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -104,6 +104,31 @@ class GutenbergFormBlockCest {
     $i->seeNoJSErrors();
   }
 
+  public function subscriptionGutenbergBlockCSS(\AcceptanceTester $i): void {
+    $formFactory = new Form();
+    $formId = (int)$formFactory
+      ->withName('Acceptance Test Block Form')
+      ->withLastName()
+      ->withFirstName()
+      ->create()->getId();
+    $postId = $this->createEmptyPost($i);
+
+    $i->wantTo('Add Gutenberg form block to the post');
+    $i->login();
+    $i->amEditingPostWithId($postId);
+    $i->waitForText('My Gutenberg form');
+    $i->type('.block-editor-rich-text__editable', '/MailPoet Subscription Form');
+    $i->selectOption('.mailpoet-block-create-forms-list', 'My form');
+    $i->click('Update');
+    $i->waitForText('Page updated.');
+
+    $i->wantTo('Verify the added form on the front-end');
+    $i->amOnPage("/?p={$postId}");
+    $i->waitForElementVisible('[data-automation-id="form_email"]');
+    $i->waitForElementVisible('[data-automation-id="form_first_name"]');
+    $i->waitForElementVisible('[data-automation-id="form_last_name"]');
+  }
+
   private function createPost(\AcceptanceTester $i, int $formId): int {
     return $i->havePostInDatabase([
       'post_author' => 1,
@@ -113,6 +138,17 @@ class GutenbergFormBlockCest {
       'post_content' => '
         <!-- wp:mailpoet/subscription-form-block {"formId":' . $formId . '} /-->
       ',
+      'post_status' => 'publish',
+    ]);
+  }
+
+  private function createEmptyPost(\AcceptanceTester $i): int {
+    return $i->havePostInDatabase([
+      'post_author' => 1,
+      'post_type' => 'page',
+      'post_name' => 'gutenberg-form-test',
+      'post_title' => 'My Gutenberg form',
+      'post_content' => '',
       'post_status' => 'publish',
     ]);
   }


### PR DESCRIPTION
## Description

Added new test scenario since there was existing test case covering most of the case but not the very important one of manually adding Gutenberg block and verifying things with MailPoet form. Now we will have also this important scenario automated.

## Code review notes

Since this was a test inside page editor with Gutenberg, I had to use their own selectors.

Sorry for a bunch of commits, I had issue with local env and played blind party with the test. After fixing local env I made proper last commit which is passing CI tests.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-2687]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-2687]: https://mailpoet.atlassian.net/browse/MAILPOET-2687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ