### PR TITLE
Reset subscribers without resubscribing [MAILPOET-5555]

### DIFF
--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -478,7 +478,7 @@ class SubscriberEntity {
   public function getSubscriberSegments(?string $status = null) {
     if (!is_null($status)) {
       $criteria = Criteria::create()
-        ->where(Criteria::expr()->eq('status', SubscriberEntity::STATUS_SUBSCRIBED));
+        ->where(Criteria::expr()->eq('status', $status));
       $subscriberSegments = $this->subscriberSegments->matching($criteria);
     } else {
       $subscriberSegments = $this->subscriberSegments;

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -81,6 +81,7 @@ class SubscriberSegmentRepository extends Repository {
   }
 
   public function resetSubscriptions(SubscriberEntity $subscriber, array $segments): void {
+    // Already existing subscriptions are stored in $existingSegments. Their IDs in $existingSegmentIds.
     $existingSegments = array_values(array_filter(array_map(
       function(SubscriberSegmentEntity $subscriberSegmentEntity): ?SegmentEntity {
         return $subscriberSegmentEntity->getSegment();
@@ -93,23 +94,33 @@ class SubscriberSegmentRepository extends Repository {
       },
       $existingSegments
     );
+
+    // $segmentIds are the IDs of the segments we want the user to be subscribed to.
     $segmentIds = array_map(
       function(SegmentEntity $segment): int {
         return $segment->getId() ?? 0;
       },
       $segments
     );
+
+    // $unsubscribedSegments are the segment IDs to which we need to unsubscribe.
     $unsubscribedSegments = array_diff($existingSegmentIds, $segmentIds);
+
+    // $newlySubscribedSegments are the segment IDs to which we need to newly subscribe.
     $newlySubscribedSegments = array_diff($segmentIds, $existingSegmentIds);
     if (!$newlySubscribedSegments && !$unsubscribedSegments) {
       return;
     }
+
+    // The segments we need to unsubscribe.
     $unsubscribe = array_filter(
       $existingSegments,
       function(SegmentEntity $segment) use ($unsubscribedSegments): bool {
         return in_array($segment->getId(), $unsubscribedSegments);
       }
     );
+
+    // The segments we need to newly subscribe.
     $subscribe = array_filter(
       $segments,
       function(SegmentEntity $segment) use ($newlySubscribedSegments): bool {

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -82,27 +82,40 @@ class SubscriberSegmentRepository extends Repository {
 
   public function resetSubscriptions(SubscriberEntity $subscriber, array $segments): void {
     $existingSegments = array_values(array_filter(array_map(
-      function(SubscriberSegmentEntity $subscriberSegmentEntity): ?SegmentEntity { return $subscriberSegmentEntity->getSegment(); 
+      function(SubscriberSegmentEntity $subscriberSegmentEntity): ?SegmentEntity {
+        return $subscriberSegmentEntity->getSegment();
       },
       $this->findBy(['subscriber' => $subscriber, 'status' => SubscriberEntity::STATUS_SUBSCRIBED])
     )));
-    $existingSegmentIds = array_map(function(SegmentEntity $segment): int { return $segment->getId() ?? 0;
-
-    }, $existingSegments);
-    $segmentIds = array_map(function(SegmentEntity $segment): int { return $segment->getId() ?? 0;
-
-    }, $segments);
+    $existingSegmentIds = array_map(
+      function(SegmentEntity $segment): int {
+        return $segment->getId() ?? 0;
+      },
+      $existingSegments
+    );
+    $segmentIds = array_map(
+      function(SegmentEntity $segment): int {
+        return $segment->getId() ?? 0;
+      },
+      $segments
+    );
     $unsubscribedSegments = array_diff($existingSegmentIds, $segmentIds);
     $newlySubscribedSegments = array_diff($segmentIds, $existingSegmentIds);
     if (!$newlySubscribedSegments && !$unsubscribedSegments) {
       return;
     }
-    $unsubscribe = array_filter($existingSegments, function(SegmentEntity $segment) use ($unsubscribedSegments): bool {
-      return in_array($segment->getId(), $unsubscribedSegments);
-    });
-    $subscribe = array_filter($segments, function(SegmentEntity $segment) use ($newlySubscribedSegments): bool {
-      return in_array($segment->getId(), $newlySubscribedSegments);
-    });
+    $unsubscribe = array_filter(
+      $existingSegments,
+      function(SegmentEntity $segment) use ($unsubscribedSegments): bool {
+        return in_array($segment->getId(), $unsubscribedSegments);
+      }
+    );
+    $subscribe = array_filter(
+      $segments,
+      function(SegmentEntity $segment) use ($newlySubscribedSegments): bool {
+        return in_array($segment->getId(), $newlySubscribedSegments);
+      }
+    );
     if ($unsubscribe) {
       $this->unsubscribeFromSegments($subscriber, $unsubscribe);
     }

--- a/mailpoet/tests/acceptance/Automation/SomeoneSubscribesAutomationTriggeredBySubscriberEditCest.php
+++ b/mailpoet/tests/acceptance/Automation/SomeoneSubscribesAutomationTriggeredBySubscriberEditCest.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+use MailPoet\Test\DataFactories\Settings;
+
+class SomeoneSubscribesAutomationTriggeredBySubscriberEditCest {
+
+  /** @var Settings */
+  private $settingsFactory;
+
+  /** @var ContainerWrapper */
+  private $container;
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  /** @var AutomationRunLogStorage */
+  private $automationRunLogStorage;
+
+  public function _before(\AcceptanceTester $i) {
+    $this->container = ContainerWrapper::getInstance();
+    $this->settingsFactory = new Settings();
+    $this->settingsFactory->withCronTriggerMethod('Action Scheduler');
+    $this->automationStorage = $this->container->get(AutomationStorage::class);
+    $this->automationRunStorage = $this->container->get(AutomationRunStorage::class);
+    $this->automationRunLogStorage = $this->container->get(AutomationRunLogStorage::class);
+  }
+
+  public function automationTriggeredByCheckout(\AcceptanceTester $i) {
+    $i->wantTo("Activate a trigger by editing a subscriber.");
+
+    $this->settingsFactory->withConfirmationEmailDisabled(); // Just so we do not have to check our mailbox first.
+
+    $someoneSubscribesTrigger = $this->container->get(SomeoneSubscribesTrigger::class);
+    (new AutomationFactory())
+      ->withName('test')
+      ->addStep(new Step('t', Step::TYPE_TRIGGER, $someoneSubscribesTrigger->getKey(), ['segment_ids' => []], []))
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+
+    $i->login();
+
+    $i->amOnMailpoetPage('subscribers');
+    $i->click('[data-automation-id="add-new-subscribers-button"]');
+
+    $subscriberEmail = 'someone@mailpoet.com';
+    $i->fillField(['name' => 'email'], $subscriberEmail);
+    $i->selectOption('[data-automation-id="subscriber-status"]', 'Subscribed');
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->see('Entered 0'); //The visible text is 0 Entered, but in the DOM it's the other way around.
+    $i->dontSee('Entered 1');
+
+    $this->amOnTheSubscriberEditPageFor($i, $subscriberEmail);
+    $i->selectOptionInSelect2('Newsletter mailing list');
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->see('Entered 1');
+    $i->dontSee('Entered 0');
+
+    // Check that a second save action does not start the automation again.
+    $this->amOnTheSubscriberEditPageFor($i, $subscriberEmail);
+    $i->click('Save');
+
+    $i->amOnMailpoetPage('automation');
+    $i->waitForText('Entered');
+    $i->see('Entered 1');
+    $i->dontSee('Entered 2');
+  }
+
+  private function amOnTheSubscriberEditPageFor(\AcceptanceTester $i, string $email) {
+    $i->amOnMailPoetPage ('Subscribers');
+    $i->waitForText($email);
+    $i->click($email);
+    $i->waitForElement('input[value="' . $email . '"]');
+  }
+
+  public function _after() {
+    $this->automationStorage->truncate();
+    $this->automationRunStorage->truncate();
+    $this->automationRunLogStorage->truncate();
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/SubscriberSegmentRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSegmentRepositoryTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class SubscriberSegmentRepositoryTest extends \MailPoetTest {
+
+  /** @var SubscriberSegmentRepository */
+  private $testee;
+
+  public function _before() {
+    $this->testee = $this->diContainer->get(SubscriberSegmentRepository::class);
+  }
+
+  public function testResetIsWorking() {
+    $subscriber = (new Subscriber())->create();
+    $segment1 = (new Segment())->create();
+    $segment2 = (new Segment())->create();
+    $segment3 = (new Segment())->create();
+    $segment4 = (new Segment())->create();
+
+    $this->testee->resetSubscriptions($subscriber, [$segment1, $segment2, $segment3, $segment4]);
+    $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
+    $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $subscribedSegmentIds = array_map(
+      function(SubscriberSegmentEntity $entity): ?int {
+        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
+      },
+      $subscribedSegments->toArray()
+    );
+
+    $this->assertEquals(0, $unsubscribedSegments->count());
+    $this->assertCount(4, $subscribedSegmentIds);
+    $this->assertContains($segment1->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment2->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment3->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment4->getId(), $subscribedSegmentIds);
+
+    $this->testee->resetSubscriptions($subscriber, [$segment2, $segment3, $segment4]);
+    $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
+    $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $subscribedSegmentIds = array_map(
+      function(SubscriberSegmentEntity $entity): ?int {
+        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
+      },
+      $subscribedSegments->toArray()
+    );
+
+    $this->assertEquals(1, $unsubscribedSegments->count());
+    $this->assertCount(3, $subscribedSegmentIds);
+    $this->assertNotContains($segment1->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment2->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment3->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment4->getId(), $subscribedSegmentIds);
+
+    $this->testee->resetSubscriptions($subscriber, [$segment1, $segment2, $segment3, $segment4]);
+    $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
+    $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $subscribedSegmentIds = array_map(
+      function(SubscriberSegmentEntity $entity): ?int {
+        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
+      },
+      $subscribedSegments->toArray()
+    );
+    $this->assertEquals(0, $unsubscribedSegments->count());
+    $this->assertCount(4, $subscribedSegmentIds);
+    $this->assertContains($segment1->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment2->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment3->getId(), $subscribedSegmentIds);
+    $this->assertContains($segment4->getId(), $subscribedSegmentIds);
+
+    $this->testee->resetSubscriptions($subscriber, []);
+    $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
+    $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->assertEquals(4, $unsubscribedSegments->count());
+    $this->assertEquals(0, $subscribedSegments->count());
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/SubscriberSegmentRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSegmentRepositoryTest.php
@@ -26,12 +26,7 @@ class SubscriberSegmentRepositoryTest extends \MailPoetTest {
     $this->testee->resetSubscriptions($subscriber, [$segment1, $segment2, $segment3, $segment4]);
     $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
     $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
-    $subscribedSegmentIds = array_map(
-      function(SubscriberSegmentEntity $entity): ?int {
-        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
-      },
-      $subscribedSegments->toArray()
-    );
+    $subscribedSegmentIds = $this->getSubscribedSegmentIds($subscribedSegments->toArray());
 
     $this->assertEquals(0, $unsubscribedSegments->count());
     $this->assertCount(4, $subscribedSegmentIds);
@@ -43,12 +38,7 @@ class SubscriberSegmentRepositoryTest extends \MailPoetTest {
     $this->testee->resetSubscriptions($subscriber, [$segment2, $segment3, $segment4]);
     $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
     $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
-    $subscribedSegmentIds = array_map(
-      function(SubscriberSegmentEntity $entity): ?int {
-        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
-      },
-      $subscribedSegments->toArray()
-    );
+    $subscribedSegmentIds = $this->getSubscribedSegmentIds($subscribedSegments->toArray());
 
     $this->assertEquals(1, $unsubscribedSegments->count());
     $this->assertCount(3, $subscribedSegmentIds);
@@ -60,12 +50,8 @@ class SubscriberSegmentRepositoryTest extends \MailPoetTest {
     $this->testee->resetSubscriptions($subscriber, [$segment1, $segment2, $segment3, $segment4]);
     $subscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_SUBSCRIBED);
     $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
-    $subscribedSegmentIds = array_map(
-      function(SubscriberSegmentEntity $entity): ?int {
-        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
-      },
-      $subscribedSegments->toArray()
-    );
+    $subscribedSegmentIds = $this->getSubscribedSegmentIds($subscribedSegments->toArray());
+
     $this->assertEquals(0, $unsubscribedSegments->count());
     $this->assertCount(4, $subscribedSegmentIds);
     $this->assertContains($segment1->getId(), $subscribedSegmentIds);
@@ -78,5 +64,18 @@ class SubscriberSegmentRepositoryTest extends \MailPoetTest {
     $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->assertEquals(4, $unsubscribedSegments->count());
     $this->assertEquals(0, $subscribedSegments->count());
+  }
+
+  /**
+   * @param SubscriberSegmentEntity[] $subscribedSegments
+   * @return int[]
+   */
+  private function getSubscribedSegmentIds(array $subscribedSegments): array {
+    return array_values(array_filter(array_map(
+      function(SubscriberSegmentEntity $entity): ?int {
+        return $entity->getSegment() ? $entity->getSegment()->getId() : null;
+      },
+      $subscribedSegments
+    )));
   }
 }


### PR DESCRIPTION
## Description
When you edit a subscriber and click save, we would resubscribe the subscriber to all selected lists and thus the subscriber would re-enter "Someone subscribed"-Automations. This PR stops actively resubscribing subscribers.

## Code review notes

In my tests I used `SubscriberEntity::getSubscriberSegments` to get the segments. This method accepted a status parameter, but did not use it's value. I think this was a bug, which I fixed in 8c2ce511faef2bc14b1e9a538090ce55c22644c9

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5555]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5555]: https://mailpoet.atlassian.net/browse/MAILPOET-5555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ