### PR TITLE
Run database migrations earlier to avoid issues [MAILPOET-5564]

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -250,7 +250,7 @@ class Initializer {
 
     $this->wpFunctions->addAction(
       'init',
-      [$this, 'maybeDbUpdate'],
+      [$this, 'maybeRunActivator'],
       PHP_INT_MIN
     );
 
@@ -378,7 +378,14 @@ class Initializer {
     $this->changelog->redirectToLandingPage();
   }
 
-  public function maybeDbUpdate() {
+  /**
+   * Checks if the plugin was updated and runs the activator if needed. The activator
+   * will run the database migrations and update the db version among a few other things.
+   *
+   * @return void
+   * @throws InvalidStateException
+   */
+  public function maybeRunActivator() {
     try {
       $currentDbVersion = $this->settings->get('db_version');
     } catch (\Exception $e) {

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -248,6 +248,12 @@ class Initializer {
       'initialize',
     ]);
 
+    $this->wpFunctions->addAction(
+      'init',
+      [$this, 'maybeDbUpdate'],
+      PHP_INT_MIN
+    );
+
     $this->wpFunctions->addAction('admin_init', [
       $this,
       'setupPrivacyPolicy',
@@ -315,7 +321,6 @@ class Initializer {
   public function initialize() {
     try {
       $this->migratorCli->initialize();
-      $this->maybeDbUpdate();
       $this->setupInstaller();
       $this->setupUpdater();
 


### PR DESCRIPTION
## Description

Before this PR, maybeDbUpdate() was called inside Initializer::initialize(). This method is called using the WP `init` hook with a priority of `10`. To avoid running into situations where MailPoet code is executed before database changes are applied, we need to run maybeDbUpdate() as early as possible. To achieve this, this PR moves maybeDbUpdate() to its own action, still using the `init` hook but with a priority of PHP_MIN_INT.

For more information on the potential problems of running the database changes too late, check this example: pcNwfB-2V6-p2.

Note that this PR also renames maybeDbUpdate() to maybeRunActivator() to better reflect what the method does.

CircleCI is failing due to an unrelated problem: https://mailpoet.atlassian.net/browse/MAILPOET-5565

## Code review notes

I'm a bit unsure about the use of `PHP_MIN_INT` to set the priority. I went with it as we are already using in some cases.

## QA notes

To test this PR, ensure that the migration system is still working. One way to do that is to install and activate an older version of MailPoet and then update to the zip generated in this PR. Then, you can check that the migrations were executed and the database changes successfully applied. For example, if starting with MailPoet <= `4.25.0`, check that the column `wp_post_id` was added to `wp_mailpoet_newsletters` (https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Migrations/Db/Migration_20230716_130221_Db.php).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5564]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5564]: https://mailpoet.atlassian.net/browse/MAILPOET-5564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ