### PR TITLE
Pin semgrep to version 1.37 [MAILPOET-5565]

### DIFF
--- a/mailpoet/tools/semgrep.sh
+++ b/mailpoet/tools/semgrep.sh
@@ -12,4 +12,4 @@ if [ ! -d $scriptdirectory/$rulesdirectory ]
 fi
 
 # Run Semgrep
-docker run --rm -v "${scriptdirectory}:/src" returntocorp/semgrep semgrep --error --text --metrics=off -c "/src/${rulesdirectory}/audit" $@
+docker run --rm -v "${scriptdirectory}:/src" returntocorp/semgrep:1.37.0 semgrep --error --text --metrics=off -c "/src/${rulesdirectory}/audit" $@


### PR DESCRIPTION
## Description

Our CircleCI builds started failing with the following error:

```
semgrep scan: unknown option '--text', did you mean '--test'?
```

Example: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/15393/workflows/50ca3a93-7867-4f17-91b8-9201ba16867f/jobs/261166?invite=true#step-105-1196_61

It seems the option `--text` doesn't exist anymore on semgrep 1.38. I opened an issue asking if this was an intentional change or something that they need to fix: https://github.com/returntocorp/semgrep/issues/8610

While we wait for a reply, I'm creating this commit pinning semgrep to version 1.37 so that our builds continue working.

## Code review notes

_N/A_

## QA notes

We can probably skip QA

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5565]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5565]: https://mailpoet.atlassian.net/browse/MAILPOET-5565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ