### PR TITLE
Add stopping propagation for DocsBot to avoid conflict on WP.com [MAILPOET-5566]

### DIFF
--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -209,7 +209,13 @@
         event.preventDefault(); // Prevent default behavior opening the url.
         window.open(mailpoet_redirect_support_link, '_blank');
       },
-    });
+    }).then(() => {
+        // stopping propagation to avoid conflicts with other keydown events form WP.com
+      function writingFixer (e) {
+        e.stopPropagation();
+      }
+      document.getElementById('docsbotai-root').addEventListener("keydown", writingFixer);
+    })
   </script>
 <% endif %>
 


### PR DESCRIPTION
## Description

This PR fixes writing the letter _n_ in the Docsbot.ai widget.

## Code review notes

_N/A_

## QA notes

Please see the ticket's description of how to test this fix. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5566]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5566]: https://mailpoet.atlassian.net/browse/MAILPOET-5566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ