### PR TITLE
Unpin semgrep [MAILPOET-5565]

### DIFF
--- a/mailpoet/tools/semgrep.sh
+++ b/mailpoet/tools/semgrep.sh
@@ -12,4 +12,4 @@ if [ ! -d $scriptdirectory/$rulesdirectory ]
 fi
 
 # Run Semgrep
-docker run --rm -v "${scriptdirectory}:/src" returntocorp/semgrep:1.37.0 semgrep --error --text --metrics=off -c "/src/${rulesdirectory}/audit" $@
+docker run --rm -v "${scriptdirectory}:/src" returntocorp/semgrep semgrep --error --text --metrics=off -c "/src/${rulesdirectory}/audit" $@


### PR DESCRIPTION
## Description

In a previous PR (#5135), semgrep was pinned to version 1.37.0 while we waited for a fix to 1.38.0 that was breaking our CircleCI builds. Now that 1.38.2 was released with a fix to the problem that was affecting us, we don't need to pin it anymore.

## Code review notes

I wonder if we considered using a different install method for semgrep that would allow us to manage its version using NPM or Composer. This way we wouldn't face problems like broken CI builds because of a new version of semgrep. I don't know if such an option exists since semgrep is written in Python but I haven't checked (cc @alex-mailpoet @alex-mpoet in case you checked this when working on the implementation).

## QA notes

No QA needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5565]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5565]: https://mailpoet.atlassian.net/browse/MAILPOET-5565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ