### PR TITLE
Add new filter for hidding DocsBot widget [MAILPOET-5559]

### DIFF
--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -197,6 +197,7 @@ class PageRenderer {
         'name' => $tag->getName(),
         ];
       }, $this->tagRepository->findAll()),
+      'display_docsbot_widget' => $this->displayDocsBotWidget(),
     ];
 
     if (!$defaults['premium_plugin_active']) {
@@ -236,5 +237,10 @@ class PageRenderer {
       'priceFormat' => $this->wooCommerceHelper->getWoocommercePriceFormat(),
 
     ];
+  }
+
+  public function displayDocsBotWidget(): bool {
+    $display = $this->wp->applyFilters('mailpoet_display_docsbot_widget', $this->settings->get('3rd_party_libs.enabled') === '1');
+    return (bool)$display;
   }
 }

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -193,7 +193,7 @@
 
 <%= do_action('mailpoet_scripts_admin_before') %>
 
-<%if is_loading_3rd_party_enabled() and not is_dotcom_ecommerce_plan() %>
+<% if display_docsbot_widget and not is_dotcom_ecommerce_plan() %>
   <%= javascript('lib/analytics.js') %>
   <script type="text/javascript">window.DocsBotAI=window.DocsBotAI||{},DocsBotAI.init=function(c){return new Promise(function(e,o){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://widget.docsbot.ai/chat.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n),t.addEventListener("load",function(){window.DocsBotAI.mount({id:c.id,supportCallback:c.supportCallback,identify:c.identify,options:c.options});var t;t=function(n){return new Promise(function(e){if(document.querySelector(n))return e(document.querySelector(n));var o=new MutationObserver(function(t){document.querySelector(n)&&(e(document.querySelector(n)),o.disconnect())});o.observe(document.body,{childList:!0,subtree:!0})})},t&&t("#docsbotai-root").then(e).catch(o)}),t.addEventListener("error",function(t){o(t.message)})})};</script>
   <script type="text/javascript">


### PR DESCRIPTION
## Description

We want to add a possibility to hide the changed widget for help.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5559]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5559]: https://mailpoet.atlassian.net/browse/MAILPOET-5559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ