### PR TITLE
Remove JS compilation from JS newsletter tests [MAILPOET-5571]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -252,11 +252,7 @@ class RoboFile extends \Robo\Tasks {
       );
     }
 
-    return $this->collectionBuilder()
-      ->addCode(function () {
-        $this->compileJs();
-      })
-      ->taskExec($command)
+    return $this->taskExec($command)
       ->run();
   }
 

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -298,8 +298,6 @@ const testConfig = {
     filename: '[name].js',
   },
   plugins: [
-    ...baseConfig.plugins,
-
     // replace MailPoet definition with a smaller version for public
     new webpack.NormalModuleReplacementPlugin(
       /mailpoet\.js/,


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

JS is compiled in the build job, so this step seems redundant.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
