### PR TITLE
New options for mailpoet_archive shortcode [MAILPOET-5574]

### DIFF
--- a/mailpoet/assets/js/src/common/button/copy_to_clipboard_button.tsx
+++ b/mailpoet/assets/js/src/common/button/copy_to_clipboard_button.tsx
@@ -1,0 +1,54 @@
+import { __ } from '@wordpress/i18n';
+import React, { useState } from 'react';
+import { Icon, copy, check, warning } from '@wordpress/icons';
+import { Button } from './button';
+import { copyToClipboard } from '../../utils';
+
+const defaultButtonText = __('Copy to clipboard', 'mailpoet');
+const defaultIcon = <Icon icon={copy} />;
+
+type Props = {
+  targetId: string;
+  alwaysSelectText?: boolean;
+} & React.ComponentProps<typeof Button>;
+
+export function CopyToClipboardButton({
+  targetId,
+  alwaysSelectText = false,
+  ...restProps
+}: Props) {
+  const [isDisabled, setIsDisabled] = useState(false);
+  const [buttonText, setButtonText] = useState(defaultButtonText);
+  const [iconStart, setIconStart] = useState(defaultIcon);
+
+  const handleCopy = (wasSuccessful: boolean) => {
+    if (wasSuccessful) {
+      setIsDisabled(true);
+      setButtonText(__('Copied to clipboard', 'mailpoet'));
+      setIconStart(<Icon icon={check} />);
+
+      setTimeout(() => {
+        setIsDisabled(false);
+        setButtonText(defaultButtonText);
+        setIconStart(defaultIcon);
+      }, 3000);
+    } else {
+      setIsDisabled(true);
+      setButtonText(__('Could not copy to clipboard', 'mailpoet'));
+      setIconStart(<Icon icon={warning} />);
+    }
+  };
+
+  return (
+    <Button
+      {...restProps}
+      isDisabled={isDisabled}
+      iconStart={iconStart}
+      onClick={async () => {
+        await copyToClipboard(targetId, handleCopy, alwaysSelectText);
+      }}
+    >
+      {buttonText}
+    </Button>
+  );
+}

--- a/mailpoet/assets/js/src/help/system_info.tsx
+++ b/mailpoet/assets/js/src/help/system_info.tsx
@@ -3,6 +3,7 @@ import { MailPoet } from 'mailpoet';
 import _ from 'underscore';
 import { Notice } from '../notices/notice';
 import { Button } from '../common';
+import { copyToClipboard } from '../utils';
 
 function handleFocus(event) {
   event.target.select();
@@ -28,32 +29,6 @@ function printData(data: Record<string, string> | undefined, id: string) {
     );
   }
   return <p>{MailPoet.I18n.t('systemInfoDataError')}</p>;
-}
-
-async function copyToClipboard(
-  id: string,
-  resultCallback: (success: boolean) => void,
-) {
-  const element: HTMLTextAreaElement | null = document.querySelector(`#${id}`);
-  if (!element) {
-    resultCallback(false);
-    return;
-  }
-  if (navigator.clipboard) {
-    const text = element.value;
-    await navigator.clipboard.writeText(text);
-    resultCallback(true);
-    return;
-  }
-
-  // Fallback if navigator.clipboard does not work.
-  element.focus();
-  element.select();
-  if (document.execCommand('copy')) {
-    resultCallback(true);
-    return;
-  }
-  resultCallback(false);
 }
 
 export function SystemInfo() {

--- a/mailpoet/assets/js/src/help/system_info.tsx
+++ b/mailpoet/assets/js/src/help/system_info.tsx
@@ -1,9 +1,6 @@
-import { useState } from 'react';
 import { MailPoet } from 'mailpoet';
 import _ from 'underscore';
-import { Notice } from '../notices/notice';
-import { Button } from '../common';
-import { copyToClipboard } from '../utils';
+import { CopyToClipboardButton } from 'common/button/copy_to_clipboard_button';
 
 function handleFocus(event) {
   event.target.select();
@@ -32,7 +29,6 @@ function printData(data: Record<string, string> | undefined, id: string) {
 }
 
 export function SystemInfo() {
-  const [copySuccess, setCopySuccess] = useState(null);
   const id = 'mailpoet-system-info';
 
   const systemInfoData = window.systemInfoData;
@@ -43,24 +39,7 @@ export function SystemInfo() {
       </div>
 
       {printData(systemInfoData, id)}
-      <Button
-        variant="secondary"
-        onClick={() => {
-          void copyToClipboard(id, setCopySuccess);
-        }}
-      >
-        {MailPoet.I18n.t('copyToClipboard')}
-      </Button>
-      {copySuccess === true && (
-        <Notice type="info">
-          <p>{MailPoet.I18n.t('copyToClipboardSuccess')}</p>
-        </Notice>
-      )}
-      {copySuccess === false && (
-        <Notice type="warning">
-          <p>{MailPoet.I18n.t('copyToClipboardFailure')}</p>
-        </Notice>
-      )}
+      <CopyToClipboardButton variant="secondary" targetId={id} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { t } from 'common/functions';
 import { Input } from 'common/form/input/input';
 import { Label, Inputs, SegmentsSelect } from 'settings/components';
+import { Datepicker } from 'common/datepicker/datepicker';
+import { MailPoet } from 'mailpoet';
+import { __ } from '@wordpress/i18n';
 
 type Props = {
   name: 'mailpoet_archive' | 'mailpoet_subscribers_count';
@@ -11,9 +14,39 @@ type Props = {
 
 export function Shortcode({ name, title, description }: Props) {
   const [segments, setSegments] = useState([]);
-  const shortcode = `[${name}${
-    segments.length ? ` segments="${segments.join(',')}"` : ''
-  }]`;
+  const [lastNDays, setLastNDays] = useState<string>('');
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [subjectContains, setSubjectContains] = useState<string>('');
+
+  let shortcode = `[${name}`;
+
+  if (segments.length) {
+    shortcode += ` segments="${segments.join(',')}"`;
+  }
+
+  if (startDate) {
+    shortcode += ` start_date="${MailPoet.Date.format(startDate, {
+      format: 'Y-m-d',
+    })}"`;
+  }
+
+  if (endDate) {
+    shortcode += ` end_date="${MailPoet.Date.format(endDate, {
+      format: 'Y-m-d',
+    })}"`;
+  }
+
+  if (lastNDays && parseInt(lastNDays, 10) > 0) {
+    shortcode += ` in_the_last_days="${lastNDays}"`;
+  }
+
+  if (subjectContains && subjectContains.length > 0) {
+    shortcode += ` subject_contains="${subjectContains}"`;
+  }
+
+  shortcode += ']';
+
   const selectText = (event) => {
     event.target.focus();
     event.target.select();
@@ -42,6 +75,73 @@ export function Shortcode({ name, title, description }: Props) {
           placeholder={t('leaveEmptyToDisplayAll')}
           segmentsSelector="getSegments"
         />
+        {name === 'mailpoet_archive' && (
+          <>
+            <br />
+            <Input
+              type="number"
+              min="1"
+              max="365000"
+              dimension="small"
+              placeholder={__('In the last days', 'mailpoet')}
+              onChange={(event) => {
+                const inputValue = event.target.value.trim();
+
+                if (inputValue === '') {
+                  setLastNDays('');
+                  return;
+                }
+
+                const newValue = Number(inputValue);
+
+                if (Number.isInteger(newValue) && newValue > 0) {
+                  setStartDate(null);
+                  setEndDate(null);
+                  setLastNDays(inputValue);
+                }
+              }}
+              value={lastNDays}
+            />
+            <br />
+            <Datepicker
+              dimension="small"
+              dateFormat="MMMM d, yyyy"
+              onChange={(value): void => {
+                setStartDate(value);
+                if (value !== null) {
+                  setLastNDays('');
+                }
+              }}
+              selected={startDate}
+              maxDate={endDate}
+              placeholderText={__('Start date', 'mailpoet')}
+              isClearable
+            />
+            <Datepicker
+              dimension="small"
+              dateFormat="MMMM d, yyyy"
+              onChange={(value): void => {
+                setEndDate(value);
+                if (value !== null) {
+                  setLastNDays('');
+                }
+              }}
+              selected={endDate}
+              minDate={startDate}
+              placeholderText={__('End date', 'mailpoet')}
+              isClearable
+            />
+            <br />
+            <Input
+              dimension="small"
+              type="text"
+              value={subjectContains}
+              onChange={(event) => setSubjectContains(event.target.value)}
+              placeholder={__('Subject lines containing', 'mailpoet')}
+            />
+            <br />
+          </>
+        )}
       </Inputs>
     </>
   );

--- a/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
@@ -18,6 +18,7 @@ export function Shortcode({ name, title, description }: Props) {
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [subjectContains, setSubjectContains] = useState<string>('');
+  const [limit, setLimit] = useState<string>('');
 
   let shortcode = `[${name}`;
 
@@ -43,6 +44,10 @@ export function Shortcode({ name, title, description }: Props) {
 
   if (subjectContains && subjectContains.length > 0) {
     shortcode += ` subject_contains="${subjectContains}"`;
+  }
+
+  if (limit && parseInt(limit, 10) > 0) {
+    shortcode += ` limit="${limit}"`;
   }
 
   shortcode += ']';
@@ -140,6 +145,28 @@ export function Shortcode({ name, title, description }: Props) {
               placeholder={__('Subject lines containing', 'mailpoet')}
             />
             <br />
+            <Input
+              type="number"
+              min="1"
+              max="1000"
+              dimension="small"
+              placeholder={__('Maximum number to display', 'mailpoet')}
+              onChange={(event) => {
+                const inputValue = event.target.value.trim();
+
+                if (inputValue === '') {
+                  setLimit('');
+                  return;
+                }
+
+                const newValue = Number(inputValue);
+
+                if (Number.isInteger(newValue) && newValue > 0) {
+                  setLimit(inputValue);
+                }
+              }}
+              value={limit}
+            />
           </>
         )}
       </Inputs>

--- a/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
@@ -5,6 +5,7 @@ import { Label, Inputs, SegmentsSelect } from 'settings/components';
 import { Datepicker } from 'common/datepicker/datepicker';
 import { MailPoet } from 'mailpoet';
 import { __ } from '@wordpress/i18n';
+import { CopyToClipboardButton } from 'common/button/copy_to_clipboard_button';
 
 type Props = {
   name: 'mailpoet_archive' | 'mailpoet_subscribers_count';
@@ -71,6 +72,11 @@ export function Shortcode({ name, title, description }: Props) {
           value={shortcode}
           onClick={selectText}
           id={`${name}-shortcode`}
+        />
+        <CopyToClipboardButton
+          variant="secondary"
+          targetId={`${name}-shortcode`}
+          alwaysSelectText
         />
         <br />
         <SegmentsSelect

--- a/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
@@ -94,6 +94,10 @@ export function Shortcode({ name, title, description }: Props) {
               min="1"
               max="365000"
               dimension="small"
+              tooltip={__(
+                'Include newsletters sent no more than this many days ago. This overrides start and end dates.',
+                'mailpoet',
+              )}
               placeholder={__('In the last days', 'mailpoet')}
               onChange={(event) => {
                 const inputValue = event.target.value.trim();

--- a/mailpoet/assets/js/src/utils.tsx
+++ b/mailpoet/assets/js/src/utils.tsx
@@ -1,3 +1,34 @@
 export function isInEnum<T>(value: unknown, enumObj: T): value is T[keyof T] {
   return Object.values(enumObj).includes(value as T[keyof T]);
 }
+
+export async function copyToClipboard(
+  id: string,
+  resultCallback: (success: boolean) => void,
+  alwaysSelectText = false,
+) {
+  const element: HTMLTextAreaElement | null = document.querySelector(`#${id}`);
+  if (!element) {
+    resultCallback(false);
+    return;
+  }
+  if (alwaysSelectText) {
+    element.focus();
+    element.select();
+  }
+  if (navigator.clipboard) {
+    const text = element.value;
+    await navigator.clipboard.writeText(text);
+    resultCallback(true);
+    return;
+  }
+
+  // Fallback if navigator.clipboard does not work.
+  element.focus();
+  element.select();
+  if (document.execCommand('copy')) {
+    resultCallback(true);
+    return;
+  }
+  resultCallback(false);
+}

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -18,6 +18,7 @@ use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Pages;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
 
 class Shortcodes {
   /** @var Pages */
@@ -140,17 +141,11 @@ class Shortcodes {
     }
   }
 
-  public function getArchive($params) {
-    $segmentIds = [];
-    if (!empty($params['segments'])) {
-      $segmentIds = array_map(function($segmentId) {
-        return (int)trim($segmentId);
-      }, explode(',', $params['segments']));
-    }
-
+  public function getArchive($params = '') {
     $html = '';
 
-    $newsletters = $this->newslettersRepository->getArchives($segmentIds);
+    $parsedParams = $this->getParsedArchiveParams($params);
+    $newsletters = $this->newslettersRepository->getArchives($parsedParams);
 
     $subscriber = $this->subscribersRepository->getCurrentWPUser();
 
@@ -180,6 +175,42 @@ class Shortcodes {
       $html .= '</ul>';
     }
     return $html;
+  }
+
+  public function getParsedArchiveParams($params): array {
+    $parsedParams = [
+      'startDate' => null,
+      'endDate' => null,
+      'segmentIds' => [],
+    ];
+
+    if (!is_array($params)) {
+      return $parsedParams;
+    }
+
+    if (!empty($params['segments'])) {
+      $parsedParams['segmentIds'] = array_map(function($segmentId) {
+        return (int)trim($segmentId);
+      }, explode(',', $params['segments']));
+    }
+
+    if ($params['start_date'] ?? null) {
+      try {
+        $parsedParams['startDate'] = new Carbon($params['start_date']);
+      } catch (\Throwable $throwable) {
+        // Don't error out if invalid date
+      }
+    }
+
+    if ($params['end_date'] ?? null) {
+      try {
+        $parsedParams['endDate'] = new Carbon($params['end_date']);
+      } catch (\Throwable $throwable) {
+        // Don't error out if invalid date
+      }
+    }
+
+    return $parsedParams;
   }
 
   public function renderArchiveDate(NewsletterEntity $newsletter) {

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -183,6 +183,7 @@ class Shortcodes {
       'endDate' => null,
       'segmentIds' => [],
       'subjectContains' => '',
+      'limit' => null,
     ];
 
     if (!is_array($params)) {
@@ -219,6 +220,11 @@ class Shortcodes {
 
     if ($params['subject_contains'] ?? null) {
       $parsedParams['subjectContains'] = trim($params['subject_contains']);
+    }
+
+    $limit = $params['limit'] ?? null;
+    if ($limit && intval($limit) > 0) {
+      $parsedParams['limit'] = intval($limit);
     }
 
     return $parsedParams;

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -182,6 +182,7 @@ class Shortcodes {
       'startDate' => null,
       'endDate' => null,
       'segmentIds' => [],
+      'subjectContains' => '',
     ];
 
     if (!is_array($params)) {
@@ -208,6 +209,10 @@ class Shortcodes {
       } catch (\Throwable $throwable) {
         // Don't error out if invalid date
       }
+    }
+
+    if ($params['subject_contains'] ?? null) {
+      $parsedParams['subjectContains'] = $params['subject_contains'];
     }
 
     return $parsedParams;

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -197,7 +197,7 @@ class Shortcodes {
 
     if ($params['start_date'] ?? null) {
       try {
-        $parsedParams['startDate'] = new Carbon($params['start_date']);
+        $parsedParams['startDate'] = new Carbon(trim($params['start_date']));
       } catch (\Throwable $throwable) {
         // Don't error out if invalid date
       }
@@ -205,14 +205,20 @@ class Shortcodes {
 
     if ($params['end_date'] ?? null) {
       try {
-        $parsedParams['endDate'] = new Carbon($params['end_date']);
+        $parsedParams['endDate'] = new Carbon(trim($params['end_date']));
       } catch (\Throwable $throwable) {
         // Don't error out if invalid date
       }
     }
 
+    $lastDays = $params['in_the_last_days'] ?? null;
+    if ($lastDays && intval(($lastDays) > 0)) {
+      $parsedParams['endDate'] = null;
+      $parsedParams['startDate'] = Carbon::now()->subDays(intval($lastDays))->startOfDay();
+    }
+
     if ($params['subject_contains'] ?? null) {
-      $parsedParams['subjectContains'] = $params['subject_contains'];
+      $parsedParams['subjectContains'] = trim($params['subject_contains']);
     }
 
     return $parsedParams;

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -18,7 +18,7 @@ use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Pages;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Carbon\CarbonImmutable;
 
 class Shortcodes {
   /** @var Pages */
@@ -198,7 +198,7 @@ class Shortcodes {
 
     if ($params['start_date'] ?? null) {
       try {
-        $parsedParams['startDate'] = new Carbon(trim($params['start_date']));
+        $parsedParams['startDate'] = new CarbonImmutable(trim($params['start_date']));
       } catch (\Throwable $throwable) {
         // Don't error out if invalid date
       }
@@ -206,7 +206,7 @@ class Shortcodes {
 
     if ($params['end_date'] ?? null) {
       try {
-        $parsedParams['endDate'] = new Carbon(trim($params['end_date']));
+        $parsedParams['endDate'] = new CarbonImmutable(trim($params['end_date']));
       } catch (\Throwable $throwable) {
         // Don't error out if invalid date
       }
@@ -215,7 +215,7 @@ class Shortcodes {
     $lastDays = $params['in_the_last_days'] ?? null;
     if ($lastDays && intval(($lastDays) > 0)) {
       $parsedParams['endDate'] = null;
-      $parsedParams['startDate'] = Carbon::now()->subDays(intval($lastDays))->startOfDay();
+      $parsedParams['startDate'] = CarbonImmutable::now()->subDays(intval($lastDays))->startOfDay();
     }
 
     if ($params['subject_contains'] ?? null) {

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -271,6 +271,11 @@ class NewslettersRepository extends Repository {
         ->setParameter('subjectContains', '%' . Helpers::escapeSearch($subjectContains) . '%');
     }
 
+    $limit = $params['limit'] ?? null;
+    if (is_int($limit) && $limit > 0) {
+      $queryBuilder->setMaxResults($limit);
+    }
+
     return $queryBuilder->getQuery()->getResult();
   }
 

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -251,14 +251,14 @@ class NewslettersRepository extends Repository {
     }
 
     $startDate = $params['startDate'] ?? null;
-    if ($startDate instanceof Carbon) {
+    if ($startDate instanceof DateTimeInterface) {
       $queryBuilder
         ->andWhere('st.processedAt >= :startDate')
         ->setParameter('startDate', $startDate);
     }
 
     $endDate = $params['endDate'] ?? null;
-    if ($endDate instanceof Carbon) {
+    if ($endDate instanceof DateTimeInterface) {
       $queryBuilder
         ->andWhere('st.processedAt <= :endDate')
         ->setParameter('endDate', $endDate);

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -23,6 +23,7 @@ use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Entities\StatsNotificationEntity;
 use MailPoet\Logging\LoggerFactory;
+use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Connection;
@@ -261,6 +262,13 @@ class NewslettersRepository extends Repository {
       $queryBuilder
         ->andWhere('st.processedAt <= :endDate')
         ->setParameter('endDate', $endDate);
+    }
+
+    $subjectContains = $params['subjectContains'] ?? null;
+    if (is_string($subjectContains)) {
+      $queryBuilder
+        ->andWhere($queryBuilder->expr()->like('n.subject', ':subjectContains'))
+        ->setParameter('subjectContains', '%' . Helpers::escapeSearch($subjectContains) . '%');
     }
 
     return $queryBuilder->getQuery()->getResult();

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -416,6 +416,9 @@ class Newsletter {
       if ($queue['updated_at']) {
         $sendingQueue->setUpdatedAt($queue['updated_at']);
       }
+      if ($queue['processed_at'] ?? null) {
+        $scheduledTask->setProcessedAt($queue['processed_at']);
+      }
       $entityManager->persist($sendingQueue);
       $sendingQueue->setNewsletter($newsletter);
       $scheduledTask->setStatus($queue['status']);

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -195,6 +195,39 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result)->stringContainsString('Newsletter 2');
   }
 
+  public function testArchiveSupportsLimit() {
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => Carbon::now()->subDays(4)])
+      ->withSentStatus()
+      ->withSubject('Newsletter 1')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => Carbon::now()->subDays(5)])
+      ->withSentStatus()
+      ->withSubject('Newsletter 2')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => Carbon::now()->subDays(7)])
+      ->withSentStatus()
+      ->withSubject('Newsletter 3')
+      ->create();
+
+    $result = do_shortcode('[mailpoet_archive limit="3"]');
+    expect($result)->stringContainsString('Newsletter 1');
+    expect($result)->stringContainsString('Newsletter 2');
+    expect($result)->stringContainsString('Newsletter 3');
+
+    $result = do_shortcode('[mailpoet_archive limit="2"]');
+    expect($result)->stringContainsString('Newsletter 1');
+    expect($result)->stringContainsString('Newsletter 2');
+    expect($result)->stringNotContainsString('Newsletter 3');
+
+    $result = do_shortcode('[mailpoet_archive limit="1"]');
+    expect($result)->stringContainsString('Newsletter 1');
+    expect($result)->stringNotContainsString('Newsletter 2');
+    expect($result)->stringNotContainsString('Newsletter 3');
+  }
+
   public function testItRendersShortcodeDefaultsInSubject() {
     $newsletterFactory = new NewsletterFactory();
     $this->newsletter = $newsletterFactory

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -135,6 +135,29 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result)->stringNotContainsString('Newsletter 3');
   }
 
+  public function testArchiveAcceptsSubjectSearch(): void {
+    (new NewsletterFactory())
+      ->withSendingQueue()
+      ->withSentStatus()
+      ->withSubject('Great subject')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue()
+      ->withSentStatus()
+      ->withSubject('Subject that is great')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue()
+      ->withSentStatus()
+      ->withSubject('Good subject')
+      ->create();
+
+    $result = do_shortcode('[mailpoet_archive subject_contains="great"]');
+    expect($result)->stringContainsString('Great subject');
+    expect($result)->stringContainsString('Subject that is great');
+    expect($result)->stringNotContainsString('Good subject');
+  }
+
   public function testArchiveAcceptsSegments(): void {
     $segment1 = (new Segment())->create();
     $segment2 = (new Segment())->create();

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -158,6 +158,22 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result)->stringNotContainsString('Good subject');
   }
 
+  public function testArchiveAcceptsLastNDays(): void {
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => Carbon::now()->subDays(4)])
+      ->withSentStatus()
+      ->withSubject('Newsletter 1')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => Carbon::now()->subDays(5)])
+      ->withSentStatus()
+      ->withSubject('Newsletter 2')
+      ->create();
+    $result = do_shortcode('[mailpoet_archive in_the_last_days="4"]');
+    expect($result)->stringContainsString('Newsletter 1');
+    expect($result)->stringNotContainsString('Newsletter 2');
+  }
+
   public function testArchiveAcceptsSegments(): void {
     $segment1 = (new Segment())->create();
     $segment2 = (new Segment())->create();

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -256,7 +256,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     expect($this->repository->findAll())->count(2);
 
     // return archives in a given segment
-    $results = $this->repository->getArchives([$segment->getId()]);
+    $results = $this->repository->getArchives(['segmentIds' => [$segment->getId()]]);
 
     expect($results)->count(1);
     expect($results[0]->getId())->equals($newsletters[1]->getId());


### PR DESCRIPTION
## Description

This PR adds a few new options to the `mailpoet_archive` shortcode:

- `start_date`: the earliest sent time
- `end_date`: the latest sent time
- `in_the_last_days`: include newsletters sent in the last N days
- `subject_contains`: only include newsletters that contain this text somewhere in their subject line
- `limit`: sets the maximum number

It's not possible to use start/end date together with the `in_the_last_days` option. If both options are present, `in_the_last_days` will take precedence.

Providing invalid input should cause the new options to simply not apply instead of throwing an error.

The shortcode generator on the settings page (`Settings > Basics > Archive page shortcode`) has been updated to make it easy to construct a shortcode with all the available options. I really wanted to have a copy to clipboard button for the shortcode generators so I created a reusable copy to clipboard button. If that's too much for this PR I can remove those commits.

## Code review notes

Please let me know if you can think of better names for these properties or better placeholders/descriptions for the inputs in the generator.

## QA notes

The shortcode generator will create dates in the format YYYY-MM-DD for start_date and end_date, but that isn't a required format. Any date string that PHP understands should also work in this shortcode, e.g. it shouldn't matter if you have `end_date="2023-09-07"` or `end_date="September 7th, 2023"`.

## Linked PRs

_N/A_

## Linked tickets
https://mailpoet.atlassian.net/browse/MAILPOET-5574

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
