### PR TITLE
Make sure flex columns in form editor occupy the whole width of the row [MAILPOET-3883]

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -257,6 +257,7 @@ div.mailpoet_form:not(.mailpoet_form_fixed_bar) {
 .mailpoet_form_column {
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
 
   // Alignment
   &.mailpoet_vertically_align_top {


### PR DESCRIPTION
## Description

Added `flex-grow` property, otherwise the flexbox children only take the space of their inside content and not the whole available space of the row.

## Code review notes

_N/A_

## QA notes

1. Make a simple popup form with email and first name in two columns:
<img width="568" alt="Screenshot 2023-09-11 at 14 17 03" src="https://github.com/mailpoet/mailpoet/assets/470616/cb2e41e4-6e24-4fef-8652-184abfa9421e">

In the preview, before this change the inputs wouldn't cover the full width:
<img width="601" alt="Screenshot 2023-09-11 at 14 18 03" src="https://github.com/mailpoet/mailpoet/assets/470616/e827329c-1b71-42a6-9eda-5a3fbdbf0014">

After this change, they do cover the full width of the row:
<img width="598" alt="Screenshot 2023-09-11 at 14 19 39" src="https://github.com/mailpoet/mailpoet/assets/470616/4c82c3a7-3273-4771-a1de-2a16840677fc">

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-3883]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-3883]: https://mailpoet.atlassian.net/browse/MAILPOET-3883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ