### PR TITLE
Fix excessive spacing in Email editor Styles panel [MAILPOET-5297]

### DIFF
--- a/mailpoet/assets/css/src/components-editor/components/_forms.scss
+++ b/mailpoet/assets/css/src/components-editor/components/_forms.scss
@@ -1,6 +1,6 @@
 .admin_page_mailpoet-newsletter-editor {
   .mailpoet_form_field {
-    margin: 19px 15px;
+    margin: 16px 0;
   }
 
   .mailpoet_form_field_title {


### PR DESCRIPTION
## Description

In [#6fdb124](https://github.com/mailpoet/mailpoet/commit/6fdb1247a75aa31d3f95e4944688835ef2596874), horizontal spacing was accidentally introduced, which caused components in the Email editor Styles section to render over two lines instead of just one.

I removed the horizontal spacing and slightly lowered the vertical one. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5297]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5297]: https://mailpoet.atlassian.net/browse/MAILPOET-5297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ