### PR TITLE
Add tracking when creating a new segment [MAILPOET-5400]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/store/actions.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/actions.ts
@@ -189,7 +189,18 @@ export function* createFromTemplate(
   };
 
   if (success) {
-    window.location.href = `admin.php?page=mailpoet-segments#${ROUTES.EDIT_DYNAMIC_SEGMENT}/${segment.id}`;
+    MailPoet.trackEvent(
+      'Segments > Template selected',
+      {
+        'Segment name': segmentTemplate.name,
+        'Segment slug': segmentTemplate.slug,
+        'Segment category': segmentTemplate.category,
+      },
+      { send_immediately: true },
+      () => {
+        window.location.href = `admin.php?page=mailpoet-segments#${ROUTES.EDIT_DYNAMIC_SEGMENT}/${segment.id}`;
+      },
+    );
   } else {
     yield setErrors(error as string[]);
   }

--- a/mailpoet/assets/js/src/segments/dynamic/templates/components/template_list_item.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/components/template_list_item.tsx
@@ -13,6 +13,7 @@ import { SegmentTemplate } from 'segments/types';
 import { getCategoryNameBySlug } from 'segments/dynamic/templates/templates';
 import { useDispatch } from '@wordpress/data';
 import { storeName } from 'segments/dynamic/store';
+import { MailPoet } from 'mailpoet';
 
 type TemplateListItemProps = {
   template: SegmentTemplate;
@@ -23,12 +24,21 @@ export function TemplateListItem({
 }: TemplateListItemProps): JSX.Element {
   const { createFromTemplate } = useDispatch(storeName);
 
+  const handleSelectingTemplate = (event): void => {
+    event.preventDefault();
+    createFromTemplate(template);
+    MailPoet.trackEvent('Segments > Template selected', {
+      'Segment name': template.name,
+      'Segment slug': template.slug,
+      'Segment category': template.category,
+    });
+  };
+
   return (
     <Card
       className="mailpoet-templates-card"
-      onClick={(e): void => {
-        e.preventDefault();
-        createFromTemplate(template);
+      onClick={(event): void => {
+        handleSelectingTemplate(event);
       }}
     >
       <CardHeader className="mailpoet-templates-card-header">

--- a/mailpoet/assets/js/src/segments/dynamic/templates/components/template_list_item.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/components/template_list_item.tsx
@@ -13,7 +13,6 @@ import { SegmentTemplate } from 'segments/types';
 import { getCategoryNameBySlug } from 'segments/dynamic/templates/templates';
 import { useDispatch } from '@wordpress/data';
 import { storeName } from 'segments/dynamic/store';
-import { MailPoet } from 'mailpoet';
 
 type TemplateListItemProps = {
   template: SegmentTemplate;
@@ -27,11 +26,6 @@ export function TemplateListItem({
   const handleSelectingTemplate = (event): void => {
     event.preventDefault();
     createFromTemplate(template);
-    MailPoet.trackEvent('Segments > Template selected', {
-      'Segment name': template.name,
-      'Segment slug': template.slug,
-      'Segment category': template.category,
-    });
   };
 
   return (

--- a/mailpoet/assets/js/src/segments/dynamic/templates/index.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/index.tsx
@@ -20,6 +20,7 @@ import * as ROUTES from 'segments/routes';
 import { useSelect } from '@wordpress/data';
 import { storeName } from 'segments/dynamic/store';
 import { APIErrorsNotice } from 'notices/api_errors_notice';
+import { MailPoet } from 'mailpoet';
 
 const tabs = [
   {
@@ -55,6 +56,10 @@ export function SegmentTemplates(): JSX.Element {
     [],
   );
 
+  const trackNewCustomSegment = (): void => {
+    MailPoet.trackEvent('Segments > New empty segment');
+  };
+
   return (
     <div className="mailpoet-templates-container">
       <HideScreenOptions />
@@ -85,6 +90,9 @@ export function SegmentTemplates(): JSX.Element {
             variant="secondary"
             href={`#${ROUTES.NEW_DYNAMIC_SEGMENT}`}
             data-automation-id="new-custom-segment"
+            onClick={(): void => {
+              trackNewCustomSegment();
+            }}
           >
             {__('Create custom segment', 'mailpoet')}
           </Button>
@@ -112,7 +120,13 @@ export function SegmentTemplates(): JSX.Element {
 
       <div className="mailpoet-templates-footer">
         <p>{__('Want to set your own conditions?', 'mailpoet')}</p>
-        <Button variant="link" href={`#${ROUTES.NEW_DYNAMIC_SEGMENT}`}>
+        <Button
+          variant="link"
+          href={`#${ROUTES.NEW_DYNAMIC_SEGMENT}`}
+          onClick={(): void => {
+            trackNewCustomSegment();
+          }}
+        >
           {__('Create custom segment', 'mailpoet')}
         </Button>
       </div>

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -9,6 +9,7 @@ import {
 export const templates: SegmentTemplate[] = [
   {
     name: __('Recently Subscribed', 'mailpoet'),
+    slug: 'recently-subscribed',
     category: SegmentTemplateCategories.ENGAGEMENT,
     description: __(
       'Contacts who have subscribed to your emails within the last 30 days.',
@@ -26,6 +27,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Engaged Subscribers (30 days)', 'mailpoet'),
+    slug: 'engaged-subscribers-30-days',
     category: SegmentTemplateCategories.ENGAGEMENT,
     description: __(
       'Contacts who have interacted with your emails or made at least one purchase, and received emails from you in the last 30 days.',
@@ -62,6 +64,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Engaged Subscribers (3 months)', 'mailpoet'),
+    slug: 'engaged-subscribers-3-months',
     category: SegmentTemplateCategories.ENGAGEMENT,
     description: __(
       'Contacts who have interacted with your emails or made at least one purchase, and received emails from you in the last 3 months.',
@@ -98,6 +101,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Engaged Subscribers (6 months)', 'mailpoet'),
+    slug: 'engaged-subscribers-6-months',
     category: SegmentTemplateCategories.ENGAGEMENT,
     description: __(
       'Contacts who have interacted with your emails or made at least one purchase, and received emails from you in the last 6 months.',
@@ -134,6 +138,7 @@ export const templates: SegmentTemplate[] = [
   },
   // {
   //   name: __('Unengaged Subscribers', 'mailpoet'),
+  //   slug: 'unengaged-subscribers',
   //   category: SegmentTemplateCategories.ENGAGEMENT,
   //   description: __(
   //     'Contacts who haven’t interacted with your emails, haven’t made a purchase, or haven’t visited your page in the last 6 months.',
@@ -143,6 +148,7 @@ export const templates: SegmentTemplate[] = [
   // },
   // {
   //   name: __('First-Time Buyers', 'mailpoet'),
+  //   slug: 'first-time-buyers',
   //   category: SegmentTemplateCategories.PURCHASE_HISTORY,
   //   description: __(
   //     'Customers who have made their first purchase in the last 30 days.',
@@ -152,6 +158,7 @@ export const templates: SegmentTemplate[] = [
   // },
   {
     name: __('Recent Buyers', 'mailpoet'),
+    slug: 'recent-buyers',
     category: SegmentTemplateCategories.PURCHASE_HISTORY,
     description: __(
       'Customers who have made a purchase within the last 30 days. ',
@@ -171,6 +178,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Repeat Buyers', 'mailpoet'),
+    slug: 'repeat-buyers',
     category: SegmentTemplateCategories.PURCHASE_HISTORY,
     description: __(
       'Customers who have made at least two purchases in the last 6 months.',
@@ -190,6 +198,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Loyal Buyers', 'mailpoet'),
+    slug: 'loyal-buyers',
     category: SegmentTemplateCategories.PURCHASE_HISTORY,
     description: __(
       'Customers who have made at least five purchases in the last 12 months.',
@@ -209,6 +218,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Win-Back', 'mailpoet'),
+    slug: 'win-back',
     category: SegmentTemplateCategories.PURCHASE_HISTORY,
     description: __(
       'Customers who have previously purchased, but haven’t made a purchase in the last 6 months.',
@@ -226,6 +236,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Lapsed Customers', 'mailpoet'),
+    slug: 'lapsed-customers',
     category: SegmentTemplateCategories.PURCHASE_HISTORY,
     description: __(
       'Customers who haven’t made a purchase in the last 9 months.',
@@ -243,6 +254,7 @@ export const templates: SegmentTemplate[] = [
   },
   // {
   //   name: __('Clickers', 'mailpoet'),
+  //   slug: 'clickers',
   //   category: SegmentTemplateCategories.ENGAGEMENT,
   //   description: __(
   //     'Contacts who regularly click on your emails in the last 90 days.',
@@ -252,6 +264,7 @@ export const templates: SegmentTemplate[] = [
   // },
   // {
   //   name: __('Non-Openers', 'mailpoet'),
+  //   slug: 'non-openers',
   //   category: SegmentTemplateCategories.ENGAGEMENT,
   //   description: __('Contacts who have received but haven’t opened an email in the last 90 days.', 'mailpoet'),
   //   isEssential: false,
@@ -268,6 +281,7 @@ export const templates: SegmentTemplate[] = [
   // },
   // {
   //   name: __('Recent Clickers', 'mailpoet'),
+  //   slug: 'recent-clickers',
   //   category: SegmentTemplateCategories.ENGAGEMENT,
   //   description: __(
   //     'Contacts who have clicked on an email in the last 7 days.',
@@ -277,6 +291,7 @@ export const templates: SegmentTemplate[] = [
   // },
   {
     name: __('Recent Openers', 'mailpoet'),
+    slug: 'recent-openers',
     category: SegmentTemplateCategories.ENGAGEMENT,
     description: __(
       'Contacts who have opened an email in the last 7 days.',
@@ -296,6 +311,7 @@ export const templates: SegmentTemplate[] = [
   },
   {
     name: __('Big Spenders', 'mailpoet'),
+    slug: 'big-spenders',
     category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
     description: __(
       'Customers who have completed $100 or more worth of orders in the last 12 months.',
@@ -315,6 +331,7 @@ export const templates: SegmentTemplate[] = [
   },
   // {
   //   name: __('Used a discount code', 'mailpoet'),
+  //   slug: 'used-a-discount-code',
   //   category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
   //   description: __(
   //     'Customers who made a purchase with a coupon code in the last 30 days.',
@@ -324,6 +341,7 @@ export const templates: SegmentTemplate[] = [
   // },
   // {
   //   name: __('Frequently uses discounts', 'mailpoet'),
+  //   slug: 'frequently-uses-discounts',
   //   category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
   //   description: __(
   //     'Customers who have regularly used coupons in the last 90 days.',

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -385,6 +385,7 @@ export enum SegmentTemplateCategories {
 
 export type SegmentTemplate = {
   name: string;
+  slug: string;
   description: string;
   category: SegmentTemplateCategories;
   isEssential: boolean;


### PR DESCRIPTION
## Description

This PR adds Mixpanel tracking when creating a new segment either from scratch or from a template.

## Code review notes

This branch was based on the branch of https://github.com/mailpoet/mailpoet/pull/5145. Only the three last commits belong to this PR. The rest of the commits belong to https://github.com/mailpoet/mailpoet/pull/5145. If you prefer, feel free to review this PR after the parent PR is merged.

## QA notes

I'm unsure if QA is needed for this PR. Maybe not, as the automated tests are likely enough.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5400]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5400]: https://mailpoet.atlassian.net/browse/MAILPOET-5400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ