### PR TITLE
Add sending recovery when sending is stucked [MAILPOET-4891]

### DIFF
--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -422,6 +422,7 @@ class Newsletter {
       $entityManager->persist($sendingQueue);
       $sendingQueue->setNewsletter($newsletter);
       $scheduledTask->setStatus($queue['status']);
+      $scheduledTask->setType(\MailPoet\Cron\Workers\SendingQueue\SendingQueue::TASK_TYPE);
       $sendingQueue->setCountProcessed($queue['count_processed']);
       $sendingQueue->setCountTotal($queue['count_total']);
       $sendingQueue->setNewsletterRenderedSubject($queue['subject'] ?? $this->data['subject']);

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -213,6 +213,11 @@ if [[ $CIRCLE_JOB == *"_with_premium_"* ]]; then
 fi
 
 # WP installs translations into the `lang` folder, and it should be writable, this change has been added in WP 6.2
+# make sure folders exist
+[[ -d wp-content/plugins/mailpoet/lang ]] || mkdir -p wp-content/plugins/mailpoet/lang
+[[ -d wp-content/plugins/mailpoet-premium/lang ]] || mkdir -p wp-content/plugins/mailpoet-premium/lang
+[[ -d wp-content/languages ]] || mkdir wp-content/languages
+[[ -d wp-content/upgrade ]] || mkdir wp-content/upgrade
 chmod -R 755 wp-content/plugins/mailpoet/lang
 chmod -R 755 wp-content/plugins/mailpoet-premium/lang
 chmod -R 755 wp-content/languages


### PR DESCRIPTION
## Description

This PR contains a recovery method for scheduled sending tasks in an invalid state. For example, when a newsletter was deleted but the scheduled task is already running.

## Code review notes

I followed the recommended solution from the Jira ticket.

## QA notes

**How to replicate the issue**
- Create a welcome email with scheduled sending  after 15 minutes
- Subscribe at least five new subscribers to a segment related to the welcome email
- Confirm your subscribers or deactivate double opt-in before subscribing
- Check that five welcome emails are scheduled
- Configure your sending method improperly - for example, SMTP
- Wait until all scheduled tasks for welcome emails are in state running - This is possible on the help page
- Deactivate the welcome email
- Fix your sending method
- Create and send a newsletter
- Observe the issue - your newsletter should not be never send 

After replication of this issue use the build containing the fix

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4891]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4891]: https://mailpoet.atlassian.net/browse/MAILPOET-4891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ