### PR TITLE
Check table exists before altering it

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
@@ -13,6 +13,12 @@ class Migration_20230825_093531_App extends AppMigration {
   public function run(): void {
 
     $wooCommerceHelper = $this->container->get(Helper::class);
+
+    // If Woo is not active and the table doesn't exist, we can skip this migration
+    if (!$wooCommerceHelper->isWooCommerceActive() && !$this->tableExists()) {
+      return;
+    }
+
     $wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled() ?
       $this->populateStatusColumnUsingHpos() : $this->populateStatusColumnUsingPost();
   }
@@ -35,5 +41,14 @@ class Migration_20230825_093531_App extends AppMigration {
 
   private function getTableName(): string {
     return $this->entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
+  }
+
+  private function tableExists(): bool {
+    global $wpdb;
+
+    $revenueTable = $this->getTableName();
+    $query = $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($revenueTable));
+
+    return $wpdb->get_var($query) === $revenueTable;
   }
 }

--- a/mailpoet/lib/Migrations/Db/Migration_20230824_054259_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20230824_054259_Db.php
@@ -22,7 +22,7 @@ class Migration_20230824_054259_Db extends DbMigration {
 
   private function createStatusColumn(): void {
     $revenueTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
-    if ($this->columnExists($revenueTable, 'status')) {
+    if (!$this->tableExists($revenueTable) || $this->columnExists($revenueTable, 'status')) {
       return;
     }
     $this->connection->executeQuery(

--- a/mailpoet/lib/Migrator/DbMigration.php
+++ b/mailpoet/lib/Migrator/DbMigration.php
@@ -50,6 +50,15 @@ abstract class DbMigration {
     ", [Env::$dbName, $tableName, $columnName])->fetchOne() !== false;
   }
 
+  protected function tableExists(string $tableName): bool {
+    return $this->connection->executeQuery("
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = COALESCE(DATABASE(), ?)
+        AND table_name = ?
+      ", [Env::$dbName, $tableName])->fetchOne() !== false;
+  }
+
   protected function indexExists(string $tableName, string $indexName): bool {
     // We had a problem with the dbName value in ENV for some customers, because it doesn't match DB name in information schema.
     // So we decided to use the DATABASE() value instead.


### PR DESCRIPTION
## Description

Table `mailpoet_statistics_woocommerce_purchases`  name is long and there are sites where it was never created because the prefix + name > 64.
This was not an issue on sites that were not using Woo but the latest migration alters the table and fails for those sites.

We will have another ticket to shorten the table name, in the meantime, this PR modifies the migrations so that it does not break those sites. 

If the table does not exist and they have Woo, the migration to populate the new column will still fail. This is on purpose because when Woo is active, that table and column need to be present.

## Code review notes

_N/A_

## QA notes

To test:
Check it still works:
With the correct table name, delete the column `status` if present
Set the latest too migrations to completed = NULL and error =NULL
Deactivate-reactivate the plugin and check there are no errors
Check status is created and populated if there was data on the table

Delete the table or truncate the name of `mailpoet_statistics_woocommerce_purchases` 
Deactivate Woo
Set the latest too migrations to completed = NULL and error =NULL
Deactivate-reactivate the plugin and check there are no errors

Reactivate Woo
Set the latest too migrations to completed = NULL and error =NULL
Deactivate-reactivate the plugin and check there are errros

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5590]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5590]: https://mailpoet.atlassian.net/browse/MAILPOET-5590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ