### PR TITLE
Refactor loading coupons to Ajax requests [MAILPOET-5123]

### DIFF
--- a/mailpoet/assets/js/src/common/form/react_select/react_select.tsx
+++ b/mailpoet/assets/js/src/common/form/react_select/react_select.tsx
@@ -1,6 +1,11 @@
+import { Spinner } from '@wordpress/components';
 import { CSSProperties, ReactNode } from 'react';
 import classnames from 'classnames';
-import Select, { OptionProps, Props as ReactSelectProps } from 'react-select';
+import Select, {
+  OptionProps,
+  Props as ReactSelectProps,
+  components,
+} from 'react-select';
 
 export type Props = ReactSelectProps & {
   dimension?: 'small';
@@ -8,6 +13,7 @@ export type Props = ReactSelectProps & {
   isFullWidth?: boolean;
   iconStart?: JSX.Element;
   automationId?: string;
+  isLoadingMore?: boolean;
 };
 
 type LabelRendererProps = {
@@ -97,11 +103,20 @@ function MultiValueLabel(props: MultiValueLabelProps) {
   );
 }
 
+function LoadingIndicator() {
+  return (
+    <div className="mailpoet-form-react-select__option mailpoet_centered">
+      <Spinner />
+    </div>
+  );
+}
+
 export function ReactSelect({
   dimension,
   isFullWidth,
   iconStart,
   automationId,
+  isLoadingMore,
   ...props
 }: Props) {
   return (
@@ -117,7 +132,17 @@ export function ReactSelect({
       <Select
         className="mailpoet-form-react-select"
         classNamePrefix="mailpoet-form-react-select"
-        components={{ Option, SingleValue, MultiValueLabel }}
+        components={{
+          Option,
+          SingleValue,
+          MultiValueLabel,
+          MenuList: (menuProps) => (
+            <components.MenuList {...menuProps}>
+              {menuProps.children}
+              {isLoadingMore && <LoadingIndicator />}
+            </components.MenuList>
+          ),
+        }}
         {...props}
       />
     </div>

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon.tsx
@@ -258,9 +258,6 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         availableDiscountTypes={App.getConfig()
           .get('coupon.discount_types')
           .toJSON()}
-        availableCoupons={App.getConfig()
-          .get('coupon.available_coupons')
-          .toJSON()}
         codePlaceholder={App.getConfig().get('coupon.code_placeholder')}
         priceDecimalSeparator={App.getConfig().get(
           'coupon.price_decimal_separator',

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/existingCoupons.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/existingCoupons.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { uniqBy } from 'lodash';
+import { uniqBy, debounce } from 'lodash';
 import { MailPoet } from '../../../mailpoet';
 import { GetValueCallback, SetValueCallback } from './types';
 
@@ -46,6 +46,10 @@ class ExistingCoupons extends Component<Props, State> {
 
   private readonly setValueCallback: SetValueCallback;
 
+  loadCouponsDebounced = debounce(() => {
+    this.loadCoupons();
+  }, 300);
+
   constructor(props: Props) {
     super(props);
     this.getValueCallback = props.getValueCallback;
@@ -72,6 +76,10 @@ class ExistingCoupons extends Component<Props, State> {
   componentDidMount() {
     this.loadCoupons();
   }
+
+  handleSearchInputChange = (couponSearch: string) => {
+    this.setState({ couponSearch }, () => this.loadCouponsDebounced());
+  };
 
   private fetchCoupons(resetCoupons: boolean) {
     const loadingKey = resetCoupons ? 'loadingInitial' : 'loadingMore';
@@ -158,9 +166,7 @@ class ExistingCoupons extends Component<Props, State> {
             <PanelRow>
               <SearchControl
                 value={this.state.couponSearch}
-                onChange={(couponSearch): void => {
-                  this.setState({ couponSearch }, () => this.loadCoupons());
-                }}
+                onChange={this.handleSearchInputChange}
               />
             </PanelRow>
             <PanelRow>

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/existingCoupons.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/existingCoupons.tsx
@@ -13,7 +13,7 @@ import { uniqBy } from 'lodash';
 import { MailPoet } from '../../../mailpoet';
 import { GetValueCallback, SetValueCallback } from './types';
 
-const COUPONS_PER_PAGE = 20;
+const COUPONS_PER_PAGE = 1000;
 
 export type Coupon = {
   id: number;
@@ -84,7 +84,7 @@ class ExistingCoupons extends Component<Props, State> {
         page_number: this.state.pageNumber,
         discount_type: this.state.couponFilterDiscountType,
         search: this.state.couponSearch,
-        include_coupon_id: this.state.couponId,
+        include_coupon_ids: [this.state.couponId],
       },
     })
       .then((response) => {

--- a/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/settings.tsx
+++ b/mailpoet/assets/js/src/newsletter_editor/blocks/coupon/settings.tsx
@@ -2,7 +2,7 @@ import { SelectControl } from '@wordpress/components';
 import { ErrorBoundary } from 'common';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { useState } from 'react';
-import { ExistingCoupons, Coupon } from './existingCoupons';
+import { ExistingCoupons } from './existingCoupons';
 import { General } from './general';
 import { SettingsHeader, SettingsTabs } from './settings_header';
 import { GetValueCallback, SetValueCallback } from './types';
@@ -11,7 +11,6 @@ import { UsageLimits } from './usage_limits';
 
 type Props = {
   availableDiscountTypes: SelectControl.Option[];
-  availableCoupons: Coupon[];
   getValueCallback: GetValueCallback;
   setValueCallback: SetValueCallback;
   priceDecimalSeparator: string;
@@ -20,7 +19,6 @@ type Props = {
 
 function Settings({
   availableDiscountTypes,
-  availableCoupons,
   getValueCallback,
   setValueCallback,
   priceDecimalSeparator,
@@ -39,19 +37,13 @@ function Settings({
             // reset code placeholder and restoring existing coupon code
             if (value === SettingsTabs.createNew) {
               setValueCallback('code', codePlaceholder);
-              setValueCallback('couponId', null);
+              setValueCallback('couponId', '');
               // Make visible the coupon overlay when creating a new coupon
               jQuery('.mailpoet_editor_coupon_overlay').css(
                 'visibility',
                 'visible',
               );
             } else if (value === SettingsTabs.allCoupons) {
-              const existingCoupon = availableCoupons.find(
-                (coupon) => coupon.id === getValueCallback('couponId'),
-              );
-              if (existingCoupon) {
-                setValueCallback('code', existingCoupon.text);
-              }
               // Hide the coupon overlay when a specific coupon is selected
               jQuery('.mailpoet_editor_coupon_overlay').css(
                 'visibility',
@@ -80,7 +72,6 @@ function Settings({
         ) : (
           <ExistingCoupons
             availableDiscountTypes={availableDiscountTypes}
-            availableCoupons={availableCoupons}
             getValueCallback={getValueCallback}
             setValueCallback={setValueCallback}
           />

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_coupon_code.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_coupon_code.tsx
@@ -185,6 +185,7 @@ export function UsedCouponCodeFields({
               key="select-coupon-codes"
               isFullWidth
               isMulti
+              isLoadingMore={additionalLoading}
               placeholder={MailPoet.I18n.t('selectWooCouponCodes')}
               options={coupons}
               value={filter((option) => {
@@ -202,7 +203,6 @@ export function UsedCouponCodeFields({
                   filterIndex,
                 );
               }}
-              isLoading={additionalLoading}
               automationId="select-shipping-methods"
               onMenuScrollToBottom={handleMenuScrollToBottom}
             />

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_coupon_code.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic_segments_filters/fields/woocommerce/used_coupon_code.tsx
@@ -5,7 +5,7 @@ import { Grid } from 'common/grid';
 import { Select } from 'common';
 import { ReactSelect } from 'common/form/react_select/react_select';
 import { MailPoet } from 'mailpoet';
-import { filter, uniqBy } from 'lodash/fp';
+import { filter, uniqBy, debounce } from 'lodash/fp';
 import { APIErrorsNotice } from '../../../../../notices/api_errors_notice';
 import {
   WooCommerceFormItem,
@@ -114,12 +114,8 @@ export function UsedCouponCodeFields({
     }
   };
 
-  /**
-   * Function for handling search input change that can filter coupons by search query when
-   * there is more coupons than one page.
-   * @param inputValue
-   */
-  const handleInputChange = (inputValue: string): void => {
+  // Define a debounced version of handleInputChange using lodash/fp
+  const debouncedHandleInputChange = debounce(300, (inputValue: string) => {
     const oldSearchQuery = searchQuery; // OldSearchQuery is used to prevent loading coupons when search query is deleted
     setSearchQuery(inputValue);
     if (
@@ -130,6 +126,15 @@ export function UsedCouponCodeFields({
       // Passing new values to loadCoupons to avoid using old values
       loadCoupons(false, 1, inputValue, hasMore);
     }
+  });
+
+  /**
+   * Function for handling search input change that can filter coupons by search query when
+   * there is more coupons than one page.
+   * @param inputValue
+   */
+  const handleInputChange = (inputValue: string): void => {
+    debouncedHandleInputChange(inputValue);
   };
 
   useEffect(() => {

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial_state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial_state.ts
@@ -44,6 +44,5 @@ export const getInitialState = (): StateType => ({
     window.mailpoet_can_use_woocommerce_subscriptions,
     window.mailpoet_can_use_woocommerce_memberships,
   ),
-  coupons: window.mailpoet_woocommerce_coupons,
   previousPage: '',
 });

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -1,7 +1,6 @@
 import {
   AnyFormItem,
   Automation,
-  Coupon,
   FilterRow,
   FilterValue,
   GroupFilterValue,
@@ -71,7 +70,6 @@ export const getSegmentFilter = (
   found = { ...state.segment.filters[index] };
   return found;
 };
-export const getCoupons = (state: StateType): Coupon[] => state.coupons;
 export const getErrors = (state: StateType): string[] => state.errors;
 export const getAvailableFilters = (state: StateType): GroupFilterValue[] =>
   state.allAvailableFilters;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -372,7 +372,7 @@ export type WooShippingMethod = {
 
 export type Coupon = {
   id: string;
-  name: string;
+  text: string;
 };
 
 export enum SegmentTemplateCategories {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -261,7 +261,6 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_subscription_products: WindowSubscriptionProducts;
   mailpoet_product_categories: WindowProductCategories;
   mailpoet_woocommerce_countries: WindowWooCommerceCountries;
-  mailpoet_woocommerce_coupons: Coupon[];
   mailpoet_woocommerce_payment_methods: WooPaymentMethod[];
   mailpoet_woocommerce_shipping_methods: WooShippingMethod[];
   mailpoet_newsletters_list: WindowNewslettersList;
@@ -297,7 +296,6 @@ export interface StateType {
   tags: Tag[];
   signupForms: SignupForm[];
   automations: Automation[];
-  coupons: Coupon[];
   previousPage: string;
 }
 

--- a/mailpoet/lib/API/JSON/v1/Coupons.php
+++ b/mailpoet/lib/API/JSON/v1/Coupons.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\JSON\v1;
+
+use MailPoet\API\JSON\Endpoint as APIEndpoint;
+use MailPoet\API\JSON\SuccessResponse;
+use MailPoet\Config\AccessControl;
+use MailPoet\WooCommerce\Helper;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Coupons extends APIEndpoint {
+  public const DEFAULT_PAGE_SIZE = 10;
+
+  /** @var Helper  */
+  public $helper;
+
+  /*** @var WPFunctions */
+  private $wp;
+
+  public $permissions = [
+    'global' => AccessControl::PERMISSION_MANAGE_EMAILS,
+  ];
+
+  public function __construct(
+    WPFunctions $wp,
+    Helper $helper
+  ) {
+    $this->wp = $wp;
+    $this->helper = $helper;
+  }
+
+  public function getCoupons(array $data = []): SuccessResponse {
+    $pageSize = $data['page_size'] ?? self::DEFAULT_PAGE_SIZE;
+    $pageNumber = $data['page_number'] ?? 0;
+    $discountType = $data['discount_type'] ?? null;
+    $search = $data['search'] ?? null;
+    $includeCouponId = $data['include_coupon_id'] ?? null;
+
+    return $this->successResponse(
+      $this->formatCoupons($this->helper->getCouponList(
+        (int)$pageSize,
+        (int)$pageNumber,
+        $discountType,
+        $search,
+        (int)$includeCouponId
+      ))
+    );
+  }
+
+  /**
+   * @param array $couponPosts
+   * @return array
+   */
+  private function formatCoupons(array $couponPosts): array {
+    return array_map(function (\WP_Post $post): array {
+      $discountType = $this->wp->getPostMeta($post->ID, 'discount_type', true);
+      return [
+        'id' => $post->ID,
+        'text' => $post->post_title, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        'excerpt' => $post->post_excerpt, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        'discountType' => $discountType,
+      ];
+    }, $couponPosts);
+  }
+}

--- a/mailpoet/lib/API/JSON/v1/Coupons.php
+++ b/mailpoet/lib/API/JSON/v1/Coupons.php
@@ -9,7 +9,7 @@ use MailPoet\WooCommerce\Helper;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Coupons extends APIEndpoint {
-  public const DEFAULT_PAGE_SIZE = 10;
+  public const DEFAULT_PAGE_SIZE = 100;
 
   /** @var Helper  */
   public $helper;
@@ -31,18 +31,17 @@ class Coupons extends APIEndpoint {
 
   public function getCoupons(array $data = []): SuccessResponse {
     $pageSize = $data['page_size'] ?? self::DEFAULT_PAGE_SIZE;
-    $pageNumber = $data['page_number'] ?? 0;
+    $pageNumber = $data['page_number'] ?? 1;
     $discountType = $data['discount_type'] ?? null;
     $search = $data['search'] ?? null;
-    $includeCouponId = $data['include_coupon_id'] ?? null;
-
+    $includeCouponIds = $data['include_coupon_ids'] ?? [];
     return $this->successResponse(
       $this->formatCoupons($this->helper->getCouponList(
         (int)$pageSize,
         (int)$pageNumber,
         $discountType,
         $search,
-        (int)$includeCouponId
+        $includeCouponIds
       ))
     );
   }

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -149,7 +149,6 @@ class DynamicSegments {
 
     $data['woocommerce_payment_methods'] = [];
     $data['woocommerce_shipping_methods'] = [];
-    $data['woocommerce_coupons'] = [];
 
     if ($this->woocommerceHelper->isWooCommerceActive()) {
       $allGateways = $this->woocommerceHelper->getPaymentGateways()->payment_gateways();
@@ -163,12 +162,6 @@ class DynamicSegments {
       $data['woocommerce_payment_methods'] = $paymentMethods;
 
       $data['woocommerce_shipping_methods'] = $this->woocommerceHelper->getShippingMethodInstancesData();
-      $data['woocommerce_coupons'] = array_map(function(array $couponData) {
-        return [
-          'id' => $couponData['id'],
-          'name' => $couponData['text'],
-        ];
-      }, $this->woocommerceHelper->getCouponList());
     }
     $data['automations'] = array_map(function(Automation $automation) {
       return [

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -129,7 +129,6 @@ class NewsletterEditor {
             'discount_types' => array_map(function($label, $value): array {
               return ['label' => $label, 'value' => $value];
             }, $discountTypes, array_keys($discountTypes)),
-            'available_coupons' => $this->woocommerceHelper->getCouponList(),
             'code_placeholder' => Coupon::CODE_PLACEHOLDER,
             'price_decimal_separator' => $this->woocommerceHelper->wcGetPriceDecimalSeparator(),
           ],

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -70,6 +70,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\API\JSON\v1\Analytics::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\AutomatedLatestContent::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\AutomaticEmails::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\Coupons::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\CustomFields::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\DynamicSegments::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\FeatureFlags::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -219,7 +219,7 @@ class Helper {
     int $pageNumber = 1,
     ?string $discountType = null,
     ?string $search = null,
-    ?int $includeCouponId = null
+    array $includeCouponIds = []
   ): array {
     $args = [
       'posts_per_page' => $pageSize,
@@ -241,9 +241,9 @@ class Helper {
 
     $includeCoupons = [];
     // We need to include the coupon with the given ID in the first page
-    if ($includeCouponId && $pageNumber === 1) {
+    if ($includeCouponIds && $pageNumber === 1) {
       $includeArgs = $args;
-      $includeArgs['include'] = [$includeCouponId];
+      $includeArgs['include'] = $includeCouponIds;
       $includeCoupons = $this->wp->getPosts($includeArgs);
     }
 

--- a/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
@@ -104,6 +104,7 @@ class EditorCouponCest {
     $i->waitForElement($couponSettingsHeading);
     $i->wantTo('Select predefined coupon');
     $i->click(Locator::contains('button', 'All coupons'));
+    $i->waitForElementClickable(Locator::contains('label', $couponCode));
     $i->click(Locator::contains('label', $couponCode));
     // because click on close button doesn't work sometimes and causes flakiness we try to click it 3 times
     for ($j = 0; $j < 3; $j++) {

--- a/mailpoet/tests/integration/API/JSON/v1/CouponsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/CouponsTest.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\API\JSON\v1;
+
+use MailPoet\API\JSON\Response as APIResponse;
+use MailPoet\API\JSON\v1\Coupons;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * @group woo
+ */
+class CouponsTest extends \MailPoetTest {
+
+  /** @var Coupons */
+  private $endpoint;
+
+  /** @var WooCommerceHelper */
+  private $wcHelper;
+
+  /** @var WPFunctions */
+  private $wpFunctions;
+
+  public function _before() {
+    parent::_before();
+    $this->endpoint = $this->diContainer->get(Coupons::class);
+    $this->wcHelper = $this->diContainer->get(WooCommerceHelper::class);
+    $this->wpFunctions = $this->diContainer->get(WPFunctions::class);
+  }
+
+  public function testItCanGetAllCoupons(): void {
+    $coupons = [
+      $this->createCoupon('coupon-1'),
+      $this->createCoupon('coupon-2'),
+      $this->createCoupon('coupon-3'),
+    ];
+    $response = $this->endpoint->getCoupons();
+
+    $this->validateResponse($response, $coupons);
+  }
+
+  public function testItGetsIncludedCouponIds(): void {
+    $coupons = [
+      $this->createCoupon('coupon-1'),
+      $this->createCoupon('coupon-2'),
+      $this->createCoupon('coupon-3'),
+      $this->createCoupon('include-coupon-4'),
+      $this->createCoupon('coupon-5'),
+      $this->createCoupon('include-coupon-6'),
+    ];
+
+    $response = $this->endpoint->getCoupons([
+      'include_coupon_ids' => [
+        $coupons[3]->get_id(),
+        $coupons[5]->get_id(),
+      ],
+      'page_size' => 1,
+    ]);
+    // expected coupons ordered by code
+    $expectedResult = [
+      $coupons[3], // include-coupon-4
+      $coupons[5], // include-coupon-6
+      $coupons[0], // coupon-1
+    ];
+
+    $this->validateResponse($response, $expectedResult);
+  }
+
+  public function testItGetsCouponsBySearchQuery(): void {
+    $coupons = [
+      $this->createCoupon('search-coupon-1'),
+      $this->createCoupon('coupon-search-2'),
+      $this->createCoupon('coupon-3'),
+      $this->createCoupon('coupon-4'),
+      $this->createCoupon('coupon-5-search'),
+      $this->createCoupon('coupon-6'),
+    ];
+
+    $response = $this->endpoint->getCoupons([
+      'search' => 'search',
+      'page_size' => 3,
+    ]);
+
+    // expected coupons ordered by code
+    $expectedResult = [
+      $coupons[4], // coupon-5-search
+      $coupons[1], // coupon-search-2
+      $coupons[0], // search-coupon-1
+    ];
+    $this->validateResponse($response, $expectedResult);
+  }
+
+  public function testItGetsCouponsByPageNumber(): void {
+    $coupons = [
+      $this->createCoupon('coupon-1'),
+      $this->createCoupon('coupon-2'),
+      $this->createCoupon('coupon-3'),
+      $this->createCoupon('coupon-4'),
+      $this->createCoupon('coupon-5'),
+      $this->createCoupon('coupon-6'),
+    ];
+
+    $response = $this->endpoint->getCoupons([
+      'page_number' => 2,
+      'page_size' => 2,
+    ]);
+
+    // expected coupons ordered by code
+    $expectedResult = [
+      $coupons[2], // coupon-3
+      $coupons[3], // coupon-4
+    ];
+    $this->validateResponse($response, $expectedResult);
+  }
+
+  public function testItGetsCouponsByDiscountType(): void {
+    $coupons = [
+      $this->createCoupon('coupon-1', 'fixed_cart'),
+      $this->createCoupon('coupon-2', 'percent'),
+      $this->createCoupon('coupon-3', 'percent'),
+      $this->createCoupon('coupon-4', 'fixed_product'),
+      $this->createCoupon('coupon-5', 'fixed_cart'),
+      $this->createCoupon('coupon-6', 'fixed_product'),
+    ];
+
+    $response = $this->endpoint->getCoupons(['discount_type' => 'fixed_product']);
+
+    // expected coupons ordered by code
+    $expectedResult = [
+      $coupons[3], // coupon-4
+      $coupons[5], // coupon-6
+    ];
+    $this->validateResponse($response, $expectedResult);
+  }
+
+  public function _after() {
+    parent::_after();
+    $coupons = $this->wpFunctions->getPosts([
+      'post_type' => 'shop_coupon',
+      'posts_per_page' => -1,
+    ]);
+    foreach ($coupons as $coupon) {
+      $this->wpFunctions->wpDeletePost($coupon->ID, true);
+    }
+  }
+
+  private function validateResponse($response, $expectedCoupons): void {
+    $returnedCoupons = $response->data;
+    expect($response->status)->equals(APIResponse::STATUS_OK);
+    expect($returnedCoupons)->count(count($expectedCoupons));
+
+    foreach ($expectedCoupons as $key => $coupon) {
+      expect($coupon->get_id())->equals($returnedCoupons[$key]['id']);
+      expect($coupon->get_code())->equals($returnedCoupons[$key]['text']);
+      expect($coupon->get_discount_type())->equals($returnedCoupons[$key]['discountType']);
+    }
+  }
+
+  private function createCoupon(?string $couponCode = null, ?string $discountType = null): \WC_Coupon {
+    $discountType = $discountType ?: current(array_keys($this->wcHelper->wcGetCouponTypes()));
+    $coupon = $this->wcHelper->createWcCoupon('');
+    $coupon->set_code($couponCode);
+    $coupon->set_discount_type($discountType);
+    $coupon->set_amount(10);
+    $coupon->save();
+    return $coupon;
+  }
+}

--- a/mailpoet/views/segments/dynamic.html
+++ b/mailpoet/views/segments/dynamic.html
@@ -19,7 +19,6 @@
     var mailpoet_woocommerce_countries = <%= json_encode(woocommerce_countries)  %>;
     var mailpoet_woocommerce_payment_methods = <%= json_encode(woocommerce_payment_methods)  %>;
     var mailpoet_woocommerce_shipping_methods = <%= json_encode(woocommerce_shipping_methods)  %>;
-    var mailpoet_woocommerce_coupons = <%= json_encode(woocommerce_coupons) %>;
     var mailpoet_signup_forms = <%= json_encode(signup_forms) %>;
     var mailpoet_automations = <%= json_encode(automations) %>;
   </script>


### PR DESCRIPTION
## Description

This PR removes loading all existing coupons into a template variable and starts using Ajax requests for loading them continually as it needed.

## Code review notes

- Because I haven't found a way how to use an existing WP or WC API for getting coupons via Ajax requests, I created our own solution.
- I implemented our own solution of an infinite scroll to the select with coupons in the segment form.
- I added loading indication to our react select component.

## QA notes

Please test that loading coupons works properly in:
- email editor: the coupon block
- segments: adding new segment of a type `used coupon code` and editing an existing one

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5123]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5123]: https://mailpoet.atlassian.net/browse/MAILPOET-5123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ