### PR TITLE
Fix form width on mobile [MAILPOET-5419]

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -27,6 +27,10 @@ $form-line-height: 1.4;
 }
 
 .mailpoet_form {
+  @include breakpoint-max-width($form-break-small-width - 1) {
+    box-sizing: border-box;
+  }
+
   .mailpoet_submit,
   .mailpoet_paragraph,
   .mailpoet_form_paragraph,


### PR DESCRIPTION
## Description

This PR fixes incorrect popup form width on small screens.

## Code review notes
I think that the issue is present on themes that don't use box-sizing: border-box for content. 
So, instead of adding the CSS from the ticket, which would break the form on the other themes, I set the box-sizing.

## QA notes

To replicate 
1) use theme Twenty Twenty-Three
2) set up a popup form (e.g., Welcome Discount)
3) view the form on mobile

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5419]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5419]: https://mailpoet.atlassian.net/browse/MAILPOET-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ