### PR TITLE
Fix Redirect to the landing page after activation [MAILPOET-5221]

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -369,12 +369,15 @@ class Initializer {
 
     // wp automatically redirect to `wp-admin/plugins.php?activate=true&...` after plugin activation
     $activatedByWpAdmin = !empty(strpos($currentUrl, 'plugins.php')) && isset($_GET['activate']) && (bool)$_GET['activate'];
-    if (!$activatedByWpAdmin) return; // not activated by wp. Do not redirect e.g WooCommerce NUX
 
-    // done with afterPluginActivation actions. Delete before redirect
+    // We want to run this only once immediately after activation.
+    // Delete the flag to prevent triggering on subsequent page loads.
     $this->wpFunctions->deleteOption(self::PLUGIN_ACTIVATED);
 
-    $this->changelog->redirectToLandingPage();
+    // If not activated by wp. Do not redirect e.g WooCommerce NUX
+    if ($activatedByWpAdmin) {
+      $this->changelog->redirectToLandingPage();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

This PR fixes unwanted redirects to the MP landing page in case the plugin was not activated via the WP plugins page.

## Code review notes
I tested the page redirect after the change, and it works when I activate the plugin on the WP plugins page.
I'm not 100% sure if there are some activation cases/flows that might be affected by this change.

## QA notes
Please follow the replication steps in the ticket.
Please test also that the redirect works correctly when we want it to happen.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5221]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [] I added sufficient test coverage - This could be covered by an acceptance test, but as this is rather an edge case, I chose to skip the test in this case.
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5221]: https://mailpoet.atlassian.net/browse/MAILPOET-5221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ