### PR TITLE
Migrate k6 to version 46

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -292,6 +292,7 @@ class RoboFile extends \Robo\Tasks {
       ->option('env', 'URL=' . $opts['url'])
       ->option('env', 'PW=' . $opts['pw'])
       ->option('env', 'K6_BROWSER_HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
+      ->option('env', 'K6_BROWSER_TIMEOUT=120s')
       ->option('env', 'SCENARIO=' . $opts['scenario'])
       ->arg($path ?? "$dir/tests/performance/scenarios.js")
       ->dir($dir)->run();

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -291,7 +291,7 @@ class RoboFile extends \Robo\Tasks {
       ->option('env', 'K6_BROWSER_ENABLED=1')
       ->option('env', 'URL=' . $opts['url'])
       ->option('env', 'PW=' . $opts['pw'])
-      ->option('env', 'HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
+      ->option('env', 'K6_BROWSER_HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
       ->option('env', 'SCENARIO=' . $opts['scenario'])
       ->arg($path ?? "$dir/tests/performance/scenarios.js")
       ->dir($dir)->run();

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -5,7 +5,6 @@ export const headlessSet = ['true', '1'].includes(
 export const scenario = __ENV.SCENARIO; // eslint-disable-line
 export const projectName = __ENV.K6_PROJECT_NAME; // eslint-disable-line
 export const k6CloudID = __ENV.K6_CLOUD_ID; // eslint-disable-line
-export const timeoutSet = '2m';
 export const fullPageSet = 'true';
 export const screenshotPath = 'tests/performance/_screenshots/';
 

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -63,7 +63,7 @@ let scenarios = {
       },
     },
     vus: 1,
-    iterations: 1,
+    iterations: 3,
     maxDuration: '30m',
     exec: 'nightly',
   },

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -28,12 +28,12 @@ export let options = {
   },
   scenarios: {},
   thresholds: {
-    webvital_largest_content_paint: ['p(75) < 8000'],
-    webvital_first_input_delay: ['p(75) < 300'],
-    webvital_cumulative_layout_shift: ['p(75) < 0.25'],
-    webvital_time_to_first_byte: ['p(75) < 4000'],
-    webvital_first_contentful_paint: ['p(75) < 4000'],
-    webvital_interaction_to_next_paint: ['p(75) < 300'],
+    browser_web_vital_lcp: ['p(75) < 8000'],
+    browser_web_vital_fid: ['p(75) < 300'],
+    browser_web_vital_cls: ['p(75) < 0.25'],
+    browser_web_vital_ttfb: ['p(75) < 4000'],
+    browser_web_vital_fcp: ['p(75) < 4000'],
+    browser_web_vital_inp: ['p(75) < 300'],
     checks: ['rate==1.0'],
   },
   tags: {
@@ -45,6 +45,11 @@ export let options = {
 let scenarios = {
   pullrequests: {
     executor: 'per-vu-iterations',
+    options: {
+      browser: {
+        type: 'chromium', // chromium is the only supported browser type
+      },
+    },
     vus: 1,
     iterations: 1,
     maxDuration: '10m',
@@ -52,6 +57,11 @@ let scenarios = {
   },
   nightlytests: {
     executor: 'per-vu-iterations',
+    options: {
+      browser: {
+        type: 'chromium',
+      },
+    },
     vus: 1,
     iterations: 3,
     maxDuration: '30m',

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -63,7 +63,7 @@ let scenarios = {
       },
     },
     vus: 1,
-    iterations: 3,
+    iterations: 1,
     maxDuration: '30m',
     exec: 'nightly',
   },

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -86,6 +86,7 @@ export async function formsAdding() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   defaultListName,
   formsPageTitle,
   fullPageSet,
@@ -26,10 +24,7 @@ import {
 import { login, selectInSelect2, waitAndClick } from '../utils/helpers.js';
 
 export async function formsAdding() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -91,7 +86,6 @@ export async function formsAdding() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -26,11 +26,10 @@ import {
 import { login, selectInSelect2, waitAndClick } from '../utils/helpers.js';
 
 export async function formsAdding() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -143,6 +143,7 @@ export async function listsComplexSegment() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   defaultListName,
   listsPageTitle,
   fullPageSet,
@@ -26,10 +24,6 @@ import {
 import { login, selectInReact } from '../utils/helpers.js';
 
 export async function listsComplexSegment() {
-  const browser = chromium.launch({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
   const page = browser.newPage();
 
   try {
@@ -149,7 +143,6 @@ export async function listsComplexSegment() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -75,6 +75,7 @@ export async function listsViewSubscribers() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -27,11 +27,10 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function listsViewSubscribers() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -17,8 +17,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   defaultListName,
   listsPageTitle,
   fullPageSet,
@@ -27,10 +25,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function listsViewSubscribers() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -80,7 +75,6 @@ export async function listsViewSubscribers() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -17,8 +17,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   emailsPageTitle,
   fullPageSet,
   screenshotPath,
@@ -26,10 +24,6 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function newsletterListing() {
-  const browser = chromium.launch({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
   const page = browser.newPage();
 
   try {
@@ -65,7 +59,6 @@ export async function newsletterListing() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -59,6 +59,7 @@ export async function newsletterListing() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -77,6 +77,7 @@ export async function newsletterSearching() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -26,11 +26,10 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function newsletterSearching() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -17,8 +17,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   emailsPageTitle,
   fullPageSet,
   screenshotPath,
@@ -26,10 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function newsletterSearching() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -82,7 +77,6 @@ export async function newsletterSearching() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -27,11 +27,10 @@ import { login, selectInSelect2 } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterSending() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   defaultListName,
   emailsPageTitle,
   fullPageSet,
@@ -27,10 +25,7 @@ import { login, selectInSelect2 } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterSending() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -109,7 +109,7 @@ export async function newsletterSending() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -17,8 +17,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   emailsPageTitle,
   fullPageSet,
   screenshotPath,
@@ -26,10 +24,7 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function newsletterStatistics() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -91,7 +86,6 @@ export async function newsletterStatistics() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -26,11 +26,10 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function newsletterStatistics() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -86,6 +86,7 @@ export async function newsletterStatistics() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -102,6 +102,7 @@ export async function onboardingWizard() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   settingsPageTitle,
   fullPageSet,
   screenshotPath,
@@ -25,10 +23,6 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function onboardingWizard() {
-  const browser = chromium.launch({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
   const page = browser.newPage();
 
   try {
@@ -108,7 +102,6 @@ export async function onboardingWizard() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   settingsPageTitle,
   fullPageSet,
   screenshotPath,
@@ -25,10 +23,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function settingsBasic() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -71,7 +66,6 @@ export async function settingsBasic() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -25,11 +25,10 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function settingsBasic() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -66,6 +66,7 @@ export async function settingsBasic() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -17,8 +17,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   firstName,
   lastName,
   defaultListName,
@@ -29,10 +27,7 @@ import {
 import { login, selectInSelect2 } from '../utils/helpers.js';
 
 export async function subscribersAdding() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     let subscriberEmail =
@@ -112,7 +107,6 @@ export async function subscribersAdding() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -107,6 +107,7 @@ export async function subscribersAdding() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -29,11 +29,10 @@ import {
 import { login, selectInSelect2 } from '../utils/helpers.js';
 
 export async function subscribersAdding() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     let subscriberEmail =

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -97,6 +97,7 @@ export async function subscribersFiltering() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   adminEmail,
   subscribersPageTitle,
   fullPageSet,
@@ -26,10 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function subscribersFiltering() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -102,7 +97,6 @@ export async function subscribersFiltering() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -26,11 +26,10 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function subscribersFiltering() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -59,6 +59,7 @@ export async function subscribersListing() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -17,8 +17,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   subscribersPageTitle,
   fullPageSet,
   screenshotPath,
@@ -26,10 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function subscribersListing() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -64,7 +59,6 @@ export async function subscribersListing() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -26,11 +26,10 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function subscribersListing() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sleep } from 'k6';
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 import {
   expect,
@@ -25,11 +25,10 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function subscribersTrashingRestoring() {
-  const browser = chromium.launch({
+  const page = browser.newPage({
     headless: headlessSet,
     timeout: timeoutSet,
   });
-  const page = browser.newPage();
 
   try {
     // Log in to WP Admin

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -97,6 +97,7 @@ export async function subscribersTrashingRestoring() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
+    browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -16,8 +16,6 @@ import {
   baseURL,
   thinkTimeMin,
   thinkTimeMax,
-  headlessSet,
-  timeoutSet,
   subscribersPageTitle,
   fullPageSet,
   screenshotPath,
@@ -25,10 +23,7 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function subscribersTrashingRestoring() {
-  const page = browser.newPage({
-    headless: headlessSet,
-    timeout: timeoutSet,
-  });
+  const page = browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -102,7 +97,6 @@ export async function subscribersTrashingRestoring() {
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     page.close();
-    browser.close();
   }
 }
 

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.45.0';
+$version = 'v0.46.0';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Not just updating to its latest version, this k6 0.46.0 version contains a lot of changes and requires some code changes in the tests.

There are some renamed labels for CWV.

## Code review notes

If you see everything as passing then it's good.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5596]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5596]: https://mailpoet.atlassian.net/browse/MAILPOET-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ