### PR TITLE
Fix automation factory method calls

### DIFF
--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/AbandonedCartTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/AbandonedCartTriggerTest.php
@@ -195,8 +195,8 @@ class AbandonedCartTriggerTest extends \MailPoetTest {
     );
     return (new AutomationFactory())
       ->withStatusActive()
-      ->addStep($trigger)
-      ->addStep($action)
+      ->withStep($trigger)
+      ->withStep($action)
       ->create();
   }
 


### PR DESCRIPTION
## Description

addStep was renamed to withStep but the calls in this helper weren't updated, and now pipelines are failing at the static analysis step.

It looks like this was caused by the merge of https://github.com/mailpoet/mailpoet/pull/5150, which must not have included the new test from https://github.com/mailpoet/mailpoet/pull/5149.

## Code review notes

_N/A_

## QA notes

No QA should be necessary

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
