### PR TITLE
Show filter segment used in listings/stats [MAILPOET-5511]

### DIFF
--- a/mailpoet/assets/css/src/components/_tags.scss
+++ b/mailpoet/assets/css/src/components/_tags.scss
@@ -3,6 +3,10 @@
   display: inline-flex;
   flex-wrap: wrap;
   gap: 6px;
+
+  & + & {
+    margin-left: 6px;
+  }
 }
 
 .mailpoet-tags-prefix {

--- a/mailpoet/assets/css/src/components/_tags.scss
+++ b/mailpoet/assets/css/src/components/_tags.scss
@@ -77,6 +77,12 @@
   }
 }
 
+.mailpoet-tag-filter_segment {
+  background-color: $color-white;
+  border-color: $color-black;
+  border-style: dashed;
+}
+
 .mailpoet-tag-wordpress {
   background: $color-wordpress-button-background;
   border-color: $color-wordpress-button-border;

--- a/mailpoet/assets/js/src/common/newsletter.ts
+++ b/mailpoet/assets/js/src/common/newsletter.ts
@@ -51,6 +51,7 @@ export type NewsLetter = {
     automationId?: string;
     afterTimeNumber: number | string;
     afterTimeType: string;
+    filterSegmentId?: string;
   };
   parent_id: null | string;
   preheader: string;
@@ -58,6 +59,11 @@ export type NewsLetter = {
     scheduled_at: string;
     count_processed: string;
     count_total: string;
+    meta: Record<string, unknown> & {
+      filterSegment?: {
+        name?: string;
+      };
+    };
   };
   reply_to_address: string;
   reply_to_name: string;

--- a/mailpoet/assets/js/src/common/tag/tag.tsx
+++ b/mailpoet/assets/js/src/common/tag/tag.tsx
@@ -8,7 +8,8 @@ export type TagVariant =
   | 'critical'
   | 'list'
   | 'unknown'
-  | 'wordpress';
+  | 'wordpress'
+  | 'filter_segment';
 
 type Props = {
   children?: ReactNode;

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Tag, TagVariant } from './tag';
 import { Tooltip } from '../tooltip/tooltip';
 import { NewsLetter } from '../newsletter';
-import { NewsletterType } from '../../newsletters/campaign_stats/newsletter_type';
+import { NewsletterType } from '../../newsletters/campaign-stats/newsletter-type';
 
 type SharedTagProps = {
   children?: ReactNode;

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
-import { Button, SegmentTags } from 'common';
+import { Button, FilterSegmentTag, SegmentTags } from 'common';
 import { NewsletterType } from './newsletter-type';
 
 type Props = {
@@ -30,6 +30,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             </span>
             {': '}
             <SegmentTags dimension="large" segments={newsletter.segments} />
+            <FilterSegmentTag newsletter={newsletter} dimension="large" />
           </div>
         )}
       </div>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
@@ -6,6 +6,11 @@ export type NewsletterType = {
   queue: {
     scheduled_at: string;
     created_at: string;
+    meta: Record<string, unknown> & {
+      filterSegment?: {
+        name?: string;
+      };
+    };
   };
   sender_address?: string;
   reply_to_address?: string;

--- a/mailpoet/assets/js/src/newsletters/listings/notification-history.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification-history.jsx
@@ -12,7 +12,7 @@ import {
   checkCronStatus,
   checkMailerStatus,
 } from 'newsletters/listings/utils.jsx';
-import { SegmentTags } from 'common/tag/tags';
+import { FilterSegmentTag, SegmentTags } from 'common/tag/tags';
 import { withBoundary } from '../../common';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
@@ -155,6 +155,7 @@ const renderItem = (newsletter, actions, meta) => {
         data-colname={__('Lists', 'mailpoet')}
       >
         <SegmentTags segments={newsletter.segments} dimension="large" />
+        <FilterSegmentTag newsletter={newsletter} dimension="large" />
       </td>
       {mailpoetTrackingEnabled === true ? (
         <td

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { Component } from 'react';
+import { Component, Fragment } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Link, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -16,7 +16,7 @@ import {
   timeOfDayValues,
   weekDayValues,
 } from 'newsletters/scheduling/common.jsx';
-import { SegmentTags } from 'common/tag/tags';
+import { FilterSegmentTag, SegmentTags } from 'common/tag/tags';
 import { Toggle } from 'common/form/toggle/toggle';
 
 import {
@@ -236,7 +236,15 @@ class NewsletterListNotificationComponent extends Component {
     const sendingToSegments = ReactStringReplace(
       __('Send to %1$s', 'mailpoet'),
       '%1$s',
-      (match, i) => <SegmentTags segments={newsletter.segments} key={i} />,
+      (match, i) => (
+        <Fragment key={i}>
+          <SegmentTags segments={newsletter.segments} key={`segment-${i}`} />
+          <FilterSegmentTag
+            key={`filter-segment-${i}`}
+            newsletter={newsletter}
+          />
+        </Fragment>
+      ),
     );
 
     // set sending frequency

--- a/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
@@ -1,12 +1,12 @@
 import classnames from 'classnames';
 import { __, _x } from '@wordpress/i18n';
-import { Component } from 'react';
+import { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Link, withRouter } from 'react-router-dom';
 import ReactStringReplace from 'react-string-replace';
 
 import { Toggle } from 'common/form/toggle/toggle';
-import { SegmentTags } from 'common/tag/tags';
+import { FilterSegmentTag, SegmentTags } from 'common/tag/tags';
 import { ScheduledIcon } from 'common/listings/newsletter-status';
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
@@ -246,7 +246,15 @@ class NewsletterListReEngagementComponent extends Component {
     const sendingToSegments = ReactStringReplace(
       __('Send to %1$s', 'mailpoet'),
       '%1$s',
-      (match, i) => <SegmentTags segments={newsletter.segments} key={i} />,
+      (match, i) => (
+        <Fragment key={i}>
+          <SegmentTags segments={newsletter.segments} key={`segment-${i}`} />
+          <FilterSegmentTag
+            key={`filter-segment-${i}`}
+            newsletter={newsletter}
+          />
+        </Fragment>
+      ),
     );
 
     let frequency = _x(

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 
 import { confirmAlert } from 'common/confirm-alert.jsx';
-import { SegmentTags } from 'common/tag/tags';
+import { FilterSegmentTag, SegmentTags } from 'common/tag/tags';
 import { Listing } from 'listing/listing.jsx';
 import { QueueStatus } from 'newsletters/listings/queue-status';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
@@ -237,6 +237,7 @@ class NewsletterListStandardComponent extends Component {
         >
           <ErrorBoundary>
             <SegmentTags segments={newsletter.segments} dimension="large" />
+            <FilterSegmentTag newsletter={newsletter} dimension="large" />
           </ErrorBoundary>
         </td>
         {mailpoetTrackingEnabled === true ? (

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -6,6 +6,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
 use MailPoet\Config\Menu;
+use MailPoet\Config\ServicesChecker;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -57,6 +58,9 @@ class Newsletters {
   /** @var SubscribersFeature */
   private $subscribersFeature;
 
+  /** @var ServicesChecker */
+  private $servicesChecker;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
@@ -69,7 +73,8 @@ class Newsletters {
     NewslettersRepository $newslettersRepository,
     Bridge $bridge,
     AuthorizedSenderDomainController $senderDomainController,
-    SubscribersFeature $subscribersFeature
+    SubscribersFeature $subscribersFeature,
+    ServicesChecker $servicesChecker
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
@@ -83,6 +88,7 @@ class Newsletters {
     $this->bridge = $bridge;
     $this->senderDomainController = $senderDomainController;
     $this->subscribersFeature = $subscribersFeature;
+    $this->servicesChecker = $servicesChecker;
   }
 
   public function render() {
@@ -121,7 +127,7 @@ class Newsletters {
 
     $data['sent_newsletters_count'] = $this->newslettersRepository->countBy(['status' => NewsletterEntity::STATUS_SENT]);
     $data['woocommerce_transactional_email_id'] = $this->settings->get(TransactionalEmails::SETTING_EMAIL_ID);
-    $data['display_detailed_stats'] = $this->subscribersFeature->hasValidPremiumKey() && !$this->subscribersFeature->check();
+    $data['display_detailed_stats'] = $this->subscribersFeature->hasValidPremiumKey() && !$this->subscribersFeature->check() && $this->servicesChecker->isPremiumPluginActive();
     $data['newsletters_templates_recently_sent_count'] = $this->newsletterTemplatesRepository->getRecentlySentCount();
 
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -495,7 +495,14 @@ class NewsletterEntity {
 
   public function getFilterSegmentId(): ?int {
     $optionValue = $this->getOptionValue(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID);
-    return $optionValue ? (int)$optionValue : null;
+    if ($optionValue) {
+      return (int)$optionValue;
+    }
+    $parentNewsletter = $this->getParent();
+    if ($parentNewsletter instanceof NewsletterEntity && $this->getId() !== $parentNewsletter->getId()) {
+      return $parentNewsletter->getFilterSegmentId();
+    }
+    return null;
   }
 
   /**

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -195,18 +195,42 @@ class NewsletterEntityTest extends \MailPoetTest {
     expect($newsletter->getFilterSegmentId())->equals(2);
   }
 
-  private function createNewsletter(): NewsletterEntity {
+  public function testItInheritsFilterSegmentIdFromParent(): void {
+    $optionField = $this->createOptionField(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID, NewsletterEntity::TYPE_NOTIFICATION);
+    $notificationNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION);
+    expect($notificationNewsletter->getFilterSegmentId())->null();
+
+    $newsletterOption = new NewsletterOptionEntity($notificationNewsletter, $optionField);
+    $newsletterOption->setValue('2');
+
+    $this->entityManager->persist($newsletterOption);
+    $this->entityManager->flush();
+
+    $this->entityManager->refresh($notificationNewsletter);
+    expect($notificationNewsletter->getFilterSegmentId())->equals(2);
+
+    $notificationHistoryNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
+    expect($notificationHistoryNewsletter->getFilterSegmentId())->null();
+
+    $notificationHistoryNewsletter->setParent($notificationNewsletter);
+    $this->entityManager->persist($notificationHistoryNewsletter);
+    $this->entityManager->flush();
+    $this->entityManager->refresh($notificationHistoryNewsletter);
+    expect($notificationHistoryNewsletter->getFilterSegmentId())->equals(2);
+  }
+
+  private function createNewsletter(string $type = NewsletterEntity::TYPE_STANDARD): NewsletterEntity {
     $newsletter = new NewsletterEntity();
-    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setType($type);
     $newsletter->setSubject('Subject');
     $this->entityManager->persist($newsletter);
     return $newsletter;
   }
 
-  private function createOptionField(string $name): NewsletterOptionFieldEntity {
+  private function createOptionField(string $name, string $type = NewsletterEntity::TYPE_STANDARD): NewsletterOptionFieldEntity {
     $newsletterOptionField = new NewsletterOptionFieldEntity();
     $newsletterOptionField->setName($name);
-    $newsletterOptionField->setNewsletterType(NewsletterEntity::TYPE_STANDARD);
+    $newsletterOptionField->setNewsletterType($type);
     $this->entityManager->persist($newsletterOptionField);
     return $newsletterOptionField;
   }


### PR DESCRIPTION
## Description

This PR adds a tag on listing pages/stats pages for newsletters that support filter segments if the email is currently configured to use a filter segment or if the email was sent using a filter segment.

Currently the UI for adding a filter segment to an email is not merged, but you can use the testing directions from https://github.com/mailpoet/mailpoet/pull/5108 to test this immediately.

The tooltip is going to be updated to include specific conditions in a separate ticket.

## Code review notes

I realized during my own testing that the filter segment data wasn't getting saved to the queue for post notification emails, and this PR fixes that issue by having the filter segment getter check the parent newsletter. This seemed cleaner to me than creating a new option in the database when creating the child newsletter.

## QA notes

For sent emails, the filter segment is stored on the sending queue itself, including the name. This means that if the segment name is changed we will continue to see the old segment name for sent emails. This also ensures we can continue to display the filter segment name if the segment gets deleted. Please make sure to test these cases, though it will change in the future to include more data.

I wasn't sure of a good way to test re-engagement emails locally, so please make sure to test that they get tested.

While working on this I noticed a bug where having premium installed but not active makes it impossible to view a newsletter's stats page. The plugin still tries to hit a premium-only endpoint, resulting in an `Invalid API Endpoint` error. This PR includes a fix for this and I would appreciate if you could test this as well.

<img width="189" alt="image" src="https://github.com/mailpoet/mailpoet/assets/8656640/fb3a29c9-070a-48c5-ac7c-3900f7ebe0fa">

## Linked PRs

You can use #5175 to add filter segments to emails.

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5512

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
