### PR TITLE
Add info messages for Woo Express customers

### DIFF
--- a/mailpoet/assets/js/src/help/help.jsx
+++ b/mailpoet/assets/js/src/help/help.jsx
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom';
 import { MailPoet } from 'mailpoet';
-import { KnowledgeBase } from 'help/knowledge_base.jsx';
+import { KnowledgeBase } from 'help/knowledge_base.tsx';
 import { SystemInfo } from 'help/system_info.tsx';
 import { SystemStatus } from 'help/system_status.jsx';
 import { YourPrivacy } from 'help/your_privacy.jsx';

--- a/mailpoet/assets/js/src/help/knowledge_base.tsx
+++ b/mailpoet/assets/js/src/help/knowledge_base.tsx
@@ -1,9 +1,11 @@
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common/button/button';
+import { AutomationsInfoNotice } from 'notices/automations_info_notice';
 
 export function KnowledgeBase() {
   return (
     <>
+      <AutomationsInfoNotice />
       <p>{MailPoet.I18n.t('knowledgeBaseIntro')}</p>
       <ul className="mailpoet-text-links">
         <li>

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -104,6 +104,11 @@ function NewsletterTypesComponent({
               {__('See video guide', 'mailpoet')}
             </a>
           )}
+          {type.kbLink && (
+            <a href={type.kbLink} target="_blank" rel="noopener noreferrer">
+              {__('Read more.', 'mailpoet')}
+            </a>
+          )}
           <div className="mailpoet-flex-grow" />
           <div className="mailpoet-newsletter-type-action">{type.action}</div>
         </div>
@@ -132,6 +137,8 @@ function NewsletterTypesComponent({
         'Convert and retain customers with automated marketing that does the hard work for you. AutomateWoo has the tools you need to grow your store and make more money.',
         'mailpoet',
       ),
+      kbLink:
+        'https://kb.mailpoet.com/article/408-integration-with-automatewoo',
       action: (
         <Button
           automationId="woocommerce_automatewoo"

--- a/mailpoet/assets/js/src/notices/automations_info_notice.tsx
+++ b/mailpoet/assets/js/src/notices/automations_info_notice.tsx
@@ -1,36 +1,30 @@
-import ReactStringReplace from 'react-string-replace';
+import { createInterpolateElement } from '@wordpress/element';
 import { MailPoet } from 'mailpoet';
 import { Notice } from 'notices/notice';
 
 function AutomationsInfoNotice() {
   if (!MailPoet.hideAutomations) return null;
-  let automationsInfo = ReactStringReplace(
+
+  const automationsInfo = createInterpolateElement(
     MailPoet.I18n.t('automationsInfoNotice'),
-    /\[link1\](.*?)\[\/link1\]/g,
-    (match) => (
-      <a
-        key={match}
-        rel="noreferrer"
-        href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
-        target="_blank"
-      >
-        {match}
-      </a>
-    ),
-  );
-  automationsInfo = ReactStringReplace(
-    automationsInfo,
-    /\[link2\](.*?)\[\/link2\]/g,
-    (match) => (
-      <a
-        key={match}
-        rel="noreferrer"
-        href="https://href.li/?https://kb.mailpoet.com/article/408-integration-with-automatewoo"
-        target="_blank"
-      >
-        {match}
-      </a>
-    ),
+    {
+      link1: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          rel="noreferrer"
+          href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
+          target="_blank"
+        />
+      ),
+      link2: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          rel="noreferrer"
+          href="https://kb.mailpoet.com/article/408-integration-with-automatewoo"
+          target="_blank"
+        />
+      ),
+    },
   );
   return (
     <Notice type="warning" scroll renderInPlace timeout={false}>

--- a/mailpoet/assets/js/src/notices/automations_info_notice.tsx
+++ b/mailpoet/assets/js/src/notices/automations_info_notice.tsx
@@ -1,0 +1,42 @@
+import ReactStringReplace from 'react-string-replace';
+import { MailPoet } from 'mailpoet';
+import { Notice } from 'notices/notice';
+
+function AutomationsInfoNotice() {
+  if (!MailPoet.hideAutomations) return null;
+  let automationsInfo = ReactStringReplace(
+    MailPoet.I18n.t('automationsInfoNotice'),
+    /\[link1\](.*?)\[\/link1\]/g,
+    (match) => (
+      <a
+        key={match}
+        rel="noreferrer"
+        href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
+        target="_blank"
+      >
+        {match}
+      </a>
+    ),
+  );
+  automationsInfo = ReactStringReplace(
+    automationsInfo,
+    /\[link2\](.*?)\[\/link2\]/g,
+    (match) => (
+      <a
+        key={match}
+        rel="noreferrer"
+        href="https://href.li/?https://kb.mailpoet.com/article/408-integration-with-automatewoo"
+        target="_blank"
+      >
+        {match}
+      </a>
+    ),
+  );
+  return (
+    <Notice type="warning" scroll renderInPlace timeout={false}>
+      <p>{automationsInfo}</p>
+    </Notice>
+  );
+}
+
+export { AutomationsInfoNotice };

--- a/mailpoet/assets/js/src/settings/pages/woo_commerce/woo_commerce.tsx
+++ b/mailpoet/assets/js/src/settings/pages/woo_commerce/woo_commerce.tsx
@@ -1,15 +1,19 @@
 import { SaveButton } from 'settings/components';
+import { AutomationsInfoNotice } from 'notices/automations_info_notice';
 import { EmailCustomizer } from './email_customizer';
 import { CheckoutOptin } from './checkout_optin';
 import { SubscribeOldCustomers } from './subscribe_old_customers';
 
 export function WooCommerce() {
   return (
-    <div className="mailpoet-settings-grid">
-      <EmailCustomizer />
-      <CheckoutOptin />
-      <SubscribeOldCustomers />
-      <SaveButton />
-    </div>
+    <>
+      <AutomationsInfoNotice />
+      <div className="mailpoet-settings-grid">
+        <EmailCustomizer />
+        <CheckoutOptin />
+        <SubscribeOldCustomers />
+        <SaveButton />
+      </div>
+    </>
   );
 }

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -83,7 +83,7 @@
   'latestActionSchedulerTrigger': _x('Next trigger run', 'Label for the next date and time of background job trigger run.'),
   'latestActionSchedulerCompletedTrigger': _x('Last trigger run', 'Label for the last date and time of background job trigger run.'),
   'latestActionSchedulerCompletedRun': _x('Last worker run', 'Label for the last date and time of background job worker run.'),
-  'automationsInfoNotice': __('Looking for [link1]MailPoet Automations[/link1]? Read how to [link2]enable them[/link2].'),
+  'automationsInfoNotice': __('Looking for <link1>MailPoet Automations</link1>? Read how to <link2>enable them</link2>.'),
 }) %>
 <% endblock %>
 

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -83,6 +83,7 @@
   'latestActionSchedulerTrigger': _x('Next trigger run', 'Label for the next date and time of background job trigger run.'),
   'latestActionSchedulerCompletedTrigger': _x('Last trigger run', 'Label for the last date and time of background job trigger run.'),
   'latestActionSchedulerCompletedRun': _x('Last worker run', 'Label for the last date and time of background job worker run.'),
+  'automationsInfoNotice': __('Looking for [link1]MailPoet Automations[/link1]? Read how to [link2]enable them[/link2].'),
 }) %>
 <% endblock %>
 

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -168,7 +168,7 @@
   'wcOptinMsgCannotBeEmpty': __('The checkbox opt-in message cannot be empty.'),
   'subscribeOldWCTitle': __('Subscribe old WooCommerce customers'),
   'subscribeOldWCDescription': __('Subscribe all my past customers to this list because they agreed to receive marketing emails from me.'),
-  'automationsInfoNotice': __('Looking for [link1]MailPoet Automations[/link1]? Read how to [link2]enable them[/link2].'),
+  'automationsInfoNotice': __('Looking for <link1>MailPoet Automations</link1>? Read how to <link2>enable them</link2>.'),
 
   'mssTitle': __('MailPoet Sending Service'),
   'youreSendingWithMss': __("You're now sending with MailPoet!"),

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -168,6 +168,7 @@
   'wcOptinMsgCannotBeEmpty': __('The checkbox opt-in message cannot be empty.'),
   'subscribeOldWCTitle': __('Subscribe old WooCommerce customers'),
   'subscribeOldWCDescription': __('Subscribe all my past customers to this list because they agreed to receive marketing emails from me.'),
+  'automationsInfoNotice': __('Looking for [link1]MailPoet Automations[/link1]? Read how to [link2]enable them[/link2].'),
 
   'mssTitle': __('MailPoet Sending Service'),
   'youreSendingWithMss': __("You're now sending with MailPoet!"),


### PR DESCRIPTION
## Description

For customers with a Woo Express subscription, when AutomateWoo and MailPoet are both active, this PR:
1) Shows a Read More link on the Automations Email type card
2) Shows a notice on WooCommerce settings tab
3) Shows a notice on KB help setting tag

## Code review notes

_N/A_

## QA notes

To test:
1) Go to MP shop Admin, search for my user with my automattic email and reset the site for subscription 564146
2) Grab the key and install it on your site (this is a Woo Express subscription)
3) Install and activate AutomateWoo
4) Go to Settings > WooCommerce, check that you see the notice
5) Go to Help > KB and check that you see the notice
6) Go to Emails > New Emails, check that you see the Read More link on the Automations card.

Disable AutomateWoo or remove the key, check that the notice goes away (refresh the page)

Please reset the site again once you are done.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5598]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5598]: https://mailpoet.atlassian.net/browse/MAILPOET-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ