### PR TITLE
Add filter to remove restriction on Woo Express

### DIFF
--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -136,7 +136,10 @@ class PageRenderer {
     if ($this->subscribersFeature->isSubscribersCountEnoughForCache($subscriberCount)) {
       $subscribersCacheCreatedAt = $this->transientCache->getOldestCreatedAt(TransientCache::SUBSCRIBERS_STATISTICS_COUNT_KEY) ?: Carbon::now();
     }
-
+    // Automations are hidden when the subscription is part of a bundle and AutomateWoo is active
+    $showAutomations = !($this->wp->isPluginActive('automatewoo/automatewoo.php') &&
+      $this->servicesChecker->isBundledSubscription());
+    $hideAutomations = !$this->wp->applyFilters('mailpoet_show_automations', $showAutomations);
     $defaults = [
       'current_page' => sanitize_text_field(wp_unslash($_GET['page'] ?? '')),
       'site_name' => $this->wp->wpSpecialcharsDecode($this->wp->getOption('blogname'), ENT_QUOTES),
@@ -177,7 +180,7 @@ class PageRenderer {
       'mss_key_pending_approval' => $this->servicesChecker->isMailPoetAPIKeyPendingApproval(),
       'mss_active' => $this->bridge->isMailpoetSendingServiceEnabled(),
       'plugin_partial_key' => $this->servicesChecker->generatePartialApiKey(),
-      'mailpoet_hide_automations' => $this->servicesChecker->isBundledSubscription() && $this->wp->isPluginActive('automatewoo/automatewoo.php'),
+      'mailpoet_hide_automations' => $hideAutomations,
       'subscriber_count' => $subscriberCount,
       'subscribers_counts_cache_created_at' => $subscribersCacheCreatedAt->format('Y-m-d\TH:i:sO'),
       'subscribers_limit' => $this->subscribersFeature->getSubscribersLimit(),

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -507,7 +507,11 @@ class Menu {
   private function registerAutomationMenu() {
     $parentSlug = self::MAIN_PAGE_SLUG;
     // Automations menu is hidden when the subscription is part of a bundle and AutomateWoo is active but pages can be accessed directly
-    if ($this->wp->isPluginActive('automatewoo/automatewoo.php') && $this->servicesChecker->isBundledSubscription()) {
+    $showAutomations = !($this->wp->isPluginActive('automatewoo/automatewoo.php') &&
+      $this->servicesChecker->isBundledSubscription());
+    if (
+      !$this->wp->applyFilters('mailpoet_show_automations', $showAutomations)
+    ) {
       $parentSlug = '';
     }
 

--- a/mailpoet/tests/integration/Config/MenuTest.php
+++ b/mailpoet/tests/integration/Config/MenuTest.php
@@ -98,4 +98,43 @@ class MenuTest extends \MailPoetTest {
     $menu->setup();
 
   }
+
+  public function testItShowsAutomationIfFilterIsTrue() {
+    $checker = Stub::make(
+      new ServicesChecker(),
+      [
+        'isPremiumKeyValid' => true,
+        'isBundledSubscription' => true,
+      ],
+      $this
+    );
+
+    $wpMock = $this->createMock(WPFunctions::class);
+    $wpMock->method('isPluginActive')->willReturn(true);
+    $wpMock->method('applyFilters')->willReturn(true);
+
+    $accessControlMock = $this->createMock(AccessControl::class);
+    $accessControlMock->method('validatePermission')->willReturn(true);
+
+    $wpMock->expects($this->any())->method('addSubmenuPage')->withConsecutive(
+      [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
+      [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
+      [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
+      [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
+      [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
+      [Menu::MAIN_PAGE_SLUG, $this->anything(), $this->anything(), $this->anything(), Menu::AUTOMATIONS_PAGE_SLUG, $this->anything()]
+    )->willReturn(true);
+
+    $menu = new Menu(
+      $accessControlMock,
+      $wpMock,
+      $checker,
+      $this->diContainer,
+      $this->diContainer->get(Router::class),
+      $this->diContainer->get(CustomFonts::class)
+    );
+
+    $menu->setup();
+
+  }
 }


### PR DESCRIPTION
## Description

Add a filter to show automations for Bundled subscriptions (Woo Express), when AutomateWoo is active.

## Code review notes

_N/A_

## QA notes
To test:

- Go to MP shop Admin, search for my user with my automattic email and reset the site for subscription 564146
- Grab the key and install it on your site (this is a Woo Express subscription)
- Install and activate AutomateWoo
- Check that you don't see the automations menu
- Go to Emails > New Email, scroll down to Woo section, check that you don't see the Woo emails (only 2 cards)
- Add the filter (you can use a plugin like [Code Snippets](https://wordpress.org/plugins/code-snippets/))
```
// Add filter for 'mailpoet_show_automations'
add_filter('mailpoet_show_automations', 'return_true_for_mailpoet_show_automations');

function return_true_for_mailpoet_show_automations($value) {
    return true;
}
```
- Reload the page and check that you see the Automations Menu
- Go to Emails > New Email, scroll down to Woo section, check that you see Woo email types

Please reset the site again once you are done.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5573]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations -> NA
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes -> NA


[MAILPOET-5573]: https://mailpoet.atlassian.net/browse/MAILPOET-5573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ