### PR TITLE
Return parent product for variations [MAILPOET-5553]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -356,9 +356,19 @@ class OrderFieldsFactory {
       }
 
       $product = $item->get_product();
-      if ($product instanceof WC_Product) {
-        $products[] = $product;
+      if (!$product instanceof WC_Product) {
+        continue;
       }
+      if (!$product->is_type( 'variation' )) {
+        $products[] = $product;
+        continue;
+      }
+
+      $parentProduct = $this->wooCommerce->wcGetProduct($product->get_parent_id());
+      if (!$parentProduct instanceof WC_Product) {
+        continue;
+      }
+      $products[] = $parentProduct;
     }
     return array_unique($products);
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerce.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerce.php
@@ -34,6 +34,14 @@ class WooCommerce {
   }
 
   /**
+   * @param mixed $product
+   * @return \WC_Product|null|false
+   */
+  public function wcGetProduct($product) {
+    return wc_get_product($product);
+  }
+
+  /**
    * @param int|bool $order
    * @return bool|\WC_Order|\WC_Order_Refund
    */

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -439,6 +439,71 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertNotContains($product3->get_id(), $value);
   }
 
+  public function testProductsFieldWithVariableProduct(): void {
+    $product1 = new \WC_Product_Variable();
+    $product1->set_name('Product 1');
+    $product1->save();
+    $variableProduct = new \WC_Product_Variation();
+    $variableProduct->set_parent_id($product1->get_id());
+    $variableProduct->set_name('Product 1 Variation 1');
+    $variableProduct->save();
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($variableProduct);
+
+    $orderPayload = new OrderPayload($order);
+    $fields = $this->getFieldsMap();
+    $purchasedProducts = $fields['woocommerce:order:products'];
+    $value = $purchasedProducts->getValue($orderPayload);
+    $this->assertIsArray($value);
+    $this->assertContains($product1->get_id(), $value);
+    $this->assertNotContains($variableProduct->get_id(), $value);
+  }
+
+  public function testProductCategoriesFieldWithVariableProduct(): void {
+    $catId = $this->tester->createWordPressTerm('Cat 1', 'product_cat', ['slug' => 'cat-1']);
+    $product1 = new \WC_Product_Variable();
+    $product1->set_name('Product 1');
+    $product1->set_category_ids([$catId]);
+    $product1->save();
+    $variableProduct = new \WC_Product_Variation();
+    $variableProduct->set_parent_id($product1->get_id());
+    $variableProduct->set_name('Product 1 Variation 1');
+    $variableProduct->save();
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($variableProduct);
+
+    $orderPayload = new OrderPayload($order);
+    $fields = $this->getFieldsMap();
+    $purchasedCategories = $fields['woocommerce:order:categories'];
+    $value = $purchasedCategories->getValue($orderPayload);
+    $this->assertIsArray($value);
+    $this->assertContains($catId, $value);
+  }
+
+  public function testProductTagssFieldWithVariableProduct(): void {
+    $tagId = $this->tester->createWordPressTerm('Tag 1', 'product_tag', ['slug' => 'tag-1']);
+    $product1 = new \WC_Product_Variable();
+    $product1->set_name('Product 1');
+    $product1->set_tag_ids([$tagId]);
+    $product1->save();
+    $variableProduct = new \WC_Product_Variation();
+    $variableProduct->set_parent_id($product1->get_id());
+    $variableProduct->set_name('Product 1 Variation 1');
+    $variableProduct->save();
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($variableProduct);
+
+    $orderPayload = new OrderPayload($order);
+    $fields = $this->getFieldsMap();
+    $purchasedCategories = $fields['woocommerce:order:tags'];
+    $value = $purchasedCategories->getValue($orderPayload);
+    $this->assertIsArray($value);
+    $this->assertContains($tagId, $value);
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);


### PR DESCRIPTION
## Description
Fixes [MAILPOET-5553]

## Code review notes
I checked a bit how we do it in other parts of the code base and also how AW does it. Usually, we just replace the variation product with the parent product. Therefore I changed `getProducts()` and return the parent product in case of a variation.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-5553]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5553]: https://mailpoet.atlassian.net/browse/MAILPOET-5553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5553]: https://mailpoet.atlassian.net/browse/MAILPOET-5553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ