### PR TITLE
Bump used WooCommerce and AutomateWoo [MAILPOET-5588]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,11 +184,11 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.0.3
+            ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2
-            ./do download:automate-woo-zip 6.0.3
+            ./do download:automate-woo-zip 6.0.5
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |


### PR DESCRIPTION
## Description

Because there was a bug in AutomateWoo in compatibility with WC 8.1.0 that was fixed in AutomateWoo 6.0.4, we can use the latest version again.

## Code review notes

_N/A_

## QA notes

If CI is passing, we can skip QA here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5588]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5588]: https://mailpoet.atlassian.net/browse/MAILPOET-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ