### PR TITLE
Remove setting click_id to zero and keep the old one for WC stats [MAILPOET-5607]

### DIFF
--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -392,7 +392,7 @@ class NewslettersRepository extends Repository {
       $statisticsPurchasesTable = $entityManager->getClassMetadata(StatisticsWooCommercePurchaseEntity::class)->getTableName();
       $entityManager->getConnection()->executeStatement("
          UPDATE $statisticsPurchasesTable s
-         SET s.`newsletter_id` = 0, s.`click_id`=0 WHERE s.`newsletter_id` IN (:ids)
+         SET s.`newsletter_id` = 0 WHERE s.`newsletter_id` IN (:ids)
       ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);
 
       // Delete newsletter posts


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

**Bug replication**
1. Send a newsletter containing WC products
2. Open this newsletter and click on a product
3. After opening a tab with this product finish your purchase
4. Repeat steps 1-3 to have WC stats for at least two newsletters
5. Try to delete both newsletters

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5607]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5607]: https://mailpoet.atlassian.net/browse/MAILPOET-5607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ