### PR TITLE
Ensure WP_DEBUG is cast to a boolean value [MAILPOET-5608]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
@@ -42,7 +42,7 @@ class StepRunLogger {
     string $stepId,
     string $stepType,
     int $runNumber,
-    bool $isWpDebug = WP_DEBUG
+    bool $isWpDebug = null
   ) {
     $this->automationRunLogStorage = $automationRunLogStorage;
     $this->hooks = $hooks;
@@ -50,7 +50,17 @@ class StepRunLogger {
     $this->stepId = $stepId;
     $this->stepType = $stepType;
     $this->runNumber = $runNumber;
-    $this->isWpDebug = $isWpDebug;
+    $this->isWpDebug = $isWpDebug !== null ? $isWpDebug : $this->getWpDebug();
+  }
+
+  private function getWpDebug(): bool {
+    if (!defined('WP_DEBUG')) {
+      return false;
+    }
+    if (!is_bool(WP_DEBUG)) {
+      return in_array(strtolower((string)WP_DEBUG), ['true', '1'], true);
+    }
+    return WP_DEBUG;
   }
 
   public function logStart(): void {


### PR DESCRIPTION
## Description
This is a quick workaround to ensure `WP_DEBUG` is cast to a boolean. In a further iteration, we might want to move this logic to `WordPress`, but I wanted this to quickly get out.

## Code review notes


## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5608]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5608]: https://mailpoet.atlassian.net/browse/MAILPOET-5608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ