### PR TITLE
Fix displaying default condition when adding a segment [MAILPOET-5614]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
@@ -9,6 +9,18 @@ import {
 
 declare let window: SegmentFormDataWindow;
 
+export function getSegmentInitialState() {
+  return {
+    filters_connect: SegmentConnectTypes.AND,
+    filters: [
+      {
+        segmentType: SegmentTypes.WordPressRole,
+        action: SubscriberActionTypes.WORDPRESS_ROLE,
+      },
+    ],
+  };
+}
+
 export const getInitialState = (): StateType => ({
   automations: window.mailpoet_automations,
   products: window.mailpoet_products,
@@ -27,15 +39,7 @@ export const getInitialState = (): StateType => ({
   customFieldsList: window.mailpoet_custom_fields,
   tags: window.mailpoet_tags,
   signupForms: window.mailpoet_signup_forms,
-  segment: {
-    filters_connect: SegmentConnectTypes.AND,
-    filters: [
-      {
-        segmentType: SegmentTypes.WordPressRole,
-        action: SubscriberActionTypes.WORDPRESS_ROLE,
-      },
-    ],
-  },
+  segment: getSegmentInitialState(),
   subscriberCount: {
     loading: false,
   },

--- a/mailpoet/assets/js/src/segments/dynamic/store/reducer.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/reducer.ts
@@ -9,6 +9,7 @@ import {
   StateType,
   SetPreviousPageActionType,
 } from '../types';
+import { getSegmentInitialState } from './initial-state';
 
 function setSegment(state: StateType, action: SetSegmentActionType): StateType {
   return {
@@ -20,7 +21,7 @@ function setSegment(state: StateType, action: SetSegmentActionType): StateType {
 function resetSegmentAndErrors(state: StateType): StateType {
   return {
     ...state,
-    segment: { filters: [] },
+    segment: getSegmentInitialState(),
     errors: [],
   };
 }


### PR DESCRIPTION
## Description

Whenever the user goes to add a new segment, MP displays `WordPress user role` as the default condition. But there was a
bug that was preventing the default condition from being displayed, if the user left the page by clicking in the back button, and then returned by clicking again on the `Create custom segment` button.

This bug was introduced in dba4ba4dfc4ef6f5ce8120eef014710f966292ae. It added code to unset the segment when the user left the segment editing page. This was necessary as, in that PR, we started using the same store for all the dynamic segment pages. The problem is that the added code sets the segment to an empty array and actually we need to restore the initial state which is a segment with the `WordPress user role` selected as its single filter. This is what is done in this PR.

## Code review notes

_N/A_

## QA notes

Check the Jira ticket for steps on how to reproduce this issue. Ensure it is not an issue anymore when testing this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5614]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5614]: https://mailpoet.atlassian.net/browse/MAILPOET-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ