### PR TITLE
Ensure that WooCommerce is actually active [MAILPOET-5613]

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -18,7 +18,7 @@ class Helper {
   }
 
   public function isWooCommerceActive() {
-    return class_exists('WooCommerce');
+    return class_exists('WooCommerce') && $this->wp->isPluginActive('woocommerce/woocommerce.php');
   }
 
   public function getWooCommerceVersion() {
@@ -148,7 +148,7 @@ class Helper {
   }
 
   public function getCustomersCount(): int {
-    if (!class_exists(Query::class)) {
+    if (!$this->isWooCommerceActive() || !class_exists(Query::class)) {
       return 0;
     }
     $query = new Query([


### PR DESCRIPTION
## Description
In a video you can see how MailPoet crashes during the activation of a lot of plugins. Following the related [blog post](https://silvanhagen.com/writing/most-popular-wordpress-plugins/) I tried to replicate the issue. Sometimes it did replicate and I got the fatal error screen, sometimes it didn't.

The error is thrown in the Migrator. It states `\WC_Query_Object` not found. In the instances where I did not get the fatal error on screen, I was still able to see, that the related migration failed. I couldn't pin it down, but I assume some autoloader of one of the plugins loads the `WooCommerce` class or the `Query` class without WooCommerce being active. This PR therefore strenghtens how we determine whether WooCommerce is actually active or not. With this PR I was not able to reproduce the issue and the migration worked as expected.

## Code review notes

_N/A_

## QA notes
Not sure if its worth the effort to install 108 plugins and all. I would instead suggest that the normal installation activation still works as expected and that all migrations work without a failure. This PR alters a bit the behavior how we determine whether Woo is active. So it might be worth a quick look whether MailPoet still works as expected with Woo active/inactive.

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-5613]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5613]: https://mailpoet.atlassian.net/browse/MAILPOET-5613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ