### PR TITLE
Ensure the integer is returned when we call paginated wc_get_orders [MAILPOET-5621]

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -235,7 +235,6 @@ class FirstPurchase {
         'paginate' => true,
       ]
     )->total;
-
-    return $ordersCount;
+    return intval($ordersCount);
   }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -135,7 +135,7 @@ class Helper {
       'paginate' => true,
     ])->total;
 
-    return $ordersCount;
+    return intval($ordersCount);
   }
 
   public function getRawPrice($price, array $args = []) {


### PR DESCRIPTION
## Description
This PR adds a preventive fix for a BC break found in Woo 8.2.0-beta.1. I reported the issue to Woo, and there is a [GH issue](https://github.com/woocommerce/woocommerce/issues/40548) for the problem. I want to be sure we don't cause 500 on the checkout page if the Woo issue is not fixed for the 8.2.0 release.

## Code review notes

I added the commit with the fix also to the testing branch, which runs with Woo 8.2.0-beta.1

Here is the [failing build where I detected the issue](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/15738/workflows/72e3b79e-7464-4c13-a1fa-f6e0188d4039).
Here is [the build with fix](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/15740/workflows/c7ad1eb5-a8ed-4544-bd5c-365b51508488). Note there is a failure with the translation test. This is related to WP 6.4 Beta, a different issue.

## QA notes

### Replication 

Install Woo Beta 8.2.0-beta.1
Add First Purchase Email
Create an order

## Linked PRs

_N/A_

## Linked tickets

https://github.com/woocommerce/woocommerce/issues/40548
[MAILPOET-5621]

## After-merge notes

_N/A_

## Tasks

- [x] ⛔  I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] ⛔ I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5621]: https://mailpoet.atlassian.net/browse/MAILPOET-5621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ