### PR TITLE
Make public.js loaded as deferred [MAILPOET-5623]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -154,6 +154,7 @@ interface Window {
   grecaptcha?: any;
   MailPoetForm?: {
     ajax_url: string;
+    ajax_common_error_message: string;
   };
   mailpoet_authorized_emails?: string[];
   mailpoet_verified_sender_domains?: string[];

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -9,6 +9,13 @@ const exitIntentEvent = 'mouseleave.mailpoet.form-exit-intent';
 const startingClassName = 'starting-to-show';
 
 jQuery(($) => {
+  // Initialize Ajax Error message
+  MailPoet.I18n.add(
+    'ajaxFailedErrorMessage',
+    window.MailPoetForm.ajax_common_error_message,
+  );
+
+  // Initialize Parsley validation
   Parsley.addValidator('names', {
     requirementType: ['string', 'string'],
     validateString: (value, errorBrackets, errorURL) => {

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -78,12 +78,23 @@ class AssetsController {
       Env::$assetsUrl . '/dist/css/' . $this->renderer->getCssAsset('mailpoet-public.css')
     );
 
+    $enqueuePlacementParams = [
+      'in_footer' => true,
+      'strategy' => 'defer',
+    ];
+
+    // BC for WP < 6.3 - Can be removed after we drop support for WP 6.2
+    global $wp_version;
+    if (version_compare($wp_version, '6.3', '<')) {
+      $enqueuePlacementParams = true;
+    }
+    
     $this->wp->wpEnqueueScript(
       'mailpoet_public',
       Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.js'),
       ['jquery'],
       Env::$version,
-      true
+      $enqueuePlacementParams
     );
 
     $ajaxFailedErrorMessage = __('An error has happened while performing a request, please try again later.', 'mailpoet');

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -86,28 +86,12 @@ class AssetsController {
       true
     );
 
+    $ajaxFailedErrorMessage = __('An error has happened while performing a request, please try again later.', 'mailpoet');
     $this->wp->wpLocalizeScript('mailpoet_public', 'MailPoetForm', [
       'ajax_url' => $this->wp->adminUrl('admin-ajax.php'),
       'is_rtl' => (function_exists('is_rtl') ? (bool)is_rtl() : false),
+      'ajax_common_error_message' => esc_js($ajaxFailedErrorMessage),
     ]);
-
-    $ajaxFailedErrorMessage = __('An error has happened while performing a request, please try again later.', 'mailpoet');
-
-    $inlineScript = <<<EOL
-function initMailpoetTranslation() {
-  if (typeof MailPoet !== 'undefined') {
-    MailPoet.I18n.add('ajaxFailedErrorMessage', '%s')
-  } else {
-    setTimeout(initMailpoetTranslation, 250);
-  }
-}
-setTimeout(initMailpoetTranslation, 250);
-EOL;
-    $this->wp->wpAddInlineScript(
-      'mailpoet_public',
-      sprintf($inlineScript, esc_js($ajaxFailedErrorMessage)),
-      'after'
-    );
   }
 
   public function setupAdminWidgetPageDependencies() {


### PR DESCRIPTION
## Description

The defer attribute is a boolean attribute that ensures that the JavaScript for a web page is downloaded in parallel to its parsing. So, it executes the script only after the browser completes the rendering activity.

This is a small enhancement towards performance. WordPress added native support for this in WP 6.3
## Code review notes

Please see the explanation in [the ticket](https://mailpoet.atlassian.net/browse/MAILPOET-5623) and commit messages.

## QA notes
Please check that the JS on the front end works as expected (forms and built-in captcha).
This PR also prevents a potential issue when jQuery is configured to be loaded as deferred, but MailPoet script is not. Please see steps to replicate in [the ticket description](https://mailpoet.atlassian.net/browse/MAILPOET-5623).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5623]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5623]: https://mailpoet.atlassian.net/browse/MAILPOET-5623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ