### PR TITLE
Fix Error when WP_Block_Editor_Context is not passed to filters [MAILPOET-5624]

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -14,6 +14,7 @@ use MailPoet\Cron\DaemonActionSchedulerRunner;
 use MailPoet\EmailEditor\Engine\EmailEditor;
 use MailPoet\EmailEditor\Integrations\Core\Initializer as CoreEmailEditorIntegration;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEditorIntegration;
+use MailPoet\Features\FeaturesController;
 use MailPoet\InvalidStateException;
 use MailPoet\Migrator\Cli as MigratorCli;
 use MailPoet\PostEditorBlocks\PostEditorBlock;
@@ -130,6 +131,9 @@ class Initializer {
   /** @var CoreEmailEditorIntegration */
   private $coreEmailEditorIntegration;
 
+  /** @var FeaturesController */
+  private $featureController;
+
   /** @var Url */
   private $urlHelper;
 
@@ -170,6 +174,7 @@ class Initializer {
     EmailEditor $emailEditor,
     MailpoetEmailEditorIntegration $mailpoetEmailEditorIntegration,
     CoreEmailEditorIntegration $coreEmailEditorIntegration,
+    FeaturesController $featureController,
     Url $urlHelper
   ) {
     $this->rendererFactory = $rendererFactory;
@@ -204,6 +209,7 @@ class Initializer {
     $this->emailEditor = $emailEditor;
     $this->mailpoetEmailEditorIntegration = $mailpoetEmailEditorIntegration;
     $this->coreEmailEditorIntegration = $coreEmailEditorIntegration;
+    $this->featureController = $featureController;
     $this->urlHelper = $urlHelper;
   }
 
@@ -360,7 +366,9 @@ class Initializer {
       $this->subscriberActivityTracker->trackActivity();
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();
-      $this->emailEditor->initialize();
+      if ($this->featureController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR)) {
+        $this->emailEditor->initialize();
+      }
 
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {

--- a/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
@@ -76,12 +76,12 @@ class EmailEditor {
 
   /**
    * @param string[]|bool $allowedBlockTypes
-   * @param \WP_Block_Editor_Context $blockEditorContext
+   * @param \WP_Block_Editor_Context|null $blockEditorContext
    * @return array|bool
    */
-  public function setAllowedBlocksInEmails($allowedBlockTypes, \WP_Block_Editor_Context $blockEditorContext) {
+  public function setAllowedBlocksInEmails($allowedBlockTypes, ?\WP_Block_Editor_Context $blockEditorContext = null) {
     $emailPostTypes = array_column($this->getPostTypes(), 'name');
-    if (!$blockEditorContext->post || !in_array($blockEditorContext->post->post_type, $emailPostTypes, true)) {
+    if ($blockEditorContext === null || !$blockEditorContext->post || !in_array($blockEditorContext->post->post_type, $emailPostTypes, true)) {
       return $allowedBlockTypes;
     }
     return self::ALLOWED_BLOCK_TYPES;
@@ -104,9 +104,9 @@ class EmailEditor {
     ]);
   }
 
-  public function updateBlockEditorSettings(array $settings, \WP_Block_Editor_Context $blockEditorContext): array {
+  public function updateBlockEditorSettings(array $settings, ?\WP_Block_Editor_Context $blockEditorContext = null): array {
     $emailPostTypes = array_column($this->getPostTypes(), 'name');
-    if (!$blockEditorContext->post || !in_array($blockEditorContext->post->post_type, $emailPostTypes, true)) {
+    if ($blockEditorContext === null || !$blockEditorContext->post || !in_array($blockEditorContext->post->post_type, $emailPostTypes, true)) {
       return $settings;
     }
     $settings['enableCustomUnits'] = ['px', '%']; // Allow only units we can support in email renderer

--- a/mailpoet/tests/integration/EmailEditor/Engine/EmailEditorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/EmailEditorTest.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\EmailEditor\Engine;
 
+use MailPoet\WP\Functions;
+
 class EmailEditorTest extends \MailPoetTest {
   /** @var EmailEditor */
   private $emailEditor;
@@ -40,6 +42,29 @@ class EmailEditorTest extends \MailPoetTest {
     expect($blockTypes)->contains('core/columns');
     expect($blockTypes)->contains('core/column');
     expect(count((array)$blockTypes))->equals(4);
+  }
+
+  public function testItWorksWithEmptyEditorContext() {
+    $settings = [
+      'test' => 1,
+    ];
+    $blockTypes = [
+      'core/paragraph',
+    ];
+    $wp = $this->diContainer->get(Functions::class);
+    $wp->removeAllFilters('block_editor_settings_all');
+    $wp->removeAllFilters('allowed_block_types_all');
+    $this->emailEditor->initialize();
+    // Test without the context argument
+    $filteredSettings = $wp->applyFilters('block_editor_settings_all', $settings);
+    $filteredBlockTypes = $wp->applyFilters('allowed_block_types_all', $blockTypes);
+    expect($filteredSettings)->equals($settings);
+    expect($filteredBlockTypes)->equals($blockTypes);
+    // Test with the context argument as null
+    $filteredSettings = $wp->applyFilters('block_editor_settings_all', $settings, null);
+    $filteredBlockTypes = $wp->applyFilters('allowed_block_types_all', $blockTypes, null);
+    expect($filteredSettings)->equals($settings);
+    expect($filteredBlockTypes)->equals($blockTypes);
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\EmailEditor\Engine\Renderer;
 
+use MailPoet\EmailEditor\Engine\EmailEditor;
 use MailPoet\EmailEditor\Engine\StylesController;
 
 require_once __DIR__ . '/DummyBlockRenderer.php';
@@ -15,6 +16,7 @@ class RendererTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
+    $this->diContainer->get(EmailEditor::class)->initialize();
     $this->renderer = $this->diContainer->get(Renderer::class);
     $this->emailPost = new \WP_Post((object)[
       'post_content' => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
+use MailPoet\EmailEditor\Engine\EmailEditor;
 use MailPoet\EmailEditor\Engine\Renderer\BlocksRenderer;
 use MailPoet\EmailEditor\Engine\StylesController;
 
@@ -42,6 +43,7 @@ class ColumnsTest extends \MailPoetTest {
   ];
 
   public function _before() {
+    $this->diContainer->get(EmailEditor::class)->initialize();
     $this->blocksRenderer = $this->diContainer->get(BlocksRenderer::class);
     $this->columnsRenderer = new Columns();
   }


### PR DESCRIPTION
## Description
This PR fixes PHP Fatal error:  Uncaught TypeError: MailPoet\EmailEditor\Engine\EmailEditor::updateBlockEditorSettings(): Argument #2 ($blockEditorContext) must be of type WP_Block_Editor_Context, null given,

1. We won't initialize hooks when editor feature is disabled
2. Callbacks will not fail when WP_Block_Editor_Context is not passed

## Code review notes

_N/A_

## QA notes
This issue was causing a plugin conflict with [Kubio page builder](https://wordpress.org/plugins/kubio/).

#### Replication

1. Install Kubio
2. From admin menu, click: Kubio > Open Kubio Editor

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5624]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫  I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5624]: https://mailpoet.atlassian.net/browse/MAILPOET-5624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ