### PR TITLE
Catch activation in progress exception when it runs on DB version check [MAILPOET-5627]

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -411,9 +411,15 @@ class Initializer {
       $currentDbVersion = null;
     }
 
+    if (version_compare((string)$currentDbVersion, Env::$version) === 0) {
+      return;
+    }
+
     // if current db version and plugin version differ
-    if (version_compare((string)$currentDbVersion, Env::$version) !== 0) {
+    try {
       $this->activator->activate();
+    } catch (InvalidStateException $e) {
+      $this->handleRunningMigration($e);
     }
   }
 

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -420,6 +420,8 @@ class Initializer {
       $this->activator->activate();
     } catch (InvalidStateException $e) {
       $this->handleRunningMigration($e);
+    } catch (\Exception $e) {
+      $this->handleFailedInitialization($e);
     }
   }
 


### PR DESCRIPTION
## Description

I think the issue was introduced when started running the activator earlier (https://github.com/mailpoet/mailpoet/pull/5134). 
With the change, we moved the activation out of the try/catch block.


## Code review notes

_N/A_

## QA notes

Please check that upgrading the plugin works as expected. I recommend testing upgrading from a couple of months old version and test upgrading via WP admin and also upgrading via uploading the new version via FTP.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5627]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5627]: https://mailpoet.atlassian.net/browse/MAILPOET-5627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ