### PR TITLE
Add email preview to the Gutenberg email editor [MAILPOET-5563]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/header-button-slot.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header-button-slot.tsx
@@ -2,9 +2,13 @@ import { useEffect, useState, createPortal } from '@wordpress/element';
 
 type NextButtonSlotPropType = {
   children: JSX.Element;
+  className?: string;
 };
 
-export function NextButtonSlot({ children }: NextButtonSlotPropType) {
+export function HeaderButtonSlot({
+  children,
+  className,
+}: NextButtonSlotPropType) {
   const [sendButtonPortalEl] = useState(document.createElement('div'));
 
   // Place element for rendering send button next to publish button
@@ -15,5 +19,8 @@ export function NextButtonSlot({ children }: NextButtonSlotPropType) {
     publishButton.parentNode.insertBefore(sendButtonPortalEl, publishButton);
   }, [sendButtonPortalEl]);
 
-  return createPortal(<>{children}</>, sendButtonPortalEl);
+  return createPortal(
+    <div className={className}>{children}</div>,
+    sendButtonPortalEl,
+  );
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/preview-dropdown.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/preview-dropdown.tsx
@@ -1,0 +1,97 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - some of Gutenberg types are not available yet
+import {
+  MenuGroup,
+  MenuItem,
+  Button,
+  DropdownMenu,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
+import { Icon, external, check, mobile, desktop } from '@wordpress/icons';
+
+type PreviewDropdownProps = {
+  newsletterPreviewUrl: string | null;
+};
+
+export function PreviewDropdown({
+  newsletterPreviewUrl,
+}: PreviewDropdownProps) {
+  // We use WP store at this moment, but if we use our own store in combination with our canvas
+  // it's possible to use use-resize-canvas for resizing the canvas by the device type
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
+    useDispatch(editPostStore);
+
+  const [deviceType, setDeviceType] = useState<string>('Desktop');
+
+  const changeDeviceType = (newDeviceType: string) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    setPreviewDeviceType(newDeviceType);
+    setDeviceType(newDeviceType);
+  };
+
+  const openInNewTab = (url: string) => {
+    window.open(url, '_blank', 'noreferrer');
+  };
+
+  const deviceIcons = {
+    mobile,
+    desktop,
+  };
+
+  return (
+    <DropdownMenu
+      className="mailpoet-preview-dropdown"
+      label={__('Preview', 'mailpoet')}
+      icon={deviceIcons[deviceType.toLowerCase()]}
+    >
+      {({ onClose }) => (
+        <>
+          <MenuGroup>
+            <MenuItem
+              className="block-editor-post-preview__button-resize"
+              onClick={() => changeDeviceType('Desktop')}
+              icon={deviceType === 'Desktop' && check}
+            >
+              {__('Desktop')}
+            </MenuItem>
+            <MenuItem
+              className="block-editor-post-preview__button-resize"
+              onClick={() => changeDeviceType('Mobile')}
+              icon={deviceType === 'Mobile' && check}
+            >
+              {__('Mobile')}
+            </MenuItem>
+          </MenuGroup>
+          <MenuGroup>
+            <MenuItem
+              className="block-editor-post-preview__button-resize"
+              onClick={() => {
+                onClose();
+              }}
+            >
+              {__('Send a test email', 'mailpoet')}
+            </MenuItem>
+          </MenuGroup>
+          <MenuGroup>
+            <div className="edit-post-header-preview__grouping-external">
+              <Button
+                className="edit-post-header-preview__button-external"
+                onClick={() => {
+                  openInNewTab(newsletterPreviewUrl);
+                }}
+              >
+                {__('Preview in new tab')}
+                <Icon icon={external} />
+              </Button>
+            </div>
+          </MenuGroup>
+        </>
+      )}
+    </DropdownMenu>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/preview-dropdown.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/preview-dropdown.tsx
@@ -14,10 +14,12 @@ import { Icon, external, check, mobile, desktop } from '@wordpress/icons';
 import { SendPreviewEmail } from './send-preview-email';
 
 type PreviewDropdownProps = {
+  newsletterId: number | null;
   newsletterPreviewUrl: string | null;
 };
 
 export function PreviewDropdown({
+  newsletterId,
   newsletterPreviewUrl,
 }: PreviewDropdownProps) {
   // We use WP store at this moment, but if we use our own store in combination with our canvas
@@ -100,6 +102,7 @@ export function PreviewDropdown({
       <SendPreviewEmail
         isOpen={isModalOpen}
         closeCallback={() => setIsModalOpen(false)}
+        newsletterId={newsletterId}
       />
     </>
   );

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/preview-dropdown.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/preview-dropdown.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { Icon, external, check, mobile, desktop } from '@wordpress/icons';
+import { SendPreviewEmail } from './send-preview-email';
 
 type PreviewDropdownProps = {
   newsletterPreviewUrl: string | null;
@@ -26,6 +27,7 @@ export function PreviewDropdown({
   const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
     useDispatch(editPostStore);
 
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [deviceType, setDeviceType] = useState<string>('Desktop');
 
   const changeDeviceType = (newDeviceType: string) => {
@@ -44,54 +46,61 @@ export function PreviewDropdown({
   };
 
   return (
-    <DropdownMenu
-      className="mailpoet-preview-dropdown"
-      label={__('Preview', 'mailpoet')}
-      icon={deviceIcons[deviceType.toLowerCase()]}
-    >
-      {({ onClose }) => (
-        <>
-          <MenuGroup>
-            <MenuItem
-              className="block-editor-post-preview__button-resize"
-              onClick={() => changeDeviceType('Desktop')}
-              icon={deviceType === 'Desktop' && check}
-            >
-              {__('Desktop')}
-            </MenuItem>
-            <MenuItem
-              className="block-editor-post-preview__button-resize"
-              onClick={() => changeDeviceType('Mobile')}
-              icon={deviceType === 'Mobile' && check}
-            >
-              {__('Mobile')}
-            </MenuItem>
-          </MenuGroup>
-          <MenuGroup>
-            <MenuItem
-              className="block-editor-post-preview__button-resize"
-              onClick={() => {
-                onClose();
-              }}
-            >
-              {__('Send a test email', 'mailpoet')}
-            </MenuItem>
-          </MenuGroup>
-          <MenuGroup>
-            <div className="edit-post-header-preview__grouping-external">
-              <Button
-                className="edit-post-header-preview__button-external"
+    <>
+      <DropdownMenu
+        className="mailpoet-preview-dropdown"
+        label={__('Preview', 'mailpoet')}
+        icon={deviceIcons[deviceType.toLowerCase()]}
+      >
+        {({ onClose }) => (
+          <>
+            <MenuGroup>
+              <MenuItem
+                className="block-editor-post-preview__button-resize"
+                onClick={() => changeDeviceType('Desktop')}
+                icon={deviceType === 'Desktop' && check}
+              >
+                {__('Desktop')}
+              </MenuItem>
+              <MenuItem
+                className="block-editor-post-preview__button-resize"
+                onClick={() => changeDeviceType('Mobile')}
+                icon={deviceType === 'Mobile' && check}
+              >
+                {__('Mobile')}
+              </MenuItem>
+            </MenuGroup>
+            <MenuGroup>
+              <MenuItem
+                className="block-editor-post-preview__button-resize"
                 onClick={() => {
-                  openInNewTab(newsletterPreviewUrl);
+                  setIsModalOpen(true);
+                  onClose();
                 }}
               >
-                {__('Preview in new tab')}
-                <Icon icon={external} />
-              </Button>
-            </div>
-          </MenuGroup>
-        </>
-      )}
-    </DropdownMenu>
+                {__('Send a test email', 'mailpoet')}
+              </MenuItem>
+            </MenuGroup>
+            <MenuGroup>
+              <div className="edit-post-header-preview__grouping-external">
+                <Button
+                  className="edit-post-header-preview__button-external"
+                  onClick={() => {
+                    openInNewTab(newsletterPreviewUrl);
+                  }}
+                >
+                  {__('Preview in new tab')}
+                  <Icon icon={external} />
+                </Button>
+              </div>
+            </MenuGroup>
+          </>
+        )}
+      </DropdownMenu>
+      <SendPreviewEmail
+        isOpen={isModalOpen}
+        closeCallback={() => setIsModalOpen(false)}
+      />
+    </>
   );
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/send-preview-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/send-preview-email.tsx
@@ -1,0 +1,72 @@
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import ReactStringReplace from 'react-string-replace';
+
+type SendPreviewEmailProps = {
+  isOpen: boolean;
+  closeCallback: () => void;
+};
+
+export function SendPreviewEmail({
+  isOpen,
+  closeCallback,
+}: SendPreviewEmailProps) {
+  let description = ReactStringReplace(
+    __(
+      'Send yourself a test email to test how your email would look like in different email apps. You could also enter your [link1]Mail Tester[/link1] email below to test your spam score. [link2]Learn more[/link2].',
+      'mailpoet',
+    ),
+    /\[link1\](.*?)\[\/link1\]/g,
+    (match, i) => (
+      <a
+        key={i}
+        href="https://www.mail-tester.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {match}
+      </a>
+    ),
+  );
+  description = ReactStringReplace(
+    description,
+    /\[link2\](.*?)\[\/link2\]/g,
+    (match, i) => (
+      <a
+        key={i}
+        href="https://kb.mailpoet.com/article/147-test-your-spam-score-with-mail-tester"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {match}
+      </a>
+    ),
+  );
+
+  return (
+    <>
+      {isOpen ? (
+        <Modal
+          className="mailpoet-send-preview-email"
+          title={__('Send a test email', 'mailpoet')}
+          onRequestClose={closeCallback}
+        >
+          <p>{description}</p>
+          <TextControl
+            label={__('Send to', 'mailpoet')}
+            onChange={() => {}}
+            value=""
+          />
+          <div className="mailpoet-send-preview-modal-footer">
+            <Button variant="tertiary" onClick={closeCallback}>
+              {__('Close', 'mailpoet')}
+            </Button>
+            <Button variant="primary" onClick={() => {}}>
+              {__('Send test email', 'mailpoet')}
+            </Button>
+          </div>
+        </Modal>
+      ) : null}
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/send-preview-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/send-preview-email.tsx
@@ -1,16 +1,27 @@
 import { Button, Modal, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import ReactStringReplace from 'react-string-replace';
+import { dispatch, useSelect } from '@wordpress/data';
+import { storeName } from '../store';
 
 type SendPreviewEmailProps = {
   isOpen: boolean;
   closeCallback: () => void;
+  newsletterId: number | null;
 };
 
 export function SendPreviewEmail({
   isOpen,
   closeCallback,
+  newsletterId,
 }: SendPreviewEmailProps) {
+  const { previewToEmail } = useSelect(
+    (select) => ({
+      previewToEmail: select(storeName).getPreviewToEmail(),
+    }),
+    [],
+  );
+
   let description = ReactStringReplace(
     __(
       'Send yourself a test email to test how your email would look like in different email apps. You could also enter your [link1]Mail Tester[/link1] email below to test your spam score. [link2]Learn more[/link2].',
@@ -43,6 +54,13 @@ export function SendPreviewEmail({
     ),
   );
 
+  const handleSendPreviewEmail = () => {
+    dispatch(storeName).requestSendingNewsletterPreview(
+      newsletterId,
+      previewToEmail,
+    );
+  };
+
   return (
     <>
       {isOpen ? (
@@ -54,14 +72,16 @@ export function SendPreviewEmail({
           <p>{description}</p>
           <TextControl
             label={__('Send to', 'mailpoet')}
-            onChange={() => {}}
-            value=""
+            onChange={(email) => {
+              dispatch(storeName).updatePreviewToEmail(email);
+            }}
+            value={previewToEmail}
           />
           <div className="mailpoet-send-preview-modal-footer">
             <Button variant="tertiary" onClick={closeCallback}>
               {__('Close', 'mailpoet')}
             </Button>
-            <Button variant="primary" onClick={() => {}}>
+            <Button variant="primary" onClick={handleSendPreviewEmail}>
               {__('Send test email', 'mailpoet')}
             </Button>
           </div>

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/send-preview-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/components/send-preview-email.tsx
@@ -2,7 +2,7 @@ import { Button, Modal, TextControl } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import ReactStringReplace from 'react-string-replace';
+import { createInterpolateElement } from '@wordpress/element';
 import { SendingPreviewStatus, storeName } from '../store';
 
 type SendPreviewEmailProps = {
@@ -25,38 +25,6 @@ export function SendPreviewEmail({
       }),
       [],
     );
-
-  let description = ReactStringReplace(
-    __(
-      'Send yourself a test email to test how your email would look like in different email apps. You could also enter your [link1]Mail Tester[/link1] email below to test your spam score. [link2]Learn more[/link2].',
-      'mailpoet',
-    ),
-    /\[link1\](.*?)\[\/link1\]/g,
-    (match, i) => (
-      <a
-        key={i}
-        href="https://www.mail-tester.com/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {match}
-      </a>
-    ),
-  );
-  description = ReactStringReplace(
-    description,
-    /\[link2\](.*?)\[\/link2\]/g,
-    (match, i) => (
-      <a
-        key={i}
-        href="https://kb.mailpoet.com/article/147-test-your-spam-score-with-mail-tester"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {match}
-      </a>
-    ),
-  );
 
   const handleSendPreviewEmail = () => {
     // We need to
@@ -84,50 +52,74 @@ export function SendPreviewEmail({
               {__('Sorry, we were unable to send this email.', 'mailpoet')}
               <ul>
                 <li>
-                  {ReactStringReplace(
+                  {createInterpolateElement(
                     __(
-                      'Please check your [link]sending method configuration[/link] with your hosting provider.',
+                      'Please check your <link>sending method configuration</link> with your hosting provider.',
                       'mailpoet',
                     ),
-                    /\[link\](.*?)\[\/link\]/g,
-                    (match) => (
-                      <a
-                        href="admin.php?page=mailpoet-settings#mta"
-                        key="check-sending"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {match}
-                      </a>
-                    ),
+                    {
+                      link: (
+                        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                        <a
+                          href="admin.php?page=mailpoet-settings#mta"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      ),
+                    },
                   )}
                 </li>
                 <li>
-                  {ReactStringReplace(
+                  {createInterpolateElement(
                     __(
-                      'Or, sign up for MailPoet Sending Service to easily send emails. [link]Sign up for free[/link]',
+                      'Or, sign up for MailPoet Sending Service to easily send emails. <link>Sign up for free</link>',
                       'mailpoet',
                     ),
-                    /\[link\](.*?)\[\/link\]/g,
-                    (match) => (
-                      <a
-                        href={new URL(
-                          'free-plan',
-                          'https://www.mailpoet.com/',
-                        ).toString()}
-                        key="sign-up-for-free"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {match}
-                      </a>
-                    ),
+                    {
+                      link: (
+                        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                        <a
+                          href={new URL(
+                            'free-plan',
+                            'https://www.mailpoet.com/',
+                          ).toString()}
+                          key="sign-up-for-free"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      ),
+                    },
                   )}
                 </li>
               </ul>
             </div>
           ) : null}
-          <p>{description}</p>
+          <p>
+            {createInterpolateElement(
+              __(
+                'Send yourself a test email to test how your email would look like in different email apps. You could also enter your <link1>Mail Tester</link1> email below to test your spam score. <link2>Learn more</link2>.',
+                'mailpoet',
+              ),
+              {
+                link1: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://www.mail-tester.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                ),
+                link2: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://kb.mailpoet.com/article/147-test-your-spam-score-with-mail-tester"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                ),
+              },
+            )}
+          </p>
           <TextControl
             label={__('Send to', 'mailpoet')}
             onChange={(email) => {

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.scss
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.scss
@@ -34,4 +34,15 @@
   .mailpoet-preview-dropdown .components-menu-item__button:nth-child(2) {
     display: none;
   }
+
+  .mailpoet-send-preview-email {
+    max-width: 456px;
+  }
+
+  .mailpoet-send-preview-modal-footer {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    padding-top: 16px;
+  }
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.scss
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.scss
@@ -27,7 +27,9 @@
     display: none;
   }
   // Keep the MailPoet "Preview" button in the header
-  .edit-post-header__settings .mailpoet-header-button-preview .block-editor-post-preview__dropdown {
+  .edit-post-header__settings
+    .mailpoet-header-button-preview
+    .block-editor-post-preview__dropdown {
     display: block;
   }
   // Hide the "Preview" button in the dropdown
@@ -44,5 +46,23 @@
     gap: 12px;
     justify-content: flex-end;
     padding-top: 16px;
+  }
+
+  .mailpoet-send-preview-modal-notice-error {
+    background-color: #fcf0f1;
+    gap: 12px;
+    padding: 12px 16px;
+
+    ul {
+      list-style: disc;
+      margin: 0;
+      padding: 5px 0 0 20px;
+    }
+  }
+
+  .mailpoet-send-preview-modal-notice-success {
+    align-items: center;
+    display: flex;
+    padding-top: 2px;
   }
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
@@ -2,7 +2,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { useSelect, select as directSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
-import { NextButtonSlot } from 'email-editor/engine/components/next-button-slot';
+import { HeaderButtonSlot } from 'email-editor/engine/components/header-button-slot';
 import { LayoutStyles } from 'email-editor/engine/components/layout-styles';
 import { useDisableWelcomeGuide } from 'email-editor/engine/hooks';
 import { NextButton } from './components/next-button';
@@ -32,9 +32,9 @@ function Editor() {
   return (
     <>
       <LayoutStyles />
-      <NextButtonSlot>
+      <HeaderButtonSlot>
         <NextButton newsletterId={mailpoetData?.id ?? null} />
-      </NextButtonSlot>
+      </HeaderButtonSlot>
       <SettingsSidebar />
     </>
   );

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
@@ -6,14 +6,14 @@ import { store as editorStore } from '@wordpress/editor';
 import { HeaderButtonSlot } from 'email-editor/engine/components/header-button-slot';
 import { LayoutStyles } from 'email-editor/engine/components/layout-styles';
 import { useDisableWelcomeGuide } from 'email-editor/engine/hooks';
+import { useState } from 'react';
 import { NextButton } from './components/next-button';
 import { SettingsSidebar } from './components/settings-panel';
 import { PreviewDropdown } from './components/preview-dropdown';
-import { useState } from 'react';
 import { createStore } from './store';
 import { MailPoetEmailData } from './types';
 
-import './email_editor.scss';
+import './email-editor.scss';
 
 // Hack to temporarily disable block patterns
 directSelect(coreStore).getBlockPatterns = () => [];

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { useSelect, select as directSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -8,6 +9,7 @@ import { useDisableWelcomeGuide } from 'email-editor/engine/hooks';
 import { NextButton } from './components/next-button';
 import { SettingsSidebar } from './components/settings-panel';
 import { PreviewDropdown } from './components/preview-dropdown';
+import { createStore } from './store';
 import { MailPoetEmailData } from './types';
 
 import './email_editor.scss';
@@ -26,6 +28,11 @@ function Editor() {
         'mailpoet_data',
       ) as MailPoetEmailData) ?? null,
   }));
+
+  // Initialize the store
+  useEffect(() => {
+    createStore();
+  }, []);
 
   // We don't want to show the editor welcome guide as it is not relevant to emails
   useDisableWelcomeGuide();

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
@@ -9,6 +9,7 @@ import { useDisableWelcomeGuide } from 'email-editor/engine/hooks';
 import { NextButton } from './components/next-button';
 import { SettingsSidebar } from './components/settings-panel';
 import { PreviewDropdown } from './components/preview-dropdown';
+import { useState } from 'react';
 import { createStore } from './store';
 import { MailPoetEmailData } from './types';
 
@@ -19,6 +20,8 @@ directSelect(coreStore).getBlockPatterns = () => [];
 directSelect(coreStore).getBlockPatternCategories = () => [];
 
 function Editor() {
+  const [isStoreInitialized, setIsStoreInitialized] = useState(false);
+
   const { mailpoetData } = useSelect((select) => ({
     mailpoetData:
       (select(editorStore).getEditedPostAttribute(
@@ -32,6 +35,7 @@ function Editor() {
   // Initialize the store
   useEffect(() => {
     createStore();
+    setIsStoreInitialized(true);
   }, []);
 
   // We don't want to show the editor welcome guide as it is not relevant to emails
@@ -40,15 +44,20 @@ function Editor() {
   return (
     <>
       <LayoutStyles />
-      <HeaderButtonSlot className="mailpoet-header-button-preview">
-        <PreviewDropdown
-          newsletterPreviewUrl={mailpoetData?.preview_url ?? null}
-        />
-      </HeaderButtonSlot>
-      <HeaderButtonSlot>
-        <NextButton newsletterId={mailpoetData?.id ?? null} />
-      </HeaderButtonSlot>
-      <SettingsSidebar />
+      {isStoreInitialized ? (
+        <>
+          <HeaderButtonSlot className="mailpoet-header-button-preview">
+            <PreviewDropdown
+              newsletterId={mailpoetData?.id ?? null}
+              newsletterPreviewUrl={mailpoetData?.preview_url ?? null}
+            />
+          </HeaderButtonSlot>
+          <HeaderButtonSlot>
+            <NextButton newsletterId={mailpoetData?.id ?? null} />
+          </HeaderButtonSlot>
+          <SettingsSidebar />
+        </>
+      ) : null}
     </>
   );
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email-editor.tsx
@@ -7,6 +7,7 @@ import { LayoutStyles } from 'email-editor/engine/components/layout-styles';
 import { useDisableWelcomeGuide } from 'email-editor/engine/hooks';
 import { NextButton } from './components/next-button';
 import { SettingsSidebar } from './components/settings-panel';
+import { PreviewDropdown } from './components/preview-dropdown';
 import { MailPoetEmailData } from './types';
 
 import './email_editor.scss';
@@ -32,6 +33,11 @@ function Editor() {
   return (
     <>
       <LayoutStyles />
+      <HeaderButtonSlot className="mailpoet-header-button-preview">
+        <PreviewDropdown
+          newsletterPreviewUrl={mailpoetData?.preview_url ?? null}
+        />
+      </HeaderButtonSlot>
       <HeaderButtonSlot>
         <NextButton newsletterId={mailpoetData?.id ?? null} />
       </HeaderButtonSlot>

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email_editor.scss
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/email_editor.scss
@@ -21,4 +21,17 @@
   .editor-styles-wrapper {
     padding-bottom: 0;
   }
+
+  // Hiding the original "Preview" button in the header
+  .edit-post-header__settings .block-editor-post-preview__dropdown {
+    display: none;
+  }
+  // Keep the MailPoet "Preview" button in the header
+  .edit-post-header__settings .mailpoet-header-button-preview .block-editor-post-preview__dropdown {
+    display: block;
+  }
+  // Hide the "Preview" button in the dropdown
+  .mailpoet-preview-dropdown .components-menu-item__button:nth-child(2) {
+    display: none;
+  }
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/global.d.ts
@@ -2,4 +2,5 @@ interface Window {
   mailpoet_json_api_root: string;
   mailpoet_token: string;
   mailpoet_api_version: string;
+  mailpoet_current_wp_user_email: string;
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/global.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  mailpoet_json_api_root: string;
+  mailpoet_token: string;
+  mailpoet_api_version: string;
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/global.d.ts
@@ -1,6 +1,8 @@
 interface Window {
-  mailpoet_json_api_root: string;
-  mailpoet_token: string;
-  mailpoet_api_version: string;
-  mailpoet_current_wp_user_email: string;
+  MailPoetEmailEditor: {
+    json_api_root: string;
+    api_token: string;
+    api_version: string;
+    current_wp_user_email: string;
+  };
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
@@ -21,13 +21,13 @@ export function* requestSendingNewsletterPreview(
   callback: () => void,
 ) {
   try {
-    const url = window.mailpoet_json_api_root;
-    const token = window.mailpoet_token;
+    const url = window.MailPoetEmailEditor.json_api_root;
+    const token = window.MailPoetEmailEditor.api_token;
     const method = 'POST';
     const body = new FormData();
     body.append('token', token);
     body.append('action', 'mailpoet');
-    body.append('api_version', 'v1');
+    body.append('api_version', window.MailPoetEmailEditor.api_version);
     body.append('endpoint', 'newsletters');
     body.append('method', 'sendPreview');
     body.append('data[subscriber]', email);

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
@@ -1,5 +1,12 @@
 import { apiFetch } from '@wordpress/data-controls';
 
+export function updatePreviewToEmail(previewToEmail: string) {
+  return {
+    type: 'UPDATE_PREVIEW_TO_EMAIL',
+    previewToEmail,
+  };
+}
+
 export function sendNewsletterPreview(newsletterId: number) {
   return {
     type: 'SEND_NEWSLETTER_PREVIEW',

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from '@wordpress/data-controls';
+import { SendingPreviewStatus } from './types';
 
 export function updatePreviewToEmail(previewToEmail: string) {
   return {
@@ -17,27 +18,54 @@ export function sendNewsletterPreview(newsletterId: number) {
 export function* requestSendingNewsletterPreview(
   newsletterId: number,
   email: string,
+  callback: () => void,
 ) {
-  const url = window.mailpoet_json_api_root;
-  const token = window.mailpoet_token;
-  const method = 'POST';
-  const body = new FormData();
-  body.append('token', token);
-  body.append('action', 'mailpoet');
-  body.append('api_version', 'v1');
-  body.append('endpoint', 'newsletters');
-  body.append('method', 'sendPreview');
-  body.append('data[subscriber]', email);
-  body.append('data[id]', newsletterId.toString());
-  const data = yield apiFetch({
-    url,
-    method,
-    body,
-  });
+  try {
+    const url = window.mailpoet_json_api_root;
+    const token = window.mailpoet_token;
+    const method = 'POST';
+    const body = new FormData();
+    body.append('token', token);
+    body.append('action', 'mailpoet');
+    body.append('api_version', 'v1');
+    body.append('endpoint', 'newsletters');
+    body.append('method', 'sendPreview');
+    body.append('data[subscriber]', email);
+    body.append('data[id]', newsletterId.toString());
+    const response = yield apiFetch({
+      url,
+      method,
+      body,
+    });
 
-  const id: number = data?.data;
-  yield {
-    type: 'SEND_NEWSLETTER_PREVIEW',
-    id,
+    const id: number = response?.data;
+    yield {
+      type: 'SEND_NEWSLETTER_PREVIEW',
+      newsletterId: id,
+    };
+    yield {
+      type: 'SET_SENDING_PREVIEW_STATUS',
+      status: SendingPreviewStatus.SUCCESS,
+    };
+  } catch (errorResponse) {
+    yield {
+      type: 'SET_SENDING_PREVIEW_STATUS',
+      status: SendingPreviewStatus.ERROR,
+    };
+  }
+  callback();
+}
+
+export function setIsSendingPreviewEmail(isSendingPreviewEmail: boolean) {
+  return {
+    type: 'SET_IS_SENDING_PREVIEW_EMAIL',
+    isSendingPreviewEmail,
+  };
+}
+
+export function setSendingPreviewStatus(status: SendingPreviewStatus | null) {
+  return {
+    type: 'SET_SENDING_PREVIEW_STATUS',
+    status,
   };
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/actions.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from '@wordpress/data-controls';
+
+export function sendNewsletterPreview(newsletterId: number) {
+  return {
+    type: 'SEND_NEWSLETTER_PREVIEW',
+    newsletterId,
+  };
+}
+
+export function* requestSendingNewsletterPreview(
+  newsletterId: number,
+  email: string,
+) {
+  const url = window.mailpoet_json_api_root;
+  const token = window.mailpoet_token;
+  const method = 'POST';
+  const body = new FormData();
+  body.append('token', token);
+  body.append('action', 'mailpoet');
+  body.append('api_version', 'v1');
+  body.append('endpoint', 'newsletters');
+  body.append('method', 'sendPreview');
+  body.append('data[subscriber]', email);
+  body.append('data[id]', newsletterId.toString());
+  const data = yield apiFetch({
+    url,
+    method,
+    body,
+  });
+
+  const id: number = data?.data;
+  yield {
+    type: 'SEND_NEWSLETTER_PREVIEW',
+    id,
+  };
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/constants.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/constants.ts
@@ -1,0 +1,1 @@
+export const storeName = 'mailpoet/email-editor';

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/index.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './store';
+export * from './types';

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial-state.ts
@@ -3,4 +3,6 @@ import { State } from './types';
 export const getInitialState = (): State => ({
   savedState: 'saved',
   previewToEmail: window.mailpoet_current_wp_user_email,
+  isSendingPreviewEmail: false,
+  sendingPreviewStatus: null,
 });

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial-state.ts
@@ -2,4 +2,5 @@ import { State } from './types';
 
 export const getInitialState = (): State => ({
   savedState: 'saved',
+  previewToEmail: window.mailpoet_current_wp_user_email,
 });

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial-state.ts
@@ -2,7 +2,7 @@ import { State } from './types';
 
 export const getInitialState = (): State => ({
   savedState: 'saved',
-  previewToEmail: window.mailpoet_current_wp_user_email,
+  previewToEmail: window.MailPoetEmailEditor.current_wp_user_email,
   isSendingPreviewEmail: false,
   sendingPreviewStatus: null,
 });

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial_state.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/initial_state.ts
@@ -1,0 +1,5 @@
+import { State } from './types';
+
+export const getInitialState = (): State => ({
+  savedState: 'saved',
+});

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/reducer.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/reducer.ts
@@ -1,0 +1,8 @@
+import { State } from './types';
+
+export function reducer(state: State, action): State {
+  switch (action.type) {
+    default:
+      return state;
+  }
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/reducer.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/reducer.ts
@@ -2,6 +2,12 @@ import { State } from './types';
 
 export function reducer(state: State, action): State {
   switch (action.type) {
+    case 'UPDATE_PREVIEW_TO_EMAIL':
+      return {
+        ...state,
+        previewToEmail: action.previewToEmail,
+      };
+
     default:
       return state;
   }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/reducer.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/reducer.ts
@@ -7,6 +7,16 @@ export function reducer(state: State, action): State {
         ...state,
         previewToEmail: action.previewToEmail,
       };
+    case 'SET_IS_SENDING_PREVIEW_EMAIL':
+      return {
+        ...state,
+        isSendingPreviewEmail: action.isSendingPreviewEmail,
+      };
+    case 'SET_SENDING_PREVIEW_STATUS':
+      return {
+        ...state,
+        sendingPreviewStatus: action.status,
+      };
 
     default:
       return state;

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/selectors.ts
@@ -1,4 +1,4 @@
-import { State } from './types';
+import { SendingPreviewStatus, State } from './types';
 
 export function getSavedState(state: State): State['savedState'] {
   return state.savedState;
@@ -6,4 +6,14 @@ export function getSavedState(state: State): State['savedState'] {
 
 export function getPreviewToEmail(state: State): string {
   return state.previewToEmail;
+}
+
+export function getIsSendingPreviewEmail(state: State): boolean {
+  return state.isSendingPreviewEmail;
+}
+
+export function getSendingPreviewStatus(
+  state: State,
+): SendingPreviewStatus | null {
+  return state.sendingPreviewStatus;
 }

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/selectors.ts
@@ -3,3 +3,7 @@ import { State } from './types';
 export function getSavedState(state: State): State['savedState'] {
   return state.savedState;
 }
+
+export function getPreviewToEmail(state: State): string {
+  return state.previewToEmail;
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/selectors.ts
@@ -1,0 +1,5 @@
+import { State } from './types';
+
+export function getSavedState(state: State): State['savedState'] {
+  return state.savedState;
+}

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/store.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/store.ts
@@ -6,7 +6,7 @@ import {
 import { controls } from '@wordpress/data-controls';
 import * as actions from './actions';
 import { storeName } from './constants';
-import { getInitialState } from './initial_state';
+import { getInitialState } from './initial-state';
 import { reducer } from './reducer';
 import * as selectors from './selectors';
 

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/store.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/store.ts
@@ -1,0 +1,49 @@
+import { createReduxStore, register } from '@wordpress/data';
+import {
+  ReduxStoreConfig,
+  StoreDescriptor as GenericStoreDescriptor,
+} from '@wordpress/data/build-types/types';
+import { controls } from '@wordpress/data-controls';
+import * as actions from './actions';
+import { storeName } from './constants';
+import { getInitialState } from './initial_state';
+import { reducer } from './reducer';
+import * as selectors from './selectors';
+
+const getConfig = () =>
+  ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the "Action" type is missing thunks with "dispatch"
+    actions: actions as any,
+    controls,
+    selectors,
+    reducer,
+    initialState: getInitialState(),
+  } as const);
+
+export type EditorStoreConfig = ReturnType<typeof getConfig>;
+
+export const createStore = () => {
+  const storeConfig = getConfig();
+  const store = createReduxStore(storeName, storeConfig);
+  register(store);
+  return store;
+};
+
+export interface EmailEditorStore {
+  getActions(): EditorStoreConfig['actions'];
+  getSelectors(): EditorStoreConfig['selectors'];
+}
+
+declare module '@wordpress/data' {
+  interface StoreMap {
+    [storeName]: GenericStoreDescriptor<
+      ReduxStoreConfig<
+        unknown,
+        ReturnType<EmailEditorStore['getActions']>,
+        ReturnType<EmailEditorStore['getSelectors']>
+      >
+    >;
+  }
+}
+
+export { actions, selectors };

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/types.ts
@@ -1,0 +1,3 @@
+export type State = {
+  savedState: 'unsaved' | 'saving' | 'saved';
+};

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/types.ts
@@ -1,3 +1,4 @@
 export type State = {
   savedState: 'unsaved' | 'saving' | 'saved';
+  previewToEmail: string;
 };

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/store/types.ts
@@ -1,4 +1,11 @@
+export enum SendingPreviewStatus {
+  SUCCESS = 'success',
+  ERROR = 'error',
+}
+
 export type State = {
   savedState: 'unsaved' | 'saving' | 'saved';
   previewToEmail: string;
+  isSendingPreviewEmail: boolean;
+  sendingPreviewStatus: SendingPreviewStatus | null;
 };

--- a/mailpoet/assets/js/src/email-editor/integrations/mailpoet/types.ts
+++ b/mailpoet/assets/js/src/email-editor/integrations/mailpoet/types.ts
@@ -2,4 +2,5 @@ export type MailPoetEmailData = {
   id: number;
   subject: string;
   preheader: string;
+  preview_url: string | null;
 };

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\NotFoundException;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Validator\Builder;
@@ -11,10 +12,15 @@ class EmailApiController {
   /** @var NewslettersRepository */
   private $newsletterRepository;
 
+  /** @var NewsletterUrl */
+  private $newsletterUrl;
+
   public function __construct(
-    NewslettersRepository $newsletterRepository
+    NewslettersRepository $newsletterRepository,
+    NewsletterUrl $newsletterUrl
   ) {
     $this->newsletterRepository = $newsletterRepository;
+    $this->newsletterUrl = $newsletterUrl;
   }
 
   /**
@@ -27,6 +33,7 @@ class EmailApiController {
       'id' => $newsletter ? $newsletter->getId() : null,
       'subject' => $newsletter ? $newsletter->getSubject() : '',
       'preheader' => $newsletter ? $newsletter->getPreheader() : '',
+      'preview_url' => $this->newsletterUrl->getViewInBrowserUrl($newsletter),
     ];
   }
 
@@ -52,6 +59,7 @@ class EmailApiController {
       'id' => Builder::integer()->nullable(),
       'subject' => Builder::string(),
       'preheader' => Builder::string(),
+      'preview_url' => Builder::string()->nullable(),
     ])->toArray();
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -59,7 +59,7 @@ class EmailApiController {
       'id' => Builder::integer()->nullable(),
       'subject' => Builder::string(),
       'preheader' => Builder::string(),
-      'preview_url' => Builder::string()->nullable(),
+      'preview_url' => Builder::string(),
     ])->toArray();
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -118,10 +118,12 @@ class EmailEditor {
     $jsonAPIRoot = rtrim($this->wp->escUrlRaw(admin_url('admin-ajax.php')), '/');
     $token = $this->wp->wpCreateNonce('mailpoet_token');
     $apiVersion = API::CURRENT_VERSION;
+    $currentUserEmail = $this->wp->wpGetCurrentUser()->user_email;
     $inlineScript = <<<EOL
 var mailpoet_json_api_root = '%s';
 var mailpoet_token = '%s';
 var mailpoet_api_version = '%s';
+var mailpoet_current_wp_user_email = '%s';
 EOL;
     $this->wp->wpAddInlineScript(
       'mailpoet_email_editor',
@@ -129,7 +131,8 @@ EOL;
         $inlineScript,
         esc_js($jsonAPIRoot),
         esc_js($token),
-        esc_js($apiVersion)
+        esc_js($apiVersion),
+        esc_js($currentUserEmail)
       )
     );
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\API\JSON\API;
 use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Features\FeaturesController;
@@ -111,6 +112,25 @@ class EmailEditor {
       Env::$assetsUrl . '/dist/js/email-editor/email_editor.css',
       [],
       $assetsParams['version']
+    );
+
+    // Enqueue inline script with MailPoet specific editor settings
+    $jsonAPIRoot = rtrim($this->wp->escUrlRaw(admin_url('admin-ajax.php')), '/');
+    $token = $this->wp->wpCreateNonce('mailpoet_token');
+    $apiVersion = API::CURRENT_VERSION;
+    $inlineScript = <<<EOL
+var mailpoet_json_api_root = '%s';
+var mailpoet_token = '%s';
+var mailpoet_api_version = '%s';
+EOL;
+    $this->wp->wpAddInlineScript(
+      'mailpoet_email_editor',
+      sprintf(
+        $inlineScript,
+        esc_js($jsonAPIRoot),
+        esc_js($token),
+        esc_js($apiVersion)
+      )
     );
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditor {
@@ -77,6 +78,7 @@ class EmailEditor {
     $newsletter->setWpPostId($postId);
     $newsletter->setSubject('New Editor Email ' . $postId);
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD); // We allow only standard emails in the new editor for now
+    $newsletter->setHash(Security::generateHash());
     $this->newsletterRepository->persist($newsletter);
     $this->newsletterRepository->flush();
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -119,21 +119,15 @@ class EmailEditor {
     $token = $this->wp->wpCreateNonce('mailpoet_token');
     $apiVersion = API::CURRENT_VERSION;
     $currentUserEmail = $this->wp->wpGetCurrentUser()->user_email;
-    $inlineScript = <<<EOL
-var mailpoet_json_api_root = '%s';
-var mailpoet_token = '%s';
-var mailpoet_api_version = '%s';
-var mailpoet_current_wp_user_email = '%s';
-EOL;
-    $this->wp->wpAddInlineScript(
+    $this->wp->wpLocalizeScript(
       'mailpoet_email_editor',
-      sprintf(
-        $inlineScript,
-        esc_js($jsonAPIRoot),
-        esc_js($token),
-        esc_js($apiVersion),
-        esc_js($currentUserEmail)
-      )
+      'MailPoetEmailEditor',
+      [
+        'json_api_root' => esc_js($jsonAPIRoot),
+        'api_token' => esc_js($token),
+        'api_version' => esc_js($apiVersion),
+        'current_wp_user_email' => esc_js($currentUserEmail),
+      ]
     );
   }
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

- As a part of this PR is removing an old fix for setting a newsletter hash
- I added a store for the new email editor
- Some changes may be a bit confusing after rebasing on trunk because the trunk branch contains a new rule for naming files and folder

## QA notes

1. Active new email editor feature if it's disabled
2. Create a new email
3. Try if all preview options work properly

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5563]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5563]: https://mailpoet.atlassian.net/browse/MAILPOET-5563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ