### PR TITLE
Remove double log entries before adding unique index [MAILPOET-5630]

### DIFF
--- a/mailpoet/lib/Migrations/Db/Migration_20230831_143755_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20230831_143755_Db.php
@@ -52,6 +52,9 @@ class Migration_20230831_143755_Db extends DbMigration {
 
     // add unique index, remove no longer needed index
     if (!$this->indexExists($logsTable, 'automation_run_id_step_id')) {
+      $this->connection->executeStatement(
+        "DELETE t1 FROM $logsTable as t1, $logsTable as t2 WHERE t1.id < t2.id AND t1.automation_run_id = t2.automation_run_id AND t1.step_id=t2.step_id"
+      );
       $this->connection->executeStatement("ALTER TABLE $logsTable ADD UNIQUE automation_run_id_step_id (automation_run_id, step_id)");
     }
     if ($this->indexExists($logsTable, 'automation_run_id')) {


### PR DESCRIPTION
## Description
Fixes [MAILPOET-5630]

## Code review notes

_N/A_

## QA notes

Install a MailPoet version not younger than version [4.26.0](https://github.com/mailpoet/mailpoet/releases/tag/4.26.0). Produce some log entries (run one or two automations). Open phpmyadmin or something similar and duplicate some of the produced rows.

Update to the MP version with the fix. This PR works when:
1. The duplicate entries disappeared
2. There is no error in the ` wp_mailpoet_migrations` table for the `Migration_20230831_143755_Db` entry, and - actually - for no entry

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-5630]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5630]: https://mailpoet.atlassian.net/browse/MAILPOET-5630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5630]: https://mailpoet.atlassian.net/browse/MAILPOET-5630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ