### PR TITLE
[MAILPOET-5625] Store lookup data for filter segments

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -167,7 +167,7 @@ class DynamicSegments {
       }
       $data['woocommerce_payment_methods'] = $paymentMethods;
 
-      $data['woocommerce_shipping_methods'] = $this->woocommerceHelper->getShippingMethodInstancesData();
+      $data['woocommerce_shipping_methods'] = array_values($this->woocommerceHelper->getShippingMethodInstancesData());
     }
     $data['automations'] = array_map(function(Automation $automation) {
       return [

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Entities;
 
+use MailPoet\InvalidStateException;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
@@ -85,6 +86,35 @@ class DynamicSegmentFilterData {
    */
   public function getParam(string $name) {
     return $this->filterData[$name] ?? null;
+  }
+
+  public function getStringParam(string $name): string {
+    $value = $this->filterData[$name] ?? null;
+    if (!is_string($value)) {
+      throw new InvalidStateException("No string value found in filter data for param $name.");
+    }
+    return $value;
+  }
+
+  public function getIntParam(string $name): int {
+    $value = $this->filterData[$name] ?? null;
+    if (is_int($value)) {
+      return $value;
+    }
+
+    if (is_string($value)) {
+      return (int)($value);
+    }
+
+    throw new InvalidStateException("No compatible integer value found in filter data for param $name.");
+  }
+
+  public function getArrayParam(string $name): array {
+    $value = $this->getParam($name);
+    if (!is_array($value)) {
+      throw new InvalidStateException("No array value found in filter data for param $name.");
+    }
+    return $value;
   }
 
   public function getFilterType(): ?string {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/AutomationsEvents.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/AutomationsEvents.php
@@ -2,7 +2,9 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoetVendor\Doctrine\DBAL\Connection;
@@ -17,21 +19,27 @@ class AutomationsEvents implements Filter {
 
   const ENTERED_ACTION = 'enteredAutomation';
   const EXITED_ACTION = 'exitedAutomation';
+  const AUTOMATION_IDS_PARAM = 'automation_ids';
 
   /** @var FilterHelper */
   private $filterHelper;
 
+  /** @var AutomationStorage */
+  private $automationStorage;
+
   public function __construct(
-    FilterHelper $filterHelper
+    FilterHelper $filterHelper,
+    AutomationStorage $automationStorage
   ) {
     $this->filterHelper = $filterHelper;
+    $this->automationStorage = $automationStorage;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $filterData = $filter->getFilterData();
     $action = $filterData->getParam('action');
     $operator = $filterData->getParam('operator');
-    $automationIds = $filterData->getParam('automation_ids');
+    $automationIds = $filterData->getParam(self::AUTOMATION_IDS_PARAM);
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:
@@ -92,6 +100,18 @@ class AutomationsEvents implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $automationIds = $filterData->getArrayParam(self::AUTOMATION_IDS_PARAM);
+    $lookupData = [
+      'automations' => [],
+    ];
+
+    foreach ($automationIds as $automationId) {
+      $automation = $this->automationStorage->getAutomation(intval($automationId));
+      if ($automation instanceof Automation) {
+        $lookupData['automations'][$automationId] = $automation->getName();
+      }
+    }
+
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/AutomationsEvents.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/AutomationsEvents.php
@@ -90,4 +90,8 @@ class AutomationsEvents implements Filter {
       ->groupBy('inner_subscriber_id')
       ->having("COUNT(DISTINCT automations.id) = " . count($automationIds));
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -215,4 +215,8 @@ class EmailAction implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailActionClickAny.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailActionClickAny.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\StatisticsClickEntity;
@@ -46,5 +47,9 @@ class EmailActionClickAny implements Filter {
     );
 
     return $queryBuilder;
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
@@ -72,4 +72,8 @@ class EmailOpensAbsoluteCountAction implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/Filter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/Filter.php
@@ -2,9 +2,12 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 interface Filter {
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder;
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array;
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
@@ -19,10 +20,15 @@ class MailPoetCustomFields implements Filter {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
   public function __construct(
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    CustomFieldsRepository $customFieldsRepository
   ) {
     $this->entityManager = $entityManager;
+    $this->customFieldsRepository = $customFieldsRepository;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -170,6 +176,14 @@ class MailPoetCustomFields implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = [
+      'customFields' => [],
+    ];
+    $customFieldId = $filterData->getIntParam('custom_field_id');
+    $customField = $this->customFieldsRepository->findOneById($customFieldId);
+    if ($customField instanceof CustomFieldEntity) {
+      $lookupData['customFields'][$customFieldId] = $customField->getName();
+    }
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
@@ -168,4 +168,8 @@ class MailPoetCustomFields implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -102,5 +103,9 @@ class SubscriberDateField implements Filter {
       default:
         throw new InvalidFilterException('Invalid action', InvalidFilterException::MISSING_ACTION);
     }
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberScore.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberScore.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\Security;
@@ -42,5 +43,9 @@ class SubscriberScore implements Filter {
     $queryBuilder->setParameter($parameter, (int)$value);
 
     return $queryBuilder;
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Util\Security;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -17,10 +18,15 @@ class SubscriberSegment implements Filter {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
   public function __construct(
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    SegmentsRepository $segmentsRepository
   ) {
     $this->entityManager = $entityManager;
+    $this->segmentsRepository = $segmentsRepository;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -61,6 +67,14 @@ class SubscriberSegment implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = [
+      'segments' => [],
+    ];
+    $segmentIds = $filterData->getArrayParam('segments');
+    $segments = $this->segmentsRepository->findBy(['id' => $segmentIds]);
+    foreach ($segments as $segment) {
+      $lookupData['segments'][$segment->getId()] = $segment->getName();
+    }
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSegment.php
@@ -59,4 +59,8 @@ class SubscriberSegment implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedViaForm.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedViaForm.php
@@ -52,4 +52,8 @@ class SubscriberSubscribedViaForm implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedViaForm.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberSubscribedViaForm.php
@@ -5,6 +5,7 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\StatisticsFormEntity;
+use MailPoet\Form\FormsRepository;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -14,10 +15,15 @@ class SubscriberSubscribedViaForm implements Filter {
   /** @var FilterHelper */
   private $filterHelper;
 
+  /** @var FormsRepository */
+  private $formsRepository;
+
   public function __construct(
-    FilterHelper $filterHelper
+    FilterHelper $filterHelper,
+    FormsRepository $formsRepository
   ) {
     $this->filterHelper = $filterHelper;
+    $this->formsRepository = $formsRepository;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -54,6 +60,14 @@ class SubscriberSubscribedViaForm implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = [
+      'forms' => [],
+    ];
+    $formIds = $filterData->getArrayParam('form_ids');
+    $forms = $this->formsRepository->findBy(['id' => $formIds]);
+    foreach ($forms as $form) {
+      $lookupData['forms'][$form->getId()] = $form->getName();
+    }
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -21,5 +22,9 @@ class SubscriberTag implements Filter {
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $this->wp->applyFilters('mailpoet_dynamic_segments_filter_subscriber_tag_apply', $queryBuilder, $filter);
     return $queryBuilder;
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
@@ -7,6 +7,9 @@ use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
+/**
+ * The filters in this class are primarily intended for the premium plugin
+ */
 class SubscriberTag implements Filter {
   const TYPE = 'subscriberTag';
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTag.php
@@ -25,6 +25,11 @@ class SubscriberTag implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $default = ['tags' => []];
+    $filteredLookupData = $this->wp->applyFilters('mailpoet_dynamic_segments_filter_subscriber_tag_getLookupData', $default, $filterData);
+    if (is_array($filteredLookupData)) {
+      return $filteredLookupData;
+    }
+    return $default;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTextField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberTextField.php
@@ -97,4 +97,8 @@ class SubscriberTextField implements Filter {
 
     throw new InvalidFilterException('Invalid action');
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -5,6 +5,7 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\InvalidStateException;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\Security;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -72,6 +73,23 @@ class UserRole implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    global $wp_roles;
+    $lookupData = [
+      'roles' => [],
+    ];
+    $roles = $filterData->getParam('wordpressRole');
+    if (is_string($roles)) {
+      $roles = [$roles];
+    }
+    if (!is_array($roles)) {
+      throw new InvalidStateException();
+    }
+    foreach ($roles as $roleSlug) {
+      $roleData = $wp_roles->roles[$roleSlug] ?? null;
+      if (is_array($roleData)) {
+        $lookupData['roles'][$roleSlug] = $roleData['name'];
+      }
+    }
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/UserRole.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/UserRole.php
@@ -70,4 +70,8 @@ class UserRole implements Filter {
     }
     return join(' OR ', $sqlParts);
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -62,4 +62,8 @@ class WooCommerceAverageSpent implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -10,6 +10,7 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
+use WP_Term;
 
 class WooCommerceCategory implements Filter {
   const ACTION_CATEGORY = 'purchasedCategory';
@@ -142,6 +143,16 @@ class WooCommerceCategory implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = [
+      'categories' => [],
+    ];
+    $categoryIds = $filterData->getArrayParam('category_ids');
+    $terms = $this->wp->getTerms('product_cat', ['include' => $categoryIds, 'hide_empty' => false]);
+    /** @var WP_Term[] $terms */
+    foreach ($terms as $term) {
+      $lookupData['categories'][$term->term_id] = $term->name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
+
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -140,4 +140,8 @@ class WooCommerceCategory implements Filter {
     $ids[] = $categoryId;
     return $ids;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCountry.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCountry.php
@@ -76,4 +76,8 @@ class WooCommerceCountry implements Filter {
     }
     return join(' OR ', $sqlParts);
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCustomerTextField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCustomerTextField.php
@@ -100,4 +100,8 @@ class WooCommerceCustomerTextField implements Filter {
 
     throw new InvalidFilterException('Invalid action');
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceMembership.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceMembership.php
@@ -84,4 +84,8 @@ class WooCommerceMembership implements Filter {
       'posts.post_parent = parentposts.id AND parentposts.post_type = "wc_membership_plan" AND parentposts.post_status = "publish"'
     );
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -113,4 +113,8 @@ class WooCommerceNumberOfOrders implements Filter {
 
     return false;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
@@ -126,4 +126,8 @@ class WooCommerceNumberOfReviews implements Filter {
     }
     $this->filterHelper->validateDaysPeriodData($data);
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -90,6 +90,9 @@ class WooCommerceProduct implements Filter {
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
     $lookupData = ['products' => []];
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return $lookupData;
+    }
     $productIds = $filterData->getArrayParam('product_ids');
     foreach ($productIds as $productId) {
       $product = $this->wooHelper->wcGetProduct($productId);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -80,4 +80,8 @@ class WooCommerceProduct implements Filter {
       ->createQueryBuilder()
       ->from($table);
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -75,5 +76,9 @@ class WooCommercePurchaseDate implements Filter {
     $queryBuilder->setParameter($dateParam, $date);
 
     return $queryBuilder;
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
@@ -59,4 +59,8 @@ class WooCommerceSingleOrderValue implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
@@ -138,4 +138,8 @@ class WooCommerceSubscription implements Filter {
       "itemmeta.order_item_id=items.order_item_id AND itemmeta.meta_key='_product_id'"
     );
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -53,4 +53,8 @@ class WooCommerceTotalSpent implements Filter {
 
     return $queryBuilder;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
@@ -5,6 +5,7 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\WooCommerce\Helper;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -20,12 +21,17 @@ class WooCommerceUsedCouponCode implements Filter {
   /** @var FilterHelper */
   private $filterHelper;
 
+  /** @var Helper */
+  private $wooHelper;
+
   public function __construct(
     WooFilterHelper $wooFilterHelper,
+    Helper $wooHelper,
     FilterHelper $filterHelper
   ) {
     $this->wooFilterHelper = $wooFilterHelper;
     $this->filterHelper = $filterHelper;
+    $this->wooHelper = $wooHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -110,6 +116,14 @@ class WooCommerceUsedCouponCode implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = ['coupons' => []];
+    $couponIds = $filterData->getArrayParam(self::COUPON_CODE_IDS_KEY);
+    foreach ($couponIds as $couponId) {
+      $couponCode = $this->wooHelper->wcGetCouponCodeById((int)$couponId);
+      if (!empty($couponCode)) {
+        $lookupData['coupons'][$couponId] = $couponCode;
+      }
+    }
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
@@ -108,4 +108,8 @@ class WooCommerceUsedCouponCode implements Filter {
       throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
     }
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
@@ -117,6 +117,9 @@ class WooCommerceUsedCouponCode implements Filter {
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
     $lookupData = ['coupons' => []];
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return $lookupData;
+    }
     $couponIds = $filterData->getArrayParam(self::COUPON_CODE_IDS_KEY);
     foreach ($couponIds as $couponId) {
       $couponCode = $this->wooHelper->wcGetCouponCodeById((int)$couponId);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -9,6 +9,7 @@ use MailPoet\WooCommerce\Helper;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use WC_Payment_Gateway;
 
 class WooCommerceUsedPaymentMethod implements Filter {
   const ACTION = 'usedPaymentMethod';
@@ -139,6 +140,18 @@ class WooCommerceUsedPaymentMethod implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = [
+      'paymentMethods' => [],
+    ];
+    $paymentMethods = $filterData->getArrayParam('payment_methods');
+    $allGateways = $this->wooHelper->getPaymentGateways()->payment_gateways();
+
+    foreach ($paymentMethods as $paymentMethod) {
+      if (isset($allGateways[$paymentMethod]) && $allGateways[$paymentMethod] instanceof WC_Payment_Gateway) {
+        $lookupData['paymentMethods'][$paymentMethod] = $allGateways[$paymentMethod]->get_method_title();
+      }
+    }
+
+    return $lookupData;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -143,6 +143,9 @@ class WooCommerceUsedPaymentMethod implements Filter {
     $lookupData = [
       'paymentMethods' => [],
     ];
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return $lookupData;
+    }
     $paymentMethods = $filterData->getArrayParam('payment_methods');
     $allGateways = $this->wooHelper->getPaymentGateways()->payment_gateways();
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -137,4 +137,8 @@ class WooCommerceUsedPaymentMethod implements Filter {
     }
     return $ordersAlias;
   }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -80,7 +80,18 @@ class WooCommerceUsedShippingMethod implements Filter {
   }
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
-    return [];
+    $lookupData = ['shippingMethods' => []];
+    $allMethods = $this->wooHelper->getShippingMethodInstancesData();
+    $configuredShippingMethodInstanceIds = $filterData->getArrayParam('shipping_methods');
+
+    foreach ($configuredShippingMethodInstanceIds as $instanceId) {
+      if (isset($allMethods[$instanceId])) {
+        $data = $allMethods[$instanceId];
+        $lookupData['shippingMethods'][$instanceId] = $data['name'];
+      }
+    }
+
+    return $lookupData;
   }
 
   private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -81,6 +81,9 @@ class WooCommerceUsedShippingMethod implements Filter {
 
   public function getLookupData(DynamicSegmentFilterData $filterData): array {
     $lookupData = ['shippingMethods' => []];
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return $lookupData;
+    }
     $allMethods = $this->wooHelper->getShippingMethodInstancesData();
     $configuredShippingMethodInstanceIds = $filterData->getArrayParam('shipping_methods');
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -79,6 +79,10 @@ class WooCommerceUsedShippingMethod implements Filter {
     return $queryBuilder;
   }
 
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    return [];
+  }
+
   private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
     $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -296,7 +296,13 @@ class Helper {
       $this->formatShippingMethods($outOfCoverageShippingZone->get_shipping_methods(), $outOfCoverageShippingZone->get_zone_name())
     );
 
-    return $formattedShippingMethodData;
+    $keyedZones = [];
+
+    foreach ($formattedShippingMethodData as $shippingMethodArray) {
+      $keyedZones[$shippingMethodArray['instanceId']] = $shippingMethodArray;
+    }
+
+    return $keyedZones;
   }
 
   protected function formatShippingMethods(array $shippingMethods, string $shippingZoneName): array {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSegmentTest.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Test\DataFactories\Segment;
 use MailPoetVendor\Carbon\CarbonImmutable;
 
 class SubscriberSegmentTest extends \MailPoetTest {
@@ -64,6 +65,17 @@ class SubscriberSegmentTest extends \MailPoetTest {
     $segmentFilterData = $this->getSegmentFilterData(DynamicSegmentFilterData::OPERATOR_NONE, [$this->segment1->getId()]);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->filter);
     $this->assertEqualsCanonicalizing(['a2@example.com', 'a3@example.com'], $emails);
+  }
+
+  public function testItRetrievesLookupData(): void {
+    $segment = (new Segment())->withName('test segment')->create();
+    $data = $this->getSegmentFilterData('all', [$segment->getId(), 293847]);
+    $lookupData = $this->filter->getLookupData($data);
+    $this->assertEqualsCanonicalizing([
+      'segments' => [
+        $segment->getId() => $segment->getName(),
+      ],
+    ], $lookupData);
   }
 
   private function getSegmentFilterData(string $operator, array $segments): DynamicSegmentFilterData {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedViaFormTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberSubscribedViaFormTest.php
@@ -92,6 +92,20 @@ class SubscriberSubscribedViaFormTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['subscriber1@example.com'], $matching);
   }
 
+  public function testItRetrievesLookupData(): void {
+    $form = (new Form())->withName('test form')->create();
+    $data = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberSubscribedViaForm::TYPE, [
+      'form_ids' => [$form->getId()],
+      'operator' => 'none',
+    ]);
+    $lookupData = $this->filter->getLookupData($data);
+    $this->assertEqualsCanonicalizing([
+      'forms' => [
+        $form->getId() => $form->getName(),
+      ],
+    ], $lookupData);
+  }
+
   private function getMatchingEmails(string $operator, array $formIds): array {
     $data = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberSubscribedViaForm::TYPE, [
       'form_ids' => $formIds,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -58,6 +58,25 @@ class UserRoleTest extends \MailPoetTest {
     expect($emails)->count(0);
   }
 
+  public function testItRetrievesLookupData(): void {
+    $data = $this->getSegmentFilterData('editor', 'all');
+    $lookupData = $this->userRoleFilter->getLookupData($data);
+    $this->assertEqualsCanonicalizing([
+      'roles' => [
+        'editor' => 'Editor',
+      ],
+    ], $lookupData);
+
+    $data = $this->getSegmentFilterData(['administrator', 'subscriber', 'nonexistent'], 'all');
+    $lookupData = $this->userRoleFilter->getLookupData($data);
+    $this->assertEqualsCanonicalizing([
+      'roles' => [
+        'administrator' => 'Administrator',
+        'subscriber' => 'Subscriber',
+      ],
+    ], $lookupData);
+  }
+
   /**
    * @param string[]|string $role
    * @param string|null $operator

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -88,6 +88,27 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
+  public function testItRetrievesLookupData(): void {
+    $category1name = 'category' . rand();
+    $category2name = 'category' . rand();
+
+    $category1 = wp_insert_term($category1name, 'product_cat');
+    $category2 = wp_insert_term($category2name, 'product_cat');
+
+    $this->assertIsArray($category1);
+    $this->assertIsArray($category2);
+
+    $data = $this->getSegmentFilterData([$category1['term_id'], $category2['term_id']], 'none');
+    $lookupData = $this->wooCommerceCategoryFilter->getLookupData($data);
+
+    $this->assertEqualsCanonicalizing([
+      'categories' => [
+        $category1['term_id'] => $category1name,
+        $category2['term_id'] => $category2name,
+      ],
+    ], $lookupData);
+  }
+
   private function getSegmentFilterData(array $categoryIds, string $operator): DynamicSegmentFilterData {
     $filterData = [
       'category_ids' => $categoryIds,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -81,6 +81,23 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
+  public function testItRetrievesLookupData(): void {
+    $productId1 = $this->createProduct('product one');
+    $productId2 = $this->createProduct('product two');
+
+    $this->productIds[] = $productId1;
+    $this->productIds[] = $productId2;
+
+    $data = $this->getSegmentFilterData([$productId1, $productId2, 12345], 'none');
+    $lookupData = $this->wooCommerceProductFilter->getLookupData($data);
+    $this->assertEqualsCanonicalizing([
+      'products' => [
+        $productId1 => 'product one',
+        $productId2 => 'product two',
+      ],
+    ], $lookupData);
+  }
+
   private function getSegmentFilterData(array $productIds, string $operator): DynamicSegmentFilterData {
     $filterData = [
       'product_ids' => $productIds,
@@ -140,8 +157,8 @@ class WooCommerceProductTest extends \MailPoetTest {
   private function cleanUp(): void {
     global $wpdb;
 
-    if (!empty($this->products)) {
-      foreach ($this->products as $productId) {
+    if (!empty($this->productIds)) {
+      foreach ($this->productIds as $productId) {
         wp_delete_post($productId);
       }
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCodeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCodeTest.php
@@ -284,6 +284,24 @@ class WooCommerceUsedCouponCodeTest extends \MailPoetTest {
     ];
   }
 
+  public function testItRetrievesLookupData(): void {
+    $couponId = $this->tester->createWooCommerceCoupon(['code' => 'coupon1']);
+    $couponId2 = $this->tester->createWooCommerceCoupon(['code' => 'coupon two']);
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedCouponCode::ACTION, [
+      'operator' => 'none',
+      'coupon_code_ids' => [$couponId, (string)$couponId2],
+      'days' => 10,
+      'timeframe' => 'allTime',
+    ]);
+
+    $lookupData = $this->filter->getLookupData($filterData);
+    $this->assertEqualsCanonicalizing(['coupons' => [
+      $couponId => 'coupon1',
+      $couponId2 => 'coupon two',
+    ]], $lookupData);
+  }
+
   private function assertFilterReturnsEmails(string $operator, array $couponCodeIds, int $days, string $timeframe, array $expectedEmails): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedCouponCode::ACTION, [
       'operator' => $operator,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethodTest.php
@@ -116,6 +116,21 @@ class WooCommerceUsedPaymentMethodTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('none', ['cash', 'paypal'], 1, 'allTime', []);
   }
 
+  public function testItRetrievesLookupData(): void {
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedPaymentMethod::ACTION, [
+      'operator' => 'all',
+      'payment_methods' => ['cod', 'cheque', 'nonexistent'],
+      'days' => 4,
+      'timeframe' => 'inTheLast',
+    ]);
+
+    $lookupData = $this->filter->getLookupData($filterData);
+    $this->assertEqualsCanonicalizing(['paymentMethods' => [
+      'cod' => 'Cash on delivery',
+      'paypal' => 'Check payments',
+    ]], $lookupData);
+  }
+
   private function assertFilterReturnsEmails(string $operator, array $paymentMethods, int $days, string $timeframe, array $expectedEmails): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedPaymentMethod::ACTION, [
       'operator' => $operator,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
@@ -5,7 +5,10 @@ namespace integration\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
 use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\WooCommerce\Helper;
 use MailPoetVendor\Carbon\Carbon;
+use WC_Shipping_Zone;
+use WC_Shipping_Zones;
 
 /**
  * @group woo
@@ -15,8 +18,12 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
   /** @var WooCommerceUsedShippingMethod */
   private $filter;
 
+  /** @var Helper */
+  private $wooHelper;
+
   public function _before(): void {
     $this->filter = $this->diContainer->get(WooCommerceUsedShippingMethod::class);
+    $this->wooHelper = $this->diContainer->get(Helper::class);
   }
 
   public function testItWorksWithAnyOperator(): void {
@@ -50,7 +57,7 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->createOrder($customerId3, Carbon::now(), 'free_shipping', 2);
     $this->createOrder($customerId3, Carbon::now(), 'flat_rate', 1);
 
-    $this->assertfilterreturnsemails('all', [1], 1, 'inTheLast', ['c1@e.com', 'c3@e.com']);
+    $this->assertFilterReturnsEmails('all', [1], 1, 'inTheLast', ['c1@e.com', 'c3@e.com']);
     $this->assertFilterReturnsEmails('all', [2], 1, 'inTheLast', ['c2@e.com', 'c3@e.com']);
     $this->assertFilterReturnsEmails('all', [2, 1], 1, 'inTheLast', ['c3@e.com']);
     $this->assertFilterReturnsEmails('all', [8, 1], 1000, 'inTheLast', []); // includes non-existing shipping method
@@ -120,6 +127,53 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('all', [2], 1, 'allTime', ['c1@e.com']);
   }
 
+  public function testItRetrievesLookupData(): void {
+    $defaultZone = WC_Shipping_Zones::get_zone(0);
+    $this->assertInstanceOf(WC_Shipping_Zone::class, $defaultZone);
+    $instanceId1 = $defaultZone->add_shipping_method('flat_rate');
+    $instanceId2 = $defaultZone->add_shipping_method('local_pickup');
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
+      'operator' => 'any',
+      'shipping_methods' => [$instanceId1, 12345],
+      'days' => 10,
+      'timeframe' => 'inTheLast',
+    ]);
+
+    $formattedMethods = $this->wooHelper->getShippingMethodInstancesData();
+
+    $lookupData = $this->filter->getLookupData($filterData);
+    $this->assertEqualsCanonicalizing([
+      'shippingMethods' => [
+        $instanceId1 => $formattedMethods[$instanceId1]['name'],
+      ],
+    ], $lookupData);
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
+      'operator' => 'any',
+      'shipping_methods' => [$instanceId2, $instanceId1, 12345],
+      'days' => 10,
+      'timeframe' => 'inTheLast',
+    ]);
+
+    $lookupData = $this->filter->getLookupData($filterData);
+    $this->assertEqualsCanonicalizing([
+      'shippingMethods' => [
+        $instanceId1 => $formattedMethods[$instanceId1]['name'],
+        $instanceId2 => $formattedMethods[$instanceId2]['name'],
+      ],
+    ], $lookupData);
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
+      'operator' => 'any',
+      'shipping_methods' => [],
+      'days' => 10,
+      'timeframe' => 'inTheLast',
+    ]);
+    $lookupData = $this->filter->getLookupData($filterData);
+    expect($lookupData)->equals(['shippingMethods' => []]);
+  }
+
   private function assertFilterReturnsEmails(string $operator, array $shippingMethodStrings, int $days, string $timeframe, array $expectedEmails): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
       'operator' => $operator,
@@ -146,5 +200,11 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->tester->updateWooOrderStats($order->get_id());
 
     return $order->get_id();
+  }
+
+  public function _after() {
+    parent::_after();
+    global $wpdb;
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods");
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/HelperTest.php
+++ b/mailpoet/tests/integration/WooCommerce/HelperTest.php
@@ -73,7 +73,7 @@ class HelperTest extends \MailPoetTest {
       ],
     ];
 
-    $this->assertEquals($expectedResult, $this->helper->getShippingMethodInstancesData());
+    $this->assertEquals($expectedResult, array_values($this->helper->getShippingMethodInstancesData()));
   }
 
   protected function createShippingZonesWithShippingMethods() {


### PR DESCRIPTION
## Description

This PR updates how we store a snapshot of filter segments to include "lookup data" for any entities that we currently only have IDs for. Currently, I believe this includes:

- entered automation (automations)
- exited automation (automations)
- was sent (emails)
- opened (emails)
- machine-opened (emails)
- clicked (emails, links)
- MailPoet custom field (custom field name)
- subscribed to list (list name)
- subscribed via form (form name)
- WordPress user role (role names)
- Purchased in category (category names)
- Purchased product (product names)
- Used coupon code (coupon code)
- Used payment method (payment method name)
- Used shipping method (shipping method name)
- tag (tag name) - handled in the premium PR

This ensures we will have the correct data available any time in the future, even if those entities change or are deleted.

## Code review notes

The main idea with this code is that we want to be able to display tooltips for filter segments on listing pages that show the exact configuration they had at send time. My first attempt involved storing way more data, including strings for operators and the names of the filters, but I realized it makes more sense to store just the lookup information that's missing and leave the tooltip generation for the frontend code. Please let me know if you can think of anything this PR leaves out that would be necessary for constructing those tooltips (see MAILPOET-5600 for more details about the tooltips).

If we ever fail to retrieve the value for a particular ID, I'm leaving it out of the return value with the assumption that the frontend code will need to assume the data might not exist.

## QA notes

This is only a change to the backend, meaning that to test it you will need to verify that lookup information is stored in the sending queue's `meta` column under the `filterSegment` key. 

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/799

## Linked tickets
[MAILPOET-5625](https://mailpoet.atlassian.net/browse/MAILPOET-5625)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5625]: https://mailpoet.atlassian.net/browse/MAILPOET-5625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ