### PR TITLE
Extra filtering of newsletter content in web view [MAILPOET-5632]

### DIFF
--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Widget;
+use MailPoet\Newsletter\NewsletterHtmlSanitizer;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
 use MailPoet\Newsletter\Shortcodes\Categories\Link;
@@ -54,6 +55,9 @@ class Shortcodes {
   /** @var Site */
   private $siteCategory;
 
+  /** @var NewsletterHtmlSanitizer */
+  private $newsletterHtmlSanitizer;
+
   public function __construct(
     Pages $subscriptionPages,
     WPFunctions $wp,
@@ -61,6 +65,7 @@ class Shortcodes {
     SubscribersRepository $subscribersRepository,
     NewsletterUrl $newsletterUrl,
     NewslettersRepository $newslettersRepository,
+    NewsletterHtmlSanitizer $newsletterHtmlSanitizer,
     Date $dateCategory,
     Link $linkCategory,
     Newsletter $newsletterCategory,
@@ -78,6 +83,7 @@ class Shortcodes {
     $this->newsletterCategory = $newsletterCategory;
     $this->subscriberCategory = $subscriberCategory;
     $this->siteCategory = $siteCategory;
+    $this->newsletterHtmlSanitizer = $newsletterHtmlSanitizer;
   }
 
   public function init() {
@@ -261,6 +267,7 @@ class Shortcodes {
       $this->newsletterCategory,
       $this->subscriberCategory,
       $this->siteCategory,
+      $this->newsletterHtmlSanitizer,
       $this->wp
     );
 

--- a/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -150,9 +150,25 @@ class PostTransformerContentsExtractor {
     $alignment = (in_array($this->args['titleAlignment'], ['left', 'right', 'center'])) ? $this->args['titleAlignment'] : 'left';
 
     $title = '<' . $tag . ' data-post-id="' . $post->ID . '" style="text-align: ' . $alignment . ';">' . $title . '</' . $tag . '>';
+
+    $commonAttributes = [
+      'data-post-id' => [],
+      'style' => [],
+    ];
+
+    $allowedTitleHtml = [
+      'a' => [
+        'href' => [],
+      ],
+      'li' => $commonAttributes,
+      'h1' => $commonAttributes,
+      'h2' => $commonAttributes,
+      'h3' => $commonAttributes,
+    ];
+
     return [
       'type' => 'text',
-      'text' => $title,
+      'text' => wp_kses($title, $allowedTitleHtml),
     ];
   }
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -6,8 +6,19 @@ use MailPoet\Newsletter\Editor\PostContentManager;
 use MailPoet\Newsletter\Renderer\EscapeHelper as EHelper;
 use MailPoet\Newsletter\Renderer\StylesHelper;
 use MailPoet\Util\pQuery\pQuery;
+use MailPoet\WP\Functions;
 
 class Text {
+
+  /** @var Functions */
+  private $wp;
+
+  public function __construct(
+    Functions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
   public function render($element) {
     $html = $element['text'];
     // replace &nbsp; with spaces
@@ -38,7 +49,7 @@ class Text {
         if (preg_match('/h\d/', $paragraph->getTag())) {
           $contents[] = $paragraph->getOuterText();
         } else {
-          $contents[] = str_replace('&', '&amp;', $paragraph->html());
+          $contents[] = $this->wp->wpKsesPost(str_replace('&', '&amp;', $paragraph->html()));
         }
           if ($index + 1 < $paragraphs->count()) $contents[] = '<br />';
           $paragraph->remove();
@@ -105,7 +116,7 @@ class Text {
       if (!preg_match('/text-align/i', $style)) {
         $style = 'text-align: left;' . $style;
       }
-      $contents = str_replace('&', '&amp;', $paragraph->html());
+      $contents = $this->wp->wpKsesPost(str_replace('&', '&amp;', $paragraph->html()));
       $paragraph->setTag('table');
       $paragraph->style = 'border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;';
       $paragraph->width = '100%';
@@ -144,7 +155,7 @@ class Text {
     if (!$lists->count()) return $html;
     foreach ($lists as $list) {
       if ($list->tag === 'li') {
-        $list->setInnertext(str_replace('&', '&amp;', $list->html()));
+        $list->setInnertext($this->wp->wpKsesPost(str_replace('&', '&amp;', $list->html())));
         $list->class = 'mailpoet_paragraph';
       } else {
         $list->class = 'mailpoet_paragraph';

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -785,6 +785,10 @@ class Functions {
     return wp_kses($string, $allowedHtml, $allowedProtocols);
   }
 
+  public function wpKsesPost($data) {
+    return wp_kses_post($data);
+  }
+
   public function deprecatedHook(string $hook_name, string $version, string $replacement, string $message) {
     _deprecated_hook(
       esc_html($hook_name),

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -40,6 +40,12 @@ class RendererTest extends \MailPoetTest {
 
   const COLUMN_BASE_WIDTH = 660;
 
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var Text */
+  private $text;
+
   public function _before() {
     parent::_before();
     $this->newsletter = new NewsletterEntity();
@@ -67,6 +73,8 @@ class RendererTest extends \MailPoetTest {
     );
     $this->columnRenderer = new ColumnRenderer();
     $this->dOMParser = new pQuery();
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+    $this->text = (new Text($this->wp));
   }
 
   public function testItRendersCompleteNewsletter() {
@@ -416,7 +424,7 @@ class RendererTest extends \MailPoetTest {
   public function testItRendersText() {
     $newsletter = (array)$this->newsletter->getBody();
     $template = $newsletter['content']['blocks'][0]['blocks'][0]['blocks'][2];
-    $DOM = $this->dOMParser->parseStr((new Text)->render($template));
+    $DOM = $this->dOMParser->parseStr($this->text->render($template));
     // blockquotes and paragraphs should be converted to spans and placed inside a table
     expect(
       $DOM('tr > td > table > tr > td.mailpoet_paragraph', 0)->html()
@@ -446,7 +454,7 @@ class RendererTest extends \MailPoetTest {
 
     // trailing line breaks should be cut off, but not inside an element
     $template = $newsletter['content']['blocks'][0]['blocks'][0]['blocks'][8];
-    $DOM = $this->dOMParser->parseStr((new Text)->render($template));
+    $DOM = $this->dOMParser->parseStr($this->text->render($template));
     expect(count($DOM('tr > td > br', 0)))
       ->equals(0);
     expect($DOM('tr > td > h3', 0)->html())

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -163,6 +163,13 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result['0'])->equals($wpPost->post_title); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
+  public function testItSanitizesOutput() {
+    $this->wPPost = $this->_createWPPost('Title <script>alert("uh oh");</script>');
+    $content = '<a data-post-id="' . $this->wPPost . '" href="#">latest post</a>';
+    $result = $this->shortcodesObject->process(['[newsletter:post_title]'], $content);
+    expect($result[0])->equals('Title alert("uh oh");');
+  }
+
   public function itCanProcessPostNotificationNewsletterNumberShortcode() {
     // create first post notification
     $postNotificationHistory = $this->_createNewsletter(
@@ -440,9 +447,9 @@ class ShortcodesTest extends \MailPoetTest {
     expect($result[0])->equals($siteUrl);
   }
 
-  public function _createWPPost() {
+  public function _createWPPost($postTitle = 'Sample Post') {
     $data = [
-      'post_title' => 'Sample Post',
+      'post_title' => $postTitle,
       'post_content' => 'contents',
       'post_status' => 'publish',
     ];

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Newsletter\Renderer\Blocks;
 use MailPoet\Newsletter\Editor\PostContentManager;
 use MailPoet\Util\pQuery\DomNode;
 use MailPoet\Util\pQuery\pQuery;
+use MailPoet\WP\Functions;
 
 class TextTest extends \MailPoetUnitTest {
 
@@ -16,13 +17,22 @@ class TextTest extends \MailPoetUnitTest {
   /** @var pQuery */
   private $parser;
 
+  /** @var Text */
+  private $text;
+
   public function _before() {
     parent::_before();
     $this->parser = new pQuery;
+    $wp = $this->make(Functions::class, [
+      'wpKsesPost' => function($text) {
+        return $text;
+      },
+    ]);
+    $this->text = (new Text($wp));
   }
 
   public function testItRendersPlainText() {
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $expectedResult = '
       <tr>
         <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;">
@@ -34,7 +44,7 @@ class TextTest extends \MailPoetUnitTest {
 
   public function testItRendersParagraph() {
     $this->block['text'] = '<p>Text</p>';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $table = $this->parser->parseStr($output)->query('table');
     $this->assertInstanceOf(pQuery::class, $table);
     $tableElement = $table[0];
@@ -54,7 +64,7 @@ class TextTest extends \MailPoetUnitTest {
       <p class="' . PostContentManager::WP_POST_CLASS . '">First</p>
       <p class="' . PostContentManager::WP_POST_CLASS . '">Second</p>
     ';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $table = $this->parser->parseStr($output)->query('table');
     $this->assertInstanceOf(pQuery::class, $table);
     $tableElement = $table[0];
@@ -84,7 +94,7 @@ class TextTest extends \MailPoetUnitTest {
       <p class="' . PostContentManager::WP_POST_CLASS . '">First</p>
       <h1>Second</h1>
     ';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $table = $this->parser->parseStr($output)->query('table');
     $this->assertInstanceOf(pQuery::class, $table);
     $tableElement = $table[0];
@@ -108,7 +118,7 @@ class TextTest extends \MailPoetUnitTest {
 
   public function testItRendersList() {
     $this->block['text'] = '<ul><li>Item 1</li><li>Item 2</li></ul>';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $ul = $this->parser->parseStr($output)->query('ul');
     $this->assertInstanceOf(pQuery::class, $ul);
     $ulElement = $ul[0];
@@ -120,7 +130,7 @@ class TextTest extends \MailPoetUnitTest {
 
   public function testItRendersBlockquotes() {
     $this->block['text'] = '<blockquote><p>Quote</p></blockquote>';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $table = $this->parser->parseStr($output)->query('table');
     $this->assertInstanceOf(pQuery::class, $table);
     $tableElement = $table[0];
@@ -147,7 +157,7 @@ class TextTest extends \MailPoetUnitTest {
 
   public function testItShouldRemoveEmptyParagraphs() {
     $this->block['text'] = '<p></p><p>Text</p><p></p><p>Text2</p><p></p><p></p>';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     $expectedResult = '
       <tr>
         <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;">
@@ -169,20 +179,20 @@ class TextTest extends \MailPoetUnitTest {
 
   public function testItStylesHeadings() {
     $this->block['text'] = '<h1>Heading</h1><h2>Heading 2</h2>';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     expect($output)->stringContainsString('<h1 style="text-align:left;padding:0;font-style:normal;font-weight:normal;">Heading</h1>');
     expect($output)->stringContainsString('<h2 style="text-align:left;padding:0;font-style:normal;font-weight:normal;">Heading 2</h2>');
   }
 
   public function testItStylesHeadingsCenter() {
     $this->block['text'] = '<h1 style="text-align: center"><strong>Let\'s Get Started! </strong></h1>';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     expect($output)->stringContainsString('<h1 style="text-align: center;padding:0;');
   }
 
   public function testItRemovesLastLineBreak() {
     $this->block['text'] = 'hello<br />';
-    $output = (new Text)->render($this->block);
+    $output = $this->text->render($this->block);
     expect($output)->stringNotContainsString('<br />');
   }
 }


### PR DESCRIPTION
## Description

This PR updates the way we filter content when we display it in a web view (e.g. preview).

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
