### PR TITLE
Use toString instead of html [MAILPOET-5632]

### DIFF
--- a/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -151,6 +151,7 @@ class PostTransformerContentsExtractor {
 
     $title = '<' . $tag . ' data-post-id="' . $post->ID . '" style="text-align: ' . $alignment . ';">' . $title . '</' . $tag . '>';
 
+    // The allowed HTML is based on all the possible ways we might construct a $title above
     $commonAttributes = [
       'data-post-id' => [],
       'style' => [],

--- a/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -150,9 +150,25 @@ class PostTransformerContentsExtractor {
     $alignment = (in_array($this->args['titleAlignment'], ['left', 'right', 'center'])) ? $this->args['titleAlignment'] : 'left';
 
     $title = '<' . $tag . ' data-post-id="' . $post->ID . '" style="text-align: ' . $alignment . ';">' . $title . '</' . $tag . '>';
+
+    $commonAttributes = [
+      'data-post-id' => [],
+      'style' => [],
+    ];
+
+    $allowedTitleHtml = [
+      'a' => [
+        'href' => [],
+      ],
+      'li' => $commonAttributes,
+      'h1' => $commonAttributes,
+      'h2' => $commonAttributes,
+      'h3' => $commonAttributes,
+    ];
+
     return [
       'type' => 'text',
-      'text' => $title,
+      'text' => wp_kses($title, $allowedTitleHtml),
     ];
   }
 

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -38,7 +38,7 @@ class Text {
         if (preg_match('/h\d/', $paragraph->getTag())) {
           $contents[] = $paragraph->getOuterText();
         } else {
-          $contents[] = str_replace('&', '&amp;', $paragraph->html());
+          $contents[] = $paragraph->toString(true, true, 1);
         }
           if ($index + 1 < $paragraphs->count()) $contents[] = '<br />';
           $paragraph->remove();
@@ -105,7 +105,7 @@ class Text {
       if (!preg_match('/text-align/i', $style)) {
         $style = 'text-align: left;' . $style;
       }
-      $contents = str_replace('&', '&amp;', $paragraph->html());
+      $contents = $paragraph->toString(true, true, 1);
       $paragraph->setTag('table');
       $paragraph->style = 'border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;';
       $paragraph->width = '100%';
@@ -144,7 +144,7 @@ class Text {
     if (!$lists->count()) return $html;
     foreach ($lists as $list) {
       if ($list->tag === 'li') {
-        $list->setInnertext(str_replace('&', '&amp;', $list->html()));
+        $list->setInnertext($list->toString(true, true, 1));
         $list->class = 'mailpoet_paragraph';
       } else {
         $list->class = 'mailpoet_paragraph';

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -185,4 +185,39 @@ class TextTest extends \MailPoetUnitTest {
     $output = (new Text)->render($this->block);
     expect($output)->stringNotContainsString('<br />');
   }
+
+  public function htmlEntitiesStrings() {
+    return [
+      'paragraph' => ["<p>Text &lt;script&gt;alert('test');&lt;/script&gt;</p>"],
+      'list' => ["<ul>Text &lt;script&gt;alert('test');&lt;/script&gt;</li></ul>"],
+      'blockquote' => ["<ul>Text &lt;script&gt;alert('test');&lt;/script&gt;</li></ul>"],
+    ];
+  }
+
+  /**
+   * @dataProvider htmlEntitiesStrings
+   */
+  public function testItDoesNotDecodeHtmlEntities($htmlString) {
+    $this->block['text'] = $htmlString;
+    $output = (new Text())->render($this->block);
+    expect($output)->stringNotContainsString('<script>');
+    expect($output)->stringContainsString("&lt;script&gt;alert('test');&lt;/script&gt;");
+  }
+
+  public function childElementStrings(): array {
+    return [
+      'paragraph' => ['<p><a href="https://example.com">Link</a></p>'],
+      'list' => ['<p><ul><li><a href="https://example.com">Link</li></ul></a></p>'],
+      'blockquote' => ['<blockquote><p><a href="https://example.com">Link</a></p></blockquote>'],
+    ];
+  }
+
+  /**
+   * @dataProvider childElementStrings
+   */
+  public function testItMaintainsHtmlInChildElements($htmlString) {
+    $this->block['text'] = $htmlString;
+    $output = (new Text())->render($this->block);
+    expect($output)->stringContainsString('<a href="https://example.com">Link</a>');
+  }
 }


### PR DESCRIPTION
## Description

The pQuery `html` method decodes all HTML entities. This isn't what we want because the editor automatically encodes entities that should be encoded. By using `toString` instead we should see more consistency between the editor and previews/rendered emails.

## Code review notes

_N/A_

## QA notes

This change could affect many different elements in a newsletter. Please be sure to test with a wide variety of content, including nested HTML content, to ensure this doesn't have any unintended side effects.

## Linked PRs

_N/A_

## Linked tickets
https://mailpoet.atlassian.net/browse/MAILPOET-5632

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
