### PR TITLE
Fix: make sure filters are ordered alphabetically [MAILPOET-5229]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automation-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automation-options.ts
@@ -1,4 +1,5 @@
 import { MailPoet } from 'mailpoet';
+import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
 import { SegmentTypes } from '../types';
 
 export enum AutomationsActionTypes {
@@ -17,4 +18,4 @@ export const AutomationsOptions = [
     label: MailPoet.I18n.t('automationsExitedAutomation'),
     group: SegmentTypes.Automations,
   },
-];
+].sort(sortFilters);

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email-options.ts
@@ -1,32 +1,8 @@
 import { MailPoet } from 'mailpoet';
+import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
 import { EmailActionTypes, SegmentTypes } from '../types';
 
 export const EmailSegmentOptions = [
-  {
-    value: EmailActionTypes.OPENS_ABSOLUTE_COUNT,
-    label: MailPoet.I18n.t('emailActionOpensAbsoluteCount'),
-    group: SegmentTypes.Email,
-  },
-  {
-    value: EmailActionTypes.MACHINE_OPENS_ABSOLUTE_COUNT,
-    label: MailPoet.I18n.t('emailActionMachineOpensAbsoluteCount'),
-    group: SegmentTypes.Email,
-  },
-  {
-    value: EmailActionTypes.WAS_SENT,
-    label: MailPoet.I18n.t('emailActionWasSent'),
-    group: SegmentTypes.Email,
-  },
-  {
-    value: EmailActionTypes.OPENED,
-    label: MailPoet.I18n.t('emailActionOpened'),
-    group: SegmentTypes.Email,
-  },
-  {
-    value: EmailActionTypes.MACHINE_OPENED,
-    label: MailPoet.I18n.t('emailActionMachineOpened'),
-    group: SegmentTypes.Email,
-  },
   {
     value: EmailActionTypes.CLICKED,
     label: MailPoet.I18n.t('emailActionClicked'),
@@ -37,4 +13,29 @@ export const EmailSegmentOptions = [
     label: MailPoet.I18n.t('emailActionClickedAnyEmail'),
     group: SegmentTypes.Email,
   },
-];
+  {
+    value: EmailActionTypes.MACHINE_OPENED,
+    label: MailPoet.I18n.t('emailActionMachineOpened'),
+    group: SegmentTypes.Email,
+  },
+  {
+    value: EmailActionTypes.MACHINE_OPENS_ABSOLUTE_COUNT,
+    label: MailPoet.I18n.t('emailActionMachineOpensAbsoluteCount'),
+    group: SegmentTypes.Email,
+  },
+  {
+    value: EmailActionTypes.OPENS_ABSOLUTE_COUNT,
+    label: MailPoet.I18n.t('emailActionOpensAbsoluteCount'),
+    group: SegmentTypes.Email,
+  },
+  {
+    value: EmailActionTypes.OPENED,
+    label: MailPoet.I18n.t('emailActionOpened'),
+    group: SegmentTypes.Email,
+  },
+  {
+    value: EmailActionTypes.WAS_SENT,
+    label: MailPoet.I18n.t('emailActionWasSent'),
+    group: SegmentTypes.Email,
+  },
+].sort(sortFilters);

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/sort-filters.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/sort-filters.ts
@@ -1,0 +1,16 @@
+/**
+ * Sort segment filters alphabetically using their label
+ * after it is translated.
+ */
+export function sortFilters(optionA, optionB) {
+  const labelA = optionA.label.toLowerCase();
+  const labelB = optionB.label.toLowerCase();
+
+  if (labelA < labelB) {
+    return -1;
+  }
+  if (labelA > labelB) {
+    return 1;
+  }
+  return 0;
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber-options.ts
@@ -1,15 +1,16 @@
 import { MailPoet } from 'mailpoet';
+import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
 import { SegmentTypes, SubscriberActionTypes } from '../types';
 
 export const SubscriberSegmentOptions = [
   {
-    value: SubscriberActionTypes.SUBSCRIBER_SCORE,
-    label: MailPoet.I18n.t('subscriberScore'),
+    value: SubscriberActionTypes.SUBSCRIBER_EMAIL,
+    label: MailPoet.I18n.t('email').toLowerCase(),
     group: SegmentTypes.WordPressRole,
   },
   {
-    value: SubscriberActionTypes.SUBSCRIBER_EMAIL,
-    label: MailPoet.I18n.t('email').toLowerCase(),
+    value: SubscriberActionTypes.SUBSCRIBER_SCORE,
+    label: MailPoet.I18n.t('subscriberScore'),
     group: SegmentTypes.WordPressRole,
   },
   {
@@ -82,4 +83,4 @@ export const SubscriberSegmentOptions = [
     label: MailPoet.I18n.t('segmentsSubscriber'),
     group: SegmentTypes.WordPressRole,
   },
-];
+].sort(sortFilters);

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
@@ -1,4 +1,5 @@
 import { MailPoet } from 'mailpoet';
+import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
 import { SegmentTypes } from '../types';
 
 // WooCommerce
@@ -36,6 +37,11 @@ export const WooCommerceOptions = [
     group: SegmentTypes.WooCommerce,
   },
   {
+    value: WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE,
+    label: MailPoet.I18n.t('wooCustomerInPostalCode'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
     value: WooCommerceActionTypes.NUMBER_OF_ORDERS,
     label: MailPoet.I18n.t('wooNumberOfOrders'),
     group: SegmentTypes.WooCommerce,
@@ -43,11 +49,6 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.NUMBER_OF_REVIEWS,
     label: MailPoet.I18n.t('wooNumberOfReviews'),
-    group: SegmentTypes.WooCommerce,
-  },
-  {
-    value: WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE,
-    label: MailPoet.I18n.t('wooCustomerInPostalCode'),
     group: SegmentTypes.WooCommerce,
   },
   {
@@ -90,7 +91,7 @@ export const WooCommerceOptions = [
     label: MailPoet.I18n.t('wooUsedShippingMethod'),
     group: SegmentTypes.WooCommerce,
   },
-];
+].sort(sortFilters);
 
 // WooCommerce Memberships
 export enum WooCommerceMembershipsActionTypes {
@@ -103,7 +104,7 @@ export const WooCommerceMembershipOptions = [
     label: MailPoet.I18n.t('segmentsActiveMembership'),
     group: SegmentTypes.WooCommerceMembership,
   },
-];
+].sort(sortFilters);
 
 // WooCommerce Subscriptions
 export enum WooCommerceSubscriptionsActionTypes {
@@ -116,4 +117,4 @@ export const WooCommerceSubscriptionOptions = [
     label: MailPoet.I18n.t('segmentsActiveSubscription'),
     group: SegmentTypes.WooCommerceSubscription,
   },
-];
+].sort(sortFilters);

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -188,14 +188,14 @@ class ManageSegmentsCest {
     $i->seeNoJSErrors();
   }
 
-  public function createEmailOpenedSegment(\AcceptanceTester $i) {
-    $i->wantTo('Create a new email opened segment');
+  public function createEmailMachineOpenedSegment(\AcceptanceTester $i) {
+    $i->wantTo('Create a new email machine opened segment');
 
-    $emailSubject = 'Segment Email Opened Test';
+    $emailSubject = 'Segment Email Machine Opened Test';
     $newsletter = (new Newsletter())
       ->withSendingQueue()->withSubject($emailSubject)->withSentStatus()->create();
 
-    $segmentTitle = 'Email Segment Opened Test';
+    $segmentTitle = 'Email Segment Machine Opened Test';
     $segmentDesc = 'Lorem ipsum dolor sit amet';
 
     $subscriber1 = (new Subscriber())
@@ -204,8 +204,8 @@ class ManageSegmentsCest {
     $subscriber2 = (new Subscriber())
       ->withEmail('stats_test2@example.com')
       ->create();
-    (new StatisticsOpens($newsletter, $subscriber1))->create();
-    (new StatisticsOpens($newsletter, $subscriber2))->create();
+    (new StatisticsOpens($newsletter, $subscriber1))->withMachineUserAgentType()->create();
+    (new StatisticsOpens($newsletter, $subscriber2))->withMachineUserAgentType()->create();
 
     $i->login();
     $i->amOnMailpoetPage('Segments');
@@ -214,10 +214,8 @@ class ManageSegmentsCest {
     $i->click('[data-automation-id="new-custom-segment"]');
     $i->fillField(['name' => 'name'], $segmentTitle);
     $i->fillField(['name' => 'description'], $segmentDesc);
-    $i->selectOptionInReactSelect('opened', '[data-automation-id="select-segment-action"]');
+    $i->selectOptionInReactSelect('machine-opened', '[data-automation-id="select-segment-action"]');
     $i->selectOptionInReactSelect($emailSubject, '[data-automation-id="segment-email"]');
-    $i->selectOption('[data-automation-id="segment-email-opens-condition"]', 'none of');
-    $i->waitForText('This segment has 0 subscribers');
     $i->selectOption('[data-automation-id="segment-email-opens-condition"]', 'any of');
     $i->waitForText('This segment has 2 subscribers');
     $i->selectOption('[data-automation-id="segment-email-opens-condition"]', 'all of');


### PR DESCRIPTION
## Description

This PR makes sure filters are ordered alphabetically per group in the page to create/edit segments. It uses .sort() to ensure the ordering happens after the label is translated if the site is using a language other than English.

It also changes the order of the filters in the .ts files where they are defined to match the order in which they are displayed when the site is in English to make it easier for developers to add new filters and to find filters when coding.

## Code review notes

Note that ordering the segments alphabetically uncovered what I believe is a bug in `AcceptanceTester::selectOptionInReactSelect()`. I was not able to find a quick solution for this bug and didn't want to spend more time on this ticket. So, in f1e359ad99d7326dbe0753e40b3b3a696b647625, I implemented a workaround. Please let me know if you can find a better approach. If not, I plan to create a ticket for us to fix `AcceptanceTester::selectOptionInReactSelect()`.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5229]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5229]: https://mailpoet.atlassian.net/browse/MAILPOET-5229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ