### PR TITLE
Use mixpanel PHP instead of JS for user properties [MAILPOET-5161]

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "php": ">=7.3",
+    "mixpanel/mixpanel-php": "2.*",
     "mtdowling/cron-expression": "^1.1",
     "woocommerce/action-scheduler": "^3.6"
   },

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0475561d7b7dd2a65a99c1e47490ee8",
+    "content-hash": "42dd5583b27e32f60e8358e489f424e9",
     "packages": [
+        {
+            "name": "mixpanel/mixpanel-php",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mixpanel/mixpanel-php.git",
+                "reference": "4b0fafacf2129eff5d50721e129b07f0c32687e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mixpanel/mixpanel-php/zipball/4b0fafacf2129eff5d50721e129b07f0c32687e7",
+                "reference": "4b0fafacf2129eff5d50721e129b07f0c32687e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "2.9.*",
+                "phpunit/phpunit": "5.6.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Mixpanel.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Mixpanel <dev@mixpanel.com>",
+                    "homepage": "https://mixpanel.com/"
+                }
+            ],
+            "description": "The Official PHP library for Mixpanel",
+            "homepage": "https://mixpanel.com/help/reference/php",
+            "keywords": [
+                "mixpanel",
+                "mixpanel php"
+            ],
+            "support": {
+                "issues": "https://github.com/mixpanel/mixpanel-php/issues",
+                "source": "https://github.com/mixpanel/mixpanel-php/tree/2.11.0"
+            },
+            "time": "2023-04-11T23:03:57+00:00"
+        },
         {
             "name": "mtdowling/cron-expression",
             "version": "v1.2.3",

--- a/mailpoet/lib/Analytics/Analytics.php
+++ b/mailpoet/lib/Analytics/Analytics.php
@@ -91,12 +91,17 @@ class Analytics {
     if (!$this->isEnabled()) {
       return false;
     }
+    $nextSend = $this->getNextSendDate();
+    return $nextSend->isPast();
+  }
+
+  public function getNextSendDate(): Carbon {
     $lastSent = $this->settings->get(Analytics::SETTINGS_LAST_SENT_KEY);
     if (!$lastSent) {
-      return true;
+      return Carbon::now()->subMinute();
     }
-    $lastSentCarbon = Carbon::createFromTimestamp(strtotime($lastSent))->addDays(Analytics::SEND_AFTER_DAYS);
-    return $lastSentCarbon->isPast();
+
+    return Carbon::createFromTimestamp(strtotime($lastSent))->addDays(self::SEND_AFTER_DAYS);
   }
 
   public function recordDataSent() {

--- a/mailpoet/lib/Analytics/Analytics.php
+++ b/mailpoet/lib/Analytics/Analytics.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Analytics;
 
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -63,13 +64,12 @@ class Analytics {
   /** @return string */
   public function getPublicId() {
     $publicId = $this->settings->get('public_id', '');
-    // if we didn't get the user public_id from the shop yet : we create one based on mixpanel distinct_id
-    if (empty($publicId) && !empty($_COOKIE['mixpanel_distinct_id'])) {
-      // the public id has to be diffent that mixpanel_distinct_id in order to be used on different browser
-      $mixpanelDistinctId = md5(sanitize_text_field(wp_unslash($_COOKIE['mixpanel_distinct_id'])));
-      $this->settings->set('public_id', $mixpanelDistinctId);
+    if (empty($publicId)) {
+      // The previous implementation used md5, so this is just to ensure consistency
+      $randomId = md5(Security::generateRandomString(32));
+      $this->settings->set('public_id', $randomId);
       $this->settings->set('new_public_id', 'true');
-      return $mixpanelDistinctId;
+      return $randomId;
     }
     return $publicId;
   }

--- a/mailpoet/lib/Analytics/Analytics.php
+++ b/mailpoet/lib/Analytics/Analytics.php
@@ -33,11 +33,15 @@ class Analytics {
   /** @return array|null */
   public function generateAnalytics() {
     if ($this->shouldSend()) {
-      $data = $this->wp->applyFilters(self::ANALYTICS_FILTER, $this->reporter->getData());
+      $data = $this->getAnalyticsData();
       $this->recordDataSent();
       return $data;
     }
     return null;
+  }
+
+  public function getAnalyticsData() {
+    return $this->wp->applyFilters(self::ANALYTICS_FILTER, $this->reporter->getData());
   }
 
   /** @return bool */

--- a/mailpoet/lib/Analytics/Analytics.php
+++ b/mailpoet/lib/Analytics/Analytics.php
@@ -87,7 +87,7 @@ class Analytics {
     return false;
   }
 
-  private function shouldSend() {
+  public function shouldSend() {
     if (!$this->isEnabled()) {
       return false;
     }
@@ -99,7 +99,7 @@ class Analytics {
     return $lastSentCarbon->isPast();
   }
 
-  private function recordDataSent() {
+  public function recordDataSent() {
     $this->settings->set(Analytics::SETTINGS_LAST_SENT_KEY, Carbon::now());
   }
 }

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -7,6 +7,7 @@ use MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck;
 use MailPoet\Cron\Workers\BackfillEngagementData;
 use MailPoet\Cron\Workers\Beamer;
 use MailPoet\Cron\Workers\InactiveSubscribers;
+use MailPoet\Cron\Workers\Mixpanel;
 use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
 use MailPoet\Cron\Workers\StatsNotifications\Worker;
 use MailPoet\Cron\Workers\SubscriberLinkTokens;
@@ -183,6 +184,7 @@ class Populator {
     $this->scheduleSubscriberLastEngagementDetection();
     $this->scheduleNewsletterTemplateThumbnails();
     $this->scheduleBackfillEngagementData();
+    $this->scheduleMixpanel();
   }
 
   private function createMailPoetPage() {
@@ -679,6 +681,10 @@ class Populator {
       SubscriberLinkTokens::TASK_TYPE,
       Carbon::createFromTimestamp($this->wp->currentTime('timestamp'))
     );
+  }
+
+  private function scheduleMixpanel() {
+    $this->scheduleTask(Mixpanel::TASK_TYPE, Carbon::createFromTimestamp($this->wp->currentTime('timestamp')));
   }
 
   private function scheduleTask($type, $datetime, $priority = null) {

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -94,5 +94,6 @@ class Daemon {
     yield $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
     yield $this->workersFactory->createAbandonedCartWorker();
     yield $this->workersFactory->createBackfillEngagementDataWorker();
+    yield $this->workersFactory->createMixpanelWorker();
   }
 }

--- a/mailpoet/lib/Cron/Workers/Mixpanel.php
+++ b/mailpoet/lib/Cron/Workers/Mixpanel.php
@@ -57,4 +57,8 @@ class Mixpanel extends SimpleWorker {
 
     return true;
   }
+
+  public function getNextRunDate() {
+    return $this->analytics->getNextSendDate()->addMinutes(rand(0, 59));
+  }
 }

--- a/mailpoet/lib/Cron/Workers/Mixpanel.php
+++ b/mailpoet/lib/Cron/Workers/Mixpanel.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Analytics\Analytics;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\WP\Functions;
+use Mixpanel as MixpanelLibrary;
+
+class Mixpanel extends SimpleWorker {
+
+  const PRODUCTION_PROJECT_ID = '8cce373b255e5a76fb22d57b85db0c92';
+
+  /** @var Analytics */
+  private $analytics;
+
+  const TASK_TYPE = 'mixpanel';
+
+  /** @var MixpanelLibrary */
+  private $mixpanel;
+
+  public function __construct(
+    Analytics $analytics,
+    Functions $wp
+  ) {
+    parent::__construct($wp);
+    $this->analytics = $analytics;
+    $this->mixpanel = MixpanelLibrary::getInstance(self::PRODUCTION_PROJECT_ID);
+    $this->mixpanel->register('Platform', 'Plugin');
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    return $this->maybeReportAnalyticsToMixpanel();
+  }
+
+  public function maybeReportAnalyticsToMixpanel(): bool {
+    if (!$this->analytics->shouldSend()) {
+      return true;
+    }
+    return $this->reportAnalyticsToMixpanel();
+  }
+
+  public function reportAnalyticsToMixpanel(): bool {
+    $publicId = $this->analytics->getPublicId();
+
+    if (strlen($publicId) < 1) {
+      return true;
+    }
+
+    $data = $this->analytics->getAnalyticsData();
+
+    $this->mixpanel->identify($publicId);
+    $this->mixpanel->people->set($publicId, $data);
+    $this->mixpanel->track('User Properties', $data);
+
+    $this->analytics->recordDataSent();
+
+    return true;
+  }
+}

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -30,6 +30,7 @@ class WorkersFactory {
     StatsNotificationsWorkerForAutomatedEmails::TASK_TYPE,
     StatsNotificationsWorker::TASK_TYPE,
     BackfillEngagementData::TASK_TYPE,
+    Mixpanel::TASK_TYPE,
   ];
 
   /** @var ContainerWrapper */
@@ -159,5 +160,9 @@ class WorkersFactory {
   /** @return BackfillEngagementData */
   public function createBackfillEngagementDataWorker() {
     return $this->container->get(BackfillEngagementData::class);
+  }
+
+  public function createMixpanelWorker() {
+    return $this->container->get(Mixpanel::class);
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -302,6 +302,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\Beamer::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersEmailCount::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\InactiveSubscribers::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\Mixpanel::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\UnsubscribeTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscriberLinkTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck::class)->setPublic(true);

--- a/mailpoet/lib/Twig/Analytics.php
+++ b/mailpoet/lib/Twig/Analytics.php
@@ -16,11 +16,6 @@ class Analytics extends AbstractExtension {
   public function getFunctions() {
     return [
       new TwigFunction(
-        'get_analytics_data',
-        [$this, 'generateAnalytics'],
-        ['is_safe' => ['all']]
-      ),
-      new TwigFunction(
         'is_analytics_enabled',
         [$this, 'isEnabled'],
         ['is_safe' => ['all']]
@@ -47,10 +42,6 @@ class Analytics extends AbstractExtension {
       throw new InvalidStateException('AnalyticsGenerator service was not registered!');
     }
     return $this->analytics;
-  }
-
-  public function generateAnalytics() {
-    return $this->getAnalytics()->generateAnalytics();
   }
 
   public function isEnabled() {

--- a/mailpoet/prefixer/fix-attributes.php
+++ b/mailpoet/prefixer/fix-attributes.php
@@ -10,7 +10,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
 $iterator = new RecursiveDirectoryIterator(__DIR__ . '/../vendor-prefixed', RecursiveDirectoryIterator::SKIP_DOTS);
 $files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
 foreach ($files as $file) {
-  if (substr($file, -3) === 'php') {
+  if (substr($file, -4) === '.php') {
     $data = file_get_contents($file);
     $data = str_replace('use MailPoetVendor\\ReturnTypeWillChange;', 'use ReturnTypeWillChange;', $data);
     file_put_contents($file, $data);

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -86,11 +86,6 @@ parameters:
 			path: ../../lib/API/JSON/v1/Segments.php
 
 		-
-			message: "#^Method MailPoet\\\\Analytics\\\\Analytics\\:\\:generateAnalytics\\(\\) should return array\\|null but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Analytics/Analytics.php
-
-		-
 			message: "#^Cannot access offset 'events' on mixed\\.$#"
 			count: 3
 			path: ../../lib/AutomaticEmails/AutomaticEmails.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -86,11 +86,6 @@ parameters:
 			path: ../../lib/API/JSON/v1/Segments.php
 
 		-
-			message: "#^Method MailPoet\\\\Analytics\\\\Analytics\\:\\:generateAnalytics\\(\\) should return array\\|null but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Analytics/Analytics.php
-
-		-
 			message: "#^Cannot access offset 'events' on mixed\\.$#"
 			count: 3
 			path: ../../lib/AutomaticEmails/AutomaticEmails.php

--- a/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8.1-baseline.neon
@@ -85,11 +85,6 @@ parameters:
 			path: ../../lib/API/JSON/v1/Segments.php
 
 		-
-			message: "#^Method MailPoet\\\\Analytics\\\\Analytics\\:\\:generateAnalytics\\(\\) should return array\\|null but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Analytics/Analytics.php
-
-		-
 			message: "#^Cannot access offset 'events' on mixed\\.$#"
 			count: 3
 			path: ../../lib/AutomaticEmails/AutomaticEmails.php

--- a/mailpoet/tests/DataFactories/NewsletterOption.php
+++ b/mailpoet/tests/DataFactories/NewsletterOption.php
@@ -5,19 +5,13 @@ namespace MailPoet\Test\DataFactories;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 
 class NewsletterOption {
-  /** @var NewsletterOptionFieldsRepository */
-  private $newsletterOptionFieldsRepository;
-
   /** @var NewsletterOptionsRepository */
   private $newsletterOptionsRepository;
 
   public function __construct() {
-    $this->newsletterOptionFieldsRepository = ContainerWrapper::getInstance()->get(NewsletterOptionFieldsRepository::class);
     $this->newsletterOptionsRepository = ContainerWrapper::getInstance()->get(NewsletterOptionsRepository::class);
   }
 
@@ -31,16 +25,7 @@ class NewsletterOption {
    * @param string|int $optionValue
    */
   public function create(NewsletterEntity $newsletter, string $optionName, $optionValue): NewsletterOptionEntity {
-    $newsletterOptionField = $this->newsletterOptionFieldsRepository->findOneBy([
-      'name' => $optionName,
-      'newsletterType' => $newsletter->getType(),
-    ]);
-    if (!$newsletterOptionField) {
-      $newsletterOptionField = new NewsletterOptionFieldEntity();
-      $newsletterOptionField->setNewsletterType($newsletter->getType());
-      $newsletterOptionField->setName($optionName);
-      $this->newsletterOptionFieldsRepository->persist($newsletterOptionField);
-    }
+    $newsletterOptionField = (new NewsletterOptionField())->findOrCreate($optionName, $newsletter->getType());
 
     $newsletterOption = $this->newsletterOptionsRepository->findOneBy([
       'newsletter' => $newsletter,

--- a/mailpoet/tests/DataFactories/NewsletterOptionField.php
+++ b/mailpoet/tests/DataFactories/NewsletterOptionField.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
+
+class NewsletterOptionField {
+  /** @var NewsletterOptionFieldsRepository */
+  private $newsletterOptionFieldsRepository;
+
+  public function __construct() {
+    $this->newsletterOptionFieldsRepository = ContainerWrapper::getInstance()->get(NewsletterOptionFieldsRepository::class);
+  }
+
+  public function findOrCreate(string $name, string $newsletterType = NewsletterEntity::TYPE_STANDARD): NewsletterOptionFieldEntity {
+    $newsletterOptionField = $this->newsletterOptionFieldsRepository->findOneBy([
+      'name' => $name,
+      'newsletterType' => $newsletterType,
+    ]);
+    if (!$newsletterOptionField) {
+      $newsletterOptionField = new NewsletterOptionFieldEntity();
+      $newsletterOptionField->setNewsletterType($newsletterType);
+      $newsletterOptionField->setName($name);
+      $this->newsletterOptionFieldsRepository->persist($newsletterOptionField);
+    }
+
+    return $newsletterOptionField;
+  }
+}

--- a/mailpoet/tests/_support/IntegrationCleanupExtension.php
+++ b/mailpoet/tests/_support/IntegrationCleanupExtension.php
@@ -34,6 +34,7 @@ class IntegrationCleanupExtension extends Extension {
       FROM information_schema.tables
       WHERE table_name LIKE '{$mpPrefix}%'
       AND table_name != '{$mpPrefix}migrations'
+      AND table_name != '{$mpPrefix}newsletter_option_fields'
     ");
 
     $this->cleanupStatements = 'SET FOREIGN_KEY_CHECKS=0;';

--- a/mailpoet/tests/integration/Analytics/AnalyticsTest.php
+++ b/mailpoet/tests/integration/Analytics/AnalyticsTest.php
@@ -137,4 +137,11 @@ class AnalyticsTest extends \MailPoetTest {
     expect($this->analytics->isPublicIdNew())->false();
     expect($this->settings->get('new_public_id'))->equals('false');
   }
+
+  public function testGetNextSendDateIsWeekFromLastSend(): void {
+    $this->settings->set('analytics_last_sent', Carbon::now());
+    $weekFromNow = Carbon::now()->addDays(7);
+    $nextSendDate = $this->analytics->getNextSendDate();
+    expect($nextSendDate->getTimestamp())->equals($weekFromNow->getTimestamp());
+  }
 }

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -308,6 +308,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createNewsletterTemplateThumbnailsWorker' => $worker,
       'createAbandonedCartWorker' => $worker,
       'createBackfillEngagementDataWorker' => $worker,
+      'createMixpanelWorker' => $worker,
       ]);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -115,6 +115,7 @@ class DaemonTest extends \MailPoetTest {
       'createNewsletterTemplateThumbnailsWorker' => $this->createSimpleWorkerMock(),
       'createAbandonedCartWorker' => $this->createSimpleWorkerMock(),
       'createBackfillEngagementDataWorker' => $this->createSimpleWorkerMock(),
+      'createMixpanelWorker' => $this->createSimpleWorkerMock(),
       ]);
   }
 

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -7,6 +7,7 @@ use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 
 class NewsletterEntityTest extends \MailPoetTest {
   /** @var NewslettersRepository */
@@ -40,7 +41,7 @@ class NewsletterEntityTest extends \MailPoetTest {
 
   public function testItRemovesOrphanedOptionRelations() {
     $newsletter = $this->createNewsletter();
-    $optionField = $this->createOptionField(NewsletterOptionFieldEntity::NAME_GROUP);
+    $optionField = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_GROUP);
     $newsletterOption = new NewsletterOptionEntity($newsletter, $optionField);
     $this->entityManager->persist($newsletterOption);
     $this->entityManager->flush();
@@ -59,7 +60,7 @@ class NewsletterEntityTest extends \MailPoetTest {
   public function testGetOptionReturnsCorrectData(): void {
     $optionValue = 'Some Value';
     $newsletter = $this->createNewsletter();
-    $optionField = $this->createOptionField(NewsletterOptionFieldEntity::NAME_EVENT);
+    $optionField = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_EVENT);
     $newsletterOption = new NewsletterOptionEntity($newsletter, $optionField);
     $newsletterOption->setValue($optionValue);
 
@@ -181,7 +182,7 @@ class NewsletterEntityTest extends \MailPoetTest {
   }
 
   public function testItCanRetrieveFilterSegmentIdOption(): void {
-    $optionField = $this->createOptionField(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID);
+    $optionField = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID);
     $newsletter = $this->createNewsletter();
     expect($newsletter->getFilterSegmentId())->null();
 
@@ -196,7 +197,7 @@ class NewsletterEntityTest extends \MailPoetTest {
   }
 
   public function testItInheritsFilterSegmentIdFromParent(): void {
-    $optionField = $this->createOptionField(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID, NewsletterEntity::TYPE_NOTIFICATION);
+    $optionField = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID, NewsletterEntity::TYPE_NOTIFICATION);
     $notificationNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION);
     expect($notificationNewsletter->getFilterSegmentId())->null();
 
@@ -225,13 +226,5 @@ class NewsletterEntityTest extends \MailPoetTest {
     $newsletter->setSubject('Subject');
     $this->entityManager->persist($newsletter);
     return $newsletter;
-  }
-
-  private function createOptionField(string $name, string $type = NewsletterEntity::TYPE_STANDARD): NewsletterOptionFieldEntity {
-    $newsletterOptionField = new NewsletterOptionFieldEntity();
-    $newsletterOptionField->setName($name);
-    $newsletterOptionField->setNewsletterType($type);
-    $this->entityManager->persist($newsletterOptionField);
-    return $newsletterOptionField;
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Listing/NewsletterListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Listing/NewsletterListingRepositoryTest.php
@@ -4,10 +4,10 @@ namespace MailPoet\Newsletter\Listing;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\Handler;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 
 class NewsletterListingRepositoryTest extends \MailPoetTest {
   public function testItAppliesGroup() {
@@ -129,10 +129,7 @@ class NewsletterListingRepositoryTest extends \MailPoetTest {
   }
 
   public function testItAppliesAutomaticEmailsGroupParameter() {
-    $newsletterOptionField = new NewsletterOptionFieldEntity();
-    $newsletterOptionField->setName('group');
-    $newsletterOptionField->setNewsletterType(NewsletterEntity::TYPE_AUTOMATIC);
-    $this->entityManager->persist($newsletterOptionField);
+    $newsletterOptionField = (new NewsletterOptionField())->findOrCreate('group', NewsletterEntity::TYPE_AUTOMATIC);
 
     $newsletter1 = new NewsletterEntity();
     $newsletter1->setType(NewsletterEntity::TYPE_AUTOMATIC);

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -21,6 +21,7 @@ use MailPoet\Entities\StatsNotificationEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -150,7 +151,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(ScheduledTaskEntity::class, $notificationHistoryStatsNotificationScheduledTask);
     $standardLink = $this->createNewsletterLink($standardNewsletter, $standardQueue);
     $notificationHistoryLink = $this->createNewsletterLink($notificationHistory, $notificationHistoryQueue);
-    $optionField = $this->createNewsletterOptionField(NewsletterEntity::TYPE_NOTIFICATION, 'option');
+    $optionField = (new NewsletterOptionField())->findOrCreate('name', NewsletterEntity::TYPE_NOTIFICATION);
     $optionValue = $this->createNewsletterOption($notificationHistory, $optionField, 'value');
     $newsletterPost = $this->createNewsletterPost($notification, 1);
 
@@ -398,15 +399,6 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($link);
     $this->entityManager->flush();
     return $link;
-  }
-
-  private function createNewsletterOptionField(string $newsletterType, string $name): NewsletterOptionFieldEntity {
-    $newsletterOptionField = new NewsletterOptionFieldEntity();
-    $newsletterOptionField->setNewsletterType($newsletterType);
-    $newsletterOptionField->setName($name);
-    $this->entityManager->persist($newsletterOptionField);
-    $this->entityManager->flush();
-    return $newsletterOptionField;
   }
 
   private function createNewsletterOption(NewsletterEntity $newsletter, NewsletterOptionFieldEntity $field, $value): NewsletterOptionEntity {

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Newsletter;
 use Codeception\Util\Fixtures;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -15,6 +14,7 @@ use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -401,10 +401,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     ];
 
     foreach ($newsletterOptions as $optionName) {
-      $newsletterOptionField = new NewsletterOptionFieldEntity();
-      $newsletterOptionField->setNewsletterType(NewsletterEntity::TYPE_NOTIFICATION);
-      $newsletterOptionField->setName($optionName);
-      $this->entityManager->persist($newsletterOptionField);
+      (new NewsletterOptionField())->findOrCreate($optionName, NewsletterEntity::TYPE_NOTIFICATION);
     }
     $this->entityManager->flush();
   }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -14,6 +14,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoetVendor\Carbon\Carbon;
@@ -37,14 +38,8 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     // Prepare Newsletter field options for configuring re-engagement emails
-    $this->afterTimeNumberOptionField = new NewsletterOptionFieldEntity();
-    $this->afterTimeNumberOptionField->setName(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER);
-    $this->afterTimeNumberOptionField->setNewsletterType(NewsletterEntity::TYPE_RE_ENGAGEMENT);
-    $this->entityManager->persist($this->afterTimeNumberOptionField);
-    $this->afterTimeTypeField = new NewsletterOptionFieldEntity();
-    $this->afterTimeTypeField->setName(NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE);
-    $this->afterTimeTypeField->setNewsletterType(NewsletterEntity::TYPE_RE_ENGAGEMENT);
-    $this->entityManager->persist($this->afterTimeTypeField);
+    $this->afterTimeNumberOptionField = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER, NewsletterEntity::TYPE_RE_ENGAGEMENT);
+    $this->afterTimeTypeField = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE, NewsletterEntity::TYPE_RE_ENGAGEMENT);
 
     $this->segment = (new Segment())->withName('Re-engagement test')->create();
     $this->sentStandardNewsletter = (new Newsletter())->withSentStatus()->withSendingQueue()->create();

--- a/mailpoet/tests/integration/Newsletter/Segment/NewsletterSegmentRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Segment/NewsletterSegmentRepositoryTest.php
@@ -11,6 +11,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 
 class NewsletterSegmentRepositoryTest extends \MailPoetTest {
   /** @var NewsletterSegmentRepository */
@@ -25,8 +26,8 @@ class NewsletterSegmentRepositoryTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     $this->repository = $this->diContainer->get(NewsletterSegmentRepository::class);
-    $this->welcomeEmailSegmentOption = $this->createNewsletterOptionField(NewsletterEntity::TYPE_WELCOME, NewsletterOptionFieldEntity::NAME_SEGMENT);
-    $this->automaticEmailSegmentOption = $this->createNewsletterOptionField(NewsletterEntity::TYPE_AUTOMATIC, NewsletterOptionFieldEntity::NAME_SEGMENT);
+    $this->welcomeEmailSegmentOption = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_SEGMENT, NewsletterEntity::TYPE_WELCOME);
+    $this->automaticEmailSegmentOption = (new NewsletterOptionField())->findOrCreate(NewsletterOptionFieldEntity::NAME_SEGMENT, NewsletterEntity::TYPE_AUTOMATIC);
   }
 
   public function testItCanGetActiveNewslettersForSegments() {
@@ -124,15 +125,6 @@ class NewsletterSegmentRepositoryTest extends \MailPoetTest {
 
     $this->entityManager->flush();
     return $queue;
-  }
-
-  private function createNewsletterOptionField(string $newsletterType, string $name): NewsletterOptionFieldEntity {
-    $newsletterOptionField = new NewsletterOptionFieldEntity();
-    $newsletterOptionField->setNewsletterType($newsletterType);
-    $newsletterOptionField->setName($name);
-    $this->entityManager->persist($newsletterOptionField);
-    $this->entityManager->flush();
-    return $newsletterOptionField;
   }
 
   private function createNewsletterOption(NewsletterEntity $newsletter, NewsletterOptionFieldEntity $field, $value): NewsletterOptionEntity {

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\StatisticsClicks;
 use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
 use MailPoet\Test\DataFactories\Subscriber;
@@ -32,11 +33,7 @@ class TrackerTest extends \MailPoetTest {
     $this->subscriber = (new Subscriber())->create();
     $this->tracker = $this->diContainer->get(Tracker::class);
     // Add dummy option field. This is needed for AUTOMATIC emails analytics
-    $newsletterOptionField = new NewsletterOptionFieldEntity();
-    $newsletterOptionField->setNewsletterType(NewsletterEntity::TYPE_AUTOMATIC);
-    $newsletterOptionField->setName('event');
-    $this->entityManager->persist($newsletterOptionField);
-    $this->entityManager->flush();
+    (new NewsletterOptionField())->findOrCreate('event', NewsletterEntity::TYPE_AUTOMATIC);
   }
 
   public function testItAddsTrackingData(): void {
@@ -46,7 +43,6 @@ class TrackerTest extends \MailPoetTest {
   }
 
   public function testItAddsTheEventOption(): void {
-
     $newsletter1 = (new Newsletter())->withSendingQueue()->withType(NewsletterEntity::TYPE_AUTOMATIC)->create();
     $field = $this->diContainer->get(NewsletterOptionFieldsRepository::class)->findOneBy([
       'name' => NewsletterOptionFieldEntity::NAME_EVENT,
@@ -197,7 +193,6 @@ class TrackerTest extends \MailPoetTest {
   }
 
   public function testItTracksTheRevenueOfDeletedCampaigns(): void {
-
     $newsletter1 = (new Newsletter())->withSendingQueue()->create();
     $newsletter2 = (new Newsletter())->withSendingQueue()->create();
     $newsletter3 = (new Newsletter())->withSendingQueue()->create();

--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -4,6 +4,7 @@ use Codeception\Stub;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -38,6 +39,9 @@ $connection = ContainerWrapper::getInstance(WP_DEBUG)->get(Connection::class);
 $entityManager = ContainerWrapper::getInstance(WP_DEBUG)->get(EntityManager::class);
 $entitiesMeta = $entityManager->getMetadataFactory()->getAllMetadata();
 foreach ($entitiesMeta as $entityMeta) {
+  if ($entityMeta->getName() === NewsletterOptionFieldEntity::class) {
+    continue;
+  }
   $tableName = $entityMeta->getTableName();
   $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
   $connection->executeStatement("TRUNCATE $tableName");

--- a/mailpoet/views/analytics.html
+++ b/mailpoet/views/analytics.html
@@ -5,12 +5,7 @@
 
 window.mixpanelTrackingId = "8cce373b255e5a76fb22d57b85db0c92";
 
-mixpanel.init(window.mixpanelTrackingId, {
-  loaded: function(mixpanel) {
-    // used in lib/Analytics/Analytics.php
-    document.cookie = "mixpanel_distinct_id=" + mixpanel.get_distinct_id();
-  }
-});
+mixpanel.init(window.mixpanelTrackingId);
 
 mixpanel.register({'Platform': 'Plugin'});
 

--- a/mailpoet/views/analytics.html
+++ b/mailpoet/views/analytics.html
@@ -5,24 +5,21 @@
 
 window.mixpanelTrackingId = "8cce373b255e5a76fb22d57b85db0c92";
 
-if (mailpoet_analytics_enabled) {
-
-  mixpanel.init(window.mixpanelTrackingId, {
-    loaded: function(mixpanel) {
-      // used in lib/Analytics/Analytics.php
-      document.cookie = "mixpanel_distinct_id=" + mixpanel.get_distinct_id();
-    }
-  });
-
-  mixpanel.register({'Platform': 'Plugin'});
-
-  if(typeof window.mailpoet_analytics_public_id === 'string' && window.mailpoet_analytics_public_id.length > 0) {
-    if(window.mailpoet_analytics_new_public_id === true) {
-      mixpanel.alias(window.mailpoet_analytics_public_id);
-    } else {
-      mixpanel.identify(window.mailpoet_analytics_public_id);
-    }
+mixpanel.init(window.mixpanelTrackingId, {
+  loaded: function(mixpanel) {
+    // used in lib/Analytics/Analytics.php
+    document.cookie = "mixpanel_distinct_id=" + mixpanel.get_distinct_id();
   }
+});
 
+mixpanel.register({'Platform': 'Plugin'});
+
+if(typeof window.mailpoet_analytics_public_id === 'string' && window.mailpoet_analytics_public_id.length > 0) {
+  if(window.mailpoet_analytics_new_public_id === true) {
+    mixpanel.alias(window.mailpoet_analytics_public_id);
+  } else {
+    mixpanel.identify(window.mailpoet_analytics_public_id);
+  }
 }
+
 </script>

--- a/mailpoet/views/analytics.html
+++ b/mailpoet/views/analytics.html
@@ -24,10 +24,5 @@ if (mailpoet_analytics_enabled) {
     }
   }
 
-  if (mailpoet_analytics_data != null) {
-    mixpanel.people.set(mailpoet_analytics_data);
-    MailPoet.trackEvent('User Properties', mailpoet_analytics_data);
-  }
-
 }
 </script>

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -175,8 +175,11 @@
 
 <% block after_translations %><% endblock %>
 
-<% if display_docsbot_widget and not is_dotcom_ecommerce_plan() %>
+<% if is_analytics_enabled() %>
   <% include 'analytics.html' %>
+<% endif %>
+
+<% if display_docsbot_widget and not is_dotcom_ecommerce_plan() %>
   <script type="text/javascript">window.DocsBotAI=window.DocsBotAI||{},DocsBotAI.init=function(c){return new Promise(function(e,o){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://widget.docsbot.ai/chat.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n),t.addEventListener("load",function(){window.DocsBotAI.mount({id:c.id,supportCallback:c.supportCallback,identify:c.identify,options:c.options});var t;t=function(n){return new Promise(function(e){if(document.querySelector(n))return e(document.querySelector(n));var o=new MutationObserver(function(t){document.querySelector(n)&&(e(document.querySelector(n)),o.disconnect())});o.observe(document.body,{childList:!0,subtree:!0})})},t&&t("#docsbotai-root").then(e).catch(o)}),t.addEventListener("error",function(t){o(t.message)})})};</script>
   <script type="text/javascript">
     DocsBotAI.init({

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -45,7 +45,6 @@
   var mailpoet_main_page_slug =   <%= json_encode(main_page) %>;
   var mailpoet_3rd_party_libs_enabled = <%= is_loading_3rd_party_enabled() | json_encode %>;
   var mailpoet_analytics_enabled = <%= is_analytics_enabled() | json_encode %>;
-  var mailpoet_analytics_data = <%= json_encode(get_analytics_data()) %>;
   var mailpoet_analytics_public_id = <%= json_encode(get_analytics_public_id()) %>;
   var mailpoet_analytics_new_public_id = <%= is_analytics_public_id_new() | json_encode %>;
   var mailpoet_free_domains = <%= json_encode(mailpoet_free_domains()) %>;


### PR DESCRIPTION
## Description

This PR moves some of our (opt-in) tracking to use the mixpanel PHP library instead of JavaScript. This is because the JS only runs when a user visits a MailPoet page, and there's no guarantee users will do that on a weekly basis.

## Code review notes

Unfortunately the PHP library does not play nicely with our prefixer. For now I'm including it unprefixed, but if you foresee that being a problem I'm happy to add a fix.

At one point I ran into a problem where a test was failing because it was running [this code](https://github.com/mailpoet/mailpoet/blob/6e705fb316e8b2099036707ba37444928addfa70/mailpoet/lib/Newsletter/NewslettersRepository.php#L176-L176), which was throwing an error because we delete all newsletter option field rows between tests. I decided to change our integration test cleanup code to leave the option field records alone because most of our code reasonably assumes these records will exist in a MailPoet installation and I thought this would get our test environment closer to real life.

## QA notes

To test, you'll need to have "Share anonymous data" enabled in MailPoet settings. You may need to deactivate and reactivate the plugin in order to schedule the very first scheduled task. Please reach out to me if you don't have access to mixpanel and need me to verify when certain data was sent.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5161](https://mailpoet.atlassian.net/browse/MAILPOET-5161)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5161]: https://mailpoet.atlassian.net/browse/MAILPOET-5161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ