### PR TITLE
Skip tracking step for dotcom [MAILPOET-5549]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -262,4 +262,5 @@ interface Window {
     type: 'default' | 'wp_users' | 'woocommerce_users' | 'dynamic';
   }>;
   mailpoet_admin_plugins_url: string;
+  mailpoet_is_dotcom: boolean;
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -178,6 +178,7 @@ interface Window {
   wizard_tracking_illustration_url: string;
   wizard_MSS_pitch_illustration_url: string;
   wizard_woocommerce_illustration_url: string;
+  wizard_has_tracking_settings: boolean;
   mailpoet_account_url: string;
   mailpoet_show_customers_import: boolean;
   mailpoet_installed_days_ago: number;

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -84,6 +84,7 @@ export const MailPoet = {
   mailFunctionEnabled: window.mailpoet_mail_function_enabled,
   corrupt_newsletters: window.corrupt_newsletters ?? [],
   adminPluginsUrl: window.mailpoet_admin_plugins_url,
+  isDotcom: window.mailpoet_is_dotcom,
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/wizard/steps-numbers.ts
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.ts
@@ -1,13 +1,21 @@
-export const getStepsCount = (): number => {
-  let stepsCount = 3;
+const getSteps = (): string[] => {
+  const steps = ['WelcomeWizardSenderStep'];
+  if (!window.mailpoet_is_dotcom) {
+    steps.push('WelcomeWizardUsageTrackingStep');
+  }
   if (window.mailpoet_woocommerce_active) {
-    stepsCount += 1;
+    steps.push('WizardWooCommerceStep');
   }
-  if (window.mailpoet_has_valid_api_key) {
-    stepsCount -= 1; // skip the MSS step if user already set API key
+  if (!window.mailpoet_has_valid_api_key) {
+    steps.push('WelcomeWizardPitchMSSStep');
   }
-  return stepsCount;
+  return steps;
 };
+
+export const getStepsCount = (): number => getSteps().length;
+
+export const mapStepNumberToStepName = (stepNumber: number): string | null =>
+  getSteps()[stepNumber - 1] || null;
 
 export const redirectToNextStep = (
   history: { push: (string) => void },
@@ -20,20 +28,4 @@ export const redirectToNextStep = (
   } else {
     finishWizard();
   }
-};
-
-export const mapStepNumberToStepName = (stepNumber: number): string | null => {
-  if (stepNumber === 1) {
-    return 'WelcomeWizardSenderStep';
-  }
-  if (stepNumber === 2) {
-    return 'WelcomeWizardUsageTrackingStep';
-  }
-  if (window.mailpoet_woocommerce_active && stepNumber === 3) {
-    return 'WizardWooCommerceStep';
-  }
-  if (!window.mailpoet_has_valid_api_key) {
-    return 'WelcomeWizardPitchMSSStep';
-  }
-  return null;
 };

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -86,16 +86,11 @@ function WelcomeWizardStepsController({
 
   const submitSender = useCallback(async () => {
     setLoading(true);
-    let currentStep = step;
-    if (window.mailpoet_is_dotcom) {
-      // Skip the next step
-      currentStep += 1;
-      if (!window.wizard_has_tracking_settings) {
-        await updateTracking(true, true);
-      }
+    if (window.mailpoet_is_dotcom && !window.wizard_has_tracking_settings) {
+      await updateTracking(true, true);
     }
     await updateSettings(createSenderSettings(sender)).then(() =>
-      redirect(currentStep),
+      redirect(step),
     );
     setLoading(false);
   }, [redirect, sender, step, updateTracking]);
@@ -105,18 +100,13 @@ function WelcomeWizardStepsController({
       e.preventDefault();
       setLoading(true);
       const defaultSenderInfo = { address: window.admin_email, name: '' };
-      let currentStep = step;
 
-      if (window.mailpoet_is_dotcom) {
-        // Skip the next step
-        currentStep += 1;
-        if (!window.wizard_has_tracking_settings) {
-          await updateTracking(true, true);
-        }
+      if (window.mailpoet_is_dotcom && !window.wizard_has_tracking_settings) {
+        await updateTracking(true, true);
       }
       await updateSettings(createSenderSettings(defaultSenderInfo)).then(() => {
         setSender(defaultSenderInfo);
-        redirect(currentStep);
+        redirect(step);
       });
       setLoading(false);
     },

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -86,25 +86,41 @@ function WelcomeWizardStepsController({
 
   const submitSender = useCallback(async () => {
     setLoading(true);
+    let currentStep = step;
+    if (window.mailpoet_is_dotcom) {
+      // Skip the next step
+      currentStep += 1;
+      if (!window.wizard_has_tracking_settings) {
+        await updateTracking(true, true);
+      }
+    }
     await updateSettings(createSenderSettings(sender)).then(() =>
-      redirect(step),
+      redirect(currentStep),
     );
     setLoading(false);
-  }, [redirect, sender, step]);
+  }, [redirect, sender, step, updateTracking]);
 
   const skipSenderStep = useCallback(
     async (e) => {
       e.preventDefault();
       setLoading(true);
       const defaultSenderInfo = { address: window.admin_email, name: '' };
+      let currentStep = step;
 
+      if (window.mailpoet_is_dotcom) {
+        // Skip the next step
+        currentStep += 1;
+        if (!window.wizard_has_tracking_settings) {
+          await updateTracking(true, true);
+        }
+      }
       await updateSettings(createSenderSettings(defaultSenderInfo)).then(() => {
         setSender(defaultSenderInfo);
-        redirect(step);
+        redirect(currentStep);
       });
       setLoading(false);
     },
-    [redirect, step, setSender],
+    [redirect, step, setSender, updateTracking],
   );
 
   const stepName = mapStepNumberToStepName(step);

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -48,11 +48,10 @@ function WelcomeWizardStepsController({
 
   const redirect = partial(redirectToNextStep, history, finishWizard);
 
-  const submitTracking = useCallback(
-    async (tracking, libs3rdParty) => {
-      setLoading(true);
+  const updateTracking = useCallback(
+    async (analytics: boolean, libs3rdParty: boolean) => {
       const analyticsData: Settings['analytics'] = {
-        enabled: tracking ? '1' : '',
+        enabled: analytics ? '1' : '',
       };
       const thirdPartyLibsData: Settings['3rd_party_libs'] = {
         enabled: libs3rdParty ? '1' : '',
@@ -64,10 +63,18 @@ function WelcomeWizardStepsController({
       await updateSettings(updateData);
       setAnalytics(analyticsData);
       setThirdPartyLibs(thirdPartyLibsData);
+    },
+    [setAnalytics, setThirdPartyLibs],
+  );
+
+  const submitTracking = useCallback(
+    async (tracking: boolean, libs3rdParty: boolean) => {
+      setLoading(true);
+      await updateTracking(tracking, libs3rdParty);
       redirect(step);
       setLoading(false);
     },
-    [redirect, step, setAnalytics, setThirdPartyLibs],
+    [redirect, step, updateTracking],
   );
 
   const updateSender = useCallback(

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -64,6 +64,7 @@ class WelcomeWizard {
       'settings' => $this->getSettings(),
       'premium_key_valid' => !empty($premiumKeyValid),
       'mss_key_valid' => !empty($mpApiKeyValid),
+      'has_tracking_settings' => $this->settings->hasSavedValue('analytics') && $this->settings->hasSavedValue('3rd_party_libs'),
     ];
     $this->pageRenderer->displayPage('welcome_wizard.html', $data);
   }

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -124,6 +124,17 @@ class SettingsController {
     unset($this->settings[$key]);
   }
 
+  /**
+   * Returns true if a value is stored in the database for the given key
+   *
+   * @param string $key
+   *
+   * @return bool
+   */
+  public function hasSavedValue(string $key): bool {
+    return $this->get($key, 'unset') !== 'unset';
+  }
+
   private function ensureLoaded() {
     if ($this->loaded) {
       return;

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -2,11 +2,13 @@
 
 namespace MailPoet\Twig;
 
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Referrals\UrlDecorator;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\FreeDomains;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Twig\Extension\AbstractExtension;
 use MailPoetVendor\Twig\TwigFunction;
@@ -44,6 +46,10 @@ class Functions extends AbstractExtension {
       $this->settings = SettingsController::getInstance();
     }
     return $this->settings;
+  }
+
+  private function getDotcomHelperFunctions(): DotcomHelperFunctions {
+    return ContainerWrapper::getInstance()->get(DotcomHelperFunctions::class);
   }
 
   private function getWp(): WPFunctions {
@@ -188,6 +194,11 @@ class Functions extends AbstractExtension {
       new TwigFunction(
         'is_dotcom_ecommerce_plan',
         [$this, 'isDotcomEcommercePlan'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
+        'is_dotcom',
+        [$this, 'isDotcom'],
         ['is_safe' => ['all']]
       ),
     ];
@@ -340,5 +351,9 @@ class Functions extends AbstractExtension {
       return wc_calypso_bridge_is_ecommerce_plan();
     }
     return false;
+  }
+
+  public function isDotcom(): bool {
+    return $this->getDotcomHelperFunctions()->isDotcom();
   }
 }

--- a/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
+++ b/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
@@ -21,7 +21,7 @@ class DotcomHelperFunctions {
    * Returns true if the site is on WordPress.com.
    */
   public function isDotcom(): bool {
-    return $this->isAtomicPlatform() ;
+    return $this->isAtomicPlatform();
   }
 
   public function isWooExpressPerformance(): bool {

--- a/mailpoet/tests/integration/Settings/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsControllerTest.php
@@ -120,6 +120,13 @@ class SettingsControllerTest extends \MailPoetTest {
     $this->assertEquals(true, true);
   }
 
+  public function testItCanCheckIfSavedValueExists(): void {
+    $this->assertFalse($this->controller->hasSavedValue('test_key'));
+    $this->createOrUpdateSetting('test_key', 'some value');
+    $this->controller->resetCache(); // force reload from database
+    $this->assertTrue($this->controller->hasSavedValue('test_key'));
+  }
+
   private function createOrUpdateSetting($name, $value) {
     $tableName = $this->entityManager->getClassMetadata(SettingEntity::class)->getTableName();
     $this->connection->executeStatement("

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -68,6 +68,7 @@
   var mailpoet_track_wizard_loaded_via_woocommerce = <%= json_encode(track_wizard_loaded_via_woocommerce) %>;
   var mailpoet_mail_function_enabled = '<%= mail_function_enabled %>';
   var mailpoet_admin_plugins_url = '<%= admin_plugins_url %>';
+  var mailpoet_is_dotcom = <%= json_encode(is_dotcom()) %>;
 
   var mailpoet_site_name = '<%= site_name %>';
   var mailpoet_site_url = "<%= site_url %>";

--- a/mailpoet/views/welcome_wizard.html
+++ b/mailpoet/views/welcome_wizard.html
@@ -15,6 +15,7 @@
   var mailpoet_settings = <%= json_encode(settings) %>;
   var mailpoet_premium_key_valid = <%= json_encode(premium_key_valid) %>;
   var mailpoet_mss_key_valid = <%= json_encode(mss_key_valid) %>;
+  var wizard_has_tracking_settings = <%= json_encode(has_tracking_settings) %>;
 </script>
 
 <div id="mailpoet-wizard-container"></div>


### PR DESCRIPTION
## Description

This PR changes the welcome wizard to skip the `Confirm privacy and data settings` step if a user is on wordpress.com. If the user doesn't have any values already saved for analytics and 3rd party libraries, they should be opted in automatically. If values already exist in the database for those settings, the wizard should not change them. 

## Code review notes

My initial implementation didn't show the correct number of steps at the top of the wizard. It would still show the number of steps that would exist with the tracking step, but it would simply skip over that step. I fixed this in 4fbd262cf2b588ece71e0c63fb875eccf2364b3a. I thought it risky how the step counter and the step mapper needed to have the same logic, so I did some refactoring to consolidate the logic to one place. tldr, please take a look to make sure this refactor didn't introduce any unintended side effects.

## QA notes

Please make sure to test the welcome wizard in all possible configurations (wpcom and not, with/without woocommerce, with/without a valid MSS key).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5549](https://mailpoet.atlassian.net/browse/MAILPOET-5549)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5549]: https://mailpoet.atlassian.net/browse/MAILPOET-5549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ