### PR TITLE
Update pending subscription notice [MAILPOET-5631]

### DIFF
--- a/mailpoet/assets/js/src/common/pending-approval-notice.tsx
+++ b/mailpoet/assets/js/src/common/pending-approval-notice.tsx
@@ -1,0 +1,87 @@
+import { MouseEvent } from 'react';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+function PendingApprovalTitle(): JSX.Element {
+  return createInterpolateElement(
+    __('MailPoet is <link>reviewing your subscription</link>.', 'mailpoet'),
+    {
+      link: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href="https://kb.mailpoet.com/article/379-our-approval-process"
+          target="_blank"
+          rel="noreferrer"
+        />
+      ),
+    },
+  );
+}
+
+function PendingApprovalBody(): JSX.Element {
+  return createInterpolateElement(
+    __(
+      `You can use all MailPoet features and send <link1>email previews</link1> to your <link2>authorized email addresses</link2>, but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject "<emailSubject/>" and reply, or <link3>contact us</link3>.`,
+      'mailpoet',
+    ),
+    {
+      link1: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href="https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it"
+          target="_blank"
+          rel="noreferrer"
+        />
+      ),
+      link2: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href="https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address"
+          target="_blank"
+          rel="noreferrer"
+        />
+      ),
+      link3: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href="https://www.mailpoet.com/support/"
+          target="_blank"
+          rel="noreferrer"
+        />
+      ),
+      emailSubject: <>Your MailPoet Subscription Review</>,
+    },
+  );
+}
+
+function PendingApprovalMessage(): JSX.Element {
+  return (
+    <>
+      <PendingApprovalTitle /> <PendingApprovalBody />
+    </>
+  );
+}
+
+interface ClickToRefreshProps {
+  onRefreshClick: (e: MouseEvent<HTMLAnchorElement>) => Promise<void>;
+}
+
+function ClickToRefresh({ onRefreshClick }: ClickToRefreshProps): JSX.Element {
+  return createInterpolateElement(
+    __(
+      `If you have already received approval email, click <link>here</link> to update the status.`,
+      'mailpoet',
+    ),
+    {
+      // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+      link: <a onClick={onRefreshClick} href="#" />,
+    },
+  );
+}
+
+export {
+  PendingApprovalTitle,
+  PendingApprovalBody,
+  PendingApprovalMessage,
+  ClickToRefresh,
+};

--- a/mailpoet/assets/js/src/common/premium-key/messages.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/messages.tsx
@@ -1,6 +1,5 @@
 import { MouseEvent } from 'react';
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
 import {
   KeyActivationState,
   MssStatus,
@@ -13,6 +12,11 @@ import {
   ServiceUnavailableMessage,
   AccessRestrictedMessages,
 } from './key-messages';
+import {
+  ClickToRefresh,
+  PendingApprovalBody,
+  PendingApprovalTitle,
+} from '../pending-approval-notice';
 
 export function Messages(
   state: KeyActivationState,
@@ -66,70 +70,14 @@ export function Messages(
       {showPendingApprovalNotice && (
         <div>
           <div className="pending_approval_heading mailpoet_error">
-            {createInterpolateElement(
-              __(
-                'MailPoet is <link>reviewing your subscription</link>.',
-                'mailpoet',
-              ),
-              {
-                link: (
-                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                  <a
-                    href="https://kb.mailpoet.com/article/379-our-approval-process"
-                    target="_blank"
-                    rel="noreferrer"
-                  />
-                ),
-              },
-            )}
+            <PendingApprovalTitle />
           </div>
           <p>
-            {createInterpolateElement(
-              __(
-                `You can use all MailPoet features and send <link1>email previews</link1> to your <link2>authorized email addresses</link2>, but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject "<emailSubject/>" and reply, or <link3>contact us</link3>.`,
-                'mailpoet',
-              ),
-              {
-                link1: (
-                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                  <a
-                    href="https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it"
-                    target="_blank"
-                    rel="noreferrer"
-                  />
-                ),
-                link2: (
-                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                  <a
-                    href="https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address"
-                    target="_blank"
-                    rel="noreferrer"
-                  />
-                ),
-                link3: (
-                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                  <a
-                    href="https://www.mailpoet.com/support/"
-                    target="_blank"
-                    rel="noreferrer"
-                  />
-                ),
-                emailSubject: <>Your MailPoet Subscription Review</>,
-              },
-            )}
+            <PendingApprovalBody />
           </p>
           {showRefreshMessage ? (
             <p>
-              {createInterpolateElement(
-                __(
-                  `If you have already received approval email, click <link>here</link> to update the status.`,
-                  'mailpoet',
-                ),
-                {
-                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                  link: <a onClick={onRefreshClick} href="#" />,
-                },
-              )}
+              <ClickToRefresh onRefreshClick={onRefreshClick} />
             </p>
           ) : null}
         </div>

--- a/mailpoet/assets/js/src/common/premium-key/messages.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/messages.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent } from 'react';
-import ReactStringReplace from 'react-string-replace';
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import {
   KeyActivationState,
   MssStatus,
@@ -13,7 +13,6 @@ import {
   ServiceUnavailableMessage,
   AccessRestrictedMessages,
 } from './key-messages';
-import { getLinkRegex } from '../utils';
 
 export function Messages(
   state: KeyActivationState,
@@ -67,32 +66,71 @@ export function Messages(
       {showPendingApprovalNotice && (
         <div>
           <div className="pending_approval_heading mailpoet_error">
-            {__(
-              'Note: this subscription is currently pending approval by MailPoet.',
-              'mailpoet',
+            {createInterpolateElement(
+              __(
+                'MailPoet is <link>reviewing your subscription</link>.',
+                'mailpoet',
+              ),
+              {
+                link: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://kb.mailpoet.com/article/379-our-approval-process"
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                ),
+              },
             )}
           </div>
-          <div>
-            {__(
-              'You should receive an email from us about it within 48h. Sending will be paused in the meantime, but you can still send email previews to yourself and explore the plugin features.',
-              'mailpoet',
+          <p>
+            {createInterpolateElement(
+              __(
+                `You can use all MailPoet features and send <link1>email previews</link1> to your <link2>authorized email addresses</link2>, but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject "<emailSubject/>" and reply, or <link3>contact us</link3>.`,
+                'mailpoet',
+              ),
+              {
+                link1: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it"
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                ),
+                link2: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address"
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                ),
+                link3: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://www.mailpoet.com/support/"
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                ),
+                emailSubject: <>Your MailPoet Subscription Review</>,
+              },
             )}
-          </div>
+          </p>
           {showRefreshMessage ? (
-            <div>
-              {ReactStringReplace(
+            <p>
+              {createInterpolateElement(
                 __(
-                  'If you have already received approval email, click [link]here[/link] to update the status.',
+                  `If you have already received approval email, click <link>here</link> to update the status.`,
                   'mailpoet',
                 ),
-                getLinkRegex(),
-                (match) => (
-                  <a onClick={onRefreshClick} href="#">
-                    {match}
-                  </a>
-                ),
+                {
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  link: <a onClick={onRefreshClick} href="#" />,
+                },
               )}
-            </div>
+            </p>
           ) : null}
         </div>
       )}

--- a/mailpoet/assets/js/src/newsletters/send/pending-newsletter-message.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/pending-newsletter-message.tsx
@@ -1,8 +1,10 @@
-import { __ } from '@wordpress/i18n';
 import { MouseEvent, useCallback, useState } from 'react';
-import ReactStringReplace from 'react-string-replace';
-import { callApi, getLinkRegex, isTruthy, withBoundary } from 'common';
+import { callApi, isTruthy, withBoundary } from 'common';
 import { MailPoet } from 'mailpoet';
+import {
+  ClickToRefresh,
+  PendingApprovalMessage,
+} from '../../common/pending-approval-notice';
 
 function PendingNewsletterMessage({
   toggleLoadingState,
@@ -42,35 +44,14 @@ function PendingNewsletterMessage({
 
   return (
     <div className="mailpoet_error">
-      {ReactStringReplace(
-        __(
-          'You’ll soon be able to send once our team reviews your account. In the meantime, you can send previews to [link]your authorized emails[/link].',
-          'mailpoet',
-        ),
-        getLinkRegex(),
-        (match) => (
-          <a
-            href="https://account.mailpoet.com/authorization"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {match}
-          </a>
-        ),
-      )}{' '}
-      {showRefreshButton &&
-        ReactStringReplace(
-          __(
-            'If you have already received approval email, click [link]here[/link] to update the status.',
-            'mailpoet',
-          ),
-          getLinkRegex(),
-          (match) => (
-            <a href="#" onClick={recheckKey}>
-              {match}
-            </a>
-          ),
-        )}
+      <PendingApprovalMessage />
+      {showRefreshButton && (
+        <>
+          <br />
+          <br />
+          <ClickToRefresh onRefreshClick={recheckKey} />
+        </>
+      )}
     </div>
   );
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -388,6 +388,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Logging\LogRepository::class)->setPublic(true);
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);
+    $container->autowire(\MailPoet\Util\Notices\PendingApprovalNotice::class);
     //Referrals
     $container->autowire(\MailPoet\Referrals\ReferralDetector::class);
     // Router

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -388,7 +388,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Logging\LogRepository::class)->setPublic(true);
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);
-    $container->autowire(\MailPoet\Util\Notices\PendingApprovalNotice::class);
+    $container->autowire(\MailPoet\Util\Notices\PendingApprovalNotice::class)->setPublic(true);
     //Referrals
     $container->autowire(\MailPoet\Referrals\ReferralDetector::class);
     // Router

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -232,7 +232,7 @@ class MailPoetMapper {
   private function getCanNotSendError(array $result, $sender): array {
     if ($result['error'] === API::ERROR_MESSAGE_PENDING_APPROVAL) {
       $operation = MailerError::OPERATION_PENDING_APPROVAL;
-      $message = $this->pendingApprovalNotice->getPendingApprovalMessage();
+      $message = $this->pendingApprovalNotice->getPendingApprovalMessage() . '<br/>';
       return [$operation, $message];
     }
 

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -10,6 +10,7 @@ use MailPoet\Mailer\SubscriberError;
 use MailPoet\Services\Bridge\API;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\Util\Notices\PendingApprovalNotice;
 use MailPoet\Util\Notices\UnauthorizedEmailNotice;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -31,14 +32,19 @@ class MailPoetMapper {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var PendingApprovalNotice */
+  private $pendingApprovalNotice;
+
   public function __construct(
     ServicesChecker $servicesChecker,
     SubscribersFeature $subscribers,
-    WPFunctions $wp
+    WPFunctions $wp,
+    PendingApprovalNotice $pendingApprovalNotice
   ) {
     $this->servicesChecker = $servicesChecker;
     $this->subscribersFeature = $subscribers;
     $this->wp = $wp;
+    $this->pendingApprovalNotice = $pendingApprovalNotice;
   }
 
   public function getInvalidApiKeyError() {
@@ -220,27 +226,13 @@ class MailPoetMapper {
     return "{$message}<br/>";
   }
 
-  private function getPendingApprovalMessage(): string {
-    $message = __("Your subscription is currently [link]pending approval[/link]. You’ll soon be able to send once our team reviews your account. In the meantime, you can send previews to your authorized emails.", 'mailpoet');
-    $message = Helpers::replaceLinkTags(
-      $message,
-      'https://kb.mailpoet.com/article/350-pending-approval-subscription',
-      [
-        'target' => '_blank',
-        'rel' => 'noopener noreferrer',
-      ]
-    );
-
-    return "{$message}<br/>";
-  }
-
   /**
    * Returns error $message and $operation for API::RESPONSE_CODE_CAN_NOT_SEND
    */
   private function getCanNotSendError(array $result, $sender): array {
     if ($result['error'] === API::ERROR_MESSAGE_PENDING_APPROVAL) {
       $operation = MailerError::OPERATION_PENDING_APPROVAL;
-      $message = $this->getPendingApprovalMessage();
+      $message = $this->pendingApprovalNotice->getPendingApprovalMessage();
       return [$operation, $message];
     }
 

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -6,6 +6,7 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Referrals\UrlDecorator;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\FreeDomains;
+use MailPoet\Util\Notices\PendingApprovalNotice;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WPCOM\DotcomHelperFunctions;
@@ -26,6 +27,9 @@ class Functions extends AbstractExtension {
 
   /** @var UrlDecorator */
   private $referralUrlDecorator = null;
+
+  /** @var PendingApprovalNotice */
+  private $pendingApprovalNotice = null;
 
   private function getWooCommerceHelper(): WooCommerceHelper {
     if ($this->woocommerceHelper === null) {
@@ -57,6 +61,13 @@ class Functions extends AbstractExtension {
       $this->wp = WPFunctions::get();
     }
     return $this->wp;
+  }
+
+  private function getPendingApprovalNotice(): PendingApprovalNotice {
+    if ($this->pendingApprovalNotice === null) {
+      $this->pendingApprovalNotice = ContainerWrapper::getInstance()->get(PendingApprovalNotice::class);
+    }
+    return $this->pendingApprovalNotice;
   }
 
   public function getFunctions() {
@@ -200,6 +211,11 @@ class Functions extends AbstractExtension {
         'is_dotcom',
         [$this, 'isDotcom'],
         ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
+        'pending_approval_message',
+        [$this, 'pendingApprovalMessage'],
+        ['is_safe' => ['html']]
       ),
     ];
   }
@@ -355,5 +371,9 @@ class Functions extends AbstractExtension {
 
   public function isDotcom(): bool {
     return $this->getDotcomHelperFunctions()->isDotcom();
+  }
+
+  public function pendingApprovalMessage(): string {
+    return $this->getPendingApprovalNotice()->getPendingApprovalMessage();
   }
 }

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -37,10 +37,11 @@ class PendingApprovalNotice {
   }
 
   private function display(): string {
-    $message = __('<b>Your subscription is currently [link1]pending approval[/link1]</b>, which means you can only send [link2]email previews[/link2] to your [link3]authorized emails[/link3] at the moment. Please check your mailbox or [link4]contact us[/link4] if you haven’t heard from our team about your subscription status in the past 48 hours.', 'mailpoet');
+    // translators: %s is the email subject, which will always be in English
+    $message = sprintf(__("MailPoet is [link1]reviewing your subscription[/link1]. You can use all MailPoet features and send [link2]email previews[/link2] to your [link3]authorized email addresses[/link3], but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject \"%s\" and reply, or [link4]contact us[/link4].", 'mailpoet'), 'Your MailPoet Subscription Review');
     $message = Helpers::replaceLinkTags(
       $message,
-      'https://kb.mailpoet.com/article/350-pending-approval-subscription',
+      'https://kb.mailpoet.com/article/379-our-approval-process',
       [
         'target' => '_blank',
       ],
@@ -56,7 +57,7 @@ class PendingApprovalNotice {
     );
     $message = Helpers::replaceLinkTags(
       $message,
-      'https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#authorize',
+      'https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address',
       [
         'target' => '_blank',
       ],

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -43,6 +43,7 @@ class PendingApprovalNotice {
       'https://kb.mailpoet.com/article/379-our-approval-process',
       [
         'target' => '_blank',
+        'rel' => 'noreferrer',
       ],
       'link'
     );
@@ -56,6 +57,7 @@ class PendingApprovalNotice {
       'https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it',
       [
         'target' => '_blank',
+        'rel' => 'noreferrer',
       ],
       'link1'
     );
@@ -64,6 +66,7 @@ class PendingApprovalNotice {
       'https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address',
       [
         'target' => '_blank',
+        'rel' => 'noreferrer',
       ],
       'link2'
     );
@@ -72,6 +75,7 @@ class PendingApprovalNotice {
       'https://www.mailpoet.com/support/',
       [
         'target' => '_blank',
+        'rel' => 'noreferrer',
       ],
       'link3'
     );

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -36,12 +36,24 @@ class PendingApprovalNotice {
     return null;
   }
 
-  public function getPendingApprovalMessage(): string {
-    // translators: %s is the email subject, which will always be in English
-    $message = sprintf(__("MailPoet is [link1]reviewing your subscription[/link1]. You can use all MailPoet features and send [link2]email previews[/link2] to your [link3]authorized email addresses[/link3], but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject \"%s\" and reply, or [link4]contact us[/link4].", 'mailpoet'), 'Your MailPoet Subscription Review');
-    $message = Helpers::replaceLinkTags(
+  public function getPendingApprovalTitle(): string {
+    $message = __("MailPoet is [link]reviewing your subscription[/link].", 'mailpoet');
+    return Helpers::replaceLinkTags(
       $message,
       'https://kb.mailpoet.com/article/379-our-approval-process',
+      [
+        'target' => '_blank',
+      ],
+      'link'
+    );
+  }
+
+  public function getPendingApprovalBody(): string {
+    // translators: %s is the email subject, which will always be in English
+    $message = sprintf(__("You can use all MailPoet features and send [link1]email previews[/link1] to your [link2]authorized email addresses[/link2], but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject \"%s\" and reply, or [link3]contact us[/link3].", 'mailpoet'), 'Your MailPoet Subscription Review');
+    $message = Helpers::replaceLinkTags(
+      $message,
+      'https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it',
       [
         'target' => '_blank',
       ],
@@ -49,7 +61,7 @@ class PendingApprovalNotice {
     );
     $message = Helpers::replaceLinkTags(
       $message,
-      'https://kb.mailpoet.com/article/290-check-your-newsletter-before-sending-it',
+      'https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address',
       [
         'target' => '_blank',
       ],
@@ -57,22 +69,18 @@ class PendingApprovalNotice {
     );
     $message = Helpers::replaceLinkTags(
       $message,
-      'https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address',
+      'https://www.mailpoet.com/support/',
       [
         'target' => '_blank',
       ],
       'link3'
     );
-    $message = Helpers::replaceLinkTags(
-      $message,
-      'https://www.mailpoet.com/support/',
-      [
-        'target' => '_blank',
-      ],
-      'link4'
-    );
 
     return $message;
+  }
+
+  public function getPendingApprovalMessage(): string {
+    return sprintf('%s %s', $this->getPendingApprovalTitle(), $this->getPendingApprovalBody());
   }
 
   private function display(): string {

--- a/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
+++ b/mailpoet/lib/Util/Notices/PendingApprovalNotice.php
@@ -36,7 +36,7 @@ class PendingApprovalNotice {
     return null;
   }
 
-  private function display(): string {
+  public function getPendingApprovalMessage(): string {
     // translators: %s is the email subject, which will always be in English
     $message = sprintf(__("MailPoet is [link1]reviewing your subscription[/link1]. You can use all MailPoet features and send [link2]email previews[/link2] to your [link3]authorized email addresses[/link3], but sending to your email list contacts is temporarily paused until we review your subscription. If you don't hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email for follow-up emails with the subject \"%s\" and reply, or [link4]contact us[/link4].", 'mailpoet'), 'Your MailPoet Subscription Review');
     $message = Helpers::replaceLinkTags(
@@ -72,6 +72,11 @@ class PendingApprovalNotice {
       'link4'
     );
 
+    return $message;
+  }
+
+  private function display(): string {
+    $message = $this->getPendingApprovalMessage();
     WPNotice::displayWarning($message, '', self::OPTION_NAME);
     return $message;
   }

--- a/mailpoet/tests/acceptance/Newsletters/NewsletterCreationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewsletterCreationCest.php
@@ -123,18 +123,18 @@ class NewsletterCreationCest {
     $i->click('.mailpoet_show_preview');
     $i->waitForElement('[data-automation-id="switch_send_to_email"]');
     $i->click('[data-automation-id="switch_send_to_email"]');
-    $i->waitForText('You’ll soon be able to send once our team reviews your account. In the meantime, you can send previews to your authorized emails.');
-    $href = $i->grabAttributeFrom('//a[text()="your authorized emails"]', 'href');
-    verify($href)->same('https://account.mailpoet.com/authorization');
+    $i->waitForText('sending to your email list contacts is temporarily paused until we review your subscription');
+    $href = $i->grabAttributeFrom('//a[text()="authorized email addresses"]', 'href');
+    verify($href)->same('https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address');
     $i->click('#mailpoet_modal_close');
     $i->scrollToTop();
     $i->click('Next');
 
     // step 4 - see notice in 'Send preview' with link to authorized emails, 'Send' button must be disabled
     $i->waitForElement('[data-automation-id="newsletter_send_heading"]');
-    $i->waitForText('You’ll soon be able to send once our team reviews your account. In the meantime, you can send previews to your authorized emails.');
-    $href = $i->grabAttributeFrom('//a[text()="your authorized emails"]', 'href');
-    verify($href)->same('https://account.mailpoet.com/authorization');
+    $i->waitForText('sending to your email list contacts is temporarily paused until we review your subscription');
+    $href = $i->grabAttributeFrom('//a[text()="authorized email addresses"]', 'href');
+    verify($href)->same('https://kb.mailpoet.com/article/266-how-to-add-an-authorized-email-address-as-the-from-address#how-to-authorize-an-email-address');
     $i->seeElement('[data-automation-id="email-submit"]:disabled');
   }
 }

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -56,8 +56,7 @@ class AddSendingKeyCest {
     $settings = new Settings();
     $settings->withMssKeyPendingApproval();
     $i->reloadPage();
-    $i->waitForText('Note: this subscription is currently pending approval by MailPoet.');
-    $i->waitForText('You should receive an email from us about it within 48h. Sending will be paused in the meantime, but you can still send email previews to yourself and explore the plugin features.');
+    $i->waitForText('sending to your email list contacts is temporarily paused until we review your subscription');
     $i->dontSee('A test email was sent to');
 
     // try invalid key
@@ -65,8 +64,8 @@ class AddSendingKeyCest {
     $i->click('Verify');
     $i->waitForText('Your key is not valid for the MailPoet Sending Service');
     $i->waitForText('Your key is not valid for MailPoet Premium');
-    $i->dontSee('Note: this subscription is currently pending approval by MailPoet.');
-    $i->dontSee('You should receive an email from us about it within 48h. Sending will be paused in the meantime, but you can still send email previews to yourself and explore the plugin features.');
+    $i->reloadPage(); // Necessary to clear the banner notice
+    $i->dontSee('sending to your email list contacts is temporarily paused until we review your subscription');
     $i->dontSee('A test email was sent to');
   }
 

--- a/mailpoet/tests/integration/Util/Notices/PendingApprovalNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PendingApprovalNoticeTest.php
@@ -26,8 +26,8 @@ class PendingApprovalNoticeTest extends \MailPoetTest {
 
     $result = $this->notice->init(true);
     // check that the notice is displayed. We cannot check the whole string because it contains HTML tags
-    verify($result)->stringContainsString('Your subscription is currently');
-    verify($result)->stringContainsString('if you haven’t heard from our team about your subscription status in the past 48 hours.');
+    verify($result)->stringContainsString('reviewing your subscription');
+    verify($result)->stringContainsString('If you don\'t hear from us within 48 hours, please check the inbox and spam folders of your MailPoet account email');
   }
 
   public function testItDoesNotDisplayWhenMSSKeyIsNotValid(): void {

--- a/mailpoet/views/newsletter/templates/components/newsletterPreview.hbs
+++ b/mailpoet/views/newsletter/templates/components/newsletterPreview.hbs
@@ -58,9 +58,13 @@
 
     {{#if mssKeyPendingApproval }}
       <div class="mailpoet_error pendindig_approval_error{{#if awaitingKeyCheck}} with-spinner{{/if}}">
-        <%= __('You’ll soon be able to send once our team reviews your account. In the meantime, you can send previews to [link]your authorized emails[/link].')|replaceLinkTags('https://account.mailpoet.com/authorization', {'target': '_blank', 'rel': 'noopener noreferrer'})|raw %>
+        <p>
+          <%= pending_approval_message() %>
+        </p>
         {{#if mssKeyPendingApprovalRefreshMessage }}
-        <%= __('If you have already received approval email, click [link]here[/link] to update the status.')|replaceLinkTags('#', {'id': 'refresh-mss-key-status'})|raw %>
+        <p>
+          <%= __('If you have already received approval email, click [link]here[/link] to update the status.')|replaceLinkTags('#', {'id': 'refresh-mss-key-status'})|raw %>
+        </p>
         {{/if}}
       </div>
     {{/if}}


### PR DESCRIPTION
## Description

This PR updates the pending approval notices throughout the plugin with new copy and to all be consistent.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5631](https://mailpoet.atlassian.net/browse/MAILPOET-5631)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5631]: https://mailpoet.atlassian.net/browse/MAILPOET-5631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ