### PR TITLE
Update acceptance test for preview [MAILPOET-5635]

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -87,9 +87,11 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->wantTo('Open standard newsletter using Gutenberg editor');
     $i->login();
     $i->amOnMailpoetPage('Emails');
-    $i->click('[data-automation-id="create_standard"]');
-    $i->waitForText('Which editor do you want to use?');
-    $i->click('Gutenberg Editor');
+    $i->click('[data-automation-id="create_standard_email_dropdown"]');
+    $i->waitForText('Create using new editor (Beta)');
+    $i->click('Create using new editor (Beta)');
+    $i->waitForText('Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.');
+    $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Edit an email');
     if (version_compare($wordPressVersion, '6.3', '<')) {


### PR DESCRIPTION
## Description

This PR fixes a Gutenberg email editor acceptance test. The problem was that PR was not rebased before merging. This caused a preview test to start failing.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5635]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5635]: https://mailpoet.atlassian.net/browse/MAILPOET-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ