### PR TITLE
Skip "MailPoet account connected" step altogether if connected when launching wizard [MAILPOET-5547]

### DIFF
--- a/mailpoet/assets/js/src/wizard/steps-numbers.jsx
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.jsx
@@ -3,6 +3,9 @@ export const getStepsCount = () => {
   if (window.mailpoet_woocommerce_active) {
     stepsCount += 1;
   }
+  if (window.mailpoet_has_valid_api_key) {
+    stepsCount -= 1; // skip the MSS step if user already set API key
+  }
   return stepsCount;
 };
 
@@ -25,5 +28,8 @@ export const mapStepNumberToStepName = (stepNumber) => {
   if (window.mailpoet_woocommerce_active && stepNumber === 3) {
     return 'WizardWooCommerceStep';
   }
-  return 'WelcomeWizardPitchMSSStep';
+  if (!window.mailpoet_has_valid_api_key) {
+    return 'WelcomeWizardPitchMSSStep';
+  }
+  return null;
 };

--- a/mailpoet/assets/js/src/wizard/steps-numbers.ts
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.ts
@@ -1,4 +1,4 @@
-export const getStepsCount = () => {
+export const getStepsCount = (): number => {
   let stepsCount = 3;
   if (window.mailpoet_woocommerce_active) {
     stepsCount += 1;
@@ -9,7 +9,11 @@ export const getStepsCount = () => {
   return stepsCount;
 };
 
-export const redirectToNextStep = (history, finishWizard, currentStep) => {
+export const redirectToNextStep = (
+  history: { push: (string) => void },
+  finishWizard: () => void,
+  currentStep: number,
+): void => {
   const stepsCount = getStepsCount();
   if (currentStep < stepsCount) {
     history.push(`/steps/${currentStep + 1}`);
@@ -18,7 +22,7 @@ export const redirectToNextStep = (history, finishWizard, currentStep) => {
   }
 };
 
-export const mapStepNumberToStepName = (stepNumber) => {
+export const mapStepNumberToStepName = (stepNumber: number): string | null => {
   if (stepNumber === 1) {
     return 'WelcomeWizardSenderStep';
   }

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -14,7 +14,7 @@ import {
   getStepsCount,
   mapStepNumberToStepName,
   redirectToNextStep,
-} from './steps-numbers.jsx';
+} from './steps-numbers';
 import { Steps } from '../common/steps/steps';
 import { StepsContent } from '../common/steps/steps-content';
 import { TopBar } from '../common/top-bar/top-bar';

--- a/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
+++ b/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
@@ -14,6 +14,11 @@ class WelcomeWizardCest {
    */
   private $settingsRepository;
 
+  /**
+   * @var SettingsFactory
+   */
+  private $settingsFactory;
+
   public function _before(\AcceptanceTester $i) {
     // for some unknown reason the SettingsController doesn't return the expected values here so the code uses the SettingsRepository
     $this->settingsRepository = ContainerWrapper::getInstance()->get(SettingsRepository::class);
@@ -21,10 +26,8 @@ class WelcomeWizardCest {
     $i->login();
     $i->activateWooCommerce();
 
-    $settingsFactory = new SettingsFactory();
-    $settingsFactory->withWelcomeWizard();
-
-    $i->amOnMailpoetPage('Welcome-Wizard');
+    $this->settingsFactory = new SettingsFactory();
+    $this->settingsFactory->withWelcomeWizard();
   }
 
   public function welcomeWizardMainFlow(\AcceptanceTester $i, Scenario $scenario) {
@@ -37,6 +40,7 @@ class WelcomeWizardCest {
     $senderAddress = 'wp@example.com';
 
     $i->wantTo('Check user can go through the welcome wizard');
+    $i->amOnMailpoetPage('Welcome-Wizard');
 
     // First step of the wizard
     $i->fillField('senderName', $senderName);
@@ -64,6 +68,47 @@ class WelcomeWizardCest {
     $i->fillField('#mailpoet_premium_key', $mailPoetSendingKey);
     $i->click('.mailpoet-verify-key-button');
     $i->waitForText('MailPoet account connected', 20);
+    $i->click('.mailpoet-wizard-continue-button');
+
+    // wizard finished and the user was redirect to the home page
+    $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
+
+    Assert::assertSame($senderName, $this->settingsRepository->findOneByName('sender')->getValue()['name']);
+    Assert::assertSame($senderAddress, $this->settingsRepository->findOneByName('sender')->getValue()['address']);
+    Assert::assertSame(['enabled' => '1'], $this->settingsRepository->findOneByName('3rd_party_libs')->getValue());
+    Assert::assertSame(['enabled' => '1'], $this->settingsRepository->findOneByName('analytics')->getValue());
+    Assert::assertSame(['level' => 'full'], $this->settingsRepository->findOneByName('tracking')->getValue());
+    Assert::assertSame($mailPoetSendingKey, $this->settingsRepository->findOneByName('mta')->getValue()['mailpoet_api_key']);
+  }
+
+  public function welcomeWizardShouldSkipMssStepIfKeyAlreadyExists(\AcceptanceTester $i, Scenario $scenario) {
+    $mailPoetSendingKey = getenv('WP_TEST_MAILER_MAILPOET_API');
+    if (!$mailPoetSendingKey) {
+      $scenario->skip("Skipping, 'WP_TEST_MAILER_MAILPOET_API' not set.");
+    }
+
+    $senderName = 'WP Admin';
+    $senderAddress = 'wp@example.com';
+
+    $this->settingsFactory->withSendingMethodMailPoet();
+
+    $i->wantTo('Check welcome wizard skips MSS step when a MSS key already exists');
+    $i->amOnMailpoetPage('Welcome-Wizard');
+
+    // First step of the wizard
+    $i->fillField('senderName', $senderName);
+    $i->fillField('senderAddress', $senderAddress);
+    $i->click('.mailpoet-wizard-continue-button');
+
+    // Second step of the wizard
+    $i->waitForText('Confirm privacy and data settings');
+    $i->click('#mailpoet-wizard-3rd-party-libs .mailpoet-form-yesno-yes');
+    $i->click('#mailpoet-wizard-tracking .mailpoet-form-yesno-yes');
+    $i->click('.mailpoet-wizard-continue-button');
+
+    // Third step of the wizard
+    $i->waitForText('Power up your WooCommerce store');
+    $i->click('.mailpoet-form-yesno-yes');
     $i->click('.mailpoet-wizard-continue-button');
 
     // wizard finished and the user was redirect to the home page


### PR DESCRIPTION
## Description

This PR changes the welcome wizard to skip the step to connect to a MailPoet account if one is already configured. See the Jira ticket description for more details.

## Code review notes

The tests were failing because of this line:

https://github.com/mailpoet/mailpoet/commit/392a370fa441eac33b0110d7c3326b486a51f5b0#diff-188744dba4f96d31e2b93ad5a59cf13aa3f4ab1d965cd93dae1a4f93f458c135R31

Originally, it was (note the missing `!`):

```
if (window.mailpoet_has_valid_api_key) {
```

I opted to amend the original commit to avoid polluting the commit history. I also added a new acceptance test to test the flow without the MSS step.

I'm unsure if we still need e034748a70974eec1aa45bb5ed182815eb8a2e46 or not. The tests pass without it. If we still need this commit, could you please elaborate on why it is needed?

## QA notes

This PR changes one behavior of the welcome wizard. There are some automated tests around it. I'm not sure if some manual testing is required as well or not.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5547]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5547]: https://mailpoet.atlassian.net/browse/MAILPOET-5547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ