### PR TITLE
Track filter segment usage [MAILPOET-5595]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -446,23 +446,21 @@ class NewsletterSendComponent extends Component<
           const segments = filters
             .map((filter) => mapFilterType(filter))
             .join(', ');
-          if (response.data.status === 'scheduled') {
+          const wasScheduled = response.data.status === 'scheduled';
+          MailPoet.trackEvent('Emails > Newsletter sent', {
+            scheduled: wasScheduled,
+            'Segment Applied': !!this.state.item.options.filterSegmentId,
+            segments,
+          });
+          if (wasScheduled) {
             this.context.notices.success(
               <p>{__('The newsletter has been scheduled.', 'mailpoet')}</p>,
             );
-            MailPoet.trackEvent('Emails > Newsletter sent', {
-              scheduled: true,
-              segments,
-            });
           } else {
             this.context.notices.success(
               <p>{__('The newsletter is being sent...', 'mailpoet')}</p>,
               { id: 'mailpoet_notice_being_sent' },
             );
-            MailPoet.trackEvent('Emails > Newsletter sent', {
-              scheduled: false,
-              segments,
-            });
           }
           MailPoet.Modal.loading(false);
         });

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -529,6 +529,7 @@ class NewsletterSendComponent extends Component<
             );
             MailPoet.trackEvent('Emails > Re-engagement email activated', {
               Inactivity: getTimingValueForTracking(opts),
+              'Segment Applied': !!this.state.item.options.filterSegmentId,
             });
           } else if (response.data.type === 'notification') {
             this.context.notices.success(
@@ -536,6 +537,7 @@ class NewsletterSendComponent extends Component<
             );
             MailPoet.trackEvent('Emails > Post notifications activated', {
               Frequency: opts.intervalType,
+              'Segment Applied': !!this.state.item.options.filterSegmentId,
             });
           }
           MailPoet.Modal.loading(false);

--- a/mailpoet/assets/js/src/newsletters/send/filter-segment.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/filter-segment.tsx
@@ -15,6 +15,7 @@ import { Tooltip } from 'common/tooltip/tooltip';
 import { Icon, help } from '@wordpress/icons';
 import ReactStringReplace from 'react-string-replace';
 import { SendContext } from '../send-context';
+import { MailPoet } from '../../mailpoet';
 
 type FilterSegmentProps = {
   item?: NewsLetter;
@@ -72,8 +73,11 @@ export function FilterSegment({
         updateFilterSegmentId('');
       }
       setIsFilterSegmentEnabled(checked);
+      MailPoet.trackEvent('Emails > Filter by segment toggled', {
+        'Email type': item.type,
+      });
     },
-    [field, onValueChange, updateFilterSegmentId],
+    [field, onValueChange, updateFilterSegmentId, item],
   );
 
   let filterSegmentSelect;
@@ -116,6 +120,9 @@ export function FilterSegment({
         field={filterSegmentField}
         onValueChange={(event: ChangeEvent<HTMLInputElement>) => {
           updateFilterSegmentId(event.target.value);
+          MailPoet.trackEvent('Emails > Filter by segment selected', {
+            'Email type': item.type,
+          });
         }}
       />
     );
@@ -166,6 +173,9 @@ export function FilterSegment({
                 rel="noopener noreferrer"
                 onClick={async (event) => {
                   event.preventDefault();
+                  MailPoet.trackEvent('Emails > Create new segment clicked', {
+                    'Email type': item.type,
+                  });
                   await context.saveDraftNewsletter();
                   window.location.href = createNewSegmentUrl;
                 }}


### PR DESCRIPTION
## Description

This PR adds some tracking to see if users opted in to analytics are using the new filter segment feature.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5595](https://mailpoet.atlassian.net/browse/MAILPOET-5595)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5595]: https://mailpoet.atlassian.net/browse/MAILPOET-5595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ