### PR TITLE
Declare cart_checkout_blocks compatibility [MAILPOET-5659]

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -345,7 +345,7 @@ class Hooks {
 
     $this->wp->addAction('before_woocommerce_init', [
       $this->hooksWooCommerce,
-      'declareHposCompatibility',
+      'declareWooCompatibility',
     ]);
 
     $this->wp->addAction('init', [

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -158,13 +158,16 @@ class HooksWooCommerce {
     }
   }
 
-  public function declareHposCompatibility() {
+  public function declareWooCompatibility() {
+
+    if (!class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+      return;
+    }
     try {
-      if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
-        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', Env::$pluginPath);
-      }
+      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', Env::$pluginPath);
+      \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', Env::$pluginPath );
     } catch (\Throwable $e) {
-      $this->logError($e, 'WooCommerce HPOS Compatibility');
+      $this->logError($e, 'WooCommerce Compatibility');
     }
   }
 


### PR DESCRIPTION
## Description
Our plugin can be used together with the checkout block. But we needed to declare this compatibility, otherwise the plugin shows up on the list of incompatible plugins: https://example.com/wp-admin/plugins.php?plugin_status=incompatible_with_feature

As only plugins which declare `WC requires at least` or `WC tested up to` in their plugins header need to declare compatibility, there is no need to add these declarations also for our premium plugin.

## Code review notes
I rewrote a bit the `declareHposCompatibility()` method and made it a general `declareWooCompatibility()` method. I assume it's likely more compatibility declarations might come down the line, so I think it makes sense to handle them at a central place.

## QA notes
1. Activate our current plugin. When you go to https://example.com/wp-admin/plugins.php?plugin_status=incompatible_with_feature you will see MailPoet in the list of plugins
2. Activate the build of this PR. Go to the same page: MailPoet will not show up

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5659]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5659]: https://mailpoet.atlassian.net/browse/MAILPOET-5659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ