### PR TITLE
Fix imports that are causing errors in the premium build [MAILPOET-5666]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automation-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automation-options.ts
@@ -1,5 +1,5 @@
 import { MailPoet } from 'mailpoet';
-import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
+import { sortFilters } from './sort-filters';
 import { SegmentTypes } from '../types';
 
 export enum AutomationsActionTypes {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email-options.ts
@@ -1,5 +1,5 @@
 import { MailPoet } from 'mailpoet';
-import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
+import { sortFilters } from './sort-filters';
 import { EmailActionTypes, SegmentTypes } from '../types';
 
 export const EmailSegmentOptions = [

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber-options.ts
@@ -1,5 +1,5 @@
 import { MailPoet } from 'mailpoet';
-import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
+import { sortFilters } from './sort-filters';
 import { SegmentTypes, SubscriberActionTypes } from '../types';
 
 export const SubscriberSegmentOptions = [

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
@@ -1,5 +1,5 @@
 import { MailPoet } from 'mailpoet';
-import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
+import { sortFilters } from './sort-filters';
 import { SegmentTypes } from '../types';
 
 // WooCommerce


### PR DESCRIPTION
## Description

For some unknown reason using the absolute paths in the files changed in this commit is causing the error below in the premium build. To fix it, this commit changes the code to use relative paths. I did not investigate why this error was happening in the first place.

The error started happening when
https://github.com/mailpoet/mailpoet/pull/5213/ was merged.

```
> tsc --noEmit

../mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automation-options.ts:2:29 - error TS2307: Cannot find module 'segments/dynamic/dynamic-segments-filters/sort-filters' or its corresponding type declarations.

2 import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email-options.ts:2:29 - error TS2307: Cannot find module 'segments/dynamic/dynamic-segments-filters/sort-filters' or its corresponding type declarations.

2 import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber-options.ts:2:29 - error TS2307: Cannot find module 'segments/dynamic/dynamic-segments-filters/sort-filters' or its corresponding type declarations.

2 import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts:2:29 - error TS2307: Cannot find module 'segments/dynamic/dynamic-segments-filters/sort-filters.ts' or its corresponding type declarations.

2 import { sortFilters } from 'segments/dynamic/dynamic-segments-filters/sort-filters.ts';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 4 errors in 4 files.
```

https://app.circleci.com/pipelines/github/mailpoet/mailpoet-premium/2862/workflows/b1fa2ad0-fc50-40df-b278-c6ca709e6ce0/jobs/20223

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5666]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5666]: https://mailpoet.atlassian.net/browse/MAILPOET-5666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ