### PR TITLE
Make sure offset in `Env` is always number [MAILPOET-5676]

### DIFF
--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -74,7 +74,7 @@ class Env {
     if ($parsedHost === false) {
       throw new \InvalidArgumentException('Invalid db host configuration.');
     }
-    list($host, $port, $socket, $isIpv6) = $parsedHost;
+    [$host, $port, $socket, $isIpv6] = $parsedHost;
 
     global $wpdb;
     self::$dbPrefix = $wpdb->prefix . self::$pluginPrefix;
@@ -93,6 +93,7 @@ class Env {
 
   public static function getDbTimezoneOffset($offset = false) {
     $offset = ($offset) ? $offset : WPFunctions::get()->getOption('gmt_offset');
+    $offset = (float)($offset);
     $mins = $offset * 60;
     $sgn = ($mins < 0 ? -1 : 1);
     $mins = abs($mins);

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -86,6 +86,7 @@ class EnvTest extends \MailPoetTest {
     verify(Env::getDbTimezoneOffset('+1.5'))->equals("+01:30");
     verify(Env::getDbTimezoneOffset('+11'))->equals("+11:00");
     verify(Env::getDbTimezoneOffset('-5.5'))->equals("-05:30");
+    verify(Env::getDbTimezoneOffset('xyz'))->equals("+00:00");
   }
 
   public function _after() {


### PR DESCRIPTION
To prevent an error 'Unsupported operand types: string * int'

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

I found this error in the logs of Atomic websites, I am not sure how to replicate it

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5676]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5676]: https://mailpoet.atlassian.net/browse/MAILPOET-5676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ