### PR TITLE
Remove usages of MailPoet\Tasks\Sending — Part 1

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -6,6 +6,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Cron\ActionScheduler\Actions\DaemonRun;
 use MailPoet\Cron\ActionScheduler\Actions\DaemonTrigger;
 use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
@@ -14,7 +15,6 @@ use MailPoet\Newsletter\Url as NewsletterURL;
 use MailPoet\Router\Endpoints\CronDaemon;
 use MailPoet\Services\Bridge;
 use MailPoet\SystemReport\SystemReportCollector;
-use MailPoet\Tasks\Sending;
 use MailPoet\WP\DateTime;
 
 class Help {
@@ -86,7 +86,7 @@ class Help {
     $systemStatusData['queueStatus']['tasksStatusCounts'] = $this->scheduledTasksRepository->getCountsPerStatus();
     $systemStatusData['queueStatus']['latestTasks'] = array_map(function ($task) {
       return $this->buildTaskData($task);
-    }, $this->scheduledTasksRepository->getLatestTasks(Sending::TASK_TYPE));
+    }, $this->scheduledTasksRepository->getLatestTasks(SendingQueue::TASK_TYPE));
     $this->pageRenderer->displayPage(
       'help.html',
       [
@@ -130,7 +130,7 @@ class Help {
 
   public function buildTaskData(ScheduledTaskEntity $task): array {
     $queue = $newsletter = null;
-    if ($task->getType() === Sending::TASK_TYPE) {
+    if ($task->getType() === SendingQueue::TASK_TYPE) {
       $queue = $this->sendingQueuesRepository->findOneBy(['task' => $task]);
       $newsletter = $queue ? $queue->getNewsletter() : null;
     }

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -158,7 +158,7 @@ class Scheduler {
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATIC) {
           $this->processScheduledAutomaticEmail($newsletter, $task);
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_RE_ENGAGEMENT) {
-          $this->processReEngagementEmail($legacyQueue);
+          $this->processReEngagementEmail($task);
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION) {
           $this->processScheduledAutomationEmail($legacyQueue);
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
@@ -338,10 +338,9 @@ class Scheduler {
     return true;
   }
 
-  private function processReEngagementEmail($queue) {
-    $queue->status = null;
-    $queue->save();
-    $this->updateScheduledTaskEntity($queue);
+  private function processReEngagementEmail(ScheduledTaskEntity $task) {
+    $task->setStatus(null);
+    $this->scheduledTasksRepository->flush();
     return true;
   }
 

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -162,7 +162,7 @@ class Scheduler {
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION) {
           $this->processScheduledAutomationEmail($task);
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
-          $this->processScheduledTransactionalEmail($legacyQueue);
+          $this->processScheduledTransactionalEmail($task);
         }
       } catch (EntityNotFoundException $e) {
         // Doctrine throws this exception when newsletter doesn't exist but is referenced in a scheduled task.
@@ -302,23 +302,20 @@ class Scheduler {
     return true;
   }
 
-  public function processScheduledTransactionalEmail($queue): bool {
-    $subscribers = $queue->getSubscribers();
-    $subscriber = (!empty($subscribers) && is_array($subscribers)) ? $this->subscribersRepository->findOneById($subscribers[0]) : null;
+  public function processScheduledTransactionalEmail(ScheduledTaskEntity $task): bool {
+    $subscribers = $task->getSubscribers();
+    $subscriber = isset($subscribers[0]) ? $subscribers[0]->getSubscriber() : null;
     if (!$subscriber) {
-      $queue->delete();
-      $this->updateScheduledTaskEntity($queue, true);
+      $this->deleteByTask($task);
       return false;
     }
-    if (!$this->verifySubscriber($subscriber, $queue)) {
-      $queue->delete();
-      $this->updateScheduledTaskEntity($queue, true);
+    if (!$this->verifySubscriber($subscriber, $task)) {
+      $this->deleteByTask($task);
       return false;
     }
 
-    $queue->status = null;
-    $queue->save();
-    $this->updateScheduledTaskEntity($queue);
+    $task->setStatus(null);
+    $this->scheduledTasksRepository->flush();
     return true;
   }
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -156,7 +156,7 @@ class Newsletter {
       // hook to the newsletter post-processing filter and add tracking image
       $this->trackingImageInserted = OpenTracking::addTrackingImage();
       // render newsletter
-      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask);
+      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask->getSendingQueueEntity());
       $renderedNewsletter = $this->wp->applyFilters(
         'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
@@ -170,7 +170,7 @@ class Newsletter {
       $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletter, $sendingTask);
     } else {
       // render newsletter
-      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask);
+      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask->getSendingQueueEntity());
       $renderedNewsletter = $this->wp->applyFilters(
         'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -15,7 +15,6 @@ use MailPoet\Mailer\MetaInfo;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -25,6 +24,7 @@ class Worker {
 
   const TASK_TYPE = 'stats_notification';
   const SETTINGS_KEY = 'stats_notifications';
+  const BATCH_SIZE = 5;
 
   /** @var Renderer */
   private $renderer;
@@ -96,7 +96,7 @@ class Worker {
     $settings = $this->settings->get(self::SETTINGS_KEY);
     // Cleanup potential orphaned task created due bug MAILPOET-3015
     $this->repository->deleteOrphanedScheduledTasks();
-    foreach ($this->repository->findScheduled(Sending::RESULT_BATCH_SIZE) as $statsNotificationEntity) {
+    foreach ($this->repository->findScheduled(self::BATCH_SIZE) as $statsNotificationEntity) {
       try {
         $extraParams = [
           'meta' => $this->mailerMetaInfo->getStatsNotificationMetaInfo(),

--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -95,8 +95,15 @@ class ScheduledTaskEntity {
    */
   private $sendingQueue;
 
+  /**
+   * @ORM\OneToMany(targetEntity="MailPoet\Entities\ScheduledTaskSubscriberEntity", mappedBy="task", orphanRemoval=true)
+   * @var Collection<int, ScheduledTaskSubscriberEntity>
+   */
+  private $scheduledTaskSubscribers;
+
   public function __construct() {
     $this->subscribers = new ArrayCollection();
+    $this->scheduledTaskSubscribers = new ArrayCollection();
   }
 
   /**

--- a/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
@@ -45,13 +45,13 @@ class ScheduledTaskSubscriberEntity {
   private $error;
 
   /**
-   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\ScheduledTaskEntity")
+   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\ScheduledTaskEntity", inversedBy="scheduledTaskSubscribers")
    * @var ScheduledTaskEntity|null
    */
   private $task;
 
   /**
-   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\SubscriberEntity")
+   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\SubscriberEntity", inversedBy="scheduledTaskSubscribers")
    * @var SubscriberEntity|null
    */
   private $subscriber;

--- a/mailpoet/lib/Entities/SendingQueueEntity.php
+++ b/mailpoet/lib/Entities/SendingQueueEntity.php
@@ -49,12 +49,6 @@ class SendingQueueEntity {
   private $newsletterRenderedSubject;
 
   /**
-   * @ORM\Column(type="text", nullable=true)
-   * @var string|null
-   */
-  private $subscribers;
-
-  /**
    * @ORM\Column(type="integer")
    * @var int
    */
@@ -128,20 +122,6 @@ class SendingQueueEntity {
    */
   public function setNewsletterRenderedSubject($newsletterRenderedSubject) {
     $this->newsletterRenderedSubject = $newsletterRenderedSubject;
-  }
-
-  /**
-   * @return string|null
-   */
-  public function getSubscribers() {
-    return $this->subscribers;
-  }
-
-  /**
-   * @param string|null $subscribers
-   */
-  public function setSubscribers($subscribers) {
-    $this->subscribers = $subscribers;
   }
 
   /**

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -215,10 +215,17 @@ class SubscriberEntity {
    */
   private $subscriberTags;
 
+  /**
+   * @ORM\OneToMany(targetEntity="MailPoet\Entities\ScheduledTaskSubscriberEntity", mappedBy="subscriber", orphanRemoval=true)
+   * @var Collection<int, ScheduledTaskSubscriberEntity>
+   */
+  private $scheduledTaskSubscribers;
+
   public function __construct() {
     $this->subscriberSegments = new ArrayCollection();
     $this->subscriberCustomFields = new ArrayCollection();
     $this->subscriberTags = new ArrayCollection();
+    $this->scheduledTaskSubscribers = new ArrayCollection();
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
@@ -6,7 +6,7 @@ use MailPoet\AutomaticEmails\WooCommerce\Events\AbandonedCart;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce as WooCommerceEmail;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Entities\SendingQueueEntity;
 
 class AbandonedCartContent {
   /** @var AutomatedLatestContentBlock  */
@@ -22,7 +22,7 @@ class AbandonedCartContent {
     NewsletterEntity $newsletter,
     array $args,
     bool $preview = false,
-    SendingTask $sendingTask = null
+    SendingQueueEntity $sendingQueue = null
   ): array {
     if (
       !in_array(
@@ -57,11 +57,11 @@ class AbandonedCartContent {
       // Display latest products for preview (no 'posts' argument specified)
       return $this->ALCBlock->render($newsletter, $args);
     }
-    if (!($sendingTask instanceof SendingTask)) {
+    if (!$sendingQueue) {
       // Do not display the block if we're not sending an email
       return [];
     }
-    $meta = $sendingTask->getMeta();
+    $meta = $sendingQueue->getMeta();
     if (empty($meta[AbandonedCart::TASK_META_NAME])) {
       // Do not display the block if a cart is empty
       return [];

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -3,9 +3,9 @@
 namespace MailPoet\Newsletter\Renderer;
 
 use MailPoet\Entities\NewsletterEntity;
-  use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Newsletter\Renderer\Blocks\AbandonedCartContent;
 use MailPoet\Newsletter\Renderer\Blocks\AutomatedLatestContentBlock;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\WooCommerce\CouponPreProcessor;
 use MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor;
 
@@ -48,7 +48,7 @@ class Preprocessor {
    * @param NewsletterEntity $newsletter
    * @return array
    */
-  public function process(NewsletterEntity $newsletter, $content, bool $preview = false, SendingTask $sendingTask = null) {
+  public function process(NewsletterEntity $newsletter, $content, bool $preview = false, SendingQueueEntity $sendingQueue = null) {
     if (!array_key_exists('blocks', $content)) {
       return $content;
     }
@@ -56,7 +56,7 @@ class Preprocessor {
     $contentBlocks = $content['blocks'];
     $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview);
     foreach ($contentBlocks as $block) {
-      $processedBlock = $this->processBlock($newsletter, $block, $preview, $sendingTask);
+      $processedBlock = $this->processBlock($newsletter, $block, $preview, $sendingQueue);
       if (!empty($processedBlock)) {
         $blocks = array_merge($blocks, $processedBlock);
       }
@@ -65,10 +65,10 @@ class Preprocessor {
     return $content;
   }
 
-  public function processBlock(NewsletterEntity $newsletter, array $block, bool $preview = false, SendingTask $sendingTask = null): array {
+  public function processBlock(NewsletterEntity $newsletter, array $block, bool $preview = false, SendingQueueEntity $sendingQueue = null): array {
     switch ($block['type']) {
       case 'abandonedCartContent':
-        return $this->abandonedCartContent->render($newsletter, $block, $preview, $sendingTask);
+        return $this->abandonedCartContent->render($newsletter, $block, $preview, $sendingQueue);
       case 'automatedLatestContentLayout':
         return $this->automatedLatestContent->render($newsletter, $block);
       case 'woocommerceHeading':

--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -2,13 +2,13 @@
 
 namespace MailPoet\Newsletter\Scheduler;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
-use MailPoet\Tasks\Sending;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -37,7 +37,7 @@ class AutomationEmailScheduler {
     }
 
     $task = new ScheduledTaskEntity();
-    $task->setType(Sending::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
     $task->setScheduledAt(Carbon::createFromTimestamp($this->wp->currentTime('timestamp')));
     $task->setPriority(ScheduledTaskEntity::PRIORITY_MEDIUM);

--- a/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Newsletter\Scheduler;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -12,7 +13,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
@@ -96,7 +96,7 @@ class ReEngagementScheduler {
     $scheduledTask = new ScheduledTaskEntity();
     $scheduledTask->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
     $scheduledTask->setScheduledAt(Carbon::createFromTimestamp($this->wp->currentTime('timestamp')));
-    $scheduledTask->setType(Sending::TASK_TYPE);
+    $scheduledTask->setType(SendingQueue::TASK_TYPE);
     $scheduledTask->setPriority(SendingQueueEntity::PRIORITY_MEDIUM);
     $this->scheduledTasksRepository->persist($scheduledTask);
     $this->scheduledTasksRepository->flush();

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -2,9 +2,11 @@
 
 namespace MailPoet\Newsletter\Scheduler;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -12,11 +14,14 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending as SendingTask;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class WelcomeScheduler {
 
   const WORDPRESS_ALL_ROLES = 'mailpoet_all';
+
+  /** @var EntityManager */
+  private $entityManager;
 
   /** @var SubscribersRepository */
   private $subscribersRepository;
@@ -34,12 +39,14 @@ class WelcomeScheduler {
   private $scheduler;
 
   public function __construct(
+    EntityManager $entityManager,
     SubscribersRepository $subscribersRepository,
     SegmentsRepository $segmentsRepository,
     NewslettersRepository $newslettersRepository,
     ScheduledTasksRepository $scheduledTasksRepository,
     Scheduler $scheduler
   ) {
+    $this->entityManager = $entityManager;
     $this->subscribersRepository = $subscribersRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newslettersRepository = $newslettersRepository;
@@ -47,22 +54,16 @@ class WelcomeScheduler {
     $this->scheduler = $scheduler;
   }
 
-  public function scheduleSubscriberWelcomeNotification($subscriberId, $segments) {
+  public function scheduleSubscriberWelcomeNotification($subscriberId, $segments): void {
     $newsletters = $this->newslettersRepository->findActiveByTypes([NewsletterEntity::TYPE_WELCOME]);
-    if (empty($newsletters)) return false;
-    $result = [];
     foreach ($newsletters as $newsletter) {
       if (
         $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EVENT) === 'segment' &&
         in_array($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SEGMENT), $segments)
       ) {
-        $sendingTask = $this->createWelcomeNotificationSendingTask($newsletter, $subscriberId);
-        if ($sendingTask) {
-          $result[] = $sendingTask;
-        }
+        $this->createWelcomeNotificationSendingTask($newsletter, $subscriberId);
       }
     }
-    return $result ?: false;
   }
 
   public function scheduleWPUserWelcomeNotification(
@@ -97,7 +98,7 @@ class WelcomeScheduler {
     }
   }
 
-  public function createWelcomeNotificationSendingTask(NewsletterEntity $newsletter, $subscriberId) {
+  public function createWelcomeNotificationSendingTask(NewsletterEntity $newsletter, $subscriberId): void {
     $subscriber = $this->subscribersRepository->findOneById($subscriberId);
     if (!($subscriber instanceof SubscriberEntity) || $subscriber->getDeletedAt() !== null) {
       return;
@@ -118,28 +119,31 @@ class WelcomeScheduler {
     if (!empty($previouslyScheduledNotification)) {
       return;
     }
-    $sendingTask = SendingTask::create();
-    $sendingTask->newsletterId = $newsletter->getId();
-    $sendingTask->setSubscribers([$subscriberId]);
-    $sendingTask->status = SendingQueueEntity::STATUS_SCHEDULED;
-    $sendingTask->priority = SendingQueueEntity::PRIORITY_HIGH;
-    $sendingTask->scheduledAt = $this->scheduler->getScheduledTimeWithDelay(
+
+    // task
+    $task = new ScheduledTaskEntity();
+    $task->setType(SendingQueue::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setPriority(ScheduledTaskEntity::PRIORITY_HIGH);
+    $task->setScheduledAt($this->scheduler->getScheduledTimeWithDelay(
       $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE),
       $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER)
-    );
+    ));
+    $this->entityManager->persist($task);
 
-    $savedSendingTask = $sendingTask->save();
+    // queue
+    $queue = new SendingQueueEntity();
+    $queue->setTask($task);
+    $queue->setNewsletter($newsletter);
+    $queue->setSubscribers((string)$subscriberId);
+    $task->setSendingQueue($queue);
+    $this->entityManager->persist($queue);
 
-    // Refreshing this entity here is needed while we are still using Paris to create the scheduled tasks and queues
-    // in the code above using \MailPoet\Tasks\Sending class. Doing this should avoid bugs where the loaded entity contain
-    // stale data after the corresponding entry in the database is updated using Paris. This code can be removed once
-    // https://mailpoet.atlassian.net/browse/MAILPOET-4375 is finished. Currently, if this code is removed a few integration
-    // tests fail (see https://app.circleci.com/pipelines/github/mailpoet/mailpoet/14806/workflows/0d441848-16db-461a-88ec-87bed101fe36/jobs/251385/tests#failed-test-0).
-    $scheduledTaskEntity = $this->scheduledTasksRepository->findOneScheduledByNewsletterAndSubscriber($newsletter, $subscriber);
-    if ($scheduledTaskEntity instanceof ScheduledTaskEntity) {
-      $this->scheduledTasksRepository->refresh($scheduledTaskEntity);
-    }
+    // task subscriber
+    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $task->getSubscribers()->add($taskSubscriber);
+    $this->entityManager->persist($taskSubscriber);
 
-    return $savedSendingTask;
+    $this->entityManager->flush();
   }
 }

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -135,7 +135,6 @@ class WelcomeScheduler {
     $queue = new SendingQueueEntity();
     $queue->setTask($task);
     $queue->setNewsletter($newsletter);
-    $queue->setSubscribers((string)$subscriberId);
     $task->setSendingQueue($queue);
     $this->entityManager->persist($queue);
 

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -220,5 +220,6 @@ class SendingQueuesRepository extends Repository {
       $queue->setCountToProcess($unprocessed);
       $queue->setCountTotal($processed + $unprocessed);
     }
+    $this->entityManager->flush();
   }
 }

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -98,6 +98,9 @@ class SubscribersFinder {
     if (!empty($dynamicSegmentIds)) {
       $count += $this->addSubscribersToTaskFromDynamicSegments($task, $dynamicSegmentIds, $filterSegmentId);
     }
+    if ($count > 0) {
+      $this->entityManager->refresh($task);
+    }
     return $count;
   }
 

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -30,7 +30,6 @@ use MailPoet\Util\Helpers;
  */
 class Sending {
   const TASK_TYPE = SendingQueueAlias::TASK_TYPE;
-  const RESULT_BATCH_SIZE = 5;
 
   /** @var ScheduledTask */
   private $task;

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\DataGenerator\Generators;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
@@ -20,7 +21,6 @@ use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -387,7 +387,7 @@ class WooCommercePastRevenues implements Generator {
 
     // Sending task
     $task = new ScheduledTaskEntity();
-    $task->setType(Sending::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $task->setCreatedAt(new Carbon($sentAt));
     $task->setProcessedAt(new Carbon($sentAt));

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SendingQueuesResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SendingQueuesResponseBuilderTest.php
@@ -3,10 +3,10 @@
 namespace integration\API\JSON\ResponseBuilders;
 
 use MailPoet\API\JSON\ResponseBuilders\SendingQueuesResponseBuilder;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
@@ -33,7 +33,7 @@ class SendingQueuesResponseBuilderTest extends \MailPoetTest {
     $this->sendingQueuesResponseBuilder = $this->diContainer->get(SendingQueuesResponseBuilder::class);
     $scheduledAt = new Carbon('2018-10-10 10:00:00');
     $this->newsletter = $newsletterFactory->create();
-    $this->scheduledTask = $scheduledTaskFactory->create(Sending::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, $scheduledAt);
+    $this->scheduledTask = $scheduledTaskFactory->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, $scheduledAt);
     $this->sendingQueue = $sendingQueueFactory->create($this->scheduledTask, $this->newsletter);
     $this->assertInstanceOf(SendingQueueEntity::class, $this->sendingQueue);
   }

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -5,12 +5,12 @@ namespace MailPoet\Test\API\JSON\v1;
 use Codeception\Util\Stub;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\SendingQueue as SendingQueueAPI;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -57,7 +57,7 @@ class SendingQueueTest extends \MailPoetTest {
     $scheduled = $scheduledTask->getScheduledAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $scheduled);
     verify($scheduled->format('Y-m-d H:i:s'))->equals($newsletterOptions['scheduledAt']);
-    verify($scheduledTask->getType())->equals(Sending::TASK_TYPE);
+    verify($scheduledTask->getType())->equals(SendingQueue::TASK_TYPE);
   }
 
   public function testItReturnsErrorIfSubscribersLimitReached() {

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -15,8 +15,6 @@ use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\SendingQueue;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
@@ -26,7 +24,6 @@ use MailPoet\Subscribers\RequiredCustomFieldValidator;
 use MailPoet\Subscribers\SubscriberSaveController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
@@ -610,15 +607,13 @@ class SubscribersTest extends \MailPoetTest {
   public function testItThrowsIfWelcomeEmailFails() {
     $settings = SettingsController::getInstance();
     $settings->set('signup_confirmation.enabled', false);
-    $task = ScheduledTask::create();
-    $task->type = 'sending';
-    $task->setError("Big Error");
-    $sendingStub = Sending::create($task, SendingQueue::create());
     $segment = $this->getSegment();
 
     $subscribers = Stub::copy($this->getSubscribers(), [
       'welcomeScheduler' => $this->make('MailPoet\Newsletter\Scheduler\WelcomeScheduler', [
-        'scheduleSubscriberWelcomeNotification' => [$sendingStub],
+        'scheduleSubscriberWelcomeNotification' => function () {
+          throw new \Exception();
+        },
       ]),
     ]);
     $API = $this->getApi($subscribers);

--- a/mailpoet/tests/integration/AdminPages/HelpTest.php
+++ b/mailpoet/tests/integration/AdminPages/HelpTest.php
@@ -5,6 +5,7 @@ namespace integration\AdminPages;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AdminPages\Pages\Help;
 use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -13,7 +14,6 @@ use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Url;
 use MailPoet\Services\Bridge;
 use MailPoet\SystemReport\SystemReportCollector;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoetVendor\Carbon\Carbon;
@@ -49,7 +49,7 @@ class HelpTest extends \MailPoetTest {
 
   public function testItFetchesNewsletterDataForSendingTasks() {
     $task = $this->scheduledTaskFactory->create(
-      Sending::TASK_TYPE,
+      SendingQueue::TASK_TYPE,
       ScheduledTaskEntity::STATUS_SCHEDULED,
       Carbon::now()->addDay()
     );
@@ -66,7 +66,7 @@ class HelpTest extends \MailPoetTest {
 
   public function testItDoesNotFailForSendingTaskWithMissingNewsletterInconsistentData() {
     $task = $this->scheduledTaskFactory->create(
-      Sending::TASK_TYPE,
+      SendingQueue::TASK_TYPE,
       ScheduledTaskEntity::STATUS_SCHEDULED,
       Carbon::now()->addDay()
     );

--- a/mailpoet/tests/integration/Analytics/UnsubscribeAnalyticsTest.php
+++ b/mailpoet/tests/integration/Analytics/UnsubscribeAnalyticsTest.php
@@ -3,8 +3,8 @@
 namespace integration\Analytics;
 
 use MailPoet\Analytics\UnsubscribeReporter;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\ScheduledTask;
 use MailPoet\Test\DataFactories\SendingQueue;
@@ -47,7 +47,7 @@ class UnsubscribeAnalyticsTest extends \MailPoetTest {
   private function createStatisticsUnsubscribe(\DateTimeInterface $createdAt, $method): StatisticsUnsubscribeEntity {
     $subscriber = (new Subscriber())->create();
     $newsletter = (new Newsletter())->create();
-    $task = (new ScheduledTask())->create(Sending::TASK_TYPE, null, (new Carbon())->subMonths(random_int(0, 12)));
+    $task = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, null, (new Carbon())->subMonths(random_int(0, 12)));
     $queue = (new SendingQueue())->create($task);
 
     $entity = new StatisticsUnsubscribeEntity($newsletter, $queue, $subscriber);

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\AutomaticEmails\WooCommerce\Events;
 
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce as WooCommerceEmail;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -17,7 +18,6 @@ use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\Track\SubscriberActivityTracker;
 use MailPoet\Statistics\Track\SubscriberCookie;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterOption as NewsletterOptionFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -326,7 +326,7 @@ class AbandonedCartTest extends \MailPoetTest {
 
   private function createSendingTask(NewsletterEntity $newsletter, SubscriberEntity $subscriber, Carbon $scheduleAt): ScheduledTaskEntity {
     $scheduledTask = new ScheduledTaskEntity();
-    $scheduledTask->setType(SendingTask::TASK_TYPE);
+    $scheduledTask->setType(SendingQueue::TASK_TYPE);
     $this->entityManager->persist($scheduledTask);
     $this->entityManager->flush();
 

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/FirstPurchaseTest.php
@@ -6,6 +6,7 @@ use Codeception\Stub;
 use Codeception\Stub\Expected;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerce;
 use MailPoet\AutomaticEmails\WooCommerce\WooCommerceStubs\OrderDetails;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -14,7 +15,6 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterOption as NewsletterOptionFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -266,9 +266,9 @@ class FirstPurchaseTest extends \MailPoetTest {
     WPFunctions::get()->removeAllFilters('woocommerce_order_status_processing');
     WPFunctions::get()->removeAllFilters('woocommerce_order_status_completed');
     $orderId = $this->_runTestItSchedulesEmailForState('processing');
-    $tasksCountBeforeStatusChange = count($this->scheduledTasksRepository->findBy(['type' => Sending::TASK_TYPE]));
+    $tasksCountBeforeStatusChange = count($this->scheduledTasksRepository->findBy(['type' => SendingQueue::TASK_TYPE]));
     WPFunctions::get()->doAction('woocommerce_order_status_completed', $orderId);
-    $tasksCountAfterStatusChange = count($this->scheduledTasksRepository->findBy(['type' => Sending::TASK_TYPE]));
+    $tasksCountAfterStatusChange = count($this->scheduledTasksRepository->findBy(['type' => SendingQueue::TASK_TYPE]));
     verify($tasksCountAfterStatusChange)->equals($tasksCountBeforeStatusChange);
   }
 

--- a/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
+++ b/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
@@ -9,6 +9,7 @@ use MailPoet\Cron\Workers\Bounce as BounceWorker;
 use MailPoet\Cron\Workers\InactiveSubscribers;
 use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
 use MailPoet\Cron\Workers\ReEngagementEmailsScheduler;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Cron\Workers\StatsNotifications\AutomatedEmails;
 use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
 use MailPoet\Cron\Workers\SubscriberLinkTokens;
@@ -26,7 +27,6 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
@@ -325,7 +325,7 @@ class WordPressTest extends \MailPoetTest {
       Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')) :
       null;
     $newsletter = (new NewsletterFactory())->create();
-    $scheduledTask = (new ScheduledTaskFactory())->create(Sending::TASK_TYPE, $status, $scheduledAt);
+    $scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, $status, $scheduledAt);
     $sendingQueue = (new SendingQueueFactory())->create($scheduledTask, $newsletter);
     return $sendingQueue;
   }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -167,19 +167,16 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItCanDeleteQueueWhenDeliveryIsSetToImmediately() {
     $newsletter = $this->_createNewsletter();
-    $newsletterEntity = $this->entityManager->getReference(NewsletterEntity::class, $newsletter->getId());
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
-    $this->newsletterOptionFactory->create($newsletterEntity, 'intervalType', 'immediately');
-
-    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $this->newsletterOptionFactory->create($newsletter, 'intervalType', 'immediately');
     $task = $this->createTaskWithQueue($newsletter);
-    $scheduler = $this->getScheduler();
 
-    // queue and associated newsletter should be deleted when interval type is set to "immediately"
-    verify($this->sendingQueuesRepository->findAll())->notEmpty();
+    // task and queue should be deleted when interval type is set to "immediately"
+    $scheduler = $this->getScheduler();
+    verify($this->sendingQueuesRepository->findAll())->arrayCount(1);
+    verify($this->scheduledTasksRepository->findAll())->arrayCount(1);
     $scheduler->deleteQueueOrUpdateNextRunDate($task, $newsletter);
     verify($this->sendingQueuesRepository->findAll())->arrayCount(0);
+    verify($this->scheduledTasksRepository->findAll())->arrayCount(0);
   }
 
   public function testItCanRescheduleQueueDeliveryTime() {

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -565,13 +565,9 @@ class SchedulerTest extends \MailPoetTest {
     $task = $this->createTaskWithQueue($newsletter);
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processWelcomeNewsletter' => Expected::exactly(1),
-      'cronHelper' => $this->cronHelper,
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     $scheduler->process();
   }
 
@@ -580,13 +576,9 @@ class SchedulerTest extends \MailPoetTest {
     $task = $this->createTaskWithQueue($newsletter);
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processPostNotificationNewsletter' => Expected::exactly(1),
-      'cronHelper' => $this->cronHelper,
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     $scheduler->process();
   }
 
@@ -595,13 +587,9 @@ class SchedulerTest extends \MailPoetTest {
     $task = $this->createTaskWithQueue($newsletter);
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::exactly(1),
-      'cronHelper' => $this->cronHelper,
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     $scheduler->process();
   }
 
@@ -610,15 +598,12 @@ class SchedulerTest extends \MailPoetTest {
     $task = $this->createTaskWithQueue($newsletter);
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processPostNotificationNewsletter' => Expected::exactly(1),
       'cronHelper' => $this->make(CronHelper::class, [
         'enforceExecutionLimit' => Expected::exactly(2), // call at start + during processing
       ]),
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     $scheduler->process();
   }
 
@@ -627,14 +612,9 @@ class SchedulerTest extends \MailPoetTest {
     $task = $this->createTaskWithQueue($newsletter);
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
-
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::never(),
-      'cronHelper' => $this->cronHelper,
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     // scheduled job is not processed
     $scheduler->process();
   }
@@ -644,14 +624,9 @@ class SchedulerTest extends \MailPoetTest {
     $task = $this->createTaskWithQueue($newsletter);
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
-
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::once(),
-      'cronHelper' => $this->cronHelper,
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     // scheduled job is processed
     $scheduler->process();
   }
@@ -712,13 +687,9 @@ class SchedulerTest extends \MailPoetTest {
     $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->entityManager->flush();
 
-    $scheduler = Stub::make(Scheduler::class, [
+    $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::once(),
-      'cronHelper' => $this->cronHelper,
-      'scheduledTasksRepository' => $this->scheduledTasksRepository,
-      'sendingQueuesRepository' => $this->sendingQueuesRepository,
-      'newslettersRepository' => $this->newslettersRepository,
-    ], $this);
+    ]);
     // scheduled job is processed
     $scheduler->process();
   }
@@ -945,6 +916,15 @@ class SchedulerTest extends \MailPoetTest {
     }
     $this->entityManager->flush();
     return $scheduledTaskSubscriber;
+  }
+
+  private function getSchedulerMock(array $mocks): Scheduler {
+    return $this->make(Scheduler::class, $mocks + [
+      'cronHelper' => $this->cronHelper,
+      'scheduledTasksRepository' => $this->scheduledTasksRepository,
+      'sendingQueuesRepository' => $this->sendingQueuesRepository,
+      'newslettersRepository' => $this->newslettersRepository,
+    ]);
   }
 
   private function getScheduler(?SubscribersFinder $subscribersFinder = null): Scheduler {

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -866,7 +866,11 @@ class SchedulerTest extends \MailPoetTest {
   public function testItDeletesScheduledAutomationEmailWhenUserDoesNotExist() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
     $subscriber = $this->_createSubscriber();
-    $this->createTaskWithQueue($newsletter);
+    $task = $this->createTaskWithQueue($newsletter);
+    $this->createTaskSubscriber($task, $subscriber);
+
+    $task = $this->scheduledTasksRepository->findOneByNewsletter($newsletter);
+    verify($task)->notNull();
 
     // remove subscriber, but not scheduled task subscriber
     $this->entityManager->getConnection()->delete(

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -550,7 +550,6 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItDeletesQueueDuringProcessingWhenNewsletterIsSoftDeleted() {
     $newsletter = $this->_createNewsletter();
-    $newsletter->setDeletedAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->createTaskWithQueue($newsletter);
     $this->newslettersRepository->flush();
 
@@ -562,9 +561,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItProcessesWelcomeNewsletters() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_WELCOME);
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processWelcomeNewsletter' => Expected::exactly(1),
     ]);
@@ -573,9 +570,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItProcessesNotificationNewsletters() {
     $newsletter = $this->_createNewsletter();
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processPostNotificationNewsletter' => Expected::exactly(1),
     ]);
@@ -584,9 +579,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItProcessesStandardScheduledNewsletters() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_STANDARD);
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::exactly(1),
     ]);
@@ -595,9 +588,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItEnforcesExecutionLimitDuringProcessing() {
     $newsletter = $this->_createNewsletter();
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processPostNotificationNewsletter' => Expected::exactly(1),
       'cronHelper' => $this->make(CronHelper::class, [
@@ -609,9 +600,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItDoesNotProcessScheduledJobsWhenNewsletterIsNotActive() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_DRAFT);
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::never(),
     ]);
@@ -621,9 +610,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItProcessesScheduledJobsWhenNewsletterIsActive() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_ACTIVE);
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::once(),
     ]);
@@ -632,7 +619,7 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItDoesNotReSchedulesBounceTaskWhenSoon() {
-    $task = $this->scheduledTaskFactory->create(
+    $this->scheduledTaskFactory->create(
       'bounce',
       ScheduledTaskEntity::STATUS_SCHEDULED,
       Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->addMinutes(5)
@@ -655,9 +642,7 @@ class SchedulerTest extends \MailPoetTest {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_SCHEDULED);
     $subscriber = $this->_createSubscriber(0, $subscriberStatus);
     $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $this->createTaskSubscriber($task, $subscriber);
-    $this->entityManager->flush();
 
     $scheduler = $this->diContainer->get(Scheduler::class);
     $scheduler->process();
@@ -683,9 +668,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItProcessesScheduledJobsWhenNewsletterIsScheduled() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SCHEDULED);
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
 
     $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::once(),
@@ -742,9 +725,7 @@ class SchedulerTest extends \MailPoetTest {
       ]
     );
 
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::now()->subDay());
-    $this->entityManager->flush();
+    $this->createTaskWithQueue($newsletter);
 
     // task should have its status set to null (i.e., sending)
     $scheduler = $this->getScheduler($this->subscribersFinder);

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -310,11 +310,11 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItProcessesWelcomeNewsletterWhenSubscriberIsVerified() {
-    $newsletter = $this->_createNewsletter();
+    $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_WELCOME);
     $subscriber = $this->_createSubscriber();
     $this->newsletterOptionFactory->create($newsletter, 'event', 'segment');
 
-    // return true when subsriber is verified and update the queue's status to null
+    // return true when subscriber is verified and update the task status to null
     $task = $this->createTaskWithQueue($newsletter);
     $this->createTaskSubscriber($task, $subscriber);
     $scheduler = Stub::make(Scheduler::class, [

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -379,7 +379,8 @@ class SchedulerTest extends \MailPoetTest {
     // return false
     $result = $scheduler->verifyMailpoetSubscriber((int)$subscriber->getId(), $newsletter, $task);
     verify($result)->false();
-    // delete queue when subscriber is not in segment specified for the newsletter
+    // delete task and queue when subscriber is not in segment specified for the newsletter
+    verify($this->scheduledTasksRepository->findAll())->arrayCount(0);
     verify($this->sendingQueuesRepository->findAll())->arrayCount(0);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -201,8 +201,8 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItFailsWPSubscriberVerificationWhenSubscriberIsNotAWPUser() {
-    $wPUser = $this->_createOrUpdateWPUser('editor');
-    $subscriber = $this->_createSubscriber();
+    $this->_createOrUpdateWPUser('author');
+    $subscriber = $this->_createSubscriber(); // do not pass WP user ID
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_WELCOME);
 
     $this->newsletterOptionFactory->create($newsletter, 'role', 'author');

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -800,7 +800,10 @@ class SchedulerTest extends \MailPoetTest {
   public function testItDeletesScheduledAutomaticEmailWhenUserDoesNotExist() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::STATUS_SCHEDULED);
     $subscriber = $this->_createSubscriber();
-    $this->createTaskWithQueue($newsletter);
+    $task = $this->createTaskWithQueue($newsletter);
+    $this->createTaskSubscriber($task, $subscriber);
+
+    verify($this->scheduledTasksRepository->findOneByNewsletter($newsletter))->notNull();
 
     // remove subscriber, but not scheduled task subscriber
     $this->entityManager->getConnection()->delete(
@@ -812,8 +815,7 @@ class SchedulerTest extends \MailPoetTest {
     // task should be deleted
     $scheduler = $this->getScheduler();
     $scheduler->process();
-    $task = $this->scheduledTasksRepository->findOneByNewsletter($newsletter);
-    verify($task)->null();
+    verify($this->scheduledTasksRepository->findOneByNewsletter($newsletter))->null();
   }
 
   public function testItProcessesScheduledAutomaticEmailWhenSendingToSegment() {

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -463,7 +463,7 @@ class SchedulerTest extends \MailPoetTest {
     $subscriber = $this->_createSubscriber();
     $segment = $this->_createSegment();
     $this->_createSubscriberSegment($subscriber->getId(), $segment->getId());
-    $newsletter = $this->_createNewsletter();
+    $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_STANDARD);
     $this->_createNewsletterSegment($newsletter->getId(), $segment->getId());
     $this->assertIsInt($segment->getId());
     $task = $this->createTaskWithQueue($newsletter);

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -551,14 +551,12 @@ class SchedulerTest extends \MailPoetTest {
   public function testItDeletesQueueDuringProcessingWhenNewsletterIsSoftDeleted() {
     $newsletter = $this->_createNewsletter();
     $newsletter->setDeletedAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->newslettersRepository->persist($newsletter);
+    $this->createTaskWithQueue($newsletter);
     $this->newslettersRepository->flush();
 
-    $task = $this->createTaskWithQueue($newsletter);
-    $task->setScheduledAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
-    $this->entityManager->flush();
     $scheduler = $this->getScheduler();
     $scheduler->process();
+    verify($this->scheduledTasksRepository->findAll())->arrayCount(0);
     verify($this->sendingQueuesRepository->findAll())->arrayCount(0);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -331,7 +331,7 @@ class SchedulerTest extends \MailPoetTest {
   }
 
   public function testItProcessesWelcomeNewsletterWhenWPUserIsVerified() {
-    $newsletter = $this->_createNewsletter();
+    $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_WELCOME);
     $subscriber = $this->_createSubscriber();
     $this->newsletterOptionFactory->create($newsletter, 'event', 'user');
 
@@ -344,7 +344,7 @@ class SchedulerTest extends \MailPoetTest {
     ], $this);
     verify($task->getStatus())->notNull();
     verify($scheduler->processWelcomeNewsletter($newsletter, $task))->true();
-    // update queue's status to null
+    // update task status to null
     $sendingQueue = $task->getSendingQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
     $scheduledTask = $this->scheduledTasksRepository->findOneBySendingQueue($sendingQueue);

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -269,10 +269,11 @@ class SchedulerTest extends \MailPoetTest {
     $newsletter = $this->_createNewsletter();
     $task = $this->createTaskWithQueue($newsletter);
 
-    // delete queue when the list of subscribers to process is blank
+    // delete task and queue when the list of subscribers to process is blank
     $scheduler = $this->getScheduler();
     $result = $scheduler->processWelcomeNewsletter($newsletter, $task);
     verify($result)->false();
+    verify($this->scheduledTasksRepository->findAll())->arrayCount(0);
     verify($this->sendingQueuesRepository->findAll())->arrayCount(0);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -892,9 +892,6 @@ class SchedulerTest extends \MailPoetTest {
     $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($scheduledTaskSubscriber);
     $task->getSubscribers()->add($scheduledTaskSubscriber);
-    if ($task->getSendingQueue()) {
-      $task->getSendingQueue()->setSubscribers((string)$subscriber->getId());
-    }
     $this->entityManager->flush();
     return $scheduledTaskSubscriber;
   }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -360,7 +360,8 @@ class SchedulerTest extends \MailPoetTest {
     // return false
     $result = $scheduler->verifyMailpoetSubscriber(PHP_INT_MAX, $newsletter, $task);
     verify($result)->false();
-    // delete queue when subscriber can't be found
+    // delete task and queue when subscriber can't be found
+    verify($this->scheduledTasksRepository->findAll())->arrayCount(0);
     verify($this->sendingQueuesRepository->findAll())->arrayCount(0);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1401,7 +1401,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   private function createQueueWithTaskAndSegment(NewsletterEntity $newsletter, $status = null, $body = null): SendingQueueEntity {
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueueWorker::TASK_TYPE);
     $task->setStatus($status);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/NewsletterLinkRepositoryTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/NewsletterLinkRepositoryTest.php
@@ -2,13 +2,13 @@
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Tasks\Sending as SendingTask;
 
 class NewsletterLinkRepositoryTest extends \MailPoetTest {
   public function testItFetchesTopLink() {
@@ -19,7 +19,7 @@ class NewsletterLinkRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($newsletter);
 
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersLifetimeEmailCountTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -11,7 +12,6 @@ use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -186,7 +186,7 @@ class SubscribersLifetimeEmailCountTest extends \MailPoetTest {
   private function createCompletedSendingTask(int $processedDaysAgo = 0): array {
     $processedAt = (new Carbon())->subDays($processedDaysAgo)->addHours(2);
     $task = new ScheduledTaskEntity();
-    $task->setType(Sending::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $task->setCreatedAt($processedAt);
     $task->setProcessedAt($processedAt);

--- a/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/WooCommerceOrdersTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Cron\Workers;
 use Codeception\Util\Stub;
 use DateTime;
 use MailPoet\Cron\CronWorkerRunner;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Cron\Workers\WooCommercePastOrders;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
@@ -15,7 +16,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\Track\WooCommercePurchases;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -155,7 +155,7 @@ class WooCommerceOrdersTest extends \MailPoetTest {
     $this->entityManager->persist($newsletter);
 
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -2,11 +2,11 @@
 
 namespace MailPoet\Entities;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Segments\SegmentsRepository;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 
 class NewsletterEntityTest extends \MailPoetTest {
@@ -85,7 +85,7 @@ class NewsletterEntityTest extends \MailPoetTest {
     $newsletter->setType(NewsletterEntity::TYPE_WELCOME);
     $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
     $this->entityManager->persist($task);
 
@@ -111,7 +111,7 @@ class NewsletterEntityTest extends \MailPoetTest {
     $newsletter->setType(NewsletterEntity::TYPE_WELCOME);
     $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
     $this->entityManager->persist($task);
 
@@ -137,7 +137,7 @@ class NewsletterEntityTest extends \MailPoetTest {
     $newsletter->setType(NewsletterEntity::TYPE_WELCOME);
     $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setScheduledAt(new \DateTimeImmutable('2012-01-02 12:23:34'));
     $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
     $this->entityManager->persist($task);

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter;
 
 use Codeception\Util\Fixtures;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
@@ -355,7 +356,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
 
   private function createQueueWithTaskAndSegmentAndSubscribers(NewsletterEntity $newsletter, $status = ScheduledTaskEntity::STATUS_SCHEDULED): SendingQueueEntity {
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus($status);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter;
 
 use Codeception\Util\Fixtures;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
@@ -13,7 +14,6 @@ use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -376,7 +376,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
 
   private function createQueueWithTask(NewsletterEntity $newsletter): SendingQueueEntity {
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Newsletter\Scheduler;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
@@ -12,7 +13,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\Segment;
@@ -120,7 +120,7 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     $this->entityManager->refresh($task);
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
-    verify($task->getType())->equals(Sending::TASK_TYPE);
+    verify($task->getType())->equals(SendingQueue::TASK_TYPE);
     $scheduledAt = $task->getScheduledAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
     verify($scheduledAt->getTimestamp())->equalsWithDelta(Carbon::now()->getTimestamp(), 1);

--- a/mailpoet/tests/integration/Newsletter/Segment/NewsletterSegmentRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Segment/NewsletterSegmentRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Segment;
 
 use Codeception\Util\Fixtures;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
@@ -10,7 +11,6 @@ use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 
 class NewsletterSegmentRepositoryTest extends \MailPoetTest {
@@ -113,7 +113,7 @@ class NewsletterSegmentRepositoryTest extends \MailPoetTest {
 
   private function createQueueWithTaskAndSegment(NewsletterEntity $newsletter, $status = ScheduledTaskEntity::STATUS_SCHEDULED): SendingQueueEntity {
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus($status);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTasksRepositoryTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Newsletter\Sending;
 use MailPoet\Cron\Workers\Bounce;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue;
 use MailPoetVendor\Carbon\Carbon;
@@ -112,7 +111,7 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
   }
 
   public function testItCanFetchBasicTasksData() {
-    $task1 = $this->scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDay());
+    $task1 = $this->scheduledTaskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDay());
     $task2 = $this->scheduledTaskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, Carbon::now()->addDay());
     $data = $this->repository->getLatestTasks();
     verify(count($data))->equals(2);
@@ -124,7 +123,7 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
     }, $data);
     $this->assertContains($task1->getId(), $ids);
     $this->assertContains($task2->getId(), $ids);
-    $this->assertContains(SendingTask::TASK_TYPE, $types);
+    $this->assertContains(SendingQueueWorker::TASK_TYPE, $types);
     $this->assertContains(Bounce::TASK_TYPE, $types);
     verify(is_int($data[1]->getPriority()))->true();
     verify($data[1]->getUpdatedAt())->instanceOf(\DateTimeInterface::class);
@@ -134,7 +133,7 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
   }
 
   public function testItCanFilterTasksByType() {
-    $this->scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->addDay());
+    $this->scheduledTaskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->addDay());
     $this->scheduledTaskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->addDay());
     $data = $this->repository->getLatestTasks(Bounce::TASK_TYPE);
     verify(count($data))->equals(1);
@@ -142,8 +141,8 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
   }
 
   public function testItCanFilterTasksByStatus() {
-    $this->scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->addDay());
-    $this->scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_PAUSED, Carbon::now()->addDay());
+    $this->scheduledTaskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->addDay());
+    $this->scheduledTaskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_PAUSED, Carbon::now()->addDay());
     $data = $this->repository->getLatestTasks(null, [ScheduledTaskEntity::STATUS_COMPLETED]);
     verify(count($data))->equals(1);
     verify($data[0]->getStatus())->equals(ScheduledTaskEntity::STATUS_COMPLETED);
@@ -151,7 +150,7 @@ class ScheduledTasksRepositoryTest extends \MailPoetTest {
 
   public function testItDoesNotFailForSendingTaskWithoutQueue() {
     $this->scheduledTaskFactory->create(
-      SendingTask::TASK_TYPE,
+      SendingQueueWorker::TASK_TYPE,
       ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING,
       Carbon::now()->addDay()
     );

--- a/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Router\Endpoints;
 
 use Codeception\Stub;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
@@ -14,7 +15,6 @@ use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Subscribers\LinkTokens;
-use MailPoet\Tasks\Sending;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterLink as NewsletterLinkFactory;
 
@@ -180,7 +180,7 @@ class TrackTest extends \MailPoetTest {
       ->withSendingQueue()
       ->create();
     $scheduledTaskEntity = $newsletter->getLatestQueue()->getTask();
-    $scheduledTaskEntity->setType(Sending::TASK_TYPE);
+    $scheduledTaskEntity->setType(SendingQueue::TASK_TYPE);
     $this->entityManager->persist($scheduledTaskEntity);
 
     $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($scheduledTaskEntity, $this->subscriber, 1);

--- a/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
@@ -52,7 +52,6 @@ class TrackTest extends \MailPoetTest {
     $queue = new SendingQueueEntity();
     $queue->setTask($task);
     $queue->setNewsletter($newsletter);
-    $queue->setSubscribers((string)$subscriber->getId());
     $this->queue = $queue;
     $this->entityManager->persist($queue);
     // create link

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -3,12 +3,12 @@
 namespace MailPoet\Segments;
 
 use Codeception\Util\Stub;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
@@ -55,7 +55,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->create();
 
     $scheduledTaskFactory = new ScheduledTaskFactory();
-    $this->scheduledTask = $scheduledTaskFactory->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
+    $this->scheduledTask = $scheduledTaskFactory->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscribersFinder = $this->diContainer->get(SubscribersFinder::class);
     $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
@@ -178,20 +178,20 @@ class SubscribersFinderTest extends \MailPoetTest {
     $this->assertIsInt($dynamicSegment->getId());
 
     // Without filtering
-    $task = (new ScheduledTaskFactory())->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
+    $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $staticCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()]);
     verify($staticCount)->equals(2);
 
-    $task = (new ScheduledTaskFactory())->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
+    $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $dynamicCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()]);
     verify($dynamicCount)->equals(4);
 
     // With filtering
-    $task = (new ScheduledTaskFactory())->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
+    $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $staticCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()], $filterSegment->getId());
     verify($staticCount)->equals(1);
 
-    $task = (new ScheduledTaskFactory())->create(SendingTask::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
+    $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $dynamicCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()], $filterSegment->getId());
     verify($dynamicCount)->equals(2);
   }

--- a/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Statistics;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -13,7 +14,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Carbon\CarbonImmutable;
 
@@ -282,7 +282,7 @@ class StatisticsOpensRepositoryTest extends \MailPoetTest {
 
   private function createSendingTask(SubscriberEntity $subscriber): ScheduledTaskEntity {
     $task = new ScheduledTaskEntity();
-    $task->setType(Sending::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $this->entityManager->persist($task);
     $sub = new ScheduledTaskSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($sub);

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -64,7 +64,6 @@ class OpensTest extends \MailPoetTest {
     $queue = new SendingQueueEntity();
     $queue->setNewsletter($newsletter);
     $queue->setTask($task);
-    $queue->setSubscribers((string)$subscriber->getId());
     $newsletter->getQueues()->add($queue);
     $this->entityManager->persist($queue);
     $this->entityManager->flush();

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Statistics\Track;
 use Codeception\Stub;
 use Codeception\Stub\Expected;
 use MailPoet\Config\SubscriberChangesNotifier;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -16,7 +17,6 @@ use MailPoet\Statistics\Track\Opens;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -57,7 +57,7 @@ class OpensTest extends \MailPoetTest {
     $this->entityManager->persist($subscriber);
     // create queue
     $task = new ScheduledTaskEntity();
-    $task->setType(SendingTask::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $this->entityManager->persist($task);
 

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -494,7 +494,6 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     $queue = new SendingQueueEntity();
     $this->entityManager->persist($queue);
     $queue->setNewsletter($newsletter);
-    $queue->setSubscribers((string)$subscriber->getId());
     $queue->setTask($task);
     $sendingTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber, 1);
     $this->entityManager->persist($sendingTaskSubscriber);

--- a/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Subscribers;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -9,7 +10,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SettingEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Tasks\Sending;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -256,7 +256,7 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
   private function createCompletedSendingTask(int $processedDaysAgo = 0): array {
     $processedAt = (new Carbon())->subDays($processedDaysAgo);
     $task = new ScheduledTaskEntity();
-    $task->setType(Sending::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $task->setCreatedAt($processedAt);
     $task->setProcessedAt($processedAt);

--- a/mailpoet/tests/integration/Subscribers/SubscribersEmailCountsControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersEmailCountsControllerTest.php
@@ -2,12 +2,12 @@
 
 namespace MailPoet\Subscribers;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Tasks\Sending;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -197,7 +197,7 @@ class SubscribersEmailCountsControllerTest extends \MailPoetTest {
   private function createCompletedSendingTask(int $processedDaysAgo = 0): array {
     $processedAt = (new Carbon())->subDays($processedDaysAgo);
     $task = new ScheduledTaskEntity();
-    $task->setType(Sending::TASK_TYPE);
+    $task->setType(SendingQueue::TASK_TYPE);
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
     $task->setCreatedAt($processedAt);
     $task->setProcessedAt($processedAt);

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Tasks;
 
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -316,7 +317,7 @@ class SendingTest extends \MailPoetTest {
 
   public function createNewScheduledTask() {
     $task = ScheduledTask::create();
-    $task->type = SendingTask::TASK_TYPE;
+    $task->type = SendingQueueWorker::TASK_TYPE;
     return $task->save();
   }
 


### PR DESCRIPTION
## Description

This PR removes the first batch of usages of `MailPoet\Tasks\Sending`.

## Code review notes

In the first part, this PR removes some fairly simple usages of `MailPoet\Tasks\Sending`. The second part removes the usages from `MailPoet\Cron\Workers\Scheduler` and does so gradually, method by method — the commits tell the story.

## QA notes

Please, verify that all types of email sending in the plugin work and that the emails render correcdtly:

1. Newsletters (immediate as well as scheduling).
2. Post notifications.
3. Welcome emails.
4. Transactional emails.
5. Automation emails (including transactional).
6. Re-engagement emails.
7. Stat notifications.

We have a fairly good test coverage for email sending, but it is worth verifying.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4375]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4375]: https://mailpoet.atlassian.net/browse/MAILPOET-4375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ