### PR TITLE
Remove remaining use of Paris from \MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter [MAILPOET-4693]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -13,7 +13,6 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Models\SendingQueue as SendingQueueModel;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\PostProcess\OpenTracking;
@@ -229,15 +228,10 @@ class Newsletter {
     $renderedNewsletter = $this->emoji->encodeEmojisInBody($renderedNewsletter);
     $sendingTask->newsletterRenderedBody = $renderedNewsletter;
     $sendingTask->save();
+
     // catch DB errors
     $queueErrors = $sendingTask->getErrors();
-    if (!$queueErrors) {
-      // verify that the rendered body was successfully saved
-      $sendingQueue = SendingQueueModel::findOne($sendingTask->id);
-      if ($sendingQueue instanceof SendingQueueModel) {
-        $queueErrors = ($sendingQueue->validate() !== true);
-      }
-    }
+
     if ($queueErrors) {
       $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-SAVE', $sendingTask->id));
     }


### PR DESCRIPTION
## Description

This PR removes the last use of Paris in \MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter. The code was used to validate the field newsletter_rendered_body. As far as I could test, calling validate() directly is not necessary. The call to $sendingTask->save() right above calls validate() internally and then any errors will be returned by $sendingTask->getErrors().

I added an integration test that seems to confirm this interpretation.

## Code review notes

_N/A_

## QA notes

This PR changes code that handles sending newsletters. It should be covered by automated tests, but checking a few cases of sending newsletters might be a good idea just in case.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4693]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4693]: https://mailpoet.atlassian.net/browse/MAILPOET-4693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ