### PR TITLE
Gracefully handle invalid segments [MAILPOET-5538]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automations.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/automations.tsx
@@ -30,5 +30,10 @@ export function AutomationsFields({ filterIndex }: FilterProps): JSX.Element {
     [filterIndex],
   );
   const Component = componentsMap[segment.action];
+
+  if (!Component) {
+    return null;
+  }
+
   return <Component filterIndex={filterIndex} />;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email.tsx
@@ -60,7 +60,9 @@ export function EmailFields({ filterIndex }: FilterProps): JSX.Element {
 
   const Component = componentsMap[segment.action];
 
-  if (!Component) return null;
+  if (!Component) {
+    return null;
+  }
 
   return <Component filterIndex={filterIndex} />;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/subscriber.tsx
@@ -130,7 +130,9 @@ export function SubscriberFields({ filterIndex }: FilterProps): JSX.Element {
     Component = componentsMap[segment.action];
   }
 
-  if (!Component) return null;
+  if (!Component) {
+    return null;
+  }
 
   return <Component filterIndex={filterIndex} />;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
@@ -128,5 +128,10 @@ export function WooCommerceFields({ filterIndex }: FilterProps): JSX.Element {
     [filterIndex],
   );
   const Component = componentsMap[segment.action];
+
+  if (!Component) {
+    return null;
+  }
+
   return <Component filterIndex={filterIndex} />;
 }

--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -229,6 +229,22 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
     verify($countWithFilter)->equals(2);
   }
 
+  public function testSubscriberCountIsZeroIfItHasAnInvalidFilter(): void {
+    $segment = new SegmentEntity('Segment' . rand(0, 10000), SegmentEntity::TYPE_DYNAMIC, 'Segment description');
+    $filterData = new DynamicSegmentFilterData(
+      'typeThatDefinitelyDoesNotExist',
+      'theActionDoesNotExistEither'
+    );
+    $dynamicFilter = new DynamicSegmentFilterEntity($segment, $filterData);
+    $segment->getDynamicFilters()->add($dynamicFilter);
+    $this->entityManager->persist($segment);
+    $this->entityManager->persist($dynamicFilter);
+    $this->entityManager->flush();
+
+    $count = $this->repository->getSubscribersCountBySegmentIds([$segment->getId()]);
+    $this->assertEquals(0, $count);
+  }
+
   public function _after() {
     parent::_after();
     $this->cleanup();


### PR DESCRIPTION
## Description

This PR prevents API calls from failing when trying to recalculate segments that have invalid/unknown filters, and also ensures that we can still load the segment editor for segments in this state.

This mostly affects developers/QA when testing new filters and then switching to a branch/version that doesn't have those filters, but it could affect users if they need to revert to an older version that doesn't know about all the filters their segments are using. Because this isn't a widespread or common issue I decided not to implement some of the nice-to-haves in the ticket.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5538](https://mailpoet.atlassian.net/browse/MAILPOET-5538)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5538]: https://mailpoet.atlassian.net/browse/MAILPOET-5538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ