### PR TITLE
Fix CircleCI zip file downloader - MAILPOET-5679

### DIFF
--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -57,7 +57,7 @@ class CircleCiController {
     $releaseZipUrl = $this->getReleaseZipUrl($job['job_number']);
 
     $this->httpClient->get($releaseZipUrl, [
-      'save_to' => $targetPath,
+      'sink' => $targetPath,
       'query' => [
         'circle-token' => $this->token, // artifact download requires token as query param
       ],


### PR DESCRIPTION


## Description

Fix CircleCI zip file downloader.

Request option `save_to` is removed from the [Guzzle library](https://github.com/guzzle/guzzle/blob/7.8/UPGRADING.md#other-backwards-compatibility-breaking-changes).

In this PR, we replace `save_to` with `sink`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5679](https://mailpoet.atlassian.net/browse/MAILPOET-5679)

## After-merge notes

_N/A_

## Tasks

- ~[ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations~
- ~[ ] I added sufficient test coverage~
- ~[ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes~


[MAILPOET-5679]: https://mailpoet.atlassian.net/browse/MAILPOET-5679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ