### PR TITLE
The minimum supported PHP version in PHPCS checks should be 7.3 [MAILPOET-5681]

### DIFF
--- a/mailpoet/tasks/code_sniffer/MailPoet/php-version.xml
+++ b/mailpoet/tasks/code_sniffer/MailPoet/php-version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <ruleset>
-  <config name="testVersion" value="7.2-"/>
+  <config name="testVersion" value="7.3-"/>
 </ruleset>


### PR DESCRIPTION
## Description

See [MAILPOET-5681]

## Code review notes

_N/A_

## QA notes

QA is not needed

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5681]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5681]: https://mailpoet.atlassian.net/browse/MAILPOET-5681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5681]: https://mailpoet.atlassian.net/browse/MAILPOET-5681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ