### PR TITLE
Refactor UnsubscribeTokens to use Doctrine instead of Paris [MAILPOET-5680]

### DIFF
--- a/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
+++ b/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
@@ -54,7 +54,7 @@ class UnsubscribeTokens extends SimpleWorker {
     $queryBuilder = $entityManager->createQueryBuilder();
 
     $entities = $queryBuilder
-      ->select('e')
+      ->select('PARTIAL e.{id}')
       ->from($entityClass, 'e')
       ->where('e.unsubscribeToken IS NULL')
       ->andWhere('e.id > :lastProcessedId')

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -173,6 +173,11 @@ class Newsletter {
     return $this;
   }
 
+  public function withUnsubscribeToken(string $unsubscribeToken) {
+    $this->data['unsubscribeToken'] = $unsubscribeToken;
+    return $this;
+  }
+
   /**
    * @return Newsletter
    */
@@ -416,6 +421,10 @@ class Newsletter {
     if (isset($this->data['deleted_at'])) $newsletter->setDeletedAt($this->data['deleted_at']);
     if (isset($this->data['ga_campaign'])) $newsletter->setGaCampaign($this->data['ga_campaign']);
     if (isset($this->data['wp_post_id'])) $newsletter->setWpPostId($this->data['wp_post_id']);
+
+    if (isset($this->data['unsubscribeToken'])) {
+      $newsletter->setUnsubscribeToken($this->data['unsubscribeToken']);
+    }
 
     return $newsletter;
   }

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -241,6 +241,16 @@ class Subscriber {
   }
 
   /**
+   * @param string $unsubscribeToken
+   *
+   * @return $this
+   */
+  public function withUnsubscribeToken(string $unsubscribeToken) {
+    $this->data['unsubscribeToken'] = $unsubscribeToken;
+    return $this;
+  }
+
+  /**
    * @return $this
    */
   public function withUpdatedAt(DateTimeInterface $updatedAt) {
@@ -271,6 +281,10 @@ class Subscriber {
     }
     if (isset($this->data['linkToken'])) {
       $subscriber->setLinkToken($this->data['linkToken']);
+    }
+
+    if (isset($this->data['unsubscribeToken'])) {
+      $subscriber->setUnsubscribeToken($this->data['unsubscribeToken']);
     }
 
     if (isset($this->data['deletedAt'])) {

--- a/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
@@ -5,25 +5,36 @@ namespace MailPoet\Test\Cron\Workers;
 use Codeception\Util\Fixtures;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\Subscriber;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
 class UnsubscribeTokensTest extends \MailPoetTest {
 
+  /** @var SubscriberEntity */
   private $subscriberWithToken;
   private $newsletterWithToken;
+
+  /** @var SubscriberEntity */
   private $subscriberWithoutToken;
   private $newsletterWithoutToken;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
   public function _before() {
     parent::_before();
-    $this->subscriberWithToken = Subscriber::createOrUpdate(['email' => 'subscriber1@test.com']);
-    $this->subscriberWithToken->set('unsubscribe_token', 'aaabbbcccdddeee');
-    $this->subscriberWithToken->save();
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
 
-    $this->subscriberWithoutToken = Subscriber::createOrUpdate(['email' => 'subscriber2@test.com']);
-    $this->subscriberWithoutToken->set('unsubscribe_token', null);
-    $this->subscriberWithoutToken->save();
+    $this->subscriberWithToken = (new SubscriberFactory())
+      ->withEmail('subscriber1@test.com')
+      ->withUnsubscribeToken('aaabbbcccdddeee')
+      ->create();
+
+    $this->subscriberWithoutToken = (new SubscriberFactory())
+      ->withEmail('subscriber2@test.com')
+      ->create();
 
     $this->newsletterWithToken = Newsletter::createOrUpdate([
       'subject' => 'My Newsletter',
@@ -43,12 +54,15 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   }
 
   public function testItAddsTokensToSubscribers() {
+    verify($this->subscriberWithoutToken->getUnsubscribeToken())->null();
     $worker = new UnsubscribeTokens();
     $worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
-    $this->subscriberWithToken = Subscriber::findOne($this->subscriberWithToken->id);
-    $this->subscriberWithoutToken = Subscriber::findOne($this->subscriberWithoutToken->id);
-    verify($this->subscriberWithToken->unsubscribe_token)->equals('aaabbbcccdddeee');
-    verify(strlen($this->subscriberWithoutToken->unsubscribe_token))->equals(15);
+    $subscriberWithToken = $this->subscribersRepository->findOneById($this->subscriberWithToken->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriberWithToken);
+    $subscriberWithoutToken = $this->subscribersRepository->findOneById($this->subscriberWithoutToken->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriberWithoutToken);
+    verify($subscriberWithToken->getUnsubscribeToken())->equals('aaabbbcccdddeee');
+    verify(strlen($subscriberWithoutToken->getUnsubscribeToken() ?? ''))->equals(15);
   }
 
   public function testItAddsTokensToNewsletters() {


### PR DESCRIPTION
## Description

This PR refactors UnsubscribeTokens and its test class to use Doctrine instead of Paris.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5680]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5680]: https://mailpoet.atlassian.net/browse/MAILPOET-5680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ