### PR TITLE
Remove usages of MailPoet\Tasks\Sending — Part 2

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
@@ -2,30 +2,36 @@
 
 namespace MailPoet\Cron\Workers\SendingQueue;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 
 class SendingErrorHandler {
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   /** @var SendingThrottlingHandler */
   private $throttlingHandler;
 
   public function __construct(
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
     SendingThrottlingHandler $throttlingHandler
   ) {
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
     $this->throttlingHandler = $throttlingHandler;
   }
 
   public function processError(
     MailerError $error,
-    SendingTask $sendingTask,
+    ScheduledTaskEntity $task,
     array $preparedSubscribersIds,
     array $preparedSubscribers
   ) {
     if ($error->getLevel() === MailerError::LEVEL_HARD) {
       return $this->processHardError($error);
     }
-    $this->processSoftError($error, $sendingTask, $preparedSubscribersIds, $preparedSubscribers);
+    $this->processSoftError($error, $task, $preparedSubscribersIds, $preparedSubscribers);
   }
 
   private function processHardError(MailerError $error) {
@@ -40,11 +46,11 @@ class SendingErrorHandler {
     }
   }
 
-  private function processSoftError(MailerError $error, SendingTask $sendingTask, $preparedSubscribersIds, $preparedSubscribers) {
+  private function processSoftError(MailerError $error, ScheduledTaskEntity $task, $preparedSubscribersIds, $preparedSubscribers) {
     foreach ($error->getSubscriberErrors() as $subscriberError) {
       $subscriberIdIndex = array_search($subscriberError->getEmail(), $preparedSubscribers);
       $message = $subscriberError->getMessage() ?: $error->getMessage();
-      $sendingTask->saveSubscriberError($preparedSubscribersIds[$subscriberIdIndex], $message);
+      $this->scheduledTaskSubscribersRepository->saveError($task, $preparedSubscribersIds[$subscriberIdIndex], $message ?? '');
     }
   }
 }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -277,7 +277,7 @@ class SendingQueue {
         );
         $legacyQueue->removeSubscribers($subscribersToRemove);
         if (!$legacyQueue->countToProcess) {
-          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $legacyQueue);
+          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $task);
           continue;
         }
         // if there aren't any subscribers to process in batch (e.g. all unsubscribed or were deleted) continue with next batch
@@ -317,7 +317,7 @@ class SendingQueue {
             'completed newsletter sending',
             ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]
           );
-          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $legacyQueue);
+          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $task);
           $this->statsNotificationsScheduler->schedule($newsletterEntity);
         }
         $this->enforceSendingAndExecutionLimits($timer);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -376,7 +376,7 @@ class SendingQueue {
         $this->newsletterTask->prepareNewsletterForSending(
           $newsletterEntity,
           $subscriberEntity,
-          $legacyQueue
+          $sendingQueueEntity
         );
       // format subscriber name/address according to mailer settings
       $preparedSubscribers[] = $this->mailerTask->prepareSubscriberForSending(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -176,7 +176,7 @@ class SendingQueue {
 
     $this->deleteTaskIfNewsletterDoesNotExist($task);
 
-    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($legacyQueue);
+    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($task);
     if (!$newsletterEntity) {
       return;
     }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -507,11 +507,7 @@ class SendingQueue {
     // log error message and schedule retry/pause sending
     if ($sendResult['response'] === false) {
       $error = $sendResult['error'];
-      $legacyTask = ScheduledTask::findOne($task->getId());
-      $legacyQueue = $legacyTask ? SendingTask::createFromScheduledTask($legacyTask) : null;
-      if ($legacyQueue) {
-        $this->errorHandler->processError($error, $legacyQueue, $preparedSubscribersIds, $preparedSubscribers);
-      }
+      $this->errorHandler->processError($error, $task, $preparedSubscribersIds, $preparedSubscribers);
     } else {
       $queue = $task->getSendingQueue();
       if (!$queue) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -559,7 +559,7 @@ class SendingQueue {
   }
 
   private function stopProgress(ScheduledTaskEntity $task): void {
-    $task->setInProgress(true);
+    $task->setInProgress(false);
     $this->scheduledTasksRepository->flush();
   }
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -182,7 +182,7 @@ class SendingQueue {
     }
 
     // pre-process newsletter (render, replace shortcodes/links, etc.)
-    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $legacyQueue);
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $task);
 
     if (!$newsletterEntity) {
       $this->deleteTask($task);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -5,6 +5,7 @@ namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Router\Endpoints\Track;
@@ -39,8 +40,8 @@ class Links {
     $this->trackingConfig = $trackingConfig;
   }
 
-  public function process($renderedNewsletter, NewsletterEntity $newsletter, $queue) {
-    [$renderedNewsletter, $links] = $this->hashAndReplaceLinks($renderedNewsletter, $newsletter->getId(), $queue->id);
+  public function process($renderedNewsletter, NewsletterEntity $newsletter, SendingQueueEntity $queue) {
+    [$renderedNewsletter, $links] = $this->hashAndReplaceLinks($renderedNewsletter, $newsletter->getId(), $queue->getId());
     $this->saveLinks($links, $newsletter, $queue);
     return $renderedNewsletter;
   }
@@ -59,8 +60,8 @@ class Links {
     ];
   }
 
-  public function saveLinks($links, NewsletterEntity $newsletter, $queue) {
-    return $this->newsletterLinks->save($links, $newsletter->getId(), $queue->id);
+  public function saveLinks($links, NewsletterEntity $newsletter, SendingQueueEntity $queue) {
+    return $this->newsletterLinks->save($links, $newsletter->getId(), $queue->getId());
   }
 
   public function getUnsubscribeUrl($queueId, SubscriberEntity $subscriber = null) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -134,17 +134,18 @@ class Newsletter {
     return $newsletter;
   }
 
-  public function preProcessNewsletter(NewsletterEntity $newsletter, Sending $sendingTask) {
+  public function preProcessNewsletter(NewsletterEntity $newsletter, ScheduledTaskEntity $task) {
     // return the newsletter if it was previously rendered
-    /** @phpstan-ignore-next-line - SendingQueue::getNewsletterRenderedBody() is called inside Sending using __call(). Sending will be refactored soon to stop using Paris models. */
-    if (!is_null($sendingTask->getNewsletterRenderedBody())) {
-      return (!$sendingTask->validate()) ?
-        $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-RENDER', $sendingTask->id)) :
-        $newsletter;
+    $queue = $task->getSendingQueue();
+    if (!$queue) {
+      return false;
+    }
+    if ($queue->getNewsletterRenderedBody() !== null) {
+      return $newsletter;
     }
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
       'pre-processing newsletter',
-      ['newsletter_id' => $newsletter->getId(), 'task_id' => $sendingTask->taskId]
+      ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
     );
 
     $campaignId = null;
@@ -154,7 +155,7 @@ class Newsletter {
       // hook to the newsletter post-processing filter and add tracking image
       $this->trackingImageInserted = OpenTracking::addTrackingImage();
       // render newsletter
-      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask->getSendingQueueEntity());
+      $renderedNewsletter = $this->renderer->render($newsletter, $queue);
       $renderedNewsletter = $this->wp->applyFilters(
         'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
@@ -165,10 +166,10 @@ class Newsletter {
       }
       $renderedNewsletter = $this->gaTracking->applyGATracking($renderedNewsletter, $newsletter);
       // hash and save all links
-      $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletter, $sendingTask);
+      $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletter, $queue);
     } else {
       // render newsletter
-      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask->getSendingQueueEntity());
+      $renderedNewsletter = $this->renderer->render($newsletter, $queue);
       $renderedNewsletter = $this->wp->applyFilters(
         'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
@@ -188,7 +189,7 @@ class Newsletter {
       // delete notification history record since it will never be sent
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
         'no posts in post notification, deleting it',
-        ['newsletter_id' => $newsletter->getId(), 'task_id' => $sendingTask->taskId]
+        ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
       );
       $this->newslettersRepository->bulkDelete([(int)$newsletter->getId()]);
       return false;
@@ -196,43 +197,41 @@ class Newsletter {
     // extract and save newsletter posts
     $this->postsTask->extractAndSave($renderedNewsletter, $newsletter);
 
-    $sendingQueueEntity = $sendingTask->getSendingQueueEntity();
-
     if ($campaignId !== null) {
-      $this->sendingQueuesRepository->saveCampaignId($sendingQueueEntity, $campaignId);
+      $this->sendingQueuesRepository->saveCampaignId($queue, $campaignId);
     }
 
     $filterSegmentId = $newsletter->getFilterSegmentId();
     if ($filterSegmentId) {
       $filterSegment = $this->segmentsRepository->findOneById($filterSegmentId);
       if ($filterSegment instanceof SegmentEntity && $filterSegment->getType() === SegmentEntity::TYPE_DYNAMIC) {
-        $this->sendingQueuesRepository->saveFilterSegmentMeta($sendingQueueEntity, $filterSegment);
+        $this->sendingQueuesRepository->saveFilterSegmentMeta($queue, $filterSegment);
       }
     }
 
     // update queue with the rendered and pre-processed newsletter
-    $sendingTask->newsletterRenderedSubject = ShortcodesTask::process(
-      $newsletter->getSubject(),
-      $renderedNewsletter['html'],
-      $newsletter,
-      null,
-      $sendingQueueEntity
+    $queue->setNewsletterRenderedSubject(
+      ShortcodesTask::process(
+        $newsletter->getSubject(),
+        $renderedNewsletter['html'],
+        $newsletter,
+        null,
+        $queue
+      )
     );
 
     // if the rendered subject is empty, use a default subject,
     // having no subject in a newsletter is considered spammy
-    if (empty(trim((string)$sendingTask->newsletterRenderedSubject))) {
-      $sendingTask->newsletterRenderedSubject = __('No subject', 'mailpoet');
+    if (empty(trim((string)$queue->getNewsletterRenderedSubject()))) {
+      $queue->setNewsletterRenderedSubject(__('No subject', 'mailpoet'));
     }
     $renderedNewsletter = $this->emoji->encodeEmojisInBody($renderedNewsletter);
-    $sendingTask->newsletterRenderedBody = $renderedNewsletter;
-    $sendingTask->save();
+    $queue->setNewsletterRenderedBody($renderedNewsletter);
 
-    // catch DB errors
-    $queueErrors = $sendingTask->getErrors();
-
-    if ($queueErrors) {
-      $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-SAVE', $sendingTask->id));
+    try {
+      $this->sendingQueuesRepository->flush();
+    } catch (\Throwable $e) {
+      $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-SAVE', $queue->getId()));
     }
     return $newsletter;
   }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -27,7 +27,6 @@ use MailPoet\Util\pQuery\DomNode;
 use MailPoet\Util\pQuery\pQuery;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Carbon\Carbon;
 
 class Newsletter {
   public $trackingEnabled;
@@ -279,15 +278,14 @@ class Newsletter {
     ];
   }
 
-  public function markNewsletterAsSent(NewsletterEntity $newsletter, Sending $sendingTask) {
+  public function markNewsletterAsSent(NewsletterEntity $newsletter, ScheduledTaskEntity $task) {
     // if it's a standard or notification history newsletter, update its status
     if (
       $newsletter->getType() === NewsletterEntity::TYPE_STANDARD ||
        $newsletter->getType() === NewsletterEntity::TYPE_NOTIFICATION_HISTORY
     ) {
-      $scheduledTask = $sendingTask->task();
       $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
-      $newsletter->setSentAt(new Carbon($scheduledTask->processedAt));
+      $newsletter->setSentAt($task->getProcessedAt());
       $this->newslettersRepository->persist($newsletter);
       $this->newslettersRepository->flush();
     }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -9,7 +9,6 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
@@ -104,10 +103,10 @@ class Newsletter {
     $this->scheduledTasksRepository = ContainerWrapper::getInstance()->get(ScheduledTasksRepository::class);
   }
 
-  public function getNewsletterFromQueue(Sending $sendingTask): ?NewsletterEntity {
+  public function getNewsletterFromQueue(ScheduledTaskEntity $task): ?NewsletterEntity {
     // get existing active or sending newsletter
-    $sendingQueue = $sendingTask->getSendingQueueEntity();
-    $newsletter = $sendingQueue->getNewsletter();
+    $queue = $task->getSendingQueue();
+    $newsletter = $queue ? $queue->getNewsletter() : null;
 
     if (
       is_null($newsletter)
@@ -115,7 +114,7 @@ class Newsletter {
       || !in_array($newsletter->getStatus(), [NewsletterEntity::STATUS_ACTIVE, NewsletterEntity::STATUS_SENDING])
       || $newsletter->getStatus() === NewsletterEntity::STATUS_CORRUPT
     ) {
-      $this->recoverFromInvalidState($newsletter, $sendingQueue);
+      $this->recoverFromInvalidState($task);
       return null;
     }
 
@@ -337,28 +336,23 @@ class Newsletter {
 
   /**
    * This method recovers the scheduled task and newsletter from a state when sending cannot proceed.
-   * @param NewsletterEntity|null $newsletter
-   * @param SendingQueueEntity $sendingQueue
-   * @return void
    */
-  private function recoverFromInvalidState(?NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue): void {
+  private function recoverFromInvalidState(ScheduledTaskEntity $task): void {
     // When newsletter does not exist, we need to remove the scheduled task and sending queue.
-    $scheduledTask = $sendingQueue->getTask();
+    $queue = $task->getSendingQueue();
+    $newsletter = $queue ? $queue->getNewsletter() : null;
     if (!$newsletter) {
-      if ($scheduledTask) {
-        $this->scheduledTasksRepository->remove($scheduledTask);
+      $this->scheduledTasksRepository->remove($task);
+      if ($queue) {
+        $this->sendingQueuesRepository->remove($queue);
       }
-      $this->sendingQueuesRepository->remove($sendingQueue);
       $this->sendingQueuesRepository->flush();
-
       return;
     }
 
     // Only deleted newsletter or newsletter with unexpected state should pass here.
     // Because this state cannot proceed with sending, we need to pause the scheduled task.
-    if ($scheduledTask) {
-      $scheduledTask->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
-      $this->scheduledTasksRepository->flush();
-    }
+    $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+    $this->scheduledTasksRepository->flush();
   }
 }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -9,6 +9,7 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
@@ -21,7 +22,6 @@ use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\GATracking;
-use MailPoet\Tasks\Sending;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\pQuery\DomNode;
 use MailPoet\Util\pQuery\pQuery;
@@ -239,31 +239,28 @@ class Newsletter {
    * Shortcodes and links will be replaced in the subject, html and text body
    * to speed the processing, join content into a continuous string.
    */
-  public function prepareNewsletterForSending(NewsletterEntity $newsletter, SubscriberEntity $subscriber, Sending $sendingTask): array {
-    $sendingQueue = $sendingTask->queue();
-    $renderedNewsletter = $sendingQueue->getNewsletterRenderedBody();
+  public function prepareNewsletterForSending(NewsletterEntity $newsletter, SubscriberEntity $subscriber, SendingQueueEntity $queue): array {
+    $renderedNewsletter = $queue->getNewsletterRenderedBody();
     $renderedNewsletter = $this->emoji->decodeEmojisInBody($renderedNewsletter);
     $preparedNewsletter = Helpers::joinObject(
       [
-        $sendingTask->newsletterRenderedSubject,
+        $queue->getNewsletterRenderedSubject(),
         $renderedNewsletter['html'],
         $renderedNewsletter['text'],
       ]
     );
-
-    $sendingQueueEntity = $sendingTask->getSendingQueueEntity();
 
     $preparedNewsletter = ShortcodesTask::process(
       $preparedNewsletter,
       null,
       $newsletter,
       $subscriber,
-      $sendingQueueEntity
+      $queue
     );
     if ($this->trackingEnabled) {
       $preparedNewsletter = $this->newsletterLinks->replaceSubscriberData(
         $subscriber->getId(),
-        $sendingTask->id,
+        $queue->getId(),
         $preparedNewsletter
       );
     }

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -154,7 +154,7 @@ class NewsletterSaveController {
     }
 
     $this->rescheduleIfNeeded($newsletter, $newsletterModel);
-    $this->updateQueue($newsletter, $newsletterModel, $data['options'] ?? []);
+    $this->updateQueue($newsletter, $data['options'] ?? []);
     $this->authorizedEmailsController->onNewsletterSenderAddressUpdate($newsletter, $oldSenderAddress);
     return $newsletter;
   }
@@ -406,7 +406,7 @@ class NewsletterSaveController {
     }
   }
 
-  private function updateQueue(NewsletterEntity $newsletter, Newsletter $newsletterModel, array $options) {
+  private function updateQueue(NewsletterEntity $newsletter, array $options) {
     if ($newsletter->getType() !== NewsletterEntity::TYPE_STANDARD) {
       return;
     }
@@ -421,15 +421,18 @@ class NewsletterSaveController {
       $this->entityManager->remove($queue);
       $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
     } else {
-      $queueModel = $newsletterModel->getQueue();
-      $queueModel->newsletterRenderedSubject = null;
-      $queueModel->newsletterRenderedBody = null;
+      $queue->setNewsletterRenderedSubject(null);
+      $queue->setNewsletterRenderedBody(null);
+      $this->entityManager->persist($queue);
 
       $newsletterQueueTask = new NewsletterQueueTask();
-      $newsletterQueueTask->preProcessNewsletter($newsletter, $queueModel);
+      $task = $queue->getTask();
 
-      // 'preProcessNewsletter' modifies queue by old model - let's reload it
-      $this->entityManager->refresh($queue);
+      if (!$task instanceof ScheduledTaskEntity) {
+        throw new InvalidStateException();
+      }
+
+      $newsletterQueueTask->preProcessNewsletter($newsletter, $task);
     }
     $this->entityManager->flush();
   }

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -263,13 +263,6 @@ class Sending {
     $this->updateCount();
   }
 
-  public function removeSubscribers(array $subscriberIds) {
-    $this->scheduledTaskSubscribersRepository->deleteByScheduledTaskAndSubscriberIds($this->scheduledTaskEntity, $subscriberIds);
-
-    $this->updateTaskStatus();
-    $this->updateCount();
-  }
-
   public function updateProcessedSubscribers(array $processedSubscribers): bool {
     $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($this->scheduledTaskEntity, $processedSubscribers);
     $this->scheduledTasksRepository->refresh($this->scheduledTaskEntity); // needed while Sending still uses Paris

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -6,7 +6,6 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueAlias;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Models\ScheduledTask;
@@ -221,16 +220,6 @@ class Sending {
 
   public function queue() {
     return $this->queue;
-  }
-
-  public function getSendingQueueEntity(): SendingQueueEntity {
-    $sendingQueueEntity = $this->sendingQueuesRepository->findOneById($this->queue->id);
-    if (!$sendingQueueEntity) {
-      throw new InvalidStateException();
-    }
-    $this->sendingQueuesRepository->refresh($sendingQueueEntity);
-
-    return $sendingQueueEntity;
   }
 
   public function task() {

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -277,23 +277,6 @@ class Sending {
     return $this->updateCount(count($processedSubscribers))->getErrors() === false;
   }
 
-  public function saveSubscriberError($subcriberId, $errorMessage) {
-    $this->scheduledTaskSubscribersRepository->saveError($this->scheduledTaskEntity, $subcriberId, $errorMessage);
-
-    $this->updateTaskStatus();
-
-    return $this->updateCount()->getErrors() === false;
-  }
-
-  private function updateTaskStatus() {
-    // we need to update those fields here as the Sending class is in a mixed state using Paris and Doctrine at the same time
-    // this probably won't be necessary anymore once https://mailpoet.atlassian.net/browse/MAILPOET-4375 is finished
-    $this->task->status = $this->scheduledTaskEntity->getStatus();
-    if (!is_null($this->scheduledTaskEntity->getProcessedAt())) {
-      $this->task->processedAt = $this->scheduledTaskEntity->getProcessedAt()->format('Y-m-d H:i:s');
-    }
-  }
-
   public function updateCount(?int $count = null) {
     if ($count) {
       // increment/decrement counts based on known subscriber count, don't exceed the bounds

--- a/mailpoet/tests/DataFactories/SendingQueue.php
+++ b/mailpoet/tests/DataFactories/SendingQueue.php
@@ -34,6 +34,7 @@ class SendingQueue {
 
     $this->entityManager->persist($queue);
     $this->entityManager->flush();
+    $this->entityManager->refresh($task);
 
     return $queue;
   }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -125,8 +125,8 @@ class SendingQueueTest extends \MailPoetTest {
     $this->subscriberSegment->segmentId = (int)$this->segment->id;
     $this->subscriberSegment->save();
     $this->newsletter = Newsletter::create();
-    $this->newsletter->type = Newsletter::TYPE_STANDARD;
-    $this->newsletter->status = Newsletter::STATUS_ACTIVE;
+    $this->newsletter->type = NewsletterEntity::TYPE_STANDARD;
+    $this->newsletter->status = NewsletterEntity::STATUS_ACTIVE;
     $this->newsletter->subject = Fixtures::get('newsletter_subject_template');
     $this->newsletter->body = Fixtures::get('newsletter_body_template');
     $this->newsletter->save();
@@ -456,7 +456,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
 
     // queue status is set to completed
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -590,7 +590,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
 
     // queue status is set to completed
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -647,7 +647,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent and sent_at date is populated
     $updatedNewsletter = $this->newslettersRepository->findOneById($this->newsletter->id);
     $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
-    verify($updatedNewsletter->getStatus())->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     verify($updatedNewsletter->getSentAt())->equalsWithDelta($scheduledTask->getProcessedAt(), 1);
 
     // queue subscriber processed/to process count is updated
@@ -761,7 +761,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->queue->updated_at = $originalUpdated;
     $this->queue->save();
 
-    $this->newsletter->type = Newsletter::TYPE_WELCOME;
+    $this->newsletter->type = NewsletterEntity::TYPE_WELCOME;
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
@@ -775,7 +775,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItCanProcessWelcomeNewsletters() {
-    $this->newsletter->type = Newsletter::TYPE_WELCOME;
+    $this->newsletter->type = NewsletterEntity::TYPE_WELCOME;
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
@@ -798,7 +798,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
 
     // queue status is set to completed
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -827,8 +827,8 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItPreventsSendingWelcomeEmailWhenSubscriberIsUnsubscribed() {
-    $this->newsletter->type = Newsletter::TYPE_WELCOME;
-    $this->subscriber->setStatus(Subscriber::STATUS_UNSUBSCRIBED);
+    $this->newsletter->type = NewsletterEntity::TYPE_WELCOME;
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
     $this->newsletterSegment->delete();
     $this->entityManager->refresh($this->sendingQueueEntity);
@@ -1082,7 +1082,7 @@ class SendingQueueTest extends \MailPoetTest {
 
     // newsletter is not sent to globally unsubscribed subscriber
     $subscriber = $this->subscriber;
-    $subscriber->setStatus(Subscriber::STATUS_UNSUBSCRIBED);
+    $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
     $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
@@ -1103,7 +1103,7 @@ class SendingQueueTest extends \MailPoetTest {
 
     // newsletter is not sent to subscriber unsubscribed from segment
     $subscriberSegment = $this->subscriberSegment;
-    $subscriberSegment->status = Subscriber::STATUS_UNSUBSCRIBED;
+    $subscriberSegment->status = SubscriberEntity::STATUS_UNSUBSCRIBED;
     $subscriberSegment->save();
     $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
@@ -1124,7 +1124,7 @@ class SendingQueueTest extends \MailPoetTest {
 
     // newsletter is not sent to inactive subscriber
     $subscriber = $this->subscriber;
-    $subscriber->setStatus(Subscriber::STATUS_INACTIVE);
+    $subscriber->setStatus(SubscriberEntity::STATUS_INACTIVE);
     $this->entityManager->flush();
     $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
@@ -1205,7 +1205,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter is sent and hash remains intact
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
     verify($updatedNewsletter->hash)->equals($this->newsletter->hash);
   }
 
@@ -1418,7 +1418,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriber->setEmail($email);
     $subscriber->setFirstName($firstName);
     $subscriber->setLastName($lastName);
-    $subscriber->setStatus(Subscriber::STATUS_SUBSCRIBED);
+    $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
     $subscriber->setSource('administrator');
     $this->entityManager->persist($subscriber);
     $this->entityManager->flush();

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -102,6 +102,12 @@ class SendingQueueTest extends \MailPoetTest {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskEntity */
+  private $scheduledTaskEntity;
+
+  /** @var SendingQueueEntity */
+  private $sendingQueueEntity;
+
   public function _before() {
     parent::_before();
     $wpUsers = get_users();
@@ -162,6 +168,15 @@ class SendingQueueTest extends \MailPoetTest {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->sendingQueueWorker = $this->getSendingQueueWorker();
+
+    $scheduledTaskEntity = $this->scheduledTasksRepository->findOneById($this->queue->taskId);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTaskEntity);
+    $this->scheduledTaskEntity = $scheduledTaskEntity;
+
+    $sendingQueueEntity = $this->sendingQueuesRepository->findOneById($this->queue->id);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueueEntity);
+    $this->sendingQueueEntity = $sendingQueueEntity;
+    $this->entityManager->refresh($this->sendingQueueEntity);
   }
 
   private function getDirectUnsubscribeURL() {
@@ -259,7 +274,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->entityManager
     );
     $sendingQueueWorker->sendNewsletters(
-      $this->queue,
+      $this->scheduledTaskEntity,
       $preparedSubscribers = [],
       $preparedNewsletters = [],
       $preparedSubscribers = [],
@@ -279,6 +294,7 @@ class SendingQueueTest extends \MailPoetTest {
     $queue = $this->queue;
     $queue->status = SendingQueue::STATUS_COMPLETED;
     $queue->save();
+    $this->entityManager->refresh($this->scheduledTaskEntity);
     $sendingQueueWorker = $this->make(
       $this->getSendingQueueWorker(),
       [
@@ -308,7 +324,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->entityManager
     );
     $sendingQueueWorker->sendNewsletters(
-      $queue,
+      $this->scheduledTaskEntity,
       $preparedSubscribers = [],
       $preparedNewsletters = [],
       $preparedSubscribers = [],
@@ -502,6 +518,12 @@ class SendingQueueTest extends \MailPoetTest {
     $queue->newsletterRenderedBody = ['html' => '<p>Hello [subscriber:email]</p>', 'text' => 'Hello [subscriber:email]'];
     $queue->newsletterRenderedSubject = 'News for [subscriber:email]';
     $queue->setSubscribers($subscriberIds);
+    $queue->save();
+    $scheduledTaskEntity = $this->scheduledTasksRepository->findOneById($queue->taskId);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTaskEntity);
+    $queueEntity = $scheduledTaskEntity->getSendingQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queueEntity);
+    $this->entityManager->refresh($queueEntity);
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
 
     $newsletter = $this->newsletter;
@@ -539,7 +561,7 @@ class SendingQueueTest extends \MailPoetTest {
       Subscriber::findOne($subscriber2->getId()),
     ];
 
-    $sendingQueueWorker->processQueue($queue, $newsletter, $subscribersModels, $timer);
+    $sendingQueueWorker->processQueue($scheduledTaskEntity, $newsletter, $subscribersModels, $timer);
   }
 
   public function testItCanProcessSubscribersInBulk() {
@@ -690,8 +712,13 @@ class SendingQueueTest extends \MailPoetTest {
       $this->entityManager
     );
 
+    $sendingQueue = $this->sendingQueuesRepository->findOneById($queue->id);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
+    $scheduledTask = $this->scheduledTasksRepository->findOneBySendingQueue($sendingQueue);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+
     $sendingQueueWorker->sendNewsletters(
-      $queue,
+      $scheduledTask,
       [$this->subscriber->getId(), $wrongSubscriber->getId()],
       [],
       [$this->subscriber->getEmail(), $wrongSubscriber->getEmail()],
@@ -699,11 +726,7 @@ class SendingQueueTest extends \MailPoetTest {
       microtime(true)
     );
 
-    // load queue and compare data after first sending
-    $sendingQueue = $this->sendingQueuesRepository->findOneById($queue->id);
-    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
-    $scheduledTask = $this->scheduledTasksRepository->findOneBySendingQueue($sendingQueue);
-    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    // compare data after first sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))->equals([$this->subscriber]);
@@ -713,7 +736,7 @@ class SendingQueueTest extends \MailPoetTest {
     verify($sendingQueue->getCountToProcess())->equals(1);
 
     $sendingQueueWorker->sendNewsletters(
-      $queue,
+      $scheduledTask,
       [$this->subscriber->getId()],
       [],
       [$this->subscriber->getEmail()],
@@ -808,6 +831,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->subscriber->setStatus(Subscriber::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
     $this->newsletterSegment->delete();
+    $this->entityManager->refresh($this->sendingQueueEntity);
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
       $this->construct(
@@ -844,6 +868,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->subscriber->getId(), // subscriber that should be processed
       $unsubscribedSubscriber->getId(), // subscriber that should be skipped
     ]);
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker = $this->getSendingQueueWorker(
       $this->construct(
         MailerTask::class,
@@ -881,6 +906,7 @@ class SendingQueueTest extends \MailPoetTest {
     ]);
     $queue->countTotal = 2;
     $queue->save();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker = $this->sendingQueueWorker;
     $sendingQueueWorker->mailerTask = $this->construct(
       MailerTask::class,
@@ -923,6 +949,7 @@ class SendingQueueTest extends \MailPoetTest {
     $queue->setSubscribers($subscribers);
     $queue->countTotal = count($subscribers);
     $queue->save();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker = $this->sendingQueueWorker;
     $sendingQueueWorker->mailerTask = $this->construct(
       MailerTask::class,
@@ -959,6 +986,7 @@ class SendingQueueTest extends \MailPoetTest {
     ]);
     $queue->countTotal = 2;
     $queue->save();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker = $this->sendingQueueWorker;
     $sendingQueueWorker->mailerTask = $this->construct(
       MailerTask::class,
@@ -995,6 +1023,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriber = $this->subscriber;
     $subscriber->setDeletedAt(Carbon::now());
     $this->entityManager->flush();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
 
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -1021,6 +1050,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriber = $this->subscriber;
     $subscriber->setStatus($subscriberStatus);
     $this->entityManager->flush();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
 
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -1054,6 +1084,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriber = $this->subscriber;
     $subscriber->setStatus(Subscriber::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
 
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -1074,6 +1105,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriberSegment = $this->subscriberSegment;
     $subscriberSegment->status = Subscriber::STATUS_UNSUBSCRIBED;
     $subscriberSegment->save();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
 
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -1094,6 +1126,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriber = $this->subscriber;
     $subscriber->setStatus(Subscriber::STATUS_INACTIVE);
     $this->entityManager->flush();
+    $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
 
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -1103,14 +1136,10 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItPausesSendingWhenProcessedSubscriberListCannotBeUpdated() {
-    $sendingTask = $this->createMock(SendingTask::class);
-    $sendingTask
+    $scheduledTaskSubscribersRepository = $this->createMock(ScheduledTaskSubscribersRepository::class);
+    $scheduledTaskSubscribersRepository
       ->method('updateProcessedSubscribers')
-      ->will($this->returnValue(false));
-    $sendingTask
-      ->method('__get')
-      ->with('id')
-      ->will($this->returnValue(100));
+      ->willThrowException(new \Exception());
     $sendingQueueWorker = $this->make(
       $this->getSendingQueueWorker()
     );
@@ -1126,7 +1155,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
-      $this->scheduledTaskSubscribersRepository,
+      $scheduledTaskSubscribersRepository,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -1140,7 +1169,7 @@ class SendingQueueTest extends \MailPoetTest {
     );
     try {
       $sendingQueueWorker->sendNewsletters(
-        $sendingTask,
+        $this->scheduledTaskEntity,
         $preparedSubscribers = [],
         $preparedNewsletters = [],
         $preparedSubscribers = [],
@@ -1156,7 +1185,7 @@ class SendingQueueTest extends \MailPoetTest {
     verify($mailerLog['error'])->equals(
       [
         'operation' => 'processed_list_update',
-        'error_message' => 'QUEUE-100-PROCESSED-LIST-UPDATE',
+        'error_message' => "QUEUE-{$this->sendingQueueEntity->getId()}-PROCESSED-LIST-UPDATE",
       ]
     );
   }
@@ -1426,6 +1455,7 @@ class SendingQueueTest extends \MailPoetTest {
     $newsletter->getQueues()->add($queue);
 
     $this->entityManager->flush();
+    $this->entityManager->refresh($queue); // I'm not sure why calling refresh() here is needed and why the tests fail without it (calling $task->getSendingQueue() returns null)
     return $queue;
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1259,7 +1259,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItPauseSendingTaskThatHasTrashedSegment() {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, 'Subject With Trashed', NewsletterEntity::STATUS_SENDING);
-    $queue = $this->createQueueWithTaskAndSegment($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
+    $queue = $this->createQueueWithTask($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
     $segment = $this->createSegment('Segment test', SegmentEntity::TYPE_DEFAULT);
     $segment->setDeletedAt(new \DateTime());
     $this->entityManager->flush();
@@ -1279,7 +1279,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItPauseSendingTaskThatHasDeletedSegment() {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, 'Subject With Deleted', NewsletterEntity::STATUS_SENDING);
-    $queue = $this->createQueueWithTaskAndSegment($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
+    $queue = $this->createQueueWithTask($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
     $segment = $this->createSegment('Segment test', SegmentEntity::TYPE_DEFAULT);
     $this->addSegmentToNewsletter($newsletter, $segment);
     $this->entityManager->createQueryBuilder()->delete(SegmentEntity::class, 's')
@@ -1384,7 +1384,7 @@ class SendingQueueTest extends \MailPoetTest {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, 'Subject With Deleted', NewsletterEntity::STATUS_SENDING);
     [$segment, $subscriber] = $this->createListWithSubscriber();
     $this->addSegmentToNewsletter($newsletter, $segment);
-    $queue = $this->createQueueWithTaskAndSegment($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
+    $queue = $this->createQueueWithTask($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
     $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->persist($subscriber);
     $this->entityManager->flush();
@@ -1436,7 +1436,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  private function createQueueWithTaskAndSegment(NewsletterEntity $newsletter, $status = null, $body = null): SendingQueueEntity {
+  private function createQueueWithTask(NewsletterEntity $newsletter, $status = null, $body = null): SendingQueueEntity {
     $task = new ScheduledTaskEntity();
     $task->setType(SendingQueueWorker::TASK_TYPE);
     $task->setStatus($status);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -39,6 +39,7 @@ use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Router\Router;
@@ -98,6 +99,9 @@ class SendingQueueTest extends \MailPoetTest {
   /** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
 
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   public function _before() {
     parent::_before();
     $wpUsers = get_users();
@@ -154,6 +158,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->tasksLinks = $this->diContainer->get(TasksLinks::class);
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->sendingQueueWorker = $this->getSendingQueueWorker();
@@ -210,6 +215,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,
@@ -241,6 +247,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -289,6 +296,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -335,6 +343,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,
@@ -669,6 +678,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -1116,6 +1126,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -1431,6 +1442,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $mailerMock ?? $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -19,6 +19,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -30,7 +31,6 @@ use MailPoet\Mailer\SubscriberError;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterSegment;
 use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsNewsletters;
@@ -468,9 +468,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueue::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->arrayCount(0);
-    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -602,9 +602,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueue::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->arrayCount(0);
-    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -651,9 +651,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($updatedNewsletter->getSentAt())->equalsWithDelta($scheduledTask->getProcessedAt(), 1);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->arrayCount(0);
-    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -729,8 +729,8 @@ class SendingQueueTest extends \MailPoetTest {
     // compare data after first sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))->equals([$this->subscriber]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))->equals([$wrongSubscriber]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))->equals([$this->subscriber]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))->equals([$wrongSubscriber]);
     verify($sendingQueue->getCountTotal())->equals(2);
     verify($sendingQueue->getCountProcessed())->equals(1);
     verify($sendingQueue->getCountToProcess())->equals(1);
@@ -747,8 +747,8 @@ class SendingQueueTest extends \MailPoetTest {
     // load queue and compare data after second sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))->equals([$this->subscriber, $wrongSubscriber]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))->equals([]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))->equals([$this->subscriber, $wrongSubscriber]);
     verify($sendingQueue->getCountTotal())->equals(2);
     verify($sendingQueue->getCountProcessed())->equals(2);
     verify($sendingQueue->getCountToProcess())->equals(0);
@@ -810,9 +810,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueue::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -852,7 +852,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
 
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([]);
     verify($sendingQueue->getCountTotal())->equals(0);
     verify($sendingQueue->getCountProcessed())->equals(0);
@@ -891,7 +891,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->scheduledTasksRepository->refresh($scheduledTask);
 
     // Unprocessable subscribers were removed
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]); // subscriber that should be processed
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -926,9 +926,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -969,9 +969,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -1002,9 +1002,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([]);
     verify($sendingQueue->getCountTotal())->equals(0);
     verify($sendingQueue->getCountProcessed())->equals(0);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -7,6 +7,7 @@ use Codeception\Stub\Expected;
 use Codeception\Util\Fixtures;
 use MailPoet\Config\Populator;
 use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\Workers\Bounce;
 use MailPoet\Cron\Workers\SendingQueue\SendingErrorHandler;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Cron\Workers\SendingQueue\SendingThrottlingHandler;
@@ -30,7 +31,6 @@ use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\SubscriberError;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterSegment;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsNewsletters;
@@ -51,6 +51,7 @@ use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\SubscriptionUrlFactory;
 use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\Security;
@@ -769,9 +770,9 @@ class SendingQueueTest extends \MailPoetTest {
     );
     $sendingQueueWorker->process();
 
-    $newQueue = ScheduledTask::findOne($this->queue->task_id);
-    $this->assertInstanceOf(ScheduledTask::class, $newQueue);
-    verify($newQueue->updatedAt)->notEquals($originalUpdated);
+    $newScheduledTask = $this->scheduledTasksRepository->findOneById($this->queue->task_id);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $newScheduledTask);
+    verify($newScheduledTask->getUpdatedAt())->notEquals($originalUpdated);
   }
 
   public function testItCanProcessWelcomeNewsletters() {
@@ -1222,11 +1223,11 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItReschedulesBounceTaskWhenPlannedInFarFuture() {
-    $task = ScheduledTask::createOrUpdate([
-      'type' => 'bounce',
-      'status' => ScheduledTask::STATUS_SCHEDULED,
-      'scheduled_at' => Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->addMonths(1),
-    ]);
+    $task = (new ScheduledTaskFactory())->create(
+      Bounce::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->addMonths(1)
+    );
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
       $this->construct(MailerTask::class, [$this->diContainer->get(MailerFactory::class)], [
@@ -1235,18 +1236,16 @@ class SendingQueueTest extends \MailPoetTest {
     );
     $sendingQueueWorker->process();
 
-    $refetchedTask = ScheduledTask::where('id', $task->id)->findOne();
-    $this->assertInstanceOf(ScheduledTask::class, $refetchedTask); // PHPStan
-    verify($refetchedTask->scheduledAt)->lessThan(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->addHours(42));
+    verify($task->getScheduledAt())->lessThan(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->addHours(42));
   }
 
-  public function testDoesNoRescheduleBounceTaskWhenPlannedInNearFuture() {
+  public function testDoesNotRescheduleBounceTaskWhenPlannedInNearFuture() {
     $inOneHour = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp'))->addHours(1);
-    $task = ScheduledTask::createOrUpdate([
-      'type' => 'bounce',
-      'status' => ScheduledTask::STATUS_SCHEDULED,
-      'scheduled_at' => $inOneHour,
-    ]);
+    $task = (new ScheduledTaskFactory())->create(
+      Bounce::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      $inOneHour
+    );
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
       $this->construct(MailerTask::class, [$this->diContainer->get(MailerFactory::class)], [
@@ -1255,9 +1254,7 @@ class SendingQueueTest extends \MailPoetTest {
     );
     $sendingQueueWorker->process();
 
-    $refetchedTask = ScheduledTask::where('id', $task->id)->findOne();
-    $this->assertInstanceOf(ScheduledTask::class, $refetchedTask); // PHPStan
-    verify($refetchedTask->scheduledAt)->equals($inOneHour);
+    verify($task->getScheduledAt())->equals($inOneHour);
   }
 
   public function testItPauseSendingTaskThatHasTrashedSegment() {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -894,6 +894,45 @@ class SendingQueueTest extends \MailPoetTest {
     verify(count($statistics))->equals(1);
   }
 
+  public function testItRemovesSubscribersFromProcessingListWhenNewsletterHasNoSegment() {
+    $this->newsletterEntity->getNewsletterSegments()->clear();
+    $invalidSubscriberId = 99999;
+
+    $this->scheduledTaskSubscribersRepository->setSubscribers(
+      $this->scheduledTask,
+      [$this->subscriber->getId(), $invalidSubscriberId]
+    );
+
+    $sendingQueueWorker = $this->sendingQueueWorker;
+    $sendingQueueWorker->mailerTask = $this->construct(
+      MailerTask::class,
+      [$this->diContainer->get(MailerFactory::class)],
+      [
+        'send' => Expected::exactly(1, function() {
+          return $this->mailerTaskDummyResponse;
+        }),
+      ]
+    );
+    $sendingQueueWorker->process();
+
+    $scheduledTask = $this->scheduledTasksRepository->findOneBySendingQueue($this->sendingQueue);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $this->sendingQueuesRepository->refresh($this->sendingQueue);
+    $this->scheduledTasksRepository->refresh($scheduledTask);
+    // queue subscriber processed/to process count is updated
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+      ->equals([]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
+      ->equals([$this->subscriber]);
+    verify($this->sendingQueue->getCountTotal())->equals(1);
+    verify($this->sendingQueue->getCountProcessed())->equals(1);
+    verify($this->sendingQueue->getCountToProcess())->equals(0);
+
+    // statistics entry should be created only for 1 subscriber
+    $statistics = StatisticsNewsletters::findMany();
+    verify(count($statistics))->equals(1);
+  }
+
   public function testItDoesNotCallMailerWithEmptyBatch() {
     $subscribers = [];
     while (count($subscribers) < 2 * SendingThrottlingHandler::BATCH_SIZE) {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1380,6 +1380,31 @@ class SendingQueueTest extends \MailPoetTest {
     verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
   }
 
+  public function testProcessMarksScheduledTaskInProgressAsFalseWhenProperlyProcessingTask() {
+    $sendingQueueWorker = $this->getSendingQueueWorker();
+    $sendingQueueWorker->process();
+    $this->assertSame(false, $this->scheduledTask->getInProgress());
+  }
+
+  public function testProcessMarksScheduledTaskProgressAsFinishedWhenThereIsAnErrorProcessingTask() {
+    $mailerTask = $this->createMock(MailerTask::class);
+    $mailerTask
+      ->method('send')
+      ->willThrowException(new \Exception());
+    $mailerTask
+      ->method('getProcessingMethod')
+      ->willReturn('individual');
+    $sendingQueueWorker = $this->getSendingQueueWorker($mailerTask);
+
+    try {
+      $sendingQueueWorker->process();
+    } catch (\Exception $e) {
+      // do nothing
+    }
+
+    $this->assertSame(false, $this->scheduledTask->getInProgress());
+  }
+
   private function createNewsletter(string $type, $subject, string $status = NewsletterEntity::STATUS_DRAFT): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType($type);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -38,9 +38,8 @@ class LinksTest extends \MailPoetTest {
         'hash' => 'some_hash',
       ],
     ];
-    $queue = (object)['id' => $this->queue->getId()];
 
-    $this->links->saveLinks($links, $this->newsletter, $queue);
+    $this->links->saveLinks($links, $this->newsletter, $this->queue);
 
     $newsletterLink = $this->newsletterLinkRepository->findOneBy(['hash' => $links[0]['hash']]);
     $this->assertInstanceOf(NewsletterLinkEntity::class, $newsletterLink);

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -387,6 +387,11 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
 
     $newsletter->getQueues()->add($queue);
     $this->entityManager->flush();
+
+    // I'm not sure why this is needed, but without it a test fails as $task->getSendingQueue() returns
+    // null in \MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter::preProcessNewsletter()
+    $this->entityManager->refresh($task);
+
     return $queue;
   }
 

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -170,26 +170,6 @@ class SendingTest extends \MailPoetTest {
     verify($this->sending->count_to_process)->equals(3);
   }
 
-  public function testItRemovesSubscribers() {
-    $subscriberIds = [$this->subscriber2->getId()];
-    $this->sending->removeSubscribers($subscriberIds);
-    verify($this->sending->getSubscribers())->equals([$this->subscriber1->getId()]);
-    verify($this->sending->count_total)->equals(1);
-    verify($this->sending->status)->null();
-  }
-
-  public function testItRemovesSubscribersShouldMarkTaskAsComplete() {
-    $subscriberIds = [$this->subscriber1->getId(), $this->subscriber2->getId()];
-    $originalProcessedAt = $this->sending->processed_at;
-
-    $this->sending->removeSubscribers($subscriberIds);
-
-    verify($this->sending->getSubscribers())->empty();
-    verify($this->sending->count_total)->equals(0);
-    verify($this->sending->status)->same(ScheduledTaskEntity::STATUS_COMPLETED);
-    verify($this->sending->processed_at)->notSame($originalProcessedAt);
-  }
-
   public function testItUpdatesProcessedSubscribers() {
     $taskSubscriber1 = $this->getTaskSubscriber($this->task->id, $this->subscriber1->getId());
     $subscriberId2 = $this->subscriber2->getId();
@@ -297,22 +277,6 @@ class SendingTest extends \MailPoetTest {
     verify($tasks[0]->getId())->equals($sending1->taskId);
     verify($tasks[1]->getId())->equals($sending3->taskId);
     verify($tasks[2]->getId())->equals($sending2->taskId);
-  }
-
-  public function testItSavesSubscriberError() {
-    $error = 'Error message';
-    $this->sending->saveSubscriberError($this->subscriber1->getId(), $error);
-    $taskSubscriber = $this->getTaskSubscriber($this->task->id, $this->subscriber1->getId());
-
-    verify($taskSubscriber->getError())->equals($error);
-    verify($taskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
-    verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
-    verify($this->sending->count_total)->equals(2);
-    verify($this->sending->count_processed)->equals(1);
-    verify($this->sending->count_to_process)->equals(1);
-
-    $this->sending->saveSubscriberError($this->subscriber2->getId(), $error);
-    verify($this->sending->status)->same(ScheduledTaskEntity::STATUS_COMPLETED);
   }
 
   public function createNewScheduledTask() {


### PR DESCRIPTION
## Description

This PR removes usages of `MailPoet\Tasks\Sending` from `MailPoet\Cron\Worker\SendingQueue` and related code.

## Code review notes

_N/A_

## QA notes

This PR has no user facing changes but it refactors a core part of MailPoet. Testing anything related to sending emails that is not coverted by automated tests is probably a good idea.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5682]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5682]: https://mailpoet.atlassian.net/browse/MAILPOET-5682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ