### PR TITLE
Fix cannot import lists that are old - MAILPOET-4255

### DIFF
--- a/mailpoet/assets/js/src/subscribers/import-export/import.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import.jsx
@@ -7,7 +7,7 @@ import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { registerTranslations, withBoundary } from 'common';
 import { StepMethodSelection } from './import/step-method-selection.jsx';
-import { StepInputValidation } from './import/step-input-validation.jsx';
+import { StepInputValidation } from './import/step-input-validation';
 import { StepDataManipulation } from './import/step-data-manipulation.jsx';
 import { StepResults } from './import/step-results.jsx';
 import { StepCleanList } from './import/step-clean-list';

--- a/mailpoet/assets/js/src/subscribers/import-export/import/clean-list.tsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/clean-list.tsx
@@ -3,9 +3,10 @@ import { MailPoet } from 'mailpoet';
 
 type Props = {
   onProceed?: () => void;
+  iHaveCleanedList?: () => void;
 };
 
-function CleanList({ onProceed }: Props): JSX.Element {
+function CleanList({ onProceed, iHaveCleanedList }: Props): JSX.Element {
   return (
     <div className="mailpoet-clean-list-step-container">
       <p>{MailPoet.I18n.t('cleanListText1')}</p>
@@ -22,6 +23,11 @@ function CleanList({ onProceed }: Props): JSX.Element {
         >
           {MailPoet.I18n.t('tryListCleaning')}
         </Button>
+        {iHaveCleanedList && (
+          <Button onClick={iHaveCleanedList} variant="secondary">
+            {MailPoet.I18n.t('cleanedList')}
+          </Button>
+        )}
       </p>
     </div>
   );

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-input-validation.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-input-validation.jsx
@@ -46,7 +46,7 @@ function StepInputValidationComponent({ stepMethodSelectionData, history }) {
 
       {importSource === 'existing-list' && lastSent === 'notRecently' && (
         <ErrorBoundary>
-          <CleanList />
+          <CleanList iHaveCleanedList={() => lastSentSubmit('recently')} />
         </ErrorBoundary>
       )}
     </>

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-input-validation.tsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-input-validation.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { withRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { ComponentType, useCallback, useEffect, useState } from 'react';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { CleanList } from 'subscribers/import-export/import/clean-list';
 import { ErrorBoundary } from 'common';
@@ -8,7 +7,24 @@ import { InitialQuestion } from './step-input-validation/initial-question.jsx';
 import { WrongSourceBlock } from './step-input-validation/wrong-source-block.jsx';
 import { LastSentQuestion } from './step-input-validation/last-sent-question.jsx';
 
-function StepInputValidationComponent({ stepMethodSelectionData, history }) {
+type StepMethodSelectionData = {
+  duplicate: string[];
+  header: string[];
+  invalid: string[];
+  role: string[];
+  subscribersCount: number;
+  subscribers: Array<string[]>;
+};
+
+type Props = {
+  history: RouteComponentProps['history'];
+  stepMethodSelectionData?: StepMethodSelectionData;
+};
+
+function StepInputValidationComponent({
+  stepMethodSelectionData,
+  history,
+}: Props): JSX.Element {
   const [importSource, setImportSource] = useState(undefined);
   const [lastSent, setLastSent] = useState(undefined);
 
@@ -53,23 +69,12 @@ function StepInputValidationComponent({ stepMethodSelectionData, history }) {
   );
 }
 
-StepInputValidationComponent.propTypes = {
-  history: PropTypes.shape({
-    push: PropTypes.func.isRequired,
-    replace: PropTypes.func.isRequired,
-  }).isRequired,
-  stepMethodSelectionData: PropTypes.shape({
-    duplicate: PropTypes.arrayOf(PropTypes.string),
-    header: PropTypes.arrayOf(PropTypes.string),
-    invalid: PropTypes.arrayOf(PropTypes.string),
-    role: PropTypes.arrayOf(PropTypes.string),
-    subscribersCount: PropTypes.number,
-    subscribers: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
-  }),
-};
-
 StepInputValidationComponent.defaultProps = {
   stepMethodSelectionData: undefined,
 };
 
-export const StepInputValidation = withRouter(StepInputValidationComponent);
+StepInputValidationComponent.displayName = 'StepInputValidationComponent';
+
+export const StepInputValidation = withRouter(
+  StepInputValidationComponent as ComponentType<RouteComponentProps>,
+);

--- a/mailpoet/views/subscribers/importExport/import.html
+++ b/mailpoet/views/subscribers/importExport/import.html
@@ -113,6 +113,7 @@
 'cleanListText1': __('We highly recommend cleaning your lists before importing them to MailPoet.'),
 'cleanListText2': __('Lists can have up to 20% of invalid addresses after a year because people change jobs and stop using their addresses. If you send with MailPoet, we will pause your sending and ask you to clean your list if we detect over 10% of invalid addresses.'),
 'tryListCleaning': _x('How can I clean my list?', 'CTA button label'),
+'cleanedList': _x('I cleaned my list', 'Text in button'),
 'listCleaningGotIt': _x('Got it, I’ll proceed to import', 'Text in a link'),
 'subscribed': __('Subscribed'),
 'unsubscribed': __('Unsubscribed'),


### PR DESCRIPTION


## Description

This PR adds the "I cleaned my list" button to the list import page.

<img width="810" alt="Screenshot 2023-10-27 at 1 33 25 PM" src="https://github.com/mailpoet/mailpoet/assets/30554163/134dd53c-0aed-42a8-803b-57b5da747fbd">


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4255](https://mailpoet.atlassian.net/browse/MAILPOET-4255)

## After-merge notes

_N/A_

## Tasks

- ~[ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations~
- ~[ ] I added sufficient test coverage~
- ~[ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes~


[MAILPOET-4255]: https://mailpoet.atlassian.net/browse/MAILPOET-4255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ