### PR TITLE
Add KB link to the error message on Key verification page - MAILPOET-5162

### DIFF
--- a/mailpoet/assets/js/src/common/premium-key/key-messages/mss-messages.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-messages/mss-messages.tsx
@@ -1,9 +1,8 @@
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import ReactStringReplace from 'react-string-replace';
+import { createInterpolateElement } from '@wordpress/element';
 import { useSelector } from 'settings/store/hooks';
 import { MssStatus } from 'settings/store/types';
-import { getLinkRegex } from '../../utils';
 
 type MssActiveMessageProps = { canUseSuccessClass: boolean };
 
@@ -25,17 +24,19 @@ function NotValidMessage({ message }: NotValidMessageProps) {
   return (
     <div className="mailpoet_error">
       {message
-        ? ReactStringReplace(message, getLinkRegex(), (text) => (
-            <a
-              className="mailpoet-link"
-              key={text}
-              href="https://kb.mailpoet.com/article/249-how-to-change-the-domain-associated-with-a-key"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {text}
-            </a>
-          ))
+        ? createInterpolateElement(message, {
+            a: (
+              <a
+                aria-label={message}
+                className="mailpoet-link"
+                href="https://kb.mailpoet.com/article/249-how-to-change-the-domain-associated-with-a-key"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                &nbsp;
+              </a>
+            ),
+          })
         : __(
             'Your key is not valid for the MailPoet Sending Service',
             'mailpoet',

--- a/mailpoet/assets/js/src/common/premium-key/key-messages/mss-messages.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-messages/mss-messages.tsx
@@ -1,7 +1,9 @@
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import ReactStringReplace from 'react-string-replace';
 import { useSelector } from 'settings/store/hooks';
 import { MssStatus } from 'settings/store/types';
+import { getLinkRegex } from '../../utils';
 
 type MssActiveMessageProps = { canUseSuccessClass: boolean };
 
@@ -22,11 +24,22 @@ type NotValidMessageProps = { message?: string };
 function NotValidMessage({ message }: NotValidMessageProps) {
   return (
     <div className="mailpoet_error">
-      {message ||
-        __(
-          'Your key is not valid for the MailPoet Sending Service',
-          'mailpoet',
-        )}
+      {message
+        ? ReactStringReplace(message, getLinkRegex(), (text) => (
+            <a
+              className="mailpoet-link"
+              key={text}
+              href="https://kb.mailpoet.com/article/249-how-to-change-the-domain-associated-with-a-key"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {text}
+            </a>
+          ))
+        : __(
+            'Your key is not valid for the MailPoet Sending Service',
+            'mailpoet',
+          )}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/common/premium-key/key-messages/premium-messages.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-messages/premium-messages.tsx
@@ -1,13 +1,12 @@
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import ReactStringReplace from 'react-string-replace';
+import { createInterpolateElement } from '@wordpress/element';
 import { useSelector } from 'settings/store/hooks';
 import { PremiumStatus } from 'settings/store/types';
 import { Button } from 'common/button/button';
 import { PremiumModal } from 'common/premium-modal';
 import { useState } from 'react';
 import { Data } from '../../premium-modal/upgrade-info';
-import { getLinkRegex } from '../../utils';
 
 type ActiveMessageProps = { canUseSuccessClass: boolean };
 
@@ -70,17 +69,19 @@ function NotValidMessage({ message }: NotValidMessageProps) {
   return (
     <div className="mailpoet_error">
       {message
-        ? ReactStringReplace(message, getLinkRegex(), (text) => (
-            <a
-              className="mailpoet-link"
-              key={text}
-              href="https://kb.mailpoet.com/article/249-how-to-change-the-domain-associated-with-a-key"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {text}
-            </a>
-          ))
+        ? createInterpolateElement(message, {
+            a: (
+              <a
+                aria-label={message}
+                className="mailpoet-link"
+                href="https://kb.mailpoet.com/article/249-how-to-change-the-domain-associated-with-a-key"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                &nbsp;
+              </a>
+            ),
+          })
         : __('Your key is not valid for MailPoet Premium', 'mailpoet')}
     </div>
   );

--- a/mailpoet/assets/js/src/common/premium-key/key-messages/premium-messages.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-messages/premium-messages.tsx
@@ -1,11 +1,13 @@
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import ReactStringReplace from 'react-string-replace';
 import { useSelector } from 'settings/store/hooks';
 import { PremiumStatus } from 'settings/store/types';
 import { Button } from 'common/button/button';
 import { PremiumModal } from 'common/premium-modal';
 import { useState } from 'react';
 import { Data } from '../../premium-modal/upgrade-info';
+import { getLinkRegex } from '../../utils';
 
 type ActiveMessageProps = { canUseSuccessClass: boolean };
 
@@ -67,7 +69,19 @@ type NotValidMessageProps = { message?: string };
 function NotValidMessage({ message }: NotValidMessageProps) {
   return (
     <div className="mailpoet_error">
-      {message || __('Your key is not valid for MailPoet Premium', 'mailpoet')}
+      {message
+        ? ReactStringReplace(message, getLinkRegex(), (text) => (
+            <a
+              className="mailpoet-link"
+              key={text}
+              href="https://kb.mailpoet.com/article/249-how-to-change-the-domain-associated-with-a-key"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {text}
+            </a>
+          ))
+        : __('Your key is not valid for MailPoet Premium', 'mailpoet')}
     </div>
   );
 }

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -140,7 +140,7 @@ class Services extends APIEndpoint {
         $error = __('Your key is not valid for the MailPoet Sending Service', 'mailpoet');
         break;
       case Bridge::KEY_ALREADY_USED:
-        $error = __('Your MailPoet Sending Service key is already [link]used on another site[/link]', 'mailpoet');
+        $error = __('Your MailPoet Sending Service key is already <a>used on another site</a>', 'mailpoet'); // we will use createInterpolateElement to replace <a> element
         break;
       default:
         $code = !empty($result['code']) ? $result['code'] : Bridge::CHECK_ERROR_UNKNOWN;
@@ -209,7 +209,7 @@ class Services extends APIEndpoint {
         $error = __('Your key is not valid for MailPoet Premium', 'mailpoet');
         break;
       case Bridge::KEY_ALREADY_USED:
-        $error = __('Your Premium key is already [link]used on another site[/link]', 'mailpoet');
+        $error = __('Your Premium key is already <a>used on another site</a>', 'mailpoet'); // we will use createInterpolateElement to replace <a> element
         break;
       default:
         $code = !empty($result['code']) ? $result['code'] : Bridge::CHECK_ERROR_UNKNOWN;

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -140,7 +140,7 @@ class Services extends APIEndpoint {
         $error = __('Your key is not valid for the MailPoet Sending Service', 'mailpoet');
         break;
       case Bridge::KEY_ALREADY_USED:
-        $error = __('Your MailPoet Sending Service key is already used on another site', 'mailpoet');
+        $error = __('Your MailPoet Sending Service key is already [link]used on another site[/link]', 'mailpoet');
         break;
       default:
         $code = !empty($result['code']) ? $result['code'] : Bridge::CHECK_ERROR_UNKNOWN;
@@ -209,7 +209,7 @@ class Services extends APIEndpoint {
         $error = __('Your key is not valid for MailPoet Premium', 'mailpoet');
         break;
       case Bridge::KEY_ALREADY_USED:
-        $error = __('Your Premium key is already used on another site', 'mailpoet');
+        $error = __('Your Premium key is already [link]used on another site[/link]', 'mailpoet');
         break;
       default:
         $code = !empty($result['code']) ? $result['code'] : Bridge::CHECK_ERROR_UNKNOWN;


### PR DESCRIPTION


## Description

This PR adds a KB link to the error message "Your MSS key is already used on another site".

<img width="565" alt="Screenshot 2023-10-27 at 3 17 11 PM" src="https://github.com/mailpoet/mailpoet/assets/30554163/e1eed6a4-909b-4f81-b842-8c8bb137d0c1">

This is mostly used on the Settings page -> key verification section.

We show a different error on other pages or on the notices
<img width="734" alt="Screenshot 2023-10-27 at 3 30 27 PM" src="https://github.com/mailpoet/mailpoet/assets/30554163/f1bdddbc-bd7f-4661-8935-116193eac72f">
Or
when the API response is unavailable 
<img width="562" alt="Screenshot 2023-10-27 at 3 35 29 PM" src="https://github.com/mailpoet/mailpoet/assets/30554163/bc7ad5c8-0e59-4be7-a5d5-c5efe1ea6ae1">


## Code review notes

_N/A_

## QA notes

* Visit: `/wp-admin/admin.php?page=mailpoet-settings#/premium` 
* Verify with an already used key e.g. API key connected to another site

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5162](https://mailpoet.atlassian.net/browse/MAILPOET-5162)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5162]: https://mailpoet.atlassian.net/browse/MAILPOET-5162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ