### PR TITLE
Improve text in preview modal for translators [MAILPOET-5693]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/preview/send-preview-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/preview/send-preview-email.tsx
@@ -97,9 +97,9 @@ export function SendPreviewEmail() {
       <p>
         {createInterpolateElement(
           __(
-            'Send yourself a test email to test how your email would look like in different email apps. You could also enter your <link1>Mail Tester</link1> email below to test your spam score. <link2>Learn more</link2>.',
+            'Send yourself a test email to test how your email would look like in different email apps. You can also test your spam score by sending a test email to <link1>{$serviceName}</link1>. <link2>Learn more</link2>.',
             'mailpoet',
-          ),
+          ).replace('{$serviceName}', 'Mail Tester'),
           {
             link1: (
               // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label


### PR DESCRIPTION
## Description

Replacing "Mail Tester" string with a variable in the original string should prevent translators from attempting to translate it. 

## Code review notes

_N/A_

## QA notes

I think it doesn't require QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5693]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5693]: https://mailpoet.atlassian.net/browse/MAILPOET-5693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ