### PR TITLE
Independently update existing subscribers info and status in import [MAILPOET-5617]

### DIFF
--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -727,8 +727,8 @@ class ImportTest extends \MailPoetTest {
     $lastSubscribedAt = Carbon::createFromFormat('Y-m-d H:i:s', '2020-08-08 08:08:00');
     $this->assertInstanceOf(Carbon::class, $lastSubscribedAt);
     $existingSubscriber = $this->createSubscriber(
-      'Adam',
-      'Smith',
+      'Adam0', // test first_name updating
+      'Smith0', // test last_name updating
       'Adam@Smith.com',
       SubscriberEntity::STATUS_UNSUBSCRIBED,
       $lastSubscribedAt
@@ -740,6 +740,32 @@ class ImportTest extends \MailPoetTest {
     $updatedSubscriber = $this->subscriberRepository->findOneBy(['email' => $existingSubscriber->getEmail()]);
     $this->assertInstanceOf(SubscriberEntity::class, $updatedSubscriber);
     verify($updatedSubscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    verify($updatedSubscriber->getFirstName())->equals('Adam');
+    verify($updatedSubscriber->getLastName())->equals('Smith');
+  }
+
+  public function testItDoesUpdateStatusExistingSubscriberWhenExistingSubscribersStatusIsSetAndUpdateSubscribersIsDisabled(): void {
+    $data = $this->testData;
+    $data['updateSubscribers'] = false;
+    $data['existingSubscribersStatus'] = SubscriberEntity::STATUS_SUBSCRIBED;
+    $lastSubscribedAt = Carbon::createFromFormat('Y-m-d H:i:s', '2020-08-08 08:08:00');
+    $this->assertInstanceOf(Carbon::class, $lastSubscribedAt);
+    $existingSubscriber = $this->createSubscriber(
+      'Adam0', // test first_name updating is disabled
+      'Smith0', // test last_name updating is disabled
+      'Adam@Smith.com',
+      SubscriberEntity::STATUS_UNSUBSCRIBED,
+      $lastSubscribedAt
+    );
+    $import = $this->createImportInstance($data);
+    $import->process();
+
+    $this->entityManager->clear();
+    $updatedSubscriber = $this->subscriberRepository->findOneBy(['email' => $existingSubscriber->getEmail()]);
+    $this->assertInstanceOf(SubscriberEntity::class, $updatedSubscriber);
+    verify($updatedSubscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    verify($updatedSubscriber->getFirstName())->equals('Adam0');
+    verify($updatedSubscriber->getLastName())->equals('Smith0');
   }
 
   public function testItDoesStatusNewSubscriberWhenNewSubscribersStatusIsSet(): void {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

WP users sync is only performed if `updateSubscribers` option is on. That sounded more logical to me.

## QA notes

Try importing subscribers while selecting these options in any combinations (one, both or none of them), make sure the behavior is correct in every case:
* Updates existing subscribers' information;
* Update existing subscribers' status.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5617]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5617]: https://mailpoet.atlassian.net/browse/MAILPOET-5617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ