### PR TITLE
Update react rendering method [MAILPOET-5120]

### DIFF
--- a/mailpoet/assets/js/src/automation/automation.tsx
+++ b/mailpoet/assets/js/src/automation/automation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { TopBarWithBeamer } from 'common/top-bar/top-bar';
 import { Popover, SlotFillProvider } from '@wordpress/components';
@@ -82,11 +82,12 @@ function App(): JSX.Element {
 window.addEventListener('DOMContentLoaded', () => {
   createStore();
 
-  const root = document.getElementById('mailpoet_automation');
-  if (root) {
+  const container = document.getElementById('mailpoet_automation');
+  if (container) {
     registerTranslations();
     registerApiErrorHandler();
     initializeApi();
-    ReactDOM.render(<App />, root);
+    const root = createRoot(container);
+    root.render(<App />);
   }
 });

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { useEffect, useState } from 'react';
 import { Button, Icon, Popover, SlotFillProvider } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
@@ -201,8 +201,8 @@ window.addEventListener('DOMContentLoaded', () => {
     sidebarActiveByDefault ? automationSidebarKey : undefined,
   );
 
-  const root = document.getElementById('mailpoet_automation_editor');
-  if (root) {
+  const container = document.getElementById('mailpoet_automation_editor');
+  if (container) {
     registerTranslations();
     registerApiErrorHandler();
     initializeApi();
@@ -210,6 +210,7 @@ window.addEventListener('DOMContentLoaded', () => {
     initializeMailPoetIntegration();
     initializeWordPressIntegration();
     initializeWooCommerceIntegration();
-    ReactDOM.render(<Editor />, root);
+    const root = createRoot(container);
+    root.render(<Editor />);
   }
 });

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -97,8 +97,8 @@ function boot() {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-  const root = document.getElementById('mailpoet_automation_analytics');
-  if (!root) {
+  const container = document.getElementById('mailpoet_automation_analytics');
+  if (!container) {
     return;
   }
   createStore();
@@ -109,5 +109,6 @@ window.addEventListener('DOMContentLoaded', () => {
   initializeWordPressIntegration();
   registerApiErrorHandler();
   boot();
-  ReactDOM.render(<App />, root);
+  const root = createRoot(container);
+  root.render(<App />);
 });

--- a/mailpoet/assets/js/src/automation/templates/index.tsx
+++ b/mailpoet/assets/js/src/automation/templates/index.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { __ } from '@wordpress/i18n';
 import { Flex } from '@wordpress/components';
 import { registerTranslations } from 'common';
@@ -33,12 +33,13 @@ function Templates(): JSX.Element {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-  const root = document.getElementById('mailpoet_automation_templates');
-  if (!root) {
+  const container = document.getElementById('mailpoet_automation_templates');
+  if (!container) {
     return;
   }
 
   registerTranslations();
   initializeApi();
-  ReactDOM.render(<Templates />, root);
+  const root = createRoot(container);
+  root.render(<Templates />);
 });

--- a/mailpoet/assets/js/src/experimental-features/experimental-features.jsx
+++ b/mailpoet/assets/js/src/experimental-features/experimental-features.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { MailPoet } from 'mailpoet';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
@@ -112,10 +112,10 @@ ExperimentalFeatures.displayName = 'ExperimentalFeatures';
 
 if (experimentalFeaturesContainer) {
   registerTranslations();
-  ReactDOM.render(
+  const root = createRoot(experimentalFeaturesContainer);
+  root.render(
     <ErrorBoundary>
       <ExperimentalFeatures />
     </ErrorBoundary>,
-    experimentalFeaturesContainer,
   );
 }

--- a/mailpoet/assets/js/src/form-editor/form-editor.jsx
+++ b/mailpoet/assets/js/src/form-editor/form-editor.jsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import apiFetch from '@wordpress/api-fetch';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
@@ -26,6 +26,7 @@ function App() {
 window.addEventListener('DOMContentLoaded', () => {
   const appElement = document.querySelector('#mailpoet_form_edit');
   if (appElement) {
+    const root = createRoot(appElement);
     // Initialize WP API
     apiFetch.use(apiFetch.createRootURLMiddleware(window.wpApiSettings.root));
     apiFetch.use(apiFetch.createNonceMiddleware(window.wpApiSettings.nonce));
@@ -35,11 +36,10 @@ window.addEventListener('DOMContentLoaded', () => {
     initRichText();
     initTranslations(window.mailpoet_translations);
     registerTranslations();
-    ReactDOM.render(
+    root.render(
       <StrictMode>
         <App />
       </StrictMode>,
-      appElement,
     );
   }
 });

--- a/mailpoet/assets/js/src/form-editor/template-selection.tsx
+++ b/mailpoet/assets/js/src/form-editor/template-selection.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { Selection } from './templates/selection';
@@ -17,14 +17,14 @@ function App() {
   );
 }
 
-const appElement = document.querySelector('#mailpoet_form_edit_templates');
-if (appElement) {
+const container = document.querySelector('#mailpoet_form_edit_templates');
+if (container) {
   registerTranslations();
   createStore();
-  ReactDOM.render(
+  const root = createRoot(container);
+  root.render(
     <StrictMode>
       <App />
     </StrictMode>,
-    appElement,
   );
 }

--- a/mailpoet/assets/js/src/forms/forms.jsx
+++ b/mailpoet/assets/js/src/forms/forms.jsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { HashRouter, Route } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
@@ -20,5 +20,6 @@ const container = document.getElementById('forms_container');
 
 if (container) {
   registerTranslations();
-  ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }

--- a/mailpoet/assets/js/src/help-tooltip-helper.js
+++ b/mailpoet/assets/js/src/help-tooltip-helper.js
@@ -1,16 +1,16 @@
 import { Tooltip } from 'help-tooltip.jsx';
 import { createElement } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 export const MailPoetHelpTooltip = {
   show: function show(domContainerNode, opts) {
-    ReactDOM.render(
+    const root = createRoot(domContainerNode);
+    root.render(
       createElement(Tooltip, {
         tooltip: opts.tooltip,
         tooltipId: opts.tooltipId,
         place: opts.place,
       }),
-      domContainerNode,
     );
   },
 };

--- a/mailpoet/assets/js/src/help/help.jsx
+++ b/mailpoet/assets/js/src/help/help.jsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { MailPoet } from 'mailpoet';
 import { KnowledgeBase } from 'help/knowledge-base.tsx';
 import { SystemInfo } from 'help/system-info.tsx';
@@ -40,5 +40,6 @@ const container = document.getElementById('help_container');
 
 if (container) {
   registerTranslations();
-  ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }

--- a/mailpoet/assets/js/src/homepage/homepage.tsx
+++ b/mailpoet/assets/js/src/homepage/homepage.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary, registerTranslations } from 'common';
 import { GlobalContext, useGlobalContextValue } from 'context';
@@ -25,10 +25,10 @@ function App(): JSX.Element {
 const container = document.getElementById('mailpoet_homepage_container');
 if (container) {
   registerTranslations();
-  ReactDOM.render(
+  const root = createRoot(container);
+  root.render(
     <ErrorBoundary>
       <App />
     </ErrorBoundary>,
-    container,
   );
 }

--- a/mailpoet/assets/js/src/landingpage/landingpage.tsx
+++ b/mailpoet/assets/js/src/landingpage/landingpage.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { ErrorBoundary, registerTranslations } from 'common';
 import { Background } from 'common/background/background';
@@ -36,16 +36,14 @@ function Landingpage() {
 
 Landingpage.displayName = 'Landingpage';
 
-const landingpageContainer = document.getElementById(
-  'mailpoet_landingpage_container',
-);
+const container = document.getElementById('mailpoet_landingpage_container');
 
-if (landingpageContainer) {
+if (container) {
   registerTranslations();
-  ReactDOM.render(
+  const root = createRoot(container);
+  root.render(
     <ErrorBoundary>
       <Landingpage />
     </ErrorBoundary>,
-    landingpageContainer,
   );
 }

--- a/mailpoet/assets/js/src/logs/logs.tsx
+++ b/mailpoet/assets/js/src/logs/logs.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { ErrorBoundary } from 'common';
 import { FilterType, List, Logs } from './list';
@@ -9,12 +9,13 @@ interface LogsWindow extends Window {
 
 declare let window: LogsWindow;
 
-const logsContainer = document.getElementById('mailpoet_logs_container');
+const container = document.getElementById('mailpoet_logs_container');
 
-if (logsContainer) {
+if (container) {
   const url = new URL(window.location.href);
 
-  ReactDOM.render(
+  const root = createRoot(container);
+  root.render(
     <ErrorBoundary>
       <List
         logs={window.mailpoet_logs}
@@ -36,6 +37,5 @@ if (logsContainer) {
         }}
       />
     </ErrorBoundary>,
-    logsContainer,
   );
 }

--- a/mailpoet/assets/js/src/newsletter-editor/blocks/coupon.tsx
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/coupon.tsx
@@ -4,7 +4,7 @@
  */
 import { App } from 'newsletter-editor/app';
 import { BaseBlock } from 'newsletter-editor/blocks/base';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import _ from 'underscore';
 import jQuery from 'jquery';
 import 'backbone.marionette';
@@ -253,7 +253,9 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
     );
   },
   onRender() {
-    ReactDOM.render(
+    const container = document.getElementById('mailpoet_coupon_block_settings');
+    const root = createRoot(container);
+    root.render(
       <Settings
         availableDiscountTypes={App.getConfig()
           .get('coupon.discount_types')
@@ -265,7 +267,6 @@ Module.CouponBlockSettingsView = base.BlockSettingsView.extend({
         setValueCallback={(name, value) => this.model.set(name, value)}
         getValueCallback={(name) => this.model.get(name)}
       />,
-      document.getElementById('mailpoet_coupon_block_settings'),
     );
   },
 });

--- a/mailpoet/assets/js/src/newsletter-editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter-editor/initializer.jsx
@@ -1,7 +1,7 @@
 import { Hooks } from 'wp-js-hooks';
 import { MailPoet } from 'mailpoet';
 import { __ } from '@wordpress/i18n';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { ListingHeadingSteps } from 'newsletters/listings/heading-steps';
 import { newsletterTypesWithActivation } from 'newsletters/listings/utils';
 import { fetchAutomaticEmailShortcodes } from 'newsletters/automatic-emails/fetch-editor-shortcodes.jsx';
@@ -64,7 +64,8 @@ const renderHeading = (newsletterType, newsletterOptions) => {
       </ErrorBoundary>
     );
 
-    ReactDOM.render(stepsHeading, stepsHeadingContainer);
+    const root = createRoot(stepsHeadingContainer);
+    root.render(stepsHeading);
   }
 };
 

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { __ } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import ReactStringReplace from 'react-string-replace';
@@ -82,12 +82,13 @@ export const checkCronStatus = (state) => {
   );
 
   MailPoet.Notice.error('', { static: true, id: 'mailpoet_cron_error' });
+  const container = jQuery('[data-id="mailpoet_cron_error"]')[0];
+  const root = createRoot(container);
 
-  ReactDOM.render(
+  root.render(
     <div>
       <p>{cronPingCheckNotice}</p>
     </div>,
-    jQuery('[data-id="mailpoet_cron_error"]')[0],
   );
 };
 

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import {
   HashRouter,
   Redirect,
@@ -289,6 +289,6 @@ function App() {
 const container = document.getElementById('newsletters_container');
 if (container) {
   registerTranslations();
-  // eslint-disable-next-line react/no-render-return-value
-  window.mailpoet_listing = ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Switch, useHistory } from 'react-router-dom';
 
 import { GlobalContext, useGlobalContextValue } from 'context';
@@ -62,5 +62,6 @@ function App(): JSX.Element {
 if (container) {
   registerTranslations();
   createStore();
-  ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }

--- a/mailpoet/assets/js/src/segments/static/static.tsx
+++ b/mailpoet/assets/js/src/segments/static/static.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 
 import { SegmentList } from 'segments/static/list';
@@ -26,5 +26,6 @@ function App(): JSX.Element {
 
 if (container) {
   registerTranslations();
-  ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }

--- a/mailpoet/assets/js/src/sending-paused-notices-authorize-email.tsx
+++ b/mailpoet/assets/js/src/sending-paused-notices-authorize-email.tsx
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 import { useState, useEffect } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { MailPoet } from 'mailpoet';
 import { extractPageNameFromUrl } from 'common/functions';
 import { AuthorizeSenderEmailAndDomainModal } from 'common/authorize-sender-email-and-domain-modal';
@@ -96,5 +96,6 @@ const container = document.getElementById(
   'mailpoet_authorize_sender_email_modal',
 );
 if (container) {
-  ReactDOM.render(<AuthorizeSenderEmailApp />, container);
+  const root = createRoot(container);
+  root.render(<AuthorizeSenderEmailApp />);
 }

--- a/mailpoet/assets/js/src/sending-paused-notices-fix-button.tsx
+++ b/mailpoet/assets/js/src/sending-paused-notices-fix-button.tsx
@@ -1,10 +1,10 @@
 import jQuery from 'jquery';
 import { useState } from 'react';
-import ReactDOM from 'react-dom';
 import { SetFromAddressModal } from 'common/set-from-address-modal';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { noop } from 'lodash';
+import { createRoot } from 'react-dom/client';
 
 type Props = {
   onRequestClose?: () => void;
@@ -44,7 +44,8 @@ App.defaultProps = {
 // ReactDOM.createPortal() but we need an element as a React root on all pages
 const container = document.getElementById('mailpoet_set_from_address_modal');
 if (container) {
-  ReactDOM.render(
+  const root = createRoot(container);
+  root.render(
     <App
       onRequestClose={() => {
         // if in Settings, reload page, so the new saved FROM address is loaded
@@ -56,6 +57,5 @@ if (container) {
         }
       }}
     />,
-    container,
   );
 }

--- a/mailpoet/assets/js/src/settings/index.tsx
+++ b/mailpoet/assets/js/src/settings/index.tsx
@@ -1,5 +1,5 @@
 import 'parsleyjs';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { initStore } from './store';
 import { Settings } from './settings';
@@ -17,5 +17,6 @@ const container = document.getElementById('settings_container');
 if (container) {
   registerTranslations();
   initStore();
-  ReactDOM.render(<Entry />, container);
+  const root = createRoot(container);
+  root.render(<Entry />);
 }

--- a/mailpoet/assets/js/src/subscribers/import-export/import.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { ScrollToTop } from 'common/scroll-to-top.jsx';
 
@@ -86,5 +86,6 @@ function ImportSubscribers() {
 
 if (container) {
   registerTranslations();
-  ReactDOM.render(<ImportSubscribers />, container);
+  const root = createRoot(container);
+  root.render(<ImportSubscribers />);
 }

--- a/mailpoet/assets/js/src/subscribers/subscribers.jsx
+++ b/mailpoet/assets/js/src/subscribers/subscribers.jsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 
 import { SubscriberList } from 'subscribers/list.tsx';
@@ -31,5 +31,6 @@ const container = document.getElementById('subscribers_container');
 
 if (container) {
   registerTranslations();
-  ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }

--- a/mailpoet/assets/js/src/wizard/wizard.tsx
+++ b/mailpoet/assets/js/src/wizard/wizard.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
@@ -38,5 +38,6 @@ const container = document.getElementById('mailpoet-wizard-container');
 if (container) {
   registerTranslations();
   initSettingsStore();
-  ReactDOM.render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 }


### PR DESCRIPTION
## Description

This PR converts all of our React Apps from using ReactDOM.render to createRoot. This switches the rendering version from React 17 to React 18. There are more details in the ticket.

## Code review notes

_N/A_

## QA notes

This PR affects many different parts of the plugin and will need to be tested carefully. We basically want to be sure that nothing has changed noticeably. I didn't see any issues when I tested locally but there are likely things that I missed.

You can see the different parts of the plugin that were affected by viewing the commit messages. There is a separate commit for every render method that was updated.

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5120

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
