### PR TITLE
Fix line break in automation analytics separator [MAILPOET-5702]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_separator.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_separator.scss
@@ -7,6 +7,7 @@ $separator-width: 1px;
   height: 64px;
   justify-content: center;
   margin: auto;
+  white-space: nowrap;
   width: $separator-width;
 }
 


### PR DESCRIPTION
## Description

Preventing line breaks in the container holding information about how many people get through each automation step.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5702]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5702]: https://mailpoet.atlassian.net/browse/MAILPOET-5702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ