### PR TITLE
Ensure we use only \WP_Taxonomy [MAILPOET-5704]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
@@ -74,7 +74,12 @@ class ContextFactory {
    */
   private function getTaxonomies(): array {
     /** @var \WP_Taxonomy[] $taxonomies */
-    $taxonomies = $this->wp->getTaxonomies([], 'object');
+    $taxonomies = array_filter(
+      $this->wp->getTaxonomies([], 'object'),
+      function($object): bool {
+        return $object instanceof \WP_Taxonomy;
+      }
+    );
     return array_values(array_map(
       function(\WP_Taxonomy $taxonomy): array {
         return [


### PR DESCRIPTION
## Description
The [docblock for `get_taxonomies()`](https://github.com/WordPress/WordPress/blob/7da5644617a1a443e8461df10c4eb04959afcc7c/wp-includes/taxonomy.php#L262-L264) says it returns `\WP_Taxonomy[]` (depending on `$output`). However, we depend on the global `$wp_taxonomy` not being altered by 3rd party plugins for that statement being true.

This PR ignores entries which are not `\WP_Taxonomy`.

## Code review notes
We have a typehint, which throws a fatal error. There are two ways we could go:

1. We could remove the typehint, and allowing basically everything inside the closure or
2.  we can filter upfront to use only `\WP_Taxonomy`.
 
Imo, we should lean on the more restrictive side and rely on the typehint. While it makes sense to assume that instead of a `\WP_Taxonomy` some kind of object will be present which has the same properties as `\WP_Taxonomy` (like in [this case](https://github.com/woocommerce/automatewoo/blob/c8ce9150eb0d6917489e77b9bc9eca82a3a60f7c/includes/User_Tags.php#L45-L68)), it makes also sense to expect the ["contract"](https://github.com/WordPress/WordPress/blob/7da5644617a1a443e8461df10c4eb04959afcc7c/wp-includes/taxonomy.php#L412)

`@global WP_Taxonomy[] $wp_taxonomies Registered taxonomies.`

is upheld by all parties. In the long run, I see more downsides in loosening our type-hinting.

## QA notes
1. Activate AutomateWoo
5. Create a new automation in MailPoet
6. If no fatal error is thrown, this PR works as expected

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5704]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5704]: https://mailpoet.atlassian.net/browse/MAILPOET-5704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ