### PR TITLE
Update UnsubscribeTokens to use dependency injection [MAILPOET-5710]

### DIFF
--- a/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
@@ -32,10 +32,14 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
+  /** @var UnsubscribeTokens */
+  private $worker;
+
   public function _before() {
     parent::_before();
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    $this->worker = $this->diContainer->get(UnsubscribeTokens::class);
 
     $this->subscriberWithToken = (new SubscriberFactory())
       ->withEmail('subscriber1@test.com')
@@ -62,8 +66,7 @@ class UnsubscribeTokensTest extends \MailPoetTest {
 
   public function testItAddsTokensToSubscribers() {
     verify($this->subscriberWithoutToken->getUnsubscribeToken())->null();
-    $worker = new UnsubscribeTokens();
-    $worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $subscriberWithToken = $this->subscribersRepository->findOneById($this->subscriberWithToken->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $subscriberWithToken);
     $subscriberWithoutToken = $this->subscribersRepository->findOneById($this->subscriberWithoutToken->getId());
@@ -74,8 +77,7 @@ class UnsubscribeTokensTest extends \MailPoetTest {
 
   public function testItAddsTokensToNewsletters() {
     verify($this->newsletterWithoutToken->getUnsubscribeToken())->null();
-    $worker = new UnsubscribeTokens();
-    $worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
+    $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
     $newsletterWithToken = $this->newslettersRepository->findOneById($this->newsletterWithToken->getId());
     $newsletterWithoutToken = $this->newslettersRepository->findOneById($this->newsletterWithoutToken->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterWithToken);


### PR DESCRIPTION
## Description

This PR updates the `UnsubscribeTokens` worker to use DI instead of retrieving services directly from the container. One of the services, `MailPoet\Util\Security`, is configured (by default) to be private and shouldn't be accessed this way. We are seeing this error: `UnsubscribeTokens: The "MailPoet\Util\Security" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.`

Currently I don't believe the UnsubscribeTokens worker is able to create tokens for users. I confirmed this by installing a fresh copy of mailpoet, observing the same error noted in the ticket, and seeing that the default subscriber doesn't have an unsubscribe token. I'm not sure precisely what effect this has. It didn't seem to affect my ability to unsubscribe using the unsubscribe link in a test email. It might also affect newsletters.

This task doesn't auto reschedule itself, but it does get scheduled when the populator runs (i.e. on plugin activation/upgrade), so any missing tokens should be filled in after the plugin updates.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5710]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5710]: https://mailpoet.atlassian.net/browse/MAILPOET-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ