### PR TITLE
Email editor add block guide [MAILPOET-5645]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Renderer/BlocksRegistry.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/BlocksRegistry.php
@@ -23,13 +23,14 @@ class BlocksRegistry {
     add_filter('render_block_' . $blockName, [$this, 'renderBlock'], 10, 2);
   }
 
-  public function removeBlockRenderer(string $blockName): void {
-    unset($this->blockRenderersMap[$blockName]);
-    remove_filter('render_block_' . $blockName, [$this, 'renderBlock']);
-  }
-
   public function getBlockRenderer(string $blockName): ?BlockRenderer {
     return apply_filters('mailpoet_block_renderer_' . $blockName, $this->blockRenderersMap[$blockName] ?? null);
+  }
+
+  public function removeAllBlockRendererFilters(): void {
+    foreach (array_keys($this->blockRenderersMap) as $blockName) {
+      $this->removeBlockRenderer($blockName);
+    }
   }
 
   public function renderBlock($blockContent, $parsedBlock): string {
@@ -38,5 +39,10 @@ class BlocksRegistry {
       throw new \InvalidArgumentException('Block renderer not found for block ' . $parsedBlock['name']);
     }
     return $this->blockRenderersMap[$parsedBlock['blockName']]->render($blockContent, $parsedBlock, $this->settingsController);
+  }
+
+  private function removeBlockRenderer(string $blockName): void {
+    unset($this->blockRenderersMap[$blockName]);
+    remove_filter('render_block_' . $blockName, [$this, 'renderBlock']);
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -94,7 +94,7 @@ class Renderer {
     foreach ($parsedBlocks as $parsedBlock) {
       $content .= render_block($parsedBlock);
     }
-
+    // @TODO We can call $this->blocksRegistry->unregisterAll() here. The registry knows all blocks and callbacks
     do_action('mailpoet_blocks_renderer_uninitialized', $this->blocksRegistry);
 
     return $content;

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -94,8 +94,12 @@ class Renderer {
     foreach ($parsedBlocks as $parsedBlock) {
       $content .= render_block($parsedBlock);
     }
-    // @TODO We can call $this->blocksRegistry->unregisterAll() here. The registry knows all blocks and callbacks
-    do_action('mailpoet_blocks_renderer_uninitialized', $this->blocksRegistry);
+
+    /**
+     *  As we use default WordPress filters, we need to remove them after email rendering
+     *  so that we don't interfere with possible post rendering that might happen later.
+     */
+    $this->blocksRegistry->removeAllBlockRendererFilters();
 
     return $content;
   }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/readme.md
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/readme.md
@@ -1,0 +1,66 @@
+# MailPoet Email Renderer
+
+The renderer is WIP and so is the API for adding support email rendering for new blocks.
+
+## Adding support for a core block
+
+1. Add block into `ALLOWED_BLOCK_TYPES` in `mailpoet/lib/EmailEditor/Engine/Renderer/AllowedBlocks.php`.
+2. Make sure the block is registered in the editor. Currently all core blocks are registered in the editor.
+3. Add BlockRender class (e.g. Heading) into `mailpoet/lib/EmailEditor/Integration/Core/Renderer/Blocks` folder. <br />
+
+```php
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class Heading implements BlockRenderer {
+  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    // here comes your rendering logic;
+    return 'HEADING_BLOCK';
+  }
+}
+```
+
+4. Register the renderer
+
+```php
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core;
+
+use MailPoet\EmailEditor\Engine\Renderer\BlocksRegistry;
+
+class Initializer {
+  public function initialize(): void {
+    add_action('mailpoet_blocks_renderer_initialized', [$this, 'registerCoreBlocksRenderers'], 10, 1);
+    add_action('mailpoet_blocks_renderer_uninitialized', [$this, 'unregisterCoreBlocksRenderers'], 10, 1);
+  }
+
+  /**
+   * Register core blocks email renderers when the blocks renderer is initialized.
+   */
+  public function registerCoreBlocksRenderers(BlocksRegistry $blocksRegistry): void {
+    $blocksRegistry->addBlockRenderer('core/heading', new Renderer\Blocks\Heading());
+  }
+
+  public function unregisterCoreBlocksRenderers(BlocksRegistry $blocksRegistry): void {
+    $blocksRegistry->removeBlockRenderer('core/heading');
+  }
+}
+```
+
+5. Implement the rendering logic in the renderer class.
+
+## Tips for adding support for block
+
+- You can take inspiration on block rendering from MJML in the https://mjml.io/try-it-live
+- Test the block in different clients [Litmus](https://litmus.com/)
+
+## TODO
+
+- add universal/fallback renderer for rendering blocks that are not covered by specialized renderers
+- add support for all core blocks
+- move the renderer to separate package

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/readme.md
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/readme.md
@@ -18,8 +18,7 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Heading implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    // here comes your rendering logic;
-    return 'HEADING_BLOCK';
+    return 'HEADING_BLOCK'; // here comes your rendering logic;
   }
 }
 ```
@@ -27,30 +26,18 @@ class Heading implements BlockRenderer {
 4. Register the renderer
 
 ```php
-<?php declare(strict_types = 1);
-
-namespace MailPoet\EmailEditor\Integrations\Core;
+<?php
 
 use MailPoet\EmailEditor\Engine\Renderer\BlocksRegistry;
 
-class Initializer {
-  public function initialize(): void {
-    add_action('mailpoet_blocks_renderer_initialized', [$this, 'registerCoreBlocksRenderers'], 10, 1);
-    add_action('mailpoet_blocks_renderer_uninitialized', [$this, 'unregisterCoreBlocksRenderers'], 10, 1);
-  }
+add_action('mailpoet_blocks_renderer_initialized', 'register_my_block_email_renderer');
 
-  /**
-   * Register core blocks email renderers when the blocks renderer is initialized.
-   */
-  public function registerCoreBlocksRenderers(BlocksRegistry $blocksRegistry): void {
-    $blocksRegistry->addBlockRenderer('core/heading', new Renderer\Blocks\Heading());
-  }
-
-  public function unregisterCoreBlocksRenderers(BlocksRegistry $blocksRegistry): void {
-    $blocksRegistry->removeBlockRenderer('core/heading');
-  }
+function register_my_block_email_renderer(BlocksRegistry $blocksRegistry): void {
+  $blocksRegistry->addBlockRenderer('core/heading', new Renderer\Blocks\Heading());
 }
 ```
+
+Note: For core blocks this is currently done in `MailPoet\EmailEditor\Integrations\Core\Initializer`.
 
 5. Implement the rendering logic in the renderer class.
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -7,7 +7,6 @@ use MailPoet\EmailEditor\Engine\Renderer\BlocksRegistry;
 class Initializer {
   public function initialize(): void {
     add_action('mailpoet_blocks_renderer_initialized', [$this, 'registerCoreBlocksRenderers'], 10, 1);
-    add_action('mailpoet_blocks_renderer_uninitialized', [$this, 'unregisterCoreBlocksRenderers'], 10, 1);
   }
 
   /**
@@ -18,12 +17,5 @@ class Initializer {
     $blocksRegistry->addBlockRenderer('core/heading', new Renderer\Blocks\Heading());
     $blocksRegistry->addBlockRenderer('core/column', new Renderer\Blocks\Column());
     $blocksRegistry->addBlockRenderer('core/columns', new Renderer\Blocks\Columns());
-  }
-
-  public function unregisterCoreBlocksRenderers(BlocksRegistry $blocksRegistry): void {
-    $blocksRegistry->removeBlockRenderer('core/paragraph');
-    $blocksRegistry->removeBlockRenderer('core/heading');
-    $blocksRegistry->removeBlockRenderer('core/column');
-    $blocksRegistry->removeBlockRenderer('core/columns');
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/BlocksRegistryTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/BlocksRegistryTest.php
@@ -41,4 +41,23 @@ class BlocksRegistryTest extends \MailPoetTest {
     verify($storedRenderer)->equals($dummyRenderer);
     remove_filter('mailpoet_block_renderer_test', $callback);
   }
+
+  public function testItRemovesAllBlockRendererFilters() {
+    $renderer = new Paragraph();
+    verify(has_filter('render_block_test'))->false();
+    verify(has_filter('render_block_test2'))->false();
+
+    $this->registry->addBlockRenderer('test', $renderer);
+    $this->registry->addBlockRenderer('test2', $renderer);
+    verify(has_filter('render_block_test'))->true();
+    verify(has_filter('render_block_test2'))->true();
+    verify($this->registry->getBlockRenderer('test'))->notNull();
+    verify($this->registry->getBlockRenderer('test2'))->notNull();
+
+    $this->registry->removeAllBlockRendererFilters();
+    verify(has_filter('render_block_test'))->false();
+    verify(has_filter('render_block_test2'))->false();
+    verify($this->registry->getBlockRenderer('test'))->null();
+    verify($this->registry->getBlockRenderer('test2'))->null();
+  }
 }


### PR DESCRIPTION
## Description

This PR adds a simple guide for adding support for a specialized core block renderer to the email renderer. It also simplifies the API for registering such a renderer.

## Code review notes

_N/A_

## QA notes

This doesn't need QA testing.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5645]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5645]: https://mailpoet.atlassian.net/browse/MAILPOET-5645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ