### PR TITLE
Add support for vertical alignment in column renderer [MAILPOET-5690]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -30,9 +30,25 @@ class Column implements BlockRenderer {
     $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
 
+    $verticalAlign = 'top';
+    // Because `stretch` is not a valid value for the `vertical-align` property, we don't override the default value
+    if (isset($parsedBlock['attrs']['verticalAlignment']) && $parsedBlock['attrs']['verticalAlignment'] !== 'stretch') {
+      $verticalAlign = $parsedBlock['attrs']['verticalAlignment'];
+    }
+
+    $mainCellStyles = [
+      'width' => $width,
+      'vertical-align' => $verticalAlign,
+    ];
+    // The default column alignment is `stretch to fill` which means that we need to set the background color to the main cell
+    // to create a feeling of a stretched column
+    if (!isset($parsedBlock['attrs']['verticalAlignment'])) {
+      $mainCellStyles['background-color'] = $backgroundColor;
+    }
+
     return '
-      <td class="block" style="vertical-align:top;width:' . $width . ';background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';">
-        <div class="email_column" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';font-size:0px;text-align:left;display:inline-block;vertical-align:top;">
+      <td class="block" style="' . $this->convertStylesToString($mainCellStyles) . '">
+        <div class="email_column" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';font-size:0px;text-align:left;display:inline-block;">
           <table class="email_column" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';vertical-align:top;" width="' . $width . '">
             <tbody>
               <tr>
@@ -45,5 +61,13 @@ class Column implements BlockRenderer {
         </div>
       </td>
     ';
+  }
+
+  private function convertStylesToString(array $styles): string {
+    $cssString = '';
+    foreach ($styles as $property => $value) {
+      $cssString .= $property . ':' . $value . '; ';
+    }
+    return trim($cssString); // Remove trailing space and return the formatted string
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
@@ -75,5 +75,14 @@ class ColumnTest extends \MailPoetTest {
     verify($rendered)->stringContainsString('padding-left:15px;');
     verify($rendered)->stringContainsString('padding-right:20px;');
     verify($rendered)->stringContainsString('padding-top:10px;');
+    verify($rendered)->stringContainsString('vertical-align:top;'); // Check for the default value of vertical alignment
+  }
+
+  public function testItContainsExpectedVerticalAlignment(): void {
+    $parsedColumn = $this->parsedColumn;
+    $parsedColumn['attrs']['verticalAlignment'] = 'bottom';
+    $rendered = $this->columnRenderer->render('', $parsedColumn, $this->settingsController);
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('vertical-align:bottom;', $rendered);
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
@@ -46,9 +46,10 @@ class ColumnTest extends \MailPoetTest {
 
   public function testItRendersColumnContent() {
     $rendered = $this->columnRenderer->render('', $this->parsedColumn, $this->settingsController);
-    verify($rendered)->stringContainsString('Column content');
-    verify($rendered)->stringContainsString('width:300px;');
-    verify($rendered)->stringContainsString('max-width:300px;');
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('Column content', $rendered);
+    $this->assertStringContainsString('width:300px;', $rendered);
+    $this->assertStringContainsString('max-width:300px;', $rendered);
   }
 
   public function testItContainsColumnsStyles(): void {
@@ -69,13 +70,14 @@ class ColumnTest extends \MailPoetTest {
       ],
     ];
     $rendered = $this->columnRenderer->render('', $parsedColumn, $this->settingsController);
-    verify($rendered)->stringContainsString('background:#abcdef;');
-    verify($rendered)->stringContainsString('background-color:#abcdef;');
-    verify($rendered)->stringContainsString('padding-bottom:5px;');
-    verify($rendered)->stringContainsString('padding-left:15px;');
-    verify($rendered)->stringContainsString('padding-right:20px;');
-    verify($rendered)->stringContainsString('padding-top:10px;');
-    verify($rendered)->stringContainsString('vertical-align:top;'); // Check for the default value of vertical alignment
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('background:#abcdef;', $rendered);
+    $this->assertStringContainsString('background-color:#abcdef;', $rendered);
+    $this->assertStringContainsString('padding-bottom:5px;', $rendered);
+    $this->assertStringContainsString('padding-left:15px;', $rendered);
+    $this->assertStringContainsString('padding-right:20px;', $rendered);
+    $this->assertStringContainsString('padding-top:10px;', $rendered);
+    $this->assertStringContainsString('vertical-align:top;', $rendered); // Check for the default value of vertical alignment
   }
 
   public function testItContainsExpectedVerticalAlignment(): void {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5690]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5690]: https://mailpoet.atlassian.net/browse/MAILPOET-5690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ