### PR TITLE
Add email campaign name [MAILPOET-5646]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_newsletter.scss
+++ b/mailpoet/assets/css/src/components-plugin/_newsletter.scss
@@ -16,6 +16,16 @@
 }
 
 .mailpoet-form-send-email {
+  .mailpoet-send-campaign-name {
+    margin-bottom: -$grid-gap-large;
+    margin-top: $grid-gap-xl;
+
+    h1 {
+      font-size: $heading-font-size-h0;
+      font-weight: 600;
+    }
+  }
+
   .mailpoet-form-grid {
     grid-template-columns: $grid-column $grid-column;
     max-width: 976px;

--- a/mailpoet/assets/js/src/common/newsletter.ts
+++ b/mailpoet/assets/js/src/common/newsletter.ts
@@ -25,6 +25,7 @@ export enum NewsletterOptionGroup {
 }
 
 export type NewsLetter = {
+  campaign_name: string | null;
   body: {
     blockDefaults: unknown;
     content: unknown;

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/campaign-name.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/campaign-name.tsx
@@ -65,10 +65,8 @@ export function CampaignName() {
         )}
         renderContent={() => (
           <div className="mailpoet-email-editor-email-title-edit">
-            <div className="mailpoet-email-editor-dropdown-name-edit-title">
-              {__('Campaign name', 'mailpoet')}
-            </div>
             <TextControl
+              label={__('Campaign name', 'mailpoet')}
               value={emailTitle}
               onChange={(newTitle) => {
                 setTitle(newTitle);

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/campaign-name.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/campaign-name.tsx
@@ -14,7 +14,7 @@ import { storeName } from '../../store';
 
 // @see https://github.com/WordPress/gutenberg/blob/5e0ffdbc36cb2e967dfa6a6b812a10a2e56a598f/packages/edit-post/src/components/header/document-actions/index.js
 
-export function DocumentActions() {
+export function CampaignName() {
   const { showIconLabels } = useSelect(
     (select) => ({
       showIconLabels: select(storeName).isFeatureActive('showIconLabels'),
@@ -31,18 +31,18 @@ export function DocumentActions() {
 
   const titleRef = useRef(null);
   return (
-    <div ref={titleRef} className="mailpoet-email-editor-document-actions">
+    <div ref={titleRef} className="mailpoet-email-editor-campaign-name">
       <Dropdown
         popoverProps={{
           placement: 'bottom',
           anchor: titleRef.current,
         }}
-        contentClassName="mailpoet-email-editor-document-actions__dropdown"
+        contentClassName="mailpoet-email-editor-campaign-name__dropdown"
         renderToggle={({ isOpen, onToggle }) => (
           <>
             <Button
               onClick={onToggle}
-              className="mailpoet-email-document-actions__link"
+              className="mailpoet-email-campaign-name__link"
             >
               <Text size="body" as="h1">
                 <VisuallyHidden as="span">
@@ -52,7 +52,7 @@ export function DocumentActions() {
               </Text>
             </Button>
             <Button
-              className="mailpoet-email-document-actions__toggle"
+              className="mailpoet-email-campaign-name__toggle"
               icon={chevronDown}
               aria-expanded={isOpen}
               aria-haspopup="true"

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/document-actions.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/document-actions.tsx
@@ -73,6 +73,7 @@ export function DocumentActions() {
               onChange={(newTitle) => {
                 setTitle(newTitle);
               }}
+              name="campaign_name"
               help={__(
                 `Name your email campaign to indicate its purpose. This would only be visible to you and not shown to your subscribers.`,
                 'mailpoet',

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/document-actions.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/document-actions.tsx
@@ -1,0 +1,86 @@
+import { useRef } from '@wordpress/element';
+import {
+  Button,
+  Dropdown,
+  VisuallyHidden,
+  __experimentalText as Text,
+  TextControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
+import { storeName } from '../../store';
+
+// @see https://github.com/WordPress/gutenberg/blob/5e0ffdbc36cb2e967dfa6a6b812a10a2e56a598f/packages/edit-post/src/components/header/document-actions/index.js
+
+export function DocumentActions() {
+  const { showIconLabels } = useSelect(
+    (select) => ({
+      showIconLabels: select(storeName).isFeatureActive('showIconLabels'),
+      postId: select(storeName).getEmailPostId(),
+    }),
+    [],
+  );
+
+  const [emailTitle = '', setTitle] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'title',
+  );
+
+  const titleRef = useRef(null);
+  return (
+    <div ref={titleRef} className="mailpoet-email-editor-document-actions">
+      <Dropdown
+        popoverProps={{
+          placement: 'bottom',
+          anchor: titleRef.current,
+        }}
+        contentClassName="mailpoet-email-editor-document-actions__dropdown"
+        renderToggle={({ isOpen, onToggle }) => (
+          <>
+            <Button
+              onClick={onToggle}
+              className="mailpoet-email-document-actions__link"
+            >
+              <Text size="body" as="h1">
+                <VisuallyHidden as="span">
+                  {__('Editing email:', 'mailpoet')}
+                </VisuallyHidden>
+                {emailTitle}
+              </Text>
+            </Button>
+            <Button
+              className="mailpoet-email-document-actions__toggle"
+              icon={chevronDown}
+              aria-expanded={isOpen}
+              aria-haspopup="true"
+              onClick={onToggle}
+              label={__('Change campaign name', 'mailpoet')}
+            >
+              {showIconLabels && __('Rename', 'mailpoet')}
+            </Button>
+          </>
+        )}
+        renderContent={() => (
+          <div className="mailpoet-email-editor-email-title-edit">
+            <div className="mailpoet-email-editor-dropdown-name-edit-title">
+              {__('Campaign name', 'mailpoet')}
+            </div>
+            <TextControl
+              value={emailTitle}
+              onChange={(newTitle) => {
+                setTitle(newTitle);
+              }}
+              help={__(
+                `Name your email campaign to indicate its purpose. This would only be visible to you and not shown to your subscribers.`,
+                'mailpoet',
+              )}
+            />
+          </div>
+        )}
+      />
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -3,14 +3,15 @@ import { PinnedItems } from '@wordpress/interface';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEntityProp, store as coreDataStore } from '@wordpress/core-data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { plus, listView, undo, redo } from '@wordpress/icons';
-import { MailPoetEmailData, storeName } from '../../store';
+import { storeName } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';
 import { SaveButton } from './save-button';
 import { CampaignName } from './campaign-name';
+import { SendButton } from './send-button';
 
 export function Header() {
   const inserterButton = useRef();
@@ -31,12 +32,6 @@ export function Header() {
       }),
       [],
     );
-  const [mailpoetEmailDa] = useEntityProp(
-    'postType',
-    'mailpoet_email',
-    'mailpoet_data',
-  );
-  const mailpoetEmailData: MailPoetEmailData = mailpoetEmailDa;
 
   const preventDefault = (event) => {
     event.preventDefault();
@@ -112,14 +107,7 @@ export function Header() {
       <div className="edit-post-header__settings">
         <SaveButton />
         <PreviewDropdown />
-        <Button
-          variant="primary"
-          onClick={() => {
-            window.location.href = `admin.php?page=mailpoet-newsletters#/send/${mailpoetEmailData.id}`;
-          }}
-        >
-          {__('Send', 'mailpoet')}
-        </Button>
+        <SendButton />
         <PinnedItems.Slot scope={storeName} />
         <MoreMenu />
       </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -10,6 +10,7 @@ import { MailPoetEmailData, storeName } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';
 import { SaveButton } from './save-button';
+import { DocumentActions } from './document-actions';
 
 export function Header() {
   const inserterButton = useRef();
@@ -104,7 +105,9 @@ export function Header() {
             />
           </div>
         </NavigableToolbar>
-        <div className="edit-post-header__center">Todo Email Name</div>
+        <div className="edit-post-header__center">
+          <DocumentActions />
+        </div>
       </div>
       <div className="edit-post-header__settings">
         <SaveButton />

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -10,7 +10,7 @@ import { MailPoetEmailData, storeName } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';
 import { SaveButton } from './save-button';
-import { DocumentActions } from './document-actions';
+import { CampaignName } from './campaign-name';
 
 export function Header() {
   const inserterButton = useRef();
@@ -106,7 +106,7 @@ export function Header() {
           </div>
         </NavigableToolbar>
         <div className="edit-post-header__center">
-          <DocumentActions />
+          <CampaignName />
         </div>
       </div>
       <div className="edit-post-header__settings">

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
@@ -26,7 +26,7 @@
 // Document actions - Popup for editing email/campaign title
 .mailpoet-email-editor-campaign-name__dropdown {
   .components-popover__content {
-    min-width: 240px;
+    min-width: 280px;
     padding: 0;
   }
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
@@ -1,5 +1,5 @@
 // Document actions - Component in header for displaying email/campaign title edit popup
-.mailpoet-email-editor-document-actions {
+.mailpoet-email-editor-campaign-name {
   align-items: center;
   display: flex;
   flex-direction: row;
@@ -15,7 +15,7 @@
     padding: 0;
   }
 
-  .mailpoet-email-document-actions__link {
+  .mailpoet-email-campaign-name__link {
     display: inline-flex;
     height: fit-content;
     margin-right: 10px;
@@ -24,7 +24,7 @@
 }
 
 // Document actions - Popup for editing email/campaign title
-.mailpoet-email-editor-document-actions__dropdown {
+.mailpoet-email-editor-campaign-name__dropdown {
   .components-popover__content {
     min-width: 240px;
     padding: 0;

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
@@ -33,8 +33,4 @@
   .mailpoet-email-editor-email-title-edit {
     padding: 16px;
   }
-
-  .mailpoet-email-editor-dropdown-name-edit-title {
-    margin-bottom: 10px;
-  }
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/index.scss
@@ -1,0 +1,40 @@
+// Document actions - Component in header for displaying email/campaign title edit popup
+.mailpoet-email-editor-document-actions {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  min-width: 0;
+
+  .components-dropdown {
+    display: inline-flex;
+  }
+
+  .components-button {
+    min-width: 0;
+    padding: 0;
+  }
+
+  .mailpoet-email-document-actions__link {
+    display: inline-flex;
+    height: fit-content;
+    margin-right: 10px;
+    margin-top: 10px;
+  }
+}
+
+// Document actions - Popup for editing email/campaign title
+.mailpoet-email-editor-document-actions__dropdown {
+  .components-popover__content {
+    min-width: 240px;
+    padding: 0;
+  }
+
+  .mailpoet-email-editor-email-title-edit {
+    padding: 16px;
+  }
+
+  .mailpoet-email-editor-dropdown-name-edit-title {
+    margin-bottom: 10px;
+  }
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/index.ts
@@ -1,1 +1,3 @@
+import './index.scss';
+
 export * from './header';

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { MailPoetEmailData } from 'email-editor/engine/store';
+import { MailPoetEmailData, storeName } from 'email-editor/engine/store';
+import { useSelect } from '@wordpress/data';
 
 export function SendButton() {
   const [mailpoetEmail] = useEntityProp(
@@ -9,6 +10,13 @@ export function SendButton() {
     'mailpoet_email',
     'mailpoet_data',
   );
+  const { hasEmptyContent } = useSelect(
+    (select) => ({
+      hasEmptyContent: select(storeName).hasEmptyContent(),
+    }),
+    [],
+  );
+
   const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
   return (
     <Button
@@ -16,6 +24,7 @@ export function SendButton() {
       onClick={() => {
         window.location.href = `admin.php?page=mailpoet-newsletters#/send/${mailpoetEmailData.id}`;
       }}
+      disabled={hasEmptyContent}
     >
       {__('Send', 'mailpoet')}
     </Button>

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
@@ -1,0 +1,23 @@
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { MailPoetEmailData } from 'email-editor/engine/store';
+
+export function SendButton() {
+  const [mailpoetEmail] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+  const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
+  return (
+    <Button
+      variant="primary"
+      onClick={() => {
+        window.location.href = `admin.php?page=mailpoet-newsletters#/send/${mailpoetEmailData.id}`;
+      }}
+    >
+      {__('Send', 'mailpoet')}
+    </Button>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -22,7 +22,7 @@ export function DetailsPanel() {
     'mailpoet_data',
   );
 
-  const { updateEmailProperty } = useDispatch(storeName);
+  const { updateEmailMailPoetProperty } = useDispatch(storeName);
 
   let subjectHelp = ReactStringReplace(
     __(
@@ -93,7 +93,7 @@ export function DetailsPanel() {
         label={subjectLabel}
         placeholder={__('Eg. The summer sale is here!', 'mailpoet')}
         value={mailpoetEmailData?.subject ?? ''}
-        onChange={(value) => updateEmailProperty('subject', value)}
+        onChange={(value) => updateEmailMailPoetProperty('subject', value)}
         data-automation-id="email_subject"
       />
       <div className="mailpoet-settings-panel__help">
@@ -108,7 +108,7 @@ export function DetailsPanel() {
           'mailpoet',
         )}
         value={mailpoetEmailData?.preheader ?? ''}
-        onChange={(value) => updateEmailProperty('preheader', value)}
+        onChange={(value) => updateEmailMailPoetProperty('preheader', value)}
         data-automation-id="email_preview_text"
       />
       <div className="mailpoet-settings-panel__help">

--- a/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
@@ -85,7 +85,7 @@ export function* saveEditedEmail() {
   });
 }
 
-export function* updateEmailProperty(name: string, subject: string) {
+export function* updateEmailMailPoetProperty(name: string, value: string) {
   const postId = select(storeName).getEmailPostId();
   // There can be a better way how to get the edited post data
   const editedPost = select(coreDataStore).getEditedEntityRecord(
@@ -103,7 +103,7 @@ export function* updateEmailProperty(name: string, subject: string) {
     {
       mailpoet_data: {
         ...mailpoetData,
-        [name]: subject,
+        [name]: value,
       },
     },
   );

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -55,9 +55,32 @@ export const isEmpty = createRegistrySelector((select) => (): boolean => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const { content, mailpoet_data: mailpoetData } = post;
-  return !content.raw && !mailpoetData.subject && !mailpoetData.preheader;
+  const { content, mailpoet_data: mailpoetData, title } = post;
+  return (
+    !content.raw &&
+    !mailpoetData.subject &&
+    !mailpoetData.preheader &&
+    !title.raw
+  );
 });
+
+export const hasEmptyContent = createRegistrySelector(
+  (select) => (): boolean => {
+    const postId = select(storeName).getEmailPostId();
+
+    const post = select(coreDataStore).getEntityRecord(
+      'postType',
+      'mailpoet_email',
+      postId,
+    );
+    if (!post) return true;
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const { content } = post;
+    return !content.raw;
+  },
+);
 
 export function getEmailPostId(state: State): number {
   return state.postId;

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -146,7 +146,14 @@ function NewsletterStatsInfo({ newsletter }: Props) {
   return (
     <Grid.ThreeColumns className="mailpoet-stats-info">
       <div>
-        <Heading level={1}>{newsletter.subject}</Heading>
+        <Heading level={1}>
+          {newsletter.campaign_name
+            ? newsletter.campaign_name
+            : newsletter.subject}
+          {newsletter.campaign_name && (
+            <span>{` (${newsletter.subject})`}</span>
+          )}
+        </Heading>
         <div>
           <Tag isInverted={false}>
             {getNewsletterStatusString(newsletter.status)}

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
@@ -2,6 +2,7 @@ export type NewsletterType = {
   id: string;
   total_sent: number;
   subject: string;
+  campaign_name: string;
   segments: { name: string; id?: string }[];
   queue: {
     scheduled_at: string;

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -76,7 +76,9 @@ const messages = {
 const columns = [
   {
     name: 'subject',
-    label: __('Subject', 'mailpoet'),
+    label: MailPoet.FeaturesController.isSupported('gutenberg_email_editor')
+      ? __('Name', 'mailpoet')
+      : __('Subject', 'mailpoet'),
     sortable: true,
   },
   {
@@ -210,6 +212,9 @@ class NewsletterListStandardComponent extends Component {
       'has-row-actions',
     );
 
+    const subject =
+      newsletter.queue.newsletter_rendered_subject || newsletter.subject;
+
     return (
       <div>
         <td className={rowClasses}>
@@ -221,7 +226,14 @@ class NewsletterListStandardComponent extends Component {
               confirmEdit(newsletter);
             }}
           >
-            {newsletter.queue.newsletter_rendered_subject || newsletter.subject}
+            {newsletter.campaign_name ? (
+              <>
+                {newsletter.campaign_name} <br />
+                <span className="mailpoet-listing-subtitle">{subject}</span>
+              </>
+            ) : (
+              subject
+            )}
           </a>
           {actions}
         </td>

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -75,7 +75,9 @@ const messages = {
 
 const columns = [
   {
-    name: 'subject',
+    name: MailPoet.FeaturesController.isSupported('gutenberg_email_editor')
+      ? 'name'
+      : 'subject',
     label: MailPoet.FeaturesController.isSupported('gutenberg_email_editor')
       ? __('Name', 'mailpoet')
       : __('Subject', 'mailpoet'),

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -811,6 +811,11 @@ class NewsletterSendComponent extends Component<
           automationId="newsletter_send_heading"
         />
         <ErrorBoundary>
+          {this.state.item.campaign_name ? (
+            <div className="mailpoet-form-grid mailpoet-send-campaign-name">
+              <h1>{this.state.item.campaign_name}</h1>
+            </div>
+          ) : null}
           <SendContext.Provider value={this.state.sendContextValue}>
             <Form
               id="mailpoet_newsletter"

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-clicks.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-clicks.tsx
@@ -44,7 +44,7 @@ export function EmailClickStatisticsFields({
       ? MailPoet.Date.format(newsletter.sent_at)
       : __('Not sent yet', 'mailpoet');
     return {
-      label: newsletter.subject,
+      label: newsletter.name,
       tag: sentAt,
       value: Number(newsletter.id),
     };

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-opens.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-opens.tsx
@@ -36,7 +36,7 @@ export function EmailOpenStatisticsFields({
       ? MailPoet.Date.format(newsletter.sent_at)
       : MailPoet.I18n.t('notSentYet');
     return {
-      label: newsletter.subject,
+      label: newsletter.name,
       tag: sentAt,
       value: Number(newsletter.id),
     };

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -234,6 +234,7 @@ export type WindowProductCategories = {
 export type WindowNewslettersList = {
   sent_at: string;
   subject: string;
+  name: string;
   id: string;
 }[];
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -81,6 +81,7 @@ class NewslettersResponseBuilder {
       'unsubscribe_token' => $newsletter->getUnsubscribeToken(),
       'ga_campaign' => $newsletter->getGaCampaign(),
       'wp_post_id' => $newsletter->getWpPostId(),
+      'campaign_name' => $newsletter->getCampaignName(),
     ];
 
     foreach ($relations as $relation) {
@@ -135,7 +136,6 @@ class NewslettersResponseBuilder {
     $couponBlockLogs = array_map(function ($item) {
       return "Coupon block: $item";
     }, $this->logRepository->getRawMessagesForNewsletter($newsletter, LoggerFactory::TOPIC_COUPONS));
-
     $data = [
       'id' => (string)$newsletter->getId(), // (string) for BC
       'hash' => $newsletter->getHash(),
@@ -159,6 +159,7 @@ class NewslettersResponseBuilder {
           : null
       ),
       'logs' => $couponBlockLogs,
+      'campaign_name' => $newsletter->getCampaignName(),
     ];
 
     if ($newsletter->getType() === NewsletterEntity::TYPE_STANDARD) {

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -186,7 +186,7 @@ class DynamicSegments {
       $result[] = [
         'id' => (string)$newsletter->getId(),
         'subject' => $newsletter->getSubject(),
-        'name' => $newsletter->getPresentableName(),
+        'name' => $newsletter->getCampaignNameOrSubject(),
         'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format('Y-m-d H:i:s') : null,
       ];
     }

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -186,6 +186,7 @@ class DynamicSegments {
       $result[] = [
         'id' => (string)$newsletter->getId(),
         'subject' => $newsletter->getSubject(),
+        'name' => $newsletter->getPresentableName(),
         'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format('Y-m-d H:i:s') : null,
       ];
     }

--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -23,7 +23,10 @@ class Env {
   public static $languagesPath;
   public static $libPath;
   public static $pluginPrefix;
+  /** @var string WP DB prefix + plugin prefix */
   public static $dbPrefix;
+  /** @var string WP DB prefix only */
+  public static $wpDbPrefix;
   public static $dbHost;
   public static $dbIsIpv6;
   public static $dbSocket;
@@ -78,6 +81,7 @@ class Env {
 
     global $wpdb;
     self::$dbPrefix = $wpdb->prefix . self::$pluginPrefix;
+    self::$wpDbPrefix = $wpdb->prefix;
     self::$dbHost = $host;
     self::$dbIsIpv6 = $isIpv6;
     self::$dbPort = $port;

--- a/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
@@ -50,7 +50,7 @@ class EmailEditor {
       'show_ui' => true,
       'show_in_menu' => false,
       'show_in_nav_menus' => false,
-      'supports' => ['editor'],
+      'supports' => ['editor', 'title'],
       'has_archive' => true,
       'show_in_rest' => true, // Important to enable Gutenberg editor
     ];

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -28,7 +28,7 @@ class EmailApiController {
    * @return array - MailPoet specific email data that will be attached to the post API response
    */
   public function getEmailData($postEmailData): array {
-    $newsletter = $this->newsletterRepository->findOneBy(['wpPostId' => $postEmailData['id']]);
+    $newsletter = $this->newsletterRepository->findOneBy(['wpPost' => $postEmailData['id']]);
     return [
       'id' => $newsletter ? $newsletter->getId() : null,
       'subject' => $newsletter ? $newsletter->getSubject() : '',

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -592,7 +592,7 @@ class NewsletterEntity {
    * Used for cases when we present newsletter by name.
    * Newsletters created via legacy editor have only subjects.
    */
-  public function getPresentableName(): string {
+  public function getCampaignNameOrSubject(): string {
     $campaignName = $this->getCampaignName();
     return $campaignName ?: $this->getSubject();
   }

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -587,4 +587,13 @@ class NewsletterEntity {
     }
     return $wpPost->getPostTitle();
   }
+
+  /**
+   * Used for cases when we present newsletter by name.
+   * Newsletters created via legacy editor have only subjects.
+   */
+  public function getPresentableName(): string {
+    $campaignName = $this->getCampaignName();
+    return $campaignName ?: $this->getSubject();
+  }
 }

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -584,4 +584,12 @@ class NewsletterEntity {
     $post = \WP_Post::get_instance($this->wpPostId);
     return $post ?: null;
   }
+
+  public function getCampaignName(): ?string {
+    $post = $this->getWpPost();
+    if (!$post) {
+      return null;
+    }
+    return $post->post_title; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
 }

--- a/mailpoet/lib/Entities/WpPostEntity.php
+++ b/mailpoet/lib/Entities/WpPostEntity.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="posts")
+ */
+class WpPostEntity {
+  /**
+   * @ORM\Column(type="integer", name="ID")
+   * @ORM\Id
+   * @ORM\GeneratedValue
+   * @var int
+   */
+  private $id;
+
+  /**
+   * @ORM\Column(type="string", name="post_title")
+   * @var string
+   */
+  private $postTitle;
+
+  public function __construct(
+    int $id,
+    string $postTitle
+  ) {
+    $this->id = $id;
+    $this->$postTitle = $postTitle;
+  }
+
+  public function getId(): int {
+    return $this->id;
+  }
+
+  public function getPostTitle(): string {
+    return $this->postTitle;
+  }
+
+  /**
+   * We don't use typehint for now because doctrine cache generator would fail as it doesn't know the class.
+   * @return \WP_Post|null
+   */
+  public function getWpPostInstance() {
+    $post = \WP_Post::get_instance($this->id);
+    return $post ?: null;
+  }
+}

--- a/mailpoet/lib/Entities/WpPostEntity.php
+++ b/mailpoet/lib/Entities/WpPostEntity.php
@@ -2,10 +2,11 @@
 
 namespace MailPoet\Entities;
 
+use MailPoet\RuntimeException;
 use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity()
+ * @ORM\Entity(readOnly=true)
  * @ORM\Table(name="posts")
  */
 class WpPostEntity {
@@ -23,12 +24,8 @@ class WpPostEntity {
    */
   private $postTitle;
 
-  public function __construct(
-    int $id,
-    string $postTitle
-  ) {
-    $this->id = $id;
-    $this->$postTitle = $postTitle;
+  public function __construct() {
+    throw new RuntimeException('WpPostEntity is read only and cannot be instantiated.');
   }
 
   public function getId(): int {

--- a/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
+++ b/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
@@ -238,6 +238,11 @@ class NewsletterListingRepository extends ListingRepository {
   }
 
   protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
+    if ($sortBy === 'name') {
+      $queryBuilder->addSelect('CONCAT(COALESCE(wpPost.postTitle, \'\'), n.subject) AS HIDDEN sortingName');
+      $queryBuilder->addOrderBy("sortingName", $sortOrder);
+      return;
+    }
     if ($sortBy === 'sentAt') {
       $queryBuilder->addSelect('CASE WHEN n.sentAt IS NULL THEN 1 ELSE 0 END AS HIDDEN sentAtIsNull');
       $queryBuilder->addOrderBy('sentAtIsNull', 'DESC');

--- a/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
+++ b/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
@@ -179,11 +179,12 @@ class NewsletterListingRepository extends ListingRepository {
   }
 
   protected function applySelectClause(QueryBuilder $queryBuilder) {
-    $queryBuilder->select("PARTIAL n.{id,subject,hash,type,status,sentAt,updatedAt,deletedAt,wpPostId}");
+    $queryBuilder->select("PARTIAL n.{id,subject,hash,type,status,sentAt,updatedAt,deletedAt}, PARTIAL wpPost.{id,postTitle}");
   }
 
   protected function applyFromClause(QueryBuilder $queryBuilder) {
-    $queryBuilder->from(NewsletterEntity::class, 'n');
+    $queryBuilder->from(NewsletterEntity::class, 'n')
+      ->leftJoin('n.wpPost', 'wpPost');
   }
 
   protected function applyGroup(QueryBuilder $queryBuilder, string $group) {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\WpPostEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Models\Newsletter;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
@@ -201,8 +202,10 @@ class NewsletterSaveController {
       $newPostId = $this->wp->wpInsertPost([
         'post_content' => $post->post_content, // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         'post_type' => $post->post_type, // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        // translators: %s is the campaign name of the mail which has been copied.
+        'post_title' => sprintf(__('Copy of %s', 'mailpoet'), $post->post_title), // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       ]);
-      $duplicate->setWpPostId($newPostId);
+      $duplicate->setWpPost($this->entityManager->getReference(WpPostEntity::class, $newPostId));
     }
 
     // create relationships between duplicate and segments

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -468,10 +468,10 @@ class NewslettersRepository extends Repository {
 
       // Fetch WP Posts IDs and delete them
       /** @var int[] $wpPostsIds */
-      $wpPostsIds = $entityManager->createQueryBuilder()->select('n.wpPostId')
+      $wpPostsIds = $entityManager->createQueryBuilder()->select('wpp.id')
         ->from(NewsletterEntity::class, 'n')
+        ->join('n.wpPost', 'wpp')
         ->where('n.id IN (:ids)')
-        ->andWhere('n.wpPostId IS NOT NULL')
         ->setParameter('ids', $ids)
         ->getQuery()->getSingleColumnResult();
       foreach ($wpPostsIds as $wpPostId) {

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -515,9 +515,10 @@ class NewslettersRepository extends Repository {
    */
   public function getStandardNewsletterList(): array {
     return $this->entityManager->createQueryBuilder()
-      ->select('PARTIAL n.{id,subject,sentAt}')
+      ->select('PARTIAL n.{id,subject,sentAt}, PARTIAL wpPost.{id, postTitle}')
       ->addSelect('CASE WHEN n.sentAt IS NULL THEN 1 ELSE 0 END as HIDDEN sent_at_is_null')
       ->from(NewsletterEntity::class, 'n')
+      ->leftJoin('n.wpPost', 'wpPost')
       ->where('n.type = :typeStandard')
       ->andWhere('n.deletedAt IS NULL')
       ->orderBy('sent_at_is_null', 'DESC')

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -87,7 +87,8 @@ class Renderer {
     $language = $this->wp->getBloginfo('language');
     $metaRobots = $preview ? '<meta name="robots" content="noindex, nofollow" />' : '';
     $subject = $subject ?: $newsletter->getSubject();
-    $wpPost = $newsletter->getWpPost();
+    $wpPostEntity = $newsletter->getWpPost();
+    $wpPost = $wpPostEntity ? $wpPostEntity->getWpPostInstance() : null;
     if ($this->featuresController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR) && $wpPost instanceof \WP_Post) {
       $renderedNewsletter = $this->guntenbergRenderer->render($wpPost, $subject, $newsletter->getPreheader(), $language, $metaRobots);
     } else {

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -91,6 +91,11 @@ parameters:
       message: '/function add_(sub)?menu_page expects callable\(\): mixed, ''''\|\(callable\(\): mixed\) given/'
       count: 2
       path: ../../lib/WP/Functions.php
+    -
+      # We don't allow seting properties for read-only entity WpPostEntity
+      message: '#^Property MailPoet\\Entities\\WpPostEntity::\$postTitle is never written, only read\.$#'
+      count: 1
+      path: ../../lib/Entities/WpPostEntity.php
 
   reportUnmatchedIgnoredErrors: true
   dynamicConstantNames:

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -12,6 +12,7 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\WpPostEntity;
 use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -420,7 +421,10 @@ class Newsletter {
     if (isset($this->data['parent'])) $newsletter->setParent($this->data['parent']);
     if (isset($this->data['deleted_at'])) $newsletter->setDeletedAt($this->data['deleted_at']);
     if (isset($this->data['ga_campaign'])) $newsletter->setGaCampaign($this->data['ga_campaign']);
-    if (isset($this->data['wp_post_id'])) $newsletter->setWpPostId($this->data['wp_post_id']);
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+    if (isset($this->data['wp_post_id'])) {
+      $newsletter->setWpPost($entityManager->getReference(WpPostEntity::class, intval($this->data['wp_post_id'])));
+    }
 
     if (isset($this->data['unsubscribeToken'])) {
       $newsletter->setUnsubscribeToken($this->data['unsubscribeToken']);

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -32,6 +32,12 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->wantTo('Verify correct WP menu item is highlighted');
     $i->waitForText('Emails', 10, '#toplevel_page_mailpoet-homepage .current');
 
+    $i->wantTo('Change Campaign name');
+    $i->click('New Email');
+    $i->waitForElement('[name="campaign_name"]');
+    $i->clearFormField('[name="campaign_name"]');
+    $i->type('My Campaign Name');
+
     $i->wantTo('Change subject and preheader');
     $i->click('[data-automation-id="email_settings_tab"]');
     $i->fillField('[data-automation-id="email_subject"]', 'My New Subject');
@@ -53,6 +59,10 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForEmailSendingOrSent();
 
     $i->triggerMailPoetActionScheduler();
+
+    $i->wantTo('Confirm the newsletter campaign name was saved');
+    $i->amOnMailpoetPage('Emails');
+    $i->waitForText('My Campaign Name', 10, '[data-automation-id="newsletters_listing_tabs"]');
 
     $i->wantTo('Confirm the newsletter was received');
     $i->checkEmailWasReceived('My New Subject');

--- a/mailpoet/tests/integration/Doctrine/TablePrefixMetadataFactoryTest.php
+++ b/mailpoet/tests/integration/Doctrine/TablePrefixMetadataFactoryTest.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Doctrine;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\WpPostEntity;
+
+class TablePrefixMetadataFactoryTest extends \MailPoetTest {
+  public function testItPrefixTablesCorrectly() {
+    $wpPostMetadata = $this->entityManager->getClassMetadata(WpPostEntity::class);
+    $newslettersMetadata = $this->entityManager->getClassMetadata(NewsletterEntity::class);
+    verify($wpPostMetadata->getTableName())->equals('mp_posts');
+    verify($newslettersMetadata->getTableName())->equals('mp_mailpoet_newsletters');
+  }
+}

--- a/mailpoet/tests/integration/Entities/WpPostEntityTest.php
+++ b/mailpoet/tests/integration/Entities/WpPostEntityTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+class WpPostEntityTest extends \MailPoetTest {
+  public function testItIsReadOnlyAndCanNotBeInstantiated() {
+    $this->expectException(\MailPoet\RuntimeException::class);
+    $this->expectExceptionMessage('WpPostEntity is read only and cannot be instantiated.');
+    new WpPostEntity();
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -20,6 +20,7 @@ use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Entities\StatsNotificationEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\WpPostEntity;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
@@ -248,11 +249,13 @@ class NewsletterRepositoryTest extends \MailPoetTest {
   public function testItDeletesWpPostsBulkDelete() {
     $newsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
     $post1Id = $this->wp->wpInsertPost(['post_title' => 'Post 1']);
-    $newsletter1->setWpPostId($post1Id);
+    $newsletter1->setWpPost($this->entityManager->getReference(WpPostEntity::class, $post1Id));
     $newsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_WELCOME, NewsletterEntity::STATUS_SENDING);
     $post2Id = $this->wp->wpInsertPost(['post_title' => 'Post 2']);
-    $newsletter2->setWpPostId($post2Id);
+    $newsletter2->setWpPost($this->entityManager->getReference(WpPostEntity::class, $post2Id));
     $newsletter3 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
+
+    $blogPost = $this->wp->wpInsertPost(['post_title' => 'Regular blog post']);
 
     verify($this->wp->getPost($post1Id))->instanceOf(\WP_Post::class);
     verify($this->wp->getPost($post2Id))->instanceOf(\WP_Post::class);
@@ -263,6 +266,7 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->repository->bulkDelete([$newsletter1->getId(), $newsletter2->getId(), $newsletter3->getId()]);
     verify($this->wp->getPost($post1Id))->null();
     verify($this->wp->getPost($post2Id))->null();
+    verify($this->wp->getPost($blogPost))->instanceOf(\WP_Post::class);
   }
 
   public function testItGetsArchiveNewslettersForSegments() {

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -10,6 +10,7 @@ use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\WpPostEntity;
 use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -336,12 +337,13 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
   public function testItDuplicatesNewsletterWithAssociatedPost() {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
     $wp = $this->diContainer->get(WPFunctions::class);
-    $postId = $wp->wpInsertPost(['post_content' => 'newsletter content']);
-    $newsletter->setWpPostId($postId);
+    $postId = $wp->wpInsertPost(['post_content' => 'newsletter content', 'post_title' => 'Newsletter Title']);
+    $newsletter->setWpPost($this->entityManager->getReference(WpPostEntity::class, $postId));
     $this->entityManager->flush();
     $duplicate = $this->saveController->duplicate($newsletter);
     verify($duplicate->getWpPostId())->notEquals($postId);
     $post = $wp->getPost($duplicate->getWpPostId());
+    verify($duplicate->getCampaignName())->equals('Copy of Newsletter Title');
     verify($post->post_content)->equals('newsletter content'); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 


### PR DESCRIPTION
## Description

This PR adds campaign name input into the new email editor, and it also adds support for the campaign name in other parts of the plugin, where we refer to an email by name.

#### Campaign Name in the editor

![Screenshot 2023-12-13 at 15 47 02](https://github.com/mailpoet/mailpoet/assets/1082140/13fcc88a-9c45-409e-96cc-118e0b9e0c47)


#### Campaign in other parts of the plugin

1. In emails listing, when an email has a campaign name we show the campaign name and a subject is displayed on the other line in smaller font.
<img width="726" alt="Screenshot 2023-11-13 at 10 05 04" src="https://github.com/mailpoet/mailpoet/assets/1082140/9d097ef3-6520-471f-992c-adbeab07642f">

2. List of emails in dynamic segments UI. For segments where a user needs to pick segment we display only the campaign name if available.
3. The page title in email stats page – we display both name and subject.

## Code review notes

@JanJakes I chose to store the campaign name as a title in `wp_post` table. I think this makes sense for the future reusability of the editor. In order to support the campaign name in listings and other places in the plugin where we use Doctrine I added a minimalistic Doctrine entity for the WPPost. To support the entity I needed to do a few changes in the metadata factory for table prefixes. I put some logic directly to the factory class which makes this class aware that some tables are from WordPress. We may want to add an abstraction, but as this is a project (not a library) I thought it is ok.  I want to ask you for review of the related commits: c5c4e47f5094e8a02fcbb5b1585425a737c33844, fc2103661e2c83d4de7ab9ef9594629987c3ccf5 

## QA notes

1. Go to the experimental page and enable the new email editor (`wp-admin/admin.php?page=mailpoet-experimental`)
2. Create a standard newsletter in the new editor and set the campaign name and title
3. Verify that the campaign name is displayed in all places as expected
4. Are there some places where we should email name I missed?

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/820

## Linked tickets

[MAILPOET-5646]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5646]: https://mailpoet.atlassian.net/browse/MAILPOET-5646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ