### PR TITLE
Load and apply core layout styles for content in the email editor [MAILPOET-5715]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -11,6 +11,9 @@ import {
   // @ts-ignore No types for this exist yet.
   __experimentalUseResizeCanvas as useResizeCanvas,
   BlockSelectionClearer,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore No types for this exist yet.
+  __unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 import { uploadMedia } from '@wordpress/media-utils';
 import classnames from 'classnames';
@@ -147,6 +150,10 @@ export function BlockEditor() {
                     'is-desktop-preview': previewDeviceType === 'Desktop',
                   })}
                 >
+                  <EditorStyles
+                    styles={settings.styles}
+                    scope=".editor-styles-wrapper"
+                  />
                   <BlockSelectionClearer
                     className="editor-styles-wrapper block-editor-writing-flow"
                     style={{ width: '100%' }}
@@ -157,7 +164,7 @@ export function BlockEditor() {
                     <BlockTools>
                       <WritingFlow>
                         <ObserveTyping>
-                          <BlockList />
+                          <BlockList className="is-layout-constrained" />
                         </ObserveTyping>
                       </WritingFlow>
                     </BlockTools>

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -102,7 +102,8 @@ class SettingsController {
 
     $settings = array_merge($coreDefaultSettings, self::DEFAULT_SETTINGS);
     $settings['allowedBlockTypes'] = self::ALLOWED_BLOCK_TYPES;
-    $settings['defaultEditorStyles'] = [[ 'css' => $this->getEmailContentStyles() ]];
+    $settings['styles'] = [['css' => wp_get_global_stylesheet(['base-layout-styles'])]];
+
     $settings['__experimentalFeatures'] = $coreSettings;
 
     return $settings;


### PR DESCRIPTION
## Description

The CSS is needed to support alignment (mostly) block settings in the email editor.

## Code review notes

We may add more styles as we go using this mechanism.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5715]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5715]: https://mailpoet.atlassian.net/browse/MAILPOET-5715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ