### PR TITLE
Black Friday/Cyber Monday 2023 changes [MAILPOET-5440][MAILPOET-5707]

### DIFF
--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -32,6 +32,7 @@ class BlackFridayNotice {
 
   public function init($shouldDisplay) {
     $shouldDisplay = $shouldDisplay
+      && !$this->servicesChecker->isBundledSubscription()
       && (time() >= strtotime(self::DATE_FROM))
       && (time() <= strtotime(self::DATE_TO))
       && !get_transient(self::OPTION_NAME);

--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -10,6 +10,8 @@ class BlackFridayNotice {
 
   const OPTION_NAME = 'dismissed-black-friday-notice';
   const DISMISS_NOTICE_TIMEOUT_SECONDS = 2592000; // 30 days
+  const DATE_FROM = '2023-11-22 14:00:00 UTC';
+  const DATE_TO = '2023-11-28 14:00:00 UTC';
 
   /** @var SubscribersRepository */
   private $subscribersRepository;
@@ -22,8 +24,8 @@ class BlackFridayNotice {
 
   public function init($shouldDisplay) {
     $shouldDisplay = $shouldDisplay
-      && (time() >= strtotime('2023-06-14 14:00:00 UTC'))
-      && (time() <= strtotime('2023-06-19 14:00:00 UTC'))
+      && (time() >= strtotime(self::DATE_FROM))
+      && (time() <= strtotime(self::DATE_TO))
       && !get_transient(self::OPTION_NAME);
     if ($shouldDisplay) {
       $this->display();
@@ -32,8 +34,8 @@ class BlackFridayNotice {
 
   private function display() {
     $subscribers = $this->subscribersRepository->countBy(['deletedAt' => null]);
-    $header = '<h3 class="mailpoet-h3">' . __('Get 40% off all MailPoet annual plans and upgrades – no coupon required.', 'mailpoet') . '</h3>';
-    $body = '<h5 class="mailpoet-h5">' . __('Offer ends at 2 pm UTC on Monday, June 19, 2023. Terms and conditions apply.', 'mailpoet') . '</h5>';
+    $header = '<h3 class="mailpoet-h3">' . __('Get up to 40% off all MailPoet annual plans and upgrades', 'mailpoet') . '</h3>';
+    $body = '<h5 class="mailpoet-h5">' . __('Our Black Friday sale is live. Save up to 40% when you switch to or upgrade an annual plan — no coupon needed. Offer ends at 2 PM UTC, 28 November.', 'mailpoet') . '</h5>';
     $link = "<p><a href='https://account.mailpoet.com/?s=$subscribers&billing=yearly&ref=sale-june-2023-plugin&utm_source=MP&utm_medium=plugin&utm_campaign=sale_june_2023' class='mailpoet-button button-primary' target='_blank'>"
       // translators: a button on a sale banner. "Save" meaning to save money - 40% discount
       . __('Pick a plan and save', 'mailpoet')

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -73,7 +73,7 @@ class PermanentNotices {
     $this->unauthorizedEmailsNotice = new UnauthorizedEmailNotice($wp, $settings);
     $this->unauthorizedEmailsInNewslettersNotice = new UnauthorizedEmailInNewslettersNotice($settings, $wp);
     $this->inactiveSubscribersNotice = new InactiveSubscribersNotice($settings, $subscribersRepository, $wp);
-    $this->blackFridayNotice = new BlackFridayNotice($subscribersRepository);
+    $this->blackFridayNotice = new BlackFridayNotice($serviceChecker, $subscribersFeature);
     $this->headersAlreadySentNotice = new HeadersAlreadySentNotice($settings, $trackingConfig, $wp);
     $this->emailWithInvalidListNotice = new EmailWithInvalidSegmentNotice($wp);
     $this->changedTrackingNotice = new ChangedTrackingNotice($wp);


### PR DESCRIPTION
## Description

This PR updates the copy and dates for the upcoming BFCM sale.

It also changes the link so that when the website has an active API key, it will link directly to the upgrade page instead of the pricing page. 

## Code review notes

AFAIK, we don't have a service like https://github.com/mailpoet/mailpoet/blob/3de159dd035d11a6f8ed3548e9635b9775bac335/mailpoet/assets/js/src/mailpoet-com-url-factory.js in PHP. For simplicity and urgency to get this out, I included the URL "generator" directly in the BlakcFridayNotice, but I acknowledge this is not the best place and long-term should be refactored in a separate service.

## QA notes

1. Test that the banner links to the upgrade page with an active API key and to the pricing page when no API key is used. 
2. Test that parameters are correct (`ref=sale-bfcm-2023-plugin` and `utm_campaign=sale_bfcm_2023`)

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5440]
[MAILPOET-5707]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5440]: https://mailpoet.atlassian.net/browse/MAILPOET-5440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5707]: https://mailpoet.atlassian.net/browse/MAILPOET-5707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ