### PR TITLE
Feat/add setup information for the mailpoet marketing channel - MAILPOET-5695

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -108,6 +108,7 @@ interface Window {
   mailpoet_woocommerce_store_config: WooCommerceStoreConfig;
   mailpoet_woocommerce_version: string;
   mailpoet_track_wizard_loaded_via_woocommerce: boolean;
+  mailpoet_track_wizard_loaded_via_woocommerce_marketing_dashboard: boolean;
   mailpoet_premium_active: boolean;
   mailpoet_subscribers_limit: number;
   mailpoet_subscribers_limit_reached: boolean;

--- a/mailpoet/assets/js/src/wizard/track-wizard-loaded-via-woocommerce.tsx
+++ b/mailpoet/assets/js/src/wizard/track-wizard-loaded-via-woocommerce.tsx
@@ -15,6 +15,21 @@ function trackWizardLoadedViaWooCommerce() {
       data: 'send_event_that_wizard_was_loaded_via_woocommerce',
     });
   }
+
+  if (window.mailpoet_track_wizard_loaded_via_woocommerce_marketing_dashboard) {
+    window.MailPoet.trackEvent(
+      'User clicked on complete MailPoet setup in WooCommerce > Multichannel Marketing dashboard',
+      {
+        'WooCommerce version': window.mailpoet_woocommerce_version,
+      },
+    );
+    void window.MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'settings',
+      action: 'delete',
+      data: 'wizard_loaded_via_woocommerce_marketing_dashboard',
+    });
+  }
 }
 
 document.addEventListener('DOMContentLoaded', trackWizardLoadedViaWooCommerce);

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -165,6 +165,7 @@ class PageRenderer {
       'send_transactional_emails' => (bool)$this->settings->get('send_transactional_emails'),
       'transactional_emails_opt_in_notice_dismissed' => (bool)$this->userFlags->get('transactional_emails_opt_in_notice_dismissed'),
       'track_wizard_loaded_via_woocommerce' => (bool)$this->settings->get(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME),
+      'track_wizard_loaded_via_woocommerce_marketing_dashboard' => (bool)$this->settings->get(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_MARKETING_DASHBOARD_SETTING_NAME),
       'mail_function_enabled' => function_exists('mail') && is_callable('mail'),
       'admin_plugins_url' => WPFunctions::get()->adminUrl('plugins.php'),
 

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -11,6 +11,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class WelcomeWizard {
   const TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME = 'send_event_that_wizard_was_loaded_via_woocommerce';
+  const TRACK_LOADDED_VIA_WOOCOMMERCE_MARKETING_DASHBOARD_SETTING_NAME = 'wizard_loaded_via_woocommerce_marketing_dashboard';
 
   /** @var PageRenderer */
   private $pageRenderer;
@@ -49,6 +50,13 @@ class WelcomeWizard {
     if (!$loadedViaWooCommerce && isset($_GET['mailpoet_wizard_loaded_via_woocommerce'])) {
       // This setting is used to send an event to Mixpanel in another request as, before completing the wizard, Mixpanel is not enabled.
       $this->settings->set(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_SETTING_NAME, 1);
+    }
+
+    $loadedViaWooCommerceMarketingDashboard = $this->settings->get(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_MARKETING_DASHBOARD_SETTING_NAME, false);
+
+    if (!$loadedViaWooCommerceMarketingDashboard && isset($_GET['mailpoet_wizard_loaded_via_woocommerce_marketing_dashboard'])) {
+      // This setting is used to send an event to Mixpanel in another request as, before completing the wizard, Mixpanel is not enabled.
+      $this->settings->set(WelcomeWizard::TRACK_LOADDED_VIA_WOOCOMMERCE_MARKETING_DASHBOARD_SETTING_NAME, 1);
     }
 
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -624,6 +624,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\CouponPreProcessor::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\WooSystemInfo::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\WooSystemInfoController::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\MultichannelMarketing\MPMarketingChannelController::class)->setPublic(true);
 
     // WooCommerce Subscriptions
     $container->autowire(\MailPoet\WooCommerce\WooCommerceSubscriptions\Helper::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce\MultichannelMarketing;
+
+use MailPoet\Features\FeaturesController;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\CdnAssetUrl;
+
+class MPMarketingChannelController {
+
+  /** @var CdnAssetUrl */
+  private $cdnAssetUrl;
+
+  /** @var FeaturesController */
+  private $featuresController;
+
+  /**
+   * @var SettingsController
+   */
+  protected $settings;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    FeaturesController $featuresController,
+    SettingsController $settings
+  ) {
+    $this->cdnAssetUrl = $cdnAssetUrl;
+    $this->featuresController = $featuresController;
+    $this->settings = $settings;
+  }
+
+  public function registerMarketingChannel($registeredMarketingChannels): array {
+    if (!$this->featuresController->isSupported(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION)) {
+      return $registeredMarketingChannels; // Do not register the marketing channel if the feature flag is not enabled
+    }
+
+    return array_merge($registeredMarketingChannels, [
+      new MPMarketingChannel(
+        $this->cdnAssetUrl,
+        $this->settings
+      ),
+    ]);
+  }
+}

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -66,6 +66,7 @@
   var mailpoet_deactivate_subscriber_after_inactive_days = <%= json_encode(deactivate_subscriber_after_inactive_days) %>;
   var mailpoet_woocommerce_version = <%= json_encode(get_woocommerce_version()) %>;
   var mailpoet_track_wizard_loaded_via_woocommerce = <%= json_encode(track_wizard_loaded_via_woocommerce) %>;
+  var mailpoet_track_wizard_loaded_via_woocommerce_marketing_dashboard = <%= json_encode(track_wizard_loaded_via_woocommerce_marketing_dashboard) %>;
   var mailpoet_mail_function_enabled = '<%= mail_function_enabled %>';
   var mailpoet_admin_plugins_url = '<%= admin_plugins_url %>';
   var mailpoet_is_dotcom = <%= json_encode(is_dotcom()) %>;


### PR DESCRIPTION
## Description

Add setup information for the MailPoet Marketing Channel

This PR handles the implementation of `is_setup_completed` and `get_setup_url`

![QhEILg.png](https://github.com/mailpoet/mailpoet/assets/30554163/6d807d50-9d82-4f8a-85f9-99d1639654ad)

## Code review notes

Please check commits

## QA notes

Start with the QA notes here: https://github.com/mailpoet/mailpoet/pull/5289

* You might want to set `version` on the `wp_mailpoet_settings` table to `null`
* Visit the WooCommerce Marketing tab at `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
* Click on "Finish Setup"
![QhEILg.png](https://github.com/mailpoet/mailpoet/assets/30554163/6d807d50-9d82-4f8a-85f9-99d1639654ad)
* Complete the welcome wizard

## Linked PRs

Child of https://github.com/mailpoet/mailpoet/pull/5289

## Linked tickets

[MAILPOET-5695](https://mailpoet.atlassian.net/browse/MAILPOET-5695)

## After-merge notes

Please, **only** merge after https://github.com/mailpoet/mailpoet/pull/5289 

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5695]: https://mailpoet.atlassian.net/browse/MAILPOET-5695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ