### PR TITLE
Revert "Update acceptance test suite to align with the new WooCommerce checkout experience"

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -583,6 +583,7 @@ class AcceptanceTester extends \Codeception\Actor {
     // Add a note to order just to avoid flakiness due to race conditions
     $i->click(Locator::contains('label', 'Add a note to your order'));
     $i->fillField('.wc-block-components-textarea', 'This is a note');
+    $i->waitForElementClickable(Locator::contains('button', 'Place Order'));
     $i->waitForText('Place Order');
     $i->waitForElementClickable(Locator::contains('button', 'Place Order'));
     $i->click(Locator::contains('button', 'Place Order'));

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -532,7 +532,7 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function optInForRegistration() {
     $i = $this;
-    $isCheckboxVisible = $i->waitForText((Locator::contains('label', 'Create an account?')));
+    $isCheckboxVisible = $i->executeJS('return document.getElementsByClassName("wc-block-checkout__create-account")');
     if ($isCheckboxVisible) {
       $i->click(Locator::contains('label', 'Create an account?'));
     }
@@ -544,7 +544,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function optInForSubscription() {
     $settings = (ContainerWrapper::getInstance())->get(SettingsController::class);
     $i = $this;
-    $isCheckboxVisible = $i->waitForText($settings->get('woocommerce.optin_on_checkout.message'));
+    $isCheckboxVisible = $i->executeJS('return document.getElementById("checkbox-control-0")');
     if ($isCheckboxVisible) {
       $i->click(Locator::contains('label', $settings->get('woocommerce.optin_on_checkout.message')));
     }
@@ -556,7 +556,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function optOutOfSubscription() {
     $settings = (ContainerWrapper::getInstance())->get(SettingsController::class);
     $i = $this;
-    $isCheckboxVisible = $i->waitForText($settings->get('woocommerce.optin_on_checkout.message'));
+    $isCheckboxVisible = $i->executeJS('return document.getElementById("checkbox-control-0")');
     if ($isCheckboxVisible) {
       $i->click(Locator::contains('label', $settings->get('woocommerce.optin_on_checkout.message')));
     }
@@ -565,7 +565,7 @@ class AcceptanceTester extends \Codeception\Actor {
   /**
    * Select a payment method (cheque, cod, ppec_paypal)
    */
-  public function selectPaymentMethod($method = 'cod') {
+  public function selectPaymentMethod($method = 'bacs') {
     $i = $this;
     // We need to scroll with some negative offset so that the input is not hidden above the top page fold
     $approximatePaymentMethodInputHeight = 40;

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -532,7 +532,7 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function optInForRegistration() {
     $i = $this;
-    $isCheckboxVisible = $i->executeJS('return document.getElementsByClassName("wc-block-checkout__create-account")');
+    $isCheckboxVisible = $i->waitForText((Locator::contains('label', 'Create an account?')));
     if ($isCheckboxVisible) {
       $i->click(Locator::contains('label', 'Create an account?'));
     }
@@ -544,7 +544,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function optInForSubscription() {
     $settings = (ContainerWrapper::getInstance())->get(SettingsController::class);
     $i = $this;
-    $isCheckboxVisible = $i->executeJS('return document.getElementById("checkbox-control-0")');
+    $isCheckboxVisible = $i->waitForText($settings->get('woocommerce.optin_on_checkout.message'));
     if ($isCheckboxVisible) {
       $i->click(Locator::contains('label', $settings->get('woocommerce.optin_on_checkout.message')));
     }
@@ -556,7 +556,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function optOutOfSubscription() {
     $settings = (ContainerWrapper::getInstance())->get(SettingsController::class);
     $i = $this;
-    $isCheckboxVisible = $i->executeJS('return document.getElementById("checkbox-control-0")');
+    $isCheckboxVisible = $i->waitForText($settings->get('woocommerce.optin_on_checkout.message'));
     if ($isCheckboxVisible) {
       $i->click(Locator::contains('label', $settings->get('woocommerce.optin_on_checkout.message')));
     }

--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -83,7 +83,7 @@ class DefaultsExtension extends Extension {
 
     // other
     update_option('woocommerce_bacs_settings', ['enabled' => 'yes'], 'yes');
-    update_option('woocommerce_cod_settings', ['enabled' => 'yes', 'enable_for_virtual' => 'yes'], 'yes');
+    update_option('woocommerce_cod_settings', ['enabled' => 'yes'], 'yes');
     update_option('woocommerce_enable_signup_and_login_from_checkout', 'yes', 'no');
     update_option('woocommerce_enable_myaccount_registration', 'yes', 'no');
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -47,8 +47,7 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->dontSee(self::MAILPOET_OPTIN_TEXT);
   }
 
-  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
-    $scenario->skip('Skip until resolved: Both AutomateWoo and MailPoet checkboxes are present in the checkout');
+  public function checkoutOptInEnabled(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
     $i->addProductToCart($this->product);
     $i->goToCheckout();
@@ -68,8 +67,7 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->seeConfirmationEmailWasNotReceived();
   }
 
-  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
-    $scenario->skip('Skip until resolved: Both AutomateWoo and MailPoet checkboxes are present in the checkout');
+  public function checkoutOptInChecked(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
     $this->settingsFactory->withConfirmationEmailEnabled();
     $customerEmail = 'woo_guest_check@example.com';

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -15,7 +15,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
  */
 class WooCheckoutAutomateWooSubscriptionsCest {
 
-  const MAILPOET_OPTIN_TEXT = 'Yes, I would like to be added to your mailing list';
+  const MAILPOET_OPTIN_ELEMENT = '#mailpoet_woocommerce_checkout_optin';
   const AUTOMATE_WOO_OPTIN_TEXT = 'I want to receive updates about products and promotions';
 
   /** @var Settings */
@@ -44,14 +44,14 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->addProductToCart($this->product);
     $i->goToCheckout();
     $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
-    $i->dontSee(self::MAILPOET_OPTIN_TEXT);
+    $i->dontSeeElement(self::MAILPOET_OPTIN_ELEMENT);
   }
 
   public function checkoutOptInEnabled(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
     $i->addProductToCart($this->product);
     $i->goToCheckout();
-    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
+    $i->waitForElement(self::MAILPOET_OPTIN_ELEMENT, 10);
     $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
   }
 


### PR DESCRIPTION
Reverts mailpoet/mailpoet#5292

Reverting this PR as we forgot that we cannot skip tests on trunk (see p1700256686194529/1700148491.383389-slack-C01H71ZLBGQ for more information)