### PR TITLE
Check if post is set when setting the title

### DIFF
--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -281,6 +281,8 @@ class Pages {
     global $post;
 
     if (
+      (!isset($post))
+      ||
       ($post->post_title !== __('MailPoet Page', 'mailpoet')) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       ||
       ($pageTitle !== $this->wp->singlePostTitle('', false))


### PR DESCRIPTION
## Description

We got a report of the following warning:
`PHP Warning:  Attempt to read property "post_title" on null in .../plugins/mailpoet/lib/Subscription/Pages.php on line 287`

I have not been able to reproduce it but the added check should remove the warning.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5716]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5716]: https://mailpoet.atlassian.net/browse/MAILPOET-5716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ