### PR TITLE
Use different method to hide menus

### DIFF
--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -33,6 +33,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class Menu {
   const MAIN_PAGE_SLUG = self::HOMEPAGE_PAGE_SLUG;
+  const NO_PARENT_PAGE_SLUG = 'mailpoet-no-parent';
 
   const EMAILS_PAGE_SLUG = 'mailpoet-newsletters';
   const FORMS_PAGE_SLUG = 'mailpoet-forms';
@@ -190,7 +191,7 @@ class Menu {
 
     // Welcome wizard page
     $this->wp->addSubmenuPage(
-      '',
+      self::NO_PARENT_PAGE_SLUG,
       $this->setPageTitle(__('Welcome Wizard', 'mailpoet')),
       esc_html__('Welcome Wizard', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -203,7 +204,7 @@ class Menu {
 
     // Landingpage
     $this->wp->addSubmenuPage(
-      '',
+      self::NO_PARENT_PAGE_SLUG,
       $this->setPageTitle(__('MailPoet', 'mailpoet')),
       esc_html__('MailPoet', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -487,7 +488,7 @@ class Menu {
 
     // WooCommerce Setup
     $this->wp->addSubmenuPage(
-      '',
+      self::NO_PARENT_PAGE_SLUG,
       $this->setPageTitle(__('WooCommerce Setup', 'mailpoet')),
       esc_html__('WooCommerce Setup', 'mailpoet'),
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
@@ -527,7 +528,7 @@ class Menu {
     if (
       !$this->wp->applyFilters('mailpoet_show_automations', $showAutomations)
     ) {
-      $parentSlug = '';
+      $parentSlug = self::NO_PARENT_PAGE_SLUG;
     }
 
     $automationPage = $this->wp->addSubmenuPage(
@@ -723,7 +724,7 @@ class Menu {
       }
     }
 
-    if ($parentSlug) {
+    if ($parentSlug && $parentSlug !== self::NO_PARENT_PAGE_SLUG) {
       // highlight parent submenu item
       $plugin_page = $parentSlug;
     } else {
@@ -783,7 +784,7 @@ class Menu {
       return false;
     }
     WPFunctions::get()->addSubmenuPage(
-      '',
+      self::NO_PARENT_PAGE_SLUG,
       'MailPoet',
       'MailPoet',
       AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,

--- a/mailpoet/tests/integration/Config/MenuTest.php
+++ b/mailpoet/tests/integration/Config/MenuTest.php
@@ -84,7 +84,7 @@ class MenuTest extends \MailPoetTest {
       [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
       [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
       [$this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything()],
-      [null, $this->anything(), $this->anything(), $this->anything(), Menu::AUTOMATIONS_PAGE_SLUG, $this->anything()]
+      [Menu::NO_PARENT_PAGE_SLUG, $this->anything(), $this->anything(), $this->anything(), Menu::AUTOMATIONS_PAGE_SLUG, $this->anything()]
     )->willReturn(true);
 
     $menu = new Menu(


### PR DESCRIPTION
## Description

`add_submenu_page` with empty `parent_slug` generates a deprecation error.
This PR uses a non-existing parent slug instead of an empty string.

## Code review notes

We could also wait for the trac ticket but not sure if it will be implemented or when.

## QA notes

2 ways to test it:
- On Jurassic.ninja, click on 'Select More Options', select 'PHP 8.1', WooCommerce, and create a new site.
- Install plugin Query Monitor.
- Upload the build
- Check there are no errors in Query Monitor when you go to MailPoet landing page

And locally:
- On your local site, if running PHP 8.1, you can test there is no log by going to:
- ?page=mailpoet-welcome-wizard
- ?page=mailpoet-landingpage
- ?page=mailpoet-woocommerce-setup

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5718]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5716]: https://mailpoet.atlassian.net/browse/MAILPOET-5716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-5718]: https://mailpoet.atlassian.net/browse/MAILPOET-5718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ