### PR TITLE
Show BFCM sale info in WP.org description [MAILPOET-5708]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -12,6 +12,14 @@ Send beautiful newsletters from WordPress. Collect subscribers with signup forms
 
 == Description ==
 
+= Get up to 40% off all MailPoet annual plans and upgrades =
+
+Our Black Friday sale is live. Save up to 40% when you switch to or upgrade an annual plan — no coupon needed. Offer ends at 2 PM UTC, 28 November.
+
+[Shop annual plans](https://account.mailpoet.com/?billing=yearly&ref=sale-bfcm-2023-wporg&utm_source=wordpress.org&utm_medium=description&utm_campaign=sale_bfcm_2023)
+
+= What is MailPoet? =
+
 Use MailPoet to create, send, manage, and grow your email marketing campaigns – all without leaving your WordPress dashboard.
 
 Our newsletter builder integrates perfectly with WordPress so any website owner can create beautiful emails from scratch, or by using our responsive templates that display flawlessly across all devices.


### PR DESCRIPTION
## Description

Added BFCM sale description in WordPress.org plugin description. I used https://wpreadme.com/ to see the readme.txt preview.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5708]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5708]: https://mailpoet.atlassian.net/browse/MAILPOET-5708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ