### PR TITLE
Fix Nightly acceptance_oldest tests

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -476,8 +476,10 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->addProductToCart($product);
     $i->goToCheckout();
     $i->fillCustomerInfo($userEmail);
+
+    $wooCommerceVersion = $i->getWooCommerceVersion();
+
     if ($doSubscribe) {
-      $wooCommerceVersion = $i->getWooCommerceVersion();
       if (version_compare($wooCommerceVersion, '8.3.0', '>=')) {
         $settings = (ContainerWrapper::getInstance())->get(SettingsController::class);
         $i->click(Locator::contains('label', $settings->get('woocommerce.optin_on_checkout.message')));
@@ -488,10 +490,11 @@ class AcceptanceTester extends \Codeception\Actor {
         }
       }
     } else {
-      $wooCommerceVersion = $i->getWooCommerceVersion();
       if (version_compare($wooCommerceVersion, '8.3.0', '<')) {
         $isCheckboxVisible = $i->executeJS('return document.getElementById("mailpoet_woocommerce_checkout_optin")');
-        $i->uncheckOption('#mailpoet_woocommerce_checkout_optin');
+        if ($isCheckboxVisible) {
+          $i->uncheckOption('#mailpoet_woocommerce_checkout_optin');
+        }
       }
     }
     if ($doRegister) {


### PR DESCRIPTION
## Description

Fix Nightly acceptance_oldest tests.

Follow up to https://github.com/mailpoet/mailpoet/pull/5299

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
