### PR TITLE
Add renderer for core/image block [MAILPOET-5705]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/columns.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/columns.tsx
@@ -36,4 +36,30 @@ function deactivateStackOnMobile() {
   );
 }
 
-export { deactivateStackOnMobile };
+/**
+ * Disables layout support for columns and column blocks because
+ * the default layout `flex` add gaps between columns that it is not possible to support in emails.
+ */
+function disableColumnsLayout() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/disable-columns-layout',
+    (settings, name) => {
+      if (name === 'core/columns' || name === 'core/column') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return {
+          ...settings,
+          supports: {
+            ...settings.supports,
+            layout: false,
+          },
+        };
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return settings;
+    },
+  );
+}
+
+export { deactivateStackOnMobile, disableColumnsLayout };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/image.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/image.tsx
@@ -25,6 +25,33 @@ const imageEditCallback = createHigherOrderComponent(
   'imageEditCallback',
 );
 
+/**
+ * Because CSS property filter is not supported in almost 50% of email clients we have to disable it
+ */
+function disableImageFilter() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/deactivate-image-filter',
+    (settings, name) => {
+      if (name === 'core/image') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return {
+          ...settings,
+          supports: {
+            ...settings.supports,
+            filter: {
+              duetone: false,
+            },
+          },
+        };
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return settings;
+    },
+  );
+}
+
 function hideExpandOnClick() {
   addFilter(
     'editor.BlockEdit',
@@ -33,4 +60,4 @@ function hideExpandOnClick() {
   );
 }
 
-export { hideExpandOnClick };
+export { hideExpandOnClick, disableImageFilter };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/image.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/image.tsx
@@ -1,0 +1,36 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+
+const imageEditCallback = createHigherOrderComponent(
+  (BlockEdit) =>
+    function alterBlocksEdits(props) {
+      if (props.name !== 'core/image') {
+        return <BlockEdit {...props} />;
+      }
+      // Because we cannot support displaying the modal with image after clicking in the email we have to hide the toggle
+      const deactivateToggleCss = `
+        .components-tools-panel .components-toggle-control { display: none; }
+      `;
+
+      return (
+        <>
+          <BlockEdit {...props} />
+          <InspectorControls>
+            <style>{deactivateToggleCss}</style>
+          </InspectorControls>
+        </>
+      );
+    },
+  'imageEditCallback',
+);
+
+function hideExpandOnClick() {
+  addFilter(
+    'editor.BlockEdit',
+    'mailpoet-email-editor/hide-expand-on-click',
+    imageEditCallback,
+  );
+}
+
+export { hideExpandOnClick };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -1,6 +1,6 @@
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { disableNestedColumns } from './core/column';
-import { deactivateStackOnMobile } from './core/columns';
+import { disableColumnsLayout, deactivateStackOnMobile } from './core/columns';
 import { hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 
@@ -9,5 +9,6 @@ export function initBlocks() {
   deactivateStackOnMobile();
   hideExpandOnClick();
   disableCertainRichTextFormats();
+  disableColumnsLayout();
   registerCoreBlocks();
 }

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -1,13 +1,14 @@
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { disableNestedColumns } from './core/column';
 import { disableColumnsLayout, deactivateStackOnMobile } from './core/columns';
-import { hideExpandOnClick } from './core/image';
+import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 
 export function initBlocks() {
   disableNestedColumns();
   deactivateStackOnMobile();
   hideExpandOnClick();
+  disableImageFilter();
   disableCertainRichTextFormats();
   disableColumnsLayout();
   registerCoreBlocks();

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -1,11 +1,13 @@
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { disableNestedColumns } from './core/column';
 import { deactivateStackOnMobile } from './core/columns';
+import { hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 
 export function initBlocks() {
   disableNestedColumns();
   deactivateStackOnMobile();
+  hideExpandOnClick();
   disableCertainRichTextFormats();
   registerCoreBlocks();
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -87,3 +87,18 @@
     }
   }
 }
+// Because by default alignleft and alignright classes are floated we need to override this behavior to have a consistent look in editor and in email
+// We decided to present the image block as a block with 100% width
+.editor-styles-wrapper .is-layout-constrained .wp-block-image.alignleft,
+.editor-styles-wrapper .is-layout-constrained .wp-block-image.alignright {
+  float: none !important;
+  margin-inline-start: 0;
+  width: 100%;
+}
+// Align left does not need any additional styles, but for aligment right we use flex to prevent for broken look by floating images
+.editor-styles-wrapper .is-layout-constrained .wp-block-image {
+  &.alignright {
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -77,10 +77,6 @@
   margin: 0;
 }
 
-.edit-post-visual-editor__content-area .wp-block-columns {
-  margin-bottom: 0;
-}
-
 .edit-post-visual-editor__content-area .is-mobile-preview {
   .wp-block-columns {
     display: flex;

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -74,6 +74,7 @@
 
 // For the WYSIWYG experience we don't want to display any margins between blocks in the editor
 .wp-block {
+  clear: both; // for ensuring that floated elements (images) are cleared
   margin: 0;
 }
 
@@ -87,18 +88,16 @@
     }
   }
 }
-// Because by default alignleft and alignright classes are floated we need to override this behavior to have a consistent look in editor and in email
-// We decided to present the image block as a block with 100% width
-.editor-styles-wrapper .is-layout-constrained .wp-block-image.alignleft,
-.editor-styles-wrapper .is-layout-constrained .wp-block-image.alignright {
-  float: none !important;
-  margin-inline-start: 0;
-  width: 100%;
-}
-// Align left does not need any additional styles, but for aligment right we use flex to prevent for broken look by floating images
+// Resetting the margin for images in the editor to avoid unexpected spacing
 .editor-styles-wrapper .is-layout-constrained .wp-block-image {
+  figcaption {
+    margin: 0;
+  }
+
+  &.alignleft,
   &.alignright {
-    display: flex;
-    justify-content: flex-end;
+    margin-inline-end: 0;
+    margin-inline-start: 0;
+    text-align: center;
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/readme.md
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/readme.md
@@ -4,7 +4,7 @@ The renderer is WIP and so is the API for adding support email rendering for new
 
 ## Adding support for a core block
 
-1. Add block into `ALLOWED_BLOCK_TYPES` in `mailpoet/lib/EmailEditor/Engine/Renderer/AllowedBlocks.php`.
+1. Add block into `ALLOWED_BLOCK_TYPES` in `mailpoet/lib/EmailEditor/Engine/Renderer/SettingsController.php`.
 2. Make sure the block is registered in the editor. Currently all core blocks are registered in the editor.
 3. Add BlockRender class (e.g. Heading) into `mailpoet/lib/EmailEditor/Integration/Core/Renderer/Blocks` folder. <br />
 
@@ -45,6 +45,7 @@ Note: For core blocks this is currently done in `MailPoet\EmailEditor\Integratio
 
 - You can take inspiration on block rendering from MJML in the https://mjml.io/try-it-live
 - Test the block in different clients [Litmus](https://litmus.com/)
+- You can take some inspirations from the HTML renderer by the old email editor
 
 ## TODO
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
@@ -115,6 +115,7 @@ img {
   height: auto;
   -ms-interpolation-mode: bicubic;
   line-height: 100%;
+  max-width: 100%;
   outline: none;
   text-decoration: none;
 }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -146,6 +146,17 @@ class SettingsController {
     return "{$width}px";
   }
 
+  /**
+   * This functions converts an array of styles to a string that can be used in HTML.
+   */
+  public function convertStylesToString(array $styles): string {
+    $cssString = '';
+    foreach ($styles as $property => $value) {
+      $cssString .= $property . ':' . $value . ';';
+    }
+    return trim($cssString); // Remove trailing space and return the formatted string
+  }
+
   private function parseNumberFromStringWithPixels(string $string): float {
     return (float)str_replace('px', '', $string);
   }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -157,7 +157,19 @@ class SettingsController {
     return trim($cssString); // Remove trailing space and return the formatted string
   }
 
-  private function parseNumberFromStringWithPixels(string $string): float {
+  public function parseStylesToArray(string $styles): array {
+    $styles = explode(';', $styles);
+    $parsedStyles = [];
+    foreach ($styles as $style) {
+      $style = explode(':', $style);
+      if (count($style) === 2) {
+        $parsedStyles[trim($style[0])] = trim($style[1]);
+      }
+    }
+    return $parsedStyles;
+  }
+
+  public function parseNumberFromStringWithPixels(string $string): float {
     return (float)str_replace('px', '', $string);
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -18,5 +18,6 @@ class Initializer {
     $blocksRegistry->addBlockRenderer('core/column', new Renderer\Blocks\Column());
     $blocksRegistry->addBlockRenderer('core/columns', new Renderer\Blocks\Columns());
     $blocksRegistry->addBlockRenderer('core/list', new Renderer\Blocks\ListBlock());
+    $blocksRegistry->addBlockRenderer('core/image', new Renderer\Blocks\Image());
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -47,7 +47,7 @@ class Column implements BlockRenderer {
     }
 
     return '
-      <td class="block" style="' . $this->convertStylesToString($mainCellStyles) . '">
+      <td class="block" style="' . $settingsController->convertStylesToString($mainCellStyles) . '">
         <div class="email_column" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';font-size:0px;text-align:left;display:inline-block;">
           <table class="email_column" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';vertical-align:top;" width="' . $width . '">
             <tbody>
@@ -61,13 +61,5 @@ class Column implements BlockRenderer {
         </div>
       </td>
     ';
-  }
-
-  private function convertStylesToString(array $styles): string {
-    $cssString = '';
-    foreach ($styles as $property => $value) {
-      $cssString .= $property . ':' . $value . '; ';
-    }
-    return trim($cssString); // Remove trailing space and return the formatted string
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -7,6 +7,114 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Image implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    // Replacing HTML tags figure and figcaption because they are not supported by all email clients
+    $blockContent = str_replace(
+      ['<figure', '</figure>', '<figcaption', '</figcaption>'],
+      ['<div', '</div>', '<div', '</div>'],
+      $blockContent
+    );
+
+    $blockContent = $this->applyRoundedStyle($blockContent, $parsedBlock);
+    $blockContent = $this->addWidthToWrapper($blockContent, $parsedBlock, $settingsController);
+    $blockContent = $this->addCaptionFontSize($blockContent, $settingsController);
+    bdump($parsedBlock);
+    bdump($blockContent);
+    return str_replace('{image_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
+  }
+
+  private function applyRoundedStyle($blockContent, array $parsedBlock) {
+    // Because the isn't an attribute for definition of rounded style, we have to check the class name
+    if (isset($parsedBlock['attrs']['className']) && strpos($parsedBlock['attrs']['className'], 'is-style-rounded') !== false) {
+      // If the image should be in a circle, we need to set the border-radius to 100%
+      // This style cannot be applied on the wrapper, and we need to set it directly on the image
+      $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'img'], 'border-radius: 100%;');
+    }
+
+    return $blockContent;
+  }
+
+  /**
+   * We need to reset font-size to avoid unexpected white spaces and set the width of the wrapper
+   * for having caption text under the image.
+   */
+  private function addWidthToWrapper($blockContent, array $parsedBlock, SettingsController $settingsController) {
+    $styles = [
+      'width' => $parsedBlock['email_attrs']['width'] ?? $parsedBlock['attrs']['width'] ?? '100%',
+      'font-size' => '0px',
+    ];
+    return $this->addStyleToElement($blockContent, ['tag_name' => 'div'], $settingsController->convertStylesToString($styles));
+  }
+
+  /**
+   * This method configure the font size of the caption because it's set to 0 for the parent element to avoid unexpected white spaces
+   */
+  private function addCaptionFontSize($blockContent, $settingsController) {
+    $contentStyles = $settingsController->getEmailContentStyles();
+
+    if (isset($contentStyles['typography']['fontSize'])) {
+      $styles = [
+        'font-size' => $contentStyles['typography']['fontSize'],
+        'text-align' => 'center',
+      ];
+      $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'div', 'class_name' => 'wp-element-caption'], $settingsController->convertStylesToString($styles));
+    }
+
+    return $blockContent;
+  }
+
+  /**
+   * Based on MJML <mj-image>
+   */
+  private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
+    $contentStyles = $settingsController->getEmailContentStyles();
+
+    $styles = [
+      'border-collapse' => 'collapse',
+      'border-spacing' => '0px',
+    ];
+    $styles = array_merge($styles, $parsedBlock['email_attrs'] ?? []);
+
+    if (!isset($styles['font-size'])) {
+      $styles['font-size'] = $contentStyles['typography']['fontSize'];
+    }
+    if (!isset($styles['font-family'])) {
+      $styles['font-family'] = $contentStyles['typography']['fontFamily'];
+    }
+
+    $styles['width'] = '100%';
+    $align = $parsedBlock['attrs']['align'] ?? 'left';
+
+    return '
+      <table
+        role="presentation"
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        style="' . $settingsController->convertStylesToString($styles) . '"
+      >
+        <tr>
+          <td align="' . $align . '">
+            {image_content}
+          </td>
+        </tr>
+      </table>
+    ';
+  }
+
+  /**
+   * @param array{tag_name: string, class_name?: string} $tag
+   * @param string $style
+   */
+  private function addStyleToElement($blockContent, array $tag, string $style) {
+    $html = new \WP_HTML_Tag_Processor($blockContent);
+    if ($html->next_tag($tag)) {
+      $elementStyle = $html->get_attribute('style');
+      $elementStyle = !empty($elementStyle) ? (rtrim($elementStyle, ';') . ';') : ''; // Adding semicolon if it's missing
+      $elementStyle .= $style;
+      $html->set_attribute('style', $elementStyle);
+      $blockContent = $html->get_updated_html();
+    }
+
     return $blockContent;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class Image implements BlockRenderer {
+  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    return $blockContent;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -8,11 +8,12 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 // We have to avoid using keyword `List`
 class ListBlock implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
-    return str_replace('{list_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $contentStyles));
+    return str_replace('{list_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
 
-  private function getBlockWrapper(array $parsedBlock, array $contentStyles): string {
+  private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
+    $contentStyles = $settingsController->getEmailContentStyles();
+
     $styles = [];
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
       $styles[$property] = $value;
@@ -31,7 +32,7 @@ class ListBlock implements BlockRenderer {
         cellpadding="0"
         cellspacing="0"
         role="presentation"
-        style="' . $this->convertStylesToString($styles) . '"
+        style="' . $settingsController->convertStylesToString($styles) . '"
       >
         <tr>
           <td>
@@ -40,13 +41,5 @@ class ListBlock implements BlockRenderer {
         </tr>
       </table>
     ';
-  }
-
-  private function convertStylesToString(array $styles): string {
-    $cssString = '';
-    foreach ($styles as $property => $value) {
-      $cssString .= $property . ':' . $value . '; ';
-    }
-    return trim($cssString); // Remove trailing space and return the formatted string
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -7,14 +7,15 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Paragraph implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
-    return str_replace('{paragraph_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $contentStyles));
+    return str_replace('{paragraph_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
 
   /**
    * Based on MJML <mj-text>
    */
-  private function getBlockWrapper(array $parsedBlock, array $contentStyles): string {
+  private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
+    $contentStyles = $settingsController->getEmailContentStyles();
+
     $styles = [];
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
       $styles[$property] = $value;
@@ -33,7 +34,7 @@ class Paragraph implements BlockRenderer {
         border="0"
         cellpadding="0"
         cellspacing="0"
-        style="' . $this->convertStylesToString($styles) . '"
+        style="' . $settingsController->convertStylesToString($styles) . '"
       >
         <tr>
           <td>
@@ -42,13 +43,5 @@ class Paragraph implements BlockRenderer {
         </tr>
       </table>
     ';
-  }
-
-  private function convertStylesToString(array $styles): string {
-    $cssString = '';
-    foreach ($styles as $property => $value) {
-      $cssString .= $property . ':' . $value . '; ';
-    }
-    return trim($cssString); // Remove trailing space and return the formatted string
   }
 }

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -63,6 +63,25 @@ namespace {
     function wcs_create_subscription($args) {
     }
   }
+
+  if (!class_exists(\WP_HTML_Tag_Processor::class)) {
+    class WP_HTML_Tag_Processor {
+      public function __construct($content) {
+      }
+
+      public function next_tag($tag) {
+      }
+
+      public function get_attribute($attribute) {
+      }
+
+      public function get_updated_html() {
+      }
+
+      public function set_attribute($attribute, $value) {
+      }
+    }
+  }
 }
 
 // Temporary stubs for Woo Custom Tables.

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ImageTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ImageTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\EmailEditor;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class ImageTest extends \MailPoetTest {
+  /** @var Image */
+  private $imageRenderer;
+
+  private $imageContent = '
+    <figure class="wp-block-image alignleft size-full is-style-default">
+        <img src="https://test.com/wp-content/uploads/2023/05/image.jpg" alt="" style=""/>
+    </figure>
+  ';
+
+  /** @var array */
+  private $parsedImage = [
+    'blockName' => 'core/image',
+    'attrs' => [
+      'align' => 'left',
+      'id' => 1,
+      'scale' => 'cover',
+      'sizeSlug' => 'full',
+      'linkDestination' => 'none',
+      'className' => 'is-style-default',
+    ],
+    'email_attrs' => [
+      'width' => '640px',
+    ],
+    'innerBlocks' => [],
+    'innerHTML' => '',
+    'innerContent' => [],
+  ];
+
+  /** @var SettingsController */
+  private $settingsController;
+
+  public function _before() {
+    $this->diContainer->get(EmailEditor::class)->initialize();
+    $this->imageRenderer = new Image();
+    $this->settingsController = $this->diContainer->get(SettingsController::class);
+  }
+
+  public function testItRendersMandatoryImageStyles(): void {
+    $parsedImage = $this->parsedImage;
+    $parsedImage['innerHTML'] = $this->imageContent; // To avoid repetition of the image content in the test we need to add it to the parsed block
+
+    $rendered = $this->imageRenderer->render($this->imageContent, $parsedImage, $this->settingsController);
+    $this->assertStringNotContainsString('<figure', $rendered);
+    $this->assertStringNotContainsString('<figcaption', $rendered);
+    $this->assertStringNotContainsString('</figure>', $rendered);
+    $this->assertStringNotContainsString('</figcaption>', $rendered);
+    $this->assertStringContainsString('width="640"', $rendered);
+    $this->assertStringContainsString('width:640px;', $rendered);
+    $this->assertStringContainsString('<img ', $rendered);
+  }
+
+  public function testItRendersBorderRadiusStyle(): void {
+    $parsedImage = $this->parsedImage;
+    $parsedImage['attrs']['className'] = 'is-style-rounded';
+    $parsedImage['innerHTML'] = $this->imageContent; // To avoid repetition of the image content in the test we need to add it to the parsed block
+
+    $rendered = $this->imageRenderer->render($this->imageContent, $parsedImage, $this->settingsController);
+    $this->assertStringNotContainsString('<figure', $rendered);
+    $this->assertStringNotContainsString('<figcaption', $rendered);
+    $this->assertStringNotContainsString('</figure>', $rendered);
+    $this->assertStringNotContainsString('</figcaption>', $rendered);
+    $this->assertStringContainsString('width="640"', $rendered);
+    $this->assertStringContainsString('width:640px;', $rendered);
+    $this->assertStringContainsString('<img ', $rendered);
+    $this->assertStringContainsString('border-radius: 100%;', $rendered);
+  }
+
+  public function testItRendersCaption(): void {
+    $imageContent = str_replace('</figure>', '<figcaption class="wp-element-caption">Caption</figcaption></figure>', $this->imageContent);
+    $parsedImage = $this->parsedImage;
+    $parsedImage['innerHTML'] = $imageContent; // To avoid repetition of the image content in the test we need to add it to the parsed block
+
+    $rendered = $this->imageRenderer->render($imageContent, $parsedImage, $this->settingsController);
+    $this->assertStringContainsString('>Caption</div>', $rendered);
+    $this->assertStringContainsString('text-align:center;', $rendered);
+  }
+
+  public function testItRendersImageAlignment(): void {
+    $imageContent = str_replace('style=""', 'style="width:400px;height:300px;"', $this->imageContent);
+    $parsedImage = $this->parsedImage;
+    $parsedImage['attrs']['align'] = 'center';
+    $parsedImage['email_attrs']['width'] = '400px';
+    $parsedImage['innerHTML'] = $imageContent; // To avoid repetition of the image content in the test we need to add it to the parsed block
+
+    $rendered = $this->imageRenderer->render($imageContent, $parsedImage, $this->settingsController);
+    $this->assertStringContainsString('align="center"', $rendered);
+    $this->assertStringContainsString('width="400"', $rendered);
+    $this->assertStringContainsString('height="300"', $rendered);
+    $this->assertStringContainsString('height:300px;', $rendered);
+    $this->assertStringContainsString('width:400px;', $rendered);
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Engine\Renderer;
+
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class SettingsControllerTest extends \MailPoetUnitTest {
+  public function testItGetsMainLayoutStyles(): void {
+    $settingsController = new SettingsController();
+    $layoutStyles = $settingsController->getEmailLayoutStyles();
+    verify($layoutStyles)->arrayHasKey('width');
+    verify($layoutStyles)->arrayHasKey('background');
+    verify($layoutStyles)->arrayHasKey('padding');
+  }
+
+  public function testItGetsCorrectLayoutWidthWithoutPadding(): void {
+    $settingsController = new SettingsController();
+    $layoutWidth = $settingsController->getLayoutWidthWithoutPadding();
+    // default width is 660px and padding for left and right is 10px
+    verify($layoutWidth)->equals('640px');
+  }
+
+  public function testItConvertsStylesToString(): void {
+    $settingsController = new SettingsController();
+    $styles = [
+      'width' => '600px',
+      'background' => '#ffffff',
+      'padding-left' => '15px',
+    ];
+    $string = $settingsController->convertStylesToString($styles);
+    verify($string)->equals('width:600px;background:#ffffff;padding-left:15px;');
+  }
+}


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

As a part of this PR are additional changes:
- avoiding code repetition for converting styles to string
- disabling layout for `core/columns`

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5705]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5705]: https://mailpoet.atlassian.net/browse/MAILPOET-5705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ