### PR TITLE
Remove usages of MailPoet\Tasks\Sending — Part 2 [MAILPOET-5682]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
@@ -2,30 +2,36 @@
 
 namespace MailPoet\Cron\Workers\SendingQueue;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Tasks\Sending as SendingTask;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 
 class SendingErrorHandler {
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   /** @var SendingThrottlingHandler */
   private $throttlingHandler;
 
   public function __construct(
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
     SendingThrottlingHandler $throttlingHandler
   ) {
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
     $this->throttlingHandler = $throttlingHandler;
   }
 
   public function processError(
     MailerError $error,
-    SendingTask $sendingTask,
+    ScheduledTaskEntity $task,
     array $preparedSubscribersIds,
     array $preparedSubscribers
   ) {
     if ($error->getLevel() === MailerError::LEVEL_HARD) {
       return $this->processHardError($error);
     }
-    $this->processSoftError($error, $sendingTask, $preparedSubscribersIds, $preparedSubscribers);
+    $this->processSoftError($error, $task, $preparedSubscribersIds, $preparedSubscribers);
   }
 
   private function processHardError(MailerError $error) {
@@ -40,11 +46,11 @@ class SendingErrorHandler {
     }
   }
 
-  private function processSoftError(MailerError $error, SendingTask $sendingTask, $preparedSubscribersIds, $preparedSubscribers) {
+  private function processSoftError(MailerError $error, ScheduledTaskEntity $task, $preparedSubscribersIds, $preparedSubscribers) {
     foreach ($error->getSubscriberErrors() as $subscriberError) {
       $subscriberIdIndex = array_search($subscriberError->getEmail(), $preparedSubscribers);
       $message = $subscriberError->getMessage() ?: $error->getMessage();
-      $sendingTask->saveSubscriberError($preparedSubscribersIds[$subscriberIdIndex], $message);
+      $this->scheduledTaskSubscribersRepository->saveError($task, $preparedSubscribersIds[$subscriberIdIndex], $message ?? '');
     }
   }
 }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -377,7 +377,7 @@ class SendingQueue {
         $this->newsletterTask->prepareNewsletterForSending(
           $newsletterEntity,
           $subscriberEntity,
-          $legacyQueue
+          $sendingQueueEntity
         );
       // format subscriber name/address according to mailer settings
       $preparedSubscribers[] = $this->mailerTask->prepareSubscriberForSending(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -508,11 +508,7 @@ class SendingQueue {
     // log error message and schedule retry/pause sending
     if ($sendResult['response'] === false) {
       $error = $sendResult['error'];
-      $legacyTask = ScheduledTask::findOne($task->getId());
-      $legacyQueue = $legacyTask ? SendingTask::createFromScheduledTask($legacyTask) : null;
-      if ($legacyQueue) {
-        $this->errorHandler->processError($error, $legacyQueue, $preparedSubscribersIds, $preparedSubscribers);
-      }
+      $this->errorHandler->processError($error, $task, $preparedSubscribersIds, $preparedSubscribers);
     } else {
       $queue = $task->getSendingQueue();
       if (!$queue) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -176,7 +176,7 @@ class SendingQueue {
 
     $this->deleteTaskIfNewsletterDoesNotExist($task);
 
-    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($legacyQueue);
+    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($task);
     if (!$newsletterEntity) {
       return;
     }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -559,7 +559,7 @@ class SendingQueue {
   }
 
   private function stopProgress(ScheduledTaskEntity $task): void {
-    $task->setInProgress(true);
+    $task->setInProgress(false);
     $this->scheduledTasksRepository->flush();
   }
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -295,8 +295,8 @@ class SendingQueue {
       $this->reScheduleBounceTask();
 
       if ($newsletterEntity->getStatus() !== NewsletterEntity::STATUS_CORRUPT) {
-        $legacyQueue = $this->processQueue(
-          $legacyQueue,
+        $this->processQueue(
+          $task,
           $_newsletter,
           $foundSubscribers,
           $timer
@@ -336,7 +336,7 @@ class SendingQueue {
     return $this->throttlingHandler->getBatchSize();
   }
 
-  public function processQueue($queue, $newsletter, $subscribers, $timer) {
+  public function processQueue(ScheduledTaskEntity $task, $newsletter, $subscribers, $timer) {
     // determine if processing is done in bulk or individually
     $processingMethod = $this->mailerTask->getProcessingMethod();
     $preparedNewsletters = [];
@@ -346,11 +346,24 @@ class SendingQueue {
     $statistics = [];
     $metas = [];
     $oneClickUnsubscribeUrls = [];
-    $sendingQueueEntity = $queue->getSendingQueueEntity();
+    $sendingQueueEntity = $task->getSendingQueue();
+    if (!$sendingQueueEntity) {
+      return;
+    }
+
+    $legacyTask = ScheduledTask::findOne($task->getId());
+    $legacyQueue = $legacyTask ? SendingTask::createFromScheduledTask($legacyTask) : null;
+    if (!$legacyQueue) {
+      return;
+    }
+
     $sendingQueueMeta = $sendingQueueEntity->getMeta() ?? [];
     $campaignId = $sendingQueueMeta['campaignId'] ?? null;
 
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->id);
+    if (!$newsletterEntity) {
+      return;
+    }
 
     foreach ($subscribers as $subscriber) {
       $subscriberEntity = $this->subscribersRepository->findOneById($subscriber->id);
@@ -359,16 +372,12 @@ class SendingQueue {
         continue;
       }
 
-      if (!$newsletterEntity instanceof NewsletterEntity) {
-        continue;
-      }
-
       // render shortcodes and replace subscriber data in tracked links
       $preparedNewsletters[] =
         $this->newsletterTask->prepareNewsletterForSending(
           $newsletterEntity,
           $subscriberEntity,
-          $queue
+          $legacyQueue
         );
       // format subscriber name/address according to mailer settings
       $preparedSubscribers[] = $this->mailerTask->prepareSubscriberForSending(
@@ -376,8 +385,8 @@ class SendingQueue {
       );
       $preparedSubscribersIds[] = $subscriber->id;
       // create personalized instant unsubsribe link
-      $unsubscribeUrls[] = $this->links->getUnsubscribeUrl($queue->id, $subscriberEntity);
-      $oneClickUnsubscribeUrls[] = $this->links->getOneClickUnsubscribeUrl($queue->id, $subscriberEntity);
+      $unsubscribeUrls[] = $this->links->getUnsubscribeUrl($sendingQueueEntity->getId(), $subscriberEntity);
+      $oneClickUnsubscribeUrls[] = $this->links->getOneClickUnsubscribeUrl($sendingQueueEntity->getId(), $subscriberEntity);
 
       $metasForSubscriber = $this->mailerMetaInfo->getNewsletterMetaInfo($newsletterEntity, $subscriberEntity);
       if ($campaignId) {
@@ -389,11 +398,11 @@ class SendingQueue {
       $statistics[] = [
         'newsletter_id' => $newsletter->id,
         'subscriber_id' => $subscriber->id,
-        'queue_id' => $queue->id,
+        'queue_id' => $sendingQueueEntity->getId(),
       ];
       if ($processingMethod === 'individual') {
-        $queue = $this->sendNewsletter(
-          $queue,
+        $this->sendNewsletter(
+          $legacyQueue,
           $preparedSubscribersIds[0],
           $preparedNewsletters[0],
           $preparedSubscribers[0],
@@ -415,8 +424,8 @@ class SendingQueue {
       }
     }
     if ($processingMethod === 'bulk') {
-      $queue = $this->sendNewsletters(
-        $queue,
+      $this->sendNewsletters(
+        $legacyQueue,
         $preparedSubscribersIds,
         $preparedNewsletters,
         $preparedSubscribers,
@@ -429,7 +438,6 @@ class SendingQueue {
         ]
       );
     }
-    return $queue;
   }
 
   public function sendNewsletter(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -21,6 +21,7 @@ use MailPoet\Models\StatisticsNewsletters as StatisticsNewslettersModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
@@ -78,6 +79,9 @@ class SendingQueue {
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
 
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
@@ -99,6 +103,7 @@ class SendingQueue {
     WPFunctions $wp,
     Links $links,
     ScheduledTasksRepository $scheduledTasksRepository,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
     MailerTask $mailerTask,
     SubscribersRepository $subscribersRepository,
     SendingQueuesRepository $sendingQueuesRepository,
@@ -119,6 +124,7 @@ class SendingQueue {
     $this->cronHelper = $cronHelper;
     $this->links = $links;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
     $this->subscribersRepository = $subscribersRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->entityManager = $entityManager;
@@ -168,7 +174,7 @@ class SendingQueue {
       ['task_id' => $task->getId()]
     );
 
-    $this->deleteTaskIfNewsletterDoesNotExist($legacyQueue);
+    $this->deleteTaskIfNewsletterDoesNotExist($task);
 
     $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($legacyQueue);
     if (!$newsletterEntity) {
@@ -179,7 +185,7 @@ class SendingQueue {
     $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $legacyQueue);
 
     if (!$newsletterEntity) {
-      $this->deleteTask($legacyQueue);
+      $this->deleteTask($task);
       return;
     }
 
@@ -564,20 +570,27 @@ class SendingQueue {
     return $this->cronHelper->getDaemonExecutionLimit() * 3;
   }
 
-  private function deleteTaskIfNewsletterDoesNotExist(SendingTask $sendingTask) {
-    $sendingQueue = $sendingTask->getSendingQueueEntity();
-    $newsletter = $sendingQueue->getNewsletter();
+  private function deleteTaskIfNewsletterDoesNotExist(ScheduledTaskEntity $task) {
+    $queue = $task->getSendingQueue();
+    $newsletter = $queue ? $queue->getNewsletter() : null;
     if ($newsletter !== null) {
       return;
     }
-    $this->deleteTask($sendingTask);
+    $this->deleteTask($task);
   }
 
-  private function deleteTask(SendingTask $queue) {
+  private function deleteTask(ScheduledTaskEntity $task) {
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
       'delete task in sending queue',
-      ['task_id' => $queue->taskId]
+      ['task_id' => $task->getId()]
     );
-    $queue->delete();
+
+    $queue = $task->getSendingQueue();
+    if ($queue) {
+      $this->sendingQueuesRepository->remove($queue);
+    }
+    $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($task);
+    $this->scheduledTasksRepository->remove($task);
+    $this->scheduledTasksRepository->flush();
   }
 }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -182,7 +182,7 @@ class SendingQueue {
     }
 
     // pre-process newsletter (render, replace shortcodes/links, etc.)
-    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $legacyQueue);
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $task);
 
     if (!$newsletterEntity) {
       $this->deleteTask($task);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -133,12 +133,6 @@ class SendingQueue {
         continue;
       }
 
-      $legacyTask = ScheduledTask::findOne($task->getId());
-      $legacyQueue = $legacyTask ? SendingTask::createFromScheduledTask($legacyTask) : null;
-      if (!$legacyQueue) {
-        continue;
-      }
-
       if ($task->getInProgress()) {
         if ($this->isTimeout($task)) {
           $this->stopProgress($task);
@@ -152,7 +146,7 @@ class SendingQueue {
 
       try {
         $this->scheduledTasksRepository->touchAllByIds([$task->getId()]);
-        $this->processSending($legacyQueue, (int)$timer);
+        $this->processSending($task, (int)$timer);
       } catch (\Exception $e) {
         $this->stopProgress($task);
         throw $e;
@@ -162,24 +156,30 @@ class SendingQueue {
     }
   }
 
-  private function processSending(SendingTask $queue, int $timer): void {
+  private function processSending(ScheduledTaskEntity $task, int $timer): void {
+    $legacyTask = ScheduledTask::findOne($task->getId());
+    $legacyQueue = $legacyTask ? SendingTask::createFromScheduledTask($legacyTask) : null;
+    if (!$legacyQueue) {
+      return;
+    }
+
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
       'sending queue processing',
-      ['task_id' => $queue->taskId]
+      ['task_id' => $task->getId()]
     );
 
-    $this->deleteTaskIfNewsletterDoesNotExist($queue);
+    $this->deleteTaskIfNewsletterDoesNotExist($legacyQueue);
 
-    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($queue);
+    $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($legacyQueue);
     if (!$newsletterEntity) {
       return;
     }
 
     // pre-process newsletter (render, replace shortcodes/links, etc.)
-    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $queue);
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletterEntity, $legacyQueue);
 
     if (!$newsletterEntity) {
-      $this->deleteTask($queue);
+      $this->deleteTask($legacyQueue);
       return;
     }
 
@@ -211,32 +211,29 @@ class SendingQueue {
     if ($newsletterSegmentsIds && !$this->checkDeletedSegments($segmentIdsToCheck)) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
         'pause task in sending queue due deleted or trashed segment',
-        ['task_id' => $queue->taskId]
+        ['task_id' => $task->getId()]
       );
-      $queue->status = ScheduledTaskEntity::STATUS_PAUSED;
-      $queue->save();
+      $legacyQueue->status = ScheduledTaskEntity::STATUS_PAUSED;
+      $legacyQueue->save();
       $this->wp->setTransient(self::EMAIL_WITH_INVALID_SEGMENT_OPTION, $newsletter->subject);
       return;
     }
 
     // get subscribers
-    $subscriberBatches = new BatchIterator($queue->taskId, $this->getBatchSize());
+    $subscriberBatches = new BatchIterator($task->getId(), $this->getBatchSize());
     if ($subscriberBatches->count() === 0) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
         'no subscribers to process',
-        ['task_id' => $queue->taskId]
+        ['task_id' => $task->getId()]
       );
-      $task = $queue->getSendingQueueEntity()->getTask();
-      if ($task) {
-        $this->scheduledTasksRepository->invalidateTask($task);
-      }
+      $this->scheduledTasksRepository->invalidateTask($task);
       return;
     }
     /** @var int[] $subscribersToProcessIds - it's required for PHPStan */
     foreach ($subscriberBatches as $subscribersToProcessIds) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
         'subscriber batch processing',
-        ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId, 'subscriber_batch_count' => count($subscribersToProcessIds)]
+        ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId(), 'subscriber_batch_count' => count($subscribersToProcessIds)]
       );
       if (!empty($newsletterSegmentsIds[0])) {
         // Check that subscribers are in segments
@@ -245,10 +242,10 @@ class SendingQueue {
         } catch (InvalidStateException $exception) {
           $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
             'paused task in sending queue due to problem finding subscribers: ' . $exception->getMessage(),
-            ['task_id' => $queue->taskId]
+            ['task_id' => $task->getId()]
           );
-          $queue->status = ScheduledTaskEntity::STATUS_PAUSED;
-          $queue->save();
+          $legacyQueue->status = ScheduledTaskEntity::STATUS_PAUSED;
+          $legacyQueue->save();
           return;
         }
         $foundSubscribers = empty($foundSubscribersIds) ? [] : SubscriberModel::whereIn('id', $foundSubscribersIds)
@@ -272,8 +269,9 @@ class SendingQueue {
           $subscribersToProcessIds,
           $foundSubscribersIds
         );
-        $queue->removeSubscribers($subscribersToRemove);
-        if (!$queue->countToProcess) {
+
+        $legacyQueue->removeSubscribers($subscribersToRemove);
+        if (!$legacyQueue->countToProcess) {
           $this->newsletterTask->markNewsletterAsSent($newsletterEntity);
           continue;
         }
@@ -284,15 +282,15 @@ class SendingQueue {
       }
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
         'before queue chunk processing',
-        ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId, 'found_subscribers_count' => count($foundSubscribers)]
+        ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId(), 'found_subscribers_count' => count($foundSubscribers)]
       );
 
       // reschedule bounce task to run sooner, if needed
       $this->reScheduleBounceTask();
 
       if ($newsletterEntity->getStatus() !== NewsletterEntity::STATUS_CORRUPT) {
-        $queue = $this->processQueue(
-          $queue,
+        $legacyQueue = $this->processQueue(
+          $legacyQueue,
           $_newsletter,
           $foundSubscribers,
           $timer
@@ -307,22 +305,22 @@ class SendingQueue {
         }
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
           'after queue chunk processing',
-          ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
+          ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]
         );
-        if ($queue->status === ScheduledTaskEntity::STATUS_COMPLETED) {
+        if ($legacyQueue->status === ScheduledTaskEntity::STATUS_COMPLETED) {
           $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
             'completed newsletter sending',
-            ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
+            ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]
           );
           $this->newsletterTask->markNewsletterAsSent($newsletterEntity);
           $this->statsNotificationsScheduler->schedule($newsletterEntity);
         }
         $this->enforceSendingAndExecutionLimits($timer);
       } else {
-        $this->sendingQueuesRepository->pause($queue->getSendingQueueEntity());
+        $this->sendingQueuesRepository->pause($legacyQueue->getSendingQueueEntity());
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->error(
           'Can\'t send corrupt newsletter',
-          ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
+          ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]
         );
       }
     }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -16,7 +16,6 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Models\Newsletter;
-use MailPoet\Models\ScheduledTask;
 use MailPoet\Models\StatisticsNewsletters as StatisticsNewslettersModel;
 use MailPoet\Models\Subscriber as SubscriberModel;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -26,7 +25,6 @@ use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Tasks\Subscribers\BatchIterator;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -164,12 +162,6 @@ class SendingQueue {
   }
 
   private function processSending(ScheduledTaskEntity $task, int $timer): void {
-    $legacyTask = ScheduledTask::findOne($task->getId());
-    $legacyQueue = $legacyTask ? SendingTask::createFromScheduledTask($legacyTask) : null;
-    if (!$legacyQueue) {
-      return;
-    }
-
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
       'sending queue processing',
       ['task_id' => $task->getId()]
@@ -177,8 +169,9 @@ class SendingQueue {
 
     $this->deleteTaskIfNewsletterDoesNotExist($task);
 
+    $queue = $task->getSendingQueue();
     $newsletterEntity = $this->newsletterTask->getNewsletterFromQueue($task);
-    if (!$newsletterEntity) {
+    if (!$queue || !$newsletterEntity) {
       return;
     }
 
@@ -220,8 +213,8 @@ class SendingQueue {
         'pause task in sending queue due deleted or trashed segment',
         ['task_id' => $task->getId()]
       );
-      $legacyQueue->status = ScheduledTaskEntity::STATUS_PAUSED;
-      $legacyQueue->save();
+      $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+      $this->scheduledTasksRepository->flush();
       $this->wp->setTransient(self::EMAIL_WITH_INVALID_SEGMENT_OPTION, $newsletter->subject);
       return;
     }
@@ -251,8 +244,8 @@ class SendingQueue {
             'paused task in sending queue due to problem finding subscribers: ' . $exception->getMessage(),
             ['task_id' => $task->getId()]
           );
-          $legacyQueue->status = ScheduledTaskEntity::STATUS_PAUSED;
-          $legacyQueue->save();
+          $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+          $this->scheduledTasksRepository->flush();
           return;
         }
         $foundSubscribers = empty($foundSubscribersIds) ? [] : SubscriberModel::whereIn('id', $foundSubscribersIds)
@@ -277,8 +270,10 @@ class SendingQueue {
           $foundSubscribersIds
         );
 
-        $legacyQueue->removeSubscribers($subscribersToRemove);
-        if (!$legacyQueue->countToProcess) {
+        $this->scheduledTaskSubscribersRepository->deleteByScheduledTaskAndSubscriberIds($task, $subscribersToRemove);
+        $this->sendingQueuesRepository->updateCounts($queue);
+
+        if (!$queue->getCountToProcess()) {
           $this->newsletterTask->markNewsletterAsSent($newsletterEntity);
           continue;
         }
@@ -314,7 +309,7 @@ class SendingQueue {
           'after queue chunk processing',
           ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]
         );
-        if ($legacyQueue->status === ScheduledTaskEntity::STATUS_COMPLETED) {
+        if ($task->getStatus() === ScheduledTaskEntity::STATUS_COMPLETED) {
           $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
             'completed newsletter sending',
             ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]
@@ -324,7 +319,7 @@ class SendingQueue {
         }
         $this->enforceSendingAndExecutionLimits($timer);
       } else {
-        $this->sendingQueuesRepository->pause($legacyQueue->getSendingQueueEntity());
+        $this->sendingQueuesRepository->pause($queue);
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->error(
           'Can\'t send corrupt newsletter',
           ['newsletter_id' => $newsletter->id, 'task_id' => $task->getId()]

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -5,6 +5,7 @@ namespace MailPoet\Cron\Workers\SendingQueue\Tasks;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
 use MailPoet\Router\Endpoints\Track;
@@ -39,8 +40,8 @@ class Links {
     $this->trackingConfig = $trackingConfig;
   }
 
-  public function process($renderedNewsletter, NewsletterEntity $newsletter, $queue) {
-    [$renderedNewsletter, $links] = $this->hashAndReplaceLinks($renderedNewsletter, $newsletter->getId(), $queue->id);
+  public function process($renderedNewsletter, NewsletterEntity $newsletter, SendingQueueEntity $queue) {
+    [$renderedNewsletter, $links] = $this->hashAndReplaceLinks($renderedNewsletter, $newsletter->getId(), $queue->getId());
     $this->saveLinks($links, $newsletter, $queue);
     return $renderedNewsletter;
   }
@@ -59,8 +60,8 @@ class Links {
     ];
   }
 
-  public function saveLinks($links, NewsletterEntity $newsletter, $queue) {
-    return $this->newsletterLinks->save($links, $newsletter->getId(), $queue->id);
+  public function saveLinks($links, NewsletterEntity $newsletter, SendingQueueEntity $queue) {
+    return $this->newsletterLinks->save($links, $newsletter->getId(), $queue->getId());
   }
 
   public function getUnsubscribeUrl($queueId, SubscriberEntity $subscriber = null) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -134,17 +134,18 @@ class Newsletter {
     return $newsletter;
   }
 
-  public function preProcessNewsletter(NewsletterEntity $newsletter, Sending $sendingTask) {
+  public function preProcessNewsletter(NewsletterEntity $newsletter, ScheduledTaskEntity $task) {
     // return the newsletter if it was previously rendered
-    /** @phpstan-ignore-next-line - SendingQueue::getNewsletterRenderedBody() is called inside Sending using __call(). Sending will be refactored soon to stop using Paris models. */
-    if (!is_null($sendingTask->getNewsletterRenderedBody())) {
-      return (!$sendingTask->validate()) ?
-        $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-RENDER', $sendingTask->id)) :
-        $newsletter;
+    $queue = $task->getSendingQueue();
+    if (!$queue) {
+      return false;
+    }
+    if ($queue->getNewsletterRenderedBody() !== null) {
+      return $newsletter;
     }
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
       'pre-processing newsletter',
-      ['newsletter_id' => $newsletter->getId(), 'task_id' => $sendingTask->taskId]
+      ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
     );
 
     $campaignId = null;
@@ -154,7 +155,7 @@ class Newsletter {
       // hook to the newsletter post-processing filter and add tracking image
       $this->trackingImageInserted = OpenTracking::addTrackingImage();
       // render newsletter
-      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask->getSendingQueueEntity());
+      $renderedNewsletter = $this->renderer->render($newsletter, $queue);
       $renderedNewsletter = $this->wp->applyFilters(
         'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
@@ -165,10 +166,10 @@ class Newsletter {
       }
       $renderedNewsletter = $this->gaTracking->applyGATracking($renderedNewsletter, $newsletter);
       // hash and save all links
-      $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletter, $sendingTask);
+      $renderedNewsletter = $this->linksTask->process($renderedNewsletter, $newsletter, $queue);
     } else {
       // render newsletter
-      $renderedNewsletter = $this->renderer->render($newsletter, $sendingTask->getSendingQueueEntity());
+      $renderedNewsletter = $this->renderer->render($newsletter, $queue);
       $renderedNewsletter = $this->wp->applyFilters(
         'mailpoet_sending_newsletter_render_after_pre_process',
         $renderedNewsletter,
@@ -188,7 +189,7 @@ class Newsletter {
       // delete notification history record since it will never be sent
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
         'no posts in post notification, deleting it',
-        ['newsletter_id' => $newsletter->getId(), 'task_id' => $sendingTask->taskId]
+        ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
       );
       $this->newslettersRepository->bulkDelete([(int)$newsletter->getId()]);
       return false;
@@ -196,43 +197,41 @@ class Newsletter {
     // extract and save newsletter posts
     $this->postsTask->extractAndSave($renderedNewsletter, $newsletter);
 
-    $sendingQueueEntity = $sendingTask->getSendingQueueEntity();
-
     if ($campaignId !== null) {
-      $this->sendingQueuesRepository->saveCampaignId($sendingQueueEntity, $campaignId);
+      $this->sendingQueuesRepository->saveCampaignId($queue, $campaignId);
     }
 
     $filterSegmentId = $newsletter->getFilterSegmentId();
     if ($filterSegmentId) {
       $filterSegment = $this->segmentsRepository->findOneById($filterSegmentId);
       if ($filterSegment instanceof SegmentEntity && $filterSegment->getType() === SegmentEntity::TYPE_DYNAMIC) {
-        $this->sendingQueuesRepository->saveFilterSegmentMeta($sendingQueueEntity, $filterSegment);
+        $this->sendingQueuesRepository->saveFilterSegmentMeta($queue, $filterSegment);
       }
     }
 
     // update queue with the rendered and pre-processed newsletter
-    $sendingTask->newsletterRenderedSubject = ShortcodesTask::process(
-      $newsletter->getSubject(),
-      $renderedNewsletter['html'],
-      $newsletter,
-      null,
-      $sendingQueueEntity
+    $queue->setNewsletterRenderedSubject(
+      ShortcodesTask::process(
+        $newsletter->getSubject(),
+        $renderedNewsletter['html'],
+        $newsletter,
+        null,
+        $queue
+      )
     );
 
     // if the rendered subject is empty, use a default subject,
     // having no subject in a newsletter is considered spammy
-    if (empty(trim((string)$sendingTask->newsletterRenderedSubject))) {
-      $sendingTask->newsletterRenderedSubject = __('No subject', 'mailpoet');
+    if (empty(trim((string)$queue->getNewsletterRenderedSubject()))) {
+      $queue->setNewsletterRenderedSubject(__('No subject', 'mailpoet'));
     }
     $renderedNewsletter = $this->emoji->encodeEmojisInBody($renderedNewsletter);
-    $sendingTask->newsletterRenderedBody = $renderedNewsletter;
-    $sendingTask->save();
+    $queue->setNewsletterRenderedBody($renderedNewsletter);
 
-    // catch DB errors
-    $queueErrors = $sendingTask->getErrors();
-
-    if ($queueErrors) {
-      $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-SAVE', $sendingTask->id));
+    try {
+      $this->sendingQueuesRepository->flush();
+    } catch (\Throwable $e) {
+      $this->stopNewsletterPreProcessing(sprintf('QUEUE-%d-SAVE', $queue->getId()));
     }
     return $newsletter;
   }

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -265,13 +265,6 @@ class Sending {
     $this->updateCount();
   }
 
-  public function removeSubscribers(array $subscriberIds) {
-    $this->scheduledTaskSubscribersRepository->deleteByScheduledTaskAndSubscriberIds($this->scheduledTaskEntity, $subscriberIds);
-
-    $this->updateTaskStatus();
-    $this->updateCount();
-  }
-
   public function updateProcessedSubscribers(array $processedSubscribers): bool {
     $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($this->scheduledTaskEntity, $processedSubscribers);
     $this->scheduledTasksRepository->refresh($this->scheduledTaskEntity); // needed while Sending still uses Paris

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -6,7 +6,6 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueAlias;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Models\ScheduledTask;
@@ -223,16 +222,6 @@ class Sending {
 
   public function queue() {
     return $this->queue;
-  }
-
-  public function getSendingQueueEntity(): SendingQueueEntity {
-    $sendingQueueEntity = $this->sendingQueuesRepository->findOneById($this->queue->id);
-    if (!$sendingQueueEntity) {
-      throw new InvalidStateException();
-    }
-    $this->sendingQueuesRepository->refresh($sendingQueueEntity);
-
-    return $sendingQueueEntity;
   }
 
   public function task() {

--- a/mailpoet/lib/Tasks/Sending.php
+++ b/mailpoet/lib/Tasks/Sending.php
@@ -279,23 +279,6 @@ class Sending {
     return $this->updateCount(count($processedSubscribers))->getErrors() === false;
   }
 
-  public function saveSubscriberError($subcriberId, $errorMessage) {
-    $this->scheduledTaskSubscribersRepository->saveError($this->scheduledTaskEntity, $subcriberId, $errorMessage);
-
-    $this->updateTaskStatus();
-
-    return $this->updateCount()->getErrors() === false;
-  }
-
-  private function updateTaskStatus() {
-    // we need to update those fields here as the Sending class is in a mixed state using Paris and Doctrine at the same time
-    // this probably won't be necessary anymore once https://mailpoet.atlassian.net/browse/MAILPOET-4375 is finished
-    $this->task->status = $this->scheduledTaskEntity->getStatus();
-    if (!is_null($this->scheduledTaskEntity->getProcessedAt())) {
-      $this->task->processedAt = $this->scheduledTaskEntity->getProcessedAt()->format('Y-m-d H:i:s');
-    }
-  }
-
   public function updateCount(?int $count = null) {
     if ($count) {
       // increment/decrement counts based on known subscriber count, don't exceed the bounds

--- a/mailpoet/tests/DataFactories/SendingQueue.php
+++ b/mailpoet/tests/DataFactories/SendingQueue.php
@@ -22,6 +22,7 @@ class SendingQueue {
   public function create(ScheduledTaskEntity $task, ?NewsletterEntity $newsletter = null, \DateTimeInterface $deletedAt = null): SendingQueueEntity {
     $queue = new SendingQueueEntity();
     $queue->setTask($task);
+    $task->setSendingQueue($queue);
 
     $newsletter = $newsletter ?: $this->entityManager->getReference(NewsletterEntity::class, rand(1, 9999));
     if ($newsletter) { // for phpstan because getReference can return null
@@ -34,7 +35,6 @@ class SendingQueue {
 
     $this->entityManager->persist($queue);
     $this->entityManager->flush();
-    $this->entityManager->refresh($task);
 
     return $queue;
   }

--- a/mailpoet/tests/DataFactories/SendingQueue.php
+++ b/mailpoet/tests/DataFactories/SendingQueue.php
@@ -34,6 +34,7 @@ class SendingQueue {
 
     $this->entityManager->persist($queue);
     $this->entityManager->flush();
+    $this->entityManager->refresh($task);
 
     return $queue;
   }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -39,6 +39,7 @@ use MailPoet\Models\SubscriberSegment;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Router\Router;
@@ -97,6 +98,9 @@ class SendingQueueTest extends \MailPoetTest {
 
   /** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
+
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
 
   public function _before() {
     parent::_before();
@@ -162,6 +166,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->tasksLinks = $this->diContainer->get(TasksLinks::class);
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->sendingQueueWorker = $this->getSendingQueueWorker();
@@ -218,6 +223,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,
@@ -249,6 +255,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -297,6 +304,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -343,6 +351,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,
@@ -677,6 +686,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -1124,6 +1134,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -1440,6 +1451,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
+      $this->scheduledTaskSubscribersRepository,
       $mailerMock ?? $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -128,11 +128,13 @@ class SendingQueueTest extends \MailPoetTest {
     $this->subscriberSegment->subscriberId = (int)$this->subscriber->getId();
     $this->subscriberSegment->segmentId = (int)$this->segment->id;
     $this->subscriberSegment->save();
+
     /** @var Newsletter $newsletter */
     $newsletter = Newsletter::create();
     $this->newsletter = $newsletter;
-    $this->newsletter->type = Newsletter::TYPE_STANDARD;
-    $this->newsletter->status = Newsletter::STATUS_ACTIVE;
+    $this->newsletter->type = NewsletterEntity::TYPE_STANDARD;
+    $this->newsletter->status = NewsletterEntity::STATUS_ACTIVE;
+
     $this->newsletter->subject = Fixtures::get('newsletter_subject_template');
     $this->newsletter->body = Fixtures::get('newsletter_body_template');
     $this->newsletter->save();
@@ -464,7 +466,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
 
     // queue status is set to completed
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -598,7 +600,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
 
     // queue status is set to completed
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -655,7 +657,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent and sent_at date is populated
     $updatedNewsletter = $this->newslettersRepository->findOneById($this->newsletter->id);
     $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
-    verify($updatedNewsletter->getStatus())->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     verify($updatedNewsletter->getSentAt())->equalsWithDelta($scheduledTask->getProcessedAt(), 1);
 
     // queue subscriber processed/to process count is updated
@@ -769,7 +771,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->queue->updated_at = $originalUpdated;
     $this->queue->save();
 
-    $this->newsletter->type = Newsletter::TYPE_WELCOME;
+    $this->newsletter->type = NewsletterEntity::TYPE_WELCOME;
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
@@ -783,7 +785,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItCanProcessWelcomeNewsletters() {
-    $this->newsletter->type = Newsletter::TYPE_WELCOME;
+    $this->newsletter->type = NewsletterEntity::TYPE_WELCOME;
     $this->newsletterSegment->delete();
 
     $sendingQueueWorker = $this->getSendingQueueWorker(
@@ -806,7 +808,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter status is set to sent
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
 
     // queue status is set to completed
     $sendingQueue = $this->sendingQueuesRepository->findOneById($this->queue->id);
@@ -835,8 +837,8 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItPreventsSendingWelcomeEmailWhenSubscriberIsUnsubscribed() {
-    $this->newsletter->type = Newsletter::TYPE_WELCOME;
-    $this->subscriber->setStatus(Subscriber::STATUS_UNSUBSCRIBED);
+    $this->newsletter->type = NewsletterEntity::TYPE_WELCOME;
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
     $this->newsletterSegment->delete();
     $this->entityManager->refresh($this->sendingQueueEntity);
@@ -1090,7 +1092,7 @@ class SendingQueueTest extends \MailPoetTest {
 
     // newsletter is not sent to globally unsubscribed subscriber
     $subscriber = $this->subscriber;
-    $subscriber->setStatus(Subscriber::STATUS_UNSUBSCRIBED);
+    $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->flush();
     $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
@@ -1111,7 +1113,7 @@ class SendingQueueTest extends \MailPoetTest {
 
     // newsletter is not sent to subscriber unsubscribed from segment
     $subscriberSegment = $this->subscriberSegment;
-    $subscriberSegment->status = Subscriber::STATUS_UNSUBSCRIBED;
+    $subscriberSegment->status = SubscriberEntity::STATUS_UNSUBSCRIBED;
     $subscriberSegment->save();
     $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
@@ -1132,7 +1134,7 @@ class SendingQueueTest extends \MailPoetTest {
 
     // newsletter is not sent to inactive subscriber
     $subscriber = $this->subscriber;
-    $subscriber->setStatus(Subscriber::STATUS_INACTIVE);
+    $subscriber->setStatus(SubscriberEntity::STATUS_INACTIVE);
     $this->entityManager->flush();
     $this->entityManager->refresh($this->sendingQueueEntity);
     $sendingQueueWorker->process();
@@ -1213,7 +1215,7 @@ class SendingQueueTest extends \MailPoetTest {
     // newsletter is sent and hash remains intact
     $updatedNewsletter = Newsletter::findOne($this->newsletter->id);
     $this->assertInstanceOf(Newsletter::class, $updatedNewsletter);
-    verify($updatedNewsletter->status)->equals(Newsletter::STATUS_SENT);
+    verify($updatedNewsletter->status)->equals(NewsletterEntity::STATUS_SENT);
     verify($updatedNewsletter->hash)->equals($this->newsletter->hash);
   }
 
@@ -1427,7 +1429,7 @@ class SendingQueueTest extends \MailPoetTest {
     $subscriber->setEmail($email);
     $subscriber->setFirstName($firstName);
     $subscriber->setLastName($lastName);
-    $subscriber->setStatus(Subscriber::STATUS_SUBSCRIBED);
+    $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
     $subscriber->setSource('administrator');
     $this->entityManager->persist($subscriber);
     $this->entityManager->flush();

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -19,6 +19,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -30,7 +31,6 @@ use MailPoet\Mailer\SubscriberError;
 use MailPoet\Models\Newsletter;
 use MailPoet\Models\NewsletterSegment;
 use MailPoet\Models\ScheduledTask;
-use MailPoet\Models\ScheduledTaskSubscriber;
 use MailPoet\Models\Segment;
 use MailPoet\Models\SendingQueue;
 use MailPoet\Models\StatisticsNewsletters;
@@ -476,9 +476,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueue::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->arrayCount(0);
-    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -610,9 +610,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueue::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->arrayCount(0);
-    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -659,9 +659,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($updatedNewsletter->getSentAt())->equalsWithDelta($scheduledTask->getProcessedAt(), 1);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->arrayCount(0);
-    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED);
+    $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -737,8 +737,8 @@ class SendingQueueTest extends \MailPoetTest {
     // compare data after first sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))->equals([$this->subscriber]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))->equals([$wrongSubscriber]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))->equals([$this->subscriber]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))->equals([$wrongSubscriber]);
     verify($sendingQueue->getCountTotal())->equals(2);
     verify($sendingQueue->getCountProcessed())->equals(1);
     verify($sendingQueue->getCountToProcess())->equals(1);
@@ -755,8 +755,8 @@ class SendingQueueTest extends \MailPoetTest {
     // load queue and compare data after second sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))->equals([$this->subscriber, $wrongSubscriber]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))->equals([]);
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))->equals([$this->subscriber, $wrongSubscriber]);
     verify($sendingQueue->getCountTotal())->equals(2);
     verify($sendingQueue->getCountProcessed())->equals(2);
     verify($sendingQueue->getCountToProcess())->equals(0);
@@ -818,9 +818,9 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueue::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -860,7 +860,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
 
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([]);
     verify($sendingQueue->getCountTotal())->equals(0);
     verify($sendingQueue->getCountProcessed())->equals(0);
@@ -899,7 +899,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->scheduledTasksRepository->refresh($scheduledTask);
 
     // Unprocessable subscribers were removed
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]); // subscriber that should be processed
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -934,9 +934,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -977,9 +977,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
     verify($sendingQueue->getCountTotal())->equals(1);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -1010,9 +1010,9 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_UNPROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
       ->equals([]);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriber::STATUS_PROCESSED))
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([]);
     verify($sendingQueue->getCountTotal())->equals(0);
     verify($sendingQueue->getCountProcessed())->equals(0);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1269,7 +1269,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItPauseSendingTaskThatHasTrashedSegment() {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, 'Subject With Trashed', NewsletterEntity::STATUS_SENDING);
-    $queue = $this->createQueueWithTaskAndSegment($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
+    $queue = $this->createQueueWithTask($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
     $segment = $this->createSegment('Segment test', SegmentEntity::TYPE_DEFAULT);
     $segment->setDeletedAt(new \DateTime());
     $this->entityManager->flush();
@@ -1289,7 +1289,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItPauseSendingTaskThatHasDeletedSegment() {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, 'Subject With Deleted', NewsletterEntity::STATUS_SENDING);
-    $queue = $this->createQueueWithTaskAndSegment($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
+    $queue = $this->createQueueWithTask($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
     $segment = $this->createSegment('Segment test', SegmentEntity::TYPE_DEFAULT);
     $this->addSegmentToNewsletter($newsletter, $segment);
     $this->entityManager->createQueryBuilder()->delete(SegmentEntity::class, 's')
@@ -1395,7 +1395,7 @@ class SendingQueueTest extends \MailPoetTest {
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, 'Subject With Deleted', NewsletterEntity::STATUS_SENDING);
     [$segment, $subscriber] = $this->createListWithSubscriber();
     $this->addSegmentToNewsletter($newsletter, $segment);
-    $queue = $this->createQueueWithTaskAndSegment($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
+    $queue = $this->createQueueWithTask($newsletter, null, ['html' => 'Hello', 'text' => 'Hello']);
     $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->entityManager->persist($subscriber);
     $this->entityManager->flush();
@@ -1447,7 +1447,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  private function createQueueWithTaskAndSegment(NewsletterEntity $newsletter, $status = null, $body = null): SendingQueueEntity {
+  private function createQueueWithTask(NewsletterEntity $newsletter, $status = null, $body = null): SendingQueueEntity {
     $task = new ScheduledTaskEntity();
     $task->setType(SendingQueueWorker::TASK_TYPE);
     $task->setStatus($status);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/LinksTest.php
@@ -38,9 +38,8 @@ class LinksTest extends \MailPoetTest {
         'hash' => 'some_hash',
       ],
     ];
-    $queue = (object)['id' => $this->queue->getId()];
 
-    $this->links->saveLinks($links, $this->newsletter, $queue);
+    $this->links->saveLinks($links, $this->newsletter, $this->queue);
 
     $newsletterLink = $this->newsletterLinkRepository->findOneBy(['hash' => $links[0]['hash']]);
     $this->assertInstanceOf(NewsletterLinkEntity::class, $newsletterLink);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -26,7 +26,6 @@ use MailPoet\Newsletter\Renderer\Blocks\Coupon;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Router;
-use MailPoet\Tasks\Sending as SendingTask;
 use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
@@ -50,9 +49,6 @@ class NewsletterTest extends \MailPoetTest {
   /** @var NewsletterEntity */
   private $parentNewsletter;
 
-  /** @var SendingTask */
-  private $sendingTask;
-
   /** @var LoggerFactory */
   private $loggerFactory;
 
@@ -67,6 +63,12 @@ class NewsletterTest extends \MailPoetTest {
 
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
+
+  /** @var ScheduledTaskEntity */
+  private $scheduledTaskEntity;
+
+  /** @var SendingQueueEntity */
+  private $sendingQueueEntity;
 
   public function _before() {
     parent::_before();
@@ -85,9 +87,9 @@ class NewsletterTest extends \MailPoetTest {
       ->withSubject('parent newsletter')
       ->create();
 
-    $this->sendingTask = SendingTask::create();
-    $this->sendingTask->newsletter_id = $this->newsletter->getId();
-    $this->sendingTask->save();
+    $this->scheduledTaskEntity = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->sendingQueueEntity = (new SendingQueueFactory())->create($this->scheduledTaskEntity, $this->newsletter);
+
     $this->loggerFactory = LoggerFactory::getInstance();
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->newsletterLinkRepository = $this->diContainer->get(NewsletterLinkRepository::class);
@@ -106,25 +108,25 @@ class NewsletterTest extends \MailPoetTest {
     $newsletterEntity->setStatus(NewsletterEntity::STATUS_DRAFT);
     $this->newslettersRepository->persist($newsletterEntity);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->null();
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->null();
 
     // active or sending statuses return newsletter
     $newsletterEntity->setStatus(NewsletterEntity::STATUS_ACTIVE);
     $this->newslettersRepository->persist($newsletterEntity);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->instanceOf(NewsletterEntity::class);
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->instanceOf(NewsletterEntity::class);
 
     $newsletterEntity->setStatus(NewsletterEntity::STATUS_SENDING);
     $this->newslettersRepository->persist($newsletterEntity);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->instanceOf(NewsletterEntity::class);
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->instanceOf(NewsletterEntity::class);
   }
 
   public function testItDoesNotGetDeletedNewsletter() {
     $this->newsletter->setDeletedAt(new Carbon());
     $this->newslettersRepository->persist($this->newsletter);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->null();
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->null();
   }
 
   public function testItDoesNotGetNewsletterWhenParentNewsletterStatusIsNotActiveOrSending() {
@@ -140,18 +142,18 @@ class NewsletterTest extends \MailPoetTest {
     $newsletterEntity->setParent($parentNewsletterEntity);
     $this->newslettersRepository->persist($newsletterEntity);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->null();
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->null();
 
     // active or sending statuses return newsletter
     $parentNewsletterEntity->setStatus(NewsletterEntity::STATUS_ACTIVE);
     $this->newslettersRepository->persist($parentNewsletterEntity);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->instanceOf(NewsletterEntity::class);
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->instanceOf(NewsletterEntity::class);
 
     $parentNewsletterEntity->setStatus(NewsletterEntity::STATUS_SENDING);
     $this->newslettersRepository->persist($parentNewsletterEntity);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->instanceOf(NewsletterEntity::class);
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->instanceOf(NewsletterEntity::class);
   }
 
   public function testItDoesNotGetDeletedNewsletterWhenParentNewsletterIsDeleted() {
@@ -163,12 +165,14 @@ class NewsletterTest extends \MailPoetTest {
     $newsletter->setParent($this->parentNewsletter);
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    verify($this->newsletterTask->getNewsletterFromQueue($this->sendingTask))->null();
+    verify($this->newsletterTask->getNewsletterFromQueue($this->scheduledTaskEntity))->null();
   }
 
   public function testItReturnsNewsletterObjectWhenRenderedNewsletterBodyExistsInTheQueue() {
-    $this->sendingTask->newsletterRenderedBody = ['html' => 'test', 'text' => 'test'];
-    $result = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $this->sendingQueueEntity->setNewsletterRenderedBody(['html' => 'test', 'text' => 'test']);
+    $this->entityManager->persist($this->sendingQueueEntity);
+    $this->entityManager->flush();
+    $result = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     verify($result instanceof NewsletterEntity)->true();
   }
 
@@ -176,13 +180,14 @@ class NewsletterTest extends \MailPoetTest {
     $wp = Stub::make(new WPFunctions, [
       'applyFilters' => asCallable([WPHooksHelper::class, 'applyFilters']),
     ]);
+    verify($this->sendingQueueEntity->getNewsletterRenderedBody())->null();
     $newsletterTask = new NewsletterTask($wp);
     $newsletterTask->trackingEnabled = true;
-    $newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     $link = $this->newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter->getId()]);
     $this->assertInstanceOf(NewsletterLinkEntity::class, $link);
-    $updatedQueue = SendingTask::getByNewsletterId($this->newsletter->getId());
-    $renderedNewsletter = $updatedQueue->getNewsletterRenderedBody();
+    $renderedNewsletter = $this->sendingQueueEntity->getNewsletterRenderedBody();
+    $this->assertIsArray($renderedNewsletter);
     verify($renderedNewsletter['html'])
       ->stringContainsString('[mailpoet_click_data]-' . $link->getHash());
     verify($renderedNewsletter['html'])
@@ -198,13 +203,14 @@ class NewsletterTest extends \MailPoetTest {
     $wp = Stub::make(new WPFunctions, [
       'applyFilters' => asCallable([WPHooksHelper::class, 'applyFilters']),
     ]);
+    verify($this->sendingQueueEntity->getNewsletterRenderedBody())->null();
     $newsletterTask = new NewsletterTask($wp);
     $newsletterTask->trackingEnabled = false;
-    $newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     $link = $this->newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter->getId()]);
     verify($link)->null();
-    $updatedQueue = SendingTask::getByNewsletterId($this->newsletter->getId());
-    $renderedNewsletter = $updatedQueue->getNewsletterRenderedBody();
+    $renderedNewsletter = $this->sendingQueueEntity->getNewsletterRenderedBody();
+    $this->assertIsArray($renderedNewsletter);
     verify($renderedNewsletter['html'])
       ->stringNotContainsString('[mailpoet_click_data]');
     verify($renderedNewsletter['html'])
@@ -226,7 +232,7 @@ class NewsletterTest extends \MailPoetTest {
     $this->newslettersRepository->persist($this->newsletter);
     $this->newslettersRepository->flush();
     // returned result is false
-    $result = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $result = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     verify($result)->false();
     // newsletter is deleted.
     $this->entityManager->clear(); // needed while part of the code uses Paris models and part uses Doctrine
@@ -246,7 +252,7 @@ class NewsletterTest extends \MailPoetTest {
       'newsletterPostRepository' => $newsletterPostRepository,
     ]);
     $newsletterTask = new NewsletterTask(new WPFunctions, $postsTask);
-    $result = $newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $result = $newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     $newsletterPost = $newsletterPostRepository->findOneBy(['newsletter' => $this->newsletter->getId()]);
     verify($newsletterPost)->instanceOf(NewsletterPostEntity::class);
     verify($result)->notEquals(false);
@@ -257,8 +263,10 @@ class NewsletterTest extends \MailPoetTest {
   public function testItUpdatesStatusAndSetsSentAtDateOnlyForStandardAndPostNotificationNewsletters() {
     $newsletter = $this->newslettersRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    $sendingQueue = $this->sendingTask->queue();
-    $sendingQueue->processedAt = new \DateTime();
+
+    $this->scheduledTaskEntity->setProcessedAt(new Carbon());
+    $this->scheduledTasksRepository->persist($this->scheduledTaskEntity);
+    $this->scheduledTasksRepository->flush();
 
     // newsletter type is 'standard'
     $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
@@ -271,7 +279,7 @@ class NewsletterTest extends \MailPoetTest {
     verify($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     $sentAt = $updatedNewsletter->getSentAt();
     $this->assertInstanceOf(\DateTime::class, $sentAt);
-    verify($sentAt->getTimestamp())->equalsWithDelta($sendingQueue->processedAt->getTimestamp(), 1);
+    verify($sentAt)->equalsWithDelta($this->scheduledTaskEntity->getProcessedAt(), 1);
 
     // newsletter type is 'notification history'
     $newsletter->setType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
@@ -284,7 +292,7 @@ class NewsletterTest extends \MailPoetTest {
     verify($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
     $sentAt = $updatedNewsletter->getSentAt();
     $this->assertInstanceOf(\DateTime::class, $sentAt);
-    verify($sentAt->getTimestamp())->equalsWithDelta($sendingQueue->processedAt->getTimestamp(), 1);
+    verify($sentAt)->equalsWithDelta($this->scheduledTaskEntity->getProcessedAt(), 1);
 
     // all other newsletter types
     $newsletter->setType(NewsletterEntity::TYPE_WELCOME);
@@ -300,32 +308,37 @@ class NewsletterTest extends \MailPoetTest {
   public function testItDoesNotRenderSubscriberShortcodeInSubjectWhenPreprocessingNewsletter() {
     $this->newsletter->setSubject('Newsletter for [subscriber:firstname] [date:dordinal]');
     $this->newslettersRepository->persist($this->newsletter);
-    $this->newslettersRepository->flush();
-    $this->newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
-    $this->sendingTask = SendingTask::getByNewsletterId($this->newsletter->getId());
+    $this->newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+
+    $sendingQueue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $this->newsletter]);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
     $wp = new WPFunctions();
-    verify($this->sendingTask->newsletterRenderedSubject)
+    verify($sendingQueue->getNewsletterRenderedSubject())
       ->stringContainsString(date_i18n('jS', $wp->currentTime('timestamp')));
   }
 
   public function testItUsesADefaultSubjectIfRenderedSubjectIsEmptyWhenPreprocessingNewsletter() {
     $this->newsletter->setSubject('  [custom_shortcode:should_render_empty]  ');
     $this->newslettersRepository->persist($this->newsletter);
-    $this->newslettersRepository->flush();
-    $this->newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
-    $this->sendingTask = SendingTask::getByNewsletterId($this->newsletter->getId());
-    verify($this->sendingTask->newsletterRenderedSubject)
+    $this->newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+
+    $sendingQueue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $this->newsletter]);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
+    verify($sendingQueue->getNewsletterRenderedSubject())
       ->equals('No subject');
   }
 
   public function testItUsesRenderedNewsletterBodyAndSubjectFromQueueObjectWhenPreparingNewsletterForSending() {
     $newsletterEntity = $this->newslettersRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
-    $this->sendingTask->newsletterRenderedBody = [
+
+    $this->sendingQueueEntity->setNewsletterRenderedBody([
       'html' => 'queue HTML body',
       'text' => 'queue TEXT body',
-    ];
-    $this->sendingTask->newsletterRenderedSubject = 'queue subject';
+    ]);
+    $this->sendingQueueEntity->setNewsletterRenderedSubject('queue subject');
+    $this->entityManager->persist($this->sendingQueueEntity);
+
     $emoji = $this->make(
       Emoji::class,
       ['decodeEmojisInBody' => Expected::once(function ($params) {
@@ -336,7 +349,7 @@ class NewsletterTest extends \MailPoetTest {
     $result = $newsletterTask->prepareNewsletterForSending(
       $newsletterEntity,
       $this->subscriber,
-      $this->sendingTask
+      $this->sendingQueueEntity
     );
     verify($result['subject'])->equals('queue subject');
     verify($result['body']['html'])->equals('queue HTML body');
@@ -344,13 +357,13 @@ class NewsletterTest extends \MailPoetTest {
   }
 
   public function testItRendersShortcodesAndReplacesSubscriberDataInLinks() {
-    $newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $newsletter = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $result = $this->newsletterTask->prepareNewsletterForSending(
       $newsletterEntity,
       $this->subscriber,
-      $this->sendingTask
+      $this->sendingQueueEntity
     );
     verify($result['subject'])->stringContainsString($this->subscriber->getFirstName());
     verify($result['body']['html'])
@@ -362,13 +375,13 @@ class NewsletterTest extends \MailPoetTest {
   public function testItDoesNotReplaceSubscriberDataInLinksWhenTrackingIsNotEnabled() {
     $newsletterTask = $this->newsletterTask;
     $newsletterTask->trackingEnabled = false;
-    $newsletter = $newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $newsletter = $newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $result = $newsletterTask->prepareNewsletterForSending(
       $newsletterEntity,
       $this->subscriber,
-      $this->sendingTask
+      $this->sendingQueueEntity
     );
     verify($result['body']['html'])
       ->stringNotContainsString(Router::NAME . '&endpoint=track&action=click&data=');
@@ -377,9 +390,17 @@ class NewsletterTest extends \MailPoetTest {
   }
 
   public function testItLogsErrorWhenQueueWithCannotBeSaved() {
-    $this->sendingTask->nonExistentColumn = true; // this will trigger save error
+    $sendingQueuesRepositoryStub = $this->createStub(SendingQueuesRepository::class);
+    $sendingQueuesRepositoryStub->method('flush')
+      ->willThrowException(new \Exception());
+
+    $newsletterTask = Stub::copy(
+      new NewsletterTask(),
+      ['sendingQueuesRepository' => $sendingQueuesRepositoryStub]
+    );
+
     try {
-      $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+      $newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
       self::fail('Sending error exception was not thrown.');
     } catch (\Exception $e) {
       $mailerLog = MailerLog::getMailerLog();
@@ -392,113 +413,22 @@ class NewsletterTest extends \MailPoetTest {
     }
   }
 
-  public function testItLogsErrorWhenExistingRenderedNewsletterBodyIsInvalid() {
-    $sendingTaskMock = $this->createMock(SendingTask::class);
-    $sendingTaskMock
-      ->expects($this->any())
-      ->method('__call')
-      ->with('getNewsletterRenderedBody')
-      ->willReturn('a:2:{s:4:"html"');
-    $sendingTaskMock
-      ->expects($this->once())
-      ->method('validate')
-      ->willReturn(false);
-    try {
-      $this->newsletterTask->preProcessNewsletter($this->newsletter, $sendingTaskMock);
-      self::fail('Sending error exception was not thrown.');
-    } catch (\Exception $e) {
-      $mailerLog = MailerLog::getMailerLog();
-      expect(is_array($mailerLog['error']));
-      if (is_array($mailerLog['error'])) {
-        verify($mailerLog['error']['operation'])->equals('queue_save');
-        verify($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
-      }
-    }
-  }
-
-  public function testItLogsErrorWhenNewlyRenderedNewsletterBodyIsInvalid() {
-    $sendingTaskMock = $this->createMock(SendingTask::class);
-    $sendingTaskMock
-      ->expects($this->any())
-      ->method('__call')
-      ->with('getNewsletterRenderedBody')
-      ->willReturn(null);
-    $sendingTaskMock
-      ->expects($this->once())
-      ->method('save');
-    $sendingTaskMock
-      ->expects($this->once())
-      ->method('getErrors')
-      ->willReturn([]);
-    $sendingTaskMock
-      ->expects($this->any())
-      ->method('__get')
-      ->will($this->onConsecutiveCalls($this->sendingTask->id, $this->sendingTask->taskId, $this->sendingTask->id));
-
-    $sendingQueuesTable = $this->entityManager->getClassMetadata(SendingQueueEntity::class)->getTableName();
-    $conn = $this->entityManager->getConnection();
-    $stmt = $conn->prepare("UPDATE $sendingQueuesTable SET newsletter_rendered_body = :invalid_body WHERE id = :id");
-    $stmt->executeQuery([
-      'invalid_body' => 'a:2:{s:4:"html"',
-      'id' => $this->sendingTask->id,
-    ]);
-    try {
-      $this->newsletterTask->preProcessNewsletter($this->newsletter, $sendingTaskMock);
-      self::fail('Sending error exception was not thrown.');
-    } catch (\Exception $e) {
-      $mailerLog = MailerLog::getMailerLog();
-      expect(is_array($mailerLog['error']));
-      if (is_array($mailerLog['error'])) {
-        verify($mailerLog['error']['operation'])->equals('queue_save');
-        verify($mailerLog['error']['error_message'])->equals('There was an error processing your newsletter during sending. If possible, please contact us and report this issue.');
-      }
-    }
-  }
-
-  public function testItPreProcessesNewsletterWhenNewlyRenderedNewsletterBodyIsValid() {
-    $sendingTaskMock = $this->createMock(SendingTask::class);
-    $sendingTaskMock
-      ->expects($this->any())
-      ->method('__call')
-      ->with('getNewsletterRenderedBody')
-      ->willReturn(null);
-    $sendingTaskMock
-      ->expects($this->once())
-      ->method('save');
-    $sendingTaskMock
-      ->expects($this->once())
-      ->method('getErrors')
-      ->willReturn([]);
-    $sendingTaskMock
-      ->expects($this->any())
-      ->method('__get')
-      ->will($this->onConsecutiveCalls($this->sendingTask->id, $this->sendingTask->taskId, $this->sendingTask->id, $this->sendingTask->newsletterRenderedBody));
-
+  public function testItJustReturnsNewsletterWhenRenderedBodyAlreadyExists() {
     // properly serialized object
-    $sendingQueue = $this->sendingQueuesRepository->findOneById($this->sendingTask->id);
-    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
-    $sendingQueue->setNewsletterRenderedBody(['html' => 'test', 'text' => 'test']);
-    $this->sendingQueuesRepository->persist($sendingQueue);
+    $this->sendingQueueEntity->setNewsletterRenderedBody(['html' => 'test', 'text' => 'test']);
+    $this->sendingQueuesRepository->persist($this->sendingQueueEntity);
     $this->sendingQueuesRepository->flush();
 
     $emoji = $this->make(
       Emoji::class,
-      ['encodeEmojisInBody' => Expected::once(function ($params) {
-        return $params;
-      })]
+      ['encodeEmojisInBody' => Expected::never()]
     );
+
     $newsletterTask = new NewsletterTask(null, null, null, $emoji);
-    verify($newsletterTask->preProcessNewsletter($this->newsletter, $sendingTaskMock))->equals($this->newsletter);
+    verify($newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity))->equals($this->newsletter);
   }
 
   public function testItThrowsExceptionWhenNewsletterRenderedBodyIsInvalid() {
-    // properly serialized object
-    $sendingQueue = $this->sendingQueuesRepository->findOneById($this->sendingTask->id);
-    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
-    $sendingQueue->setNewsletterRenderedBody(['html' => 'test', 'text' => 'test']);
-    $this->sendingQueuesRepository->persist($sendingQueue);
-    $this->sendingQueuesRepository->flush();
-
     $emoji = $this->make(
       Emoji::class,
       ['encodeEmojisInBody' => Expected::once(function ($params) {
@@ -508,7 +438,7 @@ class NewsletterTest extends \MailPoetTest {
     $newsletterTask = new NewsletterTask(null, null, null, $emoji);
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Sending is waiting to be retried.');
-    $newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask);
+    $newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
   }
 
   /**
@@ -522,16 +452,16 @@ class NewsletterTest extends \MailPoetTest {
       ->create();
     $newsletterTask = $this->newsletterTask;
     // set newsletter with coupon
-    $this->sendingTask->newsletterId = $newsletter->getId();
-    $this->sendingTask->save();
+    $this->sendingQueueEntity->setNewsletter($newsletter);
+    $this->sendingQueuesRepository->persist($this->sendingQueueEntity);
 
-    $newsletter = $newsletterTask->preProcessNewsletter($newsletter, $this->sendingTask);
+    $newsletter = $newsletterTask->preProcessNewsletter($newsletter, $this->scheduledTaskEntity);
     $newsletterEntity = $this->newslettersRepository->findOneById($newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
     $result = $newsletterTask->prepareNewsletterForSending(
       $newsletterEntity,
       $this->subscriber,
-      $this->sendingTask
+      $this->sendingQueueEntity
     );
     $wooCommerceHelper = $this->diContainer->get(Helper::class);
     $coupon = (string)$wooCommerceHelper->getLatestCoupon();
@@ -613,21 +543,19 @@ class NewsletterTest extends \MailPoetTest {
       ->withSubject(Fixtures::get('newsletter_subject_template'))
       ->withBody(json_decode(Fixtures::get('newsletter_body_template'), true))
       ->withOptions([NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID => $filterSegment->getId()])
+      ->withSendingQueue()
       ->create();
 
-    $this->sendingTask->newsletterId = $this->newsletter->getId();
-    $this->sendingTask->save();
-
     // properly serialized object
-    $sendingQueue = $this->sendingQueuesRepository->findOneById($this->sendingTask->id);
+    $sendingQueue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $this->newsletter->getId()]);
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
-    $sendingQueue->setNewsletterRenderedBody(['html' => 'test', 'text' => 'test']);
-    $this->sendingQueuesRepository->persist($sendingQueue);
-    $this->sendingQueuesRepository->flush();
+    $scheduledTask = $sendingQueue->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $this->entityManager->refresh($scheduledTask);
     $newsletterTask = new NewsletterTask();
     $sendingQueueMeta = $sendingQueue->getMeta();
     verify($sendingQueueMeta)->null();
-    verify($newsletterTask->preProcessNewsletter($this->newsletter, $this->sendingTask))->equals($this->newsletter);
+    verify($newsletterTask->preProcessNewsletter($this->newsletter, $scheduledTask))->equals($this->newsletter);
     $this->entityManager->refresh($sendingQueue);
     $updatedMeta = $sendingQueue->getMeta();
     verify($updatedMeta)->isArray();
@@ -648,12 +576,13 @@ class NewsletterTest extends \MailPoetTest {
       ->withSendingQueue(['status' => null])
       ->create();
 
-    $invalidTask = SendingTask::getByNewsletterId($invalidNewsletter->getId());
-    $scheduledTask = $this->scheduledTasksRepository->findOneById($invalidTask->taskId);
+    $sendingQueue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $invalidNewsletter->getId()]);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
+    $scheduledTask = $sendingQueue->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
-    $this->assertNull($scheduledTask->getStatus());
-    $this->assertNull($this->newsletterTask->getNewsletterFromQueue($invalidTask));
     $this->entityManager->refresh($scheduledTask);
+    $this->assertNull($scheduledTask->getStatus());
+    $this->assertNull($this->newsletterTask->getNewsletterFromQueue($scheduledTask));
     $this->assertSame($scheduledTask->getStatus(), ScheduledTaskEntity::STATUS_PAUSED);
 
     // testing recovering newsletter when the standard newsletter is deleted
@@ -666,11 +595,13 @@ class NewsletterTest extends \MailPoetTest {
       ->withSendingQueue(['status' => null])
       ->create();
 
-    $deletedTask = SendingTask::getByNewsletterId($deletedNewsletter->getId());
-    $scheduledTask = $this->scheduledTasksRepository->findOneById($deletedTask->taskId);
+    $sendingQueue = $this->sendingQueuesRepository->findOneBy(['newsletter' => $deletedNewsletter->getId()]);
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
+    $scheduledTask = $sendingQueue->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $this->entityManager->refresh($scheduledTask);
     $this->assertNull($scheduledTask->getStatus());
-    $this->assertNull($this->newsletterTask->getNewsletterFromQueue($deletedTask));
+    $this->assertNull($this->newsletterTask->getNewsletterFromQueue($scheduledTask));
     $this->entityManager->refresh($scheduledTask);
     $this->assertSame($scheduledTask->getStatus(), ScheduledTaskEntity::STATUS_PAUSED);
 
@@ -682,8 +613,7 @@ class NewsletterTest extends \MailPoetTest {
 
     $scheduledTaskId = $scheduledTask->getId();
     $sendingQueueId = $sendingQueue->getId();
-    $sendingTaskWithoutNewsletter = SendingTask::getByNewsletterId(999);
-    $this->assertNull($this->newsletterTask->getNewsletterFromQueue($sendingTaskWithoutNewsletter));
+    $this->assertNull($this->newsletterTask->getNewsletterFromQueue($scheduledTask));
     $this->entityManager->clear();
     $this->assertNull($this->scheduledTasksRepository->findOneById($scheduledTaskId));
     $this->assertNull($this->sendingQueuesRepository->findOneById($sendingQueueId));

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -406,12 +406,8 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     $this->entityManager->persist($queue);
 
     $newsletter->getQueues()->add($queue);
+    $task->setSendingQueue($queue);
     $this->entityManager->flush();
-
-    // I'm not sure why this is needed, but without it a test fails as $task->getSendingQueue() returns
-    // null in \MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter::preProcessNewsletter()
-    $this->entityManager->refresh($task);
-
     return $queue;
   }
 

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -407,6 +407,11 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
 
     $newsletter->getQueues()->add($queue);
     $this->entityManager->flush();
+
+    // I'm not sure why this is needed, but without it a test fails as $task->getSendingQueue() returns
+    // null in \MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter::preProcessNewsletter()
+    $this->entityManager->refresh($task);
+
     return $queue;
   }
 

--- a/mailpoet/tests/integration/Tasks/SendingTest.php
+++ b/mailpoet/tests/integration/Tasks/SendingTest.php
@@ -170,26 +170,6 @@ class SendingTest extends \MailPoetTest {
     verify($this->sending->count_to_process)->equals(3);
   }
 
-  public function testItRemovesSubscribers() {
-    $subscriberIds = [$this->subscriber2->getId()];
-    $this->sending->removeSubscribers($subscriberIds);
-    verify($this->sending->getSubscribers())->equals([$this->subscriber1->getId()]);
-    verify($this->sending->count_total)->equals(1);
-    verify($this->sending->status)->null();
-  }
-
-  public function testItRemovesSubscribersShouldMarkTaskAsComplete() {
-    $subscriberIds = [$this->subscriber1->getId(), $this->subscriber2->getId()];
-    $originalProcessedAt = $this->sending->processed_at;
-
-    $this->sending->removeSubscribers($subscriberIds);
-
-    verify($this->sending->getSubscribers())->empty();
-    verify($this->sending->count_total)->equals(0);
-    verify($this->sending->status)->same(ScheduledTaskEntity::STATUS_COMPLETED);
-    verify($this->sending->processed_at)->notSame($originalProcessedAt);
-  }
-
   public function testItUpdatesProcessedSubscribers() {
     $taskSubscriber1 = $this->getTaskSubscriber($this->task->id, $this->subscriber1->getId());
     $subscriberId2 = $this->subscriber2->getId();
@@ -297,22 +277,6 @@ class SendingTest extends \MailPoetTest {
     verify($tasks[0]->getId())->equals($sending1->taskId);
     verify($tasks[1]->getId())->equals($sending3->taskId);
     verify($tasks[2]->getId())->equals($sending2->taskId);
-  }
-
-  public function testItSavesSubscriberError() {
-    $error = 'Error message';
-    $this->sending->saveSubscriberError($this->subscriber1->getId(), $error);
-    $taskSubscriber = $this->getTaskSubscriber($this->task->id, $this->subscriber1->getId());
-
-    verify($taskSubscriber->getError())->equals($error);
-    verify($taskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
-    verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
-    verify($this->sending->count_total)->equals(2);
-    verify($this->sending->count_processed)->equals(1);
-    verify($this->sending->count_to_process)->equals(1);
-
-    $this->sending->saveSubscriberError($this->subscriber2->getId(), $error);
-    verify($this->sending->status)->same(ScheduledTaskEntity::STATUS_COMPLETED);
   }
 
   public function createNewScheduledTask() {


### PR DESCRIPTION
## Description

This PR removes usages of `MailPoet\Tasks\Sending` from `MailPoet\Cron\Worker\SendingQueue` and related code.

## Code review notes

_N/A_

## QA notes

This PR has no user-facing changes, but it refactors a core part of MailPoet. Testing anything related to sending emails that is not covered by automated tests is probably a good idea. Please, verify that all types of email sending in the plugin work and that the emails render correctly. This is the list of our email types:

- Newsletters (immediate as well as scheduling).
- Post notifications.
- Welcome emails.
- Transactional emails.
- Automation emails (including transactional).
- Re-engagement emails.
- Stat notifications.

We have a fairly good test coverage for email sending, but it is worth verifying.

**When QA passes, please DON'T MERGE this pull request, and assign it to @JanJakes instead.**

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5682]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5682]: https://mailpoet.atlassian.net/browse/MAILPOET-5682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ