### PR TITLE
Display the PHP outdated version warning for sites running PHP < 8.0 [MAILPOET-5727]

### DIFF
--- a/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
+++ b/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
@@ -18,13 +18,13 @@ class PHPVersionWarnings {
   }
 
   public function isOutdatedPHPVersion($phpVersion) {
-    return version_compare($phpVersion, '7.4', '<') && !get_transient(self::OPTION_NAME);
+    return version_compare($phpVersion, '8.0', '<') && !get_transient(self::OPTION_NAME);
   }
 
   public function display($phpVersion) {
     // translators: %s is the PHP version
-    $errorString = __('Your website is running an outdated version of PHP (%s), on which MailPoet might stop working in the future. We recommend upgrading to 7.4 or greater. Read our [link]simple PHP upgrade guide.[/link]', 'mailpoet');
-    $errorString = sprintf($errorString, $phpVersion);
+    $errorString = __('Your website is running an outdated version of PHP (%1$s), on which MailPoet might stop working in the future. We recommend upgrading to %2$s or greater. Read our [link]simple PHP upgrade guide.[/link]', 'mailpoet');
+    $errorString = sprintf($errorString, $phpVersion, '8.1');
     $error = Helpers::replaceLinkTags($errorString, 'https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version', [
       'target' => '_blank',
     ]);

--- a/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PHPVersionWarningsTest.php
@@ -34,8 +34,12 @@ class PHPVersionWarningsTest extends \MailPoetTest {
     verify($this->phpVersionWarning->isOutdatedPHPVersion('7.3'))->true();
   }
 
-  public function testPHP74IsNotOutdated() {
-    verify($this->phpVersionWarning->isOutdatedPHPVersion('7.4'))->false();
+  public function testPHP74IsOutdated() {
+    verify($this->phpVersionWarning->isOutdatedPHPVersion('7.4'))->true();
+  }
+
+  public function testPHP80IsNotOutdated() {
+    verify($this->phpVersionWarning->isOutdatedPHPVersion('8.0'))->false();
   }
 
   public function testItPrintsWarningFor71() {
@@ -53,6 +57,12 @@ class PHPVersionWarningsTest extends \MailPoetTest {
   public function testItPrintsWarningFor73() {
     $warning = $this->phpVersionWarning->init('7.3.0', true);
     verify($warning->getMessage())->stringContainsString('Your website is running an outdated version of PHP (7.3.0)');
+    verify($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
+  }
+
+  public function testItPrintsWarningFor74() {
+    $warning = $this->phpVersionWarning->init('7.4.0', true);
+    verify($warning->getMessage())->stringContainsString('Your website is running an outdated version of PHP (7.4.0)');
     verify($warning->getMessage())->stringContainsString('https://kb.mailpoet.com/article/251-upgrading-the-websites-php-version');
   }
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5727]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5727]: https://mailpoet.atlassian.net/browse/MAILPOET-5727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ