### PR TITLE
Fix send page layout [MAILPOET-5734]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -89,15 +89,8 @@ progress::-moz-progress-bar {
     margin: $grid-gap 0;
   }
 
-  .mailpoet-form-send-email & {
-    grid-column: 2 / -1;
-    padding-top: $grid-gap + ($heading-font-size-h4 * $heading-line-height) +
-      ($font-size * $line-height * 2);
-    text-align: right;
-  }
-
   @include respond-to(small-screen) {
-    grid-column: 1 !important;
+    grid-column: 1;
   }
 }
 

--- a/mailpoet/assets/css/src/components-plugin/_newsletter.scss
+++ b/mailpoet/assets/css/src/components-plugin/_newsletter.scss
@@ -24,4 +24,15 @@
       grid-template-columns: 1fr;
     }
   }
+
+  .mailpoet-form-actions {
+    grid-column: 2 / -1;
+    padding-top: $grid-gap + ($heading-font-size-h4 * $heading-line-height) +
+      ($font-size * $line-height * 2);
+    text-align: right;
+
+    @include respond-to(small-screen) {
+      grid-column: 1;
+    }
+  }
 }

--- a/mailpoet/assets/css/src/components-plugin/_newsletter.scss
+++ b/mailpoet/assets/css/src/components-plugin/_newsletter.scss
@@ -14,3 +14,14 @@
 .send-newsletter-buttons {
   justify-content: flex-end;
 }
+
+.mailpoet-form-send-email {
+  .mailpoet-form-grid {
+    grid-template-columns: $grid-column $grid-column;
+    max-width: 976px;
+
+    @include respond-to(small-screen) {
+      grid-template-columns: 1fr;
+    }
+  }
+}


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I decided not to use "mailpoet-main-container" because it's too wide, for two 368px columns.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5734]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5734]: https://mailpoet.atlassian.net/browse/MAILPOET-5734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ