### PR TITLE
Add missing gap between date and time components when scheduling email [MAILPOET-5738]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send/date-text.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-text.tsx
@@ -98,9 +98,7 @@ type DateTextProps = {
   validation: {
     'data-parsley-required': boolean;
     'data-parsley-required-message': string;
-    'data-parsley-type': string;
     'data-parsley-errors-container': string;
-    maxLength: number;
   };
   maxDate: Date;
   name?: string;

--- a/mailpoet/assets/js/src/newsletters/send/date-time.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-time.tsx
@@ -1,12 +1,41 @@
-import { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Component, SyntheticEvent } from 'react';
 
 import { Grid } from 'common/grid';
 import { DateText } from 'newsletters/send/date-text';
 import { TimeSelect } from 'newsletters/send/time-select.jsx';
 import { ErrorBoundary } from '../../common';
 
-class DateTime extends Component {
+type DateTimeEvent = SyntheticEvent<HTMLInputElement> & {
+  target: EventTarget & {
+    name?: string;
+    value?: string;
+  };
+};
+
+type DateTimeProps = {
+  value?: string;
+  defaultDateTime: string;
+  dateDisplayFormat: string;
+  dateStorageFormat: string;
+  onChange: (date: DateTimeEvent) => void;
+  name?: string;
+  disabled: boolean;
+  dateValidation: {
+    'data-parsley-required': boolean;
+    'data-parsley-required-message': string;
+    'data-parsley-errors-container': string;
+  };
+  timeValidation?: any;
+  timeOfDayItems: { [key: string]: string };
+  maxDate?: Date;
+};
+
+type DateTimeState = {
+  date?: string;
+  time: string;
+};
+
+class DateTime extends Component<DateTimeProps, DateTimeState> {
   DATE_TIME_SEPARATOR = ' ';
 
   constructor(props) {
@@ -29,7 +58,7 @@ class DateTime extends Component {
   getDateTime = () =>
     [this.state.date, this.state.time].join(this.DATE_TIME_SEPARATOR);
 
-  buildStateFromProps = (props) => {
+  buildStateFromProps = (props): DateTimeState => {
     const value = props.value || this.props.defaultDateTime;
     const [date, time] = value.split(this.DATE_TIME_SEPARATOR);
     return {
@@ -38,7 +67,7 @@ class DateTime extends Component {
     };
   };
 
-  handleChange = (event) => {
+  handleChange = (event: DateTimeEvent) => {
     const newState = {};
     newState[event.target.name] = event.target.value;
 
@@ -52,7 +81,7 @@ class DateTime extends Component {
           name: this.props.name || '',
           value: this.getDateTime(),
         },
-      });
+      } as DateTimeEvent);
     }
   };
 
@@ -83,28 +112,5 @@ class DateTime extends Component {
     );
   }
 }
-
-DateTime.propTypes = {
-  value: PropTypes.string,
-  defaultDateTime: PropTypes.string.isRequired,
-  dateDisplayFormat: PropTypes.string.isRequired,
-  dateStorageFormat: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
-  name: PropTypes.string,
-  disabled: PropTypes.bool,
-  dateValidation: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  timeValidation: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-  timeOfDayItems: PropTypes.objectOf(PropTypes.string).isRequired,
-  maxDate: PropTypes.instanceOf(Date),
-};
-
-DateTime.defaultProps = {
-  onChange: undefined,
-  name: '',
-  disabled: false,
-  timeValidation: undefined,
-  value: undefined,
-  maxDate: null,
-};
 
 export { DateTime };

--- a/mailpoet/assets/js/src/newsletters/send/date-time.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-time.tsx
@@ -25,7 +25,6 @@ type DateTimeProps = {
     'data-parsley-required-message': string;
     'data-parsley-errors-container': string;
   };
-  timeValidation?: any;
   timeOfDayItems: { [key: string]: string };
   maxDate?: Date;
 };
@@ -105,7 +104,6 @@ class DateTime extends Component<DateTimeProps, DateTimeState> {
             value={this.state.time}
             onChange={this.handleChange}
             disabled={this.props.disabled}
-            validation={this.props.timeValidation}
             timeOfDayItems={this.props.timeOfDayItems}
           />
         </ErrorBoundary>

--- a/mailpoet/assets/js/src/newsletters/send/date-time.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-time.tsx
@@ -99,6 +99,7 @@ class DateTime extends Component<DateTimeProps, DateTimeState> {
             validation={this.props.dateValidation}
             maxDate={this.props.maxDate}
           />
+          <div className="mailpoet-gap" />
           <TimeSelect
             name="time"
             value={this.state.time}

--- a/mailpoet/assets/js/src/newsletters/send/date-time.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-time.tsx
@@ -37,13 +37,13 @@ type DateTimeState = {
 class DateTime extends Component<DateTimeProps, DateTimeState> {
   DATE_TIME_SEPARATOR = ' ';
 
-  constructor(props) {
+  constructor(props: DateTimeProps) {
     super(props);
 
     this.state = this.buildStateFromProps(props);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: DateTimeProps) {
     if (
       this.props.value !== prevProps.value ||
       this.props.defaultDateTime !== prevProps.defaultDateTime
@@ -57,7 +57,7 @@ class DateTime extends Component<DateTimeProps, DateTimeState> {
   getDateTime = () =>
     [this.state.date, this.state.time].join(this.DATE_TIME_SEPARATOR);
 
-  buildStateFromProps = (props): DateTimeState => {
+  buildStateFromProps = (props: DateTimeProps): DateTimeState => {
     const value = props.value || this.props.defaultDateTime;
     const [date, time] = value.split(this.DATE_TIME_SEPARATOR);
     return {

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -4,7 +4,7 @@ import { Hooks } from 'wp-js-hooks';
 import Moment from 'moment';
 import { __ } from '@wordpress/i18n';
 
-import { DateTime } from 'newsletters/send/date-time.jsx';
+import { DateTime } from 'newsletters/send/date-time';
 import { SenderField } from 'newsletters/send/sender-address-field.jsx';
 import { GATrackingField } from 'newsletters/send/ga-tracking';
 import { Toggle } from 'common/form/toggle/toggle';
@@ -15,7 +15,9 @@ import { SendToFieldWithCount } from './send-to-field';
 
 const currentTime = window.mailpoet_current_time || '00:00';
 const tomorrowDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
-const timeOfDayItems = window.mailpoet_schedule_time_of_day;
+const timeOfDayItems = window.mailpoet_schedule_time_of_day as unknown as {
+  [key: string]: string;
+};
 const dateDisplayFormat = window.mailpoet_date_format;
 const dateStorageFormat = window.mailpoet_date_storage_format;
 


### PR DESCRIPTION
## Description

This PR refactors DateTime component to TypeScript and also adds missing gap between date and time components when scheduling an email.

<img width="406" alt="Screenshot 2023-11-24 at 11 26 46" src="https://github.com/mailpoet/mailpoet/assets/470616/415a7fc6-4956-4d35-b96b-32666529d6bb">

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5738]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5738]: https://mailpoet.atlassian.net/browse/MAILPOET-5738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ