### PR TITLE
Automation template detail [MAILPOET-4534] [MAILPOET-4537]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_automation.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_automation.scss
@@ -3,7 +3,7 @@
   display: grid;
   flex-grow: 1;
   grid-template-rows: auto 1fr;
-  overflow: scroll;
+  overflow: auto;
   width: 100%;
 }
 

--- a/mailpoet/assets/css/src/components-automation-listing/_sections.scss
+++ b/mailpoet/assets/css/src/components-automation-listing/_sections.scss
@@ -100,36 +100,7 @@
 }
 
 .mailpoet-section-template-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
   margin-bottom: 40px;
-
-  > li {
-    flex-grow: 1;
-    margin-right: 8px;
-    max-width: 336px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-
-    button {
-      background: #fff;
-      border: 1px solid #dcdcde;
-      border-radius: 0;
-      color: #1d2327;
-      cursor: pointer;
-      padding: 24px;
-      text-align: left;
-
-      h3 {
-        font-size: 16px;
-        font-weight: 600;
-        line-height: 24px;
-      }
-    }
-  }
 }
 
 .mailpoet-section-build-list-button {

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -91,6 +91,15 @@
   }
 }
 
+.mailpoet-automation-template-detail-preview-spinner {
+  margin: auto;
+
+  svg {
+    height: 20px;
+    width: 20px;
+  }
+}
+
 .mailpoet-automation-template-detail-footer {
   align-items: center;
   border-top: 1px solid #dcdcde;

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -108,6 +108,18 @@
   }
 }
 
+.mailpoet-automation-template-detail-preview-error {
+  color: #a7aaad;
+  display: grid;
+  gap: 12px;
+  margin: auto;
+  text-align: center;
+
+  svg {
+    fill: currentColor;
+  }
+}
+
 .mailpoet-automation-template-detail-footer {
   align-items: center;
   border-top: 1px solid #dcdcde;

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -93,6 +93,10 @@
   .mailpoet-automation-editor-automation-flow {
     padding-bottom: 32px;
   }
+
+  .mailpoet-automation-editor-step-filters {
+    max-height: 200px;
+  }
 }
 
 .mailpoet-automation-template-detail-preview-spinner {

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -1,1 +1,67 @@
 @import './mailpoet-templates';
+
+.mailpoet-automation-template-detail {
+  height: 100%;
+  max-height: min(70%, 700px);
+  width: 800px;
+
+  .components-modal__content {
+    display: grid;
+    margin: 0;
+    padding: 0;
+  }
+
+  .components-modal__header {
+    visibility: hidden;
+
+    button {
+      margin-right: -6px;
+      visibility: visible;
+    }
+  }
+}
+
+.mailpoet-automation-template-detail-content {
+  display: grid;
+  grid-template-areas:
+    'info preview'
+    'footer footer';
+  grid-template-columns: 360px auto;
+  grid-template-rows: 1fr auto;
+  height: 100%;
+  width: 100%;
+}
+
+.mailpoet-automation-template-detail-info {
+  padding: 32px;
+
+  h1 {
+    font-size: 16px;
+    line-height: 26px;
+    margin-top: 32px;
+  }
+}
+
+.mailpoet-automation-template-detail-preview {
+  background: #f6f7f7;
+}
+
+.mailpoet-automation-template-detail-footer {
+  align-items: center;
+  border-top: 1px solid #dcdcde;
+  display: flex;
+  grid-area: footer;
+  justify-content: space-between;
+  padding: 16px 24px;
+}
+
+.mailpoet-automation-template-detail-footer-navigation {
+  display: flex;
+  gap: 12px;
+  margin-left: -6px;
+}
+
+.mailpoet-automation-template-detail-footer-actions {
+  display: flex;
+  gap: 12px;
+}

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -75,19 +75,23 @@
     animation: fade-in 0.15s ease-in;
     background: none;
     box-sizing: border-box;
+    grid-template-rows: auto;
     padding: 24px;
   }
 
   .mailpoet-automation-editor-automation-wrapper {
+    $scale: 0.7;
+    display: flex;
+    height: calc(100% / $scale);
     margin: 0 auto;
     min-height: 0;
     padding: 0;
-    transform: scale(0.7);
+    transform: scale($scale);
     transform-origin: top center;
   }
 
   .mailpoet-automation-editor-automation-flow {
-    padding-bottom: 24px;
+    padding-bottom: 32px;
   }
 }
 

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -128,4 +128,15 @@
   bottom: 80px;
   position: absolute;
   right: 24px;
+
+  .components-snackbar__icon {
+    left: 15px;
+    top: 13px;
+  }
+
+  svg {
+    fill: currentColor;
+    height: 24px;
+    width: 24px;
+  }
 }

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -1,3 +1,22 @@
+// settings & mixins
+
+@import 'settings/breakpoints';
+@import 'settings/colors';
+@import 'mixins/breakpoints';
+
+// automation editor styles
+
+@import './components-automation/statistics';
+@import './components-automation-editor/editor';
+
+// automation integration styles
+
+@import './components-automation-integrations/core';
+@import './components-automation-integrations/mailpoet';
+@import './components-automation-integrations/woocommerce';
+
+// template styles
+
 @import './mailpoet-templates';
 
 .mailpoet-automation-template-detail {
@@ -6,9 +25,13 @@
   width: 800px;
 
   .components-modal__content {
-    display: grid;
+    height: 100%;
     margin: 0;
     padding: 0;
+
+    > div:not(.components-modal__header) {
+      height: 100%;
+    }
   }
 
   .components-modal__header {
@@ -33,6 +56,7 @@
 }
 
 .mailpoet-automation-template-detail-info {
+  overflow: auto;
   padding: 32px;
 
   h1 {
@@ -44,6 +68,27 @@
 
 .mailpoet-automation-template-detail-preview {
   background: #f6f7f7;
+  display: grid;
+  overflow: auto;
+
+  .mailpoet-automation-editor-automation {
+    animation: fade-in 0.15s ease-in;
+    background: none;
+    box-sizing: border-box;
+    padding: 24px;
+  }
+
+  .mailpoet-automation-editor-automation-wrapper {
+    margin: 0 auto;
+    min-height: 0;
+    padding: 0;
+    transform: scale(0.7);
+    transform-origin: top center;
+  }
+
+  .mailpoet-automation-editor-automation-flow {
+    padding-bottom: 24px;
+  }
 }
 
 .mailpoet-automation-template-detail-footer {

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -65,3 +65,9 @@
   display: flex;
   gap: 12px;
 }
+
+.mailpoet-automation-template-detail-error {
+  bottom: 80px;
+  position: absolute;
+  right: 24px;
+}

--- a/mailpoet/assets/js/src/automation/editor/api-error-handler.tsx
+++ b/mailpoet/assets/js/src/automation/editor/api-error-handler.tsx
@@ -15,6 +15,11 @@ export const registerApiErrorHandler = (): void =>
         const result = await next(options);
         return result;
       } catch (error) {
+        // do not report aborted requests as errors
+        if (options.signal.aborted) {
+          return undefined;
+        }
+
         const errorObject = error as ApiError;
         const status = errorObject.data?.status;
         const code = errorObject.code;

--- a/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
@@ -2,6 +2,8 @@ import { useMemo, useRef } from 'react';
 import {
   __unstableComposite as Composite,
   __unstableUseCompositeState as useCompositeState,
+  Popover,
+  SlotFillProvider,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -54,23 +56,26 @@ export function Automation({
   return (
     <AutomationContext.Provider value={automationContext}>
       <AutomationCompositeContext.Provider value={compositeState}>
-        <Composite
-          ref={automationRef}
-          state={compositeState}
-          role="tree"
-          aria-label={__('Automation', 'mailpoet')}
-          aria-orientation="vertical"
-          className="mailpoet-automation-editor-automation"
-        >
-          {showStatistics && <Statistics />}
-          <div className="mailpoet-automation-editor-automation-wrapper">
-            <div className="mailpoet-automation-editor-automation-flow">
-              <Flow stepData={automationData.steps.root} row={0} />
+        <SlotFillProvider>
+          <Composite
+            ref={automationRef}
+            state={compositeState}
+            role="tree"
+            aria-label={__('Automation', 'mailpoet')}
+            aria-orientation="vertical"
+            className="mailpoet-automation-editor-automation"
+          >
+            {showStatistics && <Statistics />}
+            <div className="mailpoet-automation-editor-automation-wrapper">
+              <div className="mailpoet-automation-editor-automation-flow">
+                <Flow stepData={automationData.steps.root} row={0} />
+              </div>
+              <div />
+              <Popover.Slot />
             </div>
-            <div />
-          </div>
-          <InserterPopover />
-        </Composite>
+            <InserterPopover />
+          </Composite>
+        </SlotFillProvider>
       </AutomationCompositeContext.Provider>
     </AutomationContext.Provider>
   );

--- a/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
@@ -19,12 +19,14 @@ type AutomationProps = {
   context: 'edit' | 'view';
   scroll?: boolean;
   drag?: boolean;
+  showStatistics?: boolean;
 };
 
 export function Automation({
   context,
   scroll = true,
   drag = true,
+  showStatistics = true,
 }: AutomationProps): JSX.Element {
   const automationData = useSelect(
     (select) => select(storeName).getAutomationData(),
@@ -60,7 +62,7 @@ export function Automation({
           aria-orientation="vertical"
           className="mailpoet-automation-editor-automation"
         >
-          <Statistics />
+          {showStatistics && <Statistics />}
           <div className="mailpoet-automation-editor-automation-wrapper">
             <div className="mailpoet-automation-editor-automation-flow">
               <Flow stepData={automationData.steps.root} row={0} />

--- a/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll-center.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll-center.ts
@@ -16,7 +16,9 @@ export const useAutomationScrollCenter = (
 
     // center the scroll to the first step
     const automation = automationRef.current;
-    const firstStep = automation?.querySelector('[data-step-id] > *');
+    const firstStep = automation?.querySelector(
+      '.mailpoet-automation-editor-step',
+    );
     if (firstStep instanceof HTMLElement) {
       firstStep.scrollIntoView({ block: 'nearest', inline: 'center' });
     }

--- a/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll.ts
@@ -1,5 +1,22 @@
 import { MutableRefObject, useEffect } from 'react';
 
+const findClosestScrollable = (element: HTMLElement): HTMLElement | null => {
+  const style = window.getComputedStyle(element);
+  const canScroll = [style.overflow, style.overflowX, style.overflowY].find(
+    (value) => value === 'auto' || value === 'scroll',
+  );
+  const overflows =
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.clientWidth;
+
+  if (canScroll && overflows) {
+    return element;
+  }
+  return element.parentElement
+    ? findClosestScrollable(element.parentElement)
+    : null;
+};
+
 // Handle automation scrolling, including both X and Y axes simultaneously.
 // Use animation frames to sync with browser repaints for smooth scrolling.
 export const useAutomationScroll = (
@@ -12,7 +29,13 @@ export const useAutomationScroll = (
     }
 
     let frameId: number;
-    const scrollHandler = (event) => {
+    const scrollHandler = (event: WheelEvent) => {
+      // do not hijack wheel event inside other scrollable elements
+      const scrollTarget = findClosestScrollable(event.target as HTMLElement);
+      if (scrollTarget !== automation) {
+        return;
+      }
+
       event.preventDefault();
       frameId = requestAnimationFrame(() => {
         automation.scrollLeft += event.deltaX;

--- a/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/list.tsx
@@ -33,9 +33,7 @@ export function FiltersList({
     (select) => ({
       fields: select(storeName).getRegistry().fields,
       filters: select(storeName).getRegistry().filters,
-      errors: select(storeName).getStepError(
-        select(storeName).getSelectedStep().id,
-      ),
+      errors: select(storeName).getStepError(step.id),
     }),
     [],
   );

--- a/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
+++ b/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
@@ -14,6 +14,11 @@ export const registerApiErrorHandler = (): void =>
         const result = await next(options);
         return result;
       } catch (error) {
+        // do not report aborted requests as errors
+        if (options.signal.aborted) {
+          return undefined;
+        }
+
         const errorObject = error as ApiError;
         const status = errorObject.data?.status;
 

--- a/mailpoet/assets/js/src/automation/sections/templates-section.tsx
+++ b/mailpoet/assets/js/src/automation/sections/templates-section.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { MailPoet } from '../../mailpoet';
 import { automationTemplates } from '../templates/config';
-import { TemplateListItem } from '../templates/components/template-list-item';
+import { TemplatesGrid } from '../templates/components/templates-grid';
 
 export function TemplatesSection(): JSX.Element {
   const templates = automationTemplates.slice(0, 3);
@@ -18,9 +18,7 @@ export function TemplatesSection(): JSX.Element {
           )}
         </p>
         <ul className="mailpoet-section-template-list">
-          {templates.map((template) => (
-            <TemplateListItem key={template.slug} template={template} />
-          ))}
+          <TemplatesGrid templates={templates} />
         </ul>
         <Button variant="link" href={MailPoet.urls.automationTemplates}>
           {__('Browse all templates →', 'mailpoet')}

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler, useCallback, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, Snackbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Tag } from '@woocommerce/components';
@@ -74,6 +74,14 @@ export function TemplateDetail({
             <Button icon={chevronRight} />
           </div>
           <div className="mailpoet-automation-template-detail-footer-actions">
+            {error && (
+              <Snackbar className="mailpoet-automation-template-detail-error">
+                {__(
+                  'An error occurred while creating the automation. Please, try again.',
+                  'mailpoet',
+                )}
+              </Snackbar>
+            )}
             <Button
               variant="tertiary"
               onClick={onRequestClose as MouseEventHandler}

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -1,13 +1,27 @@
-import { forwardRef, MouseEventHandler, useCallback, useState } from 'react';
+import {
+  ComponentType,
+  forwardRef,
+  MouseEventHandler,
+  ReactNode,
+  useCallback,
+  useState,
+} from 'react';
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Modal, Snackbar } from '@wordpress/components';
+import { Button, Modal, Snackbar as WpSnackbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { chevronLeft, chevronRight, warning } from '@wordpress/icons';
 import { Tag } from '@woocommerce/components';
 import { addQueryArgs } from '@wordpress/url';
 import { TemplatePreview } from './template-preview';
 import { AutomationTemplate, automationTemplateCategories } from '../config';
 import { MailPoet } from '../../../mailpoet';
+
+// snackbar icon is not annotated in the types
+const Snackbar = WpSnackbar as ComponentType<
+  WpSnackbar.Props & {
+    icon: ReactNode;
+  }
+>;
 
 const getCategory = (template: AutomationTemplate): string =>
   automationTemplateCategories.find(({ slug }) => slug === template.category)
@@ -87,7 +101,10 @@ export const TemplateDetail = forwardRef<HTMLDivElement, Props>(
             </div>
             <div className="mailpoet-automation-template-detail-footer-actions">
               {error && (
-                <Snackbar className="mailpoet-automation-template-detail-error">
+                <Snackbar
+                  className="mailpoet-automation-template-detail-error"
+                  icon={warning}
+                >
                   {__(
                     'An error occurred while creating the automation. Please, try again.',
                     'mailpoet',

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -20,6 +20,8 @@ import { MailPoet } from '../../../mailpoet';
 const Snackbar = WpSnackbar as ComponentType<
   WpSnackbar.Props & {
     icon: ReactNode;
+    isDismissible?: boolean;
+    explicitDismiss?: boolean;
   }
 >;
 
@@ -32,6 +34,7 @@ const useCreateFromTemplate = () => {
     data: undefined,
     loading: false,
     error: undefined,
+    resetError: () => setState((prevState) => ({ ...prevState, error: null })),
   });
 
   const create = useCallback(async (slug: string) => {
@@ -67,7 +70,7 @@ type Props = {
 
 export const TemplateDetail = forwardRef<HTMLDivElement, Props>(
   ({ template, onRequestClose, onPreviousClick, onNextClick }, ref) => {
-    const [createAutomationFromTemplate, { loading, error }] =
+    const [createAutomationFromTemplate, { loading, error, resetError }] =
       useCreateFromTemplate();
 
     return (
@@ -104,6 +107,9 @@ export const TemplateDetail = forwardRef<HTMLDivElement, Props>(
                 <Snackbar
                   className="mailpoet-automation-template-detail-error"
                   icon={warning}
+                  onRemove={resetError}
+                  isDismissible
+                  explicitDismiss
                 >
                   {__(
                     'An error occurred while creating the automation. Please, try again.',

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -1,0 +1,97 @@
+import { MouseEventHandler, useCallback, useState } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { Tag } from '@woocommerce/components';
+import { addQueryArgs } from '@wordpress/url';
+import { AutomationTemplate, automationTemplateCategories } from '../config';
+import { MailPoet } from '../../../mailpoet';
+
+const getCategory = (template: AutomationTemplate): string =>
+  automationTemplateCategories.find(({ slug }) => slug === template.category)
+    ?.name ?? __('Uncategorized', 'mailpoet');
+
+const useCreateFromTemplate = () => {
+  const [state, setState] = useState({
+    data: undefined,
+    loading: false,
+    error: undefined,
+  });
+
+  const create = useCallback(async (slug: string) => {
+    setState((prevState) => ({ ...prevState, loading: true }));
+    try {
+      const data = await apiFetch<{ data: { id: string } }>({
+        path: `/automations/create-from-template`,
+        method: 'POST',
+        data: { slug },
+      });
+      MailPoet.trackEvent('Automations > Template selected', {
+        'Automation slug': slug,
+      });
+      window.location.href = addQueryArgs(MailPoet.urls.automationEditor, {
+        id: data.data.id,
+      });
+    } catch (error) {
+      setState((prevState) => ({ ...prevState, error }));
+    } finally {
+      setState((prevState) => ({ ...prevState, loading: false }));
+    }
+  }, []);
+
+  return [create, state] as const;
+};
+
+type Props = {
+  template: AutomationTemplate;
+  onRequestClose: Modal.Props['onRequestClose'];
+};
+
+export function TemplateDetail({
+  template,
+  onRequestClose,
+}: Props): JSX.Element {
+  const [createAutomationFromTemplate, { loading, error }] =
+    useCreateFromTemplate();
+
+  return (
+    <Modal
+      className="mailpoet-automation-template-detail"
+      title=""
+      onRequestClose={onRequestClose}
+    >
+      <div className="mailpoet-automation-template-detail-content">
+        <div className="mailpoet-automation-template-detail-info">
+          <Tag label={getCategory(template)} />
+          <h1>{template.name}</h1>
+          {template.description}
+        </div>
+        <div className="mailpoet-automation-template-detail-preview" />
+        <div className="mailpoet-automation-template-detail-footer">
+          <div className="mailpoet-automation-template-detail-footer-navigation">
+            <Button icon={chevronLeft} />
+            <Button icon={chevronRight} />
+          </div>
+          <div className="mailpoet-automation-template-detail-footer-actions">
+            <Button
+              variant="tertiary"
+              onClick={onRequestClose as MouseEventHandler}
+              disabled={loading}
+            >
+              {__('Cancel', 'mailpoet')}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => void createAutomationFromTemplate(template.slug)}
+              isBusy={loading}
+              disabled={loading}
+            >
+              {__('Start building', 'mailpoet')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Tag } from '@woocommerce/components';
 import { addQueryArgs } from '@wordpress/url';
+import { TemplatePreview } from './template-preview';
 import { AutomationTemplate, automationTemplateCategories } from '../config';
 import { MailPoet } from '../../../mailpoet';
 
@@ -68,7 +69,9 @@ export const TemplateDetail = forwardRef<HTMLDivElement, Props>(
             <h1>{template.name}</h1>
             {template.description}
           </div>
-          <div className="mailpoet-automation-template-detail-preview" />
+          <div className="mailpoet-automation-template-detail-preview">
+            <TemplatePreview template={template} />
+          </div>
           <div className="mailpoet-automation-template-detail-footer">
             <div className="mailpoet-automation-template-detail-footer-navigation">
               <Button

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useCallback, useState } from 'react';
+import { forwardRef, MouseEventHandler, useCallback, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Modal, Snackbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -46,60 +46,70 @@ const useCreateFromTemplate = () => {
 type Props = {
   template: AutomationTemplate;
   onRequestClose: Modal.Props['onRequestClose'];
+  onPreviousClick?: MouseEventHandler<HTMLButtonElement>;
+  onNextClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export function TemplateDetail({
-  template,
-  onRequestClose,
-}: Props): JSX.Element {
-  const [createAutomationFromTemplate, { loading, error }] =
-    useCreateFromTemplate();
+export const TemplateDetail = forwardRef<HTMLDivElement, Props>(
+  ({ template, onRequestClose, onPreviousClick, onNextClick }, ref) => {
+    const [createAutomationFromTemplate, { loading, error }] =
+      useCreateFromTemplate();
 
-  return (
-    <Modal
-      className="mailpoet-automation-template-detail"
-      title=""
-      onRequestClose={onRequestClose}
-    >
-      <div className="mailpoet-automation-template-detail-content">
-        <div className="mailpoet-automation-template-detail-info">
-          <Tag label={getCategory(template)} />
-          <h1>{template.name}</h1>
-          {template.description}
-        </div>
-        <div className="mailpoet-automation-template-detail-preview" />
-        <div className="mailpoet-automation-template-detail-footer">
-          <div className="mailpoet-automation-template-detail-footer-navigation">
-            <Button icon={chevronLeft} />
-            <Button icon={chevronRight} />
+    return (
+      <Modal
+        ref={ref}
+        className="mailpoet-automation-template-detail"
+        title=""
+        onRequestClose={onRequestClose}
+      >
+        <div className="mailpoet-automation-template-detail-content">
+          <div className="mailpoet-automation-template-detail-info">
+            <Tag label={getCategory(template)} />
+            <h1>{template.name}</h1>
+            {template.description}
           </div>
-          <div className="mailpoet-automation-template-detail-footer-actions">
-            {error && (
-              <Snackbar className="mailpoet-automation-template-detail-error">
-                {__(
-                  'An error occurred while creating the automation. Please, try again.',
-                  'mailpoet',
-                )}
-              </Snackbar>
-            )}
-            <Button
-              variant="tertiary"
-              onClick={onRequestClose as MouseEventHandler}
-              disabled={loading}
-            >
-              {__('Cancel', 'mailpoet')}
-            </Button>
-            <Button
-              variant="primary"
-              onClick={() => void createAutomationFromTemplate(template.slug)}
-              isBusy={loading}
-              disabled={loading}
-            >
-              {__('Start building', 'mailpoet')}
-            </Button>
+          <div className="mailpoet-automation-template-detail-preview" />
+          <div className="mailpoet-automation-template-detail-footer">
+            <div className="mailpoet-automation-template-detail-footer-navigation">
+              <Button
+                icon={chevronLeft}
+                onClick={onPreviousClick}
+                disabled={!onPreviousClick || loading}
+              />
+              <Button
+                icon={chevronRight}
+                onClick={onNextClick}
+                disabled={!onNextClick || loading}
+              />
+            </div>
+            <div className="mailpoet-automation-template-detail-footer-actions">
+              {error && (
+                <Snackbar className="mailpoet-automation-template-detail-error">
+                  {__(
+                    'An error occurred while creating the automation. Please, try again.',
+                    'mailpoet',
+                  )}
+                </Snackbar>
+              )}
+              <Button
+                variant="tertiary"
+                onClick={onRequestClose as MouseEventHandler}
+                disabled={loading}
+              >
+                {__('Cancel', 'mailpoet')}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => void createAutomationFromTemplate(template.slug)}
+                isBusy={loading}
+                disabled={loading}
+              >
+                {__('Start building', 'mailpoet')}
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
-    </Modal>
-  );
-}
+      </Modal>
+    );
+  },
+);

--- a/mailpoet/assets/js/src/automation/templates/components/template-list-item.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-list-item.tsx
@@ -6,7 +6,6 @@ import {
   premiumValidAndActive,
 } from '../../../common/premium-modal';
 import { Item } from '../../../common/templates';
-import { TemplateDetail } from './template-detail';
 
 type Badge = ComponentProps<typeof Item>['badge'];
 
@@ -26,11 +25,11 @@ const getBadge = (template: AutomationTemplate): Badge => {
 
 type Props = {
   template: AutomationTemplate;
+  onSelect: () => void;
 };
 
-export function TemplateListItem({ template }: Props): JSX.Element {
+export function TemplateListItem({ template, onSelect }: Props): JSX.Element {
   const [showPremium, setShowPremium] = useState(false);
-  const [showDetail, setShowDetail] = useState(false);
 
   return (
     <>
@@ -44,16 +43,10 @@ export function TemplateListItem({ template }: Props): JSX.Element {
           if (template.type === 'premium' && !premiumValidAndActive) {
             setShowPremium(true);
           } else {
-            setShowDetail(true);
+            onSelect();
           }
         }}
       />
-      {showDetail && (
-        <TemplateDetail
-          template={template}
-          onRequestClose={() => setShowDetail(false)}
-        />
-      )}
       {showPremium && (
         <PremiumModal
           onRequestClose={() => {

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
+import { Spinner } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { Hooks } from 'wp-js-hooks';
 import { createStore, storeName } from '../../editor/store';
@@ -60,6 +61,8 @@ export function TemplatePreview({ template }: Props): JSX.Element {
   return isLoaded ? (
     <Automation context="view" showStatistics={false} />
   ) : (
-    <div>Loading...</div>
+    <div className="mailpoet-automation-template-detail-preview-spinner">
+      <Spinner />
+    </div>
   );
 }

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
+import { Hooks } from 'wp-js-hooks';
+import { createStore, storeName } from '../../editor/store';
+import { AutomationTemplate } from '../config';
+import { Automation } from '../../editor/components/automation';
+import { initializeIntegrations } from '../../editor/integrations';
+
+const initializeHooks = () => {
+  Hooks.addFilter(
+    'mailpoet.automation.step.more-controls',
+    'mailpoet',
+    () => () => {},
+    20,
+  );
+
+  Hooks.addFilter(
+    'mailpoet.automation.render_step_separator',
+    'mailpoet',
+    () =>
+      function Separator() {
+        return <div className="mailpoet-automation-editor-separator" />;
+      },
+  );
+};
+
+const cleanupHooks = () => {
+  Hooks.removeFilter('mailpoet.automation.step.more-controls', 'mailpoet');
+  Hooks.removeFilter('mailpoet.automation.render_step_separator', 'mailpoet');
+};
+
+type Props = {
+  template: AutomationTemplate;
+};
+
+export function TemplatePreview({ template }: Props): JSX.Element {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const loadTemplate = async () => {
+      setIsLoaded(false);
+
+      initializeHooks();
+      createStore();
+      initializeIntegrations();
+
+      const data = await apiFetch<{ data: { automation: unknown } }>({
+        path: `/automation-templates/${template.slug}`,
+        method: 'GET',
+      });
+      dispatch(storeName).updateAutomation(data.data.automation);
+      setIsLoaded(true);
+    };
+    void loadTemplate();
+
+    return cleanupHooks;
+  }, [template.slug]);
+
+  return isLoaded ? (
+    <Automation context="view" showStatistics={false} />
+  ) : (
+    <div>Loading...</div>
+  );
+}

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -39,6 +39,7 @@ export function TemplatePreview({ template }: Props): JSX.Element {
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
+    const controller = new AbortController();
     const loadTemplate = async () => {
       setIsLoaded(false);
 
@@ -49,13 +50,17 @@ export function TemplatePreview({ template }: Props): JSX.Element {
       const data = await apiFetch<{ data: { automation: unknown } }>({
         path: `/automation-templates/${template.slug}`,
         method: 'GET',
+        signal: controller.signal,
       });
       dispatch(storeName).updateAutomation(data.data.automation);
       setIsLoaded(true);
     };
     void loadTemplate();
 
-    return cleanupHooks;
+    return () => {
+      controller.abort();
+      cleanupHooks();
+    };
   }, [template.slug]);
 
   return isLoaded ? (

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { Icon, warning } from '@wordpress/icons';
 import { Hooks } from 'wp-js-hooks';
 import { createStore, storeName } from '../../editor/store';
 import { AutomationTemplate } from '../config';
@@ -70,11 +72,25 @@ export function TemplatePreview({ template }: Props): JSX.Element {
     };
   }, [template.slug]);
 
-  return state === 'loaded' ? (
-    <Automation context="view" showStatistics={false} />
-  ) : (
-    <div className="mailpoet-automation-template-detail-preview-spinner">
-      <Spinner />
-    </div>
-  );
+  if (state === 'error') {
+    return (
+      <div className="mailpoet-automation-template-detail-preview-error">
+        <div>
+          <Icon icon={warning} size={20} />
+        </div>
+        <div>{__('There was an error loading the preview.', 'mailpoet')}</div>
+        <div>{__('Please, try again.')}</div>
+      </div>
+    );
+  }
+
+  if (state === 'loading') {
+    return (
+      <div className="mailpoet-automation-template-detail-preview-spinner">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return <Automation context="view" showStatistics={false} />;
 }

--- a/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
@@ -1,17 +1,34 @@
+import { useState } from 'react';
 import { AutomationTemplate } from '../config';
 import { Grid } from '../../../common/templates';
 import { TemplateListItem } from './template-list-item';
+import { TemplateDetail } from './template-detail';
 
 type Props = {
   templates: AutomationTemplate[];
 };
 
 export function TemplatesGrid({ templates }: Props): JSX.Element {
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<AutomationTemplate>();
+
   return (
-    <Grid>
-      {templates.map((template) => (
-        <TemplateListItem key={template.slug} template={template} />
-      ))}
-    </Grid>
+    <>
+      {selectedTemplate && (
+        <TemplateDetail
+          template={selectedTemplate}
+          onRequestClose={() => setSelectedTemplate(undefined)}
+        />
+      )}
+      <Grid>
+        {templates.map((template) => (
+          <TemplateListItem
+            key={template.slug}
+            template={template}
+            onSelect={() => setSelectedTemplate(template)}
+          />
+        ))}
+      </Grid>
+    </>
   );
 }

--- a/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
@@ -43,6 +43,20 @@ export function TemplatesGrid({ templates }: Props): JSX.Element {
     ref.current?.querySelector<HTMLDivElement>('[role=dialog]')?.focus();
   }, [selectedTemplate]);
 
+  useEffect(() => {
+    // handle previous/next via keyboard keys
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft') {
+        getClickHandler('previous')?.();
+      }
+      if (event.key === 'ArrowRight') {
+        getClickHandler('next')?.();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [getClickHandler]);
+
   return (
     <>
       {selectedTemplate && (

--- a/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
@@ -1,0 +1,17 @@
+import { AutomationTemplate } from '../config';
+import { Grid } from '../../../common/templates';
+import { TemplateListItem } from './template-list-item';
+
+type Props = {
+  templates: AutomationTemplate[];
+};
+
+export function TemplatesGrid({ templates }: Props): JSX.Element {
+  return (
+    <Grid>
+      {templates.map((template) => (
+        <TemplateListItem key={template.slug} template={template} />
+      ))}
+    </Grid>
+  );
+}

--- a/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
@@ -11,11 +11,14 @@ const findTemplate = (
   position: 'previous' | 'next',
 ): AutomationTemplate | undefined => {
   const index = templates.findIndex(({ slug }) => slug === template.slug);
-  const slice =
+  const search =
     position === 'previous'
-      ? templates.slice(0, index).reverse()
-      : templates.slice(index + 1);
-  return slice.find(
+      ? [
+          ...templates.slice(0, index).reverse(),
+          ...templates.slice(index).reverse(),
+        ]
+      : [...templates.slice(index + 1), ...templates.slice(0, index + 1)];
+  return search.find(
     ({ type }) =>
       type !== 'coming-soon' && (premiumValidAndActive || type !== 'premium'),
   );

--- a/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/templates-grid.tsx
@@ -1,23 +1,57 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AutomationTemplate } from '../config';
 import { Grid } from '../../../common/templates';
 import { TemplateListItem } from './template-list-item';
 import { TemplateDetail } from './template-detail';
+import { premiumValidAndActive } from '../../../common/premium-modal';
+
+const findTemplate = (
+  templates: AutomationTemplate[],
+  template: AutomationTemplate,
+  position: 'previous' | 'next',
+): AutomationTemplate | undefined => {
+  const index = templates.findIndex(({ slug }) => slug === template.slug);
+  const slice =
+    position === 'previous'
+      ? templates.slice(0, index).reverse()
+      : templates.slice(index + 1);
+  return slice.find(
+    ({ type }) =>
+      type !== 'coming-soon' && (premiumValidAndActive || type !== 'premium'),
+  );
+};
 
 type Props = {
   templates: AutomationTemplate[];
 };
 
 export function TemplatesGrid({ templates }: Props): JSX.Element {
+  const ref = useRef<HTMLDivElement>();
   const [selectedTemplate, setSelectedTemplate] =
     useState<AutomationTemplate>();
+
+  const getClickHandler = useCallback(
+    (position: 'previous' | 'next') => {
+      const template = findTemplate(templates, selectedTemplate, position);
+      return template ? () => setSelectedTemplate(template) : undefined;
+    },
+    [selectedTemplate, templates],
+  );
+
+  useEffect(() => {
+    // prevent losing focus when previous/next button becomes disabled
+    ref.current?.querySelector<HTMLDivElement>('[role=dialog]')?.focus();
+  }, [selectedTemplate]);
 
   return (
     <>
       {selectedTemplate && (
         <TemplateDetail
+          ref={ref}
           template={selectedTemplate}
           onRequestClose={() => setSelectedTemplate(undefined)}
+          onPreviousClick={getClickHandler('previous')}
+          onNextClick={getClickHandler('next')}
         />
       )}
       <Grid>

--- a/mailpoet/assets/js/src/automation/templates/index.tsx
+++ b/mailpoet/assets/js/src/automation/templates/index.tsx
@@ -2,13 +2,13 @@ import { createRoot } from 'react-dom/client';
 import { __ } from '@wordpress/i18n';
 import { registerTranslations } from 'common';
 import { automationTemplateCategories, automationTemplates } from './config';
-import { TemplateListItem } from './components/template-list-item';
 import { initializeApi } from '../api';
 import { TopBarWithBeamer } from '../../common/top-bar/top-bar';
 import { FromScratchButton } from './components/from-scratch';
 import { BackButton, PageHeader } from '../../common/page-header';
 import { MailPoet } from '../../mailpoet';
-import { Footer, Grid, TabPanel, TabTitle } from '../../common/templates';
+import { Footer, TabPanel, TabTitle } from '../../common/templates';
+import { TemplatesGrid } from './components/templates-grid';
 
 const tabs = [
   {
@@ -52,16 +52,12 @@ function Templates(): JSX.Element {
 
       <TabPanel tabs={tabs}>
         {(tab) => (
-          <Grid>
-            {automationTemplates
-              .filter(
-                (template) =>
-                  tab.name === 'all' || template.category === tab.name,
-              )
-              .map((template) => (
-                <TemplateListItem key={template.slug} template={template} />
-              ))}
-          </Grid>
+          <TemplatesGrid
+            templates={automationTemplates.filter(
+              (template) =>
+                tab.name === 'all' || template.category === tab.name,
+            )}
+          />
         )}
       </TabPanel>
 

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -1,16 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 declare module 'wp-js-hooks' {
-  type Hooks = {
-    addFilter: (
-      name: string,
-      namespace: string,
-      callback: (...args: any[]) => any,
-      priority?: number,
-    ) => void;
-    applyFilters: (name: string, ...args: any[]) => any;
-  };
-  export const Hooks: Hooks;
+  import * as WPHooks from '@wordpress/hooks';
+
+  export const Hooks: WPHooks;
 }
 
 type ErrorResponse = {

--- a/mailpoet/lib/AdminPages/Pages/Automation.php
+++ b/mailpoet/lib/AdminPages/Pages/Automation.php
@@ -64,6 +64,44 @@ class Automation {
         },
         array_values($this->registry->getTemplateCategories())
       ),
+      'registry' => $this->buildRegistry(),
+      'context' => $this->buildContext(),
     ]);
+  }
+
+  private function buildRegistry(): array {
+    $steps = [];
+    foreach ($this->registry->getSteps() as $key => $step) {
+      $steps[$key] = [
+        'key' => $step->getKey(),
+        'name' => $step->getName(),
+        'args_schema' => $step->getArgsSchema()->toArray(),
+      ];
+    }
+
+    $subjects = [];
+    foreach ($this->registry->getSubjects() as $key => $subject) {
+      $subjects[$key] = [
+        'key' => $subject->getKey(),
+        'name' => $subject->getName(),
+        'args_schema' => $subject->getArgsSchema()->toArray(),
+        'field_keys' => array_map(function ($field) {
+          return $field->getKey();
+        }, $subject->getFields()),
+      ];
+    }
+
+    return [
+      'steps' => $steps,
+      'subjects' => $subjects,
+    ];
+  }
+
+  private function buildContext(): array {
+    $data = [];
+    foreach ($this->registry->getContextFactories() as $key => $factory) {
+      $data[$key] = $factory();
+    }
+    return $data;
   }
 }

--- a/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
@@ -60,7 +60,45 @@ class AutomationTemplates {
           },
           array_values($this->registry->getTemplateCategories())
         ),
+        'registry' => $this->buildRegistry(),
+        'context' => $this->buildContext(),
       ]
     );
+  }
+
+  private function buildRegistry(): array {
+    $steps = [];
+    foreach ($this->registry->getSteps() as $key => $step) {
+      $steps[$key] = [
+        'key' => $step->getKey(),
+        'name' => $step->getName(),
+        'args_schema' => $step->getArgsSchema()->toArray(),
+      ];
+    }
+
+    $subjects = [];
+    foreach ($this->registry->getSubjects() as $key => $subject) {
+      $subjects[$key] = [
+        'key' => $subject->getKey(),
+        'name' => $subject->getName(),
+        'args_schema' => $subject->getArgsSchema()->toArray(),
+        'field_keys' => array_map(function ($field) {
+          return $field->getKey();
+        }, $subject->getFields()),
+      ];
+    }
+
+    return [
+      'steps' => $steps,
+      'subjects' => $subjects,
+    ];
+  }
+
+  private function buildContext(): array {
+    $data = [];
+    foreach ($this->registry->getContextFactories() as $key => $factory) {
+      $data[$key] = $factory();
+    }
+    return $data;
   }
 }

--- a/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationTemplates.php
@@ -88,9 +88,36 @@ class AutomationTemplates {
       ];
     }
 
+    $fields = [];
+    foreach ($this->registry->getFields() as $key => $field) {
+      $fields[$key] = [
+        'key' => $field->getKey(),
+        'type' => $field->getType(),
+        'name' => $field->getName(),
+        'args' => $field->getArgs(),
+      ];
+    }
+
+    $filters = [];
+    foreach ($this->registry->getFilters() as $fieldType => $filter) {
+      $conditions = [];
+      foreach ($filter->getConditions() as $key => $label) {
+        $conditions[] = [
+          'key' => $key,
+          'label' => $label,
+        ];
+      }
+      $filters[$fieldType] = [
+        'field_type' => $filter->getFieldType(),
+        'conditions' => $conditions,
+      ];
+    }
+
     return [
       'steps' => $steps,
       'subjects' => $subjects,
+      'fields' => $fields,
+      'filters' => $filters,
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -68,10 +68,14 @@ class Automation {
   }
 
   public function getId(): int {
-    if (!$this->id) {
+    if ($this->id === null) {
       throw InvalidStateException::create()->withMessage('No automation ID was set');
     }
     return $this->id;
+  }
+
+  public function setId(int $id): void {
+    $this->id = $id;
   }
 
   public function getVersionId(): int {

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateGetEndpoint.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Automations;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Mappers\AutomationMapper;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Validation\AutomationValidator;
+use MailPoet\Validator\Builder;
+
+class AutomationTemplateGetEndpoint extends Endpoint {
+  /** @var AutomationMapper */
+  private $automationMapper;
+
+  /** @var AutomationValidator */
+  private $automationValidator;
+
+  /** @var Registry */
+  private $registry;
+
+  public function __construct(
+    AutomationMapper $automationMapper,
+    AutomationValidator $automationValidator,
+    Registry $registry
+  ) {
+    $this->registry = $registry;
+    $this->automationValidator = $automationValidator;
+    $this->automationMapper = $automationMapper;
+  }
+
+  public function handle(Request $request): Response {
+    $slug = strval($request->getParam('slug'));
+    $template = $this->registry->getTemplate($slug);
+    if (!$template) {
+      throw Exceptions::automationTemplateNotFound($slug);
+    }
+
+    $automation = $template->createAutomation();
+    $automation->setId(0);
+    $this->automationValidator->validate($automation);
+
+    $data = $template->toArray() + [
+      'automation' => $this->automationMapper->buildAutomation($automation),
+    ];
+    return new Response($data);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'slug' => Builder::string()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -10,6 +10,7 @@ use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDeleteEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDuplicateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\CoreIntegration;
@@ -83,6 +84,7 @@ class Engine {
       $api->registerPostRoute('automations/(?P<id>\d+)/duplicate', AutomationsDuplicateEndpoint::class);
       $api->registerPostRoute('automations/create-from-template', AutomationsCreateFromTemplateEndpoint::class);
       $api->registerGetRoute('automation-templates', AutomationTemplatesGetEndpoint::class);
+      $api->registerGetRoute('automation-templates/(?P<slug>.+)', AutomationTemplateGetEndpoint::class);
     });
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -155,6 +155,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsCreateFromTemplateEndpoint::class)->setPublic(true);

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -16,6 +16,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->click('Start with a template');
     $i->see('Start with a template', 'h1');
     $i->click('Welcome new subscribers');
+    $i->click('Start building');
 
     $i->waitForText('Draft');
     $i->click('Trigger');

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -23,6 +23,7 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->click('Start with a template');
     $i->see('Start with a template', 'h1');
     $i->click('Welcome new subscribers');
+    $i->click('Start building');
 
     $i->waitForText('Draft');
     $i->click('Trigger');

--- a/mailpoet/tests/acceptance/Misc/MailpoetMenuCest.php
+++ b/mailpoet/tests/acceptance/Misc/MailpoetMenuCest.php
@@ -67,6 +67,7 @@ class MailpoetMenuCest {
     $i->wantTo('Check if the menu is still selected if I go to the workflow editor');
     $i->waitForElementClickable(Locator::contains('button', 'Welcome new subscribers'));
     $i->click(Locator::contains('button', 'Welcome new subscribers'));
+    $i->click('Start building');
     $i->waitForElement('#mailpoet_automation_editor');
     $i->seeInCurrentUrl('?page=mailpoet-automation-editor');
     $this->assertSelectedMenuItem($i, 'Automations');

--- a/mailpoet/views/automation.html
+++ b/mailpoet/views/automation.html
@@ -11,5 +11,7 @@
   var mailpoet_automation_count = <%= json_encode(automationCount) %>;
   var mailpoet_automation_templates = <%= json_encode(templates) %>;
   var mailpoet_automation_template_categories = <%= json_encode(template_categories) %>;
+  var mailpoet_automation_registry = <%= json_encode(registry) %>;
+  var mailpoet_automation_context = <%= json_encode(context) %>;
 </script>
 <% endblock %>

--- a/mailpoet/views/automation/templates.html
+++ b/mailpoet/views/automation/templates.html
@@ -8,5 +8,7 @@
   var mailpoet_automation_api = <%= json_encode(api) %>;
   var mailpoet_automation_templates = <%= json_encode(templates) %>;
   var mailpoet_automation_template_categories = <%= json_encode(template_categories) %>;
+  var mailpoet_automation_registry = <%= json_encode(registry) %>;
+  var mailpoet_automation_context = <%= json_encode(context) %>;
 </script>
 <% endblock %>


### PR DESCRIPTION
## Description

Adds new automation template detail dialog + renders automation preview within it.

## Code review notes

Adding the automation editor store to render the automation preview is not the most elegant thing, but we're already using the same approach in automation analytics. I will consider creating a ticket to refactor this in some way.

## QA notes

Please test with premium on and off. The "<" and ">" buttons (and keyboard arrows) should skip premium templates when premium is not active, and coming soon templates always.

The same templates are also on the automation listing page (when you scroll down). Please check that too.

Please, also verify that the automation editor works, and no regressions were introduced.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4534]
[MAILPOET-4537]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4534]: https://mailpoet.atlassian.net/browse/MAILPOET-4534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-4537]: https://mailpoet.atlassian.net/browse/MAILPOET-4537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ