### PR TITLE
Feat/add error and product status information to the mailpoet marketing channel - MAILPOET-5696

### DIFF
--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -6,8 +6,8 @@ use Automattic\WooCommerce\Admin\Marketing\MarketingCampaign;
 use Automattic\WooCommerce\Admin\Marketing\MarketingCampaignType;
 use Automattic\WooCommerce\Admin\Marketing\MarketingChannelInterface;
 use MailPoet\Config\Menu;
-use MailPoet\Mailer\Mailer;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\CdnAssetUrl;
 
@@ -21,12 +21,19 @@ class MPMarketingChannel implements MarketingChannelInterface {
    */
   private $settings;
 
+  /**
+   * @var Bridge
+   */
+  private $bridge;
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
-    SettingsController $settings
+    SettingsController $settings,
+    Bridge $bridge
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->settings = $settings;
+    $this->bridge = $bridge;
   }
 
   /**
@@ -93,7 +100,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
    * @return string
    */
   public function get_product_listings_status(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    if (!$this->isUserSendingWithMSS()) {
+    if (!$this->bridge->isMailpoetSendingServiceEnabled()) {
       return self::PRODUCT_LISTINGS_NOT_APPLICABLE;
     }
 
@@ -157,14 +164,5 @@ class MPMarketingChannel implements MarketingChannelInterface {
     $version = $this->settings->get('version');
 
     return $version !== null;
-  }
-
-  /**
-   * Check if user is sending with the MailPoet sending method
-   * @return bool
-   */
-  protected function isUserSendingWithMSS(): bool {
-    $sendingMethod = $this->settings->get('mta.method', SettingsController::DEFAULT_SENDING_METHOD);
-    return $sendingMethod === Mailer::METHOD_MAILPOET;
   }
 }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -3,6 +3,7 @@
 namespace MailPoet\WooCommerce\MultichannelMarketing;
 
 use MailPoet\Features\FeaturesController;
+use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\CdnAssetUrl;
 
@@ -19,14 +20,21 @@ class MPMarketingChannelController {
    */
   protected $settings;
 
+  /**
+   * @var Bridge
+   */
+  protected $bridge;
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     FeaturesController $featuresController,
-    SettingsController $settings
+    SettingsController $settings,
+    Bridge $bridge
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->featuresController = $featuresController;
     $this->settings = $settings;
+    $this->bridge = $bridge;
   }
 
   public function registerMarketingChannel($registeredMarketingChannels): array {
@@ -37,7 +45,8 @@ class MPMarketingChannelController {
     return array_merge($registeredMarketingChannels, [
       new MPMarketingChannel(
         $this->cdnAssetUrl,
-        $this->settings
+        $this->settings,
+        $this->bridge
       ),
     ]);
   }

--- a/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Features\FeaturesController;
+use MailPoet\Mailer\Mailer;
+use MailPoet\Test\DataFactories\Features;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Settings;
+
+/**
+ * This class contains tests for the MP Marketing channel
+ * @group woo
+ */
+class MPMarketingChannelCest {
+
+  /** @var Settings */
+  private $settingsFactory;
+
+  public function _before(\AcceptanceTester $i) {
+    $i->activateWooCommerce();
+    $this->settingsFactory = new Settings();
+    $this->settingsFactory->withWooCommerceListImportPageDisplayed(true);
+    $this->settingsFactory->withCookieRevenueTrackingDisabled();
+  }
+
+  public function itShowsMailPoetSetup(\AcceptanceTester $i) {
+    $this->settingsFactory->withWelcomeWizard();
+    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
+
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
+    $i->waitForText('Channels', 10, '.woocommerce-marketing-channels-card');
+
+    $i->see('MailPoet', '.woocommerce-marketing-registered-channel-card-body');
+    $i->see('Finish setup', '.woocommerce-marketing-registered-channel-card-body');
+    $i->click('Finish setup', '.woocommerce-marketing-registered-channel-card-body');
+    $i->waitForText('Start by configuring your sender information');
+  }
+
+  public function itShowsErrorCount(\AcceptanceTester $i) {
+    (new Newsletter())->create();
+    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
+
+    $i->login();
+
+    $errorMessage = 'Could not instantiate mail function. Unprocessed subscriber: (test <test@test.test>)';
+
+    $this->settingsFactory->withSendingMethod(Mailer::METHOD_PHPMAIL);
+    $this->settingsFactory->withSendingError($errorMessage);
+
+    $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
+    $i->waitForText('Channels', 10, '.woocommerce-marketing-channels-card');
+    $i->see('MailPoet', '.woocommerce-marketing-registered-channel-card-body');
+    $i->see('1 issues to resolve', '.woocommerce-marketing-registered-channel-card-body');
+  }
+
+  public function itShowsMailPoetSyncStatus(\AcceptanceTester $i) {
+    (new Newsletter())->create();
+    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
+
+    $i->login();
+
+    $this->settingsFactory->withSendingMethodMailPoet();
+
+    $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
+    $i->waitForText('Channels', 10, '.woocommerce-marketing-channels-card');
+    $i->see('MailPoet', '.woocommerce-marketing-registered-channel-card-body');
+    $i->see('Synced', '.woocommerce-marketing-registered-channel-card-body');
+  }
+
+  public function itShowsMailPoetSyncStatusWithErrorCount(\AcceptanceTester $i) {
+    (new Newsletter())->create();
+    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
+
+    $i->login();
+
+    $this->settingsFactory->withSendingMethodMailPoet();
+    $this->settingsFactory->withSendingError('Error message');
+
+    $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
+    $i->waitForText('Channels', 10, '.woocommerce-marketing-channels-card');
+    $i->see('MailPoet', '.woocommerce-marketing-registered-channel-card-body');
+    $i->see('Sync failed', '.woocommerce-marketing-registered-channel-card-body');
+    $i->see('2 issues to resolve', '.woocommerce-marketing-registered-channel-card-body');
+  }
+}


### PR DESCRIPTION
## Description

Add error and product status information to the mailpoet marketing channel.

This PR handles the implementation of `get_product_listings_status` and `get_errors_count`

This PR is concerned with showing the MailPoet sending status. 
i.e, We show sending error or error count related to sending issues

MSS: All good, no issues
<img width="756" alt="Screenshot 2023-11-28 at 11 53 34 AM" src="https://github.com/mailpoet/mailpoet/assets/30554163/e60e815f-6398-4444-8a7d-1e107ef41c77">

MSS: Sending paused issue to resolve
<img width="753" alt="Screenshot 2023-11-27 at 12 28 48 PM" src="https://github.com/mailpoet/mailpoet/assets/30554163/7bb815b0-cb1a-4f3c-9466-8c3619554fb7">

MSS: Sending okay, issue to resolve 
<img width="770" alt="Screenshot 2023-11-27 at 12 38 17 PM" src="https://github.com/mailpoet/mailpoet/assets/30554163/198ac6ae-105e-47e5-90a0-8ef56335fd17">

Other sending methods, no issues
<img width="757" alt="Screenshot 2023-11-28 at 11 55 14 AM" src="https://github.com/mailpoet/mailpoet/assets/30554163/05577df6-f261-46e6-8523-1b8aecd7b22c">

Other sending methods with issues
<img width="768" alt="Screenshot 2023-11-28 at 9 56 33 AM" src="https://github.com/mailpoet/mailpoet/assets/30554163/4698ae2a-8d83-4fc3-bc97-1bb3b7a32d3a">


## Code review notes

Please check commits

## QA notes

Start with the QA notes here: https://github.com/mailpoet/mailpoet/pull/5289
Initiate an error e.g authorized email address error, check the WooCommerce Marketing tab at `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5696](https://mailpoet.atlassian.net/browse/MAILPOET-5696)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5696]: https://mailpoet.atlassian.net/browse/MAILPOET-5696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ