### PR TITLE
Feat/add campaign types to the mailpoet marketing channel - MAILPOET-5697

### DIFF
--- a/mailpoet/assets/js/src/newsletters/types/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/standard.jsx
@@ -5,6 +5,7 @@ import { ListingHeadingStepsRoute } from 'newsletters/listings/heading-steps-rou
 import { MailPoet } from 'mailpoet';
 import { withRouter } from 'react-router-dom';
 import { GlobalContext } from 'context';
+import { __ } from '@wordpress/i18n';
 
 class NewsletterStandardComponent extends Component {
   componentDidMount() {
@@ -15,6 +16,7 @@ class NewsletterStandardComponent extends Component {
       action: 'create',
       data: {
         type: 'standard',
+        subject: __('Subject', 'mailpoet'),
       },
     })
       .done((response) => {

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -26,6 +26,15 @@ class MPMarketingChannel implements MarketingChannelInterface {
    */
   private $bridge;
 
+  /**
+   * @var MarketingCampaignType[]
+   */
+  private $campaignTypes;
+
+  const CAMPAIGN_TYPE_NEWSLETTERS = 'mailpoet-newsletters';
+  const CAMPAIGN_TYPE_POST_NOTIFICATIONS = 'mailpoet-post-notifications';
+  const CAMPAIGN_TYPE_AUTOMATIONS = 'mailpoet-automations';
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     SettingsController $settings,
@@ -34,6 +43,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->settings = $settings;
     $this->bridge = $bridge;
+    $this->campaignTypes = $this->generateCampaignTypes();
   }
 
   /**
@@ -143,7 +153,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
    * @return MarketingCampaignType[] Array of marketing campaign type objects.
    */
   public function get_supported_campaign_types(): array { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    return []; // will be updated in MAILPOET-5697
+    return $this->campaignTypes;
   }
 
   /**
@@ -164,5 +174,39 @@ class MPMarketingChannel implements MarketingChannelInterface {
     $version = $this->settings->get('version');
 
     return $version !== null;
+  }
+
+  /**
+   * Generate the marketing channel campaign types
+   *
+   * @return MarketingCampaignType[]
+   */
+  protected function generateCampaignTypes(): array {
+    return [
+      self::CAMPAIGN_TYPE_NEWSLETTERS => new MarketingCampaignType(
+        'mailpoet-newsletters',
+        $this,
+        'MailPoet Newsletters',
+        'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new'),
+        $this->get_icon_url()
+      ),
+      self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(
+        'mailpoet-post-notifications',
+        $this,
+        'MailPoet Post notifications',
+        'Email your subscribers your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification'),
+        $this->get_icon_url()
+      ),
+      self::CAMPAIGN_TYPE_AUTOMATIONS => new MarketingCampaignType(
+        'mailpoet-automations',
+        $this,
+        'MailPoet Automations',
+        'Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.',
+        admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG),
+        $this->get_icon_url()
+      ),
+    ];
   }
 }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -61,7 +61,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
    * @return string
    */
   public function get_name(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    return __( 'MailPoet', 'mailpoet' );
+    return __('MailPoet', 'mailpoet');
   }
 
   /**
@@ -70,7 +70,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
    * @return string
    */
   public function get_description(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    return __( 'Create and send newsletters, post notifications and welcome emails from your WordPress.', 'mailpoet' );
+    return __('Create and send newsletters, post notifications and welcome emails from your WordPress.', 'mailpoet');
   }
 
   /**
@@ -186,30 +186,30 @@ class MPMarketingChannel implements MarketingChannelInterface {
       self::CAMPAIGN_TYPE_NEWSLETTERS => new MarketingCampaignType(
         'mailpoet-newsletters',
         $this,
-          __('MailPoet Newsletters', 'mailpoet'),
-          __(
-              'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
-              'mailpoet',
-          ),
+        __('MailPoet Newsletters', 'mailpoet'),
+        __(
+          'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
+          'mailpoet',
+        ),
         admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(
         'mailpoet-post-notifications',
         $this,
-          __('MailPoet Post notifications', 'mailpoet'),
-          __(
-              'Let MailPoet email your subscribers with your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
-              'mailpoet',
-          ),
+        __('MailPoet Post Notifications', 'mailpoet'),
+        __(
+          'Let MailPoet email your subscribers with your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
+          'mailpoet',
+        ),
         admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_AUTOMATIONS => new MarketingCampaignType(
         'mailpoet-automations',
         $this,
-          __('MailPoet Automations', 'mailpoet'),
-          __('Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.', 'mailpoet'),
+        __('MailPoet Automations', 'mailpoet'),
+        __('Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.', 'mailpoet'),
         admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG),
         $this->get_icon_url()
       ),

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -186,24 +186,30 @@ class MPMarketingChannel implements MarketingChannelInterface {
       self::CAMPAIGN_TYPE_NEWSLETTERS => new MarketingCampaignType(
         'mailpoet-newsletters',
         $this,
-        'MailPoet Newsletters',
-        'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
+          __('MailPoet Newsletters', 'mailpoet'),
+          __(
+              'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
+              'mailpoet',
+          ),
         admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(
         'mailpoet-post-notifications',
         $this,
-        'MailPoet Post notifications',
-        'Email your subscribers your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
+          __('MailPoet Post notifications', 'mailpoet'),
+          __(
+              'Let MailPoet email your subscribers with your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
+              'mailpoet',
+          ),
         admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_AUTOMATIONS => new MarketingCampaignType(
         'mailpoet-automations',
         $this,
-        'MailPoet Automations',
-        'Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.',
+          __('MailPoet Automations', 'mailpoet'),
+          __('Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.', 'mailpoet'),
         admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG),
         $this->get_icon_url()
       ),

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -188,7 +188,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
         $this,
         'MailPoet Newsletters',
         'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
-        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new'),
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(

--- a/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
@@ -84,4 +84,25 @@ class MPMarketingChannelCest {
     $i->see('Sync failed', '.woocommerce-marketing-registered-channel-card-body');
     $i->see('2 issues to resolve', '.woocommerce-marketing-registered-channel-card-body');
   }
+
+  public function itCanCreateMailPoetCampaigns(\AcceptanceTester $i) {
+      (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
+
+      $i->login();
+
+      $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
+      $i->see('Create a campaign', '.woocommerce-marketing-introduction-banner-buttons');
+      $i->click('Create a campaign', '.woocommerce-marketing-introduction-banner-buttons');
+      $i->waitForText('Create a new campaign');
+      $i->see('Where would you like to promote your products?');
+      $i->see('MailPoet Newsletters'); // campaign types
+      $i->see('MailPoet Post notifications');
+      $i->see('MailPoet Automations');
+      $i->click('Create', '.woocommerce-marketing-new-campaign-type');
+      $i->seeInCurrentUrl('page=mailpoet-newsletters#/new/standard'); // will be redirected to page=mailpoet-newsletters#/template
+      $i->waitForText('Simple text'); // on template selection page
+      $i->see('Template'); // on template selection page
+      $i->see('Newsletters');
+      $i->see('Your saved templates');
+  }
 }


### PR DESCRIPTION
## Description

This PR adds campaign types to the mailpoet marketing channel. 

## Code review notes

Please check commits

## QA notes

Note: This PR only adds the campaigns. Fetching and listing are done on https://github.com/mailpoet/mailpoet/pull/5321

Start with the QA notes here: https://github.com/mailpoet/mailpoet/pull/5289
* Visit the WooCommerce Marketing tab at `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
* Click on "Create new campaign"
* Select any of the MailPoet campaign types

## Linked PRs

Child of https://github.com/mailpoet/mailpoet/pull/5312

## Linked tickets

[MAILPOET-5697](https://mailpoet.atlassian.net/browse/MAILPOET-5697)

## After-merge notes

Please merge after https://github.com/mailpoet/mailpoet/pull/5312

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5697]: https://mailpoet.atlassian.net/browse/MAILPOET-5697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ