### PR TITLE
DQL delete & sync fixes [MAILPOET-5745]

### DIFF
--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -127,6 +127,24 @@ abstract class Repository {
   }
 
   /**
+   * @param callable(T): bool|null $filter
+   */
+  public function detachAll(callable $filter = null): void {
+    $className = $this->getEntityClassName();
+    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
+    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
+    foreach ($entities as $entity) {
+      if (!($entity instanceof $className)) {
+        continue;
+      }
+      if ($filter && !$filter($entity)) {
+        continue;
+      }
+      $this->entityManager->detach($entity);
+    }
+  }
+
+  /**
    * @return class-string<T>
    */
   abstract protected function getEntityClassName();

--- a/mailpoet/lib/Form/FormsRepository.php
+++ b/mailpoet/lib/Form/FormsRepository.php
@@ -96,10 +96,17 @@ class FormsRepository extends Repository {
       return 0;
     }
 
-    return $this->entityManager->createQueryBuilder()
+    $result = $this->entityManager->createQueryBuilder()
       ->delete(FormEntity::class, 'f')
       ->where('f.id IN (:ids)')
       ->setParameter('ids', $ids)
       ->getQuery()->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (FormEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
+
+    return $result;
   }
 }

--- a/mailpoet/lib/Logging/LogHandler.php
+++ b/mailpoet/lib/Logging/LogHandler.php
@@ -1,10 +1,8 @@
-<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+<?php declare(strict_types = 1);
 
 namespace MailPoet\Logging;
 
-use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Entities\LogEntity;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Monolog\Handler\AbstractProcessingHandler;
 
 class LogHandler extends AbstractProcessingHandler {
@@ -30,16 +28,8 @@ class LogHandler extends AbstractProcessingHandler {
   /** @var LogRepository */
   private $logRepository;
 
-  /** @var EntityManager */
-  private $entityManager;
-
-  /** @var EntityManagerFactory */
-  private $entityManagerFactory;
-
   public function __construct(
     LogRepository $logRepository,
-    EntityManager $entityManager,
-    EntityManagerFactory $entityManagerFactory,
     $level = \MailPoetVendor\Monolog\Logger::DEBUG,
     $bubble = \true,
     $randFunction = null
@@ -47,8 +37,6 @@ class LogHandler extends AbstractProcessingHandler {
     parent::__construct($level, $bubble);
     $this->randFunction = $randFunction;
     $this->logRepository = $logRepository;
-    $this->entityManager = $entityManager;
-    $this->entityManagerFactory = $entityManagerFactory;
   }
 
   protected function write(array $record): void {
@@ -60,13 +48,7 @@ class LogHandler extends AbstractProcessingHandler {
     $entity->setCreatedAt($record['datetime']);
     $entity->setRawMessage($record['message']);
     $entity->setContext($record['context']);
-
-    if (!$this->entityManager->isOpen()) {
-      $this->entityManager = $this->entityManagerFactory->createEntityManager();
-      $this->logRepository = new LogRepository($this->entityManager);
-    }
-    $this->logRepository->persist($entity);
-    $this->logRepository->flush();
+    $this->logRepository->saveLog($entity);
 
     if ($this->getRandom() <= self::LOG_PURGE_PROBABILITY) {
       $this->purgeOldLogs();

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -3,9 +3,7 @@
 namespace MailPoet\Logging;
 
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Settings\SettingsController;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Monolog\Processor\IntrospectionProcessor;
 use MailPoetVendor\Monolog\Processor\MemoryUsageProcessor;
 use MailPoetVendor\Monolog\Processor\WebProcessor;
@@ -50,22 +48,12 @@ class LoggerFactory {
   /** @var LogRepository */
   private $logRepository;
 
-  /** @var EntityManager */
-  private $entityManager;
-
-  /** @var EntityManagerFactory */
-  private $entityManagerFactory;
-
   public function __construct(
     LogRepository $logRepository,
-    EntityManager $entityManager,
-    EntityManagerFactory $entityManagerFactory,
     SettingsController $settings
   ) {
     $this->settings = $settings;
     $this->logRepository = $logRepository;
-    $this->entityManager = $entityManager;
-    $this->entityManagerFactory = $entityManagerFactory;
   }
 
   /**
@@ -92,8 +80,6 @@ class LoggerFactory {
 
       $this->loggerInstances[$name]->pushHandler(new LogHandler(
         $this->logRepository,
-        $this->entityManager,
-        $this->entityManagerFactory,
         $this->getDefaultLogLevel()
       ));
     }
@@ -104,8 +90,6 @@ class LoggerFactory {
     if (!self::$instance instanceof LoggerFactory) {
       self::$instance = new LoggerFactory(
         ContainerWrapper::getInstance()->get(LogRepository::class),
-        ContainerWrapper::getInstance()->get(EntityManager::class),
-        ContainerWrapper::getInstance()->get(EntityManagerFactory::class),
         SettingsController::getInstance()
       );
     }

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -127,10 +127,6 @@ class AutomaticEmailScheduler {
           $this->sendingQueuesRepository->remove($queue);
         }
         $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($task);
-        // In case any of task associated SchedulesTaskSubscriberEntity was loaded we need to detach them
-        foreach ($task->getSubscribers() as $taskSubscriber) {
-          $this->scheduledTaskSubscribersRepository->detach($taskSubscriber);
-        }
         $this->scheduledTasksRepository->remove($task);
         $this->scheduledTasksRepository->flush();
       }

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -124,6 +124,11 @@ class ScheduledTaskSubscribersRepository extends Repository {
       ->setParameter('task', $scheduledTask)
       ->getQuery()
       ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskSubscriberEntity $entity) use ($scheduledTask) {
+      return $entity->getTask() === $scheduledTask;
+    });
   }
 
   public function deleteByScheduledTaskAndSubscriberIds(ScheduledTaskEntity $scheduledTask, array $subscriberIds): void {
@@ -135,6 +140,11 @@ class ScheduledTaskSubscribersRepository extends Repository {
       ->setParameter('subscriberIds', $subscriberIds, Connection::PARAM_INT_ARRAY)
       ->getQuery()
       ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskSubscriberEntity $entity) use ($scheduledTask, $subscriberIds) {
+      return $entity->getTask() === $scheduledTask && in_array($entity->getSubscriberId(), $subscriberIds, true);
+    });
 
     $this->checkCompleted($scheduledTask);
   }

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -167,6 +167,11 @@ class SendingQueuesRepository extends Repository {
       ->setParameter('task', $scheduledTask)
       ->getQuery()
       ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (SendingQueueEntity $entity) use ($scheduledTask) {
+      return $entity->getTask() === $scheduledTask;
+    });
   }
 
   public function saveCampaignId(SendingQueueEntity $queue, string $campaignId): void {

--- a/mailpoet/tests/DataFactories/Log.php
+++ b/mailpoet/tests/DataFactories/Log.php
@@ -33,13 +33,11 @@ class Log {
 
   public function create(): LogEntity {
     $entity = new LogEntity();
-    $entity->setName( $this->data['name']);
+    $entity->setName($this->data['name']);
     $entity->setLevel($this->data['level']);
     $entity->setMessage($this->data['message']);
     $entity->setCreatedAt($this->data['created_at']);
-
-    $this->repository->persist($entity);
-    $this->repository->flush();
+    $this->repository->saveLog($entity);
     return $entity;
   }
 

--- a/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
+++ b/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
@@ -73,12 +73,12 @@ class WelcomeWizardCest {
     // wizard finished and the user was redirect to the home page
     $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
 
-    Assert::assertSame($senderName, $this->settingsRepository->findOneByName('sender')->getValue()['name']);
-    Assert::assertSame($senderAddress, $this->settingsRepository->findOneByName('sender')->getValue()['address']);
-    Assert::assertSame(['enabled' => '1'], $this->settingsRepository->findOneByName('3rd_party_libs')->getValue());
-    Assert::assertSame(['enabled' => '1'], $this->settingsRepository->findOneByName('analytics')->getValue());
-    Assert::assertSame(['level' => 'full'], $this->settingsRepository->findOneByName('tracking')->getValue());
-    Assert::assertSame($mailPoetSendingKey, $this->settingsRepository->findOneByName('mta')->getValue()['mailpoet_api_key']);
+    Assert::assertSame($senderName, $this->findSetting('sender')->getValue()['name']);
+    Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
+    Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
+    Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
+    Assert::assertSame(['level' => 'full'], $this->findSetting('tracking')->getValue());
+    Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 
   public function welcomeWizardShouldSkipMssStepIfKeyAlreadyExists(\AcceptanceTester $i, Scenario $scenario) {
@@ -114,11 +114,19 @@ class WelcomeWizardCest {
     // wizard finished and the user was redirect to the home page
     $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
 
-    Assert::assertSame($senderName, $this->settingsRepository->findOneByName('sender')->getValue()['name']);
-    Assert::assertSame($senderAddress, $this->settingsRepository->findOneByName('sender')->getValue()['address']);
-    Assert::assertSame(['enabled' => '1'], $this->settingsRepository->findOneByName('3rd_party_libs')->getValue());
-    Assert::assertSame(['enabled' => '1'], $this->settingsRepository->findOneByName('analytics')->getValue());
-    Assert::assertSame(['level' => 'full'], $this->settingsRepository->findOneByName('tracking')->getValue());
-    Assert::assertSame($mailPoetSendingKey, $this->settingsRepository->findOneByName('mta')->getValue()['mailpoet_api_key']);
+    Assert::assertSame($senderName, $this->findSetting('sender')->getValue()['name']);
+    Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
+    Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
+    Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
+    Assert::assertSame(['level' => 'full'], $this->findSetting('tracking')->getValue());
+    Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
+  }
+
+  private function findSetting(string $name) {
+    $setting = $this->settingsRepository->findOneByName($name);
+    if (!$setting) {
+      throw new \Exception("Setting '$name' not found");
+    }
+    return $setting;
   }
 }

--- a/mailpoet/tests/integration/Doctrine/RepositoryTest.php
+++ b/mailpoet/tests/integration/Doctrine/RepositoryTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Doctrine;
+
+use MailPoet\Doctrine\Repository;
+use MailPoet\Entities\SettingEntity;
+
+class RepositoryTest extends \MailPoetTest {
+  public function testItCanPersistAndFlush(): void {
+    $repository = $this->createRepository();
+
+    $setting = new SettingEntity();
+    $setting->setName('name');
+    $setting->setValue('value');
+    $repository->persist($setting);
+    $repository->flush();
+
+    $this->assertSame($this->getEntityFromIdentityMap($setting->getId()), $setting);
+  }
+
+  public function testItCanDetachAll(): void {
+    $repository = $this->createRepository();
+
+    $setting1 = $this->createSetting('name-1', 'value-1');
+    $setting2 = $this->createSetting('name-2', 'value-2');
+    $setting3 = $this->createSetting('name-3', 'value-3');
+
+    $this->assertSame($this->getEntityFromIdentityMap($setting1->getId()), $setting1);
+    $this->assertSame($this->getEntityFromIdentityMap($setting2->getId()), $setting2);
+    $this->assertSame($this->getEntityFromIdentityMap($setting3->getId()), $setting3);
+
+    $repository->detachAll();
+
+    $this->assertNull($this->getEntityFromIdentityMap($setting1->getId()));
+    $this->assertNull($this->getEntityFromIdentityMap($setting2->getId()));
+    $this->assertNull($this->getEntityFromIdentityMap($setting3->getId()));
+  }
+
+  public function testItCanDetachSelectively(): void {
+    $repository = $this->createRepository();
+
+    $setting1 = $this->createSetting('name-1', 'value-1');
+    $setting2 = $this->createSetting('name-2', 'value-2');
+    $setting3 = $this->createSetting('name-3', 'value-3');
+
+    $this->assertSame($this->getEntityFromIdentityMap($setting1->getId()), $setting1);
+    $this->assertSame($this->getEntityFromIdentityMap($setting2->getId()), $setting2);
+    $this->assertSame($this->getEntityFromIdentityMap($setting3->getId()), $setting3);
+
+    $repository->detachAll(function (SettingEntity $setting) use ($setting1, $setting3) {
+      return !in_array($setting->getId(), [$setting1->getId(), $setting3->getId()], true);
+    });
+
+    $this->assertSame($this->getEntityFromIdentityMap($setting1->getId()), $setting1);
+    $this->assertNull($this->getEntityFromIdentityMap($setting2->getId()));
+    $this->assertSame($this->getEntityFromIdentityMap($setting3->getId()), $setting3);
+  }
+
+  private function createSetting(string $name, string $value): SettingEntity {
+    $setting = new SettingEntity();
+    $setting->setName($name);
+    $setting->setValue($value);
+    $this->entityManager->persist($setting);
+    $this->entityManager->flush();
+    return $setting;
+  }
+
+  /** @return Repository<SettingEntity> */
+  private function createRepository(): Repository {
+    /** @var Repository<SettingEntity> $repository */
+    $repository = new class($this->entityManager) extends Repository {
+      protected function getEntityClassName(): string {
+        return SettingEntity::class;
+      }
+    };
+    return $repository;
+  }
+
+  private function getEntityFromIdentityMap(?int $id): ?SettingEntity {
+    /** @var SettingEntity|false $entity */
+    $entity = $this->entityManager->getUnitOfWork()->tryGetById($id, SettingEntity::class);
+    return $entity ?: null;
+  }
+}

--- a/mailpoet/tests/integration/Logging/LogHandlerTest.php
+++ b/mailpoet/tests/integration/Logging/LogHandlerTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Logging;
 use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -21,11 +22,7 @@ class LogHandlerTest extends \MailPoetTest {
   }
 
   public function testItCreatesLog() {
-    $logHandler = new LogHandler(
-      $this->repository,
-      $this->entityManager,
-      $this->entityManagerFactory
-    );
+    $logHandler = new LogHandler($this->repository);
     $time = new \DateTime();
     $logHandler->handle([
       'level' => \MailPoetVendor\Monolog\Logger::EMERGENCY,
@@ -49,9 +46,7 @@ class LogHandlerTest extends \MailPoetTest {
     $entity->setLevel(5);
     $entity->setMessage('xyz');
     $entity->setCreatedAt(Carbon::now()->subDays(100));
-
-    $this->repository->persist($entity);
-    $this->repository->flush();
+    $this->repository->saveLog($entity);
 
     $random = function() {
       return 0;
@@ -59,8 +54,6 @@ class LogHandlerTest extends \MailPoetTest {
 
     $logHandler = new LogHandler(
       $this->repository,
-      $this->entityManager,
-      $this->entityManagerFactory,
       \MailPoetVendor\Monolog\Logger::DEBUG,
       true,
       $random
@@ -84,9 +77,7 @@ class LogHandlerTest extends \MailPoetTest {
     $entity->setLevel(5);
     $entity->setMessage('xyz');
     $entity->setCreatedAt(Carbon::now()->subDays(100));
-
-    $this->repository->persist($entity);
-    $this->repository->flush();
+    $this->repository->saveLog($entity);
 
     $random = function() {
       return 100;
@@ -94,8 +85,6 @@ class LogHandlerTest extends \MailPoetTest {
 
     $logHandler = new LogHandler(
       $this->repository,
-      $this->entityManager,
-      $this->entityManagerFactory,
       \MailPoetVendor\Monolog\Logger::DEBUG,
       true,
       $random
@@ -115,12 +104,8 @@ class LogHandlerTest extends \MailPoetTest {
 
   public function testItResilientToSqlError(): void {
     $entityManager = $this->entityManagerFactory->createEntityManager();
-    $logRepository = new LogRepository($entityManager);
-    $logHandler = new LogHandler(
-      $logRepository,
-      $entityManager,
-      $this->entityManagerFactory
-    );
+    $logRepository = new LogRepository($entityManager, new WPFunctions());
+    $logHandler = new LogHandler($logRepository);
     $time = new \DateTime();
 
     try {

--- a/mailpoet/tests/integration/Settings/SettingsRepositoryTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsRepositoryTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Settings;
+
+use MailPoet\Entities\SettingEntity;
+use MailPoet\Settings\SettingsRepository;
+use MailPoetTest;
+
+class SettingsRepositoryTest extends MailPoetTest {
+  public function testItFetchesAlwaysFreshData(): void {
+    $repository = $this->diContainer->get(SettingsRepository::class);
+
+    $setting = new SettingEntity();
+    $setting->setName('name');
+    $setting->setValue('value');
+    $this->entityManager->persist($setting);
+    $this->entityManager->flush();
+
+    $this->assertSame('value', $setting->getValue());
+    $this->entityManager->createQueryBuilder()
+      ->update(SettingEntity::class, 's')
+      ->set('s.value', ':value')
+      ->where('s.name = :name')
+      ->setParameter('value', 'new value')
+      ->setParameter('name', 'name')
+      ->getQuery()
+      ->execute();
+    $this->assertSame('value', $setting->getValue());
+
+    $newSetting = $repository->findOneByName('name');
+    $this->assertSame($setting, $newSetting);
+    $this->assertSame('new value', $setting->getValue());
+    $this->assertSame('new value', $newSetting->getValue());
+  }
+
+  public function testUpdateRefreshesExistingData(): void {
+    $repository = $this->diContainer->get(SettingsRepository::class);
+
+    $setting = new SettingEntity();
+    $setting->setName('name');
+    $setting->setValue('value');
+    $this->entityManager->persist($setting);
+    $this->entityManager->flush();
+
+    $this->assertSame('value', $setting->getValue());
+    $repository->createOrUpdateByName('name', 'new value');
+    $this->assertSame('new value', $setting->getValue());
+  }
+}

--- a/mailpoet/tests/unit/Logging/LoggerFactoryTest.php
+++ b/mailpoet/tests/unit/Logging/LoggerFactoryTest.php
@@ -2,9 +2,7 @@
 
 namespace MailPoet\Logging;
 
-use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Settings\SettingsController;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Monolog\Handler\AbstractHandler;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -20,9 +18,7 @@ class LoggerFactoryTest extends \MailPoetUnitTest {
     parent::_before();
     $this->settings = $this->createMock(SettingsController::class);
     $repository = $this->createMock(LogRepository::class);
-    $entityManager = $this->createMock(EntityManager::class);
-    $entityManagerFactory = $this->createMock(EntityManagerFactory::class);
-    $this->loggerFactory = new LoggerFactory($repository, $entityManager, $entityManagerFactory, $this->settings);
+    $this->loggerFactory = new LoggerFactory($repository, $this->settings);
   }
 
   public function testItCreatesLogger() {


### PR DESCRIPTION
## Description

When deleting entities via DQL, the changes aren't reflected in the Doctrine identity map, and we need to synchronize (detach) them manually. This adds a helper to do so, without the need of fetching them to memory before.

The way it works is we iterate all entities of the type already loaded in memory, and figure out which ones to detach.

I also added a fix for calling `flush()` in the logger, which can have unintended side effects (explained in the commit and as a code comment).

I also fixed a `SettingsController::set()` side effect of clearing all settings entities, and a bug causing `SettingsController::fetch()` to return cached entity data instead of fresh data (as it was originally intended).

Fixes https://github.com/mailpoet/mailpoet/issues/5281.

## Code review notes

The DQL/DBAL vs. identity map problem is not universally solvable, and we need to manually sync such changes. For most cases, `$entityManager->refresh()` is the method to use, but for bulk deletes of large collections where we don't want to load all entities to memory, we need a way to detach them without fetching them first.

It's very much an edge case, and likely calling `$entityManager->clear()` between cron runs within the same request could prevent this (and other possible bugs) as well. But it's better to be on the safe side, and ultimately, implement both.

## QA notes

Please, test sending, especially post notification, plus some automations, and check `?page=mailpoet-logs` as well as [Action Scheduler logs](https://actionscheduler.org/admin/) to make sure no errors were logged.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5745]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5745]: https://mailpoet.atlassian.net/browse/MAILPOET-5745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ