### PR TITLE
Fix WooCommerce email counters [MAILPOET-5719]

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20231128_120355_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20231128_120355_App.php
@@ -29,7 +29,7 @@ class Migration_20231128_120355_App extends AppMigration {
     $sendingQueuesTable = $this->getTableName(SendingQueueEntity::class);
     $scheduledTasksTable = $this->getTableName(ScheduledTaskEntity::class);
     $newslettersTable = $this->getTableName(NewsletterEntity::class);
-    $typeAutomatic = NewsletterEntity::TYPE_AUTOMATIC;
+    $newsletterTypes = [NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::TYPE_WELCOME];
     $statusCompleted = ScheduledTaskEntity::STATUS_COMPLETED;
     $connection->executeStatement("
       UPDATE {$sendingQueuesTable}
@@ -38,11 +38,13 @@ class Migration_20231128_120355_App extends AppMigration {
       SET {$sendingQueuesTable}.count_total = 1,
       {$sendingQueuesTable}.count_processed = 1,
       {$sendingQueuesTable}.count_to_process = 0
-      WHERE {$newslettersTable}.type = :newsletterType
+      WHERE {$newslettersTable}.type IN (:newsletterTypes)
       AND {$scheduledTasksTable}.status = :taskStatus
     ", [
-      'newsletterType' => $typeAutomatic,
+      'newsletterTypes' => $newsletterTypes,
       'taskStatus' => $statusCompleted,
+    ], [
+      'newsletterTypes' => Connection::PARAM_STR_ARRAY,
     ]);
 
     // Fix data for scheduled tasks
@@ -54,11 +56,13 @@ class Migration_20231128_120355_App extends AppMigration {
       SET {$sendingQueuesTable}.count_total = 1,
       {$sendingQueuesTable}.count_processed = 0,
       {$sendingQueuesTable}.count_to_process = 1
-      WHERE {$newslettersTable}.type = :newsletterType
+      WHERE {$newslettersTable}.type IN (:newsletterTypes)
       AND {$scheduledTasksTable}.status = :taskStatus
     ", [
-      'newsletterType' => $typeAutomatic,
+      'newsletterTypes' => $newsletterTypes,
       'taskStatus' => $statusScheduled,
+    ], [
+      'newsletterTypes' => Connection::PARAM_STR_ARRAY,
     ]);
   }
 

--- a/mailpoet/lib/Migrations/App/Migration_20231128_120355_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20231128_120355_App.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\WooCommerce\Helper;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+
+/**
+ * Due to a bug https://mailpoet.atlassian.net/browse/MAILPOET-5719 we need to fix already existing data.
+ * The performance optimization we changed the method for updating counts in the sending queue after finishing the scheduled task.
+ * This change affected counts in automatic emails, because the value of processed emails has min and max value calculated from the total count.
+ */
+class Migration_20231128_120355_App extends AppMigration {
+  public function run(): void {
+    $wooCommerceHelper = $this->container->get(Helper::class);
+
+    // If Woo is not active and the table doesn't exist, we can skip this migration
+    if (!$wooCommerceHelper->isWooCommerceActive()) {
+      return;
+    }
+
+    $connection = $this->container->get(Connection::class);
+
+    // Fix data for completed tasks
+    $sendingQueuesTable = $this->getTableName(SendingQueueEntity::class);
+    $scheduledTasksTable = $this->getTableName(ScheduledTaskEntity::class);
+    $newslettersTable = $this->getTableName(NewsletterEntity::class);
+    $typeAutomatic = NewsletterEntity::TYPE_AUTOMATIC;
+    $statusCompleted = ScheduledTaskEntity::STATUS_COMPLETED;
+    $connection->executeStatement("
+      UPDATE {$sendingQueuesTable}
+      JOIN {$scheduledTasksTable} ON {$scheduledTasksTable}.id = {$sendingQueuesTable}.task_id
+      JOIN {$newslettersTable} ON {$newslettersTable}.id = {$sendingQueuesTable}.newsletter_id
+      SET {$sendingQueuesTable}.count_total = 1,
+      {$sendingQueuesTable}.count_processed = 1,
+      {$sendingQueuesTable}.count_to_process = 0
+      WHERE {$newslettersTable}.type = :newsletterType
+      AND {$scheduledTasksTable}.status = :taskStatus
+    ", [
+      'newsletterType' => $typeAutomatic,
+      'taskStatus' => $statusCompleted,
+    ]);
+
+    // Fix data for scheduled tasks
+    $statusScheduled = ScheduledTaskEntity::STATUS_SCHEDULED;
+    $connection->executeStatement("
+      UPDATE {$sendingQueuesTable}
+      JOIN {$scheduledTasksTable} ON {$scheduledTasksTable}.id = {$sendingQueuesTable}.task_id
+      JOIN {$newslettersTable} ON {$newslettersTable}.id = {$sendingQueuesTable}.newsletter_id
+      SET {$sendingQueuesTable}.count_total = 1,
+      {$sendingQueuesTable}.count_processed = 0,
+      {$sendingQueuesTable}.count_to_process = 1
+      WHERE {$newslettersTable}.type = :newsletterType
+      AND {$scheduledTasksTable}.status = :taskStatus
+    ", [
+      'newsletterType' => $typeAutomatic,
+      'taskStatus' => $statusScheduled,
+    ]);
+  }
+
+  private function getTableName(string $entityClassName): string {
+    return $this->entityManager->getClassMetadata($entityClassName)->getTableName();
+  }
+}

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -153,6 +153,9 @@ class AutomaticEmailScheduler {
     $sendingQueue = new SendingQueueEntity();
     $sendingQueue->setNewsletter($newsletter);
     $sendingQueue->setTask($scheduledTask);
+    // Because we changed the way how to updateCounts after sending we need to set initial counts
+    $sendingQueue->setCountTotal($subscriber ? 1 : 0);
+    $sendingQueue->setCountToProcess($subscriber ? 1 : 0);
     $scheduledTask->setSendingQueue($sendingQueue);
 
     if ($meta) {

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -135,6 +135,10 @@ class WelcomeScheduler {
     $queue = new SendingQueueEntity();
     $queue->setTask($task);
     $queue->setNewsletter($newsletter);
+    // Because we changed the way how to updateCounts after sending we need to set initial counts
+    $queue->setCountTotal(1);
+    $queue->setCountToProcess(1);
+
     $task->setSendingQueue($queue);
     $this->entityManager->persist($queue);
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -97,6 +97,9 @@ class WelcomeTest extends \MailPoetTest {
     $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     verify($queue->getId())->greaterThanOrEqual(1);
+    verify($queue->getCountProcessed())->equals(0);
+    verify($queue->getCountToProcess())->equals(1);
+    verify($queue->getCountTotal())->equals(1);
     $task = $queue->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     verify($task->getPriority())->equals(ScheduledTaskEntity::PRIORITY_HIGH);


### PR DESCRIPTION
## Description

This PR fixes the reported issue with displaying the count of sent WooCommerce emails, such as Abandoned cart, First purchase, etc.

## Code review notes

The fix is in two parts:
1.  Because we changed the logic of updating counts in sending queues after a successful finish, the method `Sending::updateCounts()` stopped working for WC emails correctly. The reason was [this commit](https://github.com/mailpoet/mailpoet/pull/5028/commits/bcea5357dc416f24fca6a1443c51c8ad072ba45b#diff-ae01c9cf1eb5e11c90936b70c6f47711f8c92e05d705cdbe3813dc2a025e654dR248) when the first part of the if statement restricts the min and max values for `countProcessed`. The counts in the sending queue were not initialized properly, and all were in the default value of 0. My solution is based on setting correct values after entity creation.
2. For the reason that the count of sent WC emails is calculated from the `countProcessed` in the sending_queue table, we need to repair the affected rows. I prepared a migration that should guarantee.

## QA notes

- In the beginning, I recommend preparing all WC email types.
- As the next step, replicate the incorrect behavior on each new email.
- After replication, install the new version containing the fix and ensure the DB migration was executed.
- Invoke sending all WC emails again and observe if the updated count of sent emails is correct.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5028

## Linked tickets

[MAILPOET-5719]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5719]: https://mailpoet.atlassian.net/browse/MAILPOET-5719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ