### PR TITLE
Drop support for PHP 7.3 [MAILPOET-5726]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ executors:
   wpcli_php_oldest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:7.3_20230518.1
+      - image: mailpoet/wordpress:7.4_20231129.1
 
   wpcli_php_max_wporg:
     <<: *default_job_config
@@ -108,7 +108,7 @@ executors:
   wpcli_php_mysql_oldest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:7.3_20230518.1
+      - image: mailpoet/wordpress:7.4_20231129.1
       - image: cimg/mysql:5.7
 
   wpcli_php_mysql_latest:
@@ -1020,7 +1020,7 @@ workflows:
           woo_memberships_version: 1.21.0
           woo_blocks_version: 6.8.0
           automate_woo_version: 5.1.1
-          codeception_image_version: 7.3-cli_20230516.0
+          codeception_image_version: 7.4-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
     parameters:
       php_version:
         type: integer
-        default: 70200
+        default: 70400
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -794,13 +794,13 @@ workflows:
       - static_analysis:
           <<: *slack-fail-post-step
           name: static_analysis_php7
-          php_version: 70200
+          php_version: 70400
           requires:
             - build
       - static_analysis:
           <<: *slack-fail-post-step
           name: static_analysis_php8
-          php_version: 80000
+          php_version: 80100
           requires:
             - build
       - security_analysis:

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -789,7 +789,7 @@ class RoboFile extends \Robo\Tasks {
         ->taskExec(
           './tasks/code_sniffer/vendor/bin/phpcbf ' .
             '--standard=./tasks/code_sniffer/MailPoet ' .
-            '--runtime-set testVersion 7.3-8.2 ' .
+            '--runtime-set testVersion 7.4-8.2 ' .
             $filePath . ' -n'
         )
         ->run();

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": ">=7.3",
+    "php": ">=7.4",
     "mixpanel/mixpanel-php": "2.*",
     "mtdowling/cron-expression": "^1.1",
     "woocommerce/action-scheduler": "^3.6"
@@ -90,7 +90,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.3.0"
+      "php": "7.4.0"
     },
     "sort-packages": true
   }

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81f7252c6827a7761b1270fff26d5884",
+    "content-hash": "f21c55c1e19f20ecbac19afd25c31138",
     "packages": [
         {
             "name": "mixpanel/mixpanel-php",
@@ -10866,7 +10866,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3"
+        "php": ">=7.4"
     },
     "platform-dev": {
         "ext-gd": "*",
@@ -10879,7 +10879,7 @@
         "ext-zip": "*"
     },
     "platform-overrides": {
-        "php": "7.3.0"
+        "php": "7.4.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/mailpoet/mailpoet-cron.php
+++ b/mailpoet/mailpoet-cron.php
@@ -34,8 +34,8 @@ if (!is_plugin_active('mailpoet/mailpoet.php')) {
 }
 
 // Check for minimum supported PHP version
-if (version_compare(phpversion(), '7.3.0', '<')) {
-  echo 'MailPoet requires PHP version 7.3 or newer (version 8.1 recommended).';
+if (version_compare(phpversion(), '7.4.0', '<')) {
+  echo 'MailPoet requires PHP version 7.4 or newer (version 8.1 recommended).';
   exit(1);
 }
 

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -46,7 +46,7 @@ if (version_compare(get_bloginfo('version'), MAILPOET_MINIMUM_REQUIRED_WP_VERSIO
 }
 
 // Check for minimum supported PHP version
-if (version_compare(phpversion(), '7.3.0', '<')) {
+if (version_compare(phpversion(), '7.4.0', '<')) {
   add_action('admin_notices', 'mailpoet_php_version_notice');
   // deactivate the plugin
   add_action('admin_init', 'mailpoet_deactivate_plugin');
@@ -121,7 +121,7 @@ function mailpoet_woocommerce_version_notice() {
 
 // Display PHP version error notice
 function mailpoet_php_version_notice() {
-  $noticeP1 = __('MailPoet requires PHP version 7.3 or newer (8.1 recommended). You are running version [version].', 'mailpoet');
+  $noticeP1 = __('MailPoet requires PHP version 7.4 or newer (8.1 recommended). You are running version [version].', 'mailpoet');
   $noticeP1 = str_replace('[version]', phpversion(), $noticeP1);
 
   $noticeP2 = __('Please read our [link]instructions[/link] on how to upgrade your site.', 'mailpoet');
@@ -135,7 +135,7 @@ function mailpoet_php_version_notice() {
   $noticeP3 = __('If you can’t upgrade the PHP version, [link]install this version[/link] of MailPoet. Remember to not update MailPoet ever again!', 'mailpoet');
   $noticeP3 = str_replace(
     '[link]',
-    '<a href="https://downloads.wordpress.org/plugin/mailpoet.4.16.0.zip" target="_blank">',
+    '<a href="https://downloads.wordpress.org/plugin/mailpoet.4.38.0.zip" target="_blank">',
     $noticeP3
   );
   $noticeP3 = str_replace('[/link]', '</a>', $noticeP3);

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -4,7 +4,7 @@ Tags: email, email marketing, post notification, woocommerce emails, email autom
 Requires at least: 6.2
 Tested up to: 6.3
 Stable tag: 4.38.0
-Requires PHP: 7.3
+Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/mailpoet/tasks/code_sniffer/MailPoet/php-version.xml
+++ b/mailpoet/tasks/code_sniffer/MailPoet/php-version.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <ruleset>
-  <config name="testVersion" value="7.3-"/>
+  <config name="testVersion" value="7.4-"/>
 </ruleset>


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/826

## Linked tickets

[MAILPOET-5726]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5726]: https://mailpoet.atlassian.net/browse/MAILPOET-5726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ