### PR TITLE
Fix displaying columns full width in the gmail app  [MAILPOET-5753]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
@@ -57,16 +57,7 @@
                   text-align: center;
                 "
               >
-                <table
-                  role="presentation"
-                  border="0"
-                  cellpadding="0"
-                  cellspacing="0"
-                >
-                  <tbody>
-                    {{email_body}}
-                  </tbody>
-                </table>
+                {{email_body}}
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
## Description

The main content wrapping table was not set with a width 100%, and it was causing the Gmail app to stretch the content area width by content size. So, it was not related to columns but rather to the main template wrapper.

We found that the table is not needed since columns add their own table wrappers.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-5753]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5753]: https://mailpoet.atlassian.net/browse/MAILPOET-5753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ