### PR TITLE
Remove preheader tooltip [MAILPOET-5757]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -1,3 +1,5 @@
+@import '~@wordpress/base-styles/colors';
+
 // Specific styles for the component EmailTypeInfo
 // Styles are based on the Block Card component from Gutenberg block editor
 .mailpoet-email-sidebar__email-type-info {
@@ -45,20 +47,17 @@
   }
 
   .mailpoet-settings-panel__preview-text-length {
-    background: white; // make sure it is visible in all themes
-    border-radius: 6px;
-    color: black; // make sure it is visible in all themes
+    color: $black;
     display: inline-block;
-    font-size: smaller;
     padding: 3px;
   }
 
   .mailpoet-settings-panel__preview-text-length-warning {
-    color: #dba617; // from wp-core warning color
+    color: $alert-yellow;
   }
 
   .mailpoet-settings-panel__preview-text-length-error {
-    color: #d63638; // from wp-core error color
+    color: $alert-red;
   }
 }
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -36,19 +36,12 @@
     }
   }
 
-  .mailpoet-settings-panel__subject-help {
+  .mailpoet-settings-panel__help {
     margin-bottom: 20px;
 
     .components-text {
       color: #757575;
     }
-  }
-
-  .mailpoet-settings-panel__preview-text
-    .components-base-control__label
-    .mailpoet-preview-text__help-icon {
-    position: relative;
-    top: 6px;
   }
 }
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -43,6 +43,23 @@
       color: #757575;
     }
   }
+
+  .mailpoet-settings-panel__preview-text-length {
+    background: white; // make sure it is visible in all themes
+    border-radius: 6px;
+    color: black; // make sure it is visible in all themes
+    display: inline-block;
+    font-size: smaller;
+    padding: 3px;
+  }
+
+  .mailpoet-settings-panel__preview-text-length-warning {
+    color: #dba617; // from wp-core warning color
+  }
+
+  .mailpoet-settings-panel__preview-text-length-error {
+    color: #d63638; // from wp-core error color
+  }
 }
 
 .edit-post-visual-editor__content-area {

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -46,9 +46,14 @@
     }
   }
 
+  .mailpoet-settings-panel__preview-text .components-base-control__label {
+    width: 100%;
+  }
+
   .mailpoet-settings-panel__preview-text-length {
     color: $black;
     display: inline-block;
+    float: right;
     padding: 3px;
   }
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -66,6 +66,22 @@ export function DetailsPanel() {
 
   const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
 
+  const preheaderLabel = (
+    <>
+      <span>{__('Preview text', 'mailpoet')}</span>
+      <span
+        className={classnames('mailpoet-settings-panel__preview-text-length', {
+          'mailpoet-settings-panel__preview-text-length-warning':
+            previewTextLength > previewTextRecommendedLength,
+          'mailpoet-settings-panel__preview-text-length-error':
+            previewTextLength > previewTextMaxLength,
+        })}
+      >
+        {previewTextLength}/{previewTextMaxLength}
+      </span>
+    </>
+  );
+
   return (
     <PanelBody
       title={__('Details', 'mailpoet')}
@@ -85,7 +101,7 @@ export function DetailsPanel() {
 
       <TextareaControl
         className="mailpoet-settings-panel__preview-text"
-        label={<span>{__('Preview text (recommended)', 'mailpoet')}</span>}
+        label={preheaderLabel}
         placeholder={__(
           "Add a preview text to capture subscribers' attention and increase open rates.",
           'mailpoet',
@@ -94,23 +110,15 @@ export function DetailsPanel() {
         onChange={(value) => updateEmailProperty('preheader', value)}
         data-automation-id="email_preview_text"
       />
-      <span
-        className={classnames('mailpoet-settings-panel__preview-text-length', {
-          'mailpoet-settings-panel__preview-text-length-warning':
-            previewTextLength > previewTextRecommendedLength,
-          'mailpoet-settings-panel__preview-text-length-error':
-            previewTextLength > previewTextMaxLength,
-        })}
-      >
-        {previewTextLength}/{previewTextMaxLength}
-      </span>
       <div className="mailpoet-settings-panel__help">
         <Text>
           {__(
             'This text will appear in the inbox, underneath the subject line.',
+            'mailpoet',
           )}{' '}
           {__(
             'We recommend to keep it short, and to use it to complement the subject line.',
+            'mailpoet',
           )}
         </Text>
       </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -10,6 +10,8 @@ import { __ } from '@wordpress/i18n';
 import ReactStringReplace from 'react-string-replace';
 import { storeName } from '../../store';
 
+const previewTextMaxLength = 150;
+
 export function DetailsPanel() {
   const [mailpoetEmailData] = useEntityProp(
     'postType',
@@ -60,6 +62,8 @@ export function DetailsPanel() {
     </>
   );
 
+  const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
+
   return (
     <PanelBody
       title={__('Details', 'mailpoet')}
@@ -88,6 +92,9 @@ export function DetailsPanel() {
         onChange={(value) => updateEmailProperty('preheader', value)}
         data-automation-id="email_preview_text"
       />
+      {previewTextLength}
+      {'/'}
+      {previewTextMaxLength}
       <div className="mailpoet-settings-panel__help">
         <Text>
           {__(

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -8,9 +8,11 @@ import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import ReactStringReplace from 'react-string-replace';
+import classnames from 'classnames';
 import { storeName } from '../../store';
 
 const previewTextMaxLength = 150;
+const previewTextRecommendedLength = 80;
 
 export function DetailsPanel() {
   const [mailpoetEmailData] = useEntityProp(
@@ -92,9 +94,16 @@ export function DetailsPanel() {
         onChange={(value) => updateEmailProperty('preheader', value)}
         data-automation-id="email_preview_text"
       />
-      {previewTextLength}
-      {'/'}
-      {previewTextMaxLength}
+      <span
+        className={classnames('mailpoet-settings-panel__preview-text-length', {
+          'mailpoet-settings-panel__preview-text-length-warning':
+            previewTextLength > previewTextRecommendedLength,
+          'mailpoet-settings-panel__preview-text-length-error':
+            previewTextLength > previewTextMaxLength,
+        })}
+      >
+        {previewTextLength}/{previewTextMaxLength}
+      </span>
       <div className="mailpoet-settings-panel__help">
         <Text>
           {__(

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -8,6 +8,7 @@ import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import ReactStringReplace from 'react-string-replace';
+import { createInterpolateElement } from '@wordpress/element';
 import classnames from 'classnames';
 import { storeName } from '../../store';
 
@@ -112,13 +113,25 @@ export function DetailsPanel() {
       />
       <div className="mailpoet-settings-panel__help">
         <Text>
-          {__(
-            'This text will appear in the inbox, underneath the subject line.',
-            'mailpoet',
-          )}{' '}
-          {__(
-            'We recommend to keep it short, and to use it to complement the subject line.',
-            'mailpoet',
+          {createInterpolateElement(
+            __(
+              '<link>This text</link> will appear in the inbox, underneath the subject line.',
+              'mailpoet',
+            ),
+            {
+              link: (
+                // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                <a
+                  href={new URL(
+                    'article/418-preview-text',
+                    'https://kb.mailpoet.com/',
+                  ).toString()}
+                  key="preview-text-kb"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+            },
           )}
         </Text>
       </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -92,6 +92,9 @@ export function DetailsPanel() {
         <Text>
           {__(
             'This text will appear in the inbox, underneath the subject line.',
+          )}{' '}
+          {__(
+            'We recommend to keep it short, and to use it to complement the subject line.',
           )}
         </Text>
       </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/details-panel.tsx
@@ -3,12 +3,10 @@ import {
   ExternalLink,
   PanelBody,
   TextareaControl,
-  Tooltip,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
-import { Icon, help } from '@wordpress/icons';
 import ReactStringReplace from 'react-string-replace';
 import { storeName } from '../../store';
 
@@ -62,22 +60,6 @@ export function DetailsPanel() {
     </>
   );
 
-  const previewTextLabel = (
-    <>
-      <span>{__('Preview text (recommended)', 'mailpoet')}</span>
-      <Tooltip
-        text={__(
-          'This text will appear in the inbox, underneath the subject line. Max length is 250 characters, but we recommend 80 characters.',
-          'mailpoet',
-        )}
-      >
-        <span className="mailpoet-preview-text__help-icon">
-          <Icon icon={help} size={20} />
-        </span>
-      </Tooltip>
-    </>
-  );
-
   return (
     <PanelBody
       title={__('Details', 'mailpoet')}
@@ -91,13 +73,13 @@ export function DetailsPanel() {
         onChange={(value) => updateEmailProperty('subject', value)}
         data-automation-id="email_subject"
       />
-      <div className="mailpoet-settings-panel__subject-help">
+      <div className="mailpoet-settings-panel__help">
         <Text>{subjectHelp}</Text>
       </div>
 
       <TextareaControl
         className="mailpoet-settings-panel__preview-text"
-        label={previewTextLabel}
+        label={<span>{__('Preview text (recommended)', 'mailpoet')}</span>}
         placeholder={__(
           "Add a preview text to capture subscribers' attention and increase open rates.",
           'mailpoet',
@@ -106,6 +88,13 @@ export function DetailsPanel() {
         onChange={(value) => updateEmailProperty('preheader', value)}
         data-automation-id="email_preview_text"
       />
+      <div className="mailpoet-settings-panel__help">
+        <Text>
+          {__(
+            'This text will appear in the inbox, underneath the subject line.',
+          )}
+        </Text>
+      </div>
     </PanelBody>
   );
 }

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -155,6 +155,7 @@
     "@types/wordpress__notices": "^3.5.1",
     "@types/wordpress__rich-text": "^6.0.0",
     "@wordpress/babel-preset-default": "^7.12.0",
+    "@wordpress/base-styles": "4.20.0",
     "@wordpress/browserslist-config": "^5.11.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^4.11.0",
     "autoprefixer": "^10.4.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,9 @@ importers:
       '@wordpress/babel-preset-default':
         specifier: ^7.12.0
         version: 7.12.0
+      '@wordpress/base-styles':
+        specifier: 4.20.0
+        version: 4.20.0
       '@wordpress/browserslist-config':
         specifier: ^5.11.0
         version: 5.11.0
@@ -821,7 +824,7 @@ packages:
       '@wordpress/primitives': 3.37.0
       '@wordpress/react-i18n': 3.36.0
       classnames: 2.3.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
@@ -878,7 +881,7 @@ packages:
       '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -985,7 +988,7 @@ packages:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.11
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.4
       semver: 6.3.1
@@ -1001,7 +1004,7 @@ packages:
       '@babel/core': 7.22.11
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.4
       semver: 6.3.1
@@ -1017,7 +1020,7 @@ packages:
       '@babel/core': 7.22.11
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -2387,7 +2390,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.11
       '@babel/types': 7.22.11
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2405,7 +2408,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2854,7 +2857,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       espree: 9.5.0
       globals: 13.20.0
       ignore: 5.2.4
@@ -2970,7 +2973,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6169,7 +6172,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/type-utils': 5.56.0(eslint@8.36.0)(typescript@5.0.2)
       '@typescript-eslint/utils': 5.56.0(eslint@8.36.0)(typescript@5.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.36.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -6194,7 +6197,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.36.0
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -6221,7 +6224,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.2)
       '@typescript-eslint/utils': 5.56.0(eslint@8.36.0)(typescript@5.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.36.0
       tsutils: 3.21.0(typescript@5.0.2)
       typescript: 5.0.2
@@ -6245,7 +6248,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -8663,7 +8666,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11157,6 +11160,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /debug@4.3.4(supports-color@9.3.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -11169,7 +11173,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.3.1
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -11896,7 +11899,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -12160,7 +12163,7 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.36.1
       comment-parser: 1.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       escape-string-regexp: 4.0.0
       eslint: 8.36.0
       esquery: 1.5.0
@@ -12299,7 +12302,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -12562,7 +12565,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -12795,7 +12798,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13607,6 +13610,7 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -13908,7 +13912,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13919,7 +13923,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13963,7 +13967,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13988,7 +13992,7 @@ packages:
       '@babel/runtime': 7.22.11
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 5.20.0(react@18.2.0)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       events: 3.3.0
       hash.js: 1.1.7
       lodash: 4.17.21
@@ -14668,7 +14672,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -16620,7 +16624,7 @@ packages:
       ajv-errors: 1.0.1(ajv@6.12.6)
       chalk: 4.1.2
       cosmiconfig: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       globby: 11.1.0
       ignore: 5.2.4
       is-plain-obj: 3.0.0
@@ -17198,7 +17202,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.11
       crc32: 0.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       seed-random: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -17978,7 +17982,7 @@ packages:
     engines: {node: '>=10.18.1'}
     dependencies:
       cross-fetch: 3.1.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       devtools-protocol: 0.0.981744
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -19672,7 +19676,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -19686,7 +19690,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -20115,7 +20119,7 @@ packages:
       colord: 2.9.3
       cosmiconfig: 7.1.0
       css-functions-list: 3.2.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       fast-glob: 3.3.1
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -20166,7 +20170,7 @@ packages:
       cosmiconfig: 8.3.6(typescript@5.0.2)
       css-functions-list: 3.2.0
       css-tree: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       fast-glob: 3.3.1
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -20229,11 +20233,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
-    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -21834,7 +21838,7 @@ packages:
     resolution: {integrity: sha512-NMp0YsBM40CuI5vWtHpjWOuf96rPfbpGkamlJpVwYvgenIh1ynRzqVnGfsnjofgz13T2qcKkdwJY0Y2X7z+W+w==}
     dependencies:
       '@babel/runtime': 7.22.11
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       progress-event: 1.0.0
       uuid: 7.0.3
       wp-error: 1.3.0


### PR DESCRIPTION
## Description

The tooltip in the preheader was hard to discover. It has been removed, and the help text is now below the input field. 

## Linked tickets

[MAILPOET-5757]

## QA notes

It is a new UI element, so some cross-browser check would be nice; check if the counter works appropriately, if it turns yellow after 80 characters and red after 150.

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5757]: https://mailpoet.atlassian.net/browse/MAILPOET-5757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ