### PR TITLE
Feat/add support for fetching campaigns to the mailpoet marketing channel - MAILPOET-5698

### DIFF
--- a/mailpoet/assets/js/src/automation/templates/index.tsx
+++ b/mailpoet/assets/js/src/automation/templates/index.tsx
@@ -35,6 +35,15 @@ const tabs = [
 ];
 
 function Templates(): JSX.Element {
+  if (window.location.search.includes('loadedvia=woo_multichannel_dashboard')) {
+    window.MailPoet.trackEvent(
+      'MailPoet - WooCommerce Multichannel Marketing dashboard > Automation template selection page',
+      {
+        'WooCommerce version': window.mailpoet_woocommerce_version,
+      },
+    );
+  }
+
   return (
     <div className="mailpoet-main-container">
       <TopBarWithBeamer />

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -195,11 +195,11 @@ const routes = [
   },
   /* New newsletter: types */
   {
-    path: '/new/standard',
+    path: '/new/standard/(.*)?',
     render: withBoundary(NewsletterTypeStandard),
   },
   {
-    path: '/new/notification',
+    path: '/new/notification/(.*)?',
     render: withBoundary(NewsletterNotification),
   },
   {

--- a/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
@@ -33,6 +33,17 @@ class NewsletterNotificationComponent extends Component {
     };
   }
 
+  componentDidMount() {
+    if (window.location.hash.includes('loadedvia=woo_multichannel_dashboard')) {
+      window.MailPoet.trackEvent(
+        'MailPoet - WooCommerce Multichannel Marketing dashboard > Create post notification page',
+        {
+          'WooCommerce version': window.mailpoet_woocommerce_version,
+        },
+      );
+    }
+  }
+
   handleValueChange = (event) => {
     const state = this.state;
     state[event.target.name] = event.target.value;

--- a/mailpoet/assets/js/src/newsletters/types/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/standard.jsx
@@ -20,6 +20,16 @@ class NewsletterStandardComponent extends Component {
       },
     })
       .done((response) => {
+        if (
+          window.location.hash.includes('loadedvia=woo_multichannel_dashboard')
+        ) {
+          window.MailPoet.trackEvent(
+            'MailPoet - WooCommerce Multichannel Marketing dashboard > Newsletter template selection page',
+            {
+              'WooCommerce version': window.mailpoet_woocommerce_version,
+            },
+          );
+        }
         this.showTemplateSelection(response.data.id);
       })
       .fail((response) => {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -625,6 +625,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\WooSystemInfo::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\WooSystemInfoController::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\MultichannelMarketing\MPMarketingChannelController::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\MultichannelMarketing\MPMarketingChannelDataController::class)->setPublic(true);
 
     // WooCommerce Subscriptions
     $container->autowire(\MailPoet\WooCommerce\WooCommerceSubscriptions\Helper::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -157,7 +157,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
           'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
           'mailpoet',
         ),
-        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard'),
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard/loadedvia=woo_multichannel_dashboard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(
@@ -168,7 +168,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
           'Let MailPoet email your subscribers with your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
           'mailpoet',
         ),
-        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification'),
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification/loadedvia=woo_multichannel_dashboard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_AUTOMATIONS => new MarketingCampaignType(
@@ -176,7 +176,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
         $this,
         __('MailPoet Automations', 'mailpoet'),
         __('Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.', 'mailpoet'),
-        admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG),
+        admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG . '&loadedvia=woo_multichannel_dashboard'),
         $this->get_icon_url()
       ),
     ];

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -285,7 +285,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
             'campaignType' => $this->campaignTypes[self::CAMPAIGN_TYPE_NEWSLETTERS],
             'url' => admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '/#/stats/' . $newsLetterId),
             'price' => [
-                'amount' => $wooRevenue ? $wooRevenue->getValue() : 0,
+                'amount' => $wooRevenue ? $this->formatPrice($wooRevenue->getValue()) : 0,
                 'currency' => $userCurrency,
             ],
         ];
@@ -312,7 +312,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
         'campaignType' => $this->campaignTypes[self::CAMPAIGN_TYPE_POST_NOTIFICATIONS],
         'url' => admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '/#/stats/' . $newsLetterId),
         'price' => [
-          'amount' => $wooRevenue ? $wooRevenue->getValue() : 0,
+          'amount' => $wooRevenue ? $this->formatPrice($wooRevenue->getValue()) : 0,
           'currency' => $userCurrency,
         ],
       ];
@@ -343,7 +343,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
         'campaignType' => $this->campaignTypes[self::CAMPAIGN_TYPE_AUTOMATIONS],
         'url' => admin_url('admin.php?page=' . Menu::AUTOMATION_ANALYTICS_PAGE_SLUG . '&id=' . $automationId),
         'price' => [
-          'amount' => $automationStatistics['revenue']['current'] ?? 0,
+          'amount' => isset($automationStatistics['revenue']['current']) ? $this->formatPrice($automationStatistics['revenue']['current']) : 0,
           'currency' => $userCurrency,
         ],
       ];
@@ -375,5 +375,14 @@ class MPMarketingChannel implements MarketingChannelInterface {
               $this->getStandardNewsletterList()
           )
       );
+  }
+
+  /**
+   * Format amount to 2 dp
+   * @param string|int|float $amount
+   * @return string
+   */
+  private function formatPrice($amount): string {
+    return number_format((float)$amount, 2, '.', '');
   }
 }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -3,9 +3,11 @@
 namespace MailPoet\WooCommerce\MultichannelMarketing;
 
 use MailPoet\Features\FeaturesController;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\CdnAssetUrl;
+use MailPoet\WooCommerce\Helper;
 
 class MPMarketingChannelController {
 
@@ -18,23 +20,37 @@ class MPMarketingChannelController {
   /**
    * @var SettingsController
    */
-  protected $settings;
+  private $settings;
 
   /**
    * @var Bridge
    */
-  protected $bridge;
+  private $bridge;
+
+  /**
+   * @var NewslettersRepository
+   */
+  private $newsletterRepository;
+
+  /**
+   * @var Helper
+   */
+  private $woocommerceHelper;
 
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     FeaturesController $featuresController,
     SettingsController $settings,
-    Bridge $bridge
+    Bridge $bridge,
+    NewslettersRepository $newsletterRepository,
+    Helper $woocommerceHelper
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->featuresController = $featuresController;
     $this->settings = $settings;
     $this->bridge = $bridge;
+    $this->newsletterRepository = $newsletterRepository;
+    $this->woocommerceHelper = $woocommerceHelper;
   }
 
   public function registerMarketingChannel($registeredMarketingChannels): array {
@@ -46,7 +62,9 @@ class MPMarketingChannelController {
       new MPMarketingChannel(
         $this->cdnAssetUrl,
         $this->settings,
-        $this->bridge
+        $this->bridge,
+        $this->newsletterRepository,
+        $this->woocommerceHelper
       ),
     ]);
   }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -5,6 +5,7 @@ namespace MailPoet\WooCommerce\MultichannelMarketing;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\CdnAssetUrl;
@@ -43,6 +44,11 @@ class MPMarketingChannelController {
    */
   private $automationStorage;
 
+  /**
+   * @var NewsletterStatisticsRepository
+   */
+  private $newsletterStatisticsRepository;
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     FeaturesController $featuresController,
@@ -50,7 +56,8 @@ class MPMarketingChannelController {
     Bridge $bridge,
     NewslettersRepository $newsletterRepository,
     Helper $woocommerceHelper,
-    AutomationStorage $automationStorage
+    AutomationStorage $automationStorage,
+    NewsletterStatisticsRepository $newsletterStatisticsRepository
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->featuresController = $featuresController;
@@ -59,6 +66,7 @@ class MPMarketingChannelController {
     $this->newsletterRepository = $newsletterRepository;
     $this->automationStorage = $automationStorage;
     $this->woocommerceHelper = $woocommerceHelper;
+    $this->newsletterStatisticsRepository = $newsletterStatisticsRepository;
   }
 
   public function registerMarketingChannel($registeredMarketingChannels): array {
@@ -73,7 +81,8 @@ class MPMarketingChannelController {
         $this->bridge,
         $this->newsletterRepository,
         $this->woocommerceHelper,
-        $this->automationStorage
+        $this->automationStorage,
+        $this->newsletterStatisticsRepository
       ),
     ]);
   }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -2,79 +2,24 @@
 
 namespace MailPoet\WooCommerce\MultichannelMarketing;
 
-use MailPoet\Automation\Engine\Storage\AutomationStorage;
-use MailPoet\Automation\Integrations\MailPoet\Analytics\Controller\OverviewStatisticsController;
 use MailPoet\Features\FeaturesController;
-use MailPoet\Newsletter\NewslettersRepository;
-use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
-use MailPoet\Services\Bridge;
-use MailPoet\Settings\SettingsController;
-use MailPoet\Util\CdnAssetUrl;
-use MailPoet\WooCommerce\Helper;
 
 class MPMarketingChannelController {
-
-  /** @var CdnAssetUrl */
-  private $cdnAssetUrl;
 
   /** @var FeaturesController */
   private $featuresController;
 
   /**
-   * @var SettingsController
+   * @var MPMarketingChannelDataController
    */
-  private $settings;
-
-  /**
-   * @var Bridge
-   */
-  private $bridge;
-
-  /**
-   * @var NewslettersRepository
-   */
-  private $newsletterRepository;
-
-  /**
-   * @var Helper
-   */
-  private $woocommerceHelper;
-
-  /**
-   * @var AutomationStorage
-   */
-  private $automationStorage;
-
-  /**
-   * @var NewsletterStatisticsRepository
-   */
-  private $newsletterStatisticsRepository;
-
-  /**
-   * @var OverviewStatisticsController
-   */
-  private $overviewStatisticsController;
+  private $channelDataController;
 
   public function __construct(
-    CdnAssetUrl $cdnAssetUrl,
     FeaturesController $featuresController,
-    SettingsController $settings,
-    Bridge $bridge,
-    NewslettersRepository $newsletterRepository,
-    Helper $woocommerceHelper,
-    AutomationStorage $automationStorage,
-    NewsletterStatisticsRepository $newsletterStatisticsRepository,
-    OverviewStatisticsController $overviewStatisticsController
+    MPMarketingChannelDataController $channelDataController
   ) {
-    $this->cdnAssetUrl = $cdnAssetUrl;
     $this->featuresController = $featuresController;
-    $this->settings = $settings;
-    $this->bridge = $bridge;
-    $this->newsletterRepository = $newsletterRepository;
-    $this->automationStorage = $automationStorage;
-    $this->woocommerceHelper = $woocommerceHelper;
-    $this->newsletterStatisticsRepository = $newsletterStatisticsRepository;
-    $this->overviewStatisticsController = $overviewStatisticsController;
+    $this->channelDataController = $channelDataController;
   }
 
   public function registerMarketingChannel($registeredMarketingChannels): array {
@@ -84,14 +29,7 @@ class MPMarketingChannelController {
 
     return array_merge($registeredMarketingChannels, [
       new MPMarketingChannel(
-        $this->cdnAssetUrl,
-        $this->settings,
-        $this->bridge,
-        $this->newsletterRepository,
-        $this->woocommerceHelper,
-        $this->automationStorage,
-        $this->newsletterStatisticsRepository,
-        $this->overviewStatisticsController
+        $this->channelDataController
       ),
     ]);
   }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\WooCommerce\MultichannelMarketing;
 
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\Bridge;
@@ -37,19 +38,26 @@ class MPMarketingChannelController {
    */
   private $woocommerceHelper;
 
+  /**
+   * @var AutomationStorage
+   */
+  private $automationStorage;
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     FeaturesController $featuresController,
     SettingsController $settings,
     Bridge $bridge,
     NewslettersRepository $newsletterRepository,
-    Helper $woocommerceHelper
+    Helper $woocommerceHelper,
+    AutomationStorage $automationStorage
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->featuresController = $featuresController;
     $this->settings = $settings;
     $this->bridge = $bridge;
     $this->newsletterRepository = $newsletterRepository;
+    $this->automationStorage = $automationStorage;
     $this->woocommerceHelper = $woocommerceHelper;
   }
 
@@ -64,7 +72,8 @@ class MPMarketingChannelController {
         $this->settings,
         $this->bridge,
         $this->newsletterRepository,
-        $this->woocommerceHelper
+        $this->woocommerceHelper,
+        $this->automationStorage
       ),
     ]);
   }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -3,6 +3,7 @@
 namespace MailPoet\WooCommerce\MultichannelMarketing;
 
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Analytics\Controller\OverviewStatisticsController;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
@@ -49,6 +50,11 @@ class MPMarketingChannelController {
    */
   private $newsletterStatisticsRepository;
 
+  /**
+   * @var OverviewStatisticsController
+   */
+  private $overviewStatisticsController;
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     FeaturesController $featuresController,
@@ -57,7 +63,8 @@ class MPMarketingChannelController {
     NewslettersRepository $newsletterRepository,
     Helper $woocommerceHelper,
     AutomationStorage $automationStorage,
-    NewsletterStatisticsRepository $newsletterStatisticsRepository
+    NewsletterStatisticsRepository $newsletterStatisticsRepository,
+    OverviewStatisticsController $overviewStatisticsController
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->featuresController = $featuresController;
@@ -67,6 +74,7 @@ class MPMarketingChannelController {
     $this->automationStorage = $automationStorage;
     $this->woocommerceHelper = $woocommerceHelper;
     $this->newsletterStatisticsRepository = $newsletterStatisticsRepository;
+    $this->overviewStatisticsController = $overviewStatisticsController;
   }
 
   public function registerMarketingChannel($registeredMarketingChannels): array {
@@ -82,7 +90,8 @@ class MPMarketingChannelController {
         $this->newsletterRepository,
         $this->woocommerceHelper,
         $this->automationStorage,
-        $this->newsletterStatisticsRepository
+        $this->newsletterStatisticsRepository,
+        $this->overviewStatisticsController
       ),
     ]);
   }

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelDataController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelDataController.php
@@ -1,0 +1,223 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce\MultichannelMarketing;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Analytics\Controller\OverviewStatisticsController;
+use MailPoet\Automation\Integrations\MailPoet\Analytics\Entities\QueryWithCompare;
+use MailPoet\Config\Menu;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
+use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\CdnAssetUrl;
+use MailPoet\WooCommerce\Helper;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * Created to pass data to the `MPMarketingChannel`.
+ *
+ * We create an instance of this class with the MailPoet DI ContainerInterface
+ *
+ * This provides the class access to other MailPoet services,
+ *  preventing us from overloading the `MPMarketingChannelController` class with imports and duplicating efforts
+ */
+class MPMarketingChannelDataController {
+
+  /** @var CdnAssetUrl */
+  private $cdnAssetUrl;
+
+  /**
+   * @var SettingsController
+   */
+  private $settings;
+
+  /**
+   * @var Bridge
+   */
+  private $bridge;
+
+  /**
+   * @var NewslettersRepository
+   */
+  private $newsletterRepository;
+
+  /**
+   * @var Helper
+   */
+  private $woocommerceHelper;
+
+  /**
+   * @var AutomationStorage
+   */
+  private $automationStorage;
+
+  /**
+   * @var NewsletterStatisticsRepository
+   */
+  private $newsletterStatisticsRepository;
+
+  /**
+   * @var OverviewStatisticsController
+   */
+  private $overviewStatisticsController;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    SettingsController $settings,
+    Bridge $bridge,
+    NewslettersRepository $newsletterRepository,
+    Helper $woocommerceHelper,
+    AutomationStorage $automationStorage,
+    NewsletterStatisticsRepository $newsletterStatisticsRepository,
+    OverviewStatisticsController $overviewStatisticsController
+  ) {
+    $this->cdnAssetUrl = $cdnAssetUrl;
+    $this->settings = $settings;
+    $this->bridge = $bridge;
+    $this->newsletterRepository = $newsletterRepository;
+    $this->automationStorage = $automationStorage;
+    $this->woocommerceHelper = $woocommerceHelper;
+    $this->newsletterStatisticsRepository = $newsletterStatisticsRepository;
+    $this->overviewStatisticsController = $overviewStatisticsController;
+  }
+
+  public function getIconUrl(): string {
+    return $this->cdnAssetUrl->generateCdnUrl('icon-white-123x128.png');
+  }
+
+  /**
+   * Whether the task is completed.
+   * If the setting 'version' is not null it means the welcome wizard
+   * was already completed so we mark this task as completed as well.
+   */
+  public function isMPSetupComplete(): bool {
+    $version = $this->settings->get('version');
+
+    return $version !== null;
+  }
+
+  /**
+   * Is MSS Enabled?
+   * @return bool
+   */
+  public function isMailPoetSendingServiceEnabled(): bool {
+    return $this->bridge->isMailpoetSendingServiceEnabled();
+  }
+
+  /**
+   * Check for error status. It's null by default when there isn't an error
+   * @return mixed
+   */
+  public function getMailPoetSendingStatus() {
+    return $this->settings->get('mta_log.status');
+  }
+
+  /**
+   * Get the number of errors available
+   * Mostly likely sending errors
+   * @return int
+   */
+  public function getErrorCount(): int {
+    $error = $this->settings->get('mta_log.error');
+
+    $count = 0;
+
+    if (!empty($error)) {
+      $count++;
+    }
+
+    $validationError = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
+
+    if ($validationError && isset($validationError['invalid_sender_address'])) {
+      $count++;
+    }
+
+    return $count;
+  }
+
+  public function getStandardNewsletterList($campaignType): array {
+    return $this->getNewsletterTypeLists(
+      $this->newsletterRepository->getStandardNewsletterListWithMultipleStatuses(10),
+      $campaignType
+    );
+  }
+
+  public function getPostNotificationNewsletters($campaignType): array {
+    return $this->getNewsletterTypeLists(
+      // fetch the most recently sent post-notification history newsletters limited to ten
+      $this->newsletterRepository->getNotificationHistoryItems(10),
+      $campaignType
+    );
+  }
+
+  public function getAutomations($campaignType): array {
+    $result = [];
+
+    // Fetch Automation stats within the last 90 days
+    $primaryAfter = new \DateTimeImmutable((string)Carbon::now()->subDays(90)->toISOString());
+    $primaryBefore = new \DateTimeImmutable((string)Carbon::now()->toISOString());
+    $now = new \DateTimeImmutable('');
+
+    $query = new QueryWithCompare($primaryAfter, $primaryBefore, $now, $now);
+    $userCurrency = $this->woocommerceHelper->getWoocommerceCurrency();
+
+    foreach ($this->automationStorage->getAutomations([Automation::STATUS_ACTIVE]) as $automation) {
+      $automationId = (string)$automation->getId();
+
+      $automationStatistics = $this->overviewStatisticsController->getStatisticsForAutomation($automation, $query);
+
+      $result[] = [
+        'id' => $automationId,
+        'name' => $automation->getName(),
+        'campaignType' => $campaignType,
+        'url' => admin_url('admin.php?page=' . Menu::AUTOMATION_ANALYTICS_PAGE_SLUG . '&id=' . $automationId),
+        'price' => [
+          'amount' => isset($automationStatistics['revenue']['current']) ? $this->formatPrice($automationStatistics['revenue']['current']) : 0,
+          'currency' => $userCurrency,
+        ],
+      ];
+    }
+
+    return $result;
+  }
+
+  private function getNewsletterTypeLists($allNewsletters, $campaignType): array {
+    $result = [];
+
+    $userCurrency = $this->woocommerceHelper->getWoocommerceCurrency();
+
+    // fetch the most recent newsletters limited to ten
+    foreach ($allNewsletters as $newsletter) {
+      $newsLetterId = (string)$newsletter->getId();
+
+      /** @var ?WooCommerceRevenue $wooRevenue */
+      $wooRevenue = $this->newsletterStatisticsRepository->getWooCommerceRevenue($newsletter);
+
+      $result[] = [
+        'id' => $newsLetterId,
+        'name' => $newsletter->getSubject(),
+        'campaignType' => $campaignType,
+        'url' => admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '/#/stats/' . $newsLetterId),
+        'price' => [
+          'amount' => $wooRevenue ? $this->formatPrice($wooRevenue->getValue()) : 0,
+          'currency' => $userCurrency,
+        ],
+      ];
+    }
+
+    return $result;
+  }
+
+  /**
+   * Format amount to 2 dp
+   * @param string|int|float $amount
+   * @return string
+   */
+  private function formatPrice($amount): string {
+    return number_format((float)$amount, 2, '.', '');
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for fetching campaigns to the mailpoet marketing channel.


## Code review notes

Please check commits

## QA notes

Start with the QA notes here: https://github.com/mailpoet/mailpoet/pull/5289
Note: Please open the campaign item in a new tab. A bug within Woo Core (fixed in 8.4.0) prevents you from navigating directly to the campaign item page.

* Create some newsletters, post notifications, automation, etc
* Visit the WooCommerce Marketing tab at `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
* You should see the Campaign list
* Right-click and select any of the items (open in a new tab)

## Linked PRs

Child of https://github.com/mailpoet/mailpoet/pull/5314

## Linked tickets

[MAILPOET-5698](https://mailpoet.atlassian.net/browse/MAILPOET-5698)

## After-merge notes

Please merge after https://github.com/mailpoet/mailpoet/pull/5314

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5698]: https://mailpoet.atlassian.net/browse/MAILPOET-5698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ