### PR TITLE
Refactor \MailPoet\Segments\WP to use Doctrine instead of Paris [MAILPOET-5752]

### DIFF
--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -69,7 +69,7 @@ class SegmentsRepository extends Repository {
       ->getResult();
   }
 
-  public function getWPUsersSegment(): ?SegmentEntity {
+  public function getWPUsersSegment(): SegmentEntity {
     $segment = $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
 
     if (!$segment) {

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -263,7 +263,7 @@ class WP {
     $this->insertUsersToSegment();
     $this->removeOrphanedSubscribers();
     $this->subscribersRepository->invalidateTotalSubscribersCache();
-    $this->subscribersRepository->detachAll();
+    $this->subscribersRepository->refreshAll();
 
     return true;
   }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -263,6 +263,7 @@ class WP {
     $this->insertUsersToSegment();
     $this->removeOrphanedSubscribers();
     $this->subscribersRepository->invalidateTotalSubscribersCache();
+    $this->subscribersRepository->detachAll();
 
     return true;
   }

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -183,6 +183,7 @@ class ImportExportRepository {
       " . implode(' AND ', $keyColumnsConditions) . "
     ", $parameters, $parameterTypes);
     $this->notifyUpdates($className, $columns, $data);
+    $this->entityManager->clear($className);
     return $count;
   }
 

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -195,8 +195,12 @@ class ImportExportRepository {
       " . implode(' AND ', $keyColumnsConditions) . "
     ", $parameters, $parameterTypes);
     $this->notifyUpdates($className, $columns, $data);
-    $this->subscribersRepository->detachAll();
-    $this->subscriberCustomFieldRepository->detachAll();
+    if ($className === SubscriberEntity::class) {
+      $this->subscribersRepository->refreshAll();
+    }
+    if ($className === SubscriberCustomFieldEntity::class) {
+      $this->subscriberCustomFieldRepository->refreshAll();
+    }
     return $count;
   }
 

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -10,6 +10,8 @@ use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\DynamicSegments\FilterHandler;
+use MailPoet\Subscribers\SubscriberCustomFieldRepository;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Driver\Statement;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -52,14 +54,24 @@ class ImportExportRepository {
   /** @var FilterHandler */
   private $filterHandler;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var SubscriberCustomFieldRepository */
+  private $subscriberCustomFieldRepository;
+
   public function __construct(
     EntityManager $entityManager,
     SubscriberChangesNotifier $changesNotifier,
-    FilterHandler $filterHandler
+    FilterHandler $filterHandler,
+    SubscribersRepository $subscribersRepository,
+    SubscriberCustomFieldRepository $subscriberCustomFieldRepository
   ) {
     $this->entityManager = $entityManager;
     $this->subscriberChangesNotifier = $changesNotifier;
     $this->filterHandler = $filterHandler;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->subscriberCustomFieldRepository = $subscriberCustomFieldRepository;
   }
 
   /**
@@ -183,7 +195,8 @@ class ImportExportRepository {
       " . implode(' AND ', $keyColumnsConditions) . "
     ", $parameters, $parameterTypes);
     $this->notifyUpdates($className, $columns, $data);
-    $this->entityManager->clear($className);
+    $this->subscribersRepository->detachAll();
+    $this->subscriberCustomFieldRepository->detachAll();
     return $count;
   }
 

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -12,6 +12,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
+use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -38,14 +39,19 @@ class SubscribersRepository extends Repository {
   /** @var SubscriberChangesNotifier */
   private $changesNotifier;
 
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
   public function __construct(
     EntityManager $entityManager,
     SubscriberChangesNotifier $changesNotifier,
-    WPFunctions $wp
+    WPFunctions $wp,
+    SegmentsRepository $segmentsRepository
   ) {
     $this->wp = $wp;
     parent::__construct($entityManager);
     $this->changesNotifier = $changesNotifier;
+    $this->segmentsRepository = $segmentsRepository;
   }
 
   protected function getEntityClassName() {
@@ -551,6 +557,24 @@ class SubscribersRepository extends Repository {
 
     $this->changesNotifier->subscribersUpdated($ids);
     return $count;
+  }
+
+  public function removeOrphanedSubscribersFromWpSegment(): void {
+    global $wpdb;
+
+    $segmentId = $this->segmentsRepository->getWpUsersSegment()->getId();
+
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+
+    $this->entityManager->getConnection()->executeStatement(
+      "DELETE s
+       FROM {$subscribersTable} s
+       INNER JOIN {$subscriberSegmentsTable} ss ON s.id = ss.subscriber_id
+       LEFT JOIN {$wpdb->users} u ON s.wp_user_id = u.id
+       WHERE ss.segment_id = :segmentId AND (u.id IS NULL OR s.email = '')",
+      ['segmentId' => $segmentId], ['segmentId' => \PDO::PARAM_INT]
+    );
   }
 
   /**

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -577,6 +577,17 @@ class SubscribersRepository extends Repository {
     );
   }
 
+  public function removeByWpUserIds(array $wpUserIds) {
+    $queryBuilder = $this->entityManager->createQueryBuilder();
+
+    $queryBuilder
+      ->delete(SubscriberEntity::class, 's')
+      ->where('s.wpUserId IN (:wpUserIds)')
+      ->setParameter('wpUserIds', $wpUserIds);
+
+    return $queryBuilder->getQuery()->execute();
+  }
+
   /**
    * @return int - number of processed ids
    */

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -581,11 +581,6 @@ parameters:
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/WP.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Segments/WooCommerce.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -571,11 +571,6 @@ parameters:
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/WP.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: ../../lib/Segments/WooCommerce.php

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -83,6 +83,19 @@ class IntegrationTester extends \Codeception\Actor {
     return $userId;
   }
 
+  /**
+   * Deletes a WP user directly from the database without triggering any hooks.
+   * Needed to be able to test deleting orphaned subscribers.
+   */
+  public function deleteWPUserFromDatabase(int $id): void {
+    global $wpdb;
+
+    $this->entityManager->getConnection()->executeStatement(
+      "DELETE FROM {$wpdb->users} WHERE id = :id",
+      ['id' => $id], ['id' => \PDO::PARAM_INT]
+    );
+  }
+
   public function createWordPressTerm(string $term, string $taxonomy, array $args = []): int {
     $term = wp_insert_term($term, $taxonomy, $args);
     if ($term instanceof WP_Error) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviewsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviewsTest.php
@@ -49,7 +49,7 @@ class WooCommerceNumberOfReviewsTest extends \MailPoetTest {
     $this->tester->createWooProductReview($customerId, 'greaterthantest@e.com', $this->productId, 2, Carbon::now()->subDay());
     $customerId = $this->tester->createCustomer('oneReviewTest@e.com');
     $this->tester->createWooProductReview($customerId, 'onereviewtest@e.com', $this->productId, 1, Carbon::now()->subDay());
-    $this->assertFilterReturnsEmails('any', '>', 1, 200, 'inTheLast', ['greaterthantest@e.com']);
+    $this->assertFilterReturnsEmails('any', '>', 1, 200, 'inTheLast', ['greaterThanTest@e.com']);
   }
 
   public function testItHandlesLessThan(): void {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -654,11 +654,11 @@ class WPTest extends \MailPoetTest {
     global $wpdb;
 
     $this->entityManager->getConnection()->executeQuery(
-      "DELETE FROM {$wpdb->usermeta} WHERE user_id IN (select id from {$wpdb->users} WHERE user_email LIKE 'user-sync-test%')",
+      "DELETE FROM {$wpdb->users} WHERE user_login != 'admin'"
     );
 
     $this->entityManager->getConnection()->executeQuery(
-      "DELETE FROM {$wpdb->users} WHERE user_email LIKE 'user-sync-test%' OR user_login LIKE 'user-sync-test%'"
+      "DELETE FROM {$wpdb->usermeta} WHERE user_id NOT IN (select id from {$wpdb->users})",
     );
   }
 

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -246,7 +246,7 @@ class WPTest extends \MailPoetTest {
     $this->updateWPUserEmail($id, '');
     $this->wpSegment->synchronizeUsers();
     verify($this->subscribersRepository->findOneBy(['wpUserId' => $id]))->null();
-    $this->deleteWPUser($id);
+    $this->tester->deleteWPUserFromDatabase($id);
   }
 
   public function testRemovesUsersWithInvalidEmailsFromSunscribersDuringSynchronization(): void {
@@ -255,7 +255,7 @@ class WPTest extends \MailPoetTest {
     $this->updateWPUserEmail($id, 'ivalid.@email.com');
     $this->wpSegment->synchronizeUsers();
     verify($this->subscribersRepository->findOneBy(['wpUserId' => $id]))->null();
-    $this->deleteWPUser($id);
+    $this->tester->deleteWPUserFromDatabase($id);
   }
 
   public function testItDoesNotSynchronizeEmptyEmailsForNewUsers(): void {
@@ -263,7 +263,7 @@ class WPTest extends \MailPoetTest {
     $this->updateWPUserEmail($id, '');
     $this->wpSegment->synchronizeUsers();
     verify($this->subscribersRepository->findOneBy(['wpUserId' => $id]))->null();
-    $this->deleteWPUser($id);
+    $this->tester->deleteWPUserFromDatabase($id);
   }
 
   public function testItSynchronizeFirstNames(): void {
@@ -372,7 +372,7 @@ class WPTest extends \MailPoetTest {
     $this->insertUser();
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
-    $this->deleteWPUser($id);
+    $this->tester->deleteWPUserFromDatabase($id);
     $this->wpSegment->synchronizeUsers();
     $subscribers = $this->subscribersRepository->findBy(['wpUserId' => $this->userIds]);
     verify(count($subscribers))->equals(1);
@@ -720,17 +720,6 @@ class WPTest extends \MailPoetTest {
        WHERE
          id = %s
     ', $wpdb->users, $name, $id));
-  }
-
-  private function deleteWPUser(int $id): void {
-    global $wpdb;
-    $db = ORM::getDb();
-    $db->exec(sprintf('
-       DELETE FROM
-         %s
-       WHERE
-         id = %s
-    ', $wpdb->users, $id));
   }
 
   private function clearEmail(SubscriberEntity $subscriber): void {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -620,6 +620,28 @@ class WPTest extends \MailPoetTest {
     remove_role('customer');
   }
 
+  public function testItDoesntCreateSubscriberForWPUserWithInvalidEmail() {
+    $userId = wp_create_user(
+      'invalid-email',
+      'password',
+      'editor@localhost'
+    );
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $userId]);
+    $this->assertNull($subscriber);
+  }
+
+  public function testItCreatesSubscriberWhenWpUserIsCreated() {
+    $userId = wp_create_user(
+      'editor',
+      'password',
+      'editor@email.com'
+    );
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $userId]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame('editor', $subscriber->getFirstName());
+    $this->assertSame('editor@email.com', $subscriber->getEmail());
+  }
+
   public function _after(): void {
     parent::_after();
     $this->cleanData();

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -509,7 +509,12 @@ class ClicksTest extends \MailPoetTest {
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
     $data = $this->trackData;
     $data->userAgent = 'User Agent';
-    $subscribersRepository = new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock);
+    $subscribersRepository = $this->getServiceWithOverrides(SubscribersRepository::class,
+      [
+        'changesNotifier' => new SubscriberChangesNotifier($wpMock),
+        'wp' => $wpMock,
+      ]
+    );
     $statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
     $opens = new Opens(
       $statisticsOpensRepository,
@@ -547,7 +552,12 @@ class ClicksTest extends \MailPoetTest {
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
     $data = $this->trackData;
     $data->userAgent = null;
-    $subscribersRepository = new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock);
+    $subscribersRepository = $this->getServiceWithOverrides(SubscribersRepository::class,
+      [
+        'changesNotifier' => new SubscriberChangesNotifier($wpMock),
+        'wp' => $wpMock,
+      ]
+    );
     $statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
     $opens = new Opens(
       $statisticsOpensRepository,
@@ -585,7 +595,12 @@ class ClicksTest extends \MailPoetTest {
     $clicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
     $data = $this->trackData;
     $data->userAgent = UserAgentEntity::MACHINE_USER_AGENTS[0];
-    $subscribersRepository = new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock);
+    $subscribersRepository = $this->getServiceWithOverrides(SubscribersRepository::class,
+      [
+        'changesNotifier' => new SubscriberChangesNotifier($wpMock),
+        'wp' => $wpMock,
+      ]
+    );
     $statisticsOpensRepository = $this->diContainer->get(StatisticsOpensRepository::class);
     $opens = new Opens(
       $statisticsOpensRepository,

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -366,7 +366,12 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
-      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock),
+      $this->getServiceWithOverrides(SubscribersRepository::class,
+        [
+          'changesNotifier' => new SubscriberChangesNotifier($wpMock),
+          'wp' => $wpMock,
+        ]
+      ),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -390,7 +395,12 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
-      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock),
+      $this->getServiceWithOverrides(SubscribersRepository::class,
+        [
+          'changesNotifier' => new SubscriberChangesNotifier($wpMock),
+          'wp' => $wpMock,
+        ]
+      ),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -414,7 +424,12 @@ class OpensTest extends \MailPoetTest {
     $opens = Stub::construct($this->opens, [
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
-      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($wpMock), $wpMock),
+      $this->getServiceWithOverrides(SubscribersRepository::class,
+        [
+          'changesNotifier' => new SubscriberChangesNotifier($wpMock),
+          'wp' => $wpMock,
+        ]
+      ),
     ], [
       'returnResponse' => null,
     ], $this);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -713,7 +713,6 @@ class ImportTest extends \MailPoetTest {
     $import = $this->createImportInstance($data);
     $import->process();
 
-    $this->entityManager->clear();
     $imported = $this->subscriberRepository->findOneBy(['email' => 'mary@jane.com']);
     $this->assertInstanceOf(SubscriberEntity::class, $imported);
     verify($imported->getFirstName())->equals($beforeImport->getFirstName()); // Subscriber name was synchronized from WP

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -415,6 +415,20 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $this->assertSame($subscribers[1], $subscriber3);
   }
 
+  public function testRemoveByWpUserIds(): void {
+    $wpUserId1 = $this->tester->createWordPressUser('subscriber1@email.com', 'author');
+    $wpUserId2 = $this->tester->createWordPressUser('subscriber2@email.com', 'author');
+    $wpUserId3 = $this->tester->createWordPressUser('subscriber3@email.com', 'author');
+    $subscriber3 = $this->repository->findOneBy(['wpUserId' => $wpUserId3]);
+
+    $deletedRows = $this->repository->removeByWpUserIds([$wpUserId1, $wpUserId2]);
+
+    $this->assertSame(2, $deletedRows);
+    $subscribers = $this->repository->findAll();
+    $this->assertCount(1, $subscribers);
+    $this->assertSame($subscribers[0], $subscriber3);
+  }
+  
   private function createSubscriber(string $email, ?DateTimeImmutable $deletedAt = null): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -398,6 +398,23 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     verify($this->repository->getMaxSubscriberId())->equals($subscriberTwo->getId());
   }
 
+  public function testRemoveOrphanedSubscribersFromWpSegment(): void {
+    $wpUserId1 = $this->tester->createWordPressUser('subscriber1@email.com', 'author');
+    $wpUserId2 = $this->tester->createWordPressUser('subscriber2@email.com', 'author');
+    $wpUserId3 = $this->tester->createWordPressUser('subscriber3@email.com', 'author');
+    $subscriber2 = $this->repository->findOneBy(['wpUserId' => $wpUserId2]);
+    $subscriber3 = $this->repository->findOneBy(['wpUserId' => $wpUserId3]);
+
+    $this->tester->deleteWPUserFromDatabase($wpUserId1);
+
+    $this->repository->removeOrphanedSubscribersFromWpSegment();
+
+    $subscribers = $this->repository->findAll();
+    $this->assertCount(2, $subscribers);
+    $this->assertSame($subscribers[0], $subscriber2);
+    $this->assertSame($subscribers[1], $subscriber3);
+  }
+
   private function createSubscriber(string $email, ?DateTimeImmutable $deletedAt = null): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);

--- a/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriberEngagementTest.php
@@ -28,9 +28,15 @@ class SubscriberEngagementTest extends \MailPoetTest {
   public function _before() {
     $this->wooCommerceHelperMock = $this->createMock(Helper::class);
     $this->wpMock = $this->createMock(WPFunctions::class);
+    $subscribersRepository = $this->getServiceWithOverrides(SubscribersRepository::class,
+      [
+        'changesNotifier' => new SubscriberChangesNotifier($this->wpMock),
+        'wp' => $this->wpMock,
+      ]
+    );
     $this->subscriberEngagement = new SubscriberEngagement(
       $this->wooCommerceHelperMock,
-      new SubscribersRepository($this->entityManager, new SubscriberChangesNotifier($this->wpMock), $this->wpMock)
+      $subscribersRepository
     );
   }
 


### PR DESCRIPTION
## Description

Rewrites the WordPress user segment to use Doctrine.

## Code review notes

_N/A_

## QA notes

Please ensure that WordPress user synchronization to the MailPoet segment works, welcome emails are scheduled, and test subscriber import and export.

**When QA passes, you can merge this PR (no need to assign back to @JanJakes).**

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5752]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5752]: https://mailpoet.atlassian.net/browse/MAILPOET-5752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ