### PR TITLE
Refactor Mailer::formatSubscriberNameAndEmailAddress() to use Doctrine 

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Mailer.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Mailer.php
@@ -8,7 +8,6 @@ use MailPoet\Mailer\Mailer as MailerInstance;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\Methods\MailPoet;
-use MailPoet\Models\Subscriber;
 
 class Mailer {
   /** @var MailerFactory */
@@ -62,9 +61,7 @@ class Mailer {
   }
 
   public function prepareSubscriberForSending(SubscriberEntity $subscriber) {
-    $subscriberModel = Subscriber::findOne($subscriber->getId());
-
-    return $this->mailer->formatSubscriberNameAndEmailAddress($subscriberModel);
+    return $this->mailer->formatSubscriberNameAndEmailAddress($subscriber);
   }
 
   public function sendBulk($preparedNewsletters, $preparedSubscribers, $extraParams = []) {

--- a/mailpoet/lib/Mailer/Mailer.php
+++ b/mailpoet/lib/Mailer/Mailer.php
@@ -4,7 +4,6 @@ namespace MailPoet\Mailer;
 
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Methods\MailerMethod;
-use MailPoet\Models\Subscriber;
 
 class Mailer {
   /** @var MailerMethod */
@@ -25,20 +24,23 @@ class Mailer {
   }
 
   public function send($newsletter, $subscriber, $extraParams = []) {
-    // This if adds support for code that calls this method to use SubscriberEntity while the Mailer class is still using the old model.
-    // Once we add support for SubscriberEntity in the Mailer class, this if can be removed.
-    if ($subscriber instanceof SubscriberEntity) {
-      $subscriber = Subscriber::findOne($subscriber->getId());
-    }
     $subscriber = $this->formatSubscriberNameAndEmailAddress($subscriber);
     return $this->mailerMethod->send($newsletter, $subscriber, $extraParams);
   }
 
   /**
-   * @param  \MailPoet\Models\Subscriber|array|string $subscriber
+   * @param SubscriberEntity|array|string $subscriber
    */
   public function formatSubscriberNameAndEmailAddress($subscriber) {
-    $subscriber = (is_object($subscriber)) ? $subscriber->asArray() : $subscriber;
+    if ($subscriber instanceof SubscriberEntity) {
+      $prepareSubscriber = [];
+      $prepareSubscriber['email'] = $subscriber->getEmail();
+      $prepareSubscriber['first_name'] = $subscriber->getFirstName();
+      $prepareSubscriber['last_name'] = $subscriber->getLastName();
+
+      $subscriber = $prepareSubscriber;
+    }
+
     if (!is_array($subscriber)) return $subscriber;
     if (isset($subscriber['address'])) $subscriber['email'] = $subscriber['address'];
     $firstName = (isset($subscriber['first_name'])) ? $subscriber['first_name'] : '';

--- a/mailpoet/tests/integration/Mailer/MailerTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerTest.php
@@ -79,6 +79,27 @@ class MailerTest extends \MailPoetTest {
         'email' => 'test@email.com',
       ])
     )->equals('First Last <test@email.com>');
+
+    $subscriber = (new SubscriberFactory())
+      ->withFirstName('First')
+      ->withLastName('Last')
+      ->withEmail('test1@email.com')
+      ->create();
+    verify($mailer->formatSubscriberNameAndEmailAddress($subscriber))
+      ->equals('First Last <test1@email.com>');
+
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('test2@email.com')
+      ->create();
+    verify($mailer->formatSubscriberNameAndEmailAddress($subscriber))
+      ->equals('test2@email.com');
+
+    $subscriber = (new SubscriberFactory())
+      ->withLastName('Last')
+      ->withEmail('test3@email.com')
+      ->create();
+    verify($mailer->formatSubscriberNameAndEmailAddress($subscriber))
+      ->equals('Last <test3@email.com>');
   }
 
   public function testItCanSend() {


### PR DESCRIPTION
## Description

This PR should be reviewed after https://github.com/mailpoet/mailpoet/pull/5317.

## Code review notes

_N/A_

## QA notes

Please, test that when sending an email, a subscriber's name is correctly formatted in the received email headers (e.g., `John Doe <john.doe@gmail.com>`).

**When QA passes, you can merge this PR (no need to assign back to @JanJakes).**

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5758]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5758]: https://mailpoet.atlassian.net/browse/MAILPOET-5758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ