### PR TITLE
Update email stats page - MAILPOET-5699

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_stats.scss
+++ b/mailpoet/assets/css/src/components-plugin/_stats.scss
@@ -90,6 +90,21 @@
   }
 }
 
+.mailpoet-no-box-shadow {
+  box-shadow: none !important;
+}
+
+.mailpoet-stats-buttons-header {
+  margin-left: 0.5rem;
+}
+
+.mailpoet-stats-button-group {
+  align-content: center;
+  display: flex;
+  flex-direction: row-reverse;
+  flex-wrap: wrap;
+}
+
 .mailpoet-stats-general-read-more {
   font-weight: bold;
   margin-bottom: 0;

--- a/mailpoet/assets/css/src/components-plugin/_stats.scss
+++ b/mailpoet/assets/css/src/components-plugin/_stats.scss
@@ -40,6 +40,12 @@
       }
     }
   }
+
+  .components-dropdown {
+    .components-button.is-primary {
+      box-shadow: none;
+    }
+  }
 }
 
 .mailpoet-stats-info,

--- a/mailpoet/assets/css/src/components-plugin/_stats.scss
+++ b/mailpoet/assets/css/src/components-plugin/_stats.scss
@@ -94,7 +94,7 @@
   box-shadow: none !important;
 }
 
-.mailpoet-stats-buttons-header {
+.mailpoet-stats-has-margin-left {
   margin-left: 0.5rem;
 }
 
@@ -106,6 +106,9 @@
 }
 
 .mailpoet-stats-general-read-more {
+  display: flex;
+  flex-direction: row-reverse;
+  flex-wrap: wrap;
   font-weight: bold;
   margin-bottom: 0;
   text-align: right;

--- a/mailpoet/assets/js/src/common/index.ts
+++ b/mailpoet/assets/js/src/common/index.ts
@@ -15,3 +15,4 @@ export * from './utils';
 export * from './thumbnail';
 export * from './controls';
 export * from './confirm-alert';
+export * from './newsletter-status-string';

--- a/mailpoet/assets/js/src/common/newsletter-status-string.ts
+++ b/mailpoet/assets/js/src/common/newsletter-status-string.ts
@@ -1,0 +1,14 @@
+import { __ } from '@wordpress/i18n';
+import { NewsletterStatus } from './newsletter';
+
+const STATUSES = {
+  [NewsletterStatus.Draft]: __('Draft', 'mailpoet'),
+  [NewsletterStatus.Scheduled]: __('Scheduled', 'mailpoet'),
+  [NewsletterStatus.Sending]: __('Sending', 'mailpoet'),
+  [NewsletterStatus.Sent]: __('Sent', 'mailpoet'),
+  [NewsletterStatus.Active]: __('Active', 'mailpoet'),
+  [NewsletterStatus.Corrupt]: __('Corrupt', 'mailpoet'),
+};
+
+export const getNewsletterStatusString = (status: string) =>
+  String(STATUSES[status]);

--- a/mailpoet/assets/js/src/common/utils.ts
+++ b/mailpoet/assets/js/src/common/utils.ts
@@ -5,3 +5,8 @@ export const isTruthy = (value: string | number | boolean) =>
 export const stopLinkPropagation = (event: React.MouseEvent) => {
   event.stopPropagation();
 };
+
+export const capitalizeFirstLetter = (str: string) => {
+  const theString = String(str);
+  return theString.charAt(0).toUpperCase() + theString.slice(1);
+};

--- a/mailpoet/assets/js/src/common/utils.ts
+++ b/mailpoet/assets/js/src/common/utils.ts
@@ -5,8 +5,3 @@ export const isTruthy = (value: string | number | boolean) =>
 export const stopLinkPropagation = (event: React.MouseEvent) => {
   event.stopPropagation();
 };
-
-export const capitalizeFirstLetter = (str: string) => {
-  const theString = String(str);
-  return theString.charAt(0).toUpperCase() + theString.slice(1);
-};

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
@@ -282,7 +282,7 @@ function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
           <a
             href={`admin.php?page=mailpoet-newsletters#/sending-status/${newsletter.id}`}
           >
-            {__('Sending stats', 'mailpoet')}
+            {__('Sending status', 'mailpoet')}
           </a>
         </p>
       </div>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
@@ -268,15 +268,24 @@ function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
         )}
         {!isWoocommerceActive && <div />}
       </Grid.ThreeColumns>
-      <p className="mailpoet-stats-general-read-more">
-        <a
-          href="https://kb.mailpoet.com/article/190-whats-a-good-email-open-rate"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {__('Read more on stats.', 'mailpoet')}
-        </a>
-      </p>
+      <div className="mailpoet-stats-general-read-more">
+        <p className="mailpoet-stats-has-margin-left">
+          <a
+            href="https://kb.mailpoet.com/article/190-whats-a-good-email-open-rate"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {__('Read more on stats.', 'mailpoet')}
+          </a>
+        </p>
+        <p>
+          <a
+            href={`admin.php?page=mailpoet-newsletters#/sending-status/${newsletter.id}`}
+          >
+            {__('Sending stats', 'mailpoet')}
+          </a>
+        </p>
+      </div>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -120,7 +120,9 @@ type Props = {
 
 function NewsletterStatsInfo({ newsletter }: Props) {
   const newsletterDate =
-    newsletter.queue.scheduled_at || newsletter.queue.created_at;
+    newsletter?.queue?.scheduled_at ||
+    newsletter?.queue?.created_at ||
+    newsletter?.created_at;
   return (
     <Grid.ThreeColumns className="mailpoet-stats-info">
       <div>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -224,7 +224,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
                   aria-expanded={isOpen}
                   variant="primary"
                 >
-                  <br />
+                  &nbsp;
                   <Icon icon={chevronDown} size={18} />
                 </Button>
               </ButtonGroup>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -181,7 +181,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             {__('Preview', 'mailpoet')}
           </Button>
           <Dropdown
-            className="mailpoet-stats-buttons-header"
+            className="mailpoet-stats-has-margin-left"
             focusOnMount={false}
             popoverProps={{ placement: 'bottom-end' }}
             renderToggle={({ isOpen, onToggle }) => (

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -1,5 +1,11 @@
 import { __ } from '@wordpress/i18n';
-import { Button, ButtonGroup, Dropdown, MenuItem } from '@wordpress/components';
+import {
+  Button,
+  ButtonGroup,
+  Dropdown,
+  MenuItem,
+  MenuGroup,
+} from '@wordpress/components';
 import { chevronDown, Icon } from '@wordpress/icons';
 import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
@@ -61,7 +67,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
           </div>
         </div>
       </div>
-      <div className="mailpoet-stats-info-sender-preview">
+      <div className="mailpoet-stats-button-group">
         <ButtonGroup>
           <Button
             href={newsletter.preview_url}
@@ -72,6 +78,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             {__('Preview', 'mailpoet')}
           </Button>
           <Dropdown
+            className="mailpoet-stats-buttons-header"
             focusOnMount={false}
             popoverProps={{ placement: 'bottom-end' }}
             renderToggle={({ isOpen, onToggle }) => (
@@ -79,25 +86,38 @@ function NewsletterStatsInfo({ newsletter }: Props) {
                 <Button href={newsletter.preview_url} variant="primary">
                   {__('Edit', 'mailpoet')}
                 </Button>
-                <Button onClick={onToggle} aria-expanded={isOpen}>
-                  <Icon icon={chevronDown} size={24} />
+                <Button
+                  onClick={onToggle}
+                  aria-expanded={isOpen}
+                  variant="primary"
+                >
+                  <br />
+                  <Icon icon={chevronDown} size={18} />
                 </Button>
               </ButtonGroup>
             )}
             renderContent={() => (
-              <>
+              <MenuGroup>
                 {newsletter.type === 'notification' && (
-                  <MenuItem variant="tertiary" onClick={() => {}}>
-                    {__('Deactivate (Only for Post notifications)', 'mailpoet')}
+                  <MenuItem
+                    className="mailpoet-no-box-shadow"
+                    variant="tertiary"
+                    onClick={() => {}}
+                  >
+                    {__('Deactivate', 'mailpoet')}
                   </MenuItem>
                 )}
-                <MenuItem variant="tertiary" onClick={() => {}}>
-                  {__('Duplicate')}
+                <MenuItem
+                  className="mailpoet-no-box-shadow"
+                  variant="tertiary"
+                  onClick={() => {}}
+                >
+                  {__('Duplicate', 'mailpoet')}
                 </MenuItem>
                 <MenuItem isDestructive onClick={() => {}}>
-                  {__('Move to Trash')}
+                  {__('Move to Trash', 'mailpoet')}
                 </MenuItem>
-              </>
+              </MenuGroup>
             )}
           />
         </ButtonGroup>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import {
   Button,
@@ -57,7 +58,10 @@ const editNewsletter = (newsletter: NewsletterType) => {
   }
 };
 
-const duplicateNewsletter = (newsletter: NewsletterType) => {
+const duplicateNewsletter = (
+  newsletter: NewsletterType,
+  performActionAfterUpdate = () => {},
+) => {
   void MailPoet.Ajax.post({
     api_version: window.mailpoet_api_version,
     endpoint: 'newsletters',
@@ -89,10 +93,16 @@ const duplicateNewsletter = (newsletter: NewsletterType) => {
           { scroll: true },
         );
       }
+    })
+    .always(() => {
+      performActionAfterUpdate();
     });
 };
 
-const trashNewsletter = (newsletter: NewsletterType) => {
+const trashNewsletter = (
+  newsletter: NewsletterType,
+  performActionAfterUpdate = () => {},
+) => {
   void MailPoet.Ajax.post({
     api_version: window.mailpoet_api_version,
     endpoint: 'newsletters',
@@ -117,6 +127,9 @@ const trashNewsletter = (newsletter: NewsletterType) => {
           { scroll: true },
         );
       }
+    })
+    .always(() => {
+      performActionAfterUpdate();
     });
 };
 
@@ -125,6 +138,7 @@ type Props = {
 };
 
 function NewsletterStatsInfo({ newsletter }: Props) {
+  const [isBusy, setIsBusy] = useState(false);
   const newsletterDate =
     newsletter?.queue?.scheduled_at ||
     newsletter?.queue?.created_at ||
@@ -218,19 +232,27 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             renderContent={() => (
               <MenuGroup>
                 <MenuItem
+                  isBusy={isBusy}
                   className="mailpoet-no-box-shadow"
                   variant="tertiary"
                   disabled={newsletter.type !== 'standard'}
                   onClick={() => {
-                    duplicateNewsletter(newsletter);
+                    setIsBusy(true);
+                    duplicateNewsletter(newsletter, () => {
+                      setIsBusy(false);
+                    });
                   }}
                 >
                   {__('Duplicate', 'mailpoet')}
                 </MenuItem>
                 <MenuItem
+                  isBusy={isBusy}
                   isDestructive
                   onClick={() => {
-                    trashNewsletter(newsletter);
+                    setIsBusy(true);
+                    trashNewsletter(newsletter, () => {
+                      setIsBusy(false);
+                    });
                   }}
                 >
                   {__('Move to Trash', 'mailpoet')}

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -10,7 +10,13 @@ import { chevronDown, Icon } from '@wordpress/icons';
 import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
-import { confirmAlert, FilterSegmentTag, SegmentTags } from 'common';
+import {
+  capitalizeFirstLetter,
+  confirmAlert,
+  FilterSegmentTag,
+  SegmentTags,
+  Tag,
+} from 'common';
 import { NewsletterType } from './newsletter-type';
 
 const redirectToNewsletterHome = () => {
@@ -128,6 +134,10 @@ function NewsletterStatsInfo({ newsletter }: Props) {
       <div>
         <Heading level={1}>{newsletter.subject}</Heading>
         <div>
+          <Tag isInverted={false}>
+            {capitalizeFirstLetter(newsletter.status)}
+          </Tag>
+          &nbsp;
           <b>
             {MailPoet.Date.short(newsletterDate)}
             {' • '}

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -1,8 +1,10 @@
 import { __ } from '@wordpress/i18n';
+import { Button, ButtonGroup, Dropdown, MenuItem } from '@wordpress/components';
+import { chevronDown, Icon } from '@wordpress/icons';
 import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
-import { Button, FilterSegmentTag, SegmentTags } from 'common';
+import { FilterSegmentTag, SegmentTags } from 'common';
 import { NewsletterType } from './newsletter-type';
 
 type Props = {
@@ -14,7 +16,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
     newsletter.queue.scheduled_at || newsletter.queue.created_at;
   return (
     <Grid.ThreeColumns className="mailpoet-stats-info">
-      <div className="mailpoet-grid-span-two-columns">
+      <div>
         <Heading level={1}>{newsletter.subject}</Heading>
         <div>
           <b>
@@ -58,15 +60,47 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             {newsletter.ga_campaign ? newsletter.ga_campaign : '-'}
           </div>
         </div>
-        <div>
+      </div>
+      <div className="mailpoet-stats-info-sender-preview">
+        <ButtonGroup>
           <Button
             href={newsletter.preview_url}
             target="_blank"
             rel="noopener noreferrer"
+            variant="secondary"
           >
             {__('Preview', 'mailpoet')}
           </Button>
-        </div>
+          <Dropdown
+            focusOnMount={false}
+            popoverProps={{ placement: 'bottom-end' }}
+            renderToggle={({ isOpen, onToggle }) => (
+              <ButtonGroup>
+                <Button href={newsletter.preview_url} variant="primary">
+                  {__('Edit', 'mailpoet')}
+                </Button>
+                <Button onClick={onToggle} aria-expanded={isOpen}>
+                  <Icon icon={chevronDown} size={24} />
+                </Button>
+              </ButtonGroup>
+            )}
+            renderContent={() => (
+              <>
+                {newsletter.type === 'notification' && (
+                  <MenuItem variant="tertiary" onClick={() => {}}>
+                    {__('Deactivate (Only for Post notifications)', 'mailpoet')}
+                  </MenuItem>
+                )}
+                <MenuItem variant="tertiary" onClick={() => {}}>
+                  {__('Duplicate')}
+                </MenuItem>
+                <MenuItem isDestructive onClick={() => {}}>
+                  {__('Move to Trash')}
+                </MenuItem>
+              </>
+            )}
+          />
+        </ButtonGroup>
       </div>
     </Grid.ThreeColumns>
   );

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -11,11 +11,11 @@ import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
 import {
-  capitalizeFirstLetter,
   confirmAlert,
   FilterSegmentTag,
   SegmentTags,
   Tag,
+  getNewsletterStatusString,
 } from 'common';
 import { NewsletterType } from './newsletter-type';
 
@@ -135,7 +135,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
         <Heading level={1}>{newsletter.subject}</Heading>
         <div>
           <Tag isInverted={false}>
-            {capitalizeFirstLetter(newsletter.status)}
+            {getNewsletterStatusString(newsletter.status)}
           </Tag>
           &nbsp;
           <b>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -185,6 +185,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             renderToggle={({ isOpen, onToggle }) => (
               <ButtonGroup>
                 <Button
+                  disabled={newsletter.type !== 'standard'}
                   onClick={() => {
                     editNewsletter(newsletter);
                   }}
@@ -204,18 +205,10 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             )}
             renderContent={() => (
               <MenuGroup>
-                {newsletter.type === 'notification' && (
-                  <MenuItem
-                    className="mailpoet-no-box-shadow"
-                    variant="tertiary"
-                    onClick={() => {}}
-                  >
-                    {__('Deactivate', 'mailpoet')}
-                  </MenuItem>
-                )}
                 <MenuItem
                   className="mailpoet-no-box-shadow"
                   variant="tertiary"
+                  disabled={newsletter.type !== 'standard'}
                   onClick={() => {
                     duplicateNewsletter(newsletter);
                   }}

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
@@ -35,4 +35,5 @@ export type NewsletterType = {
   type: string;
   status: string;
   wp_post_id?: number;
+  created_at: string;
 };

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
@@ -31,4 +31,5 @@ export type NewsletterType = {
       count: number;
     };
   };
+  type: string;
 };

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
@@ -11,6 +11,7 @@ export type NewsletterType = {
         name?: string;
       };
     };
+    status?: string;
   };
   sender_address?: string;
   reply_to_address?: string;
@@ -32,4 +33,6 @@ export type NewsletterType = {
     };
   };
   type: string;
+  status: string;
+  wp_post_id?: number;
 };

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -9,7 +9,6 @@ import { HideScreenOptions } from 'common/hide-screen-options/hide-screen-option
 import { RemoveWrapMargin } from 'common/remove-wrap-margin/remove-wrap-margin';
 import { Tabs } from 'common/tabs/tabs';
 import { Tab } from 'common/tabs/tab';
-import { Heading } from 'common/typography/heading/heading';
 import { ErrorBoundary } from 'common';
 import { NewsletterGeneralStats } from './newsletter-general-stats';
 import { NewsletterType } from './newsletter-type';
@@ -53,6 +52,7 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
         action: window.mailpoet_display_detailed_stats ? 'get' : 'getWithStats',
         data: {
           id,
+          accept: 'all',
         },
       })
         .always(() => {
@@ -91,14 +91,6 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
   const newsletter = item;
 
   if (loading) return null;
-
-  if (newsletter?.subject && !newsletter?.queue) {
-    return (
-      <div>
-        <Heading level={1}>{newsletter.subject}</Heading>
-      </div>
-    );
-  }
 
   if (!newsletter) {
     return <h3> {__('This email does not exist.', 'mailpoet')} </h3>;


### PR DESCRIPTION
## Description

We updated the email stats page in this PR.

![PjUzIr.png](https://github.com/mailpoet/mailpoet/assets/30554163/07045e9b-837c-4eb5-b029-81b5094ad0eb)


## Code review notes

Please check commits

## QA notes

Note: Please test with MailPoet Premium activated and deactivated.
Associated premium branch here: https://github.com/mailpoet/mailpoet-premium/pull/829

Start with the QA notes here: https://github.com/mailpoet/mailpoet/pull/5289
* Check email stats here: `/wp-admin/admin.php?page=mailpoet-newsletters%2F#/stats/newsletter_id`
* Please test with different types of newsletters e.g. standard, welcome, post notifications, post notifications history
* You should be able to edit, duplicate (if possible), and delete newsletters.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/829

## Linked tickets

[MAILPOET-5699](https://mailpoet.atlassian.net/browse/MAILPOET-5699)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5699]: https://mailpoet.atlassian.net/browse/MAILPOET-5699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ