### PR TITLE
Feat/update automation stats page - MAILPOET-5700

### DIFF
--- a/mailpoet/assets/css/src/components-automation-analytics/_header.scss
+++ b/mailpoet/assets/css/src/components-automation-analytics/_header.scss
@@ -2,11 +2,11 @@
 
 .mailpoet-automation-analytics-title {
   color: $color-gutenberg-grey-700;
+  font-size: 16px;
   a {
     color: inherit;
     text-decoration: none;
   }
-  font-size: 16px;
 
   strong {
     color: $color-gutenberg-grey-900;
@@ -33,6 +33,12 @@
 
     * {
       box-sizing: border-box;
+    }
+  }
+
+  .components-dropdown {
+    .components-button.is-primary {
+      box-shadow: none;
     }
   }
 }

--- a/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
@@ -7,8 +7,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { storeName } from '../../store';
 
-export function TrashButton(): JSX.Element {
+export function TrashButton({
+  performActionAfterDelete = () => {},
+}): JSX.Element {
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
   const { automation } = useSelect(
     (select) => ({
       automation: select(storeName).getAutomationData(),
@@ -24,8 +27,11 @@ export function TrashButton(): JSX.Element {
         title={__('Delete automation', 'mailpoet')}
         confirmButtonText={__('Yes, delete', 'mailpoet')}
         onConfirm={async () => {
+          setIsBusy(true);
           trash(() => {
             setShowConfirmDialog(false);
+            setIsBusy(false);
+            performActionAfterDelete();
           });
         }}
         onCancel={() => setShowConfirmDialog(false)}
@@ -40,6 +46,7 @@ export function TrashButton(): JSX.Element {
       </ConfirmDialog>
 
       <Button
+        isBusy={isBusy}
         variant="secondary"
         isDestructive
         onClick={() => setShowConfirmDialog(true)}

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -27,7 +27,7 @@ import {
 //   https://github.com/WordPress/gutenberg/blob/9601a33e30ba41bac98579c8d822af63dd961488/packages/edit-post/src/components/header/index.js
 //   https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/header/index.js
 
-function ActivateButton({ label }): JSX.Element {
+export function ActivateButton({ label }): JSX.Element {
   const { errors, isDeactivating } = useSelect(
     (select) => ({
       errors: select(storeName).getErrors(),
@@ -67,7 +67,7 @@ function ActivateButton({ label }): JSX.Element {
   return button;
 }
 
-function UpdateButton(): JSX.Element {
+export function UpdateButton(): JSX.Element {
   const { save } = useDispatch(storeName);
 
   const { automation, savedState } = useSelect(
@@ -166,7 +166,7 @@ function SaveDraftButton(): JSX.Element {
   );
 }
 
-function DeactivateButton(): JSX.Element {
+export function DeactivateButton(): JSX.Element {
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const { hasUsersInProgress } = useSelect(
@@ -206,7 +206,7 @@ function DeactivateButton(): JSX.Element {
   );
 }
 
-function DeactivateNowButton(): JSX.Element {
+export function DeactivateNowButton(): JSX.Element {
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const { hasUsersInProgress } = useSelect(

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -17,6 +17,7 @@ import {
   DeactivateNowButton,
 } from '../../../../../editor/components/header';
 import { TrashButton } from '../../../../../editor/components/actions/trash-button';
+import { EditorNotices } from '../../../../../editor/components/notices';
 
 export function Header(): JSX.Element {
   const { automation } = useSelect((s) => ({
@@ -25,6 +26,7 @@ export function Header(): JSX.Element {
   return (
     <header className="mailpoet-analytics-header">
       <Filter />
+      <EditorNotices />
       <Dropdown
         focusOnMount={false}
         popoverProps={{ placement: 'bottom-end' }}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -12,6 +12,12 @@ import { chevronDown, Icon } from '@wordpress/icons';
 import { Filter } from './filter';
 import { MailPoet } from '../../../../../../mailpoet';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
+import { AutomationStatus } from '../../../../../listing/automation';
+import {
+  ActivateButton,
+  DeactivateButton,
+  DeactivateNowButton,
+} from '../../../../../editor/components/header';
 
 export function Header(): JSX.Element {
   const { automation } = useSelect((s) => ({
@@ -41,9 +47,16 @@ export function Header(): JSX.Element {
         )}
         renderContent={() => (
           <MenuGroup>
-            <MenuItem variant="tertiary" onClick={() => {}}>
-              {__('Deactivate', 'mailpoet')}
-            </MenuItem>
+            {automation.status === AutomationStatus.ACTIVE && (
+              <DeactivateButton />
+            )}
+            {automation.status === AutomationStatus.DEACTIVATING && (
+              <>
+                <DeactivateNowButton />
+                <br />
+                <ActivateButton label={__('Update & Activate', 'mailpoet')} />
+              </>
+            )}
             <MenuItem isDestructive onClick={() => {}}>
               {__('Move to Trash', 'mailpoet')}
             </MenuItem>

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -13,7 +13,6 @@ import { MailPoet } from '../../../../../../mailpoet';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
 import { AutomationStatus } from '../../../../../listing/automation';
 import {
-  ActivateButton,
   DeactivateButton,
   DeactivateNowButton,
 } from '../../../../../editor/components/header';
@@ -40,7 +39,7 @@ export function Header(): JSX.Element {
               {__('Edit automation', 'mailpoet')}
             </Button>
             <Button onClick={onToggle} aria-expanded={isOpen} variant="primary">
-              <br />
+              &nbsp;
               <Icon icon={chevronDown} size={18} />
             </Button>
           </ButtonGroup>
@@ -51,11 +50,7 @@ export function Header(): JSX.Element {
               <DeactivateButton />
             )}
             {automation.status === AutomationStatus.DEACTIVATING && (
-              <>
-                <DeactivateNowButton />
-                <br />
-                <ActivateButton label={__('Update & Activate', 'mailpoet')} />
-              </>
+              <DeactivateNowButton />
             )}
             <TrashButton
               performActionAfterDelete={() => {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -3,7 +3,6 @@ import {
   ButtonGroup,
   Dropdown,
   MenuGroup,
-  MenuItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -18,6 +17,7 @@ import {
   DeactivateButton,
   DeactivateNowButton,
 } from '../../../../../editor/components/header';
+import { TrashButton } from '../../../../../editor/components/actions/trash-button';
 
 export function Header(): JSX.Element {
   const { automation } = useSelect((s) => ({
@@ -57,9 +57,11 @@ export function Header(): JSX.Element {
                 <ActivateButton label={__('Update & Activate', 'mailpoet')} />
               </>
             )}
-            <MenuItem isDestructive onClick={() => {}}>
-              {__('Move to Trash', 'mailpoet')}
-            </MenuItem>
+            <TrashButton
+              performActionAfterDelete={() => {
+                window.location.href = MailPoet.urls.automationListing;
+              }}
+            />
           </MenuGroup>
         )}
       />

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -1,7 +1,14 @@
-import { Button } from '@wordpress/components';
+import {
+  Button,
+  ButtonGroup,
+  Dropdown,
+  MenuGroup,
+  MenuItem,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
+import { chevronDown, Icon } from '@wordpress/icons';
 import { Filter } from './filter';
 import { MailPoet } from '../../../../../../mailpoet';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
@@ -13,14 +20,36 @@ export function Header(): JSX.Element {
   return (
     <header className="mailpoet-analytics-header">
       <Filter />
-      <Button
-        href={addQueryArgs(MailPoet.urls.automationEditor, {
-          id: automation.id,
-        })}
-        isPrimary
-      >
-        {__('Edit automation', 'mailpoet')}
-      </Button>
+      <Dropdown
+        focusOnMount={false}
+        popoverProps={{ placement: 'bottom-end' }}
+        renderToggle={({ isOpen, onToggle }) => (
+          <ButtonGroup>
+            <Button
+              href={addQueryArgs(MailPoet.urls.automationEditor, {
+                id: automation.id,
+              })}
+              isPrimary
+            >
+              {__('Edit automation', 'mailpoet')}
+            </Button>
+            <Button onClick={onToggle} aria-expanded={isOpen} variant="primary">
+              <br />
+              <Icon icon={chevronDown} size={18} />
+            </Button>
+          </ButtonGroup>
+        )}
+        renderContent={() => (
+          <MenuGroup>
+            <MenuItem variant="tertiary" onClick={() => {}}>
+              {__('Deactivate', 'mailpoet')}
+            </MenuItem>
+            <MenuItem isDestructive onClick={() => {}}>
+              {__('Move to Trash', 'mailpoet')}
+            </MenuItem>
+          </MenuGroup>
+        )}
+      />
     </header>
   );
 }


### PR DESCRIPTION
## Description

We updated the Automation statistics page in this PR.

This PR converts the `Edit automation` button to a split button and adds other buttons.
New buttons:
* Deactivate
* Move to Trash 

<img width="1608" alt="Screenshot 2023-12-04 at 11 32 57 AM" src="https://github.com/mailpoet/mailpoet/assets/30554163/c1b309a8-aae8-4d1d-b192-8c2d4cc2124e">


## Code review notes

Please check commits

## QA notes

* Visit the automation stats page `/wp-admin/admin.php?page=mailpoet-automation-analytics&id=automation_id`
* Ensure the buttons perform the actions intended. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5700](https://mailpoet.atlassian.net/browse/MAILPOET-5700)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5700]: https://mailpoet.atlassian.net/browse/MAILPOET-5700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ