### PR TITLE
Fix broken TinyMCE toolbar when page is zoomed by browser [MAILPOET-5728]

### DIFF
--- a/mailpoet/assets/css/src/components-editor/3rd-party-overrides/_overrides.scss
+++ b/mailpoet/assets/css/src/components-editor/3rd-party-overrides/_overrides.scss
@@ -183,4 +183,19 @@
       border-top-left-radius: 0;
     }
   }
+
+  /* Fix TinyMCE toolbar breaks when changing page zoom
+     We can remove this code after following issues are fixed:
+      - https://github.com/tinymce/tinymce/issues/8909
+      - https://github.com/tinymce/tinymce/issues/8865
+     We can also try removing this code after each update of tinymce
+  */
+  @include respond-to(not-small-screen) {
+    .tox .tox-toolbar {
+      flex-wrap: nowrap;
+    }
+    .tox .tox-toolbar__group {
+      flex-wrap: nowrap;
+    }
+  }
 }


### PR DESCRIPTION
## Description
It is caused by an issue in TinyMCE or the theme we use. It might be caused by a rounding error when setting the toolbar width internally in TinyMCE (adding a pixel to the computed width fixes the issue)

There are two issues reported on the TinyMCE repo:
- https://github.com/tinymce/tinymce/issues/8909
- https://github.com/tinymce/tinymce/issues/8865 

## Code review notes
I attempted to fix it in TinyMCE but could not fix it in a reasonable time, so I patched the issue in our plugin using CSS, where I forbid toolbar groups to break and display multiple lines.
We have a static list of tools in the toolbar so we should be fine forcing the toolbar group to nowrap.

## QA notes

#### Replication

1. Open the current email editor
2. Click a text block so that TinyMCE toolbar is visible
3. Try zoom in/out with the browser
4. At some zoom levels to top toolbar group breaks into two lines (could be different on different screens. It seems to be dependent on screen resolution).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5728]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5728]: https://mailpoet.atlassian.net/browse/MAILPOET-5728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ