### PR TITLE
Feat/remove multichannel integration from experimental features - MAILPOET-5701

### DIFF
--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -195,11 +195,11 @@ const routes = [
   },
   /* New newsletter: types */
   {
-    path: '/new/standard/(.*)?',
+    path: '/new/standard',
     render: withBoundary(NewsletterTypeStandard),
   },
   {
-    path: '/new/notification/(.*)?',
+    path: '/new/notification',
     render: withBoundary(NewsletterNotification),
   },
   {

--- a/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
@@ -34,7 +34,9 @@ class NewsletterNotificationComponent extends Component {
   }
 
   componentDidMount() {
-    if (window.location.hash.includes('loadedvia=woo_multichannel_dashboard')) {
+    if (
+      window.location.search.includes('loadedvia=woo_multichannel_dashboard')
+    ) {
       window.MailPoet.trackEvent(
         'MailPoet - WooCommerce Multichannel Marketing dashboard > Create post notification page',
         {

--- a/mailpoet/assets/js/src/newsletters/types/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/standard.jsx
@@ -21,7 +21,9 @@ class NewsletterStandardComponent extends Component {
     })
       .done((response) => {
         if (
-          window.location.hash.includes('loadedvia=woo_multichannel_dashboard')
+          window.location.search.includes(
+            'loadedvia=woo_multichannel_dashboard',
+          )
         ) {
           window.MailPoet.trackEvent(
             'MailPoet - WooCommerce Multichannel Marketing dashboard > Newsletter template selection page',

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -7,14 +7,12 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
   const GUTENBERG_EMAIL_EDITOR = 'gutenberg_email_editor';
-  const MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION = 'mailpoet_woocommerce_multichannel_integration';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
     self::GUTENBERG_EMAIL_EDITOR => false,
-    self::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -157,7 +157,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
           'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
           'mailpoet',
         ),
-        admin_url('admin.php?loadedvia=woo_multichannel_dashboard&page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard'),
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '&loadedvia=woo_multichannel_dashboard#/new/standard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(
@@ -168,7 +168,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
           'Let MailPoet email your subscribers with your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
           'mailpoet',
         ),
-        admin_url('admin.php?loadedvia=woo_multichannel_dashboard&page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification'),
+        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '&loadedvia=woo_multichannel_dashboard#/new/notification'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_AUTOMATIONS => new MarketingCampaignType(
@@ -176,7 +176,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
         $this,
         __('MailPoet Automations', 'mailpoet'),
         __('Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.', 'mailpoet'),
-        admin_url('admin.php?loadedvia=woo_multichannel_dashboard&page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG),
+        admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG . '&loadedvia=woo_multichannel_dashboard'),
         $this->get_icon_url()
       ),
     ];

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannel.php
@@ -157,7 +157,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
           'Send a newsletter with images, buttons, dividers, and social bookmarks. Or, just send a basic text email.',
           'mailpoet',
         ),
-        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard/loadedvia=woo_multichannel_dashboard'),
+        admin_url('admin.php?loadedvia=woo_multichannel_dashboard&page=' . Menu::EMAILS_PAGE_SLUG . '#/new/standard'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_POST_NOTIFICATIONS => new MarketingCampaignType(
@@ -168,7 +168,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
           'Let MailPoet email your subscribers with your latest content. You can send daily, weekly, monthly, or even immediately after publication.',
           'mailpoet',
         ),
-        admin_url('admin.php?page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification/loadedvia=woo_multichannel_dashboard'),
+        admin_url('admin.php?loadedvia=woo_multichannel_dashboard&page=' . Menu::EMAILS_PAGE_SLUG . '#/new/notification'),
         $this->get_icon_url()
       ),
       self::CAMPAIGN_TYPE_AUTOMATIONS => new MarketingCampaignType(
@@ -176,7 +176,7 @@ class MPMarketingChannel implements MarketingChannelInterface {
         $this,
         __('MailPoet Automations', 'mailpoet'),
         __('Set up automations to send abandoned cart reminders, welcome new subscribers, celebrate first-time buyers, and much more.', 'mailpoet'),
-        admin_url('admin.php?page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG . '&loadedvia=woo_multichannel_dashboard'),
+        admin_url('admin.php?loadedvia=woo_multichannel_dashboard&page=' . Menu::AUTOMATION_TEMPLATES_PAGE_SLUG),
         $this->get_icon_url()
       ),
     ];

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelController.php
@@ -2,12 +2,7 @@
 
 namespace MailPoet\WooCommerce\MultichannelMarketing;
 
-use MailPoet\Features\FeaturesController;
-
 class MPMarketingChannelController {
-
-  /** @var FeaturesController */
-  private $featuresController;
 
   /**
    * @var MPMarketingChannelDataController
@@ -15,18 +10,12 @@ class MPMarketingChannelController {
   private $channelDataController;
 
   public function __construct(
-    FeaturesController $featuresController,
     MPMarketingChannelDataController $channelDataController
   ) {
-    $this->featuresController = $featuresController;
     $this->channelDataController = $channelDataController;
   }
 
   public function registerMarketingChannel($registeredMarketingChannels): array {
-    if (!$this->featuresController->isSupported(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION)) {
-      return $registeredMarketingChannels; // Do not register the marketing channel if the feature flag is not enabled
-    }
-
     return array_merge($registeredMarketingChannels, [
       new MPMarketingChannel(
         $this->channelDataController

--- a/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelDataController.php
+++ b/mailpoet/lib/WooCommerce/MultichannelMarketing/MPMarketingChannelDataController.php
@@ -141,6 +141,7 @@ class MPMarketingChannelDataController {
 
   public function getStandardNewsletterList($campaignType): array {
     return $this->getNewsletterTypeLists(
+      // fetch the most recently sent post-notification history newsletters limited to ten
       $this->newsletterRepository->getStandardNewsletterListWithMultipleStatuses(10),
       $campaignType
     );

--- a/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
@@ -2,9 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
 use MailPoet\Mailer\Mailer;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Settings;
 
@@ -26,7 +24,6 @@ class MPMarketingChannelCest {
 
   public function itShowsMailPoetSetup(\AcceptanceTester $i) {
     $this->settingsFactory->withWelcomeWizard();
-    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
 
     $i->login();
     $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
@@ -40,7 +37,6 @@ class MPMarketingChannelCest {
 
   public function itShowsErrorCount(\AcceptanceTester $i) {
     (new Newsletter())->create();
-    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
 
     $i->login();
 
@@ -57,7 +53,6 @@ class MPMarketingChannelCest {
 
   public function itShowsMailPoetSyncStatus(\AcceptanceTester $i) {
     (new Newsletter())->create();
-    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
 
     $i->login();
 
@@ -71,7 +66,6 @@ class MPMarketingChannelCest {
 
   public function itShowsMailPoetSyncStatusWithErrorCount(\AcceptanceTester $i) {
     (new Newsletter())->create();
-    (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
 
     $i->login();
 
@@ -86,8 +80,6 @@ class MPMarketingChannelCest {
   }
 
   public function itCanCreateMailPoetCampaigns(\AcceptanceTester $i) {
-      (new Features())->withFeatureEnabled(FeaturesController::MAILPOET_WOOCOMMERCE_MULTICHANNEL_INTEGRATION);
-
       $i->login();
 
       $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');

--- a/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
@@ -91,7 +91,7 @@ class MPMarketingChannelCest {
       $i->see('MailPoet Post notifications');
       $i->see('MailPoet Automations');
       $i->click('Create', '.woocommerce-marketing-new-campaign-type');
-      $i->seeInCurrentUrl('page=mailpoet-newsletters#/new/standard'); // will be redirected to page=mailpoet-newsletters#/template
+      $i->seeInCurrentUrl('page=mailpoet-newsletters&loadedvia=woo_multichannel_dashboard#/new/standard'); // will be redirected to page=mailpoet-newsletters#/template
       $i->waitForText('Simple text'); // on template selection page
       $i->see('Template'); // on template selection page
       $i->see('Newsletters');


### PR DESCRIPTION
## Description

This PR refactors the `MPMarketingChannel` class and removes the multichannel integration from experimental features

## Code review notes

Please check commits

## QA notes

* Create some newsletters, post notifications, automation, etc
* Visit the WooCommerce Marketing tab at `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
* You should see **MailPoet** on the list of Channels
![oZ5dex.png](https://github.com/mailpoet/mailpoet/assets/30554163/ef726719-b8a7-4d1b-a21f-e3b25536137d)
* You should see the Campaign list
* Right-click (open in a new tab) and select any of the items

## Linked PRs

Child of https://github.com/mailpoet/mailpoet/pull/5321

## Linked tickets

[MAILPOET-5701](https://mailpoet.atlassian.net/browse/MAILPOET-5701)

## After-merge notes

Please merge after https://github.com/mailpoet/mailpoet/pull/5321

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5701]: https://mailpoet.atlassian.net/browse/MAILPOET-5701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ