### PR TITLE
Fix purchased in category filter bug [MAILPOET-5264]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -64,10 +64,9 @@ class WooCommerceCategory implements Filter {
       $this->applyProductJoin($queryBuilder, $orderStatsAlias);
       $this->applyTermRelationshipsJoin($queryBuilder);
       $this->applyTermTaxonomyJoin($queryBuilder, $parameterSuffix)
-        ->groupBy("$subscribersTable.id, $orderStatsAlias.order_id")
-        ->having("COUNT($orderStatsAlias.order_id) = :count_" . $parameterSuffix)
-        ->setParameter('count_' . $parameterSuffix, count($categoryIds));
-
+        ->groupBy("$subscribersTable.id")
+        ->having("COUNT(DISTINCT term_taxonomy.term_id) = :count_" . $parameterSuffix)
+        ->setParameter('count_' . $parameterSuffix, count($categoryIdswithChildrenIds));
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
       // subQuery with subscriber ids that bought products
       $subQuery = $this->createQueryBuilder($subscribersTable);
@@ -134,7 +133,9 @@ class WooCommerceCategory implements Filter {
 
   private function getAllCategoryIds(int $categoryId): array {
     $subcategories = $this->wp->getTerms('product_cat', ['child_of' => $categoryId]);
-    if (!is_array($subcategories) || empty($subcategories)) return [$categoryId];
+    if (!is_array($subcategories) || empty($subcategories)) {
+      return [$categoryId];
+    }
     $ids = array_map(function($category) {
       return $category->term_id; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }, $subcategories);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -33,7 +33,9 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
 
     $this->cleanUp();
+  }
 
+  public function testItGetsSubscribersThatPurchasedProductsInAnyCategory(): void {
     $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
     $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
     $customerId3OnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
@@ -61,9 +63,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->addToOrder(5, $orderId5, $productId1, $customerId5);
     $orderId6 = $this->createOrder($customerId5, Carbon::now());
     $this->addToOrder(6, $orderId6, $productId2, $customerId5);
-  }
 
-  public function testItGetsSubscribersThatPurchasedProductsInAnyCategory(): void {
     $expectedEmails = ['customer1@example.com', 'customer2@example.com', 'customer5@example.com'];
     $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ANY);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
@@ -71,6 +71,33 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   }
 
   public function testItGetsSubscribersThatDidNotPurchaseProducts(): void {
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3OnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
+    $customerId4PendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com', 'customer');
+    $customerId5 = $this->tester->createCustomer('customer5@example.com');
+
+    $this->createSubscriber('a1@example.com');
+    $this->createSubscriber('a2@example.com');
+
+    $category1 = $this->createCategory('productCat1');
+    $category2 = $this->createCategory('productCat2');
+
+    $productId1 = $this->createProduct('testProduct1', [$category1]);
+    $productId2 = $this->createProduct('testProduct2', [$category2]);
+
+    $orderId1 = $this->createOrder($customerId1, Carbon::now());
+    $this->addToOrder(1, $orderId1, $productId1, $customerId1);
+    $orderId2 = $this->createOrder($customerId2, Carbon::now());
+    $this->addToOrder(2, $orderId2, $productId2, $customerId2);
+    $orderId3 = $this->createOrder($customerId3OnHold, Carbon::now(), 'wc-on-hold');
+    $this->addToOrder(3, $orderId3, $productId2, $customerId3OnHold);
+    $orderId4 = $this->createOrder($customerId4PendingPayment, Carbon::now(), 'wc-pending');
+    $this->addToOrder(4, $orderId4, $productId2, $customerId4PendingPayment);
+    $orderId5 = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(5, $orderId5, $productId1, $customerId5);
+    $orderId6 = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(6, $orderId6, $productId2, $customerId5);
     $expectedEmails = [
       'a1@example.com',
       'a2@example.com',
@@ -84,6 +111,34 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   }
 
   public function testItGetsSubscribersThatPurchasedAllProducts(): void {
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3OnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
+    $customerId4PendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com', 'customer');
+    $customerId5 = $this->tester->createCustomer('customer5@example.com');
+
+    $this->createSubscriber('a1@example.com');
+    $this->createSubscriber('a2@example.com');
+
+    $category1 = $this->createCategory('productCat1');
+    $category2 = $this->createCategory('productCat2');
+
+    $productId1 = $this->createProduct('testProduct1', [$category1]);
+    $productId2 = $this->createProduct('testProduct2', [$category2]);
+
+    $orderId1 = $this->createOrder($customerId1, Carbon::now());
+    $this->addToOrder(1, $orderId1, $productId1, $customerId1);
+    $orderId2 = $this->createOrder($customerId2, Carbon::now());
+    $this->addToOrder(2, $orderId2, $productId2, $customerId2);
+    $orderId3 = $this->createOrder($customerId3OnHold, Carbon::now(), 'wc-on-hold');
+    $this->addToOrder(3, $orderId3, $productId2, $customerId3OnHold);
+    $orderId4 = $this->createOrder($customerId4PendingPayment, Carbon::now(), 'wc-pending');
+    $this->addToOrder(4, $orderId4, $productId2, $customerId4PendingPayment);
+    $orderId5 = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(5, $orderId5, $productId1, $customerId5);
+    $orderId6 = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(6, $orderId6, $productId2, $customerId5);
+
     $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
     verify($emails)->arrayCount(1); // customer5
@@ -94,6 +149,33 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   }
 
   public function testItGetsSubscribersThatPurchasesAllProductsInMultipleOrders(): void {
+    $customerId1 = $this->tester->createCustomer('customer1@example.com', 'customer');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
+    $customerId3OnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
+    $customerId4PendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com', 'customer');
+    $customerId5 = $this->tester->createCustomer('customer5@example.com');
+
+    $this->createSubscriber('a1@example.com');
+    $this->createSubscriber('a2@example.com');
+
+    $category1 = $this->createCategory('productCat1');
+    $category2 = $this->createCategory('productCat2');
+
+    $productId1 = $this->createProduct('testProduct1', [$category1]);
+    $productId2 = $this->createProduct('testProduct2', [$category2]);
+
+    $orderId1 = $this->createOrder($customerId1, Carbon::now());
+    $this->addToOrder(1, $orderId1, $productId1, $customerId1);
+    $orderId2 = $this->createOrder($customerId2, Carbon::now());
+    $this->addToOrder(2, $orderId2, $productId2, $customerId2);
+    $orderId3 = $this->createOrder($customerId3OnHold, Carbon::now(), 'wc-on-hold');
+    $this->addToOrder(3, $orderId3, $productId2, $customerId3OnHold);
+    $orderId4 = $this->createOrder($customerId4PendingPayment, Carbon::now(), 'wc-pending');
+    $this->addToOrder(4, $orderId4, $productId2, $customerId4PendingPayment);
+    $orderId5 = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(5, $orderId5, $productId1, $customerId5);
+    $orderId6 = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(6, $orderId6, $productId2, $customerId5);
     $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
     $expectedEmails = ['customer5@example.com'];

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -86,10 +86,17 @@ class WooCommerceCategoryTest extends \MailPoetTest {
   public function testItGetsSubscribersThatPurchasedAllProducts(): void {
     $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
-    verify($emails)->arrayCount(0);
+    verify($emails)->arrayCount(1); // customer5
     $expectedEmails = ['customer1@example.com', 'customer5@example.com'];
     $segmentFilterData = $this->getSegmentFilterData([$this->categoryIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  public function testItGetsSubscribersThatPurchasesAllProductsInMultipleOrders(): void {
+    $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
+    $expectedEmails = ['customer5@example.com'];
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -38,6 +38,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $customerId2 = $this->tester->createCustomer('customer2@example.com', 'customer');
     $customerId3OnHold = $this->tester->createCustomer('customer-on-hold@example.com', 'customer');
     $customerId4PendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com', 'customer');
+    $customerId5 = $this->tester->createCustomer('customer5@example.com');
 
     $this->createSubscriber('a1@example.com');
     $this->createSubscriber('a2@example.com');
@@ -56,10 +57,14 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->addToOrder(3, $this->orderIds[2], $this->productIds[1], $customerId3OnHold);
     $this->orderIds[] = $this->createOrder($customerId4PendingPayment, Carbon::now(), 'wc-pending');
     $this->addToOrder(4, $this->orderIds[3], $this->productIds[1], $customerId4PendingPayment);
+    $this->orderIds[] = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(5, $this->orderIds[4], $this->productIds[0], $customerId5);
+    $this->orderIds[] = $this->createOrder($customerId5, Carbon::now());
+    $this->addToOrder(6, $this->orderIds[5], $this->productIds[1], $customerId5);
   }
 
   public function testItGetsSubscribersThatPurchasedProductsInAnyCategory(): void {
-    $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
+    $expectedEmails = ['customer1@example.com', 'customer2@example.com', 'customer5@example.com'];
     $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ANY);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
@@ -82,7 +87,7 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $segmentFilterData = $this->getSegmentFilterData($this->categoryIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
     verify($emails)->arrayCount(0);
-    $expectedEmails = ['customer1@example.com'];
+    $expectedEmails = ['customer1@example.com', 'customer5@example.com'];
     $segmentFilterData = $this->getSegmentFilterData([$this->categoryIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceCategoryFilter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);


### PR DESCRIPTION
## Description

This fixes a bug with the "purchased in category" dynamic filter, where it was not correctly returning subscribers for the "all of" condition. Previously, if a subscriber made two separate purchases, one that included category1 and the other that included category2, a filter for "all of" both category1 and category2 would not return that subscriber.

## Code review notes

I'm open to ideas if you can think of a good way to restructure the query without having to rely on so many subqueries/joins, but it seems like it could get very complex due to the hierarchical nature of categories.

## QA notes

Please test the "purchased in category" filter carefully, especially the "all of" option, and please also test to ensure that the filter works as expected with hierarchical categories. For example, if you have `term1` and `term1child`, and a filter that is looking for anyone who has purchased `term1`, it should include users who have only purchased items with `term1child`.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
