### PR TITLE
Number of orders with coupon code dynamic segment filter [MAILPOET-5373]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/days-period-field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/days-period-field.tsx
@@ -84,5 +84,6 @@ export function validateDaysPeriod(formItems: DaysPeriodItem): boolean {
   if (formItems.timeframe === Timeframe.ALL_TIME) {
     return true;
   }
-  return !!formItems.days;
+  const days = parseInt(formItems.days, 10);
+  return days >= 1;
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
@@ -5,6 +5,7 @@ import { SegmentTypes } from '../types';
 // WooCommerce
 export enum WooCommerceActionTypes {
   NUMBER_OF_ORDERS = 'numberOfOrders',
+  NUMBER_OF_ORDERS_WITH_COUPON = 'numberOfOrdersWithCoupon',
   NUMBER_OF_REVIEWS = 'numberOfReviews',
   PURCHASED_CATEGORY = 'purchasedCategory',
   PURCHASE_DATE = 'purchaseDate',
@@ -45,6 +46,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.NUMBER_OF_ORDERS,
     label: __('number of orders', 'mailpoet'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.NUMBER_OF_ORDERS_WITH_COUPON,
+    label: __('number of orders with coupon code', 'mailpoet'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
@@ -67,7 +67,12 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (formItems.action === WooCommerceActionTypes.CUSTOMER_IN_COUNTRY) {
     return validateCustomerInCountry(formItems);
   }
-  if (formItems.action === WooCommerceActionTypes.NUMBER_OF_ORDERS) {
+  if (
+    [
+      WooCommerceActionTypes.NUMBER_OF_ORDERS,
+      WooCommerceActionTypes.NUMBER_OF_ORDERS_WITH_COUPON,
+    ].includes(formItems.action as WooCommerceActionTypes)
+  ) {
     return validateNumberOfOrders(formItems);
   }
   if (formItems.action === WooCommerceActionTypes.TOTAL_SPENT) {
@@ -113,6 +118,7 @@ const componentsMap = {
   [WooCommerceActionTypes.CUSTOMER_IN_CITY]: TextField,
   [WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE]: TextField,
   [WooCommerceActionTypes.NUMBER_OF_ORDERS]: NumberOfOrdersFields,
+  [WooCommerceActionTypes.NUMBER_OF_ORDERS_WITH_COUPON]: NumberOfOrdersFields,
   [WooCommerceActionTypes.NUMBER_OF_REVIEWS]: NumberOfReviewsFields,
   [WooCommerceActionTypes.PURCHASE_DATE]: DateFieldsDefaultBefore,
   [WooCommerceActionTypes.PURCHASED_PRODUCT]: PurchasedProductFields,

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -408,7 +408,7 @@ class FilterDataMapper {
       }
       $filterData['country_code'] = $data['country_code'];
       $filterData['operator'] = $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY;
-    } elseif ($data['action'] === WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS) {
+    } elseif (in_array($data['action'], WooCommerceNumberOfOrders::ACTIONS)) {
       $this->filterHelper->validateDaysPeriodData($data);
       if (
         !isset($data['number_of_orders_type'])

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -271,7 +271,7 @@ class FilterFactory {
   private function wooCommerce(?string $action) {
     if ($action === WooCommerceProduct::ACTION_PRODUCT) {
       return $this->wooCommerceProduct;
-    } elseif ($action === WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS) {
+    } elseif (in_array($action, WooCommerceNumberOfOrders::ACTIONS)) {
       return $this->wooCommerceNumberOfOrders;
     } elseif ($action === WooCommerceTotalSpent::ACTION_TOTAL_SPENT) {
       return $this->wooCommerceTotalSpent;

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -14,6 +14,12 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class WooCommerceNumberOfOrders implements Filter {
   const ACTION_NUMBER_OF_ORDERS = 'numberOfOrders';
+  const ACTION_NUMBER_OF_ORDERS_WITH_COUPON = 'numberOfOrdersWithCoupon';
+
+  const ACTIONS = [
+    self::ACTION_NUMBER_OF_ORDERS,
+    self::ACTION_NUMBER_OF_ORDERS_WITH_COUPON,
+  ];
 
   /** @var EntityManager */
   private $entityManager;

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -78,6 +78,12 @@ class WooCommerceNumberOfOrders implements Filter {
         $joinCondition
       );
 
+    $action = $filterData->getAction();
+
+    if ($action === self::ACTION_NUMBER_OF_ORDERS_WITH_COUPON) {
+      $subQuery->innerJoin('orderStats', $wpdb->prefix . 'wc_order_coupon_lookup', 'couponLookup', 'orderStats.order_id = couponLookup.order_id');
+    }
+
     $queryBuilder->add('join', [
       $subscribersTable => [
         /**


### PR DESCRIPTION
## Description

This PR adds a new dynamic segment filter for number of orders with a coupon code.

## Code review notes

Fortunately it was possible to rely almost entirely on the existing "number of purchases" filter, simply adding an inner join when we want to restrict it to orders that used coupon codes.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
