### PR TITLE
Fix error handling for requests without abort signal [MAILPOET-5789]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/api-error-handler.tsx
+++ b/mailpoet/assets/js/src/automation/editor/api-error-handler.tsx
@@ -16,7 +16,7 @@ export const registerApiErrorHandler = (): void =>
         return result;
       } catch (error) {
         // do not report aborted requests as errors
-        if (options.signal.aborted) {
+        if (options.signal?.aborted) {
           return undefined;
         }
 

--- a/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
+++ b/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
@@ -15,7 +15,7 @@ export const registerApiErrorHandler = (): void =>
         return result;
       } catch (error) {
         // do not report aborted requests as errors
-        if (options.signal.aborted) {
+        if (options.signal?.aborted) {
           return undefined;
         }
 

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -58,7 +58,7 @@ export function TemplatePreview({ template }: Props): JSX.Element {
         dispatch(storeName).updateAutomation(data.data.automation);
         setState('loaded');
       } catch (error) {
-        if (!controller.signal.aborted) {
+        if (!controller.signal?.aborted) {
           setState('error');
         }
       }


### PR DESCRIPTION
[MAILPOET-5789]

## Description

Fixes `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'aborted')`.

## Code review notes

_N/A_

## QA notes

Ensure that the error demonstrated [on Slack](https://a8c.slack.com/archives/C01GH835U90/p1702387705757789) is fixed.

Check [this video](https://d.pr/v/TKpZcl) for reproduction

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5789]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5789]: https://mailpoet.atlassian.net/browse/MAILPOET-5789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5789]: https://mailpoet.atlassian.net/browse/MAILPOET-5789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ