### PR TITLE
Add new filter to acceptance to fix when orders are out of sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.4.0-rc.1
+            ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.4.0-beta.1
+            ./do download:woo-commerce-zip 8.4.0-rc.1
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip latest
+            ./do download:woo-commerce-zip 8.4.0-beta.1
             ./do download:woo-commerce-subscriptions-zip 4.9.1
             ./do download:woo-commerce-memberships-zip 1.24.0
             ./do download:woo-commerce-blocks-zip 9.6.2

--- a/mailpoet/tests/_support/woo_cot_helper_plugin.php
+++ b/mailpoet/tests/_support/woo_cot_helper_plugin.php
@@ -49,3 +49,8 @@ function mailpoet_create_cot() {
 if (class_exists(WP_CLI::class)) {
   WP_CLI::add_command('create_cot', 'mailpoet_create_cot');
 }
+
+// Related PR in WooCommerce: https://github.com/woocommerce/woocommerce/pull/39988
+// Sometimes during tests can happen that orders are out of sync. This state can trigger and exception
+// The following filter avoids this state
+add_filter('wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true');


### PR DESCRIPTION
## Description

Jan Lysy added filter to fix the issue with syncing orders. WC now raises an exception when orders are out of sync for some reason.We have now the new filter mentioned in the [related PR](https://github.com/woocommerce/woocommerce/pull/39988) that fixes this.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5759]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5759]: https://mailpoet.atlassian.net/browse/MAILPOET-5759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ