### PR TITLE
Add full alignment support to blocks in the new email editor [MAILPOET-5688]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -46,6 +46,7 @@ export function BlockEditor() {
     hasFixedToolbar,
     focusMode,
     layoutStyles,
+    layout,
   } = useSelect(
     (select) => ({
       isFullscreenActive: select(storeName).isFeatureActive('fullscreenMode'),
@@ -60,6 +61,7 @@ export function BlockEditor() {
       hasFixedToolbar: select(storeName).isFeatureActive('fixedToolbar'),
       focusMode: select(storeName).isFeatureActive('focusMode'),
       layoutStyles: select(storeName).getLayoutStyles(),
+      layout: select(storeName).getLayout(),
     }),
     [],
   );
@@ -164,7 +166,12 @@ export function BlockEditor() {
                     <BlockTools>
                       <WritingFlow>
                         <ObserveTyping>
-                          <BlockList className="is-layout-constrained" />
+                          <BlockList
+                            className="is-layout-constrained"
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore We have an older package of @wordpress/block-editor that doesn't contain the correct type
+                            layout={layout}
+                          />
                         </ObserveTyping>
                       </WritingFlow>
                     </BlockTools>

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -95,15 +95,10 @@ export function BlockEditor() {
       width: layoutStyles.width,
       display: 'flex',
       flexFlow: 'column',
-      'box-sizing': 'border-box', // Because we want to exact email width, the padding must be included in the width.
     };
   }
   inlineStyles.background = documentBackground;
   inlineStyles.transition = 'all 0.3s ease 0s';
-  inlineStyles['padding-bottom'] = layoutStyles.padding.bottom;
-  inlineStyles['padding-left'] = layoutStyles.padding.left;
-  inlineStyles['padding-right'] = layoutStyles.padding.right;
-  inlineStyles['padding-top'] = layoutStyles.padding.top;
 
   const contentAreaStyles = {
     background:
@@ -167,7 +162,7 @@ export function BlockEditor() {
                       <WritingFlow>
                         <ObserveTyping>
                           <BlockList
-                            className="is-layout-constrained"
+                            className="is-layout-constrained has-global-padding"
                             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                             // @ts-ignore We have an older package of @wordpress/block-editor that doesn't contain the correct type
                             layout={layout}

--- a/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
@@ -1,5 +1,9 @@
 import { State } from './types';
-import { getEditorSettings, getEmailLayoutStyles } from './settings';
+import {
+  getEditorLayout,
+  getEditorSettings,
+  getEmailLayoutStyles,
+} from './settings';
 
 export function getInitialState(): State {
   const searchParams = new URLSearchParams(window.location.search);
@@ -14,6 +18,7 @@ export function getInitialState(): State {
     postId,
     editorSettings: getEditorSettings(),
     layoutStyles: getEmailLayoutStyles(),
+    layout: getEditorLayout(),
     preview: {
       deviceType: 'Desktop',
       toEmail: window.MailPoetEmailEditor.current_wp_user_email,

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -84,3 +84,7 @@ export function getPreviewState(state: State): State['preview'] {
 export function getLayoutStyles(state: State): State['layoutStyles'] {
   return state.layoutStyles;
 }
+
+export function getLayout(state: State): State['layout'] {
+  return state.layout;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/store/settings.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/settings.ts
@@ -1,4 +1,8 @@
-import { EmailEditorSettings, EmailLayoutStyles } from './types';
+import {
+  EmailEditorSettings,
+  EmailLayoutStyles,
+  EmailEditorLayout,
+} from './types';
 
 export function getEditorSettings(): EmailEditorSettings {
   return window.MailPoetEmailEditor.editor_settings as EmailEditorSettings;
@@ -6,4 +10,8 @@ export function getEditorSettings(): EmailEditorSettings {
 
 export function getEmailLayoutStyles(): EmailLayoutStyles {
   return window.MailPoetEmailEditor.email_layout_styles as EmailLayoutStyles;
+}
+
+export function getEditorLayout(): EmailEditorLayout {
+  return window.MailPoetEmailEditor.editor_layout as EmailEditorLayout;
 }

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -36,6 +36,11 @@ export type EmailLayoutStyles = {
   };
 };
 
+export type EmailEditorLayout = {
+  type: string;
+  contentSize: string;
+};
+
 export type State = {
   inserterSidebar: {
     isOpened: boolean;
@@ -46,6 +51,7 @@ export type State = {
   postId: number;
   editorSettings: EmailEditorSettings;
   layoutStyles: EmailLayoutStyles;
+  layout: EmailEditorLayout;
   preview: {
     deviceType: string;
     toEmail: string;

--- a/mailpoet/assets/js/src/email-editor/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/global.d.ts
@@ -5,6 +5,7 @@ interface Window {
     api_version: string;
     current_wp_user_email: string;
     editor_settings: unknown; // Can't import type in global.d.ts. Typed in getEditorSettings() in store/settings.ts
-    email_layout_styles: unknown; // Can't import type in global.d.ts. Typed in getEditorSettings() in store/settings.ts
+    email_layout_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailLayoutStyles() in store/settings.ts
+    editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts
   };
 }

--- a/mailpoet/lib/AdminPages/Pages/EmailEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/EmailEditor.php
@@ -59,6 +59,7 @@ class EmailEditor {
         'current_wp_user_email' => esc_js($currentUserEmail),
         'editor_settings' => $this->settingsController->getSettings(),
         'email_layout_styles' => $this->settingsController->getEmailLayoutStyles(),
+        'editor_layout' => $this->settingsController->getLayout(),
       ]
     );
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
@@ -13,11 +13,16 @@ class BlocksWidthPreprocessor implements Preprocessor {
   ];
 
   public function preprocess(array $parsedBlocks, array $layoutStyles): array {
-    $layoutWidth = $this->parseNumberFromStringWithPixels($layoutStyles['width']);
-    // Subtract padding from the width of the layout element
-    $layoutWidth -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['left'] ?? '0px');
-    $layoutWidth -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['right'] ?? '0px');
     foreach ($parsedBlocks as $key => $block) {
+      // Layout width is recalculated for each block because full-width blocks don't exclude padding
+      $layoutWidth = $this->parseNumberFromStringWithPixels($layoutStyles['width']);
+      $alignment = $block['attrs']['align'] ?? null;
+      // Subtract padding from the block width if it's not full-width
+      if ($alignment !== 'full') {
+        $layoutWidth -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['left'] ?? '0px');
+        $layoutWidth -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['right'] ?? '0px');
+      }
+
       $width = $this->convertWidthToPixels($block['attrs']['width'] ?? '100%', $layoutWidth);
 
       if ($block['blockName'] === 'core/columns') {

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TopLevelPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TopLevelPreprocessor.php
@@ -22,13 +22,22 @@ class TopLevelPreprocessor implements Preprocessor {
     $wrappedParsedBlocks = [];
     $nonColumnsBlocksBuffer = [];
     foreach ($parsedBlocks as $block) {
+      $blockAlignment = $block['attrs']['align'] ?? null;
       // The next block is columns so we can flush the buffer and add the columns block
-      if ($block['blockName'] === 'core/columns') {
+      if ($block['blockName'] === 'core/columns' || $blockAlignment === 'full') {
         if ($nonColumnsBlocksBuffer) {
           $columnsBlock = self::SINGLE_COLUMN_TEMPLATE;
           $columnsBlock['innerBlocks'][0]['innerBlocks'] = $nonColumnsBlocksBuffer;
           $nonColumnsBlocksBuffer = [];
           $wrappedParsedBlocks[] = $columnsBlock;
+        }
+        // If the block is full width and is not core/columns, we need to wrap it in a single column block, and it the columns block has to contain only the block
+        if ($blockAlignment === 'full' && $block['blockName'] !== 'core/columns') {
+          $columnsBlock = self::SINGLE_COLUMN_TEMPLATE;
+          $columnsBlock['attrs']['align'] = 'full';
+          $columnsBlock['innerBlocks'][0]['innerBlocks'] = [$block];
+          $wrappedParsedBlocks[] = $columnsBlock;
+          continue;
         }
         $wrappedParsedBlocks[] = $block;
         continue;

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
@@ -51,8 +51,6 @@
                   direction: ltr;
                   font-size: 0px;
                   padding-bottom: {{padding_bottom}};
-                  padding-left: {{padding_left}};
-                  padding-right: {{padding_right}};
                   padding-top: {{padding_top}};
                   text-align: center;
                 "

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -108,6 +108,9 @@ class SettingsController {
 
     $settings['__experimentalFeatures'] = $coreSettings;
 
+    // Enabling alignWide allows full width for specific blocks such as columns, heading, image, etc.
+    $settings['alignWide'] = true;
+
     return $settings;
   }
 

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -102,9 +102,25 @@ class SettingsController {
     $coreSettings['spacing']['units'] = ['px'];
     $coreSettings['spacing']['padding'] = true;
 
+    $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
+    $themeJson = json_decode($themeJson, true);
+    /** @var array $themeJson */
+    $theme = new \WP_Theme_JSON($themeJson);
+
+    // body selector is later transformed to .editor-styles-wrapper
+    // setting padding for bottom and top is needed because \WP_Theme_JSON::get_stylesheet() set them only for .wp-site-blocks selector
+    $contentVariables = 'body {';
+    $contentVariables .= 'padding-bottom: var(--wp--style--root--padding-bottom);';
+    $contentVariables .= 'padding-top: var(--wp--style--root--padding-top);';
+    $contentVariables .= '}';
+
     $settings = array_merge($coreDefaultSettings, self::DEFAULT_SETTINGS);
     $settings['allowedBlockTypes'] = self::ALLOWED_BLOCK_TYPES;
-    $settings['styles'] = [['css' => wp_get_global_stylesheet(['base-layout-styles'])]];
+    $settings['styles'] = [
+      ['css' => $theme->get_stylesheet()],
+      ['css' => $contentVariables],
+      ['css' => wp_get_global_stylesheet(['base-layout-styles'])],
+    ];
 
     $settings['__experimentalFeatures'] = $coreSettings;
 

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -111,6 +111,16 @@ class SettingsController {
     return $settings;
   }
 
+  /**
+   * @return array{contentSize: string, layout: string}
+   */
+  public function getLayout(): array {
+    return [
+      'contentSize' => self::EMAIL_WIDTH,
+      'layout' => 'constrained',
+    ];
+  }
+
   public function getEmailContentStyles(): array {
     return self::DEFAULT_EMAIL_CONTENT_STYLES;
   }

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "settings": {
+    "layout": {
+      "contentSize": "660px"
+    },
+    "useRootPaddingAwareAlignments": true
+  },
+  "styles": {
+    "spacing": {
+      "padding": {
+        "bottom": "10px",
+        "left": "10px",
+        "right": "10px",
+        "top": "10px"
+      }
+    }
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -30,9 +30,18 @@ class Columns implements BlockRenderer {
     $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
 
+    $align = $parsedBlock['attrs']['align'] ?? null;
+    if ($align !== 'full') {
+      $layoutPaddingLeft = $settingsController->getEmailLayoutStyles()['padding']['left'];
+      $layoutPaddingRight = $settingsController->getEmailLayoutStyles()['padding']['right'];
+    } else {
+      $layoutPaddingLeft = '0px';
+      $layoutPaddingRight = '0px';
+    }
+
     return '
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '" bgcolor="' . $backgroundColor . '" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';margin:0px auto;max-width:' . $width . ';width:100%;">
+      <div style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';margin:0px auto;max-width:' . $width . ';width:100%;padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';max-width:' . $width . ';width:100%;">
           <tbody>
             <tr>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -41,7 +41,7 @@ class Image implements BlockRenderer {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag(['tag_name' => 'img'])) {
       // Getting height from styles and if it's set, we set the height attribute
-      $styles = $html->get_attribute('style');
+      $styles = $html->get_attribute('style') ?? '';
       $styles = $settingsController->parseStylesToArray($styles);
       $height = $styles['height'] ?? null;
       if ($height && is_numeric($settingsController->parseNumberFromStringWithPixels($height))) {

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessorTest.php
@@ -241,4 +241,26 @@ class BlocksWidthPreprocessorTest extends \MailPoetUnitTest {
     verify($innerBlocks[1]['email_attrs']['width'])->equals('200px'); // already defined
     verify($innerBlocks[2]['email_attrs']['width'])->equals('200px'); // 600 -200 - 200
   }
+
+  public function testItDoesNotSubtractPaddingForFullWidthBlocks(): void {
+    $blocks = [
+      [
+        'blockName' => 'core/columns',
+        'attrs' => [
+          'align' => 'full',
+        ],
+        'innerBlocks' => [],
+      ],
+      [
+        'blockName' => 'core/columns',
+        'attrs' => [],
+        'innerBlocks' => [],
+      ],
+    ];
+    $result = $this->preprocessor->preprocess($blocks, ['width' => '660px', 'padding' => ['left' => '15px', 'right' => '15px']]);
+
+    verify($result)->arrayCount(2);
+    verify($result[0]['email_attrs']['width'])->equals('660px'); // full width
+    verify($result[1]['email_attrs']['width'])->equals('630px'); // 660 - 15 - 15
+  }
 }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TopLevelPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TopLevelPreprocessorTest.php
@@ -12,6 +12,12 @@ class TopLevelPreprocessorTest extends \MailPoetUnitTest {
     'innerHTML' => 'Paragraph content',
   ];
 
+  private $headingBlock = [
+    'blockName' => 'core/heading',
+    'attrs' => [],
+    'innerHTML' => 'Paragraph content',
+  ];
+
   private $columnsBlock = [
     'blockName' => 'core/columns',
     'attrs' => [],
@@ -61,5 +67,36 @@ class TopLevelPreprocessorTest extends \MailPoetUnitTest {
     verify($result[2]['innerBlocks'][0]['innerBlocks'])->arrayCount(2);
     verify($result[2]['innerBlocks'][0]['innerBlocks'][0]['blockName'])->equals('core/paragraph');
     verify($result[2]['innerBlocks'][0]['innerBlocks'][1]['blockName'])->equals('core/paragraph');
+  }
+
+  public function testItWrapsFullWidthBlocksIntoColumns(): void {
+    $parsedDocument = [$this->paragraphBlock, $this->columnsBlock, $this->headingBlock, $this->paragraphBlock, $this->headingBlock, $this->columnsBlock];
+    $parsedDocument[0]['attrs']['align'] = 'full';
+    $parsedDocument[4]['attrs']['align'] = 'full';
+    $parsedDocument[5]['attrs']['align'] = 'full';
+    $parsedDocument[5]['innerBlocks'][0]['innerBlocks'][] = $this->paragraphBlock;
+    // We expect to wrap top level paragraph blocks into columns so the result should three columns blocks
+    $result = $this->preprocessor->preprocess($parsedDocument, []);
+    verify($result)->arrayCount(5);
+    // First block is a full width paragraph and must be wrapped in a single column
+    verify($result[0]['blockName'])->equals('core/columns');
+    verify($result[0]['attrs'])->equals(['align' => 'full']);
+    verify($result[0]['innerBlocks'][0]['blockName'])->equals('core/column');
+    verify($result[0]['innerBlocks'][0]['innerBlocks'][0])->equals($parsedDocument[0]);
+    // Second block is a columns block and must remain unchanged
+    verify($result[1])->equals($parsedDocument[1]);
+    // Third block must contain heading and paragraph blocks
+    verify($result[2]['blockName'])->equals('core/columns');
+    verify($result[2]['innerBlocks'][0]['blockName'])->equals('core/column');
+    verify($result[2]['innerBlocks'][0]['innerBlocks'])->arrayCount(2);
+    verify($result[2]['innerBlocks'][0]['innerBlocks'][0])->equals($parsedDocument[2]);
+    verify($result[2]['innerBlocks'][0]['innerBlocks'][1])->equals($parsedDocument[3]);
+    // Fourth block is a full width heading and must be wrapped in a single column
+    verify($result[3]['blockName'])->equals('core/columns');
+    verify($result[3]['attrs'])->equals(['align' => 'full']);
+    verify($result[3]['innerBlocks'][0]['blockName'])->equals('core/column');
+    verify($result[3]['innerBlocks'][0]['innerBlocks'][0])->equals($parsedDocument[4]);
+    // Fifth block should stay unchanged
+    verify($result[4])->equals($parsedDocument[5]);
   }
 }


### PR DESCRIPTION
## Description

This PR enables full alignment for specific blocks such as `core/columns`, `core/heading`, `core/paragraph`. As part of the implementation is modifying the renderer and the email editor.

## Code review notes

- Adding `theme.json` and generating styles for the email editor is there for more straightforward implementation.
- Rendering full-width blocks is based on wrapping by the block `core/columns` on the top level because the editor doesn't allow configuration full alignment for the nested blocks.
- Left and right paddings were moved from the `layout.html` to `core/columns` block because it allows stretching blocks to full-width.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5688]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5688]: https://mailpoet.atlassian.net/browse/MAILPOET-5688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ