### PR TITLE
Fix PHPStan error about parameter passed to strval() [MAILPOET-5719]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateGetEndpoint.php
@@ -32,7 +32,9 @@ class AutomationTemplateGetEndpoint extends Endpoint {
   }
 
   public function handle(Request $request): Response {
-    $slug = strval($request->getParam('slug'));
+    /** @var string|null $slug - for PHPStan because strval() doesn't accept a value of mixed */
+    $slug = $request->getParam('slug');
+    $slug = strval($slug);
     $template = $this->registry->getTemplate($slug);
     if (!$template) {
       throw Exceptions::automationTemplateNotFound($slug);


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5719]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5719]: https://mailpoet.atlassian.net/browse/MAILPOET-5719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ