### PR TITLE
Update Woo versions [MAILPOET-5792]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,10 +191,10 @@ jobs:
           name: Download additional WP Plugins for tests
           command: |
             ./do download:woo-commerce-zip latest
-            ./do download:woo-commerce-subscriptions-zip 4.9.1
-            ./do download:woo-commerce-memberships-zip 1.24.0
-            ./do download:woo-commerce-blocks-zip 9.6.2
-            ./do download:automate-woo-zip 6.0.5
+            ./do download:woo-commerce-subscriptions-zip 5.7.0
+            ./do download:woo-commerce-memberships-zip 1.25.2
+            ./do download:woo-commerce-blocks-zip 11.7.0
+            ./do download:automate-woo-zip 6.0.10
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |
@@ -977,11 +977,11 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 8.0.0
-          woo_subscriptions_version: 4.3.0
-          woo_memberships_version: 1.21.0
-          woo_blocks_version: 6.8.0
-          automate_woo_version: 5.1.1
+          woo_core_version: 8.3.0
+          woo_subscriptions_version: 5.6.0
+          woo_memberships_version: 1.23.1
+          woo_blocks_version: 11.6.0
+          automate_woo_version: 5.8.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
@@ -1015,11 +1015,11 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 7.9.0
-          woo_subscriptions_version: 4.3.0
-          woo_memberships_version: 1.21.0
-          woo_blocks_version: 6.8.0
-          automate_woo_version: 5.1.1
+          woo_core_version: 8.3.0
+          woo_subscriptions_version: 5.6.0
+          woo_memberships_version: 1.24.0
+          woo_blocks_version: 11.6.0
+          automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 8.0.0
- * WC tested up to: 8.1.0
+ * WC requires at least: 8.3.0
+ * WC tested up to: 8.4.0
  *
  * @package WordPress
  * @author MailPoet


### PR DESCRIPTION
## Description

This PR updates are minimal and tested up to the Woo version and also Woo and Woo extensions versions used in tests on Circle CI.
The extension versions haven't been updated for some time so I updated those using the same rule L-1 as we use for Woo (except for automate_woo_version because they went from 5.8.5 to 6.0.0).


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5792]

## After-merge notes

_N/A_

## Tasks

- [X] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [X] I added sufficient test coverage
- [X] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5792]: https://mailpoet.atlassian.net/browse/MAILPOET-5792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ