### PR TITLE
Add test to prevent plugin conflict between AutomateWoo and Automation

### DIFF
--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -51,7 +51,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->click($automationTitle);
     $i->waitForText('Draft');
     $i->waitForText('Move to Trash');
-    $i->waitForText('Welcome email');
-    $i->waitForText('Wait for 2 days');
+    $i->waitForText('Someone subscribes');
+    $i->waitForText('Wait for 5 minutes');
   }
 }

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -2,9 +2,23 @@
 
 namespace MailPoet\Test\Acceptance;
 
+/**
+ * This test contains active AutomateWoo plugin
+ * in order to potentially catch issue with
+ * blank page when managing automation with
+ * the plugin AutomateWoo active.
+ */
 class ConfirmLeaveWhenUnsavedChangesCest {
+  public function _before(\AcceptanceTester $i) {
+    $i->activateWooCommerce();
+    $i->activateAutomateWoo();
+  }
+
   public function confirmationIsRequiredIfAutomationNotSaved(\AcceptanceTester $i) {
     $i->wantTo('Edit a new automation draft');
+
+    $automationTitle = 'Welcome new subscribers';
+
     $i->login();
 
     $i->amOnMailpoetPage('Automation');
@@ -15,7 +29,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
 
     $i->click('Start with a template');
     $i->see('Start with a template', 'h1');
-    $i->click('Welcome new subscribers');
+    $i->click($automationTitle);
     $i->click('Start building');
 
     $i->waitForText('Draft');
@@ -31,7 +45,13 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->wantTo('Leave the page after saving.');
     $i->click('Save');
     $i->waitForText('saved');
-    $i->reloadPage();
+    $i->amOnMailpoetPage('Automation');
+    $i->waitForText('Automations');
+    $i->waitForText($automationTitle);
+    $i->click($automationTitle);
     $i->waitForText('Draft');
+    $i->waitForText('Move to Trash');
+    $i->waitForText('Welcome email');
+    $i->waitForText('Wait for 2 days');
   }
 }

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -4,10 +4,18 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * This test contains active AutomateWoo plugin
+ * in order to potentially catch issue with
+ * blank page when managing automation with
+ * the plugin AutomateWoo active.
+ */
 class CreateEmailAutomationAndWalkThroughCest {
-  public function _before() {
+  public function _before(\AcceptanceTester $i) {
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
+    $i->activateWooCommerce();
+    $i->activateAutomateWoo();
   }
 
   public function createEmailAutomationAndReceiveAnAutomatedEmail(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
+++ b/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
@@ -9,6 +9,12 @@ use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Test\DataFactories;
 
+/**
+ * This test contains active AutomateWoo plugin
+ * in order to potentially catch issue with
+ * blank page when managing automation with
+ * the plugin AutomateWoo active.
+ */
 class RunAutomationOnlyOnceSettingCest {
 
   /** @var DataFactories\Settings */
@@ -32,6 +38,8 @@ class RunAutomationOnlyOnceSettingCest {
   private $segment;
 
   public function _before(\AcceptanceTester $i) {
+    $i->activateWooCommerce();
+    $i->activateAutomateWoo();
     $this->container = ContainerWrapper::getInstance();
     $this->settingsFactory = new DataFactories\Settings();
     $this->settingsFactory->withCronTriggerMethod('Action Scheduler');


### PR DESCRIPTION
## Description

Check Jira for more details please.
This is to have prevent plugin conflict with AutomateWoo while editing Automation newsletter.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5794]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5794]: https://mailpoet.atlassian.net/browse/MAILPOET-5794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ