### PR TITLE
Update email block core/paragraph renderer [MAILPOET-5642]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
@@ -39,10 +39,7 @@ class BlocksWidthPreprocessor implements Preprocessor {
       $modifiedLayoutStyles['padding']['left'] = $block['attrs']['style']['spacing']['padding']['left'] ?? '0px';
       $modifiedLayoutStyles['padding']['right'] = $block['attrs']['style']['spacing']['padding']['right'] ?? '0px';
 
-      // Set current block values and reassign it to $parsedBlocks, but don't set width for blocks that are not supposed to have it
-      if (!in_array($block['blockName'], self::BLOCKS_WITHOUT_WIDTH, true)) {
-        $block['email_attrs']['width'] = "{$width}px";
-      }
+      $block['email_attrs']['width'] = "{$width}px";
       $block['innerBlocks'] = $this->preprocess($block['innerBlocks'], $modifiedLayoutStyles);
       $parsedBlocks[$key] = $block;
     }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
@@ -7,11 +7,6 @@ namespace MailPoet\EmailEditor\Engine\Renderer\Preprocessors;
  * The final width in pixels is stored in the email_attrs array because we would like to avoid changing the original attributes.
  */
 class BlocksWidthPreprocessor implements Preprocessor {
-
-  const BLOCKS_WITHOUT_WIDTH = [
-    'core/paragraph',
-  ];
-
   public function preprocess(array $parsedBlocks, array $layoutStyles): array {
     foreach ($parsedBlocks as $key => $block) {
       // Layout width is recalculated for each block because full-width blocks don't exclude padding

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -101,6 +101,8 @@ class SettingsController {
     // Enable custom spacing
     $coreSettings['spacing']['units'] = ['px'];
     $coreSettings['spacing']['padding'] = true;
+    // Typography
+    $coreSettings['typography']['dropCap'] = false; // Showing large initial letter cannot be implemented in emails
 
     $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
     $themeJson = json_decode($themeJson, true);

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -103,6 +103,7 @@ class SettingsController {
     $coreSettings['spacing']['padding'] = true;
     // Typography
     $coreSettings['typography']['dropCap'] = false; // Showing large initial letter cannot be implemented in emails
+    $coreSettings['typography']['fontWeight'] = false; // Font weight will be handled by the font family later
 
     $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
     $themeJson = json_decode($themeJson, true);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -6,7 +6,7 @@ use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Column implements BlockRenderer {
-  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $content = '';
     foreach ($parsedBlock['innerBlocks'] ?? [] as $block) {
       $content .= render_block($block);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -49,7 +49,7 @@ class Column implements BlockRenderer {
     return '
       <td class="block" style="' . $settingsController->convertStylesToString($mainCellStyles) . '">
         <div class="email_column" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';font-size:0px;text-align:left;display:inline-block;">
-          <table class="email_column" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';width:100%;max-width:' . $width . ';vertical-align:top;" width="' . $width . '">
+          <table class="email_column" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';min-width:100%;width:100%;max-width:' . $width . ';vertical-align:top;" width="' . $width . '">
             <tbody>
               <tr>
                 <td align="left" style="font-size:0px;padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';">

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -42,7 +42,7 @@ class Column implements BlockRenderer {
     ];
     // The default column alignment is `stretch to fill` which means that we need to set the background color to the main cell
     // to create a feeling of a stretched column
-    if (!isset($parsedBlock['attrs']['verticalAlignment'])) {
+    if (!isset($parsedBlock['attrs']['verticalAlignment']) || $parsedBlock['attrs']['verticalAlignment'] === 'stretch') {
       $mainCellStyles['background-color'] = $backgroundColor;
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -6,7 +6,7 @@ use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Columns implements BlockRenderer {
-  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $content = '';
     foreach ($parsedBlock['innerBlocks'] ?? [] as $block) {
       $content .= render_block($block);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -8,15 +8,16 @@ use MailPoet\Util\Helpers;
 
 class Heading implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
-    $availableStylesheets = $settingsController->getAvailableStylesheets();
-    return str_replace('{heading_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $contentStyles, $availableStylesheets));
+    return str_replace('{heading_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
 
   /**
    * Based on MJML <mj-text>
    */
-  private function getBlockWrapper(array $parsedBlock, array $contentStyles, ?string $availableStylesheets): string {
+  private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
+    $contentStyles = $settingsController->getEmailContentStyles();
+    $availableStylesheets = $settingsController->getAvailableStylesheets();
+
     $styles = [];
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
       $styles[$property] = $value;
@@ -37,7 +38,7 @@ class Heading implements BlockRenderer {
         border="0"
         cellpadding="0"
         cellspacing="0"
-        style="' . $this->convertStylesToString($styles) . '"
+        style="' . $settingsController->convertStylesToString($styles) . '"
       >
         <tr>
           <td>
@@ -46,14 +47,6 @@ class Heading implements BlockRenderer {
         </tr>
       </table>
     ';
-  }
-
-  private function convertStylesToString(array $styles): string {
-    $cssString = '';
-    foreach ($styles as $property => $value) {
-      $cssString .= $property . ':' . $value . '; ';
-    }
-    return trim($cssString); // Remove trailing space and return the formatted string
   }
 
   private function fetchStylesFromBlockAttrs(?string $availableStylesheets, array $attrs = []): array {

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -7,7 +7,7 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 use MailPoet\Util\Helpers;
 
 class Heading implements BlockRenderer {
-  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $level = $parsedBlock['attrs']['level'] ?? 2; // default level is 2
     $blockContent = $this->removePaddingFromElement($blockContent, ['tag_name' => "h{$level}"]);
     return str_replace('{heading_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
@@ -118,7 +118,7 @@ class Heading implements BlockRenderer {
   /**
    * @param array{tag_name: string, class_name?: string} $tag
    */
-  private function removePaddingFromElement($blockContent, array $tag) {
+  private function removePaddingFromElement($blockContent, array $tag): string {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag($tag)) {
       $elementStyle = $html->get_attribute('style') ?? '';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -20,6 +20,7 @@ class Heading implements BlockRenderer {
 
     $styles = [];
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
+      if ($property === 'width') continue; // width is handled by the wrapping blocks (columns, column)
       $styles[$property] = $value;
     }
 
@@ -38,10 +39,10 @@ class Heading implements BlockRenderer {
         border="0"
         cellpadding="0"
         cellspacing="0"
-        style="' . $settingsController->convertStylesToString($styles) . '"
+        style="width: 100%;"
       >
         <tr>
-          <td>
+          <td style="' . $settingsController->convertStylesToString($styles) . '">
             {heading_content}
           </td>
         </tr>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -6,7 +6,7 @@ use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Image implements BlockRenderer {
-  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     // Replacing HTML tags figure and figcaption because they are not supported by all email clients
     $blockContent = str_replace(
       ['<figure', '</figure>', '<figcaption', '</figcaption>'],
@@ -37,7 +37,7 @@ class Image implements BlockRenderer {
   /**
    * Settings width and height attributes for images is important for MS Outlook.
    */
-  private function addImageDimensions($blockContent, array $parsedBlock, SettingsController $settingsController) {
+  private function addImageDimensions($blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag(['tag_name' => 'img'])) {
       // Getting height from styles and if it's set, we set the height attribute
@@ -127,7 +127,7 @@ class Image implements BlockRenderer {
    * @param array{tag_name: string, class_name?: string} $tag
    * @param string $style
    */
-  private function addStyleToElement($blockContent, array $tag, string $style) {
+  private function addStyleToElement($blockContent, array $tag, string $style): string {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag($tag)) {
       $elementStyle = $html->get_attribute('style');

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -7,7 +7,7 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 // We have to avoid using keyword `List`
 class ListBlock implements BlockRenderer {
-  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     return str_replace('{list_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -4,9 +4,11 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\Util\Helpers;
 
 class Paragraph implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    $blockContent = $this->removePaddingFromElement($blockContent, ['tag_name' => 'p']);
     return str_replace('{paragraph_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
 
@@ -15,8 +17,22 @@ class Paragraph implements BlockRenderer {
    */
   private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
     $contentStyles = $settingsController->getEmailContentStyles();
+    $availableStylesheets = $settingsController->getAvailableStylesheets();
 
-    $styles = [];
+    $align = $parsedBlock['attrs']['align'] ?? 'left';
+    $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
+    $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
+    $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
+    $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
+
+    $styles = [
+      'text-align' => $align,
+      'padding-bottom' => $paddingBottom,
+      'padding-left' => $paddingLeft,
+      'padding-right' => $paddingRight,
+      'padding-top' => $paddingTop,
+    ];
+
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
       $styles[$property] = $value;
     }
@@ -28,20 +44,78 @@ class Paragraph implements BlockRenderer {
       $styles['font-family'] = $contentStyles['typography']['fontFamily'];
     }
 
+    $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs'] ?? []));
+
     return '
       <table
         role="presentation"
         border="0"
         cellpadding="0"
         cellspacing="0"
-        style="' . $settingsController->convertStylesToString($styles) . '"
+        style="width:100%;"
       >
         <tr>
-          <td>
+          <td style="' . $settingsController->convertStylesToString($styles) . '" align="' . $align . '">
             {paragraph_content}
           </td>
         </tr>
       </table>
     ';
+  }
+
+  private function fetchStylesFromBlockAttrs(?string $availableStylesheets, array $attrs = []): array {
+    $styles = [];
+
+    // using custom rules because colors do not automatically resolve to hex value
+    $supportedColorValues = ['backgroundColor', 'textColor'];
+    foreach ($supportedColorValues as $supportedColorValue) {
+      if (array_key_exists($supportedColorValue, $attrs)) {
+        $colorKey = $attrs[$supportedColorValue];
+
+        $cssString = $availableStylesheets ?? '';
+
+        $colorRegex = "/--wp--preset--color--$colorKey: (#[0-9a-fA-F]{6});/";
+
+        // fetch color hex from available stylesheets
+        preg_match($colorRegex, $cssString, $colorMatch);
+
+        $colorValue = '';
+        if ($colorMatch) {
+          $colorValue = $colorMatch[1];
+        }
+
+        if ($supportedColorValue === 'textColor') {
+          $styles['color'] = $colorValue; // use color instead of textColor. textColor not valid CSS property
+        } else {
+          $styles[Helpers::camelCaseToKebabCase($supportedColorValue)] = $colorValue;
+        }
+
+      }
+    }
+
+    // fetch Block Style Typography e.g., fontStyle, fontWeight, etc
+    if (isset($attrs['style']['typography'])) {
+      $blockStyleTypographyKeys = array_keys($attrs['style']['typography']);
+      foreach ($blockStyleTypographyKeys as $blockStyleTypographyKey) {
+        $styles[Helpers::camelCaseToKebabCase($blockStyleTypographyKey)] = $attrs['style']['typography'][$blockStyleTypographyKey];
+      }
+    }
+
+    return $styles;
+  }
+
+  /**
+   * @param array{tag_name: string, class_name?: string} $tag
+   */
+  private function removePaddingFromElement($blockContent, array $tag) {
+    $html = new \WP_HTML_Tag_Processor($blockContent);
+    if ($html->next_tag($tag)) {
+      $elementStyle = $html->get_attribute('style') ?? '';
+      $elementStyle = preg_replace('/padding.*:.?[0-9]+px;?/', '', $elementStyle);
+      $html->set_attribute('style', $elementStyle);
+      $blockContent = $html->get_updated_html();
+    }
+
+    return $blockContent;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -65,21 +65,23 @@ class Paragraph implements BlockRenderer {
     ';
   }
 
-  private function fetchStylesFromBlockAttrs(?string $availableStylesheets, array $attrs = []): array {
+  /**
+   * @param string $availableStylesheets contains CSS styles generated from the core theme.json file
+   */
+  private function fetchStylesFromBlockAttrs(string $availableStylesheets, array $attrs = []): array {
     $styles = [];
 
-    // using custom rules because colors do not automatically resolve to hex value
+    // Fetching matched color variables by slug stored in the block attrs to the color value.
     $supportedColorValues = ['backgroundColor', 'textColor'];
     foreach ($supportedColorValues as $supportedColorValue) {
       if (array_key_exists($supportedColorValue, $attrs)) {
-        $colorKey = $attrs[$supportedColorValue];
+        $colorSlug = $attrs[$supportedColorValue];
 
-        $cssString = $availableStylesheets ?? '';
-
-        $colorRegex = "/--wp--preset--color--$colorKey: (#[0-9a-fA-F]{6});/";
+        // CSS variables are stored by current pattern `--wp--preset--{type}--{slug}` More info: https://developer.wordpress.org/themes/global-settings-and-styles/settings/color/#registering-custom-color-presets
+        $colorRegex = "/--wp--preset--color--$colorSlug: (#[0-9a-fA-F]{6});/";
 
         // fetch color hex from available stylesheets
-        preg_match($colorRegex, $cssString, $colorMatch);
+        preg_match($colorRegex, $availableStylesheets, $colorMatch);
 
         $colorValue = '';
         if ($colorMatch) {

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -54,6 +54,7 @@ class Paragraph implements BlockRenderer {
         cellpadding="0"
         cellspacing="0"
         style="width:100%;"
+        width="100%"
       >
         <tr>
           <td style="' . $settingsController->convertStylesToString($styles) . '" align="' . $align . '">

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -7,7 +7,7 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 use MailPoet\Util\Helpers;
 
 class Paragraph implements BlockRenderer {
-  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $blockContent = $this->removePaddingFromElement($blockContent, ['tag_name' => 'p']);
     return str_replace('{paragraph_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
@@ -109,7 +109,7 @@ class Paragraph implements BlockRenderer {
   /**
    * @param array{tag_name: string, class_name?: string} $tag
    */
-  private function removePaddingFromElement($blockContent, array $tag) {
+  private function removePaddingFromElement($blockContent, array $tag): string {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag($tag)) {
       $elementStyle = $html->get_attribute('style') ?? '';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -34,6 +34,7 @@ class Paragraph implements BlockRenderer {
     ];
 
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
+      if ($property === 'width') continue; // width is handled by the wrapping blocks (columns, column)
       $styles[$property] = $value;
     }
 

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
@@ -45,7 +45,8 @@ class HeadingTest extends \MailPoetTest {
   public function testItRendersContent(): void {
     $rendered = $this->headingRenderer->render('<h1>This is Heading 1</h1>', $this->parsedHeading, $this->settingsController);
     verify($rendered)->stringContainsString('This is Heading 1');
-    verify($rendered)->stringContainsString('width:640px;');
+    verify($rendered)->stringContainsString('width: 100%;');
+    verify($rendered)->stringNotContainsString('width:640px;');
   }
 
   public function testItRendersBlockAttributes(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ParagraphTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ParagraphTest.php
@@ -34,9 +34,52 @@ class ParagraphTest extends \MailPoetTest {
 
   public function testItRendersContent(): void {
     $rendered = $this->paragraphRenderer->render('<p>Lorem Ipsum</p>', $this->parsedParagraph, $this->settingsController);
-    verify($rendered)->stringNotContainsString('width:'); // Paragraph should not contain width
-    verify($rendered)->stringContainsString('Lorem Ipsum');
-    verify($rendered)->stringContainsString('font-size:16px;');
-    verify($rendered)->stringContainsString('font-family:Arial;');
+    $this->assertStringContainsString('width:100%', $rendered);
+    $this->assertStringContainsString('Lorem Ipsum', $rendered);
+    $this->assertStringContainsString('font-size:16px;', $rendered);
+    $this->assertStringContainsString('font-family:Arial;', $rendered);
+    $this->assertStringContainsString('text-align:left;', $rendered); // Check the default text-align
+    $this->assertStringContainsString('align="left"', $rendered); // Check the default align
+  }
+
+  public function testItRendersContentWithPadding(): void {
+    $parsedParagraph = $this->parsedParagraph;
+    $parsedParagraph['attrs']['style']['spacing']['padding']['top'] = '10px';
+    $parsedParagraph['attrs']['style']['spacing']['padding']['right'] = '20px';
+    $parsedParagraph['attrs']['style']['spacing']['padding']['bottom'] = '30px';
+    $parsedParagraph['attrs']['style']['spacing']['padding']['left'] = '40px';
+    $parsedParagraph['attrs']['align'] = 'center';
+
+    $rendered = $this->paragraphRenderer->render('<p>Lorem Ipsum</p>', $parsedParagraph, $this->settingsController);
+    $this->assertStringContainsString('padding-top:10px;', $rendered);
+    $this->assertStringContainsString('padding-right:20px;', $rendered);
+    $this->assertStringContainsString('padding-bottom:30px;', $rendered);
+    $this->assertStringContainsString('padding-left:40px;', $rendered);
+    $this->assertStringContainsString('text-align:center;', $rendered);
+    $this->assertStringContainsString('align="center"', $rendered);
+    $this->assertStringContainsString('Lorem Ipsum', $rendered);
+  }
+
+  public function testItConvertsBlockTypography(): void {
+    $parsedParagraph = $this->parsedParagraph;
+    $parsedParagraph['attrs']['style']['typography'] = [
+      'textTransform' => 'uppercase',
+      'letterSpacing' => '1px',
+      'textDecoration' => 'underline',
+      'fontStyle' => 'italic',
+      'fontWeight' => 'bold',
+      'fontSize' => '20px',
+      'fontFamily' => 'Times New Roman',
+    ];
+
+    $rendered = $this->paragraphRenderer->render('<p>Lorem Ipsum</p>', $parsedParagraph, $this->settingsController);
+    $this->assertStringContainsString('text-transform:uppercase;', $rendered);
+    $this->assertStringContainsString('letter-spacing:1px;', $rendered);
+    $this->assertStringContainsString('text-decoration:underline;', $rendered);
+    $this->assertStringContainsString('font-style:italic;', $rendered);
+    $this->assertStringContainsString('font-weight:bold;', $rendered);
+    $this->assertStringContainsString('font-size:20px;', $rendered);
+    $this->assertStringContainsString('font-family:Times New Roman;', $rendered);
+    $this->assertStringContainsString('Lorem Ipsum', $rendered);
   }
 }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessorTest.php
@@ -141,9 +141,9 @@ class BlocksWidthPreprocessorTest extends \MailPoetUnitTest {
 
     verify($innerBlocks)->arrayCount(2);
     verify($innerBlocks[0]['email_attrs']['width'])->equals('252px'); // (660 - 15 - 15) * 0.4
-    verify($innerBlocks[0]['innerBlocks'][0])->arrayHasNotKey('email_attrs'); // paragraph block should not have width
+    verify($innerBlocks[0]['innerBlocks'][0]['email_attrs']['width'])->equals('232px'); // 252 - 10 - 10
     verify($innerBlocks[1]['email_attrs']['width'])->equals('378px'); // (660 - 15 - 15) * 0.6
-    verify($innerBlocks[1]['innerBlocks'][0])->arrayHasNotKey('email_attrs'); // paragraph block should not have width
+    verify($innerBlocks[1]['innerBlocks'][0]['email_attrs']['width'])->equals('338px'); // 378 - 25 - 15
   }
 
   public function testItAddsMissingColumnWidth(): void {
@@ -191,11 +191,11 @@ class BlocksWidthPreprocessorTest extends \MailPoetUnitTest {
 
     verify($innerBlocks)->arrayCount(3);
     verify($innerBlocks[0]['email_attrs']['width'])->equals('200px'); // (660 - 30 - 30) * 0.33
-    verify($innerBlocks[0]['innerBlocks'][0])->arrayHasNotKey('email_attrs'); // paragraph block should not have width
+    verify($innerBlocks[0]['innerBlocks'][0]['email_attrs']['width'])->equals('200px');
     verify($innerBlocks[1]['email_attrs']['width'])->equals('200px'); // (660 - 30 - 30) * 0.33
-    verify($innerBlocks[1]['innerBlocks'][0])->arrayHasNotKey('email_attrs'); // paragraph block should not have width
+    verify($innerBlocks[1]['innerBlocks'][0]['email_attrs']['width'])->equals('200px');
     verify($innerBlocks[2]['email_attrs']['width'])->equals('200px'); // (660 - 30 - 30) * 0.33
-    verify($innerBlocks[2]['innerBlocks'][0])->arrayHasNotKey('email_attrs'); // paragraph block should not have width
+    verify($innerBlocks[2]['innerBlocks'][0]['email_attrs']['width'])->equals('200px');
   }
 
   public function testItCalculatesMissingColumnWidth(): void {


### PR DESCRIPTION
## Description

We had a simple core/paragraph block render that didn't support all possible configurations. In this renderer iteration, we add the possibility of text alignment and rendering compatibility across email clients.

## Code review notes

_N/A_

## QA notes

QA could be skipped here, I would let the decision on the reviewer.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5642]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5642]: https://mailpoet.atlassian.net/browse/MAILPOET-5642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ