### PR TITLE
Fix validation logic for "was sent" filter [MAILPOET-5801]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/email.tsx
@@ -29,9 +29,11 @@ export function validateEmail(formItems: EmailFormItem): boolean {
   }
 
   if (
-    [EmailActionTypes.OPENED, EmailActionTypes.MACHINE_OPENED].includes(
-      formItems.action as EmailActionTypes,
-    )
+    [
+      EmailActionTypes.OPENED,
+      EmailActionTypes.MACHINE_OPENED,
+      EmailActionTypes.WAS_SENT,
+    ].includes(formItems.action as EmailActionTypes)
   ) {
     return (
       Array.isArray(formItems.newsletters) && formItems.newsletters.length > 0


### PR DESCRIPTION
## Description

This fixes what should be a UI-only bug where dynamic segments would not pass validation if they contain a "was sent" filter.

The issue was introduced here: https://github.com/mailpoet/mailpoet/commit/ee9e3a791f3575db01fcf15ece3dd01fc88729f7#diff-284f6f5af06781e3eee770e40b1d36e9a710b5eb5a3c457b017987c1755042d9R31

The refactored logic didn't account specifically for the `WAS_SENT` type, which was being implicitly included previously.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5801

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
