### PR TITLE
Fix premium plugin Fatal error caused by added icons support - MAILPOET-5803

### DIFF
--- a/mailpoet/lib/Config/Installer.php
+++ b/mailpoet/lib/Config/Installer.php
@@ -95,16 +95,6 @@ class Installer {
   public function retrievePluginInformation() {
     $key = $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
     $api = new API($key);
-    $info = $api->getPluginInformation($this->slug);
-    $info = $this->formatInformation($info);
-    return $info;
-  }
-
-  private function formatInformation($info) {
-    // cast sections object to array for WP to understand
-    if (isset($info->sections)) {
-      $info->sections = (array)$info->sections;
-    }
-    return $info;
+    return $api->getPluginInformation($this->slug);
   }
 }

--- a/mailpoet/lib/Services/Release/API.php
+++ b/mailpoet/lib/Services/Release/API.php
@@ -46,17 +46,19 @@ class API {
   }
 
   private function formatPluginInformation($info) {
-    // cast sections object to array for WP to understand
-    if (isset($info->sections)) {
-      $info->sections = (array)$info->sections;
+    if (!$info instanceof \stdClass) return $info;
+
+    $propKeys = array_keys(get_object_vars($info));
+    $newInfo = clone $info;
+
+    foreach ($propKeys as $key) {
+      if (gettype($newInfo->{$key}) === 'object') {
+        // cast objects to array for WP to understand
+        $newInfo->{$key} = (array)$newInfo->{$key};
+      }
     }
 
-    // cast icons object to array for WP to understand
-    if (isset($info->icons)) {
-      $info->icons = (array)$info->icons;
-    }
-
-    return $info;
+    return $newInfo;
   }
 
   private function request($url, $params = []) {

--- a/mailpoet/lib/Services/Release/API.php
+++ b/mailpoet/lib/Services/Release/API.php
@@ -26,7 +26,7 @@ class API {
       case 200:
         $body = $this->wp->wpRemoteRetrieveBody($result);
         if ($body) {
-          $body = json_decode($body);
+          $body = $this->formatPluginInformation(json_decode($body));
         }
         break;
       default:
@@ -43,6 +43,20 @@ class API {
 
   public function getKey() {
     return $this->apiKey;
+  }
+
+  private function formatPluginInformation($info) {
+    // cast sections object to array for WP to understand
+    if (isset($info->sections)) {
+      $info->sections = (array)$info->sections;
+    }
+
+    // cast icons object to array for WP to understand
+    if (isset($info->icons)) {
+      $info->icons = (array)$info->icons;
+    }
+
+    return $info;
   }
 
   private function request($url, $params = []) {


### PR DESCRIPTION
## Description

Fix and format API response.

## Code review notes

_N/A_

## QA notes

* Install an older premium release (e.g 4.39.0)
* Visit the WP update page: `/wp-admin/update-core.php`
* Ensure you don't see an error and the plugin update list includes MailPoet premium

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5803](https://mailpoet.atlassian.net/browse/MAILPOET-5803)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5803]: https://mailpoet.atlassian.net/browse/MAILPOET-5803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ