### PR TITLE
Fix emoji sanitisation for general utf-8 columns [MAILPOET-5283]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -40,6 +40,8 @@ class RoboFile extends \Robo\Tasks {
     $this->_exec('rm -rf ' . __DIR__ . '/generated/*');
     $this->say('Cleaning up PHPStan cache.');
     $this->_exec('rm -rf ' . __DIR__ . '/temp/*');
+    $this->say('Cleaning up old testing plugins.');
+    $this->_exec('rm -rf ' . __DIR__ . '/tests/plugins/*');
   }
 
   public function update() {
@@ -493,9 +495,12 @@ class RoboFile extends \Robo\Tasks {
    * Deletes docker containers and volumes used in tests
    */
   public function resetTestDocker() {
-    return $this->taskExec(
+    return $this
+      ->taskExec(
       'docker-compose down -v --remove-orphans'
-    )->dir(__DIR__ . '/tests/docker')->run();
+      )->dir(__DIR__ . '/tests/docker')
+      ->addCode([$this, 'cleanupCachedFiles'])
+      ->run();
   }
 
   public function testFailedUnit() {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -122,8 +122,9 @@ class NewsletterSaveController {
     }
 
     if (!empty($data['body'])) {
-      $body = $this->dataSanitizer->sanitizeBody(json_decode($data['body'], true));
-      $data['body'] = $this->emoji->encodeForUTF8Column(MP_NEWSLETTERS_TABLE, 'body', json_encode($body));
+      $body = $this->emoji->encodeForUTF8Column(MP_NEWSLETTERS_TABLE, 'body', $data['body']);
+      $body = $this->dataSanitizer->sanitizeBody(json_decode($body, true));
+      $data['body'] = json_encode($body);
     }
 
     $newsletter = isset($data['id']) ? $this->getNewsletter($data) : $this->createNewsletter($data);

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -58,6 +58,21 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($newsletter->getGaCampaign())->equals('Updated GA campaign');
   }
 
+  public function testItCanSaveANewsletterWithEmojis() {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD);
+    $newsletterData = [
+      'id' => $newsletter->getId(),
+      'type' => 'Updated type',
+      'subject' => 'Subject',
+      'body' => '{"value": "Updated 🙈body"}',
+      'sender_name' => 'Updated sender name',
+      'sender_address' => 'Updated sender address',
+    ];
+
+    $newsletter = $this->saveController->save($newsletterData);
+    verify($newsletter->getBody())->equals(['value' => 'Updated 🙈body']);
+  }
+
   public function testItDoesNotRerenderPostNotificationsUponUpdate() {
     $this->createPostNotificationOptions();
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION);


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

1. Change collation on wp_mailpoet_newsletters column body to utf8_general_ci
2. Create a new email and add an emoji
3. Try to save the email
4. The email fails to save

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5283]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5283]: https://mailpoet.atlassian.net/browse/MAILPOET-5283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ