### PR TITLE
Fix mobile preview for columns with configured width [MAILPOET-5746]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -99,6 +99,8 @@
 
     .wp-block-column {
       box-sizing: border-box;
+      // override flex-basis set in style attribute to fix the height of the column in mobile preview. Blocks overriding is as a part of style.css in blocks-library
+      flex-basis: auto !important;
     }
   }
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5746]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5746]: https://mailpoet.atlassian.net/browse/MAILPOET-5746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ