### PR TITLE
Shared sender domain status logic [MAILPOET-5783]

### DIFF
--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -104,6 +104,10 @@ class AuthorizedSenderDomainController {
     return $response;
   }
 
+  public function getRewrittenEmailAddress(string $email): string {
+    return sprintf('%s@replies.sendingservice.net', str_replace('@', '=', $email));
+  }
+
   /**
    * Verify Sender Domain
    *

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -156,12 +156,8 @@ class Bridge {
   public function getAuthorizedSenderDomains($domain = 'all'): array {
     $domain = strtolower($domain);
 
-    $data = $this
-      ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
-      ->getAuthorizedSenderDomains();
-    $data = $data ?? [];
-
     $allSenderDomains = [];
+    $data = $this->getRawSenderDomainData();
 
     foreach ($data as $subarray) {
       if (isset($subarray['domain'])) {
@@ -175,6 +171,13 @@ class Bridge {
     }
 
     return $allSenderDomains;
+  }
+
+  public function getRawSenderDomainData(): array {
+    $data = $this
+      ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
+      ->getAuthorizedSenderDomains();
+    return $data ?? [];
   }
 
   /**

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -233,6 +233,11 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
     verify($isRestricted)->same('none');
   }
 
+  public function testItCanRewriteEmailAddresses(): void {
+    $email = 'jane.doe@gmail.com';
+    $this->assertSame('jane.doe=gmail.com@replies.sendingservice.net', $this->getController()->getRewrittenEmailAddress($email));
+  }
+
   private function getController($bridgeMock = null): AuthorizedSenderDomainController {
     $dmarcPolicyChecker = $this->diContainer->get(DmarcPolicyChecker::class);
     return new AuthorizedSenderDomainController($bridgeMock ?? $this->bridge, $dmarcPolicyChecker);


### PR DESCRIPTION
## Description

This PR contains logic necessary for MAILPOET-5783 as well as some of the other sender domain tickets. Since it's just the shared logic it doesn't actually complete ticket 5783 (i.e. this doesn't add any new notices). That will be handled in a separate PR.

## Code review notes

Is there a more appropriate place to put the logic for rewriting emails?

I thought about adding other helper methods but figured we could add/change as needed in other PRs. Let me know if you can think of any others we would definitely want right away though.

## QA notes

No QA should be necessary since this isn't changing any real application logic yet.

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5783

## After-merge notes

_N/A_

## Tasks

- [ ] ~I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations~
- [x] I added sufficient test coverage
- [ ] ~I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes~
