### PR TITLE
Add banner notices for unverified sender domains [MAILPOET-5783]

### DIFF
--- a/mailpoet/assets/js/src/wizard/finish-wizard.ts
+++ b/mailpoet/assets/js/src/wizard/finish-wizard.ts
@@ -3,6 +3,7 @@ import { updateSettings } from './update-settings';
 export async function finishWizard(redirect_url = null) {
   await updateSettings({
     version: window.mailpoet_version,
+    installed_after_new_domain_restrictions: 1,
   });
   if (redirect_url) {
     window.location.href = redirect_url;

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -397,6 +397,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);
     $container->autowire(\MailPoet\Util\Notices\PendingApprovalNotice::class)->setPublic(true);
+    $container->autowire(\MailPoet\Util\Notices\SenderDomainAuthenticationNotices::class)->setPublic(true);
     //Referrals
     $container->autowire(\MailPoet\Referrals\ReferralDetector::class);
     // Router
@@ -597,6 +598,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Util
     $container->autowire(\MailPoet\Util\Cookies::class);
     $container->autowire(\MailPoet\Util\DBCollationChecker::class);
+    $container->autowire(\MailPoet\Util\FreeDomains::class);
     $container->autowire(\MailPoet\Util\Url::class)->setPublic(true);
     $container->autowire(\MailPoet\Util\Installation::class);
     $container->autowire(\MailPoet\Util\Security::class);

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -173,16 +173,32 @@ class AuthorizedSenderDomainController {
     });
   }
 
-  public function getFullyVerifiedSenderDomains(): array {
-    return $this->getSenderDomainsByStatus(self::OVERALL_STATUS_VERIFIED);
+  public function getFullyVerifiedSenderDomains($domainsOnly = false): array {
+    $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_VERIFIED);
+    if ($domainsOnly) {
+      return array_map([$this, 'domainExtractor'], $domainData);
+    }
+    return $domainData;
   }
 
-  public function getPartiallyVerifiedSenderDomains(): array {
-    return $this->getSenderDomainsByStatus(self::OVERALL_STATUS_PARTIALLY_VERIFIED);
+  public function getPartiallyVerifiedSenderDomains($domainsOnly = false): array {
+    $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_PARTIALLY_VERIFIED);
+    if ($domainsOnly) {
+      return array_map([$this, 'domainExtractor'], $domainData);
+    }
+    return $domainData;
   }
 
-  public function getUnverifiedSenderDomains(): array {
-    return $this->getSenderDomainsByStatus(self::OVERALL_STATUS_UNVERIFIED);
+  public function getUnverifiedSenderDomains($domainsOnly = false): array {
+    $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_UNVERIFIED);
+    if ($domainsOnly) {
+      return array_map([$this, 'domainExtractor'], $domainData);
+    }
+    return $domainData;
+  }
+
+  private function domainExtractor(array $domainData): string {
+    return $domainData['domain'] ?? '';
   }
 
   public function getSenderDomainsGroupedByStatus(): array {

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -58,6 +58,9 @@ class PermanentNotices {
   /** @var PremiumFeaturesAvailableNotice */
   private $premiumFeaturesAvailableNotice;
 
+  /** @var SenderDomainAuthenticationNotices */
+  private $senderDomainAuthenticationNotices;
+
   public function __construct(
     WPFunctions $wp,
     TrackingConfig $trackingConfig,
@@ -65,7 +68,8 @@ class PermanentNotices {
     SettingsController $settings,
     SubscribersFeature $subscribersFeature,
     ServicesChecker $serviceChecker,
-    MailerFactory $mailerFactory
+    MailerFactory $mailerFactory,
+    SenderDomainAuthenticationNotices $senderDomainAuthenticationNotices
   ) {
     $this->wp = $wp;
     $this->phpVersionWarnings = new PHPVersionWarnings();
@@ -82,6 +86,7 @@ class PermanentNotices {
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
     $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);
+    $this->senderDomainAuthenticationNotices = $senderDomainAuthenticationNotices;
   }
 
   public function init() {
@@ -136,6 +141,9 @@ class PermanentNotices {
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->premiumFeaturesAvailableNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
+    $this->senderDomainAuthenticationNotices->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
   }

--- a/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
+++ b/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Services\AuthorizedSenderDomainController;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\FreeDomains;
+use MailPoet\Util\Helpers;
+use MailPoet\Util\License\Features\Subscribers;
+use MailPoet\WP\Notice;
+
+class SenderDomainAuthenticationNotices {
+
+  const LOWER_LIMIT = 500;
+  const UPPER_LIMIT = 1000;
+
+  const FREE_MAIL_KB_URL = 'https://kb.mailpoet.com/article/259-your-from-address-cannot-be-yahoo-com-gmail-com-outlook-com';
+  const SPF_DKIM_DMARC_KB_URL = 'https://kb.mailpoet.com/article/295-spf-dkim-dmarc';
+
+  private SettingsController $settingsController;
+
+  private Subscribers $subscribersFeatures;
+
+  private FreeDomains $freeDomains;
+
+  private AuthorizedSenderDomainController $authorizedSenderDomainController;
+
+  private Bridge $bridge;
+
+  public function __construct(
+    SettingsController $settingsController,
+    Subscribers $subscribersFeatures,
+    FreeDomains $freeDomains,
+    AuthorizedSenderDomainController $authorizedEmailsController,
+    Bridge $bridge
+  ) {
+    $this->settingsController = $settingsController;
+    $this->subscribersFeatures = $subscribersFeatures;
+    $this->freeDomains = $freeDomains;
+    $this->authorizedSenderDomainController = $authorizedEmailsController;
+    $this->bridge = $bridge;
+  }
+
+  public function getDefaultFromAddress(): string {
+    return $this->settingsController->get('sender.address', '');
+  }
+
+  public function getDefaultFromDomain(): string {
+    return Helpers::extractEmailDomain($this->getDefaultFromAddress());
+  }
+
+  public function isFreeMailUser(): bool {
+    return $this->freeDomains->isEmailOnFreeDomain($this->getDefaultFromDomain());
+  }
+
+  public function init($shouldDisplay): ?Notice {
+    if (
+      !$shouldDisplay
+      || !$this->bridge->isMailpoetSendingServiceEnabled()
+      || in_array($this->getDefaultFromDomain(), $this->authorizedSenderDomainController->getFullyVerifiedSenderDomains(true))
+      || $this->isFreeMailUser() && $this->subscribersFeatures->getSubscribersCount() <= self::LOWER_LIMIT
+    ) {
+      return null;
+    }
+
+    return $this->display();
+  }
+
+  public function display(): Notice {
+    $contactCount = $this->subscribersFeatures->getSubscribersCount();
+    $isFreeMailUser = $this->isFreeMailUser();
+
+    $isErrorStyle = $contactCount > self::UPPER_LIMIT;
+
+    $noticeContent = $isFreeMailUser
+      ? $this->getNoticeContentForFreeMailUsers($contactCount)
+      : $this->getNoticeContentForBrandedDomainUsers(in_array($this->getDefaultFromDomain(), $this->authorizedSenderDomainController->getPartiallyVerifiedSenderDomains(true)), $contactCount);
+
+    if ($isErrorStyle) {
+      return Notice::displayError($noticeContent, '', '', true, false);
+    }
+
+    return Notice::displayWarning($noticeContent);
+  }
+
+  public function getNoticeContentForFreeMailUsers(int $contactCount): string {
+    if ($contactCount <= self::UPPER_LIMIT) {
+      // translators: %1$s is the domain of the user's default from address, %2$s is a rewritten version of their default from address, %3$s is HTML for an 'update sender' button, and %4$s is HTML for a Learn More button
+      return sprintf(__("<strong>Update your sender email address to a branded domain to continue sending your campaigns.</strong>
+<span>MailPoet can no longer send from email addresses on shared 3rd party domains like <strong>%1\$s</strong>. Please change your campaigns to send from an email address on your site's branded domain. Your existing scheduled and active emails will temporarily be sent from <strong>%2\$s</strong>.</span> <p>%3\$s &nbsp; %4\$s</p>", 'mailpoet'),
+        "@" . $this->getDefaultFromDomain(),
+        $this->authorizedSenderDomainController->getRewrittenEmailAddress($this->getDefaultFromAddress()),
+        $this->getUpdateSenderButton(),
+        $this->getLearnMoreAboutFreeMailButton()
+      );
+    }
+
+    // translators: %1$s is the domain of the user's default from address, %2$s is a rewritten version of their default from address, %3$s is HTML for an 'update sender' button, and %4$s is HTML for a Learn More button
+    return sprintf(__("<strong>Your newsletters and post notifications have been paused. Update your sender email address to a branded domain to continue sending your campaigns.</strong>
+<span>MailPoet can no longer send from email addresses on shared 3rd party domains like <strong>%1\$s</strong>. Please change your campaigns to send from an email address on your site's branded domain. Your marketing automations and transactional emails will temporarily be sent from <strong>%2\$s</strong>.</span> <p>%3\$s &nbsp; %4\$s</p>", 'mailpoet'),
+      "@" . $this->getDefaultFromDomain(),
+      $this->authorizedSenderDomainController->getRewrittenEmailAddress($this->getDefaultFromAddress()),
+      $this->getUpdateSenderButton(),
+      $this->getLearnMoreAboutFreeMailButton()
+    );
+  }
+
+  public function getNoticeContentForBrandedDomainUsers(bool $isPartiallyVerified, int $contactCount): string {
+    if ($isPartiallyVerified || $contactCount <= self::LOWER_LIMIT) {
+      // translators: %1$s is HTML for an 'authenticate domain' button, %2$s is HTML for a Learn More button
+      return sprintf(__("<strong>Authenticate your sender domain to improve email delivery rates.</strong>
+<span>Major mailbox providers require you to authenticate your sender domain to confirm you sent the emails, and may place unauthenticated emails in the \"Spam\" folder. Please authenticate your sender domain to ensure your marketing campaigns are compliant and will reach your contacts.</span><p>%1\$s &nbsp; %2\$s</p>", 'mailpoet'),
+        $this->getAuthenticateDomainButton(),
+        $this->getLearnMoreAboutSpfDkimDmarcButton()
+      );
+    }
+
+    if ($contactCount <= self::UPPER_LIMIT) {
+      // translators: %1$s is a rewritten version of the user's default from address, %2$s is HTML for an 'authenticate domain' button, %3$s is HTML for a Learn More button
+      return sprintf(__("<strong>Authenticate your sender domain to send new emails.</strong>
+      <span>Major mailbox providers require you to authenticate your sender domain to confirm you sent the emails, and may place unauthenticated emails in the \"Spam\" folder. Please authenticate your sender domain to ensure your marketing campaigns are compliant and will reach your contacts. Your existing scheduled and active emails will temporarily be sent from <strong>%1\$s</strong>.</span> <p>%2\$s &nbsp; %3\$s</span>", 'mailpoet'),
+        $this->authorizedSenderDomainController->getRewrittenEmailAddress($this->getDefaultFromAddress()),
+        $this->getAuthenticateDomainButton(),
+        $this->getLearnMoreAboutSpfDkimDmarcButton()
+      );
+    }
+
+    // translators: %1$s is a rewritten version of the user's default from address, %2$s is HTML for an 'authenticate domain' button, %3$s is HTML for a Learn More button
+    return sprintf(__("<strong>Your newsletters and post notifications have been paused. Authenticate your sender domain to continue sending.</strong>
+<span>Major mailbox providers require you to authenticate your sender domain to confirm you sent the emails, and may place unauthenticated emails in the \"Spam\" folder. Please authenticate your sender domain to ensure your marketing campaigns are compliant and will reach your contacts. Your marketing automations and transactional emails will temporarily be sent from <strong>%1\$s</strong>.</span> <p>%2\$s &nbsp; %3\$s</p>", 'mailpoet'),
+      $this->authorizedSenderDomainController->getRewrittenEmailAddress($this->getDefaultFromAddress()),
+      $this->getAuthenticateDomainButton(),
+      $this->getLearnMoreAboutSpfDkimDmarcButton()
+    );
+  }
+
+  public function getUpdateSenderButton(): string {
+    $buttonClass = $this->subscribersFeatures->getSubscribersCount() > self::UPPER_LIMIT
+      ? 'button-primary'
+      : 'button-secondary';
+    $button = sprintf('<a href="admin.php?page=mailpoet-settings" class="button %1$s">%2$s</a>', $buttonClass, __('Update sender email', 'mailpoet'));
+    return $button;
+  }
+
+  public function getLearnMoreAboutFreeMailButton(): string {
+    $button = '<a href="' . self::FREE_MAIL_KB_URL . '" rel="noopener noreferer" target="_blank" class="button button-link">' . __('Learn more', 'mailpoet') . '</a>';
+    return $button;
+  }
+
+  public function getLearnMoreAboutSpfDkimDmarcButton(): string {
+    $button = '<a href="' . self::SPF_DKIM_DMARC_KB_URL . '" rel="noopener noreferer" target="_blank" class="button button-link">' . __('Learn more', 'mailpoet') . '</a>';
+    return $button;
+  }
+
+  public function getAuthenticateDomainButton() {
+    $buttonClass = $this->subscribersFeatures->getSubscribersCount() > self::UPPER_LIMIT
+      ? 'button-primary'
+      : 'button-secondary';
+    $button = sprintf('<a href="#" class="button %s mailpoet-js-button-authorize-email-and-sender-domain" data-email="%s" data-type="domain">%s</a>',
+      $buttonClass,
+      esc_attr($this->getDefaultFromAddress()),
+      __('Authenticate domain', 'mailpoet')
+    );
+    return $button;
+  }
+}

--- a/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
+++ b/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
@@ -75,11 +75,13 @@ class SenderDomainAuthenticationNotices {
       ? $this->getNoticeContentForFreeMailUsers($contactCount)
       : $this->getNoticeContentForBrandedDomainUsers($this->isPartiallyVerified(), $contactCount);
 
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+
     if ($this->isErrorStyle()) {
-      return Notice::displayError($noticeContent, '', '', true, false);
+      return Notice::displayError($noticeContent, $extraClasses, '', true, false);
     }
 
-    return Notice::displayWarning($noticeContent);
+    return Notice::displayWarning($noticeContent, $extraClasses);
   }
 
   public function isErrorStyle(): bool {

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -192,6 +192,15 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
       'partially-verified' => [$partiallyVerifiedDomain],
       'unverified' => [$unverifiedDomain],
     ], $grouped);
+
+    $domains = $controller->getFullyVerifiedSenderDomains(true);
+    $this->assertEqualsCanonicalizing(['example1.com'], $domains);
+
+    $domains = $controller->getPartiallyVerifiedSenderDomains(true);
+    $this->assertEqualsCanonicalizing(['example2.com'], $domains);
+
+    $domains = $controller->getUnverifiedSenderDomains(true);
+    $this->assertEqualsCanonicalizing(['example3.com'], $domains);
   }
 
   public function testVerifyAuthorizedSenderDomainThrowsForOtherErrors() {

--- a/mailpoet/tests/integration/Util/Notices/SenderDomainAuthenticationNoticesTest.php
+++ b/mailpoet/tests/integration/Util/Notices/SenderDomainAuthenticationNoticesTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Util\Notices;
+
+use MailPoet\Services\AuthorizedSenderDomainController;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Notices\SenderDomainAuthenticationNotices;
+
+class SenderDomainAuthenticationNoticesTest extends \MailPoetTest {
+  /** @var SenderDomainAuthenticationNotices */
+  private $notice;
+
+  /** @var SettingsController */
+  private $settings;
+
+  private AuthorizedSenderDomainController $authorizedSenderDomainController;
+
+  public function _before() {
+    parent::_before();
+    $this->settings = SettingsController::getInstance();
+    $this->notice = $this->diContainer->get(SenderDomainAuthenticationNotices::class);
+    $this->authorizedSenderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+  }
+
+  public function testItCanGetDefaultFromAddress(): void {
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => 'sender@test.com',
+    ]);
+    $defaultFrom = $this->notice->getDefaultFromAddress();
+    $this->assertSame('sender@test.com', $defaultFrom);
+  }
+
+  public function testItCanGetDefaultFromDomain(): void {
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => 'sender@test.com',
+    ]);
+    $defaultDomain = $this->notice->getDefaultFromDomain();
+    $this->assertSame('test.com', $defaultDomain);
+  }
+
+  public function testItCanDetermineIfUsingFreeMailServiceForFromAddress(): void {
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => 'sender@hotmail.com',
+    ]);
+    $this->assertTrue($this->notice->isFreeMailUser());
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => 'sender@customdomainthatprobablydoesnotevenexist.com',
+    ]);
+    $this->assertFalse($this->notice->isFreeMailUser());
+  }
+
+  public function testItRetrievesAppropriateMessageForFreeUsersWithMoreThan1000Contacts(): void {
+    $email = 'sender@hotmail.com';
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => $email,
+    ]);
+    $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
+    $message = $this->notice->getNoticeContentForFreeMailUsers(1001);
+    $this->assertStringContainsString('Your newsletters and post notifications have been paused. Update your sender email address to a branded domain to continue sending your campaigns', $message);
+    $this->assertStringContainsString(sprintf('Your marketing automations and transactional emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $message);
+    $this->assertStringContainsString('Update sender email', $message);
+  }
+
+  public function testItRetrievesAppropriateMessageForFreeMailUsersWithLessThan1000Contacts(): void {
+    $email = 'sender@hotmail.com';
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => $email,
+    ]);
+    $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
+    $message = $this->notice->getNoticeContentForFreeMailUsers(999);
+    $this->assertStringContainsString('Update your sender email address to a branded domain to continue sending your campaigns', $message);
+    $this->assertStringContainsString(sprintf('Your existing scheduled and active emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $message);
+    $this->assertStringContainsString('Update sender email', $message);
+  }
+
+  public function testItRetrievesAppropriateMessageForBrandedDomainsWithMoreThan1000Contacts(): void {
+    $email = 'sender@brandeddomain.com';
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => $email,
+    ]);
+    $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
+    $message = $this->notice->getNoticeContentForBrandedDomainUsers(false, 1001);
+    $this->assertStringContainsString('Your newsletters and post notifications have been paused. Authenticate your sender domain to continue sending.', $message);
+    $this->assertStringContainsString('Your marketing automations and transactional emails will temporarily be sent from', $message);
+    $this->assertStringContainsString($rewrittenEmail, $message);
+    $this->assertStringContainsString('Authenticate domain', $message);
+  }
+
+  public function testItRetrievesAppropriateMessageForBrandedDomainsWithLessThan1000Contacts(): void {
+    $email = 'sender@brandeddomain.com';
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => $email,
+    ]);
+    $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
+    $message = $this->notice->getNoticeContentForBrandedDomainUsers(false, 999);
+    $this->assertStringContainsString('Authenticate your sender domain to send new emails.', $message);
+    $this->assertStringContainsString('Your existing scheduled and active emails will temporarily be sent from', $message);
+    $this->assertStringContainsString($rewrittenEmail, $message);
+    $this->assertStringContainsString('Authenticate domain', $message);
+  }
+
+  public function testItRetrievesAppropriateMessageForBrandedDomainsWithLessThan500Contacts(): void {
+    $email = 'sender@brandeddomain.com';
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => $email,
+    ]);
+    $message = $this->notice->getNoticeContentForBrandedDomainUsers(false, 499);
+    $this->assertStringContainsString('Authenticate your sender domain to improve email delivery rates.', $message);
+    $this->assertStringContainsString('Authenticate domain', $message);
+  }
+
+  public function testItRetrievesAppropriateMessageForBrandedDomainsThatArePartiallyVerified(): void {
+    $email = 'sender@brandeddomain.com';
+    $this->settings->set('sender', [
+      'name' => 'Sender',
+      'address' => $email,
+    ]);
+    $message = $this->notice->getNoticeContentForBrandedDomainUsers(true, 1200);
+    $this->assertStringContainsString('Authenticate your sender domain to improve email delivery rates.', $message);
+    $this->assertStringContainsString('Authenticate domain', $message);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds banner notices based on the user's default from address (from the settings page) and the number of contacts they have. The banners will only show if the user is using MSS for sending and meet certain conditions (see ticket for details).

## Code review notes
_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5783

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
