### PR TITLE
Fix/incorrect time of sending on email listing page - MAILPOET-5795

### DIFF
--- a/mailpoet/assets/js/src/common/listings/newsletter-status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-status.tsx
@@ -81,11 +81,17 @@ function NewsletterStatus({
   const scheduled = scheduledFor && isFuture(scheduledFor);
   const inProgress =
     (!scheduledFor || isPast(scheduledFor)) && processed < total && !isCorrupt;
-  const sent = (!scheduledFor || isPast(scheduledFor)) && processed >= total;
+  const sent = status === 'sent' && processed >= total;
   const sentWithoutQueue = status === 'sent' && total === undefined;
   let percentage = 0;
   let label: string | JSX.Element = __('Not sent yet!', 'mailpoet');
-  if (scheduled) {
+
+  if (sent) {
+    label = `${MailPoet.Num.toLocaleFixed(
+      total,
+    )} / ${MailPoet.Num.toLocaleFixed(total)}`;
+    percentage = 100;
+  } else if (scheduled) {
     const scheduledDate = MailPoet.Date.short(scheduledFor);
     const scheduledTime = MailPoet.Date.time(scheduledFor);
     const now = new Date();
@@ -131,11 +137,6 @@ function NewsletterStatus({
       processed,
     )} / ${MailPoet.Num.toLocaleFixed(total)}`;
     percentage = 100 * (processed / total);
-  } else if (sent) {
-    label = `${MailPoet.Num.toLocaleFixed(
-      total,
-    )} / ${MailPoet.Num.toLocaleFixed(total)}`;
-    percentage = 100;
   } else if (sentWithoutQueue) {
     label = __('Sent', 'mailpoet');
     percentage = 100;
@@ -159,7 +160,7 @@ function NewsletterStatus({
         'mailpoet-listing-status-corrupt': isCorrupt,
       })}
     >
-      {scheduled && <ScheduledIcon />}
+      {scheduled && !sent && <ScheduledIcon />}
       {!isCorrupt && <CircularProgress percentage={percentage} />}
       <div className="mailpoet-listing-status-label">{label}</div>
       {isCorrupt && logs.length > 0 && (

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -272,7 +272,7 @@ class SendingQueue {
         );
         $queue->removeSubscribers($subscribersToRemove);
         if (!$queue->countToProcess) {
-          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $queue);
+          $this->newsletterTask->markNewsletterAsSent($newsletterEntity);
           continue;
         }
         // if there aren't any subscribers to process in batch (e.g. all unsubscribed or were deleted) continue with next batch
@@ -312,7 +312,7 @@ class SendingQueue {
             'completed newsletter sending',
             ['newsletter_id' => $newsletter->id, 'task_id' => $queue->taskId]
           );
-          $this->newsletterTask->markNewsletterAsSent($newsletterEntity, $queue);
+          $this->newsletterTask->markNewsletterAsSent($newsletterEntity);
           $this->statsNotificationsScheduler->schedule($newsletterEntity);
         }
         $this->enforceSendingAndExecutionLimits($timer);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -281,15 +281,14 @@ class Newsletter {
     ];
   }
 
-  public function markNewsletterAsSent(NewsletterEntity $newsletter, Sending $sendingTask) {
+  public function markNewsletterAsSent(NewsletterEntity $newsletter) {
     // if it's a standard or notification history newsletter, update its status
     if (
       $newsletter->getType() === NewsletterEntity::TYPE_STANDARD ||
        $newsletter->getType() === NewsletterEntity::TYPE_NOTIFICATION_HISTORY
     ) {
-      $scheduledTask = $sendingTask->task();
       $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
-      $newsletter->setSentAt(new Carbon($scheduledTask->processedAt));
+      $newsletter->setSentAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
       $this->newslettersRepository->persist($newsletter);
       $this->newslettersRepository->flush();
     }

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -182,7 +182,7 @@ class Worker {
 
   private function markTaskAsFinished(ScheduledTaskEntity $task) {
     $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
-    $task->setProcessedAt(new Carbon);
+    $task->setProcessedAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
     $task->setScheduledAt(null);
     $this->entityManager->flush();
   }

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
@@ -186,7 +187,7 @@ class ScheduledTaskSubscribersRepository extends Repository {
     $count = $this->countUnprocessed($task);
     if ($count === 0) {
       $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
-      $task->setProcessedAt(new Carbon());
+      $task->setProcessedAt(Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp')));
       $this->entityManager->flush();
     }
   }

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -138,7 +138,7 @@ class SendingQueuesRepository extends Repository {
     if (!$task instanceof ScheduledTaskEntity) return;
 
     if ($queue->getCountProcessed() === $queue->getCountTotal()) {
-      $processedAt = Carbon::createFromTimestamp($this->wp->currentTime('mysql'));
+      $processedAt = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
       $task->setProcessedAt($processedAt);
       $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
       // Update also status of newsletter if necessary

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -265,7 +265,7 @@ class NewsletterTest extends \MailPoetTest {
     $newsletter->setStatus('not_sent');
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
+    $this->newsletterTask->markNewsletterAsSent($newsletter);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
     verify($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
@@ -278,7 +278,7 @@ class NewsletterTest extends \MailPoetTest {
     $newsletter->setStatus('not_sent');
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
+    $this->newsletterTask->markNewsletterAsSent($newsletter);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
     verify($updatedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
@@ -291,7 +291,7 @@ class NewsletterTest extends \MailPoetTest {
     $newsletter->setStatus('not_sent');
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
-    $this->newsletterTask->markNewsletterAsSent($newsletter, $this->sendingTask);
+    $this->newsletterTask->markNewsletterAsSent($newsletter);
     $updatedNewsletter = $this->newslettersRepository->findOneById($newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter);
     verify($updatedNewsletter->getStatus())->notEquals(NewsletterEntity::STATUS_SENT);


### PR DESCRIPTION
## Description

Fix incorrect time of sending on email listing page

## Code review notes

Please check the commits

## QA notes

* Use a different timezone in `/wp-admin/options-general.php`
* Create and send a newsletter or Schedule a newsletter for later sending
* Confirm the Sent time reflected when the newsletter was sent

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5795](https://mailpoet.atlassian.net/browse/MAILPOET-5795)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5795]: https://mailpoet.atlassian.net/browse/MAILPOET-5795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ