### PR TITLE
Email editor - button and buttons blocks [MAILPOET-5644]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
@@ -1,0 +1,20 @@
+import { addFilter } from '@wordpress/hooks';
+import { Block } from '@wordpress/blocks';
+
+/**
+ * Disables Styles for button
+ */
+function enhanceButtonBlock() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/change-button',
+    (settings: Block, name) => {
+      if (name === 'core/button') {
+        return { ...settings, styles: [] };
+      }
+      return settings;
+    },
+  );
+}
+
+export { enhanceButtonBlock };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
@@ -12,6 +12,17 @@ function enhanceButtonBlock() {
       if (name === 'core/button') {
         return { ...settings, styles: [] };
       }
+
+      if (name === 'core/buttons') {
+        return {
+          ...settings,
+          supports: {
+            ...settings.supports,
+            layout: false, // disable block editor's layouts
+            __experimentalEmailFlexLayout: true, // enable MailPoet's reduced flex email layout
+          },
+        };
+      }
       return settings;
     },
   );

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
@@ -3,6 +3,7 @@ import { Block } from '@wordpress/blocks';
 
 /**
  * Disables Styles for button
+ * Currently we are not able read these styles in renderer
  */
 function enhanceButtonBlock() {
   addFilter(
@@ -11,17 +12,6 @@ function enhanceButtonBlock() {
     (settings: Block, name) => {
       if (name === 'core/button') {
         return { ...settings, styles: [] };
-      }
-
-      if (name === 'core/buttons') {
-        return {
-          ...settings,
-          supports: {
-            ...settings.supports,
-            layout: false, // disable block editor's layouts
-            __experimentalEmailFlexLayout: true, // enable MailPoet's reduced flex email layout
-          },
-        };
       }
       return settings;
     },

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/buttons.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/buttons.ts
@@ -1,0 +1,28 @@
+import { addFilter } from '@wordpress/hooks';
+import { Block } from '@wordpress/blocks';
+
+/**
+ * Switch layout to reduced flex email layout
+ * Email render engine can't handle full flex layout se we need to switch to reduced flex layout
+ */
+function enhanceButtonsBlock() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/change-buttons',
+    (settings: Block, name) => {
+      if (name === 'core/buttons') {
+        return {
+          ...settings,
+          supports: {
+            ...settings.supports,
+            layout: false, // disable block editor's layouts
+            __experimentalEmailFlexLayout: true, // enable MailPoet's reduced flex email layout
+          },
+        };
+      }
+      return settings;
+    },
+  );
+}
+
+export { enhanceButtonsBlock };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/column.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/column.ts
@@ -1,5 +1,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
+import { Block } from '@wordpress/blocks';
 import { storeName } from '../../store';
 
 /**
@@ -9,7 +10,7 @@ function disableNestedColumns() {
   addFilter(
     'blocks.registerBlockType',
     'mailpoet-email-editor/change-columns-allowed-nesting',
-    (settings, name) => {
+    (settings: Block, name) => {
       if (name === 'core/column') {
         // Filter out core/column and core/columns from supported blocks configured in the editor settings
         const editorSettings = select(storeName).getInitialEditorSettings();
@@ -28,7 +29,6 @@ function disableNestedColumns() {
           }
         });
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return {
           ...settings,
           attributes: {
@@ -41,7 +41,6 @@ function disableNestedColumns() {
         };
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return settings;
     },
   );

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/column.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/column.ts
@@ -23,7 +23,8 @@ function disableNestedColumns() {
           if (
             allowedBlockType !== 'core/column' &&
             allowedBlockType !== 'core/columns' &&
-            allowedBlockType !== 'core/list-item'
+            allowedBlockType !== 'core/list-item' &&
+            allowedBlockType !== 'core/button'
           ) {
             allowedBlockTypes.push(allowedBlockType);
           }

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/image.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/image.tsx
@@ -1,6 +1,7 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
+import { Block } from '@wordpress/blocks';
 
 const imageEditCallback = createHigherOrderComponent(
   (BlockEdit) =>
@@ -32,9 +33,8 @@ function disableImageFilter() {
   addFilter(
     'blocks.registerBlockType',
     'mailpoet-email-editor/deactivate-image-filter',
-    (settings, name) => {
+    (settings: Block, name) => {
       if (name === 'core/image') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return {
           ...settings,
           supports: {
@@ -45,8 +45,6 @@ function disableImageFilter() {
           },
         };
       }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return settings;
     },
   );

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -3,6 +3,7 @@ import { disableNestedColumns } from './core/column';
 import { disableColumnsLayout, deactivateStackOnMobile } from './core/columns';
 import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
+import { enhanceButtonBlock } from './core/button';
 
 export function initBlocks() {
   disableNestedColumns();
@@ -11,5 +12,6 @@ export function initBlocks() {
   disableImageFilter();
   disableCertainRichTextFormats();
   disableColumnsLayout();
+  enhanceButtonBlock();
   registerCoreBlocks();
 }

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -4,6 +4,7 @@ import { disableColumnsLayout, deactivateStackOnMobile } from './core/columns';
 import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
+import { enhanceButtonsBlock } from './core/buttons';
 
 export function initBlocks() {
   disableNestedColumns();
@@ -13,5 +14,6 @@ export function initBlocks() {
   disableCertainRichTextFormats();
   disableColumnsLayout();
   enhanceButtonBlock();
+  enhanceButtonsBlock();
   registerCoreBlocks();
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -82,9 +82,8 @@ export function BlockEditor() {
     { id: postId },
   );
 
-  // These will be set by the user in the future in email or global styles.
+  // This will be set by the user in the future in email or global styles.
   const layoutBackground = layoutStyles.background;
-  const documentBackground = '#ffffff';
 
   let inlineStyles = useResizeCanvas(previewDeviceType);
   // UseResizeCanvas returns null if the previewDeviceType is Desktop.
@@ -97,7 +96,6 @@ export function BlockEditor() {
       flexFlow: 'column',
     };
   }
-  inlineStyles.background = documentBackground;
   inlineStyles.transition = 'all 0.3s ease 0s';
 
   const contentAreaStyles = {

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -162,7 +162,13 @@ export function BlockEditor() {
                       <WritingFlow>
                         <ObserveTyping>
                           <BlockList
-                            className="is-layout-constrained has-global-padding"
+                            className={classnames(
+                              {
+                                'is-mobile-preview':
+                                  previewDeviceType === 'Mobile',
+                              },
+                              'is-layout-constrained has-global-padding',
+                            )}
                             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                             // @ts-ignore We have an older package of @wordpress/block-editor that doesn't contain the correct type
                             layout={layout}

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -84,6 +84,11 @@
   ol.has-background {
     padding-left: 40px;
   }
+
+  // Override default button border radius which is set in core to 9999px
+  .wp-block-button__link {
+    border-radius: 0;
+  }
 }
 
 // For the WYSIWYG experience we don't want to display any margins between blocks in the editor

--- a/mailpoet/assets/js/src/email-editor/engine/editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/editor.tsx
@@ -5,6 +5,7 @@ import { Popover, SlotFillProvider } from '@wordpress/components';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { EntityProvider } from '@wordpress/core-data';
 import { initBlocks } from './blocks';
+import { initializeLayout } from './layouts/flex-email';
 import { BlockEditor } from './components/block-editor';
 import { createStore, storeName } from './store';
 import { initHooks } from './hooks';
@@ -39,6 +40,7 @@ export function initialize(elementId: string) {
     return;
   }
   createStore();
+  initializeLayout();
   initBlocks();
   initHooks();
   const root = createRoot(container);

--- a/mailpoet/assets/js/src/email-editor/engine/layouts/flex-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/layouts/flex-email.tsx
@@ -9,7 +9,14 @@ import classnames from 'classnames';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { Block, getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
-import { InspectorControls } from '@wordpress/block-editor';
+
+import {
+  BlockControls,
+  InspectorControls,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  JustifyContentControl,
+} from '@wordpress/block-editor';
 import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
 
 import {
@@ -33,7 +40,64 @@ function hasLayoutBlockSupport(blockName: string) {
   return hasBlockSupport(blockName, layoutBlockSupportKey);
 }
 
-function LayoutPanel({ setAttributes, attributes, name: blockName }) {
+function JustificationControls({
+  justificationValue,
+  onChange,
+  isToolbar = false,
+}) {
+  const justificationOptions = [
+    {
+      value: 'left',
+      icon: justifyLeft,
+      label: __('Justify items left'),
+    },
+    {
+      value: 'center',
+      icon: justifyCenter,
+      label: __('Justify items center'),
+    },
+    {
+      value: 'right',
+      icon: justifyRight,
+      label: __('Justify items right'),
+    },
+  ];
+
+  if (isToolbar) {
+    const allowedValues = justificationOptions.map((option) => option.value);
+    return (
+      <JustifyContentControl
+        value={justificationValue}
+        onChange={onChange}
+        allowedControls={allowedValues}
+        popoverProps={{
+          placement: 'bottom-start',
+        }}
+      />
+    );
+  }
+
+  return (
+    <ToggleGroupControl
+      __nextHasNoMarginBottom
+      label={__('Justification')}
+      value={justificationValue}
+      onChange={onChange}
+      className="block-editor-hooks__flex-layout-justification-controls"
+    >
+      {justificationOptions.map(({ value, icon, label }) => (
+        <ToggleGroupControlOptionIcon
+          key={value}
+          value={value}
+          icon={icon}
+          label={label}
+        />
+      ))}
+    </ToggleGroupControl>
+  );
+}
+
+function LayoutControls({ setAttributes, attributes, name: blockName }) {
   const layoutBlockSupport = getBlockSupport(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     blockName,
@@ -58,49 +122,30 @@ function LayoutPanel({ setAttributes, attributes, name: blockName }) {
     });
   };
 
-  const justificationOptions = [
-    {
-      value: 'left',
-      icon: justifyLeft,
-      label: __('Justify items left'),
-    },
-    {
-      value: 'center',
-      icon: justifyCenter,
-      label: __('Justify items center'),
-    },
-    {
-      value: 'right',
-      icon: justifyRight,
-      label: __('Justify items right'),
-    },
-  ];
-
   return (
-    <InspectorControls>
-      <PanelBody title={__('Layout')}>
-        <Flex>
-          <FlexItem>
-            <ToggleGroupControl
-              __nextHasNoMarginBottom
-              label={__('Justification')}
-              value={justifyContent}
-              onChange={onJustificationChange}
-              className="block-editor-hooks__flex-layout-justification-controls"
-            >
-              {justificationOptions.map(({ value, icon, label }) => (
-                <ToggleGroupControlOptionIcon
-                  key={value}
-                  value={value}
-                  icon={icon}
-                  label={label}
-                />
-              ))}
-            </ToggleGroupControl>
-          </FlexItem>
-        </Flex>
-      </PanelBody>
-    </InspectorControls>
+    <>
+      <InspectorControls>
+        <PanelBody title={__('Layout')}>
+          <Flex>
+            <FlexItem>
+              <JustificationControls
+                justificationValue={justifyContent}
+                onChange={onJustificationChange}
+              />
+            </FlexItem>
+          </Flex>
+        </PanelBody>
+      </InspectorControls>
+      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+      {/* @ts-ignore */}
+      <BlockControls group="block" __experimentalShareWithChildBlocks>
+        <JustificationControls
+          justificationValue={justifyContent}
+          onChange={onJustificationChange}
+          isToolbar
+        />
+      </BlockControls>
+    </>
   );
 }
 
@@ -141,7 +186,7 @@ export const withLayoutControls = createHigherOrderComponent(
     const supportLayout = hasLayoutBlockSupport(props.name);
 
     return [
-      supportLayout && <LayoutPanel key="layout" {...props} />,
+      supportLayout && <LayoutControls key="layout" {...props} />,
       <BlockEdit key="edit" {...props} />,
     ];
   },

--- a/mailpoet/assets/js/src/email-editor/engine/layouts/flex-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/layouts/flex-email.tsx
@@ -1,0 +1,199 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+import { Block, getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
+
+import {
+  Flex,
+  FlexItem,
+  PanelBody,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  __experimentalToggleGroupControl as ToggleGroupControl,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  __experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const layoutBlockSupportKey = '__experimentalEmailFlexLayout';
+
+function hasLayoutBlockSupport(blockName: string) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return hasBlockSupport(blockName, layoutBlockSupportKey);
+}
+
+function LayoutPanel({ setAttributes, attributes, name: blockName }) {
+  const layoutBlockSupport = getBlockSupport(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    blockName,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    layoutBlockSupportKey,
+    {},
+  );
+
+  if (!layoutBlockSupport) {
+    return null;
+  }
+
+  const { justifyContent = 'left' } = attributes.layout || {};
+
+  const onJustificationChange = (value) => {
+    setAttributes({
+      layout: {
+        ...attributes.layout,
+        justifyContent: value,
+      },
+    });
+  };
+
+  const justificationOptions = [
+    {
+      value: 'left',
+      icon: justifyLeft,
+      label: __('Justify items left'),
+    },
+    {
+      value: 'center',
+      icon: justifyCenter,
+      label: __('Justify items center'),
+    },
+    {
+      value: 'right',
+      icon: justifyRight,
+      label: __('Justify items right'),
+    },
+  ];
+
+  return (
+    <InspectorControls>
+      <PanelBody title={__('Layout')}>
+        <Flex>
+          <FlexItem>
+            <ToggleGroupControl
+              __nextHasNoMarginBottom
+              label={__('Justification')}
+              value={justifyContent}
+              onChange={onJustificationChange}
+              className="block-editor-hooks__flex-layout-justification-controls"
+            >
+              {justificationOptions.map(({ value, icon, label }) => (
+                <ToggleGroupControlOptionIcon
+                  key={value}
+                  value={value}
+                  icon={icon}
+                  label={label}
+                />
+              ))}
+            </ToggleGroupControl>
+          </FlexItem>
+        </Flex>
+      </PanelBody>
+    </InspectorControls>
+  );
+}
+
+/**
+ * Filters registered block settings, extending attributes to include `layout`.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+export function addAttribute(settings: Block) {
+  if (hasLayoutBlockSupport(settings.name)) {
+    return {
+      ...settings,
+      attributes: {
+        ...settings.attributes,
+        layout: {
+          type: 'object',
+        },
+      },
+    };
+  }
+  return settings;
+}
+
+/**
+ * Override the default edit UI to include layout controls
+ *
+ * @param {Function} BlockEdit Original component.
+ *
+ * @return {Function} Wrapped component.
+ */
+export const withLayoutControls = createHigherOrderComponent(
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  (BlockEdit) => (props) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const supportLayout = hasLayoutBlockSupport(props.name);
+
+    return [
+      supportLayout && <LayoutPanel key="layout" {...props} />,
+      <BlockEdit key="edit" {...props} />,
+    ];
+  },
+  'withLayoutControls',
+);
+
+function BlockWithLayoutStyles({ block: BlockListBlock, props }) {
+  const { attributes } = props;
+  const { layout } = attributes;
+
+  const layoutClasses = 'is-layout-email-flex is-layout-flex';
+  const justify = (layout?.justifyContent as string) || 'left';
+  const justificationClass = `is-content-justification-${justify}`;
+
+  const layoutClassNames = classnames(justificationClass, layoutClasses);
+  return <BlockListBlock {...props} className={layoutClassNames} />;
+}
+
+/**
+ * Override the default block element to add the layout classes.
+ *
+ * @param {Function} BlockListBlock Original component.
+ *
+ * @return {Function} Wrapped component.
+ */
+export const withLayoutStyles = createHigherOrderComponent(
+  (BlockListBlock) =>
+    function maybeWrapWithLayoutStyles(props) {
+      const blockSupportsLayout = hasLayoutBlockSupport(props.name as string);
+      if (!blockSupportsLayout) {
+        return <BlockListBlock {...props} />;
+      }
+
+      return <BlockWithLayoutStyles block={BlockListBlock} props={props} />;
+    },
+  'withLayoutStyles',
+);
+
+export function initializeLayout() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/layout/addAttribute',
+    addAttribute,
+  );
+  addFilter(
+    'editor.BlockListBlock',
+    'mailpoet-email-editor/with-layout-styles',
+    withLayoutStyles,
+  );
+  addFilter(
+    'editor.BlockEdit',
+    'mailpoet-email-editor/with-inspector-controls',
+    withLayoutControls,
+  );
+}

--- a/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
+++ b/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
@@ -27,6 +27,8 @@ export function EditorSelectModal({
         <img
           src={`${MailPoet.cdnUrl}email-editor/new-editor-modal-header.png`}
           alt={__('New editor', 'mailpoet')}
+          width="324"
+          height="130"
         />
       </div>
       <p>

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Layout/FlexLayoutRenderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Layout/FlexLayoutRenderer.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Renderer\Layout;
+
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+/**
+ * This class provides functionality to render inner blocks of a block that supports reduced flex layout.
+ */
+class FlexLayoutRenderer {
+  public function renderInnerBlocksInLayout(array $parsedBlock, SettingsController $settingsController): string {
+    $innerBlocks = $this->computeWidthsForFlexLayout($parsedBlock, $settingsController);
+
+    // MS Outlook doesn't support style attribute in divs so we conditionally wrap the buttons in a table and repeat styles
+    $outputHtml = '<!--[if mso | IE]><table align="{align}" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="" style="{style}" ><![endif]-->
+        <div style="{style}"><table class="layout-flex-wrapper" style="display:inline-block"><tbody><tr>';
+
+    foreach ($innerBlocks as $key => $block) {
+      $styles = [];
+      if ($block['email_attrs']['layout_width'] ?? null) {
+        $styles['width'] = $block['email_attrs']['layout_width'];
+      }
+      if ($key > 0) {
+        $styles['padding-left'] = SettingsController::FLEX_GAP;
+      }
+      $outputHtml .= '<td class="layout-flex-item" style="' . esc_html($settingsController->convertStylesToString($styles)) . '">' . render_block($block) . '</td>';
+    }
+    $outputHtml .= '</tr></table></div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->';
+
+    $styles = wp_style_engine_get_styles($parsedBlock['attrs']['style'])['css'];
+    $justify = $parsedBlock['attrs']['layout']['justifyContent'] ?? 'left';
+    $styles .= 'text-align: ' . esc_attr($justify);
+    $outputHtml = str_replace('{style}', $styles, $outputHtml);
+    $outputHtml = str_replace('{align}', $justify, $outputHtml);
+
+    return $outputHtml;
+  }
+
+  private function computeWidthsForFlexLayout(array $parsedBlock, SettingsController $settingsController): array {
+    $blocksCount = count($parsedBlock['innerBlocks']);
+    $totalSetWidth = 0; // Total width set by user. Excludes items that have no width set
+    $totalUsedWidth = 0; // Total width assuming items without set width would consume proportional width
+    $parentWidth = $settingsController->parseNumberFromStringWithPixels($parsedBlock['email_attrs']['width'] ?? SettingsController::EMAIL_WIDTH);
+    $flexGap = $settingsController->parseNumberFromStringWithPixels(SettingsController::FLEX_GAP);
+    $innerBlocks = $parsedBlock['innerBlocks'] ?? [];
+
+    foreach ($innerBlocks as $key => $block) {
+      $blockWidthPercent = ($block['attrs']['width'] ?? 0) ? intval($block['attrs']['width']) : 0;
+      $blockWidth = floor($parentWidth * ($blockWidthPercent / 100));
+      $totalSetWidth += $blockWidth;
+      // If width is not set, we assume it's 25% of the parent width
+      $totalUsedWidth += $blockWidth ?: floor($parentWidth * (25 / 100));
+
+      if (!$blockWidth) {
+        $innerBlocks[$key]['email_attrs']['layout_width'] = null; // Will be rendered as auto
+        continue;
+      }
+      // How many percent of width we will strip to keep some space fot the gap
+      // Todo add more precise comment
+      $widthGapReduction = $flexGap * ((100 - $blockWidthPercent) / 100);
+      $innerBlocks[$key]['email_attrs']['layout_width'] = floor($blockWidth - $widthGapReduction) . 'px';
+    }
+
+    // When there is only one block, or percentage is set reasonably we don't need to adjust and just render as set by user
+    if ($blocksCount <= 1 || ($totalSetWidth < $parentWidth)) {
+      return $innerBlocks;
+    }
+
+    foreach ($innerBlocks as $key => $block) {
+      $proportionalSpaceOverflow = $parentWidth / $totalUsedWidth;
+      $blockWidth = $block['email_attrs']['layout_width'] ? $settingsController->parseNumberFromStringWithPixels($block['email_attrs']['layout_width']) : 0;
+      $innerBlocks[$key]['email_attrs']['layout_width'] = $blockWidth ? intval(round($blockWidth * $proportionalSpaceOverflow)) . 'px' : null;
+    }
+    return $innerBlocks;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
@@ -19,6 +19,8 @@ class BlocksWidthPreprocessor implements Preprocessor {
       }
 
       $widthInput = $block['attrs']['width'] ?? '100%';
+      // Currently we support only % and px units in case only the number is provided we assume it's %
+      // because editor saves percent values as a number.
       $widthInput = is_numeric($widthInput) ? "$widthInput%" : $widthInput;
       $width = $this->convertWidthToPixels($widthInput, $layoutWidth);
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
@@ -18,7 +18,9 @@ class BlocksWidthPreprocessor implements Preprocessor {
         $layoutWidth -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['right'] ?? '0px');
       }
 
-      $width = $this->convertWidthToPixels($block['attrs']['width'] ?? '100%', $layoutWidth);
+      $widthInput = $block['attrs']['width'] ?? '100%';
+      $widthInput = is_numeric($widthInput) ? "$widthInput%" : $widthInput;
+      $width = $this->convertWidthToPixels($widthInput, $layoutWidth);
 
       if ($block['blockName'] === 'core/columns') {
         // Calculate width of the columns based on the layout width and padding

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -73,8 +73,12 @@ class TypographyPreprocessor implements Preprocessor {
 
   private function setDefaultsFromTheme(array $block): array {
     $themeData = $this->settingsController->getTheme()->get_data();
+    $contentStyles = $this->settingsController->getEmailContentStyles();
     if (!($block['email_attrs']['color'] ?? '')) {
       $block['email_attrs']['color'] = $themeData['styles']['color']['text'] ?? null;
+    }
+    if (!($block['email_attrs']['font-size'] ?? '')) {
+      $block['email_attrs']['font-size'] = $contentStyles['typography']['fontSize'];
     }
     return $block;
   }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -11,6 +11,7 @@ class TypographyPreprocessor implements Preprocessor {
     'color',
     'font-size',
     'font-family',
+    'text-decoration',
   ];
 
   public function preprocess(array $parsedBlocks, array $layoutStyles): array {
@@ -44,6 +45,9 @@ class TypographyPreprocessor implements Preprocessor {
     }
     if (isset($block['attrs']['style']['typography']['fontSize'])) {
       $emailAttrs['font-size'] = $block['attrs']['style']['typography']['fontSize'];
+    }
+    if (isset($block['attrs']['style']['typography']['textDecoration'])) {
+      $emailAttrs['text-decoration'] = $block['attrs']['style']['typography']['textDecoration'];
     }
     $block['email_attrs'] = array_merge($emailAttrs, $block['email_attrs'] ?? []);
     return $block;

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -43,6 +43,8 @@ class Renderer {
     $parsedBlocks = $parser->parse($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
     $layoutStyles = $this->settingsController->getEmailLayoutStyles();
+    $themeData = $this->settingsController->getTheme()->get_data();
+    $contentBackground = $themeData['styles']['color']['background'] ?? $layoutStyles['background'];
     $parsedBlocks = $this->preprocessManager->preprocess($parsedBlocks, $layoutStyles);
     $renderedBody = $this->renderBlocks($parsedBlocks);
 
@@ -53,8 +55,8 @@ class Renderer {
 
     // Apply layout styles
     $template = str_replace(
-      ['{{width}}', '{{background}}', '{{padding_top}}', '{{padding_right}}', '{{padding_bottom}}', '{{padding_left}}'],
-      [$layoutStyles['width'], $layoutStyles['background'], $layoutStyles['padding']['top'], $layoutStyles['padding']['right'], $layoutStyles['padding']['bottom'], $layoutStyles['padding']['left']],
+      ['{{width}}', '{{layout_background}}', '{{content_background}}', '{{padding_top}}', '{{padding_right}}', '{{padding_bottom}}', '{{padding_left}}'],
+      [$layoutStyles['width'], $layoutStyles['background'], $contentBackground, $layoutStyles['padding']['top'], $layoutStyles['padding']['right'], $layoutStyles['padding']['bottom'], $layoutStyles['padding']['left']],
       $template
     );
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
@@ -146,10 +146,6 @@ ol {
   visibility: hidden;
 }
 
-.email_content_wrapper {
-  background: #fff;
-}
-
 @media screen and (max-width: 660px) {
   .email_column {
     max-width: 100% !important;

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
@@ -150,7 +150,7 @@ ol {
   background: #fff;
 }
 
-@media screen and (max-width: 599px) {
+@media screen and (max-width: 660px) {
   .email_column {
     max-width: 100% !important;
   }
@@ -158,5 +158,27 @@ ol {
     display: block;
     width: 100% !important;
   }
+
+  /* Flex Layout */
+  .layout-flex-wrapper,
+  .layout-flex-wrapper tbody,
+  .layout-flex-wrapper tr {
+    display: block !important;
+    width: 100% !important;
+  }
+
+  .layout-flex-item {
+    display: block !important;
+    padding-bottom: 8px !important; /* Half of the flex gap between blocks */
+    padding-left: 0 !important;
+    width: 100% !important;
+  }
+
+  .layout-flex-item table,
+  .layout-flex-item td {
+    display: block !important;
+    width: 100% !important;
+  }
+  /* Flex Layout End */
 }
 /* stylelint-enable property-no-unknown */

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
@@ -17,8 +17,8 @@
       {{email_template_styles}}
     </style>
   </head>
-  <body style="word-spacing:normal;background:{{background}};">
-    <div class="email_layout_wrapper" style="background:{{background}}">
+  <body style="word-spacing:normal;background:{{layout_background}};">
+    <div class="email_layout_wrapper" style="background:{{layout_background}}">
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:{{width}};" width="{{width}}" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin: 0px auto; max-width: {{width}}">
         <table
@@ -53,6 +53,7 @@
                   padding-bottom: {{padding_bottom}};
                   padding-top: {{padding_top}};
                   text-align: center;
+                  background: {{content_background}};
                 "
               >
                 {{email_body}}

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -131,6 +131,7 @@ class SettingsController {
     $flexEmailLayoutStyles = file_get_contents(__DIR__ . '/flex-email-layout.css');
 
     $settings['styles'] = [
+      $coreDefaultSettings['defaultEditorStyles'][0],
       ['css' => wp_get_global_stylesheet(['base-layout-styles'])],
       ['css' => $theme->get_stylesheet()],
       ['css' => $contentVariables],

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -51,6 +51,12 @@ class SettingsController {
   const EMAIL_PADDING = '10px';
 
   /**
+   * Gap between blocks in flex layouts
+   * @var string
+   */
+  const FLEX_GAP = '16px';
+
+  /**
    * Default styles applied to the email. These are going to be replaced by style settings.
    * This is currently more af a proof of concept that we can apply styles to the email.
    * We will gradually replace these hardcoded values with styles saved as global styles or styles saved with the email.
@@ -118,13 +124,17 @@ class SettingsController {
     $contentVariables .= 'padding-bottom: var(--wp--style--root--padding-bottom);';
     $contentVariables .= 'padding-top: var(--wp--style--root--padding-top);';
     $contentVariables .= '}';
+    $contentVariables .= '--mp-flex-layout-gap:' . self::FLEX_GAP . ';';
 
     $settings = array_merge($coreDefaultSettings, self::DEFAULT_SETTINGS);
     $settings['allowedBlockTypes'] = self::ALLOWED_BLOCK_TYPES;
+    $flexEmailLayoutStyles = file_get_contents(__DIR__ . '/flex-email-layout.css');
+
     $settings['styles'] = [
+      ['css' => wp_get_global_stylesheet(['base-layout-styles'])],
       ['css' => $theme->get_stylesheet()],
       ['css' => $contentVariables],
-      ['css' => wp_get_global_stylesheet(['base-layout-styles'])],
+      ['css' => $flexEmailLayoutStyles],
     ];
 
     $settings['__experimentalFeatures'] = $coreSettings;

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -128,6 +128,13 @@ class SettingsController {
     ];
 
     $settings['__experimentalFeatures'] = $coreSettings;
+    // Enable border radius, color, style and width where possible
+    $settings['__experimentalFeatures']['border'] = [
+      "radius" => true,
+      "color" => true,
+      "style" => true,
+      "width" => true,
+    ];
 
     // Enabling alignWide allows full width for specific blocks such as columns, heading, image, etc.
     $settings['alignWide'] = true;

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -39,10 +39,10 @@ class SettingsController {
   const EMAIL_WIDTH = '660px';
 
   /**
-   * Width of the email in pixels.
+   * Color of email layout background.
    * @var string
    */
-  const EMAIL_BACKGROUND = '#cccccc';
+  const EMAIL_LAYOUT_BACKGROUND = '#cccccc';
 
   /**
    * Padding of the email in pixels.
@@ -113,10 +113,7 @@ class SettingsController {
     $coreSettings['typography']['dropCap'] = false; // Showing large initial letter cannot be implemented in emails
     $coreSettings['typography']['fontWeight'] = false; // Font weight will be handled by the font family later
 
-    $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
-    $themeJson = json_decode($themeJson, true);
-    /** @var array $themeJson */
-    $theme = new \WP_Theme_JSON($themeJson);
+    $theme = $this->getTheme();
 
     // body selector is later transformed to .editor-styles-wrapper
     // setting padding for bottom and top is needed because \WP_Theme_JSON::get_stylesheet() set them only for .wp-site-blocks selector
@@ -180,7 +177,7 @@ class SettingsController {
   public function getEmailLayoutStyles(): array {
     return [
       'width' => self::EMAIL_WIDTH,
-      'background' => self::EMAIL_BACKGROUND,
+      'background' => self::EMAIL_LAYOUT_BACKGROUND,
       'padding' => [
         'bottom' => self::EMAIL_PADDING,
         'left' => self::EMAIL_PADDING,
@@ -223,5 +220,12 @@ class SettingsController {
 
   public function parseNumberFromStringWithPixels(string $string): float {
     return (float)str_replace('px', '', $string);
+  }
+
+  public function getTheme(): \WP_Theme_JSON {
+    $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
+    $themeJson = json_decode($themeJson, true);
+    /** @var array $themeJson */
+    return new \WP_Theme_JSON($themeJson);
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -5,6 +5,8 @@ namespace MailPoet\EmailEditor\Engine;
 class SettingsController {
 
   const ALLOWED_BLOCK_TYPES = [
+    'core/button',
+    'core/buttons',
     'core/paragraph',
     'core/heading',
     'core/column',

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -123,8 +123,8 @@ class SettingsController {
     $contentVariables = 'body {';
     $contentVariables .= 'padding-bottom: var(--wp--style--root--padding-bottom);';
     $contentVariables .= 'padding-top: var(--wp--style--root--padding-top);';
+    $contentVariables .= '--wp--style--block-gap:' . self::FLEX_GAP . ';';
     $contentVariables .= '}';
-    $contentVariables .= '--mp-flex-layout-gap:' . self::FLEX_GAP . ';';
 
     $settings = array_merge($coreDefaultSettings, self::DEFAULT_SETTINGS);
     $settings['allowedBlockTypes'] = self::ALLOWED_BLOCK_TYPES;

--- a/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
+++ b/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
@@ -3,7 +3,7 @@
 }
 
 :where(body .is-layout-flex) {
-  gap: var(--mp-flex-layout-gap, 16px);
+  gap: var(--wp--style--block-gap, 16px);
 }
 
 .is-mobile-preview .is-layout-email-flex {

--- a/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
+++ b/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
@@ -1,0 +1,20 @@
+.is-layout-email-flex {
+  flex-wrap: nowrap;
+}
+
+:where(body .is-layout-flex) {
+  gap: var(--mp-flex-layout-gap, 16px);
+}
+
+.is-mobile-preview .is-layout-email-flex {
+  display: block;
+}
+
+.is-mobile-preview .is-layout-email-flex .block-editor-block-list__block {
+  padding: 5px 0;
+  width: 100%;
+}
+
+.is-mobile-preview .is-layout-email-flex .wp-block-button__link {
+  width: 100%;
+}

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
   "settings": {
     "layout": {

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -15,6 +15,10 @@
         "right": "10px",
         "top": "10px"
       }
+    },
+    "color": {
+      "background": "#ffffff",
+      "text": "#000000"
     }
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -19,5 +19,7 @@ class Initializer {
     $blocksRegistry->addBlockRenderer('core/columns', new Renderer\Blocks\Columns());
     $blocksRegistry->addBlockRenderer('core/list', new Renderer\Blocks\ListBlock());
     $blocksRegistry->addBlockRenderer('core/image', new Renderer\Blocks\Image());
+    $blocksRegistry->addBlockRenderer('core/buttons', new Renderer\Blocks\Buttons());
+    $blocksRegistry->addBlockRenderer('core/button', new Renderer\Blocks\Button());
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\Core;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlocksRegistry;
+use MailPoet\EmailEditor\Engine\Renderer\Layout\FlexLayoutRenderer;
 
 class Initializer {
   public function initialize(): void {
@@ -19,7 +20,7 @@ class Initializer {
     $blocksRegistry->addBlockRenderer('core/columns', new Renderer\Blocks\Columns());
     $blocksRegistry->addBlockRenderer('core/list', new Renderer\Blocks\ListBlock());
     $blocksRegistry->addBlockRenderer('core/image', new Renderer\Blocks\Image());
-    $blocksRegistry->addBlockRenderer('core/buttons', new Renderer\Blocks\Buttons());
+    $blocksRegistry->addBlockRenderer('core/buttons', new Renderer\Blocks\Buttons(new FlexLayoutRenderer()));
     $blocksRegistry->addBlockRenderer('core/button', new Renderer\Blocks\Button());
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -46,41 +46,41 @@ class Button implements BlockRenderer {
 
     // Styles attributes
     $wrapperStyles = [
-      "background: $bgColor",
-      'cursor: auto',
-      'word-break: break-word',
-      'box-sizing: border-box',
+      'background' => $bgColor,
+      'cursor' => 'auto',
+      'word-break' => 'break-word',
+      'box-sizing' => 'border-box',
     ];
     $linkStyles = [
-      'display: block',
-      'line-height: 120%',
-      'margin: 0',
-      'mso-padding-alt: 0px',
+      'display' => 'block',
+      'line-height' => '120%',
+      'margin' => '0',
+      'mso-padding-alt' => '0px',
     ];
 
     // Border
     if ($parsedBlock['attrs']['style']['border'] ?? '') {
-      $wrapperStyles[] = wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['css'];
+      $wrapperStyles = array_merge($wrapperStyles, wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['declarations']);
     }
     if ($parsedBlock['attrs']['style']['border']['width'] ?? '') {
-      $wrapperStyles[] = 'border-style: solid';
+      $wrapperStyles['border-style'] = 'solid';
     } else {
-      $wrapperStyles[] = 'border: none';
+      $wrapperStyles['border'] = 'none';
     }
 
     // Spacing
     if ($parsedBlock['attrs']['style']['spacing']['padding'] ?? '') {
       $padding = $parsedBlock['attrs']['style']['spacing']['padding'];
-      $wrapperStyles[] = "mso-padding-alt: {$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
-      $linkStyles[] = "padding: {$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
+      $wrapperStyles['mso-padding-alt'] = "{$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
+      $linkStyles['padding'] = "{$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
     }
 
     // Typography
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
     $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
-    $linkStyles[] = wp_style_engine_get_styles(['typography' => $typography])['css'];
+    $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography])['declarations']);
     if ($parsedBlock['attrs']['style']['color']['text'] ?? '') {
-      $linkStyles[] = "color: {$parsedBlock['attrs']['style']['color']['text']}";
+      $linkStyles['color'] = $parsedBlock['attrs']['style']['color']['text'];
     }
 
     // Escaping
@@ -88,10 +88,10 @@ class Button implements BlockRenderer {
     $linkStyles = array_map('esc_attr', $linkStyles);
     // Font family may contain single quotes
     $contentStyles = $settingsController->getEmailContentStyles();
-    $linkStyles[] = str_replace('&#039;', "'", esc_attr("font-family: {$contentStyles['typography']['fontFamily']}"));
+    $linkStyles['font-family'] = str_replace('&#039;', "'", esc_attr("{$contentStyles['typography']['fontFamily']}"));
 
-    $markup = str_replace('{linkStyles}', join(';', $linkStyles) . ';', $markup);
-    $markup = str_replace('{wrapperStyles}', join(';', $wrapperStyles) . ';', $markup);
+    $markup = str_replace('{linkStyles}', $settingsController->convertStylesToString($linkStyles), $markup);
+    $markup = str_replace('{wrapperStyles}', $settingsController->convertStylesToString($wrapperStyles), $markup);
 
     return $markup;
   }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -85,9 +85,7 @@ class Button implements BlockRenderer {
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
     $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
     $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography])['declarations']);
-    if ($parsedBlock['attrs']['style']['color']['text'] ?? '') {
-      $linkStyles['color'] = $parsedBlock['attrs']['style']['color']['text'];
-    }
+    $linkStyles['color'] = $parsedBlock['email_attrs']['color'];
 
     // Escaping
     $wrapperStyles = array_map('esc_attr', $wrapperStyles);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -51,8 +51,6 @@ class Button implements BlockRenderer {
       'line-height: 120%',
       'margin: 0',
       'mso-padding-alt: 0px',
-      'text-decoration: none',
-      'text-transform: none',
     ];
 
     // Border
@@ -72,20 +70,21 @@ class Button implements BlockRenderer {
       $linkStyles[] = "padding: {$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
     }
 
-    // Font
+    // Typography
     $contentStyles = $settingsController->getEmailContentStyles();
-    $linkStyles[] = "font-family: {$contentStyles['typography']['fontFamily']}";
-    $linkStyles[] = "font-size: {$contentStyles['typography']['fontSize']}";
-    if ($parsedBlock['attrs']['style']['typography']) {
-      $linkStyles[] = wp_style_engine_get_styles(['typography' => $parsedBlock['attrs']['style']['typography']])['css'];
-    }
+    $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
+    $typography['textDecoration'] = $typography['textDecoration'] ?? 'inherit'; // TODO FIX inherit doesn't work
+    $typography['textTransform'] = $typography['textTransform'] ?? 'inherit'; // TODO FIX inherit doesn't work
+    $linkStyles[] = wp_style_engine_get_styles(['typography' => $typography])['css'];
     if ($parsedBlock['attrs']['style']['color']['text'] ?? '') {
       $linkStyles[] = "color: {$parsedBlock['attrs']['style']['color']['text']}";
     }
 
     // Escaping
-    $linkStyles = array_map('esc_attr', $linkStyles);
     $wrapperStyles = array_map('esc_attr', $wrapperStyles);
+    $linkStyles = array_map('esc_attr', $linkStyles);
+    // Font family may contain single quotes
+    $linkStyles[] = str_replace('&#039;', "'", esc_attr("font-family: {$contentStyles['typography']['fontFamily']}"));
 
     $markup = str_replace('{linkStyles}', join(';', $linkStyles) . ';', $markup);
     $markup = str_replace('{wrapperStyles}', join(';', $wrapperStyles) . ';', $markup);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -45,6 +45,7 @@ class Button implements BlockRenderer {
       "background: $bgColor",
       'cursor: auto',
       'word-break: break-word',
+      'box-sizing: border-box',
     ];
     $linkStyles = [
       'display: block',

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -5,8 +5,91 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 
+/**
+ * Renders a button block.
+ * @see https://www.activecampaign.com/blog/email-buttons
+ * @see https://documentation.mjml.io/#mj-button
+ */
+
 class Button implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    return $blockContent;
+    $buttonDom = new \DOMDocument();
+    $buttonDom->loadHTML($parsedBlock['innerHTML']);
+    $buttonLink = $buttonDom->getElementsByTagName('a')->item(0);
+
+    if (!$buttonLink instanceof \DOMElement || !$buttonLink->attributes) {
+      return '';
+    }
+
+    $markup = $this->getMarkup();
+
+    // Add Link Text
+    $markup = str_replace('{linkText}', $buttonLink->textContent ?: '', $markup);
+    $markup = str_replace('{linkUrl}', $buttonLink->getAttribute('href') ?: '#', $markup);
+
+    // Width
+    $markup = str_replace('{width}', $parsedBlock['email_attrs']['width'] ?? '100%', $markup);
+
+    // Background
+    $bgColor = $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent';
+    $markup = str_replace('{backgroundColor}', $bgColor, $markup);
+
+    // Styles attributes
+    $wrapperStyles = [
+      "background: $bgColor",
+      'cursor: auto',
+    ];
+    $linkStyles = [
+      "background: $bgColor",
+      'display: inline-block',
+      'line-height: 120%',
+      'margin: 0',
+      'mso-padding-alt: 0px',
+      'text-decoration: none',
+      'text-transform: none',
+    ];
+
+    // Border
+    if ($parsedBlock['attrs']['style']['border'] ?? '') {
+      $wrapperStyles[] = wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['css'];
+      $wrapperStyles[] = 'border-style: solid';
+    }
+
+    // Spacing
+    if ($parsedBlock['attrs']['style']['spacing']['padding'] ?? '') {
+      $padding = $parsedBlock['attrs']['style']['spacing']['padding'];
+      $wrapperStyles[] = "mso-padding-alt: {$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
+      $linkStyles[] = "padding: {$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
+    }
+
+    // Font
+    $contentStyles = $settingsController->getEmailContentStyles();
+    $linkStyles[] = "font-family: {$contentStyles['typography']['fontFamily']}";
+    $linkStyles[] = "font-size: {$contentStyles['typography']['fontSize']}";
+    if ($parsedBlock['attrs']['style']['typography']) {
+      $linkStyles[] = wp_style_engine_get_styles(['typography' => $parsedBlock['attrs']['style']['typography']])['css'];
+    }
+    if ($parsedBlock['attrs']['style']['color']['text'] ?? '') {
+      $linkStyles[] = "color: {$parsedBlock['attrs']['style']['color']['text']}";
+    }
+
+    // Escaping
+    $linkStyles = array_map('esc_attr', $linkStyles);
+    $wrapperStyles = array_map('esc_attr', $wrapperStyles);
+
+    $markup = str_replace('{linkStyles}', join(';', $linkStyles) . ';', $markup);
+    $markup = str_replace('{wrapperStyles}', join(';', $wrapperStyles) . ';', $markup);
+
+    return $markup;
+  }
+
+  private function getMarkup(): string {
+    return '<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;width:{width};">
+        <tr>
+          <td align="center" bgcolor="{backgroundColor}" role="presentation" style="{wrapperStyles}" valign="middle">
+            <a href="{linkUrl}" style="{linkStyles}" target="_blank">{linkText}</a>
+          </td>
+        </tr>
+      </table>';
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -35,7 +35,7 @@ class Button implements BlockRenderer {
     // Parent block prepares container with proper width. If the width is set let's use full width of the container
     // otherwise let's use auto width.
     $width = 'auto';
-    if (($parsedBlock['attrs']['width'] ?? null)) {
+    if (isset($parsedBlock['attrs']['width'])) {
       $width = '100%';
     }
     $markup = str_replace('{width}', $width, $markup);
@@ -59,7 +59,7 @@ class Button implements BlockRenderer {
     ];
 
     // Border
-    if ($parsedBlock['attrs']['style']['border'] ?? '') {
+    if (isset($parsedBlock['attrs']['style']['border']) && !empty($parsedBlock['attrs']['style']['border'])) {
       // Use text color if border color is not set
       if (!($parsedBlock['attrs']['style']['border']['color'] ?? '')) {
         $parsedBlock['attrs']['style']['border']['color'] = $parsedBlock['attrs']['style']['color']['text'] ?? null;
@@ -72,7 +72,7 @@ class Button implements BlockRenderer {
     }
 
     // Spacing
-    if ($parsedBlock['attrs']['style']['spacing']['padding'] ?? '') {
+    if (isset($parsedBlock['attrs']['style']['spacing']['padding'])) {
       $padding = $parsedBlock['attrs']['style']['spacing']['padding'];
       $wrapperStyles['mso-padding-alt'] = "{$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
       $linkStyles['padding-top'] = $padding['top'];

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -17,7 +17,7 @@ class Button implements BlockRenderer {
     $buttonDom->loadHTML($parsedBlock['innerHTML']);
     $buttonLink = $buttonDom->getElementsByTagName('a')->item(0);
 
-    if (!$buttonLink instanceof \DOMElement || !$buttonLink->attributes) {
+    if (!$buttonLink instanceof \DOMElement) {
       return '';
     }
 
@@ -28,7 +28,13 @@ class Button implements BlockRenderer {
     $markup = str_replace('{linkUrl}', $buttonLink->getAttribute('href') ?: '#', $markup);
 
     // Width
-    $markup = str_replace('{width}', $parsedBlock['email_attrs']['width'] ?? '100%', $markup);
+    // Parent block prepares container with proper width. If the width is set let's use full width of the container
+    // otherwise let's use auto width.
+    $width = 'auto';
+    if (($parsedBlock['attrs']['width'] ?? null)) {
+      $width = '100%';
+    }
+    $markup = str_replace('{width}', $width, $markup);
 
     // Background
     $bgColor = $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent';
@@ -38,10 +44,10 @@ class Button implements BlockRenderer {
     $wrapperStyles = [
       "background: $bgColor",
       'cursor: auto',
+      'word-break: break-word',
     ];
     $linkStyles = [
-      "background: $bgColor",
-      'display: inline-block',
+      'display: block',
       'line-height: 120%',
       'margin: 0',
       'mso-padding-alt: 0px',
@@ -52,7 +58,11 @@ class Button implements BlockRenderer {
     // Border
     if ($parsedBlock['attrs']['style']['border'] ?? '') {
       $wrapperStyles[] = wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['css'];
+    }
+    if ($parsedBlock['attrs']['style']['border']['width'] ?? '') {
       $wrapperStyles[] = 'border-style: solid';
+    } else {
+      $wrapperStyles[] = 'border: none';
     }
 
     // Spacing
@@ -84,7 +94,7 @@ class Button implements BlockRenderer {
   }
 
   private function getMarkup(): string {
-    return '<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;width:{width};">
+    return '<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;border-collapse:separate;line-height:100%;width:{width};">
         <tr>
           <td align="center" bgcolor="{backgroundColor}" role="presentation" style="{wrapperStyles}" valign="middle">
             <a href="{linkUrl}" style="{linkStyles}" target="_blank">{linkText}</a>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -13,6 +13,10 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Button implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    // Don't render empty buttons
+    if (empty($parsedBlock['innerHTML'])) {
+      return '';
+    }
     $buttonDom = new \DOMDocument();
     $buttonDom->loadHTML($parsedBlock['innerHTML']);
     $buttonLink = $buttonDom->getElementsByTagName('a')->item(0);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -83,6 +83,7 @@ class Button implements BlockRenderer {
 
     // Typography
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
+    $typography['fontSize'] = $typography['fontSize'] ?? ($parsedBlock['email_attrs']['font-size'] ?? 'inherit');
     $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
     $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography])['declarations']);
     $linkStyles['color'] = $parsedBlock['email_attrs']['color'];

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -72,10 +72,8 @@ class Button implements BlockRenderer {
     }
 
     // Typography
-    $contentStyles = $settingsController->getEmailContentStyles();
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
-    $typography['textDecoration'] = $typography['textDecoration'] ?? 'inherit'; // TODO FIX inherit doesn't work
-    $typography['textTransform'] = $typography['textTransform'] ?? 'inherit'; // TODO FIX inherit doesn't work
+    $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
     $linkStyles[] = wp_style_engine_get_styles(['typography' => $typography])['css'];
     if ($parsedBlock['attrs']['style']['color']['text'] ?? '') {
       $linkStyles[] = "color: {$parsedBlock['attrs']['style']['color']['text']}";
@@ -85,6 +83,7 @@ class Button implements BlockRenderer {
     $wrapperStyles = array_map('esc_attr', $wrapperStyles);
     $linkStyles = array_map('esc_attr', $linkStyles);
     // Font family may contain single quotes
+    $contentStyles = $settingsController->getEmailContentStyles();
     $linkStyles[] = str_replace('&#039;', "'", esc_attr("font-family: {$contentStyles['typography']['fontFamily']}"));
 
     $markup = str_replace('{linkStyles}', join(';', $linkStyles) . ';', $markup);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class Button implements BlockRenderer {
+  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    return $blockContent;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -60,11 +60,14 @@ class Button implements BlockRenderer {
 
     // Border
     if ($parsedBlock['attrs']['style']['border'] ?? '') {
+      // Use text color if border color is not set
+      if (!($parsedBlock['attrs']['style']['border']['color'] ?? '')) {
+        $parsedBlock['attrs']['style']['border']['color'] = $parsedBlock['attrs']['style']['color']['text'] ?? null;
+      }
       $wrapperStyles = array_merge($wrapperStyles, wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['declarations']);
-    }
-    if ($parsedBlock['attrs']['style']['border']['width'] ?? '') {
       $wrapperStyles['border-style'] = 'solid';
     } else {
+      // Some clients render 1px border when not set as none
       $wrapperStyles['border'] = 'none';
     }
 
@@ -72,7 +75,10 @@ class Button implements BlockRenderer {
     if ($parsedBlock['attrs']['style']['spacing']['padding'] ?? '') {
       $padding = $parsedBlock['attrs']['style']['spacing']['padding'];
       $wrapperStyles['mso-padding-alt'] = "{$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
-      $linkStyles['padding'] = "{$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
+      $linkStyles['padding-top'] = $padding['top'];
+      $linkStyles['padding-right'] = $padding['right'];
+      $linkStyles['padding-bottom'] = $padding['bottom'];
+      $linkStyles['padding-left'] = $padding['left'];
     }
 
     // Typography

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class Buttons implements BlockRenderer {
+  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    return $blockContent;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
@@ -3,87 +3,24 @@
 namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
+use MailPoet\EmailEditor\Engine\Renderer\Layout\FlexLayoutRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Buttons implements BlockRenderer {
+  /** @var FlexLayoutRenderer */
+  private $flexLayoutRenderer;
+
+  public function __construct(
+    FlexLayoutRenderer $flexLayoutRenderer
+  ) {
+    $this->flexLayoutRenderer = $flexLayoutRenderer;
+  }
+
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $contentStyles = $settingsController->getEmailContentStyles();
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
     $typography['fontSize'] = $typography['fontSize'] ?? $contentStyles['typography']['fontSize'];
     $parsedBlock['attrs']['style']['typography'] = $typography;
-    $styles = wp_style_engine_get_styles($parsedBlock['attrs']['style'])['css'];
-    $content = $this->renderButtonsInLayout($parsedBlock, $settingsController);
-    $justify = $parsedBlock['attrs']['layout']['justifyContent'] ?? 'left';
-    $styles .= 'text-align: ' . esc_attr($justify);
-
-    $markup = $this->getMarkup();
-    $markup = str_replace('{style}', $styles, $markup);
-    $markup = str_replace('{align}', $justify, $markup);
-    $markup = str_replace('{buttons}', $content, $markup);
-
-    return $markup;
-  }
-
-  private function getMarkup(): string {
-    // MS Outlook doesn't support style attribute in divs so we conditionally wrap the buttons in a table and repeat styles
-    return '<!--[if mso | IE]><table align="{align}" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="" style="{style}" ><![endif]-->
-        <div style="{style}">{buttons}</div>
-    <!--[if mso | IE]></td></tr></table><![endif]-->';
-  }
-
-  private function renderButtonsInLayout(array $parsedBlock, SettingsController $settingsController): string {
-    $innerBlocks = $this->computeWidthsForFlexLayout($parsedBlock, $settingsController);
-
-    $blocksHtml = '<table class="layout-flex-wrapper" style="display:inline-block"><tbody><tr>';
-    foreach ($innerBlocks as $key => $block) {
-      $styles = [];
-      if ($block['email_attrs']['layout_width'] ?? null) {
-        $styles['width'] = $block['email_attrs']['layout_width'];
-      }
-      if ($key > 0) {
-        $styles['padding-left'] = SettingsController::FLEX_GAP;
-      }
-      $blocksHtml .= '<td class="layout-flex-item" style="' . esc_html($settingsController->convertStylesToString($styles)) . '">' . render_block($block) . '</td>';
-    }
-    $blocksHtml .= '</tr></table>';
-    return $blocksHtml;
-  }
-
-  private function computeWidthsForFlexLayout(array $parsedBlock, SettingsController $settingsController): array {
-    $blocksCount = count($parsedBlock['innerBlocks']);
-    $totalSetWidth = 0; // Total width set by user. Excludes items that have no width set
-    $totalUsedWidth = 0; // Total width assuming items without set width would consume proportional width
-    $parentWidth = $settingsController->parseNumberFromStringWithPixels($parsedBlock['email_attrs']['width'] ?? SettingsController::EMAIL_WIDTH);
-    $flexGap = $settingsController->parseNumberFromStringWithPixels(SettingsController::FLEX_GAP);
-    $innerBlocks = $parsedBlock['innerBlocks'] ?? [];
-
-    foreach ($innerBlocks as $key => $block) {
-      $blockWidthPercent = ($block['attrs']['width'] ?? 0) ? intval($block['attrs']['width']) : 0;
-      $blockWidth = floor($parentWidth * ($blockWidthPercent / 100));
-      $totalSetWidth += $blockWidth;
-      // If width is not set, we assume it's 25% of the parent width
-      $totalUsedWidth += $blockWidth ?: floor($parentWidth * (25 / 100));
-
-      if (!$blockWidth) {
-        $innerBlocks[$key]['email_attrs']['layout_width'] = null; // Will be rendered as auto
-        continue;
-      }
-      // How many percent of width we will strip to keep some space fot the gap
-      // Todo add more precise comment
-      $widthGapReduction = $flexGap * ((100 - $blockWidthPercent) / 100);
-      $innerBlocks[$key]['email_attrs']['layout_width'] = floor($blockWidth - $widthGapReduction) . 'px';
-    }
-
-    // When there is only one block, or percentage is set reasonably we don't need to adjust and just render as set by user
-    if ($blocksCount <= 1 || ($totalSetWidth < $parentWidth)) {
-      return $innerBlocks;
-    }
-
-    foreach ($innerBlocks as $key => $block) {
-      $proportionalSpaceOverflow = $parentWidth / $totalUsedWidth;
-      $blockWidth = $block['email_attrs']['layout_width'] ? $settingsController->parseNumberFromStringWithPixels($block['email_attrs']['layout_width']) : 0;
-      $innerBlocks[$key]['email_attrs']['layout_width'] = $blockWidth ? intval(round($blockWidth * $proportionalSpaceOverflow)) . 'px' : null;
-    }
-    return $innerBlocks;
+    return $this->flexLayoutRenderer->renderInnerBlocksInLayout($parsedBlock, $settingsController);
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
@@ -7,6 +7,83 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Buttons implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    return $blockContent;
+    $contentStyles = $settingsController->getEmailContentStyles();
+    $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
+    $typography['fontSize'] = $typography['fontSize'] ?? $contentStyles['typography']['fontSize'];
+    $parsedBlock['attrs']['style']['typography'] = $typography;
+    $styles = wp_style_engine_get_styles($parsedBlock['attrs']['style'])['css'];
+    $content = $this->renderButtonsInLayout($parsedBlock, $settingsController);
+    $justify = $parsedBlock['attrs']['layout']['justifyContent'] ?? 'left';
+    $styles .= 'text-align: ' . esc_attr($justify);
+
+    $markup = $this->getMarkup();
+    $markup = str_replace('{style}', $styles, $markup);
+    $markup = str_replace('{align}', $justify, $markup);
+    $markup = str_replace('{buttons}', $content, $markup);
+
+    return $markup;
+  }
+
+  private function getMarkup(): string {
+    // MS Outlook doesn't support style attribute in divs so we conditionally wrap the buttons in a table and repeat styles
+    return '<!--[if mso | IE]><table align="{align}" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="" style="{style}" ><![endif]-->
+        <div style="{style}">{buttons}</div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->';
+  }
+
+  private function renderButtonsInLayout(array $parsedBlock, SettingsController $settingsController): string {
+    $innerBlocks = $this->computeWidthsForFlexLayout($parsedBlock, $settingsController);
+
+    $blocksHtml = '<table class="layout-flex-wrapper" style="display:inline-block"><tbody><tr>';
+    foreach ($innerBlocks as $key => $block) {
+      $styles = [];
+      if ($block['email_attrs']['layout_width'] ?? null) {
+        $styles['width'] = $block['email_attrs']['layout_width'];
+      }
+      if ($key > 0) {
+        $styles['padding-left'] = SettingsController::FLEX_GAP;
+      }
+      $blocksHtml .= '<td class="layout-flex-item" style="' . esc_html($settingsController->convertStylesToString($styles)) . '">' . render_block($block) . '</td>';
+    }
+    $blocksHtml .= '</tr></table>';
+    return $blocksHtml;
+  }
+
+  private function computeWidthsForFlexLayout(array $parsedBlock, SettingsController $settingsController): array {
+    $blocksCount = count($parsedBlock['innerBlocks']);
+    $totalSetWidth = 0; // Total width set by user. Excludes items that have no width set
+    $totalUsedWidth = 0; // Total width assuming items without set width would consume proportional width
+    $parentWidth = $settingsController->parseNumberFromStringWithPixels($parsedBlock['email_attrs']['width'] ?? SettingsController::EMAIL_WIDTH);
+    $flexGap = $settingsController->parseNumberFromStringWithPixels(SettingsController::FLEX_GAP);
+    $innerBlocks = $parsedBlock['innerBlocks'] ?? [];
+
+    foreach ($innerBlocks as $key => $block) {
+      $blockWidthPercent = ($block['attrs']['width'] ?? 0) ? intval($block['attrs']['width']) : 0;
+      $blockWidth = floor($parentWidth * ($blockWidthPercent / 100));
+      $totalSetWidth += $blockWidth;
+      // If width is not set, we assume it's 25% of the parent width
+      $totalUsedWidth += $blockWidth ?: floor($parentWidth * (25 / 100));
+
+      if (!$blockWidth) {
+        $innerBlocks[$key]['email_attrs']['layout_width'] = null; // Will be rendered as auto
+        continue;
+      }
+      // How many percent of width we will strip to keep some space fot the gap
+      // Todo add more precise comment
+      $widthGapReduction = $flexGap * ((100 - $blockWidthPercent) / 100);
+      $innerBlocks[$key]['email_attrs']['layout_width'] = floor($blockWidth - $widthGapReduction) . 'px';
+    }
+
+    // When there is only one block, or percentage is set reasonably we don't need to adjust and just render as set by user
+    if ($blocksCount <= 1 || ($totalSetWidth < $parentWidth)) {
+      return $innerBlocks;
+    }
+
+    foreach ($innerBlocks as $key => $block) {
+      $proportionalSpaceOverflow = $parentWidth / $totalUsedWidth;
+      $blockWidth = $block['email_attrs']['layout_width'] ? $settingsController->parseNumberFromStringWithPixels($block['email_attrs']['layout_width']) : 0;
+      $innerBlocks[$key]['email_attrs']['layout_width'] = $blockWidth ? intval(round($blockWidth * $proportionalSpaceOverflow)) . 'px' : null;
+    }
+    return $innerBlocks;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Buttons.php
@@ -17,10 +17,12 @@ class Buttons implements BlockRenderer {
   }
 
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
-    $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
-    $typography['fontSize'] = $typography['fontSize'] ?? $contentStyles['typography']['fontSize'];
-    $parsedBlock['attrs']['style']['typography'] = $typography;
+    // Ignore font size set on the buttons block
+    // We rely on TypographyPreprocessor to set the font size on the buttons
+    // Rendering font size on the wrapper causes unwanted whitespace below the buttons
+    if (isset($parsedBlock['attrs']['style']['typography']['fontSize'])) {
+      unset($parsedBlock['attrs']['style']['typography']['fontSize']);
+    }
     return $this->flexLayoutRenderer->renderInnerBlocksInLayout($parsedBlock, $settingsController);
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -41,7 +41,7 @@ class Columns implements BlockRenderer {
 
     return '
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '" bgcolor="' . $backgroundColor . '" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';margin:0px auto;max-width:' . $width . ';width:100%;padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
+      <div style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';margin:0px auto;max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';max-width:' . $width . ';width:100%;">
           <tbody>
             <tr>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -18,8 +18,6 @@ class Image implements BlockRenderer {
     $blockContent = $this->addImageDimensions($blockContent, $parsedBlock, $settingsController);
     $blockContent = $this->addWidthToWrapper($blockContent, $parsedBlock, $settingsController);
     $blockContent = $this->addCaptionFontSize($blockContent, $settingsController);
-    bdump($parsedBlock);
-    bdump($blockContent);
     return str_replace('{image_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
   }
 

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -82,6 +82,12 @@ namespace {
       }
     }
   }
+
+  // The function is currently not included in wordpress-stubs (https://github.com/php-stubs/wordpress-stubs)
+  if (!function_exists('wp_style_engine_get_styles')) {
+    function wp_style_engine_get_styles($block_styles, $options = []) {
+    }
+  }
 }
 
 // Temporary stubs for Woo Custom Tables.

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -110,6 +110,7 @@ parameters:
       - ../../tests/_support/_generated
       - ../../tests/integration/Models # Old models are deprecated and will be removed soon
       - ../../tests/unit/Entities/SubscriberEntityTest.php
+      - ../../tests/unit/_stubs.php # Contains stubs for WP classes etc.
       - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php # does not yet offer support for PHP 8.1
 includes:
   - extensions/CodeceptionExtension/extension.neon

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/DummyBlockRenderer.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/DummyBlockRenderer.php
@@ -6,10 +6,6 @@ use MailPoet\EmailEditor\Engine\SettingsController;
 
 class DummyBlockRenderer implements BlockRenderer {
   public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    if (!isset($parsedBlock['innerBlocks']) || empty($parsedBlock['innerBlocks'])) {
-      return $parsedBlock['innerHTML'];
-    }
-    // Wrapper is rendered in parent Columns block because it needs to operate with columns count etc.
-    return '[' . $this->render('', $parsedBlock['innerBlocks'], $settingsController) . ']';
+    return $parsedBlock['innerHtml'];
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/Layout/FlexLayoutRendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/Layout/FlexLayoutRendererTest.php
@@ -19,7 +19,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
   /** @var SettingsController */
   private $settingsController;
 
-  public function _before() {
+  public function _before(): void {
     parent::_before();
     $this->settingsController = new SettingsController();
     $this->registry = new BlocksRegistry($this->settingsController);
@@ -28,7 +28,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
     register_block_type('dummy/block', []);
   }
 
-  public function testItRendersInnerBlocks() {
+  public function testItRendersInnerBlocks(): void {
     $parsedBlock = [
       'innerBlocks' => [
         [
@@ -47,7 +47,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
     verify($output)->stringContainsString('Dummy 2');
   }
 
-  public function testItHandlesJustification() {
+  public function testItHandlesJustification(): void {
     $parsedBlock = [
       'innerBlocks' => [
         [
@@ -73,7 +73,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
     verify($output)->stringContainsString('align="center"');
   }
 
-  public function testItEscapesAttributes() {
+  public function testItEscapesAttributes(): void {
     $parsedBlock = [
       'innerBlocks' => [
         [
@@ -88,7 +88,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
     verify($output)->stringNotContainsString('<script>alert("XSS")</script>');
   }
 
-  public function testInComputesProperWidthsForReasonableSettings() {
+  public function testInComputesProperWidthsForReasonableSettings(): void {
     $parsedBlock = [
       'innerBlocks' => [],
       'email_attrs' => [
@@ -157,7 +157,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
     verify($flexItems[1])->stringContainsString('width:312px;');
   }
 
-  public function testInComputesWidthsForStrangeSettingsValues() {
+  public function testInComputesWidthsForStrangeSettingsValues(): void {
     $parsedBlock = [
       'innerBlocks' => [],
       'email_attrs' => [
@@ -227,7 +227,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
     return explode('><', $matches[0][0] ?? []);
   }
 
-  public function _after() {
+  public function _after(): void {
     parent::_after();
     unregister_block_type('dummy/block');
   }

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/Layout/FlexLayoutRendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/Layout/FlexLayoutRendererTest.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Renderer\Layout;
+
+use MailPoet\EmailEditor\Engine\Renderer\BlocksRegistry;
+use MailPoet\EmailEditor\Engine\Renderer\DummyBlockRenderer;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+require_once __DIR__ . '/../DummyBlockRenderer.php';
+
+class FlexLayoutRendererTest extends \MailPoetTest {
+
+  /** @var BlocksRegistry */
+  private $registry;
+
+  /** @var FlexLayoutRenderer */
+  private $renderer;
+
+  /** @var SettingsController */
+  private $settingsController;
+
+  public function _before() {
+    parent::_before();
+    $this->settingsController = new SettingsController();
+    $this->registry = new BlocksRegistry($this->settingsController);
+    $this->renderer = new FlexLayoutRenderer();
+    $this->registry->addBlockRenderer('dummy/block', new DummyBlockRenderer());
+    register_block_type('dummy/block', []);
+  }
+
+  public function testItRendersInnerBlocks() {
+    $parsedBlock = [
+      'innerBlocks' => [
+        [
+          'blockName' => 'dummy/block',
+          'innerHtml' => 'Dummy 1',
+        ],
+        [
+          'blockName' => 'dummy/block',
+          'innerHtml' => 'Dummy 2',
+        ],
+      ],
+      'email_attrs' => [],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    verify($output)->stringContainsString('Dummy 1');
+    verify($output)->stringContainsString('Dummy 2');
+  }
+
+  public function testItHandlesJustification() {
+    $parsedBlock = [
+      'innerBlocks' => [
+        [
+          'blockName' => 'dummy/block',
+          'innerHtml' => 'Dummy 1',
+        ],
+      ],
+      'email_attrs' => [],
+    ];
+    // Default justification is left
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    verify($output)->stringContainsString('text-align: left');
+    verify($output)->stringContainsString('align="left"');
+    // Right justification
+    $parsedBlock['attrs']['layout']['justifyContent'] = 'right';
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    verify($output)->stringContainsString('text-align: right');
+    verify($output)->stringContainsString('align="right"');
+    // Center justification
+    $parsedBlock['attrs']['layout']['justifyContent'] = 'center';
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    verify($output)->stringContainsString('text-align: center');
+    verify($output)->stringContainsString('align="center"');
+  }
+
+  public function testItEscapesAttributes() {
+    $parsedBlock = [
+      'innerBlocks' => [
+        [
+          'blockName' => 'dummy/block',
+          'innerHtml' => 'Dummy 1',
+        ],
+      ],
+      'email_attrs' => [],
+    ];
+    $parsedBlock['attrs']['layout']['justifyContent'] = '"> <script>alert("XSS")</script><div style="text-align: right';
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    verify($output)->stringNotContainsString('<script>alert("XSS")</script>');
+  }
+
+  public function testInComputesProperWidthsForReasonableSettings() {
+    $parsedBlock = [
+      'innerBlocks' => [],
+      'email_attrs' => [
+        'width' => '640px',
+      ],
+    ];
+
+    // 50% and 25%
+    $parsedBlock['innerBlocks'] = [
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 1',
+        'attrs' => ['width' => '50'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 2',
+        'attrs' => ['width' => '25'],
+      ],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    $flexItems = $this->getFlexItemsFromOutput($output);
+    verify($flexItems[0])->stringContainsString('width:312px;');
+    verify($flexItems[1])->stringContainsString('width:148px;');
+
+    // 25% and 25% and auto
+    $parsedBlock['innerBlocks'] = [
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 1',
+        'attrs' => ['width' => '25'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 2',
+        'attrs' => ['width' => '25'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 3',
+        'attrs' => [],
+      ],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    $flexItems = $this->getFlexItemsFromOutput($output);
+    verify($flexItems[0])->stringContainsString('width:148px;');
+    verify($flexItems[1])->stringContainsString('width:148px;');
+    verify($flexItems[2])->stringNotContainsString('width:');
+
+    // 50% and 50%
+    $parsedBlock['innerBlocks'] = [
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 1',
+        'attrs' => ['width' => '50'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 2',
+        'attrs' => ['width' => '50'],
+      ],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    $flexItems = $this->getFlexItemsFromOutput($output);
+    verify($flexItems[0])->stringContainsString('width:312px;');
+    verify($flexItems[1])->stringContainsString('width:312px;');
+  }
+
+  public function testInComputesWidthsForStrangeSettingsValues() {
+    $parsedBlock = [
+      'innerBlocks' => [],
+      'email_attrs' => [
+        'width' => '640px',
+      ],
+    ];
+
+    // 100% and 25%
+    $parsedBlock['innerBlocks'] = [
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 1',
+        'attrs' => ['width' => '100'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 2',
+        'attrs' => ['width' => '25'],
+      ],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    $flexItems = $this->getFlexItemsFromOutput($output);
+    verify($flexItems[0])->stringContainsString('width:508px;');
+    verify($flexItems[1])->stringContainsString('width:105px;');
+
+    // 100% and 100%
+    $parsedBlock['innerBlocks'] = [
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 1',
+        'attrs' => ['width' => '100'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 2',
+        'attrs' => ['width' => '100'],
+      ],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    $flexItems = $this->getFlexItemsFromOutput($output);
+    verify($flexItems[0])->stringContainsString('width:312px;');
+    verify($flexItems[1])->stringContainsString('width:312px;');
+
+
+    // 100% and auto
+    $parsedBlock['innerBlocks'] = [
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 1',
+        'attrs' => ['width' => '100'],
+      ],
+      [
+        'blockName' => 'dummy/block',
+        'innerHtml' => 'Dummy 2',
+        'attrs' => [],
+      ],
+    ];
+    $output = $this->renderer->renderInnerBlocksInLayout($parsedBlock, $this->settingsController);
+    $flexItems = $this->getFlexItemsFromOutput($output);
+    verify($flexItems[0])->stringContainsString('width:508px;');
+    verify($flexItems[1])->stringNotContainsString('width:');
+  }
+
+  private function getFlexItemsFromOutput(string $output): array {
+    $matches = [];
+    preg_match_all('/<td class="layout-flex-item" style="(.*)">/', $output, $matches);
+    return explode('><', $matches[0][0] ?? []);
+  }
+
+  public function _after() {
+    parent::_after();
+    unregister_block_type('dummy/block');
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -1,0 +1,164 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\EmailEditor;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class ButtonTest extends \MailPoetTest {
+  /** @var Button */
+  private $buttonRenderer;
+
+  /** @var array */
+  private $parsedButton = [
+    'blockName' => 'core/button',
+    'attrs' => [
+      'width' => 50,
+      'style' => [
+        'spacing' => [
+          'padding' => [
+            'left' => '10px',
+            'right' => '10px',
+            'top' => '10px',
+            'bottom' => '10px',
+          ],
+        ],
+        'color' => [
+          'background' => '#dddddd',
+          'text' => '#111111',
+        ],
+      ],
+    ],
+    'innerBlocks' => [],
+    'innerHTML' => '<div class="wp-block-button has-custom-width wp-block-button__width-50"><a href="http://example.com" class="wp-block-button__link has-text-color has-background has-link-color wp-element-button" style="color:#111111;background-color:#dddddd;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px">Button Text</a></div>',
+    'innerContent' => ['<div class="wp-block-button has-custom-width wp-block-button__width-50"><a href="http://example.com" class="wp-block-button__link has-text-color has-background has-link-color wp-element-button" style="color:#111111;background-color:#dddddd;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px">Button Text</a></div>'],
+    'email_attrs' => [
+      'color' => '#111111',
+      'width' => '320px',
+    ],
+  ];
+
+  /** @var SettingsController */
+  private $settingsController;
+
+  public function _before() {
+    $this->diContainer->get(EmailEditor::class)->initialize();
+    $this->buttonRenderer = new Button();
+    $this->settingsController = $this->diContainer->get(SettingsController::class);
+  }
+
+  public function testItRendersLink() {
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('href="http://example.com"');
+    verify($output)->stringContainsString('Button Text');
+  }
+
+  public function testItRendersPaddingBasedOnAttributesValue() {
+    $this->parsedButton['attrs']['style']['spacing']['padding'] = [
+      'left' => '10px',
+      'right' => '20px',
+      'top' => '30px',
+      'bottom' => '40px',
+    ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('padding-left:10px;');
+    verify($output)->stringContainsString('padding-right:20px;');
+    verify($output)->stringContainsString('padding-top:30px;');
+    verify($output)->stringContainsString('padding-bottom:40px;');
+  }
+
+  public function testItRendersColors() {
+    $this->parsedButton['attrs']['style']['color'] = [
+      'background' => '#000000',
+      'text' => '#111111',
+    ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('bgcolor="#000000"');
+    verify($output)->stringContainsString('background:#000000;');
+    verify($output)->stringContainsString('color:#111111;');
+  }
+
+  public function testItRendersBorder() {
+    $this->parsedButton['attrs']['style']['border'] = [
+      'width' => '10px',
+      'color' => '#111111',
+    ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('border-color:#111111;');
+    verify($output)->stringContainsString('border-width:10px;');
+    verify($output)->stringContainsString('border-style:solid;');
+  }
+
+  public function testItRendersBorderNone() {
+    $this->parsedButton['attrs']['style']['border'] = [];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('border:none;');
+  }
+
+  public function testItRendersBorderWithTextColorFallback() {
+    $this->parsedButton['attrs']['style']['border'] = [
+      'width' => '10px',
+    ];
+    $this->parsedButton['attrs']['style']['color'] = [
+      'text' => '#111111',
+    ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('border-color:#111111;');
+  }
+
+  public function testItRendersEachSideSpecificBorder() {
+    $this->parsedButton['attrs']['style']['border'] = [
+      'top' => ['width' => '1px', 'color' => '#111111'],
+      'right' => ['width' => '2px', 'color' => '#222222'],
+      'bottom' => ['width' => '3px', 'color' => '#333333'],
+      'left' => ['width' => '4px', 'color' => '#444444'],
+    ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('border-top-width:1px;');
+    verify($output)->stringContainsString('border-top-color:#111111;');
+
+    verify($output)->stringContainsString('border-right-width:2px;');
+    verify($output)->stringContainsString('border-right-color:#222222;');
+
+    verify($output)->stringContainsString('border-bottom-width:3px;');
+    verify($output)->stringContainsString('border-bottom-color:#333333;');
+
+    verify($output)->stringContainsString('border-left-width:4px;');
+    verify($output)->stringContainsString('border-left-color:#444444;');
+
+    verify($output)->stringContainsString('border-style:solid;');
+  }
+
+  public function testItRendersBorderRadius() {
+    $this->parsedButton['attrs']['style']['border'] = [
+      'radius' => '10px',
+    ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('border-radius:10px;');
+  }
+
+  public function testItRendersCornerSpecificBorderRadius() {
+    $this->parsedButton['attrs']['style']['border']['radius'] = [
+      'topLeft' => '1px',
+      'topRight' => '2px',
+      'bottomLeft' => '3px',
+      'bottomRight' => '4px',
+      ];
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('border-top-left-radius:1px;');
+    verify($output)->stringContainsString('border-top-right-radius:2px;');
+    verify($output)->stringContainsString('border-bottom-left-radius:3px;');
+    verify($output)->stringContainsString('border-bottom-right-radius:4px;');
+  }
+
+  public function testItAllowsSingleQuotesInFontFamilyDefinition() {
+    $settingsControllerMock = $this->createPartialMock(SettingsController::class, ['getEmailContentStyles']);
+    $settingsControllerMock->method('getEmailContentStyles')->willReturn([
+      'typography' => [
+        'fontFamily' => '"Font\'", serif',
+      ],
+    ]);
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $settingsControllerMock);
+    verify($output)->stringContainsString('&quot;Font\'&quot;, serif');
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -41,19 +41,19 @@ class ButtonTest extends \MailPoetTest {
   /** @var SettingsController */
   private $settingsController;
 
-  public function _before() {
+  public function _before(): void {
     $this->diContainer->get(EmailEditor::class)->initialize();
     $this->buttonRenderer = new Button();
     $this->settingsController = $this->diContainer->get(SettingsController::class);
   }
 
-  public function testItRendersLink() {
+  public function testItRendersLink(): void {
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     verify($output)->stringContainsString('href="http://example.com"');
     verify($output)->stringContainsString('Button Text');
   }
 
-  public function testItRendersPaddingBasedOnAttributesValue() {
+  public function testItRendersPaddingBasedOnAttributesValue(): void {
     $this->parsedButton['attrs']['style']['spacing']['padding'] = [
       'left' => '10px',
       'right' => '20px',
@@ -67,7 +67,7 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('padding-bottom:40px;');
   }
 
-  public function testItRendersColors() {
+  public function testItRendersColors(): void {
     $this->parsedButton['attrs']['style']['color'] = [
       'background' => '#000000',
       'text' => '#111111',
@@ -78,7 +78,7 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('color:#111111;');
   }
 
-  public function testItRendersBorder() {
+  public function testItRendersBorder(): void {
     $this->parsedButton['attrs']['style']['border'] = [
       'width' => '10px',
       'color' => '#111111',
@@ -89,13 +89,13 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-style:solid;');
   }
 
-  public function testItRendersBorderNone() {
+  public function testItRendersBorderNone(): void {
     $this->parsedButton['attrs']['style']['border'] = [];
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     verify($output)->stringContainsString('border:none;');
   }
 
-  public function testItRendersBorderWithTextColorFallback() {
+  public function testItRendersBorderWithTextColorFallback(): void {
     $this->parsedButton['attrs']['style']['border'] = [
       'width' => '10px',
     ];
@@ -106,7 +106,7 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-color:#111111;');
   }
 
-  public function testItRendersEachSideSpecificBorder() {
+  public function testItRendersEachSideSpecificBorder(): void {
     $this->parsedButton['attrs']['style']['border'] = [
       'top' => ['width' => '1px', 'color' => '#111111'],
       'right' => ['width' => '2px', 'color' => '#222222'],
@@ -129,7 +129,7 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-style:solid;');
   }
 
-  public function testItRendersBorderRadius() {
+  public function testItRendersBorderRadius(): void {
     $this->parsedButton['attrs']['style']['border'] = [
       'radius' => '10px',
     ];
@@ -137,13 +137,13 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-radius:10px;');
   }
 
-  public function testItRendersCornerSpecificBorderRadius() {
+  public function testItRendersCornerSpecificBorderRadius(): void {
     $this->parsedButton['attrs']['style']['border']['radius'] = [
       'topLeft' => '1px',
       'topRight' => '2px',
       'bottomLeft' => '3px',
       'bottomRight' => '4px',
-      ];
+    ];
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     verify($output)->stringContainsString('border-top-left-radius:1px;');
     verify($output)->stringContainsString('border-top-right-radius:2px;');
@@ -151,7 +151,7 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-bottom-right-radius:4px;');
   }
 
-  public function testItAllowsSingleQuotesInFontFamilyDefinition() {
+  public function testItAllowsSingleQuotesInFontFamilyDefinition(): void {
     $settingsControllerMock = $this->createPartialMock(SettingsController::class, ['getEmailContentStyles']);
     $settingsControllerMock->method('getEmailContentStyles')->willReturn([
       'typography' => [

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -3,6 +3,7 @@
 namespace unit\EmailEditor\Engine\Renderer\Preprocessors;
 
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor;
+use MailPoet\EmailEditor\Engine\SettingsController;
 
 class TypographyPreprocessorTest extends \MailPoetUnitTest {
 
@@ -11,7 +12,17 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
 
   public function _before() {
     parent::_before();
-    $this->preprocessor = new TypographyPreprocessor();
+    $settingsMock = $this->createMock(SettingsController::class);
+    $themeMock = $this->createMock(\WP_Theme_JSON::class);
+    $themeMock->method('get_data')->willReturn([
+      'styles' => [
+        'color' => [
+          'text' => '#000000',
+        ],
+      ],
+    ]);
+    $settingsMock->method('getTheme')->willReturn($themeMock);
+    $this->preprocessor = new TypographyPreprocessor($settingsMock);
   }
 
   public function testItCopiesColumnsTypography(): void {
@@ -88,10 +99,10 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $result = $this->preprocessor->preprocess($blocks, []);
     $result = $result[0];
     verify($result['innerBlocks'])->arrayCount(2);
-    verify($result['email_attrs'])->equals(['width' => '640px']);
-    verify($result['innerBlocks'][0]['email_attrs'])->equals([]);
-    verify($result['innerBlocks'][1]['email_attrs'])->equals([]);
-    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals([]);
+    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000']);
+    verify($result['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000']);
+    verify($result['innerBlocks'][1]['email_attrs'])->equals(['color' => '#000000']);
+    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000']);
   }
 
   public function testItOverridesColumnsTypography(): void {
@@ -191,7 +202,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     verify($child1['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child1['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child2['innerBlocks'])->arrayCount(1);
-    verify($child2['email_attrs'])->equals([]);
+    verify($child2['email_attrs'])->equals(['color' => '#000000']);
     verify($child2['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
     verify($child2['innerBlocks'][0]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
   }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -25,6 +25,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
           'typography' => [
             'fontFamily' => 'Arial',
             'fontSize' => '12px',
+            'textDecoration' => 'underline',
           ],
         ],
       ],
@@ -49,6 +50,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       'color' => '#aa00dd',
       'font-family' => 'Arial',
       'font-size' => '12px',
+      'text-decoration' => 'underline',
     ];
     $result = $this->preprocessor->preprocess($blocks, []);
     $result = $result[0];

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -22,6 +22,11 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       ],
     ]);
     $settingsMock->method('getTheme')->willReturn($themeMock);
+    $settingsMock->method('getEmailContentStyles')->willReturn([
+      'typography' => [
+        'fontSize' => '13px',
+      ],
+    ]);
     $this->preprocessor = new TypographyPreprocessor($settingsMock);
   }
 
@@ -99,10 +104,10 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $result = $this->preprocessor->preprocess($blocks, []);
     $result = $result[0];
     verify($result['innerBlocks'])->arrayCount(2);
-    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000']);
-    verify($result['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000']);
-    verify($result['innerBlocks'][1]['email_attrs'])->equals(['color' => '#000000']);
-    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000']);
+    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000', 'font-size' => '13px']);
+    verify($result['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
+    verify($result['innerBlocks'][1]['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
+    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
   }
 
   public function testItOverridesColumnsTypography(): void {
@@ -202,7 +207,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     verify($child1['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child1['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child2['innerBlocks'])->arrayCount(1);
-    verify($child2['email_attrs'])->equals(['color' => '#000000']);
+    verify($child2['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
     verify($child2['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
     verify($child2['innerBlocks'][0]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
   }

--- a/mailpoet/tests/unit/_bootstrap.php
+++ b/mailpoet/tests/unit/_bootstrap.php
@@ -38,3 +38,4 @@ abstract class MailPoetUnitTest extends \Codeception\TestCase\Test {
 }
 
 include '_fixtures.php';
+include '_stubs.php';

--- a/mailpoet/tests/unit/_stubs.php
+++ b/mailpoet/tests/unit/_stubs.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+// phpcs:ignoreFile - We want to allow multiple classes etc.
+
+// Dummy WP classes
+if (!class_exists(\WP_Theme_JSON::class)) {
+  class WP_Theme_JSON {
+    public function get_data() {
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR adds support for buttons and button blocks to the email editor.

## Code review notes
- colors set via CSS class don't work in renderer (we have an extra ticket for that 5741)

## QA notes
I would suggest skipping QA for now and doing QA after we finish bug fixes and refactoring the renderer.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5644]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5644]: https://mailpoet.atlassian.net/browse/MAILPOET-5644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ