### PR TITLE
Fix columns width calculation [MAILPOET-5739]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -117,3 +117,10 @@
     text-align: center;
   }
 }
+
+.editor-styles-wrapper {
+  .wp-block-columns:not(.is-not-stacked-on-mobile)
+    > .wp-block-column[style*='flex-basis'] {
+    box-sizing: border-box;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessor.php
@@ -74,6 +74,10 @@ class BlocksWidthPreprocessor implements Preprocessor {
       if (isset($column['attrs']['width']) && !empty($column['attrs']['width'])) {
         $columnsCountWithDefinedWidth++;
         $definedColumnWidth += $this->convertWidthToPixels($column['attrs']['width'], $columnsWidth);
+      } else {
+        // When width is not set we need to add padding to the defined column width for better ratio accuracy
+        $definedColumnWidth += $this->parseNumberFromStringWithPixels($column['attrs']['style']['spacing']['padding']['left'] ?? '0px');
+        $definedColumnWidth += $this->parseNumberFromStringWithPixels($column['attrs']['style']['spacing']['padding']['right'] ?? '0px');
       }
     }
 
@@ -81,7 +85,11 @@ class BlocksWidthPreprocessor implements Preprocessor {
       $defaultColumnsWidth = round(($columnsWidth - $definedColumnWidth) / ($columnsCount - $columnsCountWithDefinedWidth), 2);
       foreach ($columns as $key => $column) {
         if (!isset($column['attrs']['width']) || empty($column['attrs']['width'])) {
-          $columns[$key]['attrs']['width'] = "{$defaultColumnsWidth}px";
+          // Add padding to the specific column width because it's not included in the default width
+          $columnWidth = $defaultColumnsWidth;
+          $columnWidth += $this->parseNumberFromStringWithPixels($column['attrs']['style']['spacing']['padding']['left'] ?? '0px');
+          $columnWidth += $this->parseNumberFromStringWithPixels($column['attrs']['style']['spacing']['padding']['right'] ?? '0px');
+          $columns[$key]['attrs']['width'] = "{$columnWidth}px";
         }
       }
     }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/BlocksWidthPreprocessorTest.php
@@ -263,4 +263,103 @@ class BlocksWidthPreprocessorTest extends \MailPoetUnitTest {
     verify($result[0]['email_attrs']['width'])->equals('660px'); // full width
     verify($result[1]['email_attrs']['width'])->equals('630px'); // 660 - 15 - 15
   }
+
+  public function testItCalculatesWidthForColumnWithoutDefinition(): void {
+    $blocks = [[
+      'blockName' => 'core/columns',
+      'attrs' => [
+        'style' => [
+          'spacing' => [
+            'padding' => [
+              'left' => '25px',
+              'right' => '15px',
+            ],
+          ],
+        ],
+      ],
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/column',
+          'attrs' => [
+            'width' => '140px',
+            'style' => [
+              'spacing' => [
+                'padding' => [
+                  'left' => '25px',
+                  'right' => '15px',
+                ],
+              ],
+            ],
+          ],
+          'innerBlocks' => [],
+        ],
+        [
+          'blockName' => 'core/column',
+          'attrs' => [
+            'style' => [
+              'spacing' => [
+                'padding' => [
+                  'left' => '10px',
+                  'right' => '10px',
+                ],
+              ],
+            ],
+          ],
+          'innerBlocks' => [],
+        ],
+        [
+          'blockName' => 'core/column',
+          'attrs' => [
+            'style' => [
+              'spacing' => [
+                'padding' => [
+                  'left' => '20px',
+                  'right' => '20px',
+                ],
+              ],
+            ],
+          ],
+          'innerBlocks' => [],
+        ],
+      ],
+    ]];
+
+    $result = $this->preprocessor->preprocess($blocks, ['width' => '660px', 'padding' => ['left' => '10px', 'right' => '10px']]);
+    verify($result[0]['innerBlocks'])->arrayCount(3);
+    verify($result[0]['innerBlocks'][0]['email_attrs']['width'])->equals('140px');
+    verify($result[0]['innerBlocks'][1]['email_attrs']['width'])->equals('220px');
+    verify($result[0]['innerBlocks'][2]['email_attrs']['width'])->equals('240px');
+
+    $blocks = [[
+      'blockName' => 'core/columns',
+      'attrs' => [],
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/column',
+          'attrs' => [
+            'width' => '140px',
+            'style' => [
+              'spacing' => [
+                'padding' => [
+                  'left' => '25px',
+                  'right' => '15px',
+                ],
+              ],
+            ],
+          ],
+          'innerBlocks' => [],
+        ],
+        [
+          'blockName' => 'core/column',
+          'attrs' => [],
+          'innerBlocks' => [],
+        ],
+      ],
+    ]];
+
+    $result = $this->preprocessor->preprocess($blocks, ['width' => '660px', 'padding' => ['left' => '10px', 'right' => '10px']]);
+    verify($result[0]['innerBlocks'])->arrayCount(2);
+    verify($result[0]['innerBlocks'][0]['email_attrs']['width'])->equals('140px');
+    verify($result[0]['innerBlocks'][1]['email_attrs']['width'])->equals('500px');
+  }
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I had to change the box-sizing style with a different value than is used in the post editor because the implementation in emails wouldn't be possible. The main issue would be with the columns' width in percent.

## QA notes

We can skip QA here and postpone detailed testing after merging all blocks and rendering fixes.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5739]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5739]: https://mailpoet.atlassian.net/browse/MAILPOET-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ