### PR TITLE
Fix rendering compatibility of the image block [MAILPOET-5788]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -121,6 +121,10 @@
     margin-inline-start: 0;
     text-align: center;
   }
+  &.aligncenter {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .editor-styles-wrapper {

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -40,12 +40,12 @@ class Columns implements BlockRenderer {
     }
 
     return '
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '" bgcolor="' . $backgroundColor . '" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';margin:0px auto;max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '"><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <div style="margin:0px auto;max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';max-width:' . $width . ';width:100%;">
           <tbody>
             <tr>
-              <td style="font-size:0px;padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';text-align:left;">
+              <td style="font-size:0px;background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';text-align:left;">
                 <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;">
                   <tr>
                     {columns_content}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -6,30 +6,48 @@ use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 
 class Image implements BlockRenderer {
-  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    // Replacing HTML tags figure and figcaption because they are not supported by all email clients
-    $blockContent = str_replace(
-      ['<figure', '</figure>', '<figcaption', '</figcaption>'],
-      ['<div', '</div>', '<div', '</div>'],
-      $blockContent
-    );
+  public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    $parsedHtml = $this->parseBlockContent($blockContent);
 
-    $blockContent = $this->applyRoundedStyle($blockContent, $parsedBlock);
-    $blockContent = $this->addImageDimensions($blockContent, $parsedBlock, $settingsController);
-    $blockContent = $this->addWidthToWrapper($blockContent, $parsedBlock, $settingsController);
-    $blockContent = $this->addCaptionFontSize($blockContent, $settingsController);
-    return str_replace('{image_content}', $blockContent, $this->getBlockWrapper($parsedBlock, $settingsController));
+    if (!$parsedHtml) {
+      return '';
+    }
+
+    $imageUrl = $parsedHtml['imageUrl'];
+    $image = $parsedHtml['image'];
+    $caption = $parsedHtml['caption'];
+
+    $parsedBlock = $this->addImageSizeWhenMissing($parsedBlock, $imageUrl);
+    $image = $this->applyRoundedStyle($image, $parsedBlock);
+    $image = $this->addImageDimensions($image, $parsedBlock, $settingsController);
+
+    return str_replace(
+      ['{image_content}', '{caption_content}'],
+      [$image, $caption],
+      $this->getBlockWrapper($parsedBlock, $settingsController)
+    );
   }
 
-  private function applyRoundedStyle($blockContent, array $parsedBlock) {
+  private function applyRoundedStyle(string $blockContent, array $parsedBlock): string {
     // Because the isn't an attribute for definition of rounded style, we have to check the class name
     if (isset($parsedBlock['attrs']['className']) && strpos($parsedBlock['attrs']['className'], 'is-style-rounded') !== false) {
-      // If the image should be in a circle, we need to set the border-radius to 100%
+      // If the image should be in a circle, we need to set the border-radius to 9999px to make it the same as is in the editor
       // This style cannot be applied on the wrapper, and we need to set it directly on the image
-      $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'img'], 'border-radius: 100%;');
+      $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'img'], 'border-radius: 9999px;');
     }
 
     return $blockContent;
+  }
+
+  /**
+   * When the width is not set, it's important to get it for the image to be displayed correctly
+   */
+  private function addImageSizeWhenMissing(array $parsedBlock, string $imageUrl): array {
+    if (!isset($parsedBlock['attrs']['width'])) {
+      $imageSize = wp_getimagesize($imageUrl);
+      $parsedBlock['attrs']['width'] = $imageSize ? "{$imageSize[0]}px" : '100%';
+    }
+    return $parsedBlock;
   }
 
   /**
@@ -46,7 +64,9 @@ class Image implements BlockRenderer {
         $html->set_attribute('height', $settingsController->parseNumberFromStringWithPixels($height));
       }
 
-      $html->set_attribute('width', $settingsController->parseNumberFromStringWithPixels($parsedBlock['email_attrs']['width']));
+      if (isset($parsedBlock['attrs']['width'])) {
+        $html->set_attribute('width', $settingsController->parseNumberFromStringWithPixels($parsedBlock['attrs']['width']));
+      }
       $blockContent = $html->get_updated_html();
     }
 
@@ -54,54 +74,43 @@ class Image implements BlockRenderer {
   }
 
   /**
-   * We need to reset font-size to avoid unexpected white spaces and set the width of the wrapper
-   * for having caption text under the image.
-   */
-  private function addWidthToWrapper($blockContent, array $parsedBlock, SettingsController $settingsController) {
-    $styles = [
-      'width' => $parsedBlock['email_attrs']['width'] ?? $parsedBlock['attrs']['width'] ?? '100%',
-      'font-size' => '0px',
-    ];
-    return $this->addStyleToElement($blockContent, ['tag_name' => 'div'], $settingsController->convertStylesToString($styles));
-  }
-
-  /**
    * This method configure the font size of the caption because it's set to 0 for the parent element to avoid unexpected white spaces
    */
-  private function addCaptionFontSize($blockContent, $settingsController) {
+  private function getCaptionStyles(SettingsController $settingsController, array $parsedBlock): string {
     $contentStyles = $settingsController->getEmailContentStyles();
 
+    // If the alignment is set, we need to center the caption
+    $styles = [
+      'text-align' => isset($parsedBlock['attrs']['align']) ? 'center' : 'left',
+    ];
+
     if (isset($contentStyles['typography']['fontSize'])) {
-      $styles = [
-        'font-size' => $contentStyles['typography']['fontSize'],
-        'text-align' => 'center',
-      ];
-      $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'div', 'class_name' => 'wp-element-caption'], $settingsController->convertStylesToString($styles));
+      $styles['font-size'] = $contentStyles['typography']['fontSize'];
     }
 
-    return $blockContent;
+    return $settingsController->convertStylesToString($styles);
   }
 
   /**
-   * Based on MJML <mj-image>
+   * Based on MJML <mj-image> but because MJML doesn't support captions, our solution is a bit different
    */
   private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
-
     $styles = [
       'border-collapse' => 'collapse',
       'border-spacing' => '0px',
+      'font-size' => '0px',
+      'vertical-align' => 'top',
+      'width' => '100%',
     ];
-    $styles = array_merge($styles, $parsedBlock['email_attrs'] ?? []);
 
-    if (!isset($styles['font-size'])) {
-      $styles['font-size'] = $contentStyles['typography']['fontSize'];
-    }
-    if (!isset($styles['font-family'])) {
-      $styles['font-family'] = $contentStyles['typography']['fontFamily'];
-    }
+    // When the image is not aligned, the wrapper is set to 100% width due to caption that can be longer than the image
+    $wrapperWidth = isset($parsedBlock['attrs']['align']) ? ($parsedBlock['attrs']['width'] ?? '100%') : '100%';
+    $wrapperStyles = $styles;
+    $wrapperStyles['width'] = $wrapperWidth;
 
-    $styles['width'] = '100% !important'; // Using important is necessary for Gmail app on mobile devices
+    $captionStyles = $this->getCaptionStyles($settingsController, $parsedBlock);
+
+    $styles['width'] = '100%';
     $align = $parsedBlock['attrs']['align'] ?? 'left';
 
     return '
@@ -111,10 +120,25 @@ class Image implements BlockRenderer {
         cellpadding="0"
         cellspacing="0"
         style="' . $settingsController->convertStylesToString($styles) . '"
+        width="100%"
       >
         <tr>
           <td align="' . $align . '">
-            {image_content}
+            <table
+              role="presentation"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              style="' . $settingsController->convertStylesToString($wrapperStyles) . '"
+              width="' . $wrapperWidth . '"
+            >
+              <tr>
+                <td>{image_content}</td>
+              </tr>
+              <tr>
+                <td style="' . $captionStyles . '">{caption_content}</td>
+              </tr>
+            </table>
           </td>
         </tr>
       </table>
@@ -136,5 +160,34 @@ class Image implements BlockRenderer {
     }
 
     return $blockContent;
+  }
+
+  /**
+   * @param string $blockContent
+   * @return array{imageUrl: string, image: string, caption: string}|null
+   */
+  private function parseBlockContent(string $blockContent): ?array {
+    // Suppress warnings for invalid HTML tags
+    libxml_use_internal_errors(true);
+    $dom = new \DOMDocument();
+    $dom->loadHTML($blockContent);
+    $figureTag = $dom->getElementsByTagName('figure')->item(0);
+    libxml_clear_errors();
+
+    if (!$figureTag) return null;
+
+    $imgTag = $figureTag->getElementsByTagName('img')->item(0);
+    $image = $dom->saveHTML($imgTag);
+    if (!$image) return null;
+
+    $figcaption = $figureTag->getElementsByTagName('figcaption')->item(0);
+    $figcaptionText = $figcaption ? $dom->saveHTML($figcaption) : '';
+    $figcaptionText = str_replace(['<figcaption', '</figcaption>'], ['<span', '</span>'], (string)$figcaptionText);
+
+    return [
+      'imageUrl' => $imgTag ? $imgTag->getAttribute('src') : '',
+      'image' => $image,
+      'caption' => $figcaptionText ?: '',
+    ];
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -44,8 +44,10 @@ class Image implements BlockRenderer {
    */
   private function addImageSizeWhenMissing(array $parsedBlock, string $imageUrl): array {
     if (!isset($parsedBlock['attrs']['width'])) {
+      $maxWidth = $parsedBlock['email_attrs']['width'] ?? '660px';
       $imageSize = wp_getimagesize($imageUrl);
-      $parsedBlock['attrs']['width'] = $imageSize ? "{$imageSize[0]}px" : '100%';
+      $imageSize = $imageSize ? "{$imageSize[0]}px" : $maxWidth;
+      $parsedBlock['attrs']['width'] = ($imageSize > $maxWidth) ? $maxWidth : $imageSize;
     }
     return $parsedBlock;
   }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -44,7 +44,7 @@ class Image implements BlockRenderer {
    */
   private function addImageSizeWhenMissing(array $parsedBlock, string $imageUrl): array {
     if (!isset($parsedBlock['attrs']['width'])) {
-      $maxWidth = $parsedBlock['email_attrs']['width'] ?? '660px';
+      $maxWidth = $parsedBlock['email_attrs']['width'] ?? SettingsController::EMAIL_WIDTH;
       $imageSize = wp_getimagesize($imageUrl);
       $imageSize = $imageSize ? "{$imageSize[0]}px" : $maxWidth;
       $parsedBlock['attrs']['width'] = ($imageSize > $maxWidth) ? $maxWidth : $imageSize;

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -47,7 +47,7 @@ class Image implements BlockRenderer {
       $maxWidth = $parsedBlock['email_attrs']['width'] ?? SettingsController::EMAIL_WIDTH;
       $imageSize = wp_getimagesize($imageUrl);
       $imageSize = $imageSize ? "{$imageSize[0]}px" : $maxWidth;
-      $parsedBlock['attrs']['width'] = ($imageSize > $maxWidth) ? $maxWidth : $imageSize;
+      $parsedBlock['attrs']['width'] = min($imageSize, $maxWidth);
     }
     return $parsedBlock;
   }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -169,6 +169,8 @@ class Image implements BlockRenderer {
    * @return array{imageUrl: string, image: string, caption: string}|null
    */
   private function parseBlockContent(string $blockContent): ?array {
+    // If block's image is not set, we don't need to parse the content
+    if (!$blockContent) return null;
     // Suppress warnings for invalid HTML tags
     libxml_use_internal_errors(true);
     $dom = new \DOMDocument();

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ImageTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ImageTest.php
@@ -25,8 +25,6 @@ class ImageTest extends \MailPoetTest {
       'sizeSlug' => 'full',
       'linkDestination' => 'none',
       'className' => 'is-style-default',
-    ],
-    'email_attrs' => [
       'width' => '640px',
     ],
     'innerBlocks' => [],
@@ -70,7 +68,7 @@ class ImageTest extends \MailPoetTest {
     $this->assertStringContainsString('width="640"', $rendered);
     $this->assertStringContainsString('width:640px;', $rendered);
     $this->assertStringContainsString('<img ', $rendered);
-    $this->assertStringContainsString('border-radius: 100%;', $rendered);
+    $this->assertStringContainsString('border-radius: 9999px;', $rendered);
   }
 
   public function testItRendersCaption(): void {
@@ -79,7 +77,7 @@ class ImageTest extends \MailPoetTest {
     $parsedImage['innerHTML'] = $imageContent; // To avoid repetition of the image content in the test we need to add it to the parsed block
 
     $rendered = $this->imageRenderer->render($imageContent, $parsedImage, $this->settingsController);
-    $this->assertStringContainsString('>Caption</div>', $rendered);
+    $this->assertStringContainsString('>Caption</span>', $rendered);
     $this->assertStringContainsString('text-align:center;', $rendered);
   }
 
@@ -87,7 +85,7 @@ class ImageTest extends \MailPoetTest {
     $imageContent = str_replace('style=""', 'style="width:400px;height:300px;"', $this->imageContent);
     $parsedImage = $this->parsedImage;
     $parsedImage['attrs']['align'] = 'center';
-    $parsedImage['email_attrs']['width'] = '400px';
+    $parsedImage['attrs']['width'] = '400px';
     $parsedImage['innerHTML'] = $imageContent; // To avoid repetition of the image content in the test we need to add it to the parsed block
 
     $rendered = $this->imageRenderer->render($imageContent, $parsedImage, $this->settingsController);


### PR DESCRIPTION
## Description

This PR fixes rendering issues in Outlook and also some specific problems with caption.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5788]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5788]: https://mailpoet.atlassian.net/browse/MAILPOET-5788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ