### PR TITLE
Fix multisite tests issues [MAILPOET-5813]

### DIFF
--- a/mailpoet/tests/integration/Automation/Integrations/WordPress/Fields/CommentFieldsTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WordPress/Fields/CommentFieldsTest.php
@@ -187,6 +187,9 @@ class CommentFieldsTest extends \MailPoetTest {
   }
 
   public function testHasChildrenField() {
+    $postId = wp_insert_post([
+      'post_title' => 'Hello World!',
+    ]);
     $fields = $this->getFieldsMap();
 
     $field = $fields['wordpress:comment:has-children'];
@@ -196,7 +199,7 @@ class CommentFieldsTest extends \MailPoetTest {
 
     $this->assertFalse($field->getValue(new CommentPayload(0, $this->wp)));
     $commentId = wp_insert_comment([
-      'comment_post_ID' => 1,
+      'comment_post_ID' => $postId,
     ]);
     $this->assertNotFalse($commentId);
     $comment = get_comment($commentId);
@@ -205,7 +208,7 @@ class CommentFieldsTest extends \MailPoetTest {
 
     $childId = wp_insert_comment([
       'comment_parent' => $commentId,
-      'comment_post_ID' => 1,
+      'comment_post_ID' => $postId,
     ]);
     $this->assertNotFalse($childId);
     $this->assertTrue($field->getValue(new CommentPayload($commentId, $this->wp)));

--- a/mailpoet/tests/integration/Doctrine/TablePrefixMetadataFactoryTest.php
+++ b/mailpoet/tests/integration/Doctrine/TablePrefixMetadataFactoryTest.php
@@ -7,9 +7,11 @@ use MailPoet\Entities\WpPostEntity;
 
 class TablePrefixMetadataFactoryTest extends \MailPoetTest {
   public function testItPrefixTablesCorrectly() {
+    global $wpdb;
+    $dbPrefix = $wpdb->prefix;
     $wpPostMetadata = $this->entityManager->getClassMetadata(WpPostEntity::class);
     $newslettersMetadata = $this->entityManager->getClassMetadata(NewsletterEntity::class);
-    verify($wpPostMetadata->getTableName())->equals('mp_posts');
-    verify($newslettersMetadata->getTableName())->equals('mp_mailpoet_newsletters');
+    verify($wpPostMetadata->getTableName())->equals($dbPrefix . 'posts');
+    verify($newslettersMetadata->getTableName())->equals($dbPrefix . 'mailpoet_newsletters');
   }
 }


### PR DESCRIPTION
## Description

This PR fixes two integration tests that fail on multisite.

## Code review notes

The first test failed because it had a hardcoded DB prefix in asserts, but we have a different prefix on multisite.
For the second one please see the commit message.

## QA notes

We can skip QA for this one.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
