### PR TITLE
Email editor/preview submit improvements [MAILPOET-5764]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/preview/send-preview-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/preview/send-preview-email.tsx
@@ -47,6 +47,9 @@ export function SendPreviewEmail() {
       className="mailpoet-send-preview-email"
       title={__('Send a test email', 'mailpoet')}
       onRequestClose={closeCallback}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - the value can be by docs: boolean, "firstElement", "firstContentElement"
+      focusOnMount="firstContentElement"
     >
       {sendingPreviewStatus === SendingPreviewStatus.ERROR ? (
         <div className="mailpoet-send-preview-modal-notice-error">
@@ -108,6 +111,7 @@ export function SendPreviewEmail() {
                 href="https://www.mail-tester.com/"
                 target="_blank"
                 rel="noopener noreferrer"
+                tabIndex={-1}
               />
             ),
             link2: (
@@ -116,6 +120,7 @@ export function SendPreviewEmail() {
                 href="https://kb.mailpoet.com/article/147-test-your-spam-score-with-mail-tester"
                 target="_blank"
                 rel="noopener noreferrer"
+                tabIndex={-1}
               />
             ),
           },

--- a/mailpoet/assets/js/src/email-editor/engine/components/preview/send-preview-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/preview/send-preview-email.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { check, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
 import { isEmail } from '@wordpress/url';
 import { useEntityProp } from '@wordpress/core-data';
 import {
@@ -124,6 +125,13 @@ export function SendPreviewEmail() {
         label={__('Send to', 'mailpoet')}
         onChange={(email) => {
           updateSendPreviewEmail(email);
+        }}
+        onKeyDown={(event) => {
+          const { keyCode } = event;
+          if (keyCode === ENTER) {
+            event.preventDefault();
+            handleSendPreviewEmail();
+          }
         }}
         value={previewToEmail}
         type="email"

--- a/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
@@ -113,6 +113,11 @@ export function* requestSendingNewsletterPreview(
   newsletterId: number,
   email: string,
 ) {
+  // If preview is already sending do nothing
+  const previewState = select(storeName).getPreviewState();
+  if (previewState.isSendingPreviewEmail) {
+    return;
+  }
   // Initiate sending
   yield {
     type: 'CHANGE_PREVIEW_STATE',


### PR DESCRIPTION
## Description

This PR should improve three things:
- Add the possibility to submit a preview after pressing enter when the focus is in the text field
- Switching focus to the text field after opening the modal
- Submit only one preview when the enter key is pressed twice in a row in a short time

## Code review notes

_N/A_

## QA notes

Please see the ticket.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5764]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5764]: https://mailpoet.atlassian.net/browse/MAILPOET-5764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ