### PR TITLE
Allow verification of partially verified Sender domains

### DIFF
--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -121,8 +121,6 @@ class AuthorizedSenderDomainController {
     $records = $this->bridge->getAuthorizedSenderDomains();
 
     $allDomains = $this->returnAllDomains($records);
-    $verifiedDomains = $this->returnVerifiedDomains($records);
-
     $alreadyExist = in_array($domain, $allDomains);
 
     if (!$alreadyExist) {
@@ -130,6 +128,7 @@ class AuthorizedSenderDomainController {
       throw new \InvalidArgumentException(self::AUTHORIZED_SENDER_DOMAIN_ERROR_NOT_CREATED);
     }
 
+    $verifiedDomains = $this->getFullyVerifiedSenderDomains(true);
     $alreadyVerified = in_array($domain, $verifiedDomains);
 
     if ($alreadyVerified) {


### PR DESCRIPTION
## Description

Fixes a bug where partially verified domains can not be verified again

## Code review notes

_N/A_

## QA notes

To test:

- Remove the DMARC record of a verified domain and verify it again from the shop
- Check the DMARC record shows as pending
- Add the DMARC record back
- From the plugin click on 'Authenticate' on the page notice
- Verify the domain
- From the shop, check that the DMARC record is verified
- Reload the page and check the notice is gone

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5817]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes -> NA


[MAILPOET-5817]: https://mailpoet.atlassian.net/browse/MAILPOET-5817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ