### PR TITLE
Move filter adding MailPoet image resolution [MAILPOET-5749]

### DIFF
--- a/dev/php82/Dockerfile
+++ b/dev/php82/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.0RC6-apache
+FROM wordpress:php8.2-apache
 
 ARG UID=1000
 ARG GID=1000

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -92,6 +92,7 @@ class NewsletterEditor {
   }
 
   public function render() {
+    $this->setupImageSize();
     $this->assetsController->setupNewsletterEditorDependencies();
     $newsletterId = (isset($_GET['id']) ? (int)$_GET['id'] : 0);
     $woocommerceTemplateId = (int)$this->settings->get(TransactionalEmails::SETTING_EMAIL_ID, null);
@@ -187,5 +188,16 @@ class NewsletterEditor {
       'unsubscribe_token' => $subscriber->getUnsubscribeToken(),
       'link_token' => $subscriber->getLinkToken(),
     ];
+  }
+
+  private function setupImageSize(): void {
+    $this->wp->addFilter(
+      'image_size_names_choose',
+      function ($sizes): array {
+        return array_merge($sizes, [
+          'mailpoet_newsletter_max' => __('MailPoet Newsletter', 'mailpoet'),
+        ]);
+      }
+    );
   }
 }

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -108,7 +108,6 @@ class Hooks {
     $this->setupWooCommercePurchases();
     $this->setupWooCommerceSubscriberEngagement();
     $this->setupWooCommerceTracking();
-    $this->setupImageSize();
     $this->setupListing();
     $this->setupSubscriptionEvents();
     $this->setupWooCommerceSubscriptionEvents();
@@ -454,20 +453,6 @@ class Hooks {
       [$this->hooksWooCommerce, 'addTrackingData'],
       10
     );
-  }
-
-  public function setupImageSize() {
-    $this->wp->addFilter(
-      'image_size_names_choose',
-      [$this, 'appendImageSize'],
-      10, 1
-    );
-  }
-
-  public function appendImageSize($sizes) {
-    return array_merge($sizes, [
-      'mailpoet_newsletter_max' => __('MailPoet Newsletter', 'mailpoet'),
-    ]);
   }
 
   public function setupListing() {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

- From my understanding, moving the filter that adds MailPoet image size to the NewsletterEditor page shouldn't break anything.

## QA notes

1. Create a newsletter containing at least one image and Post with the featured image. All photos should have a width higher than 1320px.
2. Send a preview and check that all images in the email are with MailPoet resolution (width 1320px)
3. Send the newsletter and check again the image sizes.
4. Test it for all email types

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5749]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5749]: https://mailpoet.atlassian.net/browse/MAILPOET-5749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ