### PR TITLE
Email editor - Fix multiple duplication [MAILPOET-5810]

### DIFF
--- a/mailpoet/assets/js/src/context/index.ts
+++ b/mailpoet/assets/js/src/context/index.ts
@@ -22,9 +22,9 @@ export function useGlobalContextValue(data) {
   };
 }
 
-export const GlobalContext = createContext<
-  ReturnType<typeof useGlobalContextValue>
->({
+export type GlobalContextValue = ReturnType<typeof useGlobalContextValue>;
+
+export const GlobalContext = createContext<GlobalContextValue>({
   features: null,
   segments: null,
   users: null,

--- a/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
+++ b/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useCallback } from 'react';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { GlobalContext, GlobalContextValue } from 'context';
@@ -15,6 +15,38 @@ export function EditorSelectModal({
 }: EditorSelectModalProps) {
   const [isLoading, setIsLoading] = useState(false);
   const { notices } = useContext<GlobalContextValue>(GlobalContext);
+
+  const createNewsletterAndOpenEditor = useCallback(() => {
+    setIsLoading(true);
+    void MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'newsletters',
+      action: 'create',
+      data: {
+        type: 'standard',
+        subject: __('Subject', 'mailpoet'),
+        new_editor: true,
+      },
+    })
+      .done((response) => {
+        window.location.href = `admin.php?page=mailpoet-email-editor&postId=${
+          response.data.wp_post_id as number
+        }`;
+      })
+      .fail((response) => {
+        setIsLoading(false);
+        onClose();
+        if (response.errors.length > 0) {
+          notices.error(
+            response.errors.map((error) => (
+              <p key={error.message}>{error.message}</p>
+            )),
+            { scroll: true },
+          );
+        }
+      });
+  }, [notices, onClose]);
+
   if (!isModalOpen) {
     return null;
   }
@@ -61,36 +93,7 @@ export function EditorSelectModal({
           type="button"
           variant="primary"
           isBusy={isLoading}
-          onClick={() => {
-            setIsLoading(true);
-            void MailPoet.Ajax.post({
-              api_version: window.mailpoet_api_version,
-              endpoint: 'newsletters',
-              action: 'create',
-              data: {
-                type: 'standard',
-                subject: __('Subject', 'mailpoet'),
-                new_editor: true,
-              },
-            })
-              .done((response) => {
-                window.location.href = `admin.php?page=mailpoet-email-editor&postId=${
-                  response.data.wp_post_id as number
-                }`;
-              })
-              .fail((response) => {
-                setIsLoading(false);
-                onClose();
-                if (response.errors.length > 0) {
-                  notices.error(
-                    response.errors.map((error) => (
-                      <p key={error.message}>{error.message}</p>
-                    )),
-                    { scroll: true },
-                  );
-                }
-              });
-          }}
+          onClick={createNewsletterAndOpenEditor}
         >
           {__('Continue', 'mailpoet')}
         </Button>

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -368,7 +368,6 @@ class Initializer {
       $this->automationEngine->initialize();
       if ($this->featureController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR)) {
         $this->emailEditor->initialize();
-        $this->maybeRedirectEditor();
       }
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {
@@ -584,25 +583,5 @@ class Initializer {
   private function setupDeactivationPoll(): void {
     $deactivationPoll = new DeactivationPoll($this->wpFunctions, $this->renderer);
     $deactivationPoll->init();
-  }
-
-  private function maybeRedirectEditor() {
-    if (!isset($_GET['page']) || $_GET['page'] !== 'mailpoet-email-editor') {
-      return;
-    }
-    $postId = isset($_GET['postId']) ? intval($_GET['postId']) : 0;
-    $post = get_post($postId);
-    if (!$post instanceof \WP_Post || $post->post_type !== \MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $postId = wp_insert_post([
-        'post_title' => 'New Email',
-        'post_content' => '',
-        'post_status' => 'draft',
-        'post_author' => get_current_user_id(),
-        'post_type' => \MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::MAILPOET_EMAIL_POST_TYPE,
-      ]);
-      wp_safe_redirect(
-        admin_url('admin.php?page=mailpoet-email-editor&postId=' . $postId)
-      );
-    }
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -2,13 +2,8 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
-use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\WpPostEntity;
 use MailPoet\Features\FeaturesController;
-use MailPoet\Newsletter\NewsletterSaveController;
-use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class EmailEditor {
   const MAILPOET_EMAIL_POST_TYPE = 'mailpoet_email';
@@ -19,32 +14,17 @@ class EmailEditor {
   /** @var FeaturesController */
   private $featuresController;
 
-  /** @var NewslettersRepository */
-  private $newsletterRepository;
-
   /** @var EmailApiController */
   private $emailApiController;
-
-  /** @var EntityManager */
-  private $entityManager;
-
-  /** @var NewsletterSaveController */
-  private $newsletterSaveController;
 
   public function __construct(
     WPFunctions $wp,
     FeaturesController $featuresController,
-    NewslettersRepository $newsletterRepository,
-    EmailApiController $emailApiController,
-    EntityManager $entityManager,
-    NewsletterSaveController $newsletterSaveController
+    EmailApiController $emailApiController
   ) {
     $this->wp = $wp;
     $this->featuresController = $featuresController;
-    $this->newsletterRepository = $newsletterRepository;
     $this->emailApiController = $emailApiController;
-    $this->entityManager = $entityManager;
-    $this->newsletterSaveController = $newsletterSaveController;
   }
 
   public function initialize(): void {
@@ -52,7 +32,6 @@ class EmailEditor {
       return;
     }
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
-    $this->wp->addFilter('save_post', [$this, 'onEmailSave'], 10, 2);
     $this->extendEmailPostApi();
   }
 
@@ -68,26 +47,6 @@ class EmailEditor {
       ],
     ];
     return $postTypes;
-  }
-
-  /**
-   * This method ensures that saved email has an associated newsletter entity.
-   * In the future we will also need to save additional parameters like subject, type, etc.
-   */
-  public function onEmailSave($postId, \WP_Post $post): void {
-    if ($post->post_type !== self::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      return;
-    }
-    $newsletter = $this->newsletterRepository->findOneBy(['wpPost' => $postId]);
-    if ($newsletter) {
-      return;
-    }
-    $newsletter = $this->newsletterSaveController->save([
-      'subject' => __('Subject', 'mailpoet'),
-      'type' => NewsletterEntity::TYPE_STANDARD, // We allow only standard emails in the new editor for now
-    ]);
-    $newsletter->setWpPost($this->entityManager->getReference(WpPostEntity::class, $postId));
-    $this->newsletterRepository->flush();
   }
 
   public function extendEmailPostApi() {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -204,6 +204,8 @@ class NewsletterSaveController {
     $post = $this->wp->getPost($newsletter->getWpPostId());
     if ($post instanceof \WP_Post) {
       $newPostId = $this->wp->wpInsertPost([
+        'post_status' => NewsletterEntity::STATUS_DRAFT,
+        'post_author' => $this->wp->getCurrentUserId(),
         'post_content' => $post->post_content, // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         'post_type' => $post->post_type, // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         // translators: %s is the campaign name of the mail which has been copied.

--- a/mailpoet/tests/integration/EmailEditor/Integration/MailPoet/EmailEditorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/MailPoet/EmailEditorTest.php
@@ -5,9 +5,6 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Features\FeatureFlagsController;
 use MailPoet\Features\FeaturesController;
-use MailPoet\Newsletter\NewslettersRepository;
-use MailPoet\Settings\SettingsController;
-use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditorTest extends \MailPoetTest {
   /** @var EmailEditor */
@@ -15,19 +12,11 @@ class EmailEditorTest extends \MailPoetTest {
 
   /** @var FeatureFlagsController */
   private $featureFlagsController;
-
-  /** @var NewslettersRepository */
-  private $newslettersRepository;
-
-  /** @var SettingsController */
-  private $settingsController;
-
+  
   public function _before() {
     $this->emailEditor = $this->diContainer->get(EmailEditor::class);
-    $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->featureFlagsController = $this->diContainer->get(FeatureFlagsController::class);
     $this->featureFlagsController->set(FeaturesController::GUTENBERG_EMAIL_EDITOR, true);
-    $this->settingsController = $this->diContainer->get(SettingsController::class);
   }
 
   public function testItRegistersMailPoetEmailPostType() {
@@ -37,40 +26,9 @@ class EmailEditorTest extends \MailPoetTest {
     $this->assertArrayHasKey('mailpoet_email', $postTypes);
   }
 
-  public function testItCreatesAssociatedNewsletterEntity() {
-    $this->emailEditor->initialize();
-    $newsletters = $this->newslettersRepository->findAll();
-    verify(count($newsletters))->equals(0);
-    $wp = $this->diContainer->get(WPFunctions::class);
-    $this->settingsController->set('sender', [
-      'address' => 'sender@example.com',
-      'name' => 'Sender Name',
-    ]);
-
-    // Add email post
-    $postId = $wp->wpInsertPost(['post_type' => 'mailpoet_email']);
-    $newsletters = $this->newslettersRepository->findAll();
-    verify(count($newsletters))->equals(1);
-    // Newsletter Entity has proper data
-    $newsletter = $newsletters[0];
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    verify($newsletter->getWpPostId())->greaterThan(0);
-    verify($newsletter->getWpPostId())->equals($postId);
-    verify($newsletter->getType())->equals(NewsletterEntity::TYPE_STANDARD);
-    verify($newsletter->getSenderAddress())->equals('sender@example.com');
-    verify($newsletter->getSenderName())->equals('Sender Name');
-
-    // Add non-email standard post
-    $wp->wpInsertPost(['post_type' => 'post']);
-    $newsletters = $this->newslettersRepository->findAll();
-    // Newsletters count should not change
-    verify(count($newsletters))->equals(1);
-  }
-
   public function _after() {
     parent::_after();
     remove_filter('mailpoet_email_editor_post_types', [$this->emailEditor, 'addEmailPostType']);
-    remove_filter('save_post', [$this->emailEditor, 'onEmailSave']);
     $this->truncateEntity(NewsletterEntity::class);
     $this->featureFlagsController->set(FeaturesController::GUTENBERG_EMAIL_EDITOR, false);
   }

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -360,6 +360,30 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($newsletter->getId())->notNull();
   }
 
+  public function testItCreatesNewNewsletterForBlockEditor() {
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $data = [
+      'subject' => 'My First Newsletter',
+      'type' => NewsletterEntity::TYPE_STANDARD,
+      'new_editor' => true,
+    ];
+
+    $newsletter = $this->saveController->save($data);
+    verify($newsletter->getSubject())->equals($data['subject']);
+    verify($newsletter->getType())->equals($data['type']);
+    verify($newsletter->getHash())->notNull();
+    verify($newsletter->getId())->notNull();
+    verify($newsletter->getWpPostId())->notNull();
+    $postEntity = $newsletter->getWpPost();
+    $this->assertInstanceOf(WpPostEntity::class, $postEntity);
+    verify($postEntity->getPostTitle())->equals('New Email');
+    $wpPost = $postEntity->getWpPostInstance();
+    $this->assertInstanceOf(\WP_Post::class, $wpPost);
+    verify($wpPost->post_content)->equals(''); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify($wpPost->post_author)->equals($wp->getCurrentUserId()); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify($wpPost->post_status)->equals('draft'); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
   public function testItCreatesNewsletterWithDefaultSender() {
     $settings = $this->diContainer->get(SettingsController::class);
     $settings->set('sender', [

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -345,6 +345,8 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     $post = $wp->getPost($duplicate->getWpPostId());
     verify($duplicate->getCampaignName())->equals('Copy of Newsletter Title');
     verify($post->post_content)->equals('newsletter content'); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify($post->post_author)->equals($wp->getCurrentUserId()); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify($post->post_status)->equals('draft'); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function testItCreatesNewNewsletter() {


### PR DESCRIPTION
## Description
This PR fixes the bug that duplication of an email created in the new editor created multiple copies.

## Code review notes
I found this was caused by hook that was added when we used the built-in post editor and was added to make sure that each post created via the post editor has an associated NewsletterEntity.
After switching to a custom editor, we still used the hook for creating new newsletters, but the code was in two places (Initializer + EmailEditorController). 
I decided to fix the issue by refactoring the code we use to create new newsletters to API.

## QA notes

#### Replication

1. Create a newsletter in the new email editor and save it.
2.  Go to the newsletter listing. 
3. Click on duplicate action in the listing below the created newsletter 
4. Observe the issue

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5810]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5810]: https://mailpoet.atlassian.net/browse/MAILPOET-5810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ