### PR TITLE
Fix the Trash button deleting email permanently [MAILPOET-5811]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -106,17 +106,14 @@ const trashNewsletter = (
   void MailPoet.Ajax.post({
     api_version: window.mailpoet_api_version,
     endpoint: 'newsletters',
-    action: 'delete',
+    action: 'trash',
     data: {
       id: newsletter.id,
     },
   })
     .done(() => {
       MailPoet.Notice.success(
-        __('Email "%1$s" has been deleted.', 'mailpoet').replace(
-          '%1$s',
-          newsletter.subject,
-        ),
+        __('1 email was moved to the trash.', 'mailpoet'),
       );
       redirectToNewsletterHome();
     })


### PR DESCRIPTION
## Description

An incorrect endpoint was used, and the email was deleted permanently instead of trashing it.

## Code review notes

For the translation, I re-used the exact string that was already used in the listings. This way, it will be translated immediately after the release.

## QA notes

_N/A_

## Linked PRs

[MAILPOET-5811]

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5811]: https://mailpoet.atlassian.net/browse/MAILPOET-5811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ