### PR TITLE
Fix 3rd party library loading

### DIFF
--- a/mailpoet/assets/js/src/common/top-bar/top-bar.tsx
+++ b/mailpoet/assets/js/src/common/top-bar/top-bar.tsx
@@ -6,6 +6,7 @@ import { MailPoetLogoResponsive } from './mailpoet-logo-responsive';
 import { BeamerIcon } from './beamer-icon';
 import { ScreenOptionsFix } from './screen-options-fix';
 import { withBoundary } from '../error-boundary';
+import { MailPoet } from '../../mailpoet';
 
 type Props = {
   children?: ReactNode;
@@ -29,7 +30,7 @@ export function TopBar({
       <MailPoetLogoResponsive withLink={logoWithLink} />
       <div className="mailpoet-top-bar-children">{children}</div>
       <div className="mailpoet-flex-grow" />
-      {onBeamerClick && (
+      {onBeamerClick && MailPoet.libs3rdPartyEnabled && (
         <div>
           <a
             role="button"

--- a/mailpoet/lib/Cron/Workers/Beamer.php
+++ b/mailpoet/lib/Cron/Workers/Beamer.php
@@ -24,7 +24,14 @@ class Beamer extends SimpleWorker {
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    if (!$this->isBeamerEnabled()) {
+      return false;
+    }
     return $this->setLastAnnouncementDate();
+  }
+
+  private function isBeamerEnabled(): bool {
+    return $this->settings->get('3rd_party_libs.enabled') === '1';
   }
 
   public function setLastAnnouncementDate() {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -158,7 +158,10 @@ To improve user experience, MailPoet may use the following 3rd party libraries i
 
 * [Satismeter](https://www.satismeter.com/) - used to ask for feedback. [TOS](https://www.satismeter.com/terms/) and [Privacy Policy](https://www.satismeter.com/privacy-policy/)
 
-* [beamer](https://www.getbeamer.com/) - used to load our latest blogposts and announcements. [TOS](https://www.getbeamer.com/terms) and [Privacy Policy](https://www.getbeamer.com/privacy)
+* [Beamer](https://www.getbeamer.com/) - used to load our latest blogposts and announcements. [TOS](https://www.getbeamer.com/terms) and [Privacy Policy](https://www.getbeamer.com/privacy)
+
+* [Crowdsignal](https://crowdsignal.com/) - used to load our deactivation poll to improve our plugin. [TOS](https://crowdsignal.com/terms/) and [Privacy Policy](https://automattic.com/privacy/)
+
 
 Loading all these libraries is disabled by default. The option can be enabled in the _MailPoet's Settings > Advanced > Load 3rd-party libraries_.
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -150,13 +150,13 @@ Have a question for us? Reach us at security@ our domain, or report security iss
 
 To improve user experience, MailPoet may use the following 3rd party libraries if the _Load 3rd-party libraries_ setting is enabled:
 
-* [Google Fonts](https://fonts.google.com/) - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts)
+* [Google Fonts](https://fonts.google.com/) - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts). [TOS](https://policies.google.com/terms?hl=en) and [Privacy Policy](https://policies.google.com/privacy?hl=en)
 
-* [DocsBot](https://docsbot.ai) - used for searching in Knowledge Base with the help of AI. This functionality may load scripts from [https://widget.docsbot.ai/chat.js](https://widget.docsbot.ai/chat.js)
+* [DocsBot](https://docsbot.ai) - used for searching in Knowledge Base with the help of AI. This functionality may load scripts from [https://widget.docsbot.ai/chat.js](https://widget.docsbot.ai/chat.js). [TOS and Privacy Policy](https://docsbot.ai/legal)
 
-* [Mixpanel](https://mixpanel.com/) - used to send data about the usage of the MailPoet plugin when you [agree with sharing usage data with us](https://kb.mailpoet.com/article/130-sharing-your-data-with-us)
+* [Mixpanel](https://mixpanel.com/) - used to send data about the usage of the MailPoet plugin when you [agree with sharing usage data with us](https://kb.mailpoet.com/article/130-sharing-your-data-with-us). [TOS](https://mixpanel.com/legal/terms-of-use/) and [Privacy Policy](https://mixpanel.com/legal/privacy-policy/)
 
-* [Satismeter](https://www.satismeter.com/) - used to ask for feedback.
+* [Satismeter](https://www.satismeter.com/) - used to ask for feedback. [TOS](https://www.satismeter.com/terms/) and [Privacy Policy](https://www.satismeter.com/privacy-policy/)
 
 Loading all these libraries is disabled by default. The option can be enabled in the _MailPoet's Settings > Advanced > Load 3rd-party libraries_.
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -158,6 +158,8 @@ To improve user experience, MailPoet may use the following 3rd party libraries i
 
 * [Satismeter](https://www.satismeter.com/) - used to ask for feedback. [TOS](https://www.satismeter.com/terms/) and [Privacy Policy](https://www.satismeter.com/privacy-policy/)
 
+* [beamer](https://www.getbeamer.com/) - used to load our latest blogposts and announcements. [TOS](https://www.getbeamer.com/terms) and [Privacy Policy](https://www.getbeamer.com/privacy)
+
 Loading all these libraries is disabled by default. The option can be enabled in the _MailPoet's Settings > Advanced > Load 3rd-party libraries_.
 
 == Frequently Asked Questions ==

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -148,6 +148,10 @@ Have a question for us? Reach us at security@ our domain, or report security iss
 
 = Use of 3rd Party Services =
 
+MailPoet uses the following services that are necessary for its full functionality:
+
+* [Translate WordPress.com](https://translate.wordpress.com/) - used to download translations for the plugin.
+
 To improve user experience, MailPoet may use the following 3rd party libraries if the _Load 3rd-party libraries_ setting is enabled:
 
 * [Google Fonts](https://fonts.google.com/) - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts). [TOS](https://policies.google.com/terms?hl=en) and [Privacy Policy](https://policies.google.com/privacy?hl=en)

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -150,13 +150,13 @@ Have a question for us? Reach us at security@ our domain, or report security iss
 
 To improve user experience, MailPoet may use the following 3rd party libraries if the _Load 3rd-party libraries_ setting is enabled:
 
-* Google Fonts - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts)
+* [Google Fonts](https://fonts.google.com/) - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts)
 
-* DocsBot - used for searching in Knowledge Base with the help of AI. This functionality may load scripts from [https://widget.docsbot.ai/chat.js](https://widget.docsbot.ai/chat.js)
+* [DocsBot](https://docsbot.ai) - used for searching in Knowledge Base with the help of AI. This functionality may load scripts from [https://widget.docsbot.ai/chat.js](https://widget.docsbot.ai/chat.js)
 
-* Mixpanel - used to send data about the usage of the MailPoet plugin when you [agree with sharing usage data with us](https://kb.mailpoet.com/article/130-sharing-your-data-with-us)
+* [Mixpanel](https://mixpanel.com/) - used to send data about the usage of the MailPoet plugin when you [agree with sharing usage data with us](https://kb.mailpoet.com/article/130-sharing-your-data-with-us)
 
-* Satismeter - used to ask for feedback.
+* [Satismeter](https://www.satismeter.com/) - used to ask for feedback.
 
 Loading all these libraries is disabled by default. The option can be enabled in the _MailPoet's Settings > Advanced > Load 3rd-party libraries_.
 

--- a/mailpoet/views/deactivationPoll/embedded-poll.html
+++ b/mailpoet/views/deactivationPoll/embedded-poll.html
@@ -1,0 +1,53 @@
+<div class="mailpoet-deactivate-survey-modal" id="mailpoet-deactivate-survey-modal">
+  <div class="mailpoet-deactivate-survey-wrap">
+    <div class="mailpoet-deactivate-survey">
+      <script type="text/javascript">
+        window.addEventListener('load', function() {
+          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
+          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
+          var closeButton = document.querySelector('#mailpoet-deactivate-survey-close');
+          var formOpen = false;
+
+          if (!deactivateLink || !overlay || !closeButton) {
+            return;
+          }
+
+          deactivateLink.addEventListener('click', function (event) {
+            event.preventDefault();
+            overlay.style.display = 'table';
+            formOpen = true;
+          });
+
+          closeButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            overlay.style.display = 'none';
+            formOpen = false;
+            location.href = deactivateLink.getAttribute('href');
+          });
+
+          document.addEventListener('keyup', function (event) {
+            if ((event.keyCode === 27) && formOpen) {
+              location.href = deactivateLink.getAttribute('href');
+            }
+          });
+        });
+
+        // This callback is by docs, and guarantees that the modal window is closed and deactivated only after the vote has been submitted
+        var pd_callback = function(json) {
+          var obj = JSON.parse(json);
+          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
+          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
+          if (obj.result === 'already-registered' || obj.result === 'registered') {
+            overlay.style.display = 'none';
+            location.href = deactivateLink.getAttribute('href');
+          }
+        };
+      </script>
+      <script type="text/javascript" charset="utf-8" src="https://secure.polldaddy.com/p/11161195.js"></script>
+
+      <noscript><a href="https://poll.fm/11161195">We're sorry to see you leave. Could you tell us more why are you deactivating MailPoet?</a></noscript>
+
+      <a class="button" id="mailpoet-deactivate-survey-close"><%= __('Skip survey and deactivate MailPoet') %> &rarr;</a>
+    </div>
+  </div>
+</div>

--- a/mailpoet/views/deactivationPoll/embedded-poll.html
+++ b/mailpoet/views/deactivationPoll/embedded-poll.html
@@ -45,7 +45,7 @@
       </script>
       <script type="text/javascript" charset="utf-8" src="https://secure.polldaddy.com/p/11161195.js"></script>
 
-      <noscript><a href="https://poll.fm/11161195">We're sorry to see you leave. Could you tell us more why are you deactivating MailPoet?</a></noscript>
+      <noscript><a href="https://poll.fm/11161195"><%= __("We're sorry to see you leave. Could you tell us more why are you deactivating MailPoet?") %></a></noscript>
 
       <a class="button" id="mailpoet-deactivate-survey-close"><%= __('Skip survey and deactivate MailPoet') %> &rarr;</a>
     </div>

--- a/mailpoet/views/deactivationPoll/index.html
+++ b/mailpoet/views/deactivationPoll/index.html
@@ -1,53 +1,6 @@
-<div class="mailpoet-deactivate-survey-modal" id="mailpoet-deactivate-survey-modal">
-  <div class="mailpoet-deactivate-survey-wrap">
-    <div class="mailpoet-deactivate-survey">
-      <script type="text/javascript">
-        window.addEventListener('load', function() {
-          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
-          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
-          var closeButton = document.querySelector('#mailpoet-deactivate-survey-close');
-          var formOpen = false;
+<% if(is_loading_3rd_party_enabled()) %>
+  <% include 'deactivationPoll/embedded-poll.html' %>
+<% else %>
+  <% include 'deactivationPoll/link-poll.html' %>
+<% endif %>
 
-          if (!deactivateLink || !overlay || !closeButton) {
-            return;
-          }
-
-          deactivateLink.addEventListener('click', function (event) {
-            event.preventDefault();
-            overlay.style.display = 'table';
-            formOpen = true;
-          });
-
-          closeButton.addEventListener('click', function (event) {
-            event.preventDefault();
-            overlay.style.display = 'none';
-            formOpen = false;
-            location.href = deactivateLink.getAttribute('href');
-          });
-
-          document.addEventListener('keyup', function (event) {
-            if ((event.keyCode === 27) && formOpen) {
-              location.href = deactivateLink.getAttribute('href');
-            }
-          });
-        });
-
-        // This callback is by docs, and guarantees that the modal window is closed and deactivated only after the vote has been submitted
-        var pd_callback = function(json) {
-          var obj = JSON.parse(json);
-          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
-          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
-          if (obj.result === 'already-registered' || obj.result === 'registered') {
-            overlay.style.display = 'none';
-            location.href = deactivateLink.getAttribute('href');
-          }
-        };
-      </script>
-      <script type="text/javascript" charset="utf-8" src="https://secure.polldaddy.com/p/11161195.js"></script>
-
-      <noscript><a href="https://poll.fm/11161195">We're sorry to see you leave. Could you tell us more why are you deactivating MailPoet?</a></noscript>
-
-      <a class="button" id="mailpoet-deactivate-survey-close"><%= __('Skip survey and deactivate MailPoet') %> &rarr;</a>
-    </div>
-  </div>
-</div>

--- a/mailpoet/views/deactivationPoll/link-poll.html
+++ b/mailpoet/views/deactivationPoll/link-poll.html
@@ -1,0 +1,62 @@
+<div class="mailpoet-deactivate-survey-modal" id="mailpoet-deactivate-survey-modal">
+  <div class="mailpoet-deactivate-survey-wrap">
+    <div class="mailpoet-deactivate-survey">
+
+      <script type="text/javascript">
+        window.addEventListener('load', function() {
+          var deactivateLink = document.querySelector('#the-list [data-slug="mailpoet"] span.deactivate a');
+          var overlay = document.querySelector('#mailpoet-deactivate-survey-modal');
+          var closeButton = document.querySelector('#mailpoet-deactivate-survey-close');
+          var participateButton = document.querySelector('#mailpoet-deactivate-survey-participate');
+          var formOpen = false;
+
+          if (!deactivateLink || !overlay || !closeButton || !participateButton) {
+            return;
+          }
+
+          deactivateLink.addEventListener('click', function (event) {
+            event.preventDefault();
+            overlay.style.display = 'table';
+            formOpen = true;
+          });
+
+          closeButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            overlay.style.display = 'none';
+            formOpen = false;
+            location.href = deactivateLink.getAttribute('href');
+          });
+
+          participateButton.addEventListener('click', function (event) {
+                setTimeout(function() {closeButton.click(); }, 50);
+          });
+
+          document.addEventListener('keyup', function (event) {
+            if ((event.keyCode === 27) && formOpen) {
+              location.href = deactivateLink.getAttribute('href');
+            }
+          });
+        });
+      </script>
+
+      <p><strong>
+
+        <%= __("We're sorry to see you go. Would you be open to sharing how MailPoet didn't work for you so we could improve it?") %>
+      </strong><br>It will take only a minute.</p>
+      <a
+        class="button button-primary"
+        id="mailpoet-deactivate-survey-participate"
+        href="https://poll.fm/11161195"
+        target="_blank"
+        rel="noopener nofollow"
+      ><%= __("Yes") %> &rarr;</a>
+
+      <a
+        class="button"
+        id="mailpoet-deactivate-survey-close"
+      >
+        <%= __('No') %>
+      </a>
+    </div>
+  </div>
+</div>

--- a/mailpoet/views/deactivationPoll/link-poll.html
+++ b/mailpoet/views/deactivationPoll/link-poll.html
@@ -42,7 +42,7 @@
       <p><strong>
 
         <%= __("We're sorry to see you go. Would you be open to sharing how MailPoet didn't work for you so we could improve it?") %>
-      </strong><br>It will take only a minute.</p>
+      </strong><br><%= __('It will take only a minute.') %></p>
       <a
         class="button button-primary"
         id="mailpoet-deactivate-survey-participate"


### PR DESCRIPTION
## Description
This PR updates the readme.txt and adds two missing 3rd party libraries to the description. It also updates the links to the Terms and Privacy pages of the services.

Additionally:
1. Out Crowdsignal integration did not respect the 3rd party setting of the user. This PR loads the Crowdsignal resources now only when 3rd parties are allowed. Otherwise we present the user a link to the poll when the plugin gets deactivated.
2. Beamer loaded in the moment the user clicked the "Updates"-button in the top right corner. This happened also when the user did not allow for 3rd party libraries. Now, the "Updates"-button is not visible when 3rd party libraries are not enabled and also the background job does not run in that case.

## Linked tickets

[MAILPOET-5826]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5826]: https://mailpoet.atlassian.net/browse/MAILPOET-5826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ