### PR TITLE
Detach Entities after bulkdeleting newsletters [MAILPOET-5829]

### DIFF
--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -145,6 +145,24 @@ abstract class Repository {
   }
 
   /**
+   * @param class-string<object> $className
+   * @param callable|null $filter
+   */
+  public function detachEntitiesOfType($className, callable $filter = null): void {
+    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
+    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
+    foreach ($entities as $entity) {
+      if (!($entity instanceof $className)) {
+        continue;
+      }
+      if ($filter && !$filter($entity)) {
+        continue;
+      }
+      $this->entityManager->detach($entity);
+    }
+  }
+
+  /**
    * @return class-string<T>
    */
   abstract protected function getEntityClassName();

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -368,7 +368,15 @@ class NewslettersRepository extends Repository {
     $childrenIds = $this->fetchChildrenIds($ids);
     $ids = array_merge($ids, $childrenIds);
 
-    $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids) {
+    $isRelatedNewsletterToBeDeleted = function($entity) use ($ids): bool {
+      if (is_string($entity) || !method_exists($entity, 'getNewsletter')) {
+        return false;
+      }
+      $newsletter = $entity->getNewsletter();
+      $newsletterId = $newsletter ? $newsletter->getId() : null;
+      return in_array($newsletterId, $ids, true);
+    };
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, $isRelatedNewsletterToBeDeleted) {
       // Delete statistics data
       $newsletterStatisticsTable = $entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
       $entityManager->getConnection()->executeStatement("
@@ -484,6 +492,27 @@ class NewslettersRepository extends Repository {
         ->where('n.id IN (:ids)')
         ->setParameter('ids', $ids)
         ->getQuery()->execute();
+
+
+      $entityTypesToBeDetached = [
+        StatisticsNewsletterEntity::class,
+        StatisticsOpenEntity::class,
+        StatisticsClickEntity::class,
+        NewsletterPostEntity::class,
+        NewsletterOptionEntity::class,
+        NewsletterLinkEntity::class,
+        StatsNotificationEntity::class,
+        SendingQueueEntity::class,
+        ScheduledTaskSubscriberEntity::class,
+        NewsletterSegmentEntity::class,
+      ];
+      foreach ($entityTypesToBeDetached as $entityType) {
+        $this->detachEntitiesOfType($entityType, $isRelatedNewsletterToBeDeleted);
+      }
+
+      $this->detachEntitiesOfType(ScheduledTaskEntity::class, function($entity) use ($taskIds): bool {
+        return !is_string($entity) && method_exists($entity, 'getId') && in_array($entity->getId(), $taskIds, true);
+      });
     });
     return count($ids);
   }


### PR DESCRIPTION
## Description
This solves [MAILPOET-5829]

## Code review notes
This PR builds on top of https://github.com/mailpoet/mailpoet/pull/5315. It introduces a second helper method which allows for detaching other entity types as well.

## QA notes
Get a post notification scheduled and ensure that at the time of sending no post is to be send out. You should find an error message like this in your logs:

```
SendingQueue: A new entity was found through the relationship 'MailPoet\Entities\NewsletterLinkEntity#queue' that was not configured to cascade persist operations for entity: MailPoet\Entities\SendingQueueEntity@2448. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'MailPoet\Entities\SendingQueueEntity#__toString()' to get a clue.
```

After applying the PR you shouldn't see this error no more.

You can simulate this also with the following mu-plugin and MailPoet version 4.41.1:

```
<?php
/**
 * Plugin Name: Test
 **/

add_action('init', function() {
  $post = get_post(501);
  wp_transition_post_status('publish', 'publish', $post);
});
```

Replace the 501 in `get_post(501);` with the ID of an post which you have already send out and which is published. This works only as long as https://github.com/mailpoet/mailpoet/pull/5367 is not merged (e.g. MailPoet version 4.41.1)

Please also test other instances where newsletters get deleted (in bulk) to see that everything works as expected there as well.

## Linked tickets
[MAILPOET-5829]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5829]: https://mailpoet.atlassian.net/browse/MAILPOET-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5829]: https://mailpoet.atlassian.net/browse/MAILPOET-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ