### PR TITLE
Sender domain Activation rules

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -158,6 +158,8 @@ interface Window {
     upperLimit: number;
     isNewUser: boolean;
     isEnforcementOfNewRestrictionsInEffect: boolean;
+    isAuthorizedDomainRequiredForNewCampaigns?: boolean;
+    campaignTypes?: string[];
   };
   mailpoet_all_sender_domains?: string[];
   mailpoet_mss_active: boolean;

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -236,6 +236,20 @@ class NewsletterSendComponent extends Component<
 
   isValid = () => jQuery('#mailpoet_newsletter').parsley().isValid();
 
+  isCampaign = () => {
+    const campaignTypes =
+      window.mailpoet_sender_restrictions?.campaignTypes ?? [];
+    return campaignTypes.includes(this.state?.item?.type);
+  };
+
+  isAuthorizedDomainRequired = () => {
+    const isAuthorizedDomainRequiredForNewCampaigns =
+      window.mailpoet_sender_restrictions
+        ?.isAuthorizedDomainRequiredForNewCampaigns || false;
+
+    return this.isCampaign() && isAuthorizedDomainRequiredForNewCampaigns;
+  };
+
   isValidFromAddress = async () => {
     if (window.mailpoet_mta_method !== 'MailPoet') {
       return true;
@@ -248,7 +262,8 @@ class NewsletterSendComponent extends Component<
     }
     const addresses = await this.loadAuthorizedEmailAddresses();
     const fromAddress = this.state.item.sender_address;
-    return addresses.indexOf(fromAddress) !== -1;
+    const isFromAddressAuthorized = addresses.indexOf(fromAddress) !== -1;
+    return isFromAddressAuthorized && !this.isAuthorizedDomainRequired();
   };
 
   loadItem = (id) => {

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -142,8 +142,8 @@ class Newsletters {
 
     if ($this->bridge->isMailpoetSendingServiceEnabled()) {
       $data['authorized_emails'] = $this->bridge->getAuthorizedEmailAddresses();
-      $data['verified_sender_domains'] = array_values($this->senderDomainController->getFullyVerifiedSenderDomains(true));
-      $data['partially_verified_sender_domains'] = array_values($this->senderDomainController->getPartiallyVerifiedSenderDomains(true));
+      $data['verified_sender_domains'] = $this->senderDomainController->getFullyVerifiedSenderDomains(true);
+      $data['partially_verified_sender_domains'] = $this->senderDomainController->getPartiallyVerifiedSenderDomains(true);
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();
       $data['sender_restrictions'] = [
         'lowerLimit' => AuthorizedSenderDomainController::LOWER_LIMIT,

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -150,6 +150,8 @@ class Newsletters {
         'upperLimit' => AuthorizedSenderDomainController::UPPER_LIMIT,
         'isNewUser' => $this->senderDomainController->isNewUser(),
         'isEnforcementOfNewRestrictionsInEffect' => $this->senderDomainController->isEnforcementOfNewRestrictionsInEffect(),
+        'isAuthorizedDomainRequiredForNewCampaigns' => $this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns(),
+        'campaignTypes' => NewsletterEntity::CAMPAIGN_TYPES,
       ];
     }
 

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -101,8 +101,8 @@ class Settings {
 
     if ($this->bridge->isMailpoetSendingServiceEnabled() && $mpApiKeyValid) {
       $data['authorized_emails'] = $this->bridge->getAuthorizedEmailAddresses();
-      $data['verified_sender_domains'] = array_values($this->senderDomainController->getFullyVerifiedSenderDomains(true));
-      $data['partially_verified_sender_domains'] = array_values($this->senderDomainController->getPartiallyVerifiedSenderDomains(true));
+      $data['verified_sender_domains'] = $this->senderDomainController->getFullyVerifiedSenderDomains(true);
+      $data['partially_verified_sender_domains'] = $this->senderDomainController->getPartiallyVerifiedSenderDomains(true);
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();
       $data['sender_restrictions'] = [
         'lowerLimit' => AuthorizedSenderDomainController::LOWER_LIMIT,

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -51,6 +51,15 @@ class NewsletterEntity {
     NewsletterEntity::TYPE_STANDARD,
   ];
 
+  /**
+   * Newsletters that have additional restrictions for activation and sending
+   */
+  const CAMPAIGN_TYPES = [
+    NewsletterEntity::TYPE_STANDARD,
+    NewsletterEntity::TYPE_NOTIFICATION,
+    NewsletterEntity::TYPE_RE_ENGAGEMENT,
+  ];
+
   // automatic newsletters status
   const STATUS_ACTIVE = 'active';
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -153,6 +153,23 @@ class AuthorizedEmailsController {
     }
   }
 
+  public function isSenderAddressValidForActivation(NewsletterEntity $newsletter): bool {
+    if ($this->settings->get('mta.method') !== Mailer::METHOD_MAILPOET) {
+      return true;
+    }
+
+    if (!in_array($newsletter->getType(), NewsletterEntity::CAMPAIGN_TYPES)) {
+      return true;
+    }
+
+    if (!$this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns()) {
+      return true;
+    }
+
+    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
+    return $this->validateEmailDomainIsVerified($verifiedDomains, $newsletter->getSenderAddress());
+  }
+
   private function validateAddressesInSettings($authorizedEmails, $verifiedDomains, $result = []) {
     $defaultSenderAddress = $this->settings->get('sender.address');
 

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -160,24 +160,29 @@ class AuthorizedSenderDomainController {
     return $response;
   }
 
-  public function getSenderDomainsByStatus(string $status): array {
+  public function getSenderDomainsByStatus(array $status): array {
     return array_filter($this->getAllRawData(), function(array $senderDomainData) use ($status) {
-      return ($senderDomainData['domain_status'] ?? null) === $status;
+      return in_array($senderDomainData['domain_status'] ?? null, $status);
     });
   }
 
   public function getFullyVerifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_VERIFIED);
+    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_VERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
   public function getPartiallyVerifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_PARTIALLY_VERIFIED);
+    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_PARTIALLY_VERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
   public function getUnverifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_UNVERIFIED);
+    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_UNVERIFIED]);
+    return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
+  }
+
+  public function getFullyOrPartiallyVerifiedSenderDomains($domainsOnly = false): array {
+    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_PARTIALLY_VERIFIED,self::OVERALL_STATUS_VERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -168,26 +168,25 @@ class AuthorizedSenderDomainController {
 
   public function getFullyVerifiedSenderDomains($domainsOnly = false): array {
     $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_VERIFIED);
-    if ($domainsOnly) {
-      return array_map([$this, 'domainExtractor'], $domainData);
-    }
-    return $domainData;
+    return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
   public function getPartiallyVerifiedSenderDomains($domainsOnly = false): array {
     $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_PARTIALLY_VERIFIED);
-    if ($domainsOnly) {
-      return array_map([$this, 'domainExtractor'], $domainData);
-    }
-    return $domainData;
+    return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
   public function getUnverifiedSenderDomains($domainsOnly = false): array {
     $domainData = $this->getSenderDomainsByStatus(self::OVERALL_STATUS_UNVERIFIED);
-    if ($domainsOnly) {
-      return array_map([$this, 'domainExtractor'], $domainData);
+    return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
+  }
+
+  private function extractDomains(array $domainData): array {
+    $extractedDomains = [];
+    foreach ($domainData as $data) {
+      $extractedDomains[] = $this->domainExtractor($data);
     }
-    return $domainData;
+    return $extractedDomains;
   }
 
   private function domainExtractor(array $domainData): string {

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -227,13 +227,13 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     $controller = $this->getController($bridgeMock);
 
-    $domainsByStatus = $controller->getSenderDomainsByStatus('verified');
+    $domainsByStatus = $controller->getSenderDomainsByStatus(['verified']);
     $this->assertEqualsCanonicalizing([$verifiedDomain], $domainsByStatus);
 
-    $domainsByStatus = $controller->getSenderDomainsByStatus('partially-verified');
+    $domainsByStatus = $controller->getSenderDomainsByStatus(['partially-verified']);
     $this->assertEqualsCanonicalizing([$partiallyVerifiedDomain], $domainsByStatus);
 
-    $domainsByStatus = $controller->getSenderDomainsByStatus('unverified');
+    $domainsByStatus = $controller->getSenderDomainsByStatus(['unverified']);
     $this->assertEqualsCanonicalizing([$unverifiedDomain], $domainsByStatus);
 
     $grouped = $controller->getSenderDomainsGroupedByStatus();
@@ -248,6 +248,9 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     $domains = $controller->getPartiallyVerifiedSenderDomains(true);
     $this->assertEqualsCanonicalizing(['example2.com'], $domains);
+
+    $domains = $controller->getFullyOrPartiallyVerifiedSenderDomains(true);
+    $this->assertEqualsCanonicalizing(['example1.com', 'example2.com'], $domains);
 
     $domains = $controller->getUnverifiedSenderDomains(true);
     $this->assertEqualsCanonicalizing(['example3.com'], $domains);


### PR DESCRIPTION
## Description

This PR applies the new sender domain restrictions for new emails activation (when using the sending service):
- Do not allow activation of new campaigns if domain is not authorized and is not a small sender
- The rule applies to new users. It will apply to existing users from Feb 1st.

The rules for existing active and scheduled emails will be done in a separate PR (That rule is only for existing users and will not apply until Feb 1st)

## Code review notes

Starts on bafbfc33176a2dfa45a2fa0044a814205749a32e

## QA notes

The changes apply:
-  to the button 'Send' or 'Activate' in the send screen
-  to the toggle in the listing for Post notifications and Re-engagement emails

To test the different cases you can modify AuthorizedSenderDomainController.php changing LOWER_LIMIT
Please test on a new installation or change the return of isNewUser() on AuthorizedSenderDomainController.php

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5786]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5786]: https://mailpoet.atlassian.net/browse/MAILPOET-5786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ