### PR TITLE
Hide AutomateWoo checkout opt-in block so only one checkbox is visible [MAILPOET-5721]

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -62,7 +62,7 @@ parameters:
       path: ../../lib/WooCommerce/Helper.php
     -
       message: '/^Cannot call method get\(\) on mixed.$/'
-      count: 1
+      count: 2
       path: ../../lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
     -
       message: '/^Call to an undefined method Codeception\\TestInterface::getName()./'

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -22,8 +22,6 @@ class CheckSkippedTestsExtension extends Extension {
       'testAllSubscribersFoundWithOperatorAllOf',
       'automationTriggeredByRegistrationWitConfirmationNeeded',
       'automationTriggeredByRegistrationWithoutConfirmationNeeded',
-      'checkoutOptInEnabled',
-      'checkoutOptInChecked',
     ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -48,7 +48,6 @@ class WooCheckoutAutomateWooSubscriptionsCest {
   }
 
   public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
-    $scenario->skip('Skip until resolved: Both AutomateWoo and MailPoet checkboxes are present in the checkout');
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
     $i->addProductToCart($this->product);
     $i->goToCheckout();
@@ -69,7 +68,6 @@ class WooCheckoutAutomateWooSubscriptionsCest {
   }
 
   public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
-    $scenario->skip('Skip until resolved: Both AutomateWoo and MailPoet checkboxes are present in the checkout');
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
     $this->settingsFactory->withConfirmationEmailEnabled();
     $customerEmail = 'woo_guest_check@example.com';


### PR DESCRIPTION
## Description

Notes:
1. I used the code which removes the frontend block, but leaves a block stub in the editor:
![image](https://github.com/mailpoet/mailpoet/assets/141430865/4cd15255-dcd0-42d6-b80a-32877223925d)
The latter if deactivated leaves another stub:
![image](https://github.com/mailpoet/mailpoet/assets/141430865/708f8d07-5aa9-44aa-b3cf-46f533a86094)
I personally like the first one better. Removing the last one would mean editing the checkout page content (potentially in multiple page versions) which is too intrusive, IMO. So I'd leave the first one.
2. This error was only reproducible in acceptance tests: 
![Screenshot on 2023-11-21 at 14 00 58](https://github.com/mailpoet/mailpoet/assets/141430865/8a7c2748-ec03-4cb4-86a3-4b1f7c58d814)
I could not reproduce it in my dev environment, but I solved it by unregistering the Store API extension by AW.

## Code review notes

_N/A_

## QA notes

Testing instructions are the same as in https://github.com/mailpoet/mailpoet/pull/4740, but the new block-based Woo checkout page should be tested, not the old checkout page. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5721]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5721]: https://mailpoet.atlassian.net/browse/MAILPOET-5721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ