### PR TITLE
Update link for banned users [MAILPOET-5825]

### DIFF
--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -165,7 +165,7 @@ class MailPoetMapper {
     );
     $message = Helpers::replaceLinkTags(
       $message,
-      'https://www.mailpoet.com/support/',
+      'https://www.mailpoet.com/support-for-banned-users/',
       [
         'target' => '_blank',
         'rel' => 'noopener noreferrer',


### PR DESCRIPTION
## Description
Replaces the link to the support link in the following notice:
```
MailPoet Sending Service has been temporarily suspended for your site due to [link1]degraded email deliverability[/link1]. Please [link2]contact our support team[/link2] to resolve the issue.
```
Fixes [MAILPOET-5825]

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5825]: https://mailpoet.atlassian.net/browse/MAILPOET-5825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ