### PR TITLE
Automatic emails to automations fixes [MAILPOET-5779] [MAILPOET-5830]

### DIFF
--- a/mailpoet/assets/js/src/automation/automation.tsx
+++ b/mailpoet/assets/js/src/automation/automation.tsx
@@ -13,6 +13,7 @@ import { registerApiErrorHandler } from './listing/api-error-handler';
 import { Notices } from './listing/components/notices';
 import { BuildYourOwnSection, HeroSection, TemplatesSection } from './sections';
 import { MailPoet } from '../mailpoet';
+import { useAutomationListingNotices } from './listing/automation-listing-notices';
 import { LegacyAutomationsNotice } from './listing/legacy-automations-notice';
 
 const trackOpenEvent = () => {
@@ -62,6 +63,8 @@ function Content(): JSX.Element {
 }
 
 function Automations(): JSX.Element {
+  useAutomationListingNotices();
+
   return (
     <>
       <TopBarWithBeamer />

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -26,7 +26,7 @@ import { Automation } from './components/automation';
 import { automationSidebarKey, createStore, storeName } from './store';
 import { initializeApi } from '../api';
 import { MailPoet } from '../../mailpoet';
-import { LISTING_NOTICE_PARAMETERS } from '../listing/automation-listing-notices';
+import { LISTING_NOTICES } from '../listing/automation-listing-notices';
 import { registerApiErrorHandler } from './api-error-handler';
 import { ActivatePanel } from './components/panel/activate-panel';
 import { AutomationStatus } from '../listing/automation';
@@ -125,7 +125,7 @@ function Editor(): JSX.Element {
 
   if (automation.status === 'trash') {
     window.location.href = addQueryArgs(MailPoet.urls.automationListing, {
-      [LISTING_NOTICE_PARAMETERS.automationHadBeenDeleted]: automation.id,
+      notice: LISTING_NOTICES.automationHadBeenDeleted,
     });
     return null;
   }

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -7,7 +7,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { addQueryArgs } from '@wordpress/url';
 import { storeName } from './constants';
 import { Feature, State } from './types';
-import { LISTING_NOTICE_PARAMETERS } from '../../listing/automation-listing-notices';
+import { LISTING_NOTICES } from '../../listing/automation-listing-notices';
 import { MailPoet } from '../../../mailpoet';
 import { AutomationStatus } from '../../listing/automation';
 
@@ -216,7 +216,7 @@ export function* trash(onTrashed: () => void = undefined) {
 
   if (data?.status === AutomationStatus.TRASH) {
     window.location.href = addQueryArgs(MailPoet.urls.automationListing, {
-      [LISTING_NOTICE_PARAMETERS.automationDeleted]: automation.id,
+      notice: LISTING_NOTICES.automationDeleted,
     });
   }
 

--- a/mailpoet/assets/js/src/automation/listing/automation-listing-notices.tsx
+++ b/mailpoet/assets/js/src/automation/listing/automation-listing-notices.tsx
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 
 export const LISTING_NOTICES = {
+  automationActivated: 'activated',
+  automationSaved: 'saved',
   automationDeleted: 'deleted',
   automationHadBeenDeleted: 'had-been-deleted',
 } as const;
@@ -14,8 +16,14 @@ export function useAutomationListingNotices(): void {
 
   useEffect(() => {
     const notice = getQueryArg(window.location.href, 'notice');
-
-    if (notice === LISTING_NOTICES.automationDeleted) {
+    if (notice === LISTING_NOTICES.automationActivated) {
+      createNotice('success', __('Your automation is now active.', 'mailpoet'));
+    } else if (notice === LISTING_NOTICES.automationSaved) {
+      createNotice(
+        'success',
+        __('Your automation has been saved.', 'mailpoet'),
+      );
+    } else if (notice === LISTING_NOTICES.automationDeleted) {
       createNotice(
         'success',
         __('1 automation moved to the Trash.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -12,7 +12,7 @@ import {
 import { useHistory, useLocation } from 'react-router-dom';
 import { plusIcon } from 'common/button/icon/plus';
 import { getRow } from './get-row';
-import { storeName } from './store';
+import { AutomationItem, storeName } from './store';
 import { Automation, AutomationStatus } from './automation';
 import { MailPoet } from '../../mailpoet';
 import { PageHeader } from '../../common/page-header';
@@ -146,7 +146,7 @@ export function AutomationListing(): JSX.Element {
 
   const renderTabs = useCallback(
     (tab) => {
-      const filteredAutomations: Automation[] =
+      const filteredAutomations: AutomationItem[] =
         groupedAutomations[tab.name] ?? [];
       const rowsPerPage = parseInt(pageSearch.get('per_page') ?? '25', 10);
       const currentPage = parseInt(pageSearch.get('paged') ?? '1', 10);
@@ -167,7 +167,10 @@ export function AutomationListing(): JSX.Element {
             >['headers']
           }
           rows={rows}
-          rowKey={(_, i) => filteredAutomations[i].id}
+          rowKey={(_, i) =>
+            filteredAutomations[i].id *
+            (filteredAutomations[i].isLegacy ? -1 : 1)
+          }
           rowsPerPage={rowsPerPage}
           onQueryChange={(key) => (value) => {
             updateUrlSearchString({ [key]: value });

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -445,8 +445,8 @@ class NewsletterSendComponent extends Component<
             this.props.history.push(`/send/congratulate/${this.state.item.id}`);
             return;
           }
-          // redirect to listing based on newsletter type
-          this.props.history.push(`/${this.state.item.type || ''}`);
+          this.redirectToListing();
+
           // prepare segments
           let filters = [];
           saveResponse.data.segments.map((segment) =>
@@ -504,14 +504,10 @@ class NewsletterSendComponent extends Component<
             this.props.history.push(`/send/congratulate/${this.state.item.id}`);
             return;
           }
-          // redirect to listing based on newsletter type
-          const opts = this.state.item.options;
-          this.props.history.push(
-            this.state.item.type === 'automatic'
-              ? `/${opts.group}`
-              : `/${this.state.item.type || ''}`,
-          );
+          this.redirectToListing();
+
           // display success message depending on newsletter type
+          const opts = this.state.item.options;
           if (
             this.state.item.type === 'automatic' &&
             automaticEmails[opts.group]
@@ -583,7 +579,7 @@ class NewsletterSendComponent extends Component<
             },
           })
             .done(() => {
-              this.props.history.push(`/${this.state.item.type || ''}`);
+              this.redirectToListing();
               this.context.notices.success(
                 <p>
                   {__('The newsletter sending has been resumed.', 'mailpoet')}
@@ -614,15 +610,20 @@ class NewsletterSendComponent extends Component<
         );
       })
       .done(() => {
-        const path =
-          this.state.item.type === 'automatic'
-            ? this.state.item.options.group
-            : this.state.item.type;
-        this.props.history.push(`/${path || ''}`);
+        this.redirectToListing();
       })
       .fail((err) => {
         this.showError(err);
       });
+  };
+
+  redirectToListing = () => {
+    // redirect to listing based on newsletter type
+    if (['automatic', 'welcome'].includes(this.state.item.type)) {
+      window.location.href = 'admin.php?page=mailpoet-automation';
+    } else {
+      this.props.history.push(`/${this.state.item.type}`);
+    }
   };
 
   handleRedirectToDesign = (e) => {

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -445,7 +445,7 @@ class NewsletterSendComponent extends Component<
             this.props.history.push(`/send/congratulate/${this.state.item.id}`);
             return;
           }
-          this.redirectToListing();
+          this.redirectToListing('activated');
 
           // prepare segments
           let filters = [];
@@ -504,7 +504,7 @@ class NewsletterSendComponent extends Component<
             this.props.history.push(`/send/congratulate/${this.state.item.id}`);
             return;
           }
-          this.redirectToListing();
+          this.redirectToListing('activated');
 
           // display success message depending on newsletter type
           const opts = this.state.item.options;
@@ -579,7 +579,7 @@ class NewsletterSendComponent extends Component<
             },
           })
             .done(() => {
-              this.redirectToListing();
+              this.redirectToListing('activated');
               this.context.notices.success(
                 <p>
                   {__('The newsletter sending has been resumed.', 'mailpoet')}
@@ -610,17 +610,17 @@ class NewsletterSendComponent extends Component<
         );
       })
       .done(() => {
-        this.redirectToListing();
+        this.redirectToListing('saved');
       })
       .fail((err) => {
         this.showError(err);
       });
   };
 
-  redirectToListing = () => {
+  redirectToListing = (action: 'activated' | 'saved') => {
     // redirect to listing based on newsletter type
     if (['automatic', 'welcome'].includes(this.state.item.type)) {
-      window.location.href = 'admin.php?page=mailpoet-automation';
+      window.location.href = `admin.php?page=mailpoet-automation&notice=${action}`;
     } else {
       this.props.history.push(`/${this.state.item.type}`);
     }

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -158,6 +158,7 @@ function NewsletterTypesComponent({
     </ButtonGroup>
   ) : (
     <Button
+      variant="secondary"
       onClick={createStandardNewsletter}
       isBusy={isCreating}
       data-automation-id="create_standard"

--- a/mailpoet/assets/js/src/notices/legacy-automatic-emails-notice.tsx
+++ b/mailpoet/assets/js/src/notices/legacy-automatic-emails-notice.tsx
@@ -4,7 +4,7 @@ import { Notice } from './notice';
 
 export function LegacyAutomaticEmailsNotice(): JSX.Element {
   return (
-    <Notice type="info" timeout={false} closable={false} renderInPlace>
+    <Notice type="info" timeout={false} closable renderInPlace>
       <p>
         {createInterpolateElement(
           __(

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -73,7 +73,7 @@ class AutomationEditor {
     }
 
     if ($automation->getStatus() === Automation::STATUS_TRASH) {
-      $this->wp->wpSafeRedirect($this->wp->adminUrl('admin.php?page=mailpoet-automation&status=trash'));
+      $this->wp->wpSafeRedirect($this->wp->adminUrl('admin.php?page=mailpoet-automation&status=trash&notice=had-been-deleted'));
       exit();
     }
 


### PR DESCRIPTION
## Description

This PR contains various fixes related to https://github.com/mailpoet/mailpoet/pull/5340:
1. Fixed create email button when Gutenberg email editor is not active ([Slack](https://a8c.slack.com/archives/C01GPBNS1RS/p1705334114450069)).
2. Make legacy automatic email notice closable ([ticket](https://mailpoet.atlassian.net/browse/MAILPOET-5830)).
3. Fix redirects to email listings after moving legacy automatic emails (reported [here](https://github.com/mailpoet/mailpoet/pull/5340#issuecomment-1881994583)).
4. Fixed notices on automation listing page — such as when automation is trashed, saved, or activated, including showing these notices for legacy automatic emails (when those are saved or activated).
5. Fixed a JS console warning on the automation listing page.

## Code review notes

Skipping code review as per: https://codep2.wordpress.com/2023/12/08/experiment-code-reviews-optional-in-january/

## QA notes

Please, check the cases listed in the description above + verify other newsletters still redirect to the old newsletter listing page.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5779]
[MAILPOET-5830]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5779]: https://mailpoet.atlassian.net/browse/MAILPOET-5779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5830]: https://mailpoet.atlassian.net/browse/MAILPOET-5830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ