### PR TITLE
Legacy automatic emails fixes [MAILPOET-5779]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-listing/_listing.scss
+++ b/mailpoet/assets/css/src/components-automation-listing/_listing.scss
@@ -18,14 +18,10 @@
 }
 
 .mailpoet-automation-listing-cell-name.woocommerce-table__item {
-  position: relative;
   width: 100%;
 
   > a:only-child {
-    display: flex;
-    inset: 0 0 2px;
-    padding: 16px 24px;
-    position: absolute;
+    display: inline-flex;
   }
 }
 

--- a/mailpoet/assets/js/src/automation/automation.tsx
+++ b/mailpoet/assets/js/src/automation/automation.tsx
@@ -35,7 +35,10 @@ function Content(): JSX.Element {
     count > 0 ? (
       <>
         <AutomationListingHeader />
-        {legacyAutomationCount > 0 && <LegacyAutomationsNotice />}
+        {legacyAutomationCount > 0 &&
+          !window.mailpoet_legacy_automations_notice_dismissed && (
+            <LegacyAutomationsNotice />
+          )}
         <AutomationListing />
       </>
     ) : (

--- a/mailpoet/assets/js/src/automation/listing/components/actions/analytics.tsx
+++ b/mailpoet/assets/js/src/automation/listing/components/actions/analytics.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function Analytics({ automation, label }: Props): JSX.Element {
   const { id, isLegacy } = automation;
   return isLegacy ? (
-    <a href={`?page=mailpoet-newsletters#/stats/${id}`}>
+    <a href={`?page=mailpoet-newsletters&context=automation#/stats/${id}`}>
       {label ?? __('Analytics', 'mailpoet')}
     </a>
   ) : (

--- a/mailpoet/assets/js/src/automation/listing/components/actions/edit-automation.tsx
+++ b/mailpoet/assets/js/src/automation/listing/components/actions/edit-automation.tsx
@@ -12,9 +12,9 @@ type Props = {
 export function EditAutomation({ automation, label }: Props): JSX.Element {
   const { id, isLegacy } = automation;
   return isLegacy ? (
-    <a href={`?page=mailpoet-newsletter-editor&id=${id}`}>
+    <Button variant="link" href={`?page=mailpoet-newsletter-editor&id=${id}`}>
       {label ?? __('Edit', 'mailpoet')}
-    </a>
+    </Button>
   ) : (
     <Button
       variant="link"

--- a/mailpoet/assets/js/src/automation/listing/legacy-automations-notice.tsx
+++ b/mailpoet/assets/js/src/automation/listing/legacy-automations-notice.tsx
@@ -1,10 +1,26 @@
+import { useCallback } from 'react';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from 'notices/notice';
+import { legacyApiFetch } from './store/legacy-api';
 
 export function LegacyAutomationsNotice(): JSX.Element {
+  const saveNoticeDismissed = useCallback(() => {
+    void legacyApiFetch({
+      endpoint: 'UserFlags',
+      method: 'set',
+      'data[legacy_automations_notice_dismissed]': '1',
+    });
+  }, []);
+
   return (
-    <Notice type="info" timeout={false} closable renderInPlace>
+    <Notice
+      type="info"
+      timeout={false}
+      closable
+      renderInPlace
+      onClose={saveNoticeDismissed}
+    >
       <p>
         {createInterpolateElement(
           __(

--- a/mailpoet/assets/js/src/automation/listing/store/types.ts
+++ b/mailpoet/assets/js/src/automation/listing/store/types.ts
@@ -19,6 +19,7 @@ declare global {
         events: Record<string, Record<string, unknown>>;
       }
     >;
+    mailpoet_legacy_automations_notice_dismissed: boolean;
   }
 }
 

--- a/mailpoet/assets/js/src/newsletters/newsletters.jsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.jsx
@@ -48,9 +48,10 @@ const Tabs = withNpsPoll(() => {
       <ListingHeadingDisplay>
         <ListingHeading />
       </ListingHeadingDisplay>
-      {window.mailpoet_legacy_automatic_emails_count > 0 && (
-        <LegacyAutomaticEmailsNotice />
-      )}
+      {window.mailpoet_legacy_automatic_emails_count > 0 &&
+        !window.mailpoet_legacy_automatic_emails_notice_dismissed && (
+          <LegacyAutomaticEmailsNotice />
+        )}
       {MailPoet.corrupt_newsletters.length > 0 && (
         <CorruptEmailNotice newsletters={MailPoet.corrupt_newsletters} />
       )}

--- a/mailpoet/assets/js/src/notices/legacy-automatic-emails-notice.tsx
+++ b/mailpoet/assets/js/src/notices/legacy-automatic-emails-notice.tsx
@@ -1,10 +1,26 @@
+import { useCallback } from 'react';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from './notice';
+import { legacyApiFetch } from '../automation/listing/store/legacy-api';
 
 export function LegacyAutomaticEmailsNotice(): JSX.Element {
+  const saveNoticeDismissed = useCallback(() => {
+    void legacyApiFetch({
+      endpoint: 'UserFlags',
+      method: 'set',
+      'data[legacy_automatic_emails_notice_dismissed]': '1',
+    });
+  }, []);
+
   return (
-    <Notice type="info" timeout={false} closable renderInPlace>
+    <Notice
+      type="info"
+      timeout={false}
+      closable
+      renderInPlace
+      onClose={saveNoticeDismissed}
+    >
       <p>
         {createInterpolateElement(
           __(

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -163,6 +163,8 @@ class Newsletters extends APIEndpoint {
     $newsletter = $this->newsletterSaveController->save($data);
     $response = $this->newslettersResponseBuilder->build($newsletter, [
       NewslettersResponseBuilder::RELATION_SEGMENTS,
+      NewslettersResponseBuilder::RELATION_OPTIONS,
+      NewslettersResponseBuilder::RELATION_QUEUE,
     ]);
     $previewUrl = $this->getViewInBrowserUrl($newsletter);
     $response = $this->wp->applyFilters('mailpoet_api_newsletters_save_after', $response);
@@ -237,7 +239,11 @@ class Newsletters extends APIEndpoint {
     $this->newslettersRepository->flush();
 
     return $this->successResponse(
-      $this->newslettersResponseBuilder->build($newsletter)
+      $this->newslettersResponseBuilder->build($newsletter, [
+        NewslettersResponseBuilder::RELATION_SEGMENTS,
+        NewslettersResponseBuilder::RELATION_OPTIONS,
+        NewslettersResponseBuilder::RELATION_QUEUE,
+      ])
     );
   }
 
@@ -247,7 +253,11 @@ class Newsletters extends APIEndpoint {
       $this->newslettersRepository->bulkRestore([$newsletter->getId()]);
       $this->newslettersRepository->refresh($newsletter);
       return $this->successResponse(
-        $this->newslettersResponseBuilder->build($newsletter),
+        $this->newslettersResponseBuilder->build($newsletter, [
+          NewslettersResponseBuilder::RELATION_SEGMENTS,
+          NewslettersResponseBuilder::RELATION_OPTIONS,
+          NewslettersResponseBuilder::RELATION_QUEUE,
+        ]),
         ['count' => 1]
       );
     } else {
@@ -263,7 +273,11 @@ class Newsletters extends APIEndpoint {
       $this->newslettersRepository->bulkTrash([$newsletter->getId()]);
       $this->newslettersRepository->refresh($newsletter);
       return $this->successResponse(
-        $this->newslettersResponseBuilder->build($newsletter),
+        $this->newslettersResponseBuilder->build($newsletter, [
+          NewslettersResponseBuilder::RELATION_SEGMENTS,
+          NewslettersResponseBuilder::RELATION_OPTIONS,
+          NewslettersResponseBuilder::RELATION_QUEUE,
+        ]),
         ['count' => 1]
       );
     } else {
@@ -294,7 +308,11 @@ class Newsletters extends APIEndpoint {
       $duplicate = $this->newsletterSaveController->duplicate($newsletter);
       $this->wp->doAction('mailpoet_api_newsletters_duplicate_after', $newsletter, $duplicate);
       return $this->successResponse(
-        $this->newslettersResponseBuilder->build($duplicate),
+        $this->newslettersResponseBuilder->build($duplicate, [
+          NewslettersResponseBuilder::RELATION_SEGMENTS,
+          NewslettersResponseBuilder::RELATION_OPTIONS,
+          NewslettersResponseBuilder::RELATION_QUEUE,
+        ]),
         ['count' => 1]
       );
     } else {

--- a/mailpoet/lib/AdminPages/Pages/Automation.php
+++ b/mailpoet/lib/AdminPages/Pages/Automation.php
@@ -12,6 +12,7 @@ use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Settings\UserFlagsController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Automation {
@@ -36,6 +37,8 @@ class Automation {
 
   private SegmentsSimpleListRepository $segmentsListRepository;
 
+  private UserFlagsController $userFlagsController;
+
   public function __construct(
     AssetsController $assetsController,
     AutomaticEmails $automaticEmails,
@@ -44,7 +47,8 @@ class Automation {
     AutomationStorage $automationStorage,
     Registry $registry,
     NewslettersRepository $newslettersRepository,
-    SegmentsSimpleListRepository $segmentsListRepository
+    SegmentsSimpleListRepository $segmentsListRepository,
+    UserFlagsController $userFlagsController
   ) {
     $this->assetsController = $assetsController;
     $this->automaticEmails = $automaticEmails;
@@ -54,6 +58,7 @@ class Automation {
     $this->registry = $registry;
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsListRepository = $segmentsListRepository;
+    $this->userFlagsController = $userFlagsController;
   }
 
   public function render() {
@@ -90,6 +95,7 @@ class Automation {
       'segments' => $this->segmentsListRepository->getListWithSubscribedSubscribersCounts(),
       'roles' => $wp_roles->get_names() + ['mailpoet_all' => __('In any WordPress role', 'mailpoet')],
       'automatic_emails' => $this->automaticEmails->getAutomaticEmails(),
+      'legacy_automations_notice_dismissed' => (bool)$this->userFlagsController->get('legacy_automations_notice_dismissed'),
     ]);
   }
 

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -15,6 +15,7 @@ use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\UserFlagsController;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\TransactionalEmails;
 use MailPoet\WP\AutocompletePostListLoader as WPPostListLoader;
@@ -61,6 +62,8 @@ class Newsletters {
   /** @var ServicesChecker */
   private $servicesChecker;
 
+  private UserFlagsController $userFlagsController;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
@@ -74,7 +77,8 @@ class Newsletters {
     Bridge $bridge,
     AuthorizedSenderDomainController $senderDomainController,
     SubscribersFeature $subscribersFeature,
-    ServicesChecker $servicesChecker
+    ServicesChecker $servicesChecker,
+    UserFlagsController $userFlagsController
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
@@ -89,6 +93,7 @@ class Newsletters {
     $this->senderDomainController = $senderDomainController;
     $this->subscribersFeature = $subscribersFeature;
     $this->servicesChecker = $servicesChecker;
+    $this->userFlagsController = $userFlagsController;
   }
 
   public function render() {
@@ -160,6 +165,8 @@ class Newsletters {
     $data['legacy_automatic_emails_count'] = $this->newslettersRepository->countBy([
       'type' => [NewsletterEntity::TYPE_WELCOME, NewsletterEntity::TYPE_AUTOMATIC],
     ]);
+
+    $data['legacy_automatic_emails_notice_dismissed'] = (bool)$this->userFlagsController->get('legacy_automatic_emails_notice_dismissed');
 
     $this->pageRenderer->displayPage('newsletters.html', $data);
   }

--- a/mailpoet/lib/Settings/UserFlagsController.php
+++ b/mailpoet/lib/Settings/UserFlagsController.php
@@ -25,6 +25,8 @@ class UserFlagsController {
       'form_editor_tutorial_seen' => false,
       'display_new_form_editor_nps_survey' => false,
       'transactional_emails_opt_in_notice_dismissed' => false,
+      'legacy_automations_notice_dismissed' => false,
+      'legacy_automatic_emails_notice_dismissed' => false,
     ];
     $this->userFlagsRepository = $userFlagsRepository;
   }

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 4.41.2
+ * Version: 4.41.3
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '4.41.2',
+  'version' => '4.41.3',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 6.3
 Tested up to: 6.4
-Stable tag: 4.41.2
+Stable tag: 4.41.3
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -218,6 +218,14 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 6. WooCommerce emails
 
 == Changelog ==
+
+= 4.41.3 - 2024-01-16 =
+* Added: a new segment for "Number of orders with coupon code";
+* Improved: Sender email input validation for DMARC and other verification records;
+* Improved: move legacy Welcome and WooCommerce emails to Automations;
+* Fixed: Some HTML markup fixes in the admin;
+* Fixed: Do not attempt to queue a newsletter notification for already published posts;
+* Fixed: The trash button on the newsletter stats page deleted a newsletter permanently.
 
 = 4.41.2 - 2024-01-11 =
 * Improved: notices in the banners now indicate that the new sending rules will be enforced on February 1st.

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -201,7 +201,13 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $updatedNewsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $updatedNewsletter); // PHPStan
-    verify($response->data)->equals($this->newslettersResponseBuilder->build($updatedNewsletter, [NewslettersResponseBuilder::RELATION_SEGMENTS]));
+    verify($response->data)->equals(
+      $this->newslettersResponseBuilder->build($updatedNewsletter, [
+        NewslettersResponseBuilder::RELATION_SEGMENTS,
+        NewslettersResponseBuilder::RELATION_OPTIONS,
+        NewslettersResponseBuilder::RELATION_QUEUE,
+      ])
+    );
     verify($updatedNewsletter->getType())->equals('Updated type');
     verify($updatedNewsletter->getSubject())->equals('Updated subject');
     verify($updatedNewsletter->getPreheader())->equals('Updated preheader');
@@ -347,7 +353,13 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    verify($response->data)->equals($this->newslettersResponseBuilder->build($newsletter));
+    verify($response->data)->equals(
+      $this->newslettersResponseBuilder->build($newsletter, [
+        NewslettersResponseBuilder::RELATION_SEGMENTS,
+        NewslettersResponseBuilder::RELATION_OPTIONS,
+        NewslettersResponseBuilder::RELATION_QUEUE,
+      ])
+    );
     verify($response->data['deleted_at'])->null();
     verify($response->meta['count'])->equals(1);
   }
@@ -357,7 +369,13 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    verify($response->data)->equals($this->newslettersResponseBuilder->build($newsletter));
+    verify($response->data)->equals(
+      $this->newslettersResponseBuilder->build($newsletter, [
+        NewslettersResponseBuilder::RELATION_SEGMENTS,
+        NewslettersResponseBuilder::RELATION_OPTIONS,
+        NewslettersResponseBuilder::RELATION_QUEUE,
+      ])
+    );
     verify($response->data['deleted_at'])->notNull();
     verify($response->meta['count'])->equals(1);
   }
@@ -382,7 +400,13 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $newsletterCopy = $this->newsletterRepository->findOneBy(['subject' => 'Copy of My Standard Newsletter']);
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterCopy);
-    verify($response->data)->equals($this->newslettersResponseBuilder->build($newsletterCopy));
+    verify($response->data)->equals(
+      $this->newslettersResponseBuilder->build($newsletterCopy, [
+        NewslettersResponseBuilder::RELATION_SEGMENTS,
+        NewslettersResponseBuilder::RELATION_OPTIONS,
+        NewslettersResponseBuilder::RELATION_QUEUE,
+      ])
+    );
     verify($response->meta['count'])->equals(1);
 
     $hookName = 'mailpoet_api_newsletters_duplicate_after';
@@ -393,7 +417,13 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $newsletterCopy = $this->newsletterRepository->findOneBy(['subject' => 'Copy of My Post Notification']);
     $this->assertInstanceOf(NewsletterEntity::class, $newsletterCopy);
-    verify($response->data)->equals($this->newslettersResponseBuilder->build($newsletterCopy));
+    verify($response->data)->equals(
+      $this->newslettersResponseBuilder->build($newsletterCopy, [
+        NewslettersResponseBuilder::RELATION_SEGMENTS,
+        NewslettersResponseBuilder::RELATION_OPTIONS,
+        NewslettersResponseBuilder::RELATION_QUEUE,
+      ])
+    );
     verify($response->meta['count'])->equals(1);
   }
 

--- a/mailpoet/views/automation.html
+++ b/mailpoet/views/automation.html
@@ -17,5 +17,6 @@
   var mailpoet_segments = <%= json_encode(segments) %>;
   var mailpoet_roles = <%= json_encode(roles) %>;
   var mailpoet_woocommerce_automatic_emails = <%= json_encode(automatic_emails) %>;
+  var mailpoet_legacy_automations_notice_dismissed = <%= json_encode(legacy_automations_notice_dismissed) %>;
 </script>
 <% endblock %>

--- a/mailpoet/views/automation.html
+++ b/mailpoet/views/automation.html
@@ -1,9 +1,7 @@
 <% extends 'layout.html' %>
 
 <% block content %>
-<div class="wrap">
-  <div id="mailpoet_automation"></div>
-</div>
+<div id="mailpoet_automation"></div>
 
 <script type="text/javascript">
   var mailpoet_locale_full = <%= json_encode(locale_full) %>;

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -55,6 +55,7 @@
     var mailpoet_newsletters_templates_recently_sent_count = <%= json_decode(newsletters_templates_recently_sent_count) %>;
     var corrupt_newsletters = <%= json_encode(corrupt_newsletters) %>;
     var mailpoet_legacy_automatic_emails_count = <%= legacy_automatic_emails_count %>;
+    var mailpoet_legacy_automatic_emails_notice_dismissed = <%= json_encode(legacy_automatic_emails_notice_dismissed) %>;
 
   </script>
 <% endblock %>


### PR DESCRIPTION
## Description

This PR contains various fixes related to https://github.com/mailpoet/mailpoet/pull/5340:
1. When restoring only Woo emails [I don’t see them as restored](https://d.pr/i/0vWbB8) visually but only after page reload.
2. When trashing Woo emails, [I see the popup always as present](https://d.pr/i/vsbajC). Can’t be auto dismissed so it’s like not working, but it works.
3. The legacy automation notices [can’t be dismissed forever](https://d.pr/i/KDZQqs). After page reload - it is again present.
4. Woo emails are[ clickable only by the title](https://d.pr/i/iKQ3GO) but normal Automation emails are [clickable by the row itself](https://d.pr/i/resftl).
5. When on analytics page for Woo email, [I see I am on Emails and not on Automations page](https://d.pr/i/q5O2qO).

## Code review notes

Skipping code review as per: https://codep2.wordpress.com/2023/12/08/experiment-code-reviews-optional-in-january/

## QA notes

Please, check the cases listed in the description above + verify other newsletters still redirect to the old newsletter listing page.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5779]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5779]: https://mailpoet.atlassian.net/browse/MAILPOET-5779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ