### PR TITLE
Bump WooCommerce versions: minimum to 8.4, tested up to 8.5 [MAILPOET-5834]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -977,7 +977,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 8.3.0
+          woo_core_version: 8.4.0
           woo_subscriptions_version: 5.6.0
           woo_memberships_version: 1.23.1
           woo_blocks_version: 11.6.0
@@ -1015,7 +1015,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 8.3.0
+          woo_core_version: 8.4.0
           woo_subscriptions_version: 5.6.0
           woo_memberships_version: 1.24.0
           woo_blocks_version: 11.6.0

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 8.3.0
- * WC tested up to: 8.4.0
+ * WC requires at least: 8.4.0
+ * WC tested up to: 8.5.1
  *
  * @package WordPress
  * @author MailPoet


### PR DESCRIPTION
## Description

Bump WooCommerce versions: minimum to 8.4, tested up to 8.5

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5834]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5834]: https://mailpoet.atlassian.net/browse/MAILPOET-5834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ