### PR TITLE
Fix multisite tests failing on trunk [MAILPOET-5835]

### DIFF
--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -919,7 +919,7 @@ class SchedulerTest extends \MailPoetTest {
 
   public function _after() {
     if (is_int($this->wpUserId)) {
-      wp_delete_user($this->wpUserId);
+      is_multisite() ? wpmu_delete_user($this->wpUserId) : wp_delete_user($this->wpUserId);
     }
 
     parent::_after();


### PR DESCRIPTION
## Description

The fix for single-site was done in https://github.com/mailpoet/mailpoet/commit/895c2ad3e16420864284dad1491f65002def64a0, this commit adds a fix for multisite.

## Code review notes

Please merge after review. QA not needed.

## QA notes

QA not needed, only tests.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5835]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5835]: https://mailpoet.atlassian.net/browse/MAILPOET-5835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ