### PR TITLE
Remove gradients from email editor [MAILPOET-5824]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/button.ts
@@ -3,7 +3,7 @@ import { Block } from '@wordpress/blocks';
 
 /**
  * Disables Styles for button
- * Currently we are not able read these styles in renderer
+ * Currently we are not able to read these styles in renderer
  */
 function enhanceButtonBlock() {
   addFilter(

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -147,6 +147,12 @@ class SettingsController {
     // Enabling alignWide allows full width for specific blocks such as columns, heading, image, etc.
     $settings['alignWide'] = true;
 
+    // Disable gradients. We cannot render them in emails.
+    $settings['disableCustomGradients'] = true;
+    $settings['__experimentalFeatures']['color']['customGradient'] = false;
+    $settings['__experimentalFeatures']['color']['defaultGradients'] = false;
+    $settings['__experimentalFeatures']['color']['gradients'] = [];
+
     return $settings;
   }
 


### PR DESCRIPTION
## Description

We cannot render gradients in the emails, so we need to remove them for now.

## Code review notes

_N/A_

## QA notes

Users shouldn't be able to apply a gradient background to any element, like a button. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5824]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5824]: https://mailpoet.atlassian.net/browse/MAILPOET-5824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ