### PR TITLE
Add default spacing between blocks [MAILPOET-5816]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -70,9 +70,8 @@
   display: block; // Override flex to achieve height follow the length of the document
 
   // Because block editor uses .has-background class after setting a background color
-  // we want to reset margin and padding for this class to avoid unexpected spacing
+  // we want to reset padding for this class to avoid unexpected spacing
   .has-background {
-    margin: 0;
     padding: 0;
   }
 
@@ -94,7 +93,6 @@
 // For the WYSIWYG experience we don't want to display any margins between blocks in the editor
 .wp-block {
   clear: both; // for ensuring that floated elements (images) are cleared
-  margin: 0;
 }
 
 .edit-post-visual-editor__content-area .is-mobile-preview {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -339,6 +339,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\SettingsController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TopLevelPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Renderer::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Layout/FlexLayoutRenderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Layout/FlexLayoutRenderer.php
@@ -30,6 +30,8 @@ class FlexLayoutRenderer {
 
     $wpGeneratedStyles = wp_style_engine_get_styles($parsedBlock['attrs']['style'] ?? []);
     $styles = $wpGeneratedStyles['css'] ?? '';
+    $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
+    $styles .= 'margin-top: ' . $marginTop . ';';
     $justify = esc_attr($parsedBlock['attrs']['layout']['justifyContent'] ?? 'left');
     $styles .= 'text-align: ' . $justify;
     $outputHtml = str_replace('{style}', $styles, $outputHtml);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/PreprocessManager.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/PreprocessManager.php
@@ -5,6 +5,7 @@ namespace MailPoet\EmailEditor\Engine\Renderer;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\Preprocessor;
+use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TopLevelPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor;
 
@@ -16,12 +17,14 @@ class PreprocessManager {
     CleanupPreprocessor $cleanupPreprocessor,
     TopLevelPreprocessor $topLevelPreprocessor,
     BlocksWidthPreprocessor $blocksWidthPreprocessor,
-    TypographyPreprocessor $typographyPreprocessor
+    TypographyPreprocessor $typographyPreprocessor,
+    SpacingPreprocessor $spacingPreprocessor
   ) {
     $this->registerPreprocessor($cleanupPreprocessor);
     $this->registerPreprocessor($topLevelPreprocessor);
     $this->registerPreprocessor($blocksWidthPreprocessor);
     $this->registerPreprocessor($typographyPreprocessor);
+    $this->registerPreprocessor($spacingPreprocessor);
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessor.php
@@ -16,8 +16,8 @@ class SpacingPreprocessor implements Preprocessor {
 
   private function addMarginTopToBlocks(array $parsedBlocks): array {
     foreach ($parsedBlocks as $key => $block) {
-      // We don't want to add margin-top to column block
-      if ($key !== 0 && $block['blockName'] !== 'core/column') {
+      // We don't want to add margin-top to the first block in the email or to the first block in the columns block
+      if ($key !== 0) {
         $block['email_attrs']['margin-top'] = SettingsController::FLEX_GAP;
       }
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessor.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Renderer\Preprocessors;
+
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+/**
+ * This preprocessor is responsible for setting default spacing values for blocks.
+ * In the early development phase, we are setting only margin-top for blocks that are not first or last in the columns block.
+ */
+class SpacingPreprocessor implements Preprocessor {
+  public function preprocess(array $parsedBlocks, array $layoutStyles): array {
+    $parsedBlocks = $this->addMarginTopToBlocks($parsedBlocks);
+    return $parsedBlocks;
+  }
+
+  private function addMarginTopToBlocks(array $parsedBlocks): array {
+    foreach ($parsedBlocks as $key => $block) {
+      // We don't want to add margin-top to column block
+      if ($key !== 0 && $block['blockName'] !== 'core/column') {
+        $block['email_attrs']['margin-top'] = SettingsController::FLEX_GAP;
+      }
+
+      $block['innerBlocks'] = $this->addMarginTopToBlocks($block['innerBlocks'] ?? []);
+
+      $parsedBlocks[$key] = $block;
+    }
+
+    return $parsedBlocks;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
@@ -55,6 +55,11 @@ ol {
   margin-top: 0;
   padding: 0 0 0 40px;
 }
+/* Outlook was adding weird spaces around lists in some versions. Resetting vertical margin for list items solved it */
+li {
+  margin-bottom: 0;
+  margin-top: 0;
+}
 
 /* https://www.emailonacid.com/blog/article/email-development/tips-for-coding-email-preheaders */
 .email_preheader,

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
@@ -2,91 +2,6 @@
 /* Created based on original MailPoet template for rendering emails */
 /* StyleLint is disabled because some rules contain properties that linter marks as unknown, but they are valid for email rendering */
 /* stylelint-disable property-no-unknown */
-
-/* Base CSS resets to fix Browser quirks and ensure consistent display between email editor and email preview */
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
 body {
   margin: 0;
   padding: 0;
@@ -120,6 +35,16 @@ img {
 p {
   display: block;
   margin: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 0;
+  margin-top: 0;
 }
 
 /* Wa want ensure the same design for all email clients */

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
@@ -20,7 +20,7 @@
   <body style="word-spacing:normal;background:{{layout_background}};">
     <div class="email_layout_wrapper" style="background:{{layout_background}}">
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:{{width}};" width="{{width}}" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="margin: 0px auto; max-width: {{width}}">
+      <div style="margin:0px auto;max-width:{{width}}">
         <table
           align="center"
           border="0"

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -33,12 +33,6 @@ class SettingsController {
   const EMAIL_LAYOUT_BACKGROUND = '#cccccc';
 
   /**
-   * Padding of the email in pixels.
-   * @var string
-   */
-  const EMAIL_PADDING = '10px';
-
-  /**
    * Gap between blocks in flex layouts
    * @var string
    */
@@ -105,10 +99,10 @@ class SettingsController {
       'width' => self::EMAIL_WIDTH,
       'background' => self::EMAIL_LAYOUT_BACKGROUND,
       'padding' => [
-        'bottom' => self::EMAIL_PADDING,
-        'left' => self::EMAIL_PADDING,
-        'right' => self::EMAIL_PADDING,
-        'top' => self::EMAIL_PADDING,
+        'bottom' => self::FLEX_GAP,
+        'left' => self::FLEX_GAP,
+        'right' => self::FLEX_GAP,
+        'top' => self::FLEX_GAP,
       ],
     ];
   }

--- a/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
+++ b/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
@@ -18,3 +18,25 @@
 .is-mobile-preview .is-layout-email-flex .wp-block-button__link {
   width: 100%;
 }
+
+/*
+ * Email Editor specific styles for vertical gap between blocks in column.
+ * This is needed because we disable layout for core/column and core/columns blocks, and .is-layout-flex is not applied.
+ */
+.wp-block-columns:not(.is-not-stacked-on-mobile)
+  > .wp-block-column
+  > .wp-block:first-child {
+  margin-top: 0;
+}
+
+.wp-block-columns:not(.is-not-stacked-on-mobile)
+  > .wp-block-column
+  > .wp-block {
+  margin: var(--wp--style--block-gap, 16px) 0;
+}
+
+.wp-block-columns:not(.is-not-stacked-on-mobile)
+  > .wp-block-column
+  > .wp-block:last-child {
+  margin-bottom: 0;
+}

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -149,10 +149,10 @@
     "spacing": {
       "blockGap": "var(--wp--style--block-gap)",
       "padding": {
-        "bottom": "10px",
-        "left": "10px",
-        "right": "10px",
-        "top": "10px"
+        "bottom": "var(--wp--style--block-gap)",
+        "left": "var(--wp--style--block-gap)",
+        "right": "var(--wp--style--block-gap)",
+        "top": "var(--wp--style--block-gap)"
       }
     },
     "color": {

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -12,6 +12,7 @@
     },
     "spacing": {
       "units": ["px"],
+      "blockGap": true,
       "padding": true,
       "margin": false
     },
@@ -146,6 +147,7 @@
   },
   "styles": {
     "spacing": {
+      "blockGap": "var(--wp--style--block-gap)",
       "padding": {
         "bottom": "10px",
         "left": "10px",

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -29,6 +29,7 @@ class Columns implements BlockRenderer {
     $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
     $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
+    $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
 
     $align = $parsedBlock['attrs']['align'] ?? null;
     if ($align !== 'full') {
@@ -41,8 +42,15 @@ class Columns implements BlockRenderer {
 
     return '
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '"><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="margin:0px auto;max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
-        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';max-width:' . $width . ';width:100%;">
+      <div style="margin-top:' . $marginTop . ';max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
+        <table
+          align="center"
+          border="0"
+          cellpadding="0"
+          cellspacing="0"
+          role="presentation"
+          style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';max-width:' . $width . ';width:100%;"
+        >
           <tbody>
             <tr>
               <td style="font-size:0px;background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';text-align:left;">

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -19,44 +19,45 @@ class Heading implements BlockRenderer {
   private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
 
     $availableStylesheets = $settingsController->getAvailableStylesheets();
+    $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
 
     // Styles for padding need to be set on the wrapping table cell due to support in Outlook
-    $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
-    $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
-    $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
-    $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
-
     $styles = [
       'background-color' => $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent',
       'min-width' => '100%', // prevent Gmail App from shrinking the table on mobile devices
-      'padding-bottom' => $paddingBottom,
-      'padding-left' => $paddingLeft,
-      'padding-right' => $paddingRight,
-      'padding-top' => $paddingTop,
+      'padding-bottom' => $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px',
+      'padding-left' => $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px',
+      'padding-right' => $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px',
+      'padding-top' => $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px',
     ];
 
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
       if ($property === 'width') continue; // width is handled by the wrapping blocks (columns, column)
+      if ($property === 'margin-top') continue; // margin-top is set on the wrapping div co we need to avoid duplication
       $styles[$property] = $value;
     }
 
     $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs']));
 
     return '
-      <table
-        role="presentation"
-        border="0"
-        cellpadding="0"
-        cellspacing="0"
-        style="min-width: 100%;"
-        width="100%"
-      >
-        <tr>
-          <td style="' . $settingsController->convertStylesToString($styles) . '">
-            {heading_content}
-          </td>
-        </tr>
-      </table>
+      <!--[if mso | IE]><table align="left" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td><![endif]-->
+        <div style="margin-top: ' . $marginTop . ';">
+          <table
+            role="presentation"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            style="min-width: 100%;"
+            width="100%"
+          >
+            <tr>
+              <td style="' . $settingsController->convertStylesToString($styles) . '">
+                {heading_content}
+              </td>
+            </tr>
+          </table>
+        </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     ';
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -27,6 +27,7 @@ class Heading implements BlockRenderer {
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
 
     $styles = [
+      'background-color' => $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent',
       'min-width' => '100%', // prevent Gmail App from shrinking the table on mobile devices
       'padding-bottom' => $paddingBottom,
       'padding-left' => $paddingLeft,

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -112,6 +112,7 @@ class Image implements BlockRenderer {
 
     $styles['width'] = '100%';
     $align = $parsedBlock['attrs']['align'] ?? 'left';
+    $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
 
     return '
       <table
@@ -133,7 +134,7 @@ class Image implements BlockRenderer {
               width="' . $wrapperWidth . '"
             >
               <tr>
-                <td>{image_content}</td>
+                <td style="padding-top:' . $marginTop . '">{image_content}</td>
               </tr>
               <tr>
                 <td style="' . $captionStyles . '">{caption_content}</td>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -28,7 +28,21 @@ class ListBlock implements BlockRenderer {
       $blockContent = $html->get_updated_html();
     }
 
+    $wrapperStyle = $settingsController->convertStylesToString([
+      'margin-top' => $parsedBlock['email_attrs']['margin-top'] ?? '0px',
+    ]);
+
     // \WP_HTML_Tag_Processor escapes the content, so we have to replace it back
-    return str_replace('&#039;', "'", $blockContent);
+    $blockContent = str_replace('&#039;', "'", $blockContent);
+    $blockContent = str_replace('{listContent}', $blockContent, $this->getMarkup());
+    $blockContent = str_replace('{wrapperStyle}', $wrapperStyle, $blockContent);
+    return $blockContent;
+  }
+
+  private function getMarkup(): string {
+    return '
+      <div style="{wrapperStyle}">
+            {listContent}
+      </div>';
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -20,22 +20,20 @@ class Paragraph implements BlockRenderer {
     $availableStylesheets = $settingsController->getAvailableStylesheets();
 
     $align = $parsedBlock['attrs']['align'] ?? 'left';
-    $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
-    $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
-    $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
-    $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
+    $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
 
     $styles = [
       'background-color' => $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent',
       'text-align' => $align,
-      'padding-bottom' => $paddingBottom,
-      'padding-left' => $paddingLeft,
-      'padding-right' => $paddingRight,
-      'padding-top' => $paddingTop,
+      'padding-bottom' => $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px',
+      'padding-left' => $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px',
+      'padding-right' => $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px',
+      'padding-top' => $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px',
     ];
 
     foreach ($parsedBlock['email_attrs'] ?? [] as $property => $value) {
       if ($property === 'width') continue; // width is handled by the wrapping blocks (columns, column)
+      if ($property === 'margin-top') continue; // margin-top is set on the wrapping div co we need to avoid duplication
       $styles[$property] = $value;
     }
 
@@ -46,20 +44,17 @@ class Paragraph implements BlockRenderer {
     $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs'] ?? []));
 
     return '
-      <table
-        role="presentation"
-        border="0"
-        cellpadding="0"
-        cellspacing="0"
-        style="width:100%;"
-        width="100%"
-      >
-        <tr>
-          <td style="' . $settingsController->convertStylesToString($styles) . '" align="' . $align . '">
-            {paragraph_content}
-          </td>
-        </tr>
-      </table>
+      <!--[if mso | IE]><table align="left" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td><![endif]-->
+        <div style="margin-top: ' . $marginTop . ';">
+          <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;"width="100%">
+            <tr>
+              <td style="' . $settingsController->convertStylesToString($styles) . '" align="' . $align . '">
+                {paragraph_content}
+              </td>
+            </tr>
+          </table>
+        </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     ';
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -26,6 +26,7 @@ class Paragraph implements BlockRenderer {
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
 
     $styles = [
+      'background-color' => $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent',
       'text-align' => $align,
       'padding-bottom' => $paddingBottom,
       'padding-left' => $paddingLeft,

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/PreprocessManagerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/PreprocessManagerTest.php
@@ -5,6 +5,7 @@ namespace unit\EmailEditor\Engine\Renderer;
 use MailPoet\EmailEditor\Engine\Renderer\PreprocessManager;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
+use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TopLevelPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor;
 
@@ -32,10 +33,13 @@ class PreprocessManagerTest extends \MailPoetUnitTest {
     $typography = $this->createMock(TypographyPreprocessor::class);
     $typography->expects($this->once())->method('preprocess')->willReturn([]);
 
+    $spacing = $this->createMock(SpacingPreprocessor::class);
+    $spacing->expects($this->once())->method('preprocess')->willReturn([]);
+
     $secondPreprocessor = $this->createMock(TopLevelPreprocessor::class);
     $secondPreprocessor->expects($this->once())->method('preprocess')->willReturn([]);
 
-    $preprocessManager = new PreprocessManager($cleanup, $topLevel, $blocksWidth, $typography);
+    $preprocessManager = new PreprocessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing);
     $preprocessManager->registerPreprocessor($secondPreprocessor);
     verify($preprocessManager->preprocess([], $layoutStyles))->equals([]);
   }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessorTest.php
@@ -76,7 +76,6 @@ class SpacingPreprocessorTest extends \MailPoetUnitTest {
     verify($firstColumns)->arrayHasNotKey('email_attrs');
     verify($secondColumns['email_attrs'])->equals($expectedEmailAttrs);
     verify($firstColumns['innerBlocks'][0])->arrayHasNotKey('email_attrs');
-    verify($firstColumns['innerBlocks'][1])->arrayHasNotKey('email_attrs');
     verify($secondColumns['innerBlocks'][0])->arrayHasNotKey('email_attrs');
     // Verify margins for the first columns blocks
     $firstColumn = $firstColumns['innerBlocks'][0];

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/SpacingPreprocessorTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Engine\Renderer\Preprocessors;
+
+use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
+use MailPoet\EmailEditor\Engine\SettingsController;
+
+class SpacingPreprocessorTest extends \MailPoetUnitTest {
+
+  /** @var SpacingPreprocessor */
+  private $preprocessor;
+
+  public function _before() {
+    parent::_before();
+    $this->preprocessor = new SpacingPreprocessor();
+  }
+
+  public function testItAddsDefaultVerticalSpacing(): void {
+    $blocks = [
+      [
+        'blockName' => 'core/columns',
+        'attrs' => [],
+        'innerBlocks' => [
+          [
+            'blockName' => 'core/column',
+            'attrs' => [],
+            'innerBlocks' => [
+              [
+                'blockName' => 'core/list',
+                'attrs' => [],
+                'innerBlocks' => [],
+              ],
+              [
+                'blockName' => 'core/img',
+                'attrs' => [],
+                'innerBlocks' => [],
+              ],
+            ],
+          ],
+          [
+            'blockName' => 'core/column',
+            'attrs' => [],
+            'innerBlocks' => [
+              [
+                'blockName' => 'core/heading',
+                'attrs' => [],
+                'innerBlocks' => [],
+              ],
+              [
+                'blockName' => 'core/paragraph',
+                'attrs' => [],
+                'innerBlocks' => [],
+              ],
+            ],
+          ],
+        ],
+      ],
+      [
+        'blockName' => 'core/columns',
+        'attrs' => [],
+        'innerBlocks' => [
+          [
+            'blockName' => 'core/column',
+            'attrs' => [],
+            'innerBlocks' => [],
+          ],
+        ],
+      ],
+    ];
+
+    $expectedEmailAttrs = ['margin-top' => SettingsController::FLEX_GAP];
+    $result = $this->preprocessor->preprocess($blocks, []);
+    verify($result)->arrayCount(2);
+    $firstColumns = $result[0];
+    $secondColumns = $result[1];
+    verify($firstColumns)->arrayHasNotKey('email_attrs');
+    verify($secondColumns['email_attrs'])->equals($expectedEmailAttrs);
+    verify($firstColumns['innerBlocks'][0])->arrayHasNotKey('email_attrs');
+    verify($firstColumns['innerBlocks'][1])->arrayHasNotKey('email_attrs');
+    verify($secondColumns['innerBlocks'][0])->arrayHasNotKey('email_attrs');
+    // Verify margins for the first columns blocks
+    $firstColumn = $firstColumns['innerBlocks'][0];
+    verify($firstColumn['innerBlocks'][0])->arrayHasNotKey('email_attrs');
+    verify($firstColumn['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs);
+    $secondColumn = $firstColumns['innerBlocks'][1];
+    verify($secondColumn['innerBlocks'][0])->arrayHasNotKey('email_attrs');
+    verify($secondColumn['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs);
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -16,8 +16,9 @@ class SettingsControllerTest extends \MailPoetUnitTest {
   public function testItGetsCorrectLayoutWidthWithoutPadding(): void {
     $settingsController = new SettingsController();
     $layoutWidth = $settingsController->getLayoutWidthWithoutPadding();
-    // default width is 660px and padding for left and right is 10px
-    verify($layoutWidth)->equals('640px');
+    // default width is 660px and if we subtract padding from left and right we must get the correct value
+    $expectedWidth = (int)SettingsController::EMAIL_WIDTH - (int)SettingsController::FLEX_GAP * 2;
+    verify($layoutWidth)->equals($expectedWidth . 'px');
   }
 
   public function testItConvertsStylesToString(): void {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

- I decided to use the `FLEX_GAP` constant as a default padding in the email because the unified spaces look better.
- As a part of this PR, it is removing some reset CSS styles because it makes the rendered HTML not transparent.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5816]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5716]: https://mailpoet.atlassian.net/browse/MAILPOET-5716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-5816]: https://mailpoet.atlassian.net/browse/MAILPOET-5816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ