### PR TITLE
Block sending existing campaigns for big senders    if sender domain is not authorized

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -193,7 +193,7 @@ class Newsletters extends APIEndpoint {
       ]);
     }
 
-    if ($status === NewsletterEntity::STATUS_ACTIVE && !$this->authorizedEmailsController->isSenderAddressValidForActivation($newsletter)) {
+    if ($status === NewsletterEntity::STATUS_ACTIVE && !$this->authorizedEmailsController->isSenderAddressValid($newsletter)) {
           return $this->errorResponse([
             APIError::FORBIDDEN => __('The sender address is not an authorized sender domain.', 'mailpoet'),
           ], [], Response::STATUS_FORBIDDEN);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron\Workers\SendingQueue;
 
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
@@ -19,14 +20,19 @@ class SendingErrorHandler {
   /** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
 
+  /** @var LoggerFactory */
+  private $loggerFactory;
+
   public function __construct(
     ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
     SendingThrottlingHandler $throttlingHandler,
-    SendingQueuesRepository $sendingQueuesRepository
+    SendingQueuesRepository $sendingQueuesRepository,
+    LoggerFactory $loggerFactory
   ) {
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
     $this->throttlingHandler = $throttlingHandler;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->loggerFactory = $loggerFactory;
   }
 
   public function processError(
@@ -63,6 +69,14 @@ class SendingErrorHandler {
     $queue = $task->getSendingQueue();
 
     if ($queue instanceof SendingQueueEntity) {
+      if ($error->getOperation() === MailerError::OPERATION_DOMAIN_AUTHORIZATION) {
+        $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->info(
+          'Paused task in sending queue due to sender domain authorization error',
+          ['task_id' => $task->getId()]
+        );
+        $this->sendingQueuesRepository->pause($queue);
+        return;
+      }
       $this->sendingQueuesRepository->updateCounts($queue);
     }
   }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -308,6 +308,8 @@ class SendingQueue {
       $this->reScheduleBounceTask();
 
       // Check task has not been paused before continue processing
+      // This is needed because the task can be paused in the middle of the batch processing,
+      // for example on API error ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN
       if ($task->getStatus() === ScheduledTaskEntity::STATUS_PAUSED) {
         return;
       }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -307,6 +307,11 @@ class SendingQueue {
       // reschedule bounce task to run sooner, if needed
       $this->reScheduleBounceTask();
 
+      // Check task has not been paused before continue processing
+      if ($task->getStatus() === ScheduledTaskEntity::STATUS_PAUSED) {
+        return;
+      }
+
       if ($newsletter->getStatus() !== NewsletterEntity::STATUS_CORRUPT) {
         $this->processQueue(
           $task,

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -57,6 +57,7 @@ class NewsletterEntity {
   const CAMPAIGN_TYPES = [
     NewsletterEntity::TYPE_STANDARD,
     NewsletterEntity::TYPE_NOTIFICATION,
+    NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
     NewsletterEntity::TYPE_RE_ENGAGEMENT,
   ];
 

--- a/mailpoet/lib/Mailer/MailerError.php
+++ b/mailpoet/lib/Mailer/MailerError.php
@@ -6,6 +6,7 @@ class MailerError {
   const OPERATION_CONNECT = 'connect';
   const OPERATION_SEND = 'send';
   const OPERATION_AUTHORIZATION = 'authorization';
+  const OPERATION_DOMAIN_AUTHORIZATION = 'domain_authorization';
   const OPERATION_INSUFFICIENT_PRIVILEGES = 'insufficient_privileges';
   const OPERATION_SUBSCRIBER_LIMIT_REACHED = 'subscriber_limit_reached';
   const OPERATION_EMAIL_LIMIT_REACHED = 'email_limit_reached';

--- a/mailpoet/lib/Mailer/Methods/MailPoet.php
+++ b/mailpoet/lib/Mailer/Methods/MailPoet.php
@@ -82,21 +82,28 @@ class MailPoet implements MailerMethod {
   }
 
   public function processSendError($result, $subscriber, $newsletter) {
-    if (!empty($result['code'])) {
-      if ($result['code'] === API::RESPONSE_CODE_KEY_INVALID) {
-        $this->bridge->invalidateMssKey();
-      } elseif (
-        ($result['code'] === API::RESPONSE_CODE_CAN_NOT_SEND
-          && $result['error'] === API::ERROR_MESSAGE_INVALID_FROM
-        )
-        ||
-        ($result['code'] === API::RESPONSE_CODE_PAYLOAD_ERROR
-          && !empty($result['error']) && $result['error'] === API::ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN
-        )
-      ) {
-          $this->authorizedEmailsController->checkAuthorizedEmailAddresses();
-      }
+    if (empty($result['code'])) {
+      return $this->errorMapper->getErrorForResult($result, $subscriber, $this->sender, $newsletter);
     }
+
+    switch ($result['code']) {
+      case API::RESPONSE_CODE_KEY_INVALID:
+        $this->bridge->invalidateMssKey();
+        break;
+
+      case API::RESPONSE_CODE_CAN_NOT_SEND:
+        if ($result['error'] === API::ERROR_MESSAGE_INVALID_FROM) {
+          $this->authorizedEmailsController->checkAuthorizedEmailAddresses();
+        }
+        break;
+
+      case API::RESPONSE_CODE_PAYLOAD_ERROR:
+        if (!empty($result['error']) && $result['error'] === API::ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN) {
+          $this->authorizedEmailsController->checkAuthorizedEmailAddresses();
+        }
+        break;
+    }
+
     return $this->errorMapper->getErrorForResult($result, $subscriber, $this->sender, $newsletter);
   }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -153,16 +153,16 @@ class AuthorizedEmailsController {
     }
   }
 
-  public function isSenderAddressValidForActivation(NewsletterEntity $newsletter): bool {
-    if ($this->settings->get('mta.method') !== Mailer::METHOD_MAILPOET) {
-      return true;
-    }
-
+  public function isSenderAddressValid(NewsletterEntity $newsletter, string $context = 'activation'): bool {
     if (!in_array($newsletter->getType(), NewsletterEntity::CAMPAIGN_TYPES)) {
       return true;
     }
 
-    if (!$this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns()) {
+    $isAuthorizedDomainRequired = $context === 'activation' ?
+      $this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns() :
+      $this->senderDomainController->isAuthorizedDomainRequiredForExistingCampaigns();
+
+    if (!$isAuthorizedDomainRequired) {
       return true;
     }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -166,7 +166,10 @@ class AuthorizedEmailsController {
       return true;
     }
 
-    $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
+    $verifiedDomains = $context === 'activation' ?
+      $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache() :
+      $this->senderDomainController->getVerifiedSenderDomains();
+
     return $this->validateEmailDomainIsVerified($verifiedDomains, $newsletter->getSenderAddress());
   }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -158,17 +158,17 @@ class AuthorizedEmailsController {
       return true;
     }
 
-    $isAuthorizedDomainRequired = $context === 'activation' ?
-      $this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns() :
-      $this->senderDomainController->isAuthorizedDomainRequiredForExistingCampaigns();
+    $isAuthorizedDomainRequired = $context === 'activation'
+      ? $this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns()
+      : $this->senderDomainController->isAuthorizedDomainRequiredForExistingCampaigns();
 
     if (!$isAuthorizedDomainRequired) {
       return true;
     }
 
-    $verifiedDomains = $context === 'activation' ?
-      $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache() :
-      $this->senderDomainController->getVerifiedSenderDomains();
+    $verifiedDomains = $context === 'activation'
+      ? $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache()
+      : $this->senderDomainController->getVerifiedSenderDomains();
 
     return $this->validateEmailDomainIsVerified($verifiedDomains, $newsletter->getSenderAddress());
   }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -291,7 +291,7 @@ class AuthorizedSenderDomainController {
     return $this->subscribers->getSubscribersCount() > self::UPPER_LIMIT;
   }
 
-  private function restrictionsApply() {
+  private function restrictionsApply(): bool {
     if ($this->settingsController->get('mta.method') !== Mailer::METHOD_MAILPOET) {
       return false;
     }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -11,10 +11,6 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class AuthorizedSenderDomainController {
-  const DOMAIN_VERIFICATION_STATUS_VALID = 'valid';
-  const DOMAIN_VERIFICATION_STATUS_INVALID = 'invalid';
-  const DOMAIN_VERIFICATION_STATUS_PENDING = 'pending';
-
   const OVERALL_STATUS_VERIFIED = 'verified';
   const OVERALL_STATUS_PARTIALLY_VERIFIED = 'partially-verified';
   const OVERALL_STATUS_UNVERIFIED = 'unverified';
@@ -85,11 +81,6 @@ class AuthorizedSenderDomainController {
    */
   public function getAllSenderDomains(): array {
     return $this->returnAllDomains($this->getAllRecords());
-  }
-
-  public function getAllSenderDomainsIgnoringCache(): array {
-    $this->currentRecords = null;
-    return $this->getAllSenderDomains();
   }
 
   /**

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -275,7 +275,11 @@ class AuthorizedSenderDomainController {
     return $this->subscribers->getSubscribersCount() <= self::LOWER_LIMIT;
   }
 
-  public function isAuthorizedDomainRequiredForNewCampaigns(): bool {
+  public function isBigSender(): bool {
+    return $this->subscribers->getSubscribersCount() > self::UPPER_LIMIT;
+  }
+
+  private function restrictionsApply() {
     if ($this->settingsController->get('mta.method') !== Mailer::METHOD_MAILPOET) {
       return false;
     }
@@ -285,6 +289,14 @@ class AuthorizedSenderDomainController {
       return false;
     }
 
-    return !$this->isSmallSender();
+    return true;
+  }
+
+  public function isAuthorizedDomainRequiredForNewCampaigns(): bool {
+    return $this->restrictionsApply() && !$this->isSmallSender();
+  }
+
+  public function isAuthorizedDomainRequiredForExistingCampaigns(): bool {
+    return $this->restrictionsApply() && $this->isBigSender();
   }
 }

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -31,6 +31,7 @@ class API {
   public const ERROR_MESSAGE_INVALID_FROM = 'The email address is not authorized';
   public const ERROR_MESSAGE_PENDING_APPROVAL = 'Key is valid, but not approved yet; you can send only to authorized email addresses at the moment';
   public const ERROR_MESSAGE_DMRAC = "Email violates Sender Domain's DMARC policy. Please set up sender authentication.";
+  public const ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN = 'Bulk email are forbidden for the sender address';
   // Bridge message from https://github.com/mailpoet/services-bridge/blob/master/extensions/authentication/basic_strategy.rb
   public const ERROR_MESSAGE_UNAUTHORIZED = 'No valid API key provided';
   public const ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges';
@@ -363,6 +364,8 @@ class API {
         return __('Key is valid, but not approved yet; you can send only to authorized email addresses at the moment.', 'mailpoet');
       case self::ERROR_MESSAGE_DMRAC:
         return __("Email violates Sender Domain's DMARC policy. Please set up sender authentication.", 'mailpoet');
+      case self::ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN:
+        return __('Email violates Sender Domain requirements. Please authenticate the sender domain.', 'mailpoet');
       case self::ERROR_MESSAGE_UNAUTHORIZED:
         return __('No valid API key provided.', 'mailpoet');
       case self::ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES:

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -236,7 +236,7 @@ class NewslettersTest extends \MailPoetTest {
       'cronHelper' => $this->cronHelper,
       'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true]),
       'authorizedEmailsController' => Stub::make(AuthorizedEmailsController::class, [
-        'isSenderAddressValidForActivation' => Expected::once(false),
+        'isSenderAddressValid' => Expected::once(false),
       ]),
     ]);
     $res = $endpoint->setStatus([

--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -551,7 +551,7 @@ class ServicesTest extends \MailPoetTest {
 
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
-      'getVerifiedSenderDomains' => Expected::once($verifiedDomains),
+      'getVerifiedSenderDomainsIgnoringCache' => Expected::once($verifiedDomains),
     ]);
 
     $servicesEndpoint = $this->createServicesEndpointWithMocks([

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingErrorHandlerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingErrorHandlerTest.php
@@ -6,9 +6,13 @@ use Codeception\Stub;
 use Codeception\Stub\Expected;
 use MailPoet\Cron\Workers\SendingQueue\SendingErrorHandler;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\SubscriberError;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoetVendor\Monolog\Logger;
 
 class SendingErrorHandlerTest extends \MailPoetTest {
   public function testItShouldProcessSoftErrorCorrectly() {
@@ -51,5 +55,34 @@ class SendingErrorHandlerTest extends \MailPoetTest {
       ]
     );
     $errorHandler->processError($error, new ScheduledTaskEntity(), $subscriberIds, $subscribers);
+  }
+
+  public function testItShouldProcessSoftErrorForDomainAuthorizationCorrectly() {
+    $error = new MailerError(
+      MailerError::OPERATION_DOMAIN_AUTHORIZATION,
+      MailerError::LEVEL_SOFT,
+      'Email violates Sender Domain requirements. Please authenticate the sender domain.',
+      null,
+      []
+    );
+    $sendingQueuesRepository = Stub::make(
+      SendingQueuesRepository::class,
+      ['pause' => Expected::once()],
+    );
+
+    $errorHandler = $this->getServiceWithOverrides(
+      SendingErrorHandler::class, [
+        'sendingQueuesRepository' => $sendingQueuesRepository,
+        'loggerFactory' => Stub::makeEmpty(
+          LoggerFactory::class,
+          ['getLogger' => Stub::makeEmpty(Logger::class, ['info' => Expected::once()])]
+        ),
+      ]
+    );
+
+    $sendingQueue = new SendingQueueEntity();
+    $taskEntity = Stub::make(ScheduledTaskEntity::class, ['getSendingQueue' => $sendingQueue]);
+
+    $errorHandler->processError($error, $taskEntity, [], []);
   }
 }

--- a/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/MailPoetAPITest.php
@@ -277,6 +277,24 @@ class MailPoetAPITest extends \MailPoetTest {
     verify($result['error']->getOperation())->equals(MailerError::OPERATION_SEND);
   }
 
+  public function testFormatPayloadDomainAuthenticationError() {
+    $this->mailer->api = Stub::makeEmpty(
+      'MailPoet\Services\Bridge\API',
+      ['sendMessages' => [
+        'code' => API::RESPONSE_CODE_PAYLOAD_ERROR,
+        'status' => API::SENDING_STATUS_SEND_ERROR,
+        'error' => API::ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN,
+        'message' => 'Api Error',
+      ]],
+      $this
+    );
+    $result = $this->mailer->send([$this->newsletter, $this->newsletter], ['a@example.com', 'c d <b@example.com>']);
+    verify($result['response'])->false();
+    verify($result['error'])->instanceOf(MailerError::class);
+    verify($result['error']->getOperation())->equals(MailerError::OPERATION_DOMAIN_AUTHORIZATION);
+    verify($result['error']->getLevel())->equals(MailerError::LEVEL_SOFT);
+  }
+
   public function testFormatPayloadErrorWithErrorMessage() {
     $this->mailer->api = Stub::makeEmpty(
       'MailPoet\Services\Bridge\API',

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -284,7 +284,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
       'isAuthorizedDomainRequiredForExistingCampaigns' => Expected::once(true),
-      'getVerifiedSenderDomainsIgnoringCache' => Expected::once($verifiedDomains),
+      'getVerifiedSenderDomains' => Expected::once($verifiedDomains),
     ]);
 
     $newsletter = new NewsletterEntity();

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -362,12 +362,25 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
     $this->settings->set('version', MAILPOET_VERSION);
     $this->settings->set('installed_after_new_domain_restrictions', '1');
 
-    // Is big sender
+    // Is not small sender
     $subscribersMock = $this->make(Subscribers::class, [
       'getSubscribersCount' => Expected::once(501),
     ]);
 
     $this->assertTrue($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForNewCampaigns());
+  }
+
+  public function testIsAuthorizedDomainRequiredForExistingCampaigns(): void {
+    // Is new user
+    $this->settings->set('version', MAILPOET_VERSION);
+    $this->settings->set('installed_after_new_domain_restrictions', '1');
+
+    // Is Big Sender
+    $subscribersMock = $this->make(Subscribers::class, [
+      'getSubscribersCount' => Expected::once(1001),
+    ]);
+
+    $this->assertTrue($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForExistingCampaigns());
   }
 
   public function testNotIsAuthorizedDomainRequiredForNewCampaignsForExistingUsersBeforeEnforcementDate(): void {
@@ -391,7 +404,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
     // After EnforcementDate
     Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:01 UTC'));
 
-    // Is big sender
+    // Is not small sender
     $subscribersMock = $this->make(Subscribers::class, [
       'getSubscribersCount' => Expected::once(501),
     ]);

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -67,13 +67,20 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
   public function testItReturnsVerifiedSenderDomains() {
     $bridgeResponse = [
-      'mailpoet.com' => Bridge\BridgeTestMockAPI::VERIFIED_DOMAIN_RESPONSE['dns'],
-      'good' => ['data'],
-      'testdomain.com' => ['data'],
+      [
+        'domain' => 'mailpoet.com',
+        'domain_status' => 'verified',
+        'dns' => Bridge\BridgeTestMockAPI::VERIFIED_DOMAIN_RESPONSE['dns'],
+        ],
+      [
+        'domain' => 'testdomain.com',
+        'domain_status' => 'unverified',
+        'dns' => [],
+      ],
     ];
 
     $bridgeMock = $this->make(Bridge::class, [
-      'getAuthorizedSenderDomains' => Expected::once($bridgeResponse),
+      'getRawSenderDomainData' => Expected::once($bridgeResponse),
     ]);
 
     $controller = $this->getController($bridgeMock);
@@ -84,16 +91,22 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
   public function testItReturnsEmptyArrayWhenNoVerifiedSenderDomains() {
     $expectation = Expected::once([]); // with empty array
 
-    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedSenderDomains' => $expectation]);
+    $bridgeMock = $this->make(Bridge::class, ['getRawSenderDomainData' => $expectation]);
     $controller = $this->getController($bridgeMock);
 
     $verifiedDomains = $controller->getVerifiedSenderDomains();
     verify($verifiedDomains)->same([]);
 
-    $domains = ['testdomain.com' => []];
+    $domains = [
+      [
+        'domain' => 'testdomain.com',
+        'domain_status' => 'unverified',
+        'dns' => [],
+      ],
+    ];
     $expectation = Expected::once($domains);
 
-    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedSenderDomains' => $expectation]);
+    $bridgeMock = $this->make(Bridge::class, ['getRawSenderDomainData' => $expectation]);
     $controller = $this->getController($bridgeMock);
     $verifiedDomains = $controller->getVerifiedSenderDomains();
     verify($verifiedDomains)->same([]);

--- a/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
+++ b/mailpoet/tests/integration/Services/BridgeTestMockAPI.php
@@ -29,6 +29,13 @@ class BridgeTestMockAPI extends API {
         'status' => 'valid',
         'message' => '',
       ],
+      [
+        'host' => '_dmarc.example.com',
+        'value' => 'v=DMARC1; p=none;',
+        'type' => 'TXT',
+        'status' => 'valid',
+        'message' => '',
+      ],
     ],
     'status' => API::RESPONSE_STATUS_OK,
   ];


### PR DESCRIPTION
## Description

Implements the remaining sending rules regarding sender domain authentication.

If using MSS and is a big sender (>1000 subscribers), existing campaigns with unauthenticated domains will be paused during sending.

This rule will be applied to existing users on February 1st.

## Code review notes

I have added a transient to reduce the number of API calls.
The function `checkAuthorizedEmailAddresses` uses `getVerifiedSenderDomainsIgnoringCache` that resets the transient. I believe this function is used in all the places where we would need to update the verified sender domains but please double check I did not forget anything.


## QA notes

We can't test yet the errors from the API but you can test the check before sending:

Reduce the lower_limit and upper_limit so that your subscribers number > upper_limit
Activate a post notification that sends immediately and that uses a verified domain as sender address.
Remove the verified domain from the shop (make sure the address is still authenticated)
Publish a post
Check that the post notification history is not sent and it is paused.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5832]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5832]: https://mailpoet.atlassian.net/browse/MAILPOET-5832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ