### PR TITLE
Email editor – font styles + default button block  [MAILPOET-5740][MAILPOET-5814]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -69,12 +69,11 @@ class TypographyPreprocessor implements Preprocessor {
 
   private function setDefaultsFromTheme(array $block): array {
     $themeData = $this->settingsController->getTheme()->get_data();
-    $contentStyles = $this->settingsController->getEmailContentStyles();
     if (!($block['email_attrs']['color'] ?? '')) {
       $block['email_attrs']['color'] = $themeData['styles']['color']['text'] ?? null;
     }
     if (!($block['email_attrs']['font-size'] ?? '')) {
-      $block['email_attrs']['font-size'] = $contentStyles['typography']['fontSize'];
+      $block['email_attrs']['font-size'] = $themeData['styles']['typography']['fontSize'];
     }
     return $block;
   }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -55,7 +55,7 @@ class TypographyPreprocessor implements Preprocessor {
       $emailAttrs['color'] = $block['attrs']['style']['color']['text'];
     }
     if (isset($block['attrs']['fontFamily'])) {
-      $emailAttrs['font-family'] = $block['attrs']['fontFamily'];
+      $emailAttrs['font-family'] = $this->getFontFamilyBySlug($block['attrs']['fontFamily']);
     }
     if (isset($block['attrs']['style']['typography']['fontSize'])) {
       $emailAttrs['font-size'] = $block['attrs']['style']['typography']['fontSize'];
@@ -84,5 +84,16 @@ class TypographyPreprocessor implements Preprocessor {
       $block['email_attrs']['font-family'] = $contentStyles['typography']['fontFamily'];
     }
     return $block;
+  }
+
+  private function getFontFamilyBySlug(string $slug): ?string {
+    $themeData = $this->settingsController->getTheme()->get_data();
+    $fontFamilies = $themeData['settings']['typography']['fontFamilies'] ?? [];
+    foreach ($fontFamilies as $fontFamily) {
+      if ($fontFamily['slug'] === $slug) {
+        return $fontFamily['fontFamily'];
+      }
+    }
+    return null;
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -53,6 +53,12 @@ class TypographyPreprocessor implements Preprocessor {
     if (isset($block['attrs']['style']['color']['text'])) {
       $emailAttrs['color'] = $block['attrs']['style']['color']['text'];
     }
+    // In case the fontSize is set via a slug (small, medium, large, etc.) we translate it to a number
+    // The font size slug is set in $block['attrs']['fontSize'] and value in $block['attrs']['style']['typography']['fontSize']
+    if (isset($block['attrs']['fontSize'])) {
+      $block['attrs']['style']['typography']['fontSize'] = $this->settingsController->translateSlugToFontSize($block['attrs']['fontSize']);
+    }
+    // Pass font size to email_attrs
     if (isset($block['attrs']['style']['typography']['fontSize'])) {
       $emailAttrs['font-size'] = $block['attrs']['style']['typography']['fontSize'];
     }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -12,7 +12,6 @@ class TypographyPreprocessor implements Preprocessor {
   private const TYPOGRAPHY_STYLES = [
     'color',
     'font-size',
-    'font-family',
     'text-decoration',
   ];
 
@@ -54,9 +53,6 @@ class TypographyPreprocessor implements Preprocessor {
     if (isset($block['attrs']['style']['color']['text'])) {
       $emailAttrs['color'] = $block['attrs']['style']['color']['text'];
     }
-    if (isset($block['attrs']['fontFamily'])) {
-      $emailAttrs['font-family'] = $this->getFontFamilyBySlug($block['attrs']['fontFamily']);
-    }
     if (isset($block['attrs']['style']['typography']['fontSize'])) {
       $emailAttrs['font-size'] = $block['attrs']['style']['typography']['fontSize'];
     }
@@ -80,20 +76,6 @@ class TypographyPreprocessor implements Preprocessor {
     if (!($block['email_attrs']['font-size'] ?? '')) {
       $block['email_attrs']['font-size'] = $contentStyles['typography']['fontSize'];
     }
-    if (!($block['email_attrs']['font-family'] ?? '')) {
-      $block['email_attrs']['font-family'] = $contentStyles['typography']['fontFamily'];
-    }
     return $block;
-  }
-
-  private function getFontFamilyBySlug(string $slug): ?string {
-    $themeData = $this->settingsController->getTheme()->get_data();
-    $fontFamilies = $themeData['settings']['typography']['fontFamilies'] ?? [];
-    foreach ($fontFamilies as $fontFamily) {
-      if ($fontFamily['slug'] === $slug) {
-        return $fontFamily['fontFamily'];
-      }
-    }
-    return null;
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessor.php
@@ -54,8 +54,8 @@ class TypographyPreprocessor implements Preprocessor {
     if (isset($block['attrs']['style']['color']['text'])) {
       $emailAttrs['color'] = $block['attrs']['style']['color']['text'];
     }
-    if (isset($block['attrs']['style']['typography']['fontFamily'])) {
-      $emailAttrs['font-family'] = $block['attrs']['style']['typography']['fontFamily'];
+    if (isset($block['attrs']['fontFamily'])) {
+      $emailAttrs['font-family'] = $block['attrs']['fontFamily'];
     }
     if (isset($block['attrs']['style']['typography']['fontSize'])) {
       $emailAttrs['font-size'] = $block['attrs']['style']['typography']['fontSize'];
@@ -79,6 +79,9 @@ class TypographyPreprocessor implements Preprocessor {
     }
     if (!($block['email_attrs']['font-size'] ?? '')) {
       $block['email_attrs']['font-size'] = $contentStyles['typography']['fontSize'];
+    }
+    if (!($block['email_attrs']['font-family'] ?? '')) {
+      $block['email_attrs']['font-family'] = $contentStyles['typography']['fontFamily'];
     }
     return $block;
   }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -49,6 +49,7 @@ class Renderer {
     $renderedBody = $this->renderBlocks($parsedBlocks);
 
     $styles = (string)file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_STYLES_FILE);
+    $styles .= $this->settingsController->getStylesheetForRendering();
     $styles = apply_filters('mailpoet_email_renderer_styles', $styles, $post);
 
     $template = (string)file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_FILE);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -45,6 +45,7 @@ class Renderer {
     $layoutStyles = $this->settingsController->getEmailLayoutStyles();
     $themeData = $this->settingsController->getTheme()->get_data();
     $contentBackground = $themeData['styles']['color']['background'] ?? $layoutStyles['background'];
+    $contentFontFamily = $themeData['styles']['typography']['fontFamily'];
     $parsedBlocks = $this->preprocessManager->preprocess($parsedBlocks, $layoutStyles);
     $renderedBody = $this->renderBlocks($parsedBlocks);
 
@@ -54,10 +55,10 @@ class Renderer {
 
     $template = (string)file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_FILE);
 
-    // Apply layout styles
+    // Replace style settings placeholders with values
     $template = str_replace(
-      ['{{width}}', '{{layout_background}}', '{{content_background}}', '{{padding_top}}', '{{padding_right}}', '{{padding_bottom}}', '{{padding_left}}'],
-      [$layoutStyles['width'], $layoutStyles['background'], $contentBackground, $layoutStyles['padding']['top'], $layoutStyles['padding']['right'], $layoutStyles['padding']['bottom'], $layoutStyles['padding']['left']],
+      ['{{width}}', '{{layout_background}}', '{{content_background}}', '{{content_font_family}}', '{{padding_top}}', '{{padding_right}}', '{{padding_bottom}}', '{{padding_left}}'],
+      [$layoutStyles['width'], $layoutStyles['background'], $contentBackground, $contentFontFamily, $layoutStyles['padding']['top'], $layoutStyles['padding']['right'], $layoutStyles['padding']['bottom'], $layoutStyles['padding']['left']],
       $template
     );
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template.html
@@ -50,6 +50,7 @@
                 style="
                   direction: ltr;
                   font-size: 0px;
+                  font-family: {{content_font_family}};
                   padding-bottom: {{padding_bottom}};
                   padding-top: {{padding_top}};
                   text-align: center;

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -56,45 +56,6 @@ class SettingsController {
    */
   const FLEX_GAP = '16px';
 
-  /**
-   * Default styles applied to the email. These are going to be replaced by style settings.
-   * This is currently more af a proof of concept that we can apply styles to the email.
-   * We will gradually replace these hardcoded values with styles saved as global styles or styles saved with the email.
-   * @var array
-   */
-  const DEFAULT_EMAIL_CONTENT_STYLES = [
-    'h1' => [
-      'typography' => [
-        'fontSize' => '32px',
-      ],
-    ],
-    'h2' => [
-      'typography' => [
-        'fontSize' => '24px',
-      ],
-    ],
-    'h3' => [
-      'typography' => [
-        'fontSize' => '18px',
-      ],
-    ],
-    'h4' => [
-      'typography' => [
-        'fontSize' => '16px',
-      ],
-    ],
-    'h5' => [
-      'typography' => [
-        'fontSize' => '14px',
-      ],
-    ],
-    'h6' => [
-      'typography' => [
-        'fontSize' => '12px',
-      ],
-    ],
-  ];
-
   private $availableStylesheets = '';
 
   public function getSettings(): array {
@@ -162,10 +123,6 @@ class SettingsController {
       'contentSize' => self::EMAIL_WIDTH,
       'layout' => 'constrained',
     ];
-  }
-
-  public function getEmailContentStyles(): array {
-    return self::DEFAULT_EMAIL_CONTENT_STYLES;
   }
 
   public function getAvailableStylesheets(): string {

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -106,14 +106,16 @@ class SettingsController {
     $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
     $coreSettings = $coreThemeData->get_settings();
 
+    // Email Editor Theme
+    $editorTheme = $this->getTheme();
+
     // Enable custom spacing
     $coreSettings['spacing']['units'] = ['px'];
     $coreSettings['spacing']['padding'] = true;
     // Typography
     $coreSettings['typography']['dropCap'] = false; // Showing large initial letter cannot be implemented in emails
     $coreSettings['typography']['fontWeight'] = false; // Font weight will be handled by the font family later
-
-    $theme = $this->getTheme();
+    $coreSettings['typography']['fontFamilies']['default'] = $editorTheme->get_data()['settings']['typography']['fontFamilies'];
 
     // body selector is later transformed to .editor-styles-wrapper
     // setting padding for bottom and top is needed because \WP_Theme_JSON::get_stylesheet() set them only for .wp-site-blocks selector
@@ -130,7 +132,7 @@ class SettingsController {
     $settings['styles'] = [
       $coreDefaultSettings['defaultEditorStyles'][0],
       ['css' => wp_get_global_stylesheet(['base-layout-styles'])],
-      ['css' => $theme->get_stylesheet()],
+      ['css' => $editorTheme->get_stylesheet()],
       ['css' => $contentVariables],
       ['css' => $flexEmailLayoutStyles],
     ];

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -63,10 +63,6 @@ class SettingsController {
    * @var array
    */
   const DEFAULT_EMAIL_CONTENT_STYLES = [
-    'typography' => [
-      'fontFamily' => "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-      'fontSize' => '16px',
-    ],
     'h1' => [
       'typography' => [
         'fontSize' => '32px',

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -184,10 +184,12 @@ class SettingsController {
   }
 
   public function getTheme(): \WP_Theme_JSON {
+    $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
     $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
     $themeJson = json_decode($themeJson, true);
     /** @var array $themeJson */
-    return new \WP_Theme_JSON($themeJson);
+    $coreThemeData->merge(new \WP_Theme_JSON($themeJson, 'default'));
+    return $coreThemeData;
   }
 
   public function getStylesheetForRendering(): string {
@@ -195,7 +197,7 @@ class SettingsController {
     $emailThemeSettings = $this->getTheme()->get_settings();
     $css = '';
     // Font family classes
-    foreach ($emailThemeSettings['typography']['fontFamilies']['theme'] as $fontFamily) {
+    foreach ($emailThemeSettings['typography']['fontFamilies']['default'] as $fontFamily) {
       $css .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
     }
     // Font size classes

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -60,19 +60,8 @@ class SettingsController {
 
   public function getSettings(): array {
     $coreDefaultSettings = get_default_block_editor_settings();
-    $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
-    $coreSettings = $coreThemeData->get_settings();
-
-    // Email Editor Theme
     $editorTheme = $this->getTheme();
-
-    // Enable custom spacing
-    $coreSettings['spacing']['units'] = ['px'];
-    $coreSettings['spacing']['padding'] = true;
-    // Typography
-    $coreSettings['typography']['dropCap'] = false; // Showing large initial letter cannot be implemented in emails
-    $coreSettings['typography']['fontWeight'] = false; // Font weight will be handled by the font family later
-    $coreSettings['typography']['fontFamilies']['default'] = $editorTheme->get_data()['settings']['typography']['fontFamilies'];
+    $themeSettings = $editorTheme->get_settings();
 
     // body selector is later transformed to .editor-styles-wrapper
     // setting padding for bottom and top is needed because \WP_Theme_JSON::get_stylesheet() set them only for .wp-site-blocks selector
@@ -94,7 +83,7 @@ class SettingsController {
       ['css' => $flexEmailLayoutStyles],
     ];
 
-    $settings['__experimentalFeatures'] = $coreSettings;
+    $settings['__experimentalFeatures'] = $themeSettings;
     // Enable border radius, color, style and width where possible
     $settings['__experimentalFeatures']['border'] = [
       "radius" => true,

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -236,4 +236,14 @@ class SettingsController {
     /** @var array $themeJson */
     return new \WP_Theme_JSON($themeJson);
   }
+
+  public function getStylesheetForRendering(): string {
+    $settings = $this->getTheme()->get_settings();
+    $css = '';
+    // Font family classes
+    foreach ($settings['typography']['fontFamilies']['theme'] as $fontFamily) {
+      $css .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
+    }
+    return $css;
+  }
 }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -191,11 +191,16 @@ class SettingsController {
   }
 
   public function getStylesheetForRendering(): string {
-    $settings = $this->getTheme()->get_settings();
+    $coreThemeSettings = \WP_Theme_JSON_Resolver::get_core_data()->get_settings();
+    $emailThemeSettings = $this->getTheme()->get_settings();
     $css = '';
     // Font family classes
-    foreach ($settings['typography']['fontFamilies']['theme'] as $fontFamily) {
+    foreach ($emailThemeSettings['typography']['fontFamilies']['theme'] as $fontFamily) {
       $css .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
+    }
+    // Font size classes
+    foreach ($coreThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
+      $css .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
     }
     return $css;
   }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -77,12 +77,6 @@ class SettingsController {
     // Enabling alignWide allows full width for specific blocks such as columns, heading, image, etc.
     $settings['alignWide'] = true;
 
-    // Disable gradients. We cannot render them in emails.
-    $settings['disableCustomGradients'] = true;
-    $settings['__experimentalFeatures']['color']['customGradient'] = false;
-    $settings['__experimentalFeatures']['color']['defaultGradients'] = false;
-    $settings['__experimentalFeatures']['color']['gradients'] = [];
-
     return $settings;
   }
 

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -70,6 +70,8 @@ class SettingsController {
       ['css' => $flexEmailLayoutStyles],
     ];
 
+    $settings['styles'] = apply_filters('mailpoet_email_editor_editor_styles', $settings['styles']);
+
     $settings['__experimentalFeatures'] = $themeSettings;
     // Enable border radius, color, style and width where possible
     $settings['__experimentalFeatures']['border'] = [

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -193,7 +193,6 @@ class SettingsController {
   }
 
   public function getStylesheetForRendering(): string {
-    $coreThemeSettings = \WP_Theme_JSON_Resolver::get_core_data()->get_settings();
     $emailThemeSettings = $this->getTheme()->get_settings();
     $css = '';
     // Font family classes
@@ -201,16 +200,15 @@ class SettingsController {
       $css .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
     }
     // Font size classes
-    foreach ($coreThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
+    foreach ($emailThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
       $css .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
     }
     return $css;
   }
 
   public function translateSlugToFontSize(string $fontSize): string {
-    $coreTheme = \WP_Theme_JSON_Resolver::get_core_data();
-    $coreSettings = $coreTheme->get_settings();
-    foreach ($coreSettings['typography']['fontSizes']['default'] as $fontSizeDefinition) {
+    $settings = $this->getTheme()->get_settings();
+    foreach ($settings['typography']['fontSizes']['default'] as $fontSizeDefinition) {
       if ($fontSizeDefinition['slug'] === $fontSize) {
         return $fontSizeDefinition['size'];
       }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -64,7 +64,6 @@ class SettingsController {
     $flexEmailLayoutStyles = file_get_contents(__DIR__ . '/flex-email-layout.css');
 
     $settings['styles'] = [
-      $coreDefaultSettings['defaultEditorStyles'][0],
       ['css' => wp_get_global_stylesheet(['base-layout-styles'])],
       ['css' => $editorTheme->get_stylesheet()],
       ['css' => $contentVariables],

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -199,4 +199,15 @@ class SettingsController {
     }
     return $css;
   }
+
+  public function translateSlugToFontSize(string $fontSize): string {
+    $coreTheme = \WP_Theme_JSON_Resolver::get_core_data();
+    $coreSettings = $coreTheme->get_settings();
+    foreach ($coreSettings['typography']['fontSizes']['default'] as $fontSizeDefinition) {
+      if ($fontSizeDefinition['slug'] === $fontSize) {
+        return $fontSizeDefinition['size'];
+      }
+    }
+    return $fontSize;
+  }
 }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -73,13 +73,6 @@ class SettingsController {
     $settings['styles'] = apply_filters('mailpoet_email_editor_editor_styles', $settings['styles']);
 
     $settings['__experimentalFeatures'] = $themeSettings;
-    // Enable border radius, color, style and width where possible
-    $settings['__experimentalFeatures']['border'] = [
-      "radius" => true,
-      "color" => true,
-      "style" => true,
-      "width" => true,
-    ];
 
     // Enabling alignWide allows full width for specific blocks such as columns, heading, image, etc.
     $settings['alignWide'] = true;

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -178,7 +178,7 @@ class SettingsController {
     $themeJson = json_decode($themeJson, true);
     /** @var array $themeJson */
     $coreThemeData->merge(new \WP_Theme_JSON($themeJson, 'default'));
-    return $coreThemeData;
+    return apply_filters('mailpoet_email_editor_theme_json', $coreThemeData);
   }
 
   public function getStylesheetForRendering(): string {

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -183,16 +183,25 @@ class SettingsController {
 
   public function getStylesheetForRendering(): string {
     $emailThemeSettings = $this->getTheme()->get_settings();
-    $css = '';
+
+    $cssPresets = '';
     // Font family classes
     foreach ($emailThemeSettings['typography']['fontFamilies']['default'] as $fontFamily) {
-      $css .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
+      $cssPresets .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
     }
     // Font size classes
     foreach ($emailThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
-      $css .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
+      $cssPresets .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
     }
-    return $css;
+
+    // Block specific styles
+    $cssBlocks = '';
+    $blocks = $this->getTheme()->get_styles_block_nodes();
+    foreach ($blocks as $blockMetadata) {
+      $cssBlocks .= $this->getTheme()->get_styles_for_block($blockMetadata);
+    }
+
+    return $cssPresets . $cssBlocks;
   }
 
   public function translateSlugToFontSize(string $fontSize): string {

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -18,18 +18,6 @@ class SettingsController {
 
   const DEFAULT_SETTINGS = [
     'enableCustomUnits' => ['px', '%'],
-    '__experimentalFeatures' => [
-      'color' => [
-        'custom' => true,
-        'text' => true,
-        'background' => true,
-        'customGradient' => false,
-        'defaultPalette' => true,
-        'palette' => [
-          'default' => [],
-        ],
-      ],
-    ],
   ];
 
   /**

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -2,6 +2,11 @@
   "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
   "settings": {
+    "color": {
+      "customGradient": false,
+      "defaultGradients": false,
+      "gradients": []
+    },
     "layout": {
       "contentSize": "660px"
     },

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -138,6 +138,10 @@
     "color": {
       "background": "#ffffff",
       "text": "#000000"
+    },
+    "typography": {
+      "fontFamily": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+      "fontSize": "16px"
     }
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -5,7 +5,14 @@
     "layout": {
       "contentSize": "660px"
     },
+    "spacing": {
+      "units": ["px"],
+      "padding": true,
+      "margin": false
+    },
     "typography": {
+      "dropCap": false,
+      "fontWeight": false,
       "fontFamilies": [
         {
           "name": "Arial",

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -5,6 +5,20 @@
     "layout": {
       "contentSize": "660px"
     },
+    "typography": {
+      "fontFamilies": [
+        {
+          "fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
+          "name": "System Sans-serif",
+          "slug": "system-sans-serif"
+        },
+        {
+          "fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+          "name": "System Serif",
+          "slug": "system-Serif"
+        }
+      ]
+    },
     "useRootPaddingAwareAlignments": true
   },
   "styles": {

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -8,14 +8,119 @@
     "typography": {
       "fontFamilies": [
         {
-          "fontFamily": "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif",
-          "name": "System Sans-serif",
-          "slug": "system-sans-serif"
+          "name": "Arial",
+          "slug": "arial",
+          "fontFamily": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
         },
         {
-          "fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "name": "System Serif",
-          "slug": "system-Serif"
+          "name": "Comic Sans MS",
+          "slug": "comic-sans-ms",
+          "fontFamily": "'Comic Sans MS', 'Marker Felt-Thin', Arial, sans-serif"
+        },
+        {
+          "name": "Courier New",
+          "slug": "courier-new",
+          "fontFamily": "'Courier New', Courier, 'Lucida Sans Typewriter', 'Lucida Typewriter', monospace"
+        },
+        {
+          "name": "Georgia",
+          "slug": "georgia",
+          "fontFamily": "Georgia, Times, 'Times New Roman', serif"
+        },
+        {
+          "name": "Lucida",
+          "slug": "lucida",
+          "fontFamily": "'Lucida Sans Unicode', 'Lucida Grande', sans-serif"
+        },
+        {
+          "name": "Tahoma",
+          "slug": "tahoma",
+          "fontFamily": "'Tahoma, Verdana, Segoe, sans-serif'"
+        },
+        {
+          "name": "Times New Roman",
+          "slug": "times-new-roman",
+          "fontFamily": "'Times New Roman', Times, Baskerville, Georgia, serif"
+        },
+        {
+          "name": "Trebuchet MS",
+          "slug": "trebuchet-ms",
+          "fontFamily": "'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif"
+        },
+        {
+          "name": "Verdana",
+          "slug": "verdana",
+          "fontFamily": "'Verdana, Geneva, sans-serif'"
+        },
+        {
+          "name": "Arvo",
+          "slug": "arvo",
+          "fontFamily": "'arvo, courier, georgia, serif'"
+        },
+        {
+          "name": "Lato",
+          "slug": "lato",
+          "fontFamily": "lato, 'helvetica neue', helvetica, arial, sans-serif"
+        },
+        {
+          "name": "Lora",
+          "slug": "lora",
+          "fontFamily": "lora, georgia, 'times new roman', serif"
+        },
+        {
+          "name": "Merriweather",
+          "slug": "merriweather",
+          "fontFamily": "merriweather, georgia, 'times new roman', serif"
+        },
+        {
+          "name": "Merriweather Sans",
+          "slug": "merriweather-sans",
+          "fontFamily": "'merriweather sans', 'helvetica neue', helvetica, arial, sans-serif"
+        },
+        {
+          "name": "Noticia Text",
+          "slug": "noticia-text",
+          "fontFamily": "'noticia text', georgia, 'times new roman', serif"
+        },
+        {
+          "name": "Open Sans",
+          "slug": "open-sans",
+          "fontFamily": "'open sans', 'helvetica neue', helvetica, arial, sans-serif"
+        },
+        {
+          "name": "Playfair Display",
+          "slug": "playfair-display",
+          "fontFamily": "'playfair display', georgia, 'times new roman', serif"
+        },
+        {
+          "name": "Roboto",
+          "slug": "roboto",
+          "fontFamily": "roboto, 'helvetica neue', helvetica, arial, sans-serif"
+        },
+        {
+          "name": "Source Sans Pro",
+          "slug": "source-sans-pro",
+          "fontFamily": "'source sans pro', 'helvetica neue', helvetica, arial, sans-serif"
+        },
+        {
+          "name": "Oswald",
+          "slug": "oswald",
+          "fontFamily": "Oswald, 'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif"
+        },
+        {
+          "name": "Raleway",
+          "slug": "raleway",
+          "fontFamily": "Raleway, 'Century Gothic', CenturyGothic, AppleGothic, sans-serif"
+        },
+        {
+          "name": "Permanent Marker",
+          "slug": "permanent-marker",
+          "fontFamily": "'Permanent Marker', Tahoma, Verdana, Segoe, sans-serif"
+        },
+        {
+          "name": "Pacifico",
+          "slug": "pacifico",
+          "fontFamily": "Pacifico, 'Arial Narrow', Arial, sans-serif"
         }
       ]
     },

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -149,23 +149,6 @@
     "typography": {
       "fontFamily": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
       "fontSize": "16px"
-    },
-    "blocks": {
-      "core/button": {
-        "variations": {},
-        "color": {
-          "background": "#32373c",
-          "text": "#ffffff"
-        },
-        "spacing": {
-          "padding": {
-            "bottom": "0.7em",
-            "left": "1.4em",
-            "right": "1.4em",
-            "top": "0.7em"
-          }
-        }
-      }
     }
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -10,6 +10,12 @@
       "padding": true,
       "margin": false
     },
+    "border": {
+      "radius": true,
+      "color": true,
+      "style": true,
+      "width": true
+    },
     "typography": {
       "dropCap": false,
       "fontWeight": false,

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -149,6 +149,23 @@
     "typography": {
       "fontFamily": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
       "fontSize": "16px"
+    },
+    "blocks": {
+      "core/button": {
+        "variations": {},
+        "color": {
+          "background": "#32373c",
+          "text": "#ffffff"
+        },
+        "spacing": {
+          "padding": {
+            "bottom": "0.7em",
+            "left": "1.4em",
+            "right": "1.4em",
+            "top": "0.7em"
+          }
+        }
+      }
     }
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/theme.md
+++ b/mailpoet/lib/EmailEditor/Engine/theme.md
@@ -1,0 +1,20 @@
+# Theme.json for the email editor
+
+We use theme.json to define settings and styles for the email editor and we reuse the definitions also in the rendering engine.
+The theme is used in combination with the [core's theme.json](https://github.com/WordPress/WordPress/blob/master/wp-includes/theme.json). We load the core's theme.json first and then we merge the email editor's theme.json on top of it.
+
+In this file we want to document settings and styles that are specific to the email editor.
+
+## Settings
+
+- **color**: We disable gradients, because they are not supported in many email clients. We may add the support later.
+- **layout**: We set content width to 660px, because it's the most common width for emails. This is meant as a default value.
+- **spacing**: We allow only px units, because they are the most reliable in email clients. We may add the support for other units later with some sort of conversion to px. We also disable margins because they are not supported in our renderer (margin collapsing might be tricky).
+- **border**: We want to allow all types of borders and border styles.
+- **typography**: We disabled fontWeight and dropCap appearance settings, because they are not supported in our renderer. We may add the support later. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle tested legacy editor.
+
+## Styles
+
+- **spacing**: We define default padding for the emails.
+- **color**: We define default colors for text and background of the emails.
+- **typography**: We define default font family and font size for the emails.

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -9,6 +9,8 @@ class Initializer {
   public function initialize(): void {
     add_action('mailpoet_blocks_renderer_initialized', [$this, 'registerCoreBlocksRenderers'], 10, 1);
     add_filter('mailpoet_email_editor_theme_json', [$this, 'adjustThemeJson'], 10, 1);
+    add_filter('mailpoet_email_editor_editor_styles', [$this, 'addEditorStyles'], 10, 1);
+    add_filter('mailpoet_email_renderer_styles', [$this, 'addRendererStyles'], 10, 1);
   }
 
   /**
@@ -34,5 +36,17 @@ class Initializer {
     /** @var array $themeJson */
     $editorThemeJson->merge(new \WP_Theme_JSON($themeJson, 'default'));
     return $editorThemeJson;
+  }
+
+  public function addEditorStyles(array $styles) {
+    $declaration = (string)file_get_contents(dirname(__FILE__) . '/styles.css');
+    $styles[] = ['css' => $declaration];
+    return $styles;
+  }
+
+  public function addRendererStyles(string $styles) {
+    $declaration = (string)file_get_contents(dirname(__FILE__) . '/styles.css');
+    $styles .= $declaration;
+    return $styles;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -8,6 +8,7 @@ use MailPoet\EmailEditor\Engine\Renderer\Layout\FlexLayoutRenderer;
 class Initializer {
   public function initialize(): void {
     add_action('mailpoet_blocks_renderer_initialized', [$this, 'registerCoreBlocksRenderers'], 10, 1);
+    add_filter('mailpoet_email_editor_theme_json', [$this, 'adjustThemeJson'], 10, 1);
   }
 
   /**
@@ -22,5 +23,16 @@ class Initializer {
     $blocksRegistry->addBlockRenderer('core/image', new Renderer\Blocks\Image());
     $blocksRegistry->addBlockRenderer('core/buttons', new Renderer\Blocks\Buttons(new FlexLayoutRenderer()));
     $blocksRegistry->addBlockRenderer('core/button', new Renderer\Blocks\Button());
+  }
+
+  /**
+   * Adjusts the editor's theme to add blocks specific settings for core blocks.
+   */
+  public function adjustThemeJson(\WP_Theme_JSON $editorThemeJson): \WP_Theme_JSON {
+    $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
+    $themeJson = json_decode($themeJson, true);
+    /** @var array $themeJson */
+    $editorThemeJson->merge(new \WP_Theme_JSON($themeJson, 'default'));
+    return $editorThemeJson;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -25,7 +25,11 @@ class Button implements BlockRenderer {
       return '';
     }
 
+    $buttonOriginalWrapper = $buttonDom->getElementsByTagName('div')->item(0);
+    $buttonClasses = $buttonOriginalWrapper instanceof \DOMElement ? $buttonOriginalWrapper->getAttribute('class') : '';
+
     $markup = $this->getMarkup();
+    $markup = str_replace('{classes}', $buttonClasses, $markup);
 
     // Add Link Text
     $markup = str_replace('{linkText}', $buttonLink->textContent ?: '', $markup);
@@ -91,8 +95,6 @@ class Button implements BlockRenderer {
     // Escaping
     $wrapperStyles = array_map('esc_attr', $wrapperStyles);
     $linkStyles = array_map('esc_attr', $linkStyles);
-    // Font family may contain single quotes
-    $linkStyles['font-family'] = str_replace('&#039;', "'", esc_attr("{$parsedBlock['email_attrs']['font-family']}"));
 
     $markup = str_replace('{linkStyles}', $settingsController->convertStylesToString($linkStyles), $markup);
     $markup = str_replace('{wrapperStyles}', $settingsController->convertStylesToString($wrapperStyles), $markup);
@@ -103,7 +105,7 @@ class Button implements BlockRenderer {
   private function getMarkup(): string {
     return '<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;border-collapse:separate;line-height:100%;width:{width};">
         <tr>
-          <td align="center" bgcolor="{backgroundColor}" role="presentation" style="{wrapperStyles}" valign="middle">
+          <td align="center" class="{classes}" bgcolor="{backgroundColor}" role="presentation" style="{wrapperStyles}" valign="middle">
             <a href="{linkUrl}" style="{linkStyles}" target="_blank">{linkText}</a>
           </td>
         </tr>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -45,7 +45,9 @@ class Button implements BlockRenderer {
     $markup = str_replace('{width}', $width, $markup);
 
     // Background
-    $bgColor = $parsedBlock['attrs']['style']['color']['background'] ?? 'transparent';
+    $themeData = $settingsController->getTheme()->get_data();
+    $defaultColor = $themeData['styles']['blocks']['core/button']['color']['background'] ?? 'transparent';
+    $bgColor = $parsedBlock['attrs']['style']['color']['background'] ?? $defaultColor;
     $markup = str_replace('{backgroundColor}', $bgColor, $markup);
 
     // Styles attributes
@@ -85,12 +87,12 @@ class Button implements BlockRenderer {
       $linkStyles['padding-left'] = $padding['left'];
     }
 
-    // Typography
+    // Typography + colors
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
+    $color = $parsedBlock['attrs']['style']['color'] ?? [];
     $typography['fontSize'] = $parsedBlock['email_attrs']['font-size'] ?? 'inherit';
     $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
-    $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography])['declarations']);
-    $linkStyles['color'] = $parsedBlock['email_attrs']['color'];
+    $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography, 'color' => $color])['declarations']);
 
     // Escaping
     $wrapperStyles = array_map('esc_attr', $wrapperStyles);
@@ -106,7 +108,7 @@ class Button implements BlockRenderer {
     return '<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;border-collapse:separate;line-height:100%;width:{width};">
         <tr>
           <td align="center" class="{classes}" bgcolor="{backgroundColor}" role="presentation" style="{wrapperStyles}" valign="middle">
-            <a href="{linkUrl}" style="{linkStyles}" target="_blank">{linkText}</a>
+            <a class="wp-block-button__link" href="{linkUrl}" style="{linkStyles}" target="_blank">{linkText}</a>
           </td>
         </tr>
       </table>';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -87,7 +87,7 @@ class Button implements BlockRenderer {
 
     // Typography
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
-    $typography['fontSize'] = $typography['fontSize'] ?? ($parsedBlock['email_attrs']['font-size'] ?? 'inherit');
+    $typography['fontSize'] = $parsedBlock['email_attrs']['font-size'] ?? 'inherit';
     $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
     $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography])['declarations']);
     $linkStyles['color'] = $parsedBlock['email_attrs']['color'];

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -92,8 +92,7 @@ class Button implements BlockRenderer {
     $wrapperStyles = array_map('esc_attr', $wrapperStyles);
     $linkStyles = array_map('esc_attr', $linkStyles);
     // Font family may contain single quotes
-    $contentStyles = $settingsController->getEmailContentStyles();
-    $linkStyles['font-family'] = str_replace('&#039;', "'", esc_attr("{$contentStyles['typography']['fontFamily']}"));
+    $linkStyles['font-family'] = str_replace('&#039;', "'", esc_attr("{$parsedBlock['email_attrs']['font-family']}"));
 
     $markup = str_replace('{linkStyles}', $settingsController->convertStylesToString($linkStyles), $markup);
     $markup = str_replace('{wrapperStyles}', $settingsController->convertStylesToString($wrapperStyles), $markup);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -17,7 +17,7 @@ class Heading implements BlockRenderer {
    * Based on MJML <mj-text>
    */
   private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
+    $themeData = $settingsController->getTheme()->get_data();
     $availableStylesheets = $settingsController->getAvailableStylesheets();
 
     // Styles for padding need to be set on the wrapping table cell due to support in Outlook
@@ -40,7 +40,7 @@ class Heading implements BlockRenderer {
     }
 
     if (!isset($styles['font-size'])) {
-      $styles['font-size'] = $contentStyles['typography']['fontSize'];
+      $styles['font-size'] = $themeData['styles']['typography']['fontSize'];
     }
 
     $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs']));

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -42,9 +42,6 @@ class Heading implements BlockRenderer {
     if (!isset($styles['font-size'])) {
       $styles['font-size'] = $contentStyles['typography']['fontSize'];
     }
-    if (!isset($styles['font-family'])) {
-      $styles['font-family'] = $contentStyles['typography']['fontFamily'];
-    }
 
     $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs']));
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -77,19 +77,17 @@ class Image implements BlockRenderer {
 
   /**
    * This method configure the font size of the caption because it's set to 0 for the parent element to avoid unexpected white spaces
+   * We try to use font-size passed down from the parent element $parsedBlock['email_attrs']['font-size'], but if it's not set, we use the default font-size from the email theme.
    */
   private function getCaptionStyles(SettingsController $settingsController, array $parsedBlock): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
+    $themeData = $settingsController->getTheme()->get_data();
 
     // If the alignment is set, we need to center the caption
     $styles = [
       'text-align' => isset($parsedBlock['attrs']['align']) ? 'center' : 'left',
     ];
 
-    if (isset($contentStyles['typography']['fontSize'])) {
-      $styles['font-size'] = $contentStyles['typography']['fontSize'];
-    }
-
+    $styles['font-size'] = $parsedBlock['email_attrs']['font-size'] ?? $themeData['styles']['typography']['fontSize'];
     return $settingsController->convertStylesToString($styles);
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -23,9 +23,6 @@ class ListBlock implements BlockRenderer {
       if (!isset($styles['font-size'])) {
         $styles['font-size'] = $contentStyles['typography']['fontSize'];
       }
-      if (!isset($styles['font-family'])) {
-        $styles['font-family'] = $contentStyles['typography']['fontFamily'];
-      }
 
       $html->set_attribute('style', $settingsController->convertStylesToString($styles));
       $blockContent = $html->get_updated_html();

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -18,10 +18,10 @@ class ListBlock implements BlockRenderer {
       // List block does not need width specification and it can cause issues for nested lists
       unset($styles['width'] );
 
-      // Use font-size and font-family from Settings when those properties are not set
-      $contentStyles = $settingsController->getEmailContentStyles();
+      // Use font-size from email theme when those properties are not set
+      $themeData = $settingsController->getTheme()->get_data();
       if (!isset($styles['font-size'])) {
-        $styles['font-size'] = $contentStyles['typography']['fontSize'];
+        $styles['font-size'] = $themeData['styles']['typography']['fontSize'];
       }
 
       $html->set_attribute('style', $settingsController->convertStylesToString($styles));

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -16,7 +16,7 @@ class Paragraph implements BlockRenderer {
    * Based on MJML <mj-text>
    */
   private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
-    $contentStyles = $settingsController->getEmailContentStyles();
+    $themeData = $settingsController->getTheme()->get_data();
     $availableStylesheets = $settingsController->getAvailableStylesheets();
 
     $align = $parsedBlock['attrs']['align'] ?? 'left';
@@ -39,7 +39,7 @@ class Paragraph implements BlockRenderer {
     }
 
     if (!isset($styles['font-size'])) {
-      $styles['font-size'] = $contentStyles['typography']['fontSize'];
+      $styles['font-size'] = $themeData['styles']['typography']['fontSize'];
     }
 
     $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs'] ?? []));

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -41,9 +41,6 @@ class Paragraph implements BlockRenderer {
     if (!isset($styles['font-size'])) {
       $styles['font-size'] = $contentStyles['typography']['fontSize'];
     }
-    if (!isset($styles['font-family'])) {
-      $styles['font-family'] = $contentStyles['typography']['fontFamily'];
-    }
 
     $styles = array_merge($styles, $this->fetchStylesFromBlockAttrs($availableStylesheets, $parsedBlock['attrs'] ?? []));
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/styles.css
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/styles.css
@@ -1,0 +1,23 @@
+h1 {
+  font-size: 48px;
+}
+
+h2 {
+  font-size: 42px;
+}
+
+h3 {
+  font-size: 36px;
+}
+
+h4 {
+  font-size: 26px;
+}
+
+h5 {
+  font-size: 20px;
+}
+
+h6 {
+  font-size: 13px;
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/theme.json
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/theme.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "version": 2,
+  "styles": {
+    "blocks": {
+      "core/button": {
+        "variations": {},
+        "color": {
+          "background": "#32373c",
+          "text": "#ffffff"
+        },
+        "spacing": {
+          "padding": {
+            "bottom": "0.7em",
+            "left": "1.4em",
+            "right": "1.4em",
+            "top": "0.7em"
+          }
+        }
+      }
+    }
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
@@ -140,25 +140,4 @@ class RendererTest extends \MailPoetTest {
     verify($style)->stringContainsString('padding-top:3px;');
     verify($style)->stringContainsString('padding-bottom:4px;');
   }
-
-  public function testItInlinesButtonDefaultStyles() {
-    $this->emailPost = new \WP_Post((object)[
-      'post_content' => '<!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
-    ]);
-    $rendered = $this->renderer->render($this->emailPost, 'Subject', '', 'en');
-    $doc = new \DOMDocument();
-    $doc->loadHTML($rendered['html']);
-    $xpath = new \DOMXPath($doc);
-    $nodes = $xpath->query('//td[contains(@class, "wp-block-button")]');
-    $button = null;
-    if (($nodes instanceof \DOMNodeList) && $nodes->length > 0) {
-      $button = $nodes->item(0);
-    }
-    $this->assertInstanceOf(\DOMElement::class, $button);
-    $this->assertInstanceOf(\DOMDocument::class, $button->ownerDocument);
-    $buttonHtml = $button->ownerDocument->saveHTML($button);
-    verify($buttonHtml)->stringContainsString('color:#ffffff');
-    verify($buttonHtml)->stringContainsString('padding:.7em 1.4em');
-    verify($buttonHtml)->stringContainsString('background:#32373c');
-  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
@@ -140,4 +140,25 @@ class RendererTest extends \MailPoetTest {
     verify($style)->stringContainsString('padding-top:3px;');
     verify($style)->stringContainsString('padding-bottom:4px;');
   }
+
+  public function testItInlinesButtonDefaultStyles() {
+    $this->emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
+    ]);
+    $rendered = $this->renderer->render($this->emailPost, 'Subject', '', 'en');
+    $doc = new \DOMDocument();
+    $doc->loadHTML($rendered['html']);
+    $xpath = new \DOMXPath($doc);
+    $nodes = $xpath->query('//td[contains(@class, "wp-block-button")]');
+    $button = null;
+    if (($nodes instanceof \DOMNodeList) && $nodes->length > 0) {
+      $button = $nodes->item(0);
+    }
+    $this->assertInstanceOf(\DOMElement::class, $button);
+    $this->assertInstanceOf(\DOMDocument::class, $button->ownerDocument);
+    $buttonHtml = $button->ownerDocument->saveHTML($button);
+    verify($buttonHtml)->stringContainsString('color:#ffffff');
+    verify($buttonHtml)->stringContainsString('padding:.7em 1.4em');
+    verify($buttonHtml)->stringContainsString('background:#32373c');
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
@@ -13,7 +13,27 @@ class SettingsControllerTest extends \MailPoetTest {
 
   public function testItGeneratesCssStylesForThemeWithFontFamilies() {
     $css = $this->settingsController->getStylesheetForRendering();
-    verify($css)->stringContainsString('.has-system-sans-serif-font-family');
-    verify($css)->stringContainsString('.has-system-Serif-font-family');
+    verify($css)->stringContainsString('.has-arial-font-family');
+    verify($css)->stringContainsString('.has-comic-sans-ms-font-family');
+    verify($css)->stringContainsString('.has-courier-new-font-family');
+    verify($css)->stringContainsString('.has-georgia-font-family');
+    verify($css)->stringContainsString('.has-lucida-font-family');
+    verify($css)->stringContainsString('.has-tahoma-font-family');
+    verify($css)->stringContainsString('.has-times-new-roman-font-family');
+    verify($css)->stringContainsString('.has-trebuchet-ms-font-family');
+    verify($css)->stringContainsString('.has-verdana-font-family');
+    verify($css)->stringContainsString('.has-arvo-font-family');
+    verify($css)->stringContainsString('.has-lato-font-family');
+    verify($css)->stringContainsString('.has-merriweather-font-family');
+    verify($css)->stringContainsString('.has-merriweather-sans-font-family');
+    verify($css)->stringContainsString('.has-noticia-text-font-family');
+    verify($css)->stringContainsString('.has-open-sans-font-family');
+    verify($css)->stringContainsString('.has-playfair-display-font-family');
+    verify($css)->stringContainsString('.has-roboto-font-family');
+    verify($css)->stringContainsString('.has-source-sans-pro-font-family');
+    verify($css)->stringContainsString('.has-oswald-font-family');
+    verify($css)->stringContainsString('.has-raleway-font-family');
+    verify($css)->stringContainsString('.has-permanent-marker-font-family');
+    verify($css)->stringContainsString('.has-pacifico-font-family');
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
@@ -36,4 +36,12 @@ class SettingsControllerTest extends \MailPoetTest {
     verify($css)->stringContainsString('.has-permanent-marker-font-family');
     verify($css)->stringContainsString('.has-pacifico-font-family');
   }
+
+  public function testItCanTranslateFontSizeSlug() {
+    verify($this->settingsController->translateSlugToFontSize('small'))->equals('13px');
+    verify($this->settingsController->translateSlugToFontSize('medium'))->equals('20px');
+    verify($this->settingsController->translateSlugToFontSize('large'))->equals('36px');
+    verify($this->settingsController->translateSlugToFontSize('x-large'))->equals('42px');
+    verify($this->settingsController->translateSlugToFontSize('unknown'))->equals('unknown');
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine;
+
+class SettingsControllerTest extends \MailPoetTest {
+  /** @var SettingsController */
+  private $settingsController;
+
+  public function _before() {
+    parent::_before();
+    $this->settingsController = $this->diContainer->get(SettingsController::class);
+  }
+
+  public function testItGeneratesCssStylesForThemeWithFontFamilies() {
+    $css = $this->settingsController->getStylesheetForRendering();
+    verify($css)->stringContainsString('.has-system-sans-serif-font-family');
+    verify($css)->stringContainsString('.has-system-Serif-font-family');
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
@@ -11,7 +11,7 @@ class SettingsControllerTest extends \MailPoetTest {
     $this->settingsController = $this->diContainer->get(SettingsController::class);
   }
 
-  public function testItGeneratesCssStylesForThemeWithFontFamilies() {
+  public function testItGeneratesCssStylesForRenderer() {
     $css = $this->settingsController->getStylesheetForRendering();
     verify($css)->stringContainsString('.has-arial-font-family');
     verify($css)->stringContainsString('.has-comic-sans-ms-font-family');
@@ -35,6 +35,11 @@ class SettingsControllerTest extends \MailPoetTest {
     verify($css)->stringContainsString('.has-raleway-font-family');
     verify($css)->stringContainsString('.has-permanent-marker-font-family');
     verify($css)->stringContainsString('.has-pacifico-font-family');
+
+    verify($css)->stringContainsString('.has-small-font-size');
+    verify($css)->stringContainsString('.has-medium-font-size');
+    verify($css)->stringContainsString('.has-large-font-size');
+    verify($css)->stringContainsString('.has-x-large-font-size');
   }
 
   public function testItCanTranslateFontSizeSlug() {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -150,15 +150,4 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-bottom-left-radius:3px;');
     verify($output)->stringContainsString('border-bottom-right-radius:4px;');
   }
-
-  public function testItAllowsSingleQuotesInFontFamilyDefinition(): void {
-    $settingsControllerMock = $this->createPartialMock(SettingsController::class, ['getEmailContentStyles']);
-    $settingsControllerMock->method('getEmailContentStyles')->willReturn([
-      'typography' => [
-        'fontFamily' => '"Font\'", serif',
-      ],
-    ]);
-    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $settingsControllerMock);
-    verify($output)->stringContainsString('&quot;Font\'&quot;, serif');
-  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -156,4 +156,14 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-bottom-left-radius:3px;');
     verify($output)->stringContainsString('border-bottom-right-radius:4px;');
   }
+
+  public function testItRendersDefaultBackgroundColor(): void {
+    unset($this->parsedButton['attrs']['style']['color']);
+    unset($this->parsedButton['attrs']['style']['spacing']['padding']);
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    // Verify default background colors theme.json for email editor
+    // These can't be set via CSS inliner because of special email HTML markup
+    verify($output)->stringContainsString('bgcolor="#32373c"');
+    verify($output)->stringContainsString('background:#32373c;');
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -137,6 +137,12 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-radius:10px;');
   }
 
+  public function testItRendersFontSizeFromEmailAttrs(): void {
+    $this->parsedButton['email_attrs']['font-size'] = '10px';
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    verify($output)->stringContainsString('font-size:10px;');
+  }
+
   public function testItRendersCornerSpecificBorderRadius(): void {
     $this->parsedButton['attrs']['style']['border']['radius'] = [
       'topLeft' => '1px',

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
@@ -20,11 +20,13 @@ class HeadingTest extends \MailPoetTest {
       'style' => [
         'typography' => [
           'textTransform' => 'lowercase',
+          'fontSize' => '24px',
         ],
       ],
     ],
     'email_attrs' => [
       'width' => '640px',
+      'font-size' => '24px',
     ],
     'innerBlocks' => [],
     'innerHTML' => '<h1 class="has-pale-cyan-blue-color has-vivid-red-background-color has-text-color has-background">This is Heading 1</h1>',
@@ -46,6 +48,7 @@ class HeadingTest extends \MailPoetTest {
     $rendered = $this->headingRenderer->render('<h1>This is Heading 1</h1>', $this->parsedHeading, $this->settingsController);
     verify($rendered)->stringContainsString('This is Heading 1');
     verify($rendered)->stringContainsString('width: 100%;');
+    verify($rendered)->stringContainsString('font-size:24px;');
     verify($rendered)->stringNotContainsString('width:640px;');
   }
 
@@ -55,5 +58,10 @@ class HeadingTest extends \MailPoetTest {
     verify($rendered)->stringContainsString('color:#8ed1fc;'); // color from theme.json matching pale-cyan-blue
     verify($rendered)->stringContainsString('text-transform:lowercase;');
     verify($rendered)->stringContainsString('text-align:center;');
+  }
+
+  public function testItReplacesFluidFontSizeInContent(): void {
+    $rendered = $this->headingRenderer->render('<h1 style="font-size:clamp(10px, 20px, 24px)">This is Heading 1</h1>', $this->parsedHeading, $this->settingsController);
+    verify($rendered)->stringContainsString('font-size:24px');
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer;
+
+use MailPoet\EmailEditor\Engine\EmailEditor;
+use MailPoet\EmailEditor\Engine\Renderer\Renderer;
+use MailPoet\EmailEditor\Integrations\Core\Initializer;
+
+class RendererTest extends \MailPoetTest {
+  /** @var Renderer */
+  private $renderer;
+
+  public function _before() {
+    parent::_before();
+    $this->renderer = $this->diContainer->get(Renderer::class);
+    $this->diContainer->get(EmailEditor::class)->initialize();
+    $this->diContainer->get(Initializer::class)->initialize();
+  }
+
+  public function testItInlinesButtonDefaultStyles() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $doc = new \DOMDocument();
+    $doc->loadHTML($rendered['html']);
+    $xpath = new \DOMXPath($doc);
+    $nodes = $xpath->query('//td[contains(@class, "wp-block-button")]');
+    $button = null;
+    if (($nodes instanceof \DOMNodeList) && $nodes->length > 0) {
+      $button = $nodes->item(0);
+    }
+    $this->assertInstanceOf(\DOMElement::class, $button);
+    $this->assertInstanceOf(\DOMDocument::class, $button->ownerDocument);
+    $buttonHtml = $button->ownerDocument->saveHTML($button);
+    verify($buttonHtml)->stringContainsString('color:#ffffff');
+    verify($buttonHtml)->stringContainsString('padding:.7em 1.4em');
+    verify($buttonHtml)->stringContainsString('background:#32373c');
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -22,19 +22,32 @@ class RendererTest extends \MailPoetTest {
       'post_content' => '<!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
-    $doc = new \DOMDocument();
-    $doc->loadHTML($rendered['html']);
-    $xpath = new \DOMXPath($doc);
-    $nodes = $xpath->query('//td[contains(@class, "wp-block-button")]');
-    $button = null;
-    if (($nodes instanceof \DOMNodeList) && $nodes->length > 0) {
-      $button = $nodes->item(0);
-    }
-    $this->assertInstanceOf(\DOMElement::class, $button);
-    $this->assertInstanceOf(\DOMDocument::class, $button->ownerDocument);
-    $buttonHtml = $button->ownerDocument->saveHTML($button);
+    $buttonHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-button', 'td');
     verify($buttonHtml)->stringContainsString('color:#ffffff');
     verify($buttonHtml)->stringContainsString('padding:.7em 1.4em');
     verify($buttonHtml)->stringContainsString('background:#32373c');
+  }
+
+  public function testItInlinesHeadingFontSize() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"large"}}} --><h1 class="wp-block-heading">Hello</h1><!-- /wp:heading -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $headingHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-heading', 'h1');
+    verify($headingHtml)->stringContainsString('font-size:48px'); // large is 48px
+  }
+
+  private function extractBlockHtml(string $html, string $blockClass, string $tag): string {
+    $doc = new \DOMDocument();
+    $doc->loadHTML($html);
+    $xpath = new \DOMXPath($doc);
+    $nodes = $xpath->query('//' . $tag . '[contains(@class, "' . $blockClass . '")]');
+    $block = null;
+    if (($nodes instanceof \DOMNodeList) && $nodes->length > 0) {
+      $block = $nodes->item(0);
+    }
+    $this->assertInstanceOf(\DOMElement::class, $block);
+    $this->assertInstanceOf(\DOMDocument::class, $block->ownerDocument);
+    return (string)$block->ownerDocument->saveHTML($block);
   }
 }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -20,6 +20,22 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
           'text' => '#000000',
         ],
       ],
+      'settings' => [
+        'typography' => [
+          'fontFamilies' => [
+            [
+              'slug' => 'arial-slug',
+              'name' => 'Arial Name',
+              'fontFamily' => 'Arial',
+            ],
+            [
+              'slug' => 'georgia-slug',
+              'name' => 'Georgia Name',
+              'fontFamily' => 'Georgia',
+            ],
+          ],
+        ],
+      ],
     ]);
     $settingsMock->method('getTheme')->willReturn($themeMock);
     $settingsMock->method('getEmailContentStyles')->willReturn([
@@ -35,7 +51,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $blocks = [[
       'blockName' => 'core/columns',
       'attrs' => [
-        'fontFamily' => 'Arial',
+        'fontFamily' => 'arial-slug',
         'style' => [
           'color' => [
             'text' => '#aa00dd',
@@ -117,7 +133,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       [
         'blockName' => 'core/columns',
         'attrs' => [
-          'fontFamily' => 'Arial',
+          'fontFamily' => 'arial-slug',
           'style' => [
             'color' => [
               'text' => '#aa00dd',
@@ -131,7 +147,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
           [
             'blockName' => 'core/column',
             'attrs' => [
-              'fontFamily' => 'Georgia',
+              'fontFamily' => 'georgia-slug',
               'style' => [
                 'color' => [
                   'text' => '#cc22aa',
@@ -168,7 +184,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
           [
             'blockName' => 'core/column',
             'attrs' => [
-              'fontFamily' => 'Georgia',
+              'fontFamily' => 'georgia-slug',
               'style' => [
                 'color' => [
                   'text' => '#cc22aa',

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -25,6 +25,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $settingsMock->method('getEmailContentStyles')->willReturn([
       'typography' => [
         'fontSize' => '13px',
+        'fontFamily' => 'Arial',
       ],
     ]);
     $this->preprocessor = new TypographyPreprocessor($settingsMock);
@@ -34,12 +35,12 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $blocks = [[
       'blockName' => 'core/columns',
       'attrs' => [
+        'fontFamily' => 'Arial',
         'style' => [
           'color' => [
             'text' => '#aa00dd',
           ],
           'typography' => [
-            'fontFamily' => 'Arial',
             'fontSize' => '12px',
             'textDecoration' => 'underline',
           ],
@@ -104,10 +105,11 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $result = $this->preprocessor->preprocess($blocks, []);
     $result = $result[0];
     verify($result['innerBlocks'])->arrayCount(2);
-    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000', 'font-size' => '13px']);
-    verify($result['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
-    verify($result['innerBlocks'][1]['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
-    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
+    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000', 'font-size' => '13px', 'font-family' => 'Arial']);
+    $defaultFontStyles = ['color' => '#000000', 'font-size' => '13px', 'font-family' => 'Arial'];
+    verify($result['innerBlocks'][0]['email_attrs'])->equals($defaultFontStyles);
+    verify($result['innerBlocks'][1]['email_attrs'])->equals($defaultFontStyles);
+    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($defaultFontStyles);
   }
 
   public function testItOverridesColumnsTypography(): void {
@@ -115,12 +117,12 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       [
         'blockName' => 'core/columns',
         'attrs' => [
+          'fontFamily' => 'Arial',
           'style' => [
             'color' => [
               'text' => '#aa00dd',
             ],
             'typography' => [
-              'fontFamily' => 'Arial',
               'fontSize' => '12px',
             ],
           ],
@@ -129,12 +131,12 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
           [
             'blockName' => 'core/column',
             'attrs' => [
+              'fontFamily' => 'Georgia',
               'style' => [
                 'color' => [
                   'text' => '#cc22aa',
                 ],
                 'typography' => [
-                  'fontFamily' => 'Georgia',
                   'fontSize' => '18px',
                 ],
               ],
@@ -166,12 +168,12 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
           [
             'blockName' => 'core/column',
             'attrs' => [
+              'fontFamily' => 'Georgia',
               'style' => [
                 'color' => [
                   'text' => '#cc22aa',
                 ],
                 'typography' => [
-                  'fontFamily' => 'Georgia',
                   'fontSize' => '18px',
                 ],
               ],
@@ -207,7 +209,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     verify($child1['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child1['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child2['innerBlocks'])->arrayCount(1);
-    verify($child2['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
+    verify($child2['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px', 'font-family' => 'Arial']);
     verify($child2['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
     verify($child2['innerBlocks'][0]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
   }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -19,6 +19,10 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
         'color' => [
           'text' => '#000000',
         ],
+        'typography' => [
+          'fontSize' => '13px',
+          'fontFamily' => 'Arial',
+        ],
       ],
       'settings' => [
         'typography' => [
@@ -38,12 +42,6 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       ],
     ]);
     $settingsMock->method('getTheme')->willReturn($themeMock);
-    $settingsMock->method('getEmailContentStyles')->willReturn([
-      'typography' => [
-        'fontSize' => '13px',
-        'fontFamily' => 'Arial',
-      ],
-    ]);
     $this->preprocessor = new TypographyPreprocessor($settingsMock);
   }
 

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -42,6 +42,10 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       ],
     ]);
     $settingsMock->method('getTheme')->willReturn($themeMock);
+    // This slug translate mock expect slugs in format slug-10px and will return 10px
+    $settingsMock->method('translateSlugToFontSize')->willReturnCallback(function($slug) {
+      return str_replace('slug-', '', $slug);
+    });
     $this->preprocessor = new TypographyPreprocessor($settingsMock);
   }
 
@@ -81,6 +85,43 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
       'color' => '#aa00dd',
       'font-size' => '12px',
       'text-decoration' => 'underline',
+    ];
+    $result = $this->preprocessor->preprocess($blocks, []);
+    $result = $result[0];
+    verify($result['innerBlocks'])->arrayCount(2);
+    verify($result['email_attrs'])->equals($expectedEmailAttrs);
+    verify($result['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs);
+    verify($result['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs);
+    verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs);
+  }
+
+  public function testItReplacesFontSizeSlugsWithValues(): void {
+    $blocks = [[
+      'blockName' => 'core/columns',
+      'attrs' => [
+        'fontSize' => 'slug-20px',
+        'style' => [],
+      ],
+      'innerBlocks' => [
+        [
+          'blockName' => 'core/column',
+          'innerBlocks' => [],
+        ],
+        [
+          'blockName' => 'core/column',
+          'innerBlocks' => [
+            [
+              'blockName' => 'core/paragraph',
+              'attrs' => [],
+              'innerBlocks' => [],
+            ],
+          ],
+        ],
+      ],
+    ]];
+    $expectedEmailAttrs = [
+      'color' => '#000000',
+      'font-size' => '20px',
     ];
     $result = $this->preprocessor->preprocess($blocks, []);
     $result = $result[0];

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Preprocessors/TypographyPreprocessorTest.php
@@ -81,7 +81,6 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     ]];
     $expectedEmailAttrs = [
       'color' => '#aa00dd',
-      'font-family' => 'Arial',
       'font-size' => '12px',
       'text-decoration' => 'underline',
     ];
@@ -121,8 +120,8 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     $result = $this->preprocessor->preprocess($blocks, []);
     $result = $result[0];
     verify($result['innerBlocks'])->arrayCount(2);
-    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000', 'font-size' => '13px', 'font-family' => 'Arial']);
-    $defaultFontStyles = ['color' => '#000000', 'font-size' => '13px', 'font-family' => 'Arial'];
+    verify($result['email_attrs'])->equals(['width' => '640px', 'color' => '#000000', 'font-size' => '13px']);
+    $defaultFontStyles = ['color' => '#000000', 'font-size' => '13px'];
     verify($result['innerBlocks'][0]['email_attrs'])->equals($defaultFontStyles);
     verify($result['innerBlocks'][1]['email_attrs'])->equals($defaultFontStyles);
     verify($result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($defaultFontStyles);
@@ -207,12 +206,10 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     ];
     $expectedEmailAttrs1 = [
       'color' => '#aa00dd',
-      'font-family' => 'Arial',
       'font-size' => '12px',
     ];
     $expectedEmailAttrs2 = [
       'color' => '#cc22aa',
-      'font-family' => 'Georgia',
       'font-size' => '18px',
     ];
     $result = $this->preprocessor->preprocess($blocks, []);
@@ -225,7 +222,7 @@ class TypographyPreprocessorTest extends \MailPoetUnitTest {
     verify($child1['innerBlocks'][1]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child1['innerBlocks'][1]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs1);
     verify($child2['innerBlocks'])->arrayCount(1);
-    verify($child2['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px', 'font-family' => 'Arial']);
+    verify($child2['email_attrs'])->equals(['color' => '#000000', 'font-size' => '13px']);
     verify($child2['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
     verify($child2['innerBlocks'][0]['innerBlocks'][0]['email_attrs'])->equals($expectedEmailAttrs2);
   }


### PR DESCRIPTION
## Description
This PR enables font family and font-size settings for all supported blocks and adds default button styles.

It also changes how we work with theme.json a bit. Instead of loading core theme.json and manually inserting some stuff from the editor's theme.json, we now load the core theme and merge the editor's theme into it. The benefit is that we no longer have to manually change individual settings and we can use WP_Theme_JSON::get_settings and other methods. I have also moved a few configurations (which were easy to move) from SettingsController to theme.json.

## Code review notes
I tried to explain changes in the commit messages.

I included the default button styles in this PR because when doing small refactors around theme.json processing, the default styles started somewhat to work in the editor, so I decided to fix it and add the support also to the renderer. It makes the PR a bit bigger, though. Sorry about that!

## QA notes
I would skip QA for now and pass it to QA after we fix/implement the rest of the tickets related to the rendering.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5740][MAILPOET-5814]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5740]: https://mailpoet.atlassian.net/browse/MAILPOET-5740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ