### PR TITLE
Prevent stale/orphaned Doctrine data when using DQL/SQL [MAILPOET-5845]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -15,6 +15,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Listing;
 use MailPoet\Newsletter\Listing\NewsletterListingRepository;
+use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewsletterSaveController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\NewsletterValidator;
@@ -73,6 +74,8 @@ class Newsletters extends APIEndpoint {
   /** @var NewsletterSaveController */
   private $newsletterSaveController;
 
+  private NewsletterDeleteController $newsletterDeleteController;
+
   /** @var NewsletterUrl */
   private $newsletterUrl;
 
@@ -98,6 +101,7 @@ class Newsletters extends APIEndpoint {
     Emoji $emoji,
     SendPreviewController $sendPreviewController,
     NewsletterSaveController $newsletterSaveController,
+    NewsletterDeleteController $newsletterDeleteController,
     NewsletterUrl $newsletterUrl,
     Scheduler $scheduler,
     NewsletterValidator $newsletterValidator,
@@ -115,6 +119,7 @@ class Newsletters extends APIEndpoint {
     $this->emoji = $emoji;
     $this->sendPreviewController = $sendPreviewController;
     $this->newsletterSaveController = $newsletterSaveController;
+    $this->newsletterDeleteController = $newsletterDeleteController;
     $this->newsletterUrl = $newsletterUrl;
     $this->scheduler = $scheduler;
     $this->newsletterValidator = $newsletterValidator;
@@ -291,7 +296,7 @@ class Newsletters extends APIEndpoint {
     $newsletter = $this->getNewsletter($data);
     if ($newsletter instanceof NewsletterEntity) {
       $this->wp->doAction('mailpoet_api_newsletters_delete_before', [$newsletter->getId()]);
-      $this->newslettersRepository->bulkDelete([$newsletter->getId()]);
+      $this->newsletterDeleteController->bulkDelete([(int)$newsletter->getId()]);
       $this->wp->doAction('mailpoet_api_newsletters_delete_after', [$newsletter->getId()]);
       return $this->successResponse(null, ['count' => 1]);
     } else {
@@ -401,7 +406,7 @@ class Newsletters extends APIEndpoint {
       $this->newslettersRepository->bulkRestore($ids);
     } elseif ($data['action'] === 'delete') {
       $this->wp->doAction('mailpoet_api_newsletters_delete_before', $ids);
-      $this->newslettersRepository->bulkDelete($ids);
+      $this->newsletterDeleteController->bulkDelete($ids);
       $this->wp->doAction('mailpoet_api_newsletters_delete_after', $ids);
     } else {
       throw UnexpectedValueException::create()

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewslettersRepository;
 
 class AutomationEditorLoadingHooks {
@@ -20,14 +21,18 @@ class AutomationEditorLoadingHooks {
   /** @var NewslettersRepository  */
   private $newslettersRepository;
 
+  private NewsletterDeleteController $newsletterDeleteController;
+
   public function __construct(
     WordPress $wp,
     AutomationStorage $automationStorage,
-    NewslettersRepository $newslettersRepository
+    NewslettersRepository $newslettersRepository,
+    NewsletterDeleteController $newsletterDeleteController
   ) {
     $this->wp = $wp;
     $this->automationStorage = $automationStorage;
     $this->newslettersRepository = $newslettersRepository;
+    $this->newsletterDeleteController = $newsletterDeleteController;
   }
 
   public function init(): void {
@@ -59,7 +64,7 @@ class AutomationEditorLoadingHooks {
         continue;
       }
 
-      $this->newslettersRepository->bulkDelete([$emailId]);
+      $this->newsletterDeleteController->bulkDelete([$emailId]);
       $args = $step->getArgs();
       unset($args['email_id']);
       $updatedStep = new Step(

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -14,6 +14,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
+use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\PostProcess\OpenTracking;
 use MailPoet\Newsletter\Renderer\Renderer;
@@ -50,6 +51,9 @@ class Newsletter {
 
   /** @var NewslettersRepository */
   private $newslettersRepository;
+
+  /** @var NewsletterDeleteController  */
+  private $newsletterDeleteController;
 
   /** @var Emoji */
   private $emoji;
@@ -96,6 +100,7 @@ class Newsletter {
     $this->emoji = $emoji;
     $this->renderer = ContainerWrapper::getInstance()->get(Renderer::class);
     $this->newslettersRepository = ContainerWrapper::getInstance()->get(NewslettersRepository::class);
+    $this->newsletterDeleteController = ContainerWrapper::getInstance()->get(NewsletterDeleteController::class);
     $this->linksTask = ContainerWrapper::getInstance()->get(LinksTask::class);
     $this->newsletterLinks = ContainerWrapper::getInstance()->get(NewsletterLinks::class);
     $this->sendingQueuesRepository = ContainerWrapper::getInstance()->get(SendingQueuesRepository::class);
@@ -191,7 +196,7 @@ class Newsletter {
         'no posts in post notification, deleting it',
         ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
       );
-      $this->newslettersRepository->bulkDelete([(int)$newsletter->getId()]);
+      $this->newsletterDeleteController->bulkDelete([(int)$newsletter->getId()]);
       return false;
     }
     // extract and save newsletter posts

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
@@ -40,4 +40,20 @@ class NewsletterLinkRepository extends Repository {
     }
     return null;
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(NewsletterLinkEntity::class, 'l')
+      ->where('l.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (NewsletterLinkEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/StatsNotificationsRepository.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/StatsNotificationsRepository.php
@@ -65,4 +65,20 @@ class StatsNotificationsRepository extends Repository {
        WHERE sn.id IS NULL AND st.type = :taskType;
     ", ['taskType' => Worker::TASK_TYPE]);
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(StatsNotificationEntity::class, 'n')
+      ->where('n.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (StatsNotificationEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -543,6 +543,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\ApiDataSanitizer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\AutomatedLatestContent::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterSaveController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\NewsletterDeleteController::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterPostsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewslettersRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\AutomaticEmailsRepository::class)->setPublic(true);

--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -111,6 +111,24 @@ abstract class Repository {
     $this->entityManager->refresh($entity);
   }
 
+  /**
+   * @param callable(T): bool|null $filter
+   */
+  public function refreshAll(callable $filter = null): void {
+    $className = $this->getEntityClassName();
+    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
+    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
+    foreach ($entities as $entity) {
+      if (!($entity instanceof $className)) {
+        continue;
+      }
+      if ($filter && !$filter($entity)) {
+        continue;
+      }
+      $this->entityManager->refresh($entity);
+    }
+  }
+
   public function flush() {
     $this->entityManager->flush();
   }

--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -163,24 +163,6 @@ abstract class Repository {
   }
 
   /**
-   * @param class-string<object> $className
-   * @param callable|null $filter
-   */
-  public function detachEntitiesOfType($className, callable $filter = null): void {
-    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
-    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
-    foreach ($entities as $entity) {
-      if (!($entity instanceof $className)) {
-        continue;
-      }
-      if ($filter && !$filter($entity)) {
-        continue;
-      }
-      $this->entityManager->detach($entity);
-    }
-  }
-
-  /**
    * @return class-string<T>
    */
   abstract protected function getEntityClassName();

--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -115,13 +115,8 @@ abstract class Repository {
    * @param callable(T): bool|null $filter
    */
   public function refreshAll(callable $filter = null): void {
-    $className = $this->getEntityClassName();
-    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
-    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
+    $entities = $this->getAllFromIdentityMap();
     foreach ($entities as $entity) {
-      if (!($entity instanceof $className)) {
-        continue;
-      }
       if ($filter && !$filter($entity)) {
         continue;
       }
@@ -148,18 +143,28 @@ abstract class Repository {
    * @param callable(T): bool|null $filter
    */
   public function detachAll(callable $filter = null): void {
-    $className = $this->getEntityClassName();
-    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
-    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
+    $entities = $this->getAllFromIdentityMap();
     foreach ($entities as $entity) {
-      if (!($entity instanceof $className)) {
-        continue;
-      }
       if ($filter && !$filter($entity)) {
         continue;
       }
       $this->entityManager->detach($entity);
     }
+  }
+
+  /** @return T[] */
+  public function getAllFromIdentityMap(): array {
+    $className = $this->getEntityClassName();
+    $rootClassName = $this->entityManager->getClassMetadata($className)->rootEntityName;
+    $entities = $this->entityManager->getUnitOfWork()->getIdentityMap()[$rootClassName] ?? [];
+
+    $result = [];
+    foreach ($entities as $entity) {
+      if ($entity instanceof $className) {
+        $result[] = $entity;
+      }
+    }
+    return $result;
   }
 
   /**

--- a/mailpoet/lib/Entities/StatisticsWooCommercePurchaseEntity.php
+++ b/mailpoet/lib/Entities/StatisticsWooCommercePurchaseEntity.php
@@ -20,7 +20,7 @@ class StatisticsWooCommercePurchaseEntity {
 
   /**
    * @ORM\ManyToOne(targetEntity="MailPoet\Entities\NewsletterEntity")
-   * @ORM\JoinColumn(name="newsletter_id", referencedColumnName="id")
+   * @ORM\JoinColumn(name="newsletter_id", referencedColumnName="id", nullable=true)
    * @var NewsletterEntity|null
    */
   private $newsletter;

--- a/mailpoet/lib/Form/FormsRepository.php
+++ b/mailpoet/lib/Form/FormsRepository.php
@@ -69,12 +69,19 @@ class FormsRepository extends Repository {
       return 0;
     }
 
-    return $this->entityManager->createQueryBuilder()
+    $result = $this->entityManager->createQueryBuilder()
       ->update(FormEntity::class, 'f')
       ->set('f.deletedAt', 'CURRENT_TIMESTAMP()')
       ->where('f.id IN (:ids)')
       ->setParameter('ids', $ids)
       ->getQuery()->execute();
+
+    // update was done via DQL, make sure the entities are also refreshed in the entity manager
+    $this->refreshAll(function (FormEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
+
+    return $result;
   }
 
   public function bulkRestore(array $ids): int {
@@ -82,13 +89,20 @@ class FormsRepository extends Repository {
       return 0;
     }
 
-    return $this->entityManager->createQueryBuilder()
+    $result = $this->entityManager->createQueryBuilder()
       ->update(FormEntity::class, 'f')
       ->set('f.deletedAt', ':deletedAt')
       ->where('f.id IN (:ids)')
       ->setParameter('deletedAt', null)
       ->setParameter('ids', $ids)
       ->getQuery()->execute();
+
+    // update was done via DQL, make sure the entities are also refreshed in the entity manager
+    $this->refreshAll(function (FormEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
+
+    return $result;
   }
 
   public function bulkDelete(array $ids): int {

--- a/mailpoet/lib/Migrations/Db/Migration_20240119_113943_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20240119_113943_Db.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20240119_113943_Db extends DbMigration {
+  public function run(): void {
+    $table = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
+
+    // make "newsletter_id" nullable
+    $this->connection->executeStatement("ALTER TABLE $table CHANGE newsletter_id newsletter_id int(11) unsigned NULL");
+
+    // update data
+    $this->connection->executeStatement("UPDATE $table SET newsletter_id = NULL WHERE newsletter_id = 0");
+  }
+}

--- a/mailpoet/lib/Models/Newsletter.php
+++ b/mailpoet/lib/Models/Newsletter.php
@@ -4,6 +4,7 @@ namespace MailPoet\Models;
 
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Settings\SettingsController;
@@ -141,7 +142,7 @@ class Newsletter extends Model {
 
   public function delete() {
     trigger_error('Calling Newsletter::delete() is deprecated and will be removed. Use \MailPoet\Newsletter\NewslettersRepository instead.', E_USER_DEPRECATED);
-    ContainerWrapper::getInstance()->get(NewslettersRepository::class)->bulkDelete([$this->id]);
+    ContainerWrapper::getInstance()->get(NewsletterDeleteController::class)->bulkDelete([$this->id]);
     return null;
   }
 

--- a/mailpoet/lib/Newsletter/NewsletterDeleteController.php
+++ b/mailpoet/lib/Newsletter/NewsletterDeleteController.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter;
+
+use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
+use MailPoet\Cron\Workers\StatsNotifications\StatsNotificationsRepository;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatsNotificationEntity;
+use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
+use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Statistics\StatisticsClicksRepository;
+use MailPoet\Statistics\StatisticsNewslettersRepository;
+use MailPoet\Statistics\StatisticsOpensRepository;
+use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+use Throwable;
+
+class NewsletterDeleteController {
+  private EntityManager $entityManager;
+  private NewslettersRepository $newslettersRepository;
+  private NewsletterLinkRepository $newsletterLinkRepository;
+  private NewsletterOptionsRepository $newsletterOptionsRepository;
+  private NewsletterPostsRepository $newsletterPostsRepository;
+  private NewsletterSegmentRepository $newsletterSegmentRepository;
+  private ScheduledTasksRepository $scheduledTasksRepository;
+  private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
+  private SendingQueuesRepository $sendingQueuesRepository;
+  private StatisticsClicksRepository $statisticsClicksRepository;
+  private StatisticsNewslettersRepository $statisticsNewslettersRepository;
+  private StatisticsOpensRepository $statisticsOpensRepository;
+  private StatisticsWooCommercePurchasesRepository $statisticsWooCommercePurchasesRepository;
+  private StatsNotificationsRepository $statsNotificationsRepository;
+  private WPFunctions $wp;
+
+  public function __construct(
+    EntityManager $entityManager,
+    NewslettersRepository $newslettersRepository,
+    NewsletterLinkRepository $newsletterLinkRepository,
+    NewsletterOptionsRepository $newsletterOptionsRepository,
+    NewsletterPostsRepository $newsletterPostsRepository,
+    NewsletterSegmentRepository $newsletterSegmentRepository,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
+    StatisticsClicksRepository $statisticsClicksRepository,
+    StatisticsNewslettersRepository $statisticsNewslettersRepository,
+    StatisticsOpensRepository $statisticsOpensRepository,
+    StatisticsWooCommercePurchasesRepository $statisticsWooCommercePurchasesRepository,
+    StatsNotificationsRepository $statsNotificationsRepository,
+    WPFunctions $wp
+  ) {
+    $this->entityManager = $entityManager;
+    $this->newslettersRepository = $newslettersRepository;
+    $this->newsletterLinkRepository = $newsletterLinkRepository;
+    $this->newsletterOptionsRepository = $newsletterOptionsRepository;
+    $this->newsletterPostsRepository = $newsletterPostsRepository;
+    $this->newsletterSegmentRepository = $newsletterSegmentRepository;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->statisticsClicksRepository = $statisticsClicksRepository;
+    $this->statisticsNewslettersRepository = $statisticsNewslettersRepository;
+    $this->statisticsOpensRepository = $statisticsOpensRepository;
+    $this->statisticsWooCommercePurchasesRepository = $statisticsWooCommercePurchasesRepository;
+    $this->statsNotificationsRepository = $statsNotificationsRepository;
+    $this->wp = $wp;
+  }
+
+  /** @param int[] $ids */
+  public function bulkDelete(array $ids): int {
+    if (!$ids) {
+      return 0;
+    }
+
+    // Fetch children ids for deleting
+    $childrenIds = $this->newslettersRepository->fetchChildrenIds($ids);
+    $ids = array_merge($ids, $childrenIds);
+
+    $this->entityManager->beginTransaction();
+    try {
+      // Delete statistics data
+      $this->statisticsNewslettersRepository->deleteByNewsletterIds($ids);
+      $this->statisticsOpensRepository->deleteByNewsletterIds($ids);
+      $this->statisticsClicksRepository->deleteByNewsletterIds($ids);
+
+      // Update WooCommerce statistics and remove newsletter and click id
+      $this->statisticsWooCommercePurchasesRepository->removeNewsletterDataByNewsletterIds($ids);
+
+      // Delete newsletter posts, options, links, and segments
+      $this->newsletterPostsRepository->deleteByNewsletterIds($ids);
+      $this->newsletterOptionsRepository->deleteByNewsletterIds($ids);
+      $this->newsletterLinkRepository->deleteByNewsletterIds($ids);
+      $this->newsletterSegmentRepository->deleteByNewsletterIds($ids);
+
+      // Delete stats notifications and related tasks
+      /** @var string[] $taskIds */
+      $taskIds = $this->entityManager->createQueryBuilder()
+        ->select('IDENTITY(sn.task)')
+        ->from(StatsNotificationEntity::class, 'sn')
+        ->where('sn.newsletter IN (:ids)')
+        ->setParameter('ids', $ids)
+        ->getQuery()
+        ->getSingleColumnResult();
+      $taskIds = array_map('intval', $taskIds);
+
+      $this->scheduledTasksRepository->deleteByIds($taskIds);
+      $this->statsNotificationsRepository->deleteByNewsletterIds($ids);
+
+      // Delete scheduled task subscribers, scheduled tasks, and sending queues
+      /** @var string[] $taskIds */
+      $taskIds = $this->entityManager->createQueryBuilder()
+        ->select('IDENTITY(q.task)')
+        ->from(SendingQueueEntity::class, 'q')
+        ->where('q.newsletter IN (:ids)')
+        ->setParameter('ids', $ids)
+        ->getQuery()
+        ->getSingleColumnResult();
+      $taskIds = array_map('intval', $taskIds);
+
+      $this->scheduledTaskSubscribersRepository->deleteByTaskIds($taskIds);
+      $this->scheduledTasksRepository->deleteByIds($taskIds);
+      $this->sendingQueuesRepository->deleteByNewsletterIds($ids);
+
+      // Fetch WP Posts IDs and delete them
+      /** @var string[] $wpPostIds */
+      $wpPostIds = $this->entityManager->createQueryBuilder()
+        ->select('IDENTITY(n.wpPost) AS id')
+        ->from(NewsletterEntity::class, 'n')
+        ->where('n.id IN (:ids)')
+        ->andWhere('n.wpPost IS NOT NULL')
+        ->setParameter('ids', $ids)
+        ->getQuery()
+        ->getSingleColumnResult();
+      $wpPostIds = array_map('intval', $wpPostIds);
+
+      foreach ($wpPostIds as $wpPostId) {
+        $this->wp->wpDeletePost($wpPostId, true);
+      }
+
+      // Delete newsletter entities
+      $this->newslettersRepository->deleteByIds($ids);
+
+      $this->entityManager->commit();
+    } catch (Throwable $e) {
+      $this->entityManager->rollback();
+      throw $e;
+    }
+
+    return count($ids);
+  }
+}

--- a/mailpoet/lib/Newsletter/NewsletterPostsRepository.php
+++ b/mailpoet/lib/Newsletter/NewsletterPostsRepository.php
@@ -12,4 +12,20 @@ class NewsletterPostsRepository extends Repository {
   protected function getEntityClassName() {
     return NewsletterPostEntity::class;
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(NewsletterPostEntity::class, 'p')
+      ->where('p.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (NewsletterPostEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -38,6 +38,7 @@ use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
  */
 class NewslettersRepository extends Repository {
   private LoggerFactory $loggerFactory;
+  private NewsletterPostsRepository $newsletterPostsRepository;
   private StatisticsClicksRepository $statisticsClicksRepository;
   private StatisticsNewslettersRepository $statisticsNewslettersRepository;
   private StatisticsOpensRepository $statisticsOpensRepository;
@@ -45,6 +46,7 @@ class NewslettersRepository extends Repository {
 
   public function __construct(
     EntityManager $entityManager,
+    NewsletterPostsRepository $newsletterPostsRepository,
     StatisticsClicksRepository $statisticsClicksRepository,
     StatisticsNewslettersRepository $statisticsNewslettersRepository,
     StatisticsOpensRepository $statisticsOpensRepository,
@@ -52,6 +54,7 @@ class NewslettersRepository extends Repository {
   ) {
     parent::__construct($entityManager);
     $this->loggerFactory = LoggerFactory::getInstance();
+    $this->newsletterPostsRepository = $newsletterPostsRepository;
     $this->statisticsClicksRepository = $statisticsClicksRepository;
     $this->statisticsNewslettersRepository = $statisticsNewslettersRepository;
     $this->statisticsOpensRepository = $statisticsOpensRepository;
@@ -399,11 +402,7 @@ class NewslettersRepository extends Repository {
       ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);
 
       // Delete newsletter posts
-      $postsTable = $entityManager->getClassMetadata(NewsletterPostEntity::class)->getTableName();
-      $entityManager->getConnection()->executeStatement("
-         DELETE np FROM $postsTable np
-         WHERE np.`newsletter_id` IN (:ids)
-      ", ['ids' => $ids], ['ids' => Connection::PARAM_INT_ARRAY]);
+      $this->newsletterPostsRepository->deleteByNewsletterIds($ids);
 
       // Delete newsletter options
       $optionsTable = $entityManager->getClassMetadata(NewsletterOptionEntity::class)->getTableName();

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -467,17 +467,7 @@ class NewslettersRepository extends Repository {
       }
 
       // Delete newsletter entities
-      $this->entityManager->createQueryBuilder()
-        ->delete(NewsletterEntity::class, 'n')
-        ->where('n.id IN (:ids)')
-        ->setParameter('ids', $ids)
-        ->getQuery()
-        ->execute();
-
-      // delete was done via DQL, make sure the entities are also detached from the entity manager
-      $this->detachAll(function (NewsletterEntity $entity) use ($ids) {
-        return in_array($entity->getId(), $ids, true);
-      });
+      $this->deleteByIds($ids);
 
       $this->entityManager->commit();
     } catch (Throwable $e) {
@@ -486,6 +476,22 @@ class NewslettersRepository extends Repository {
     }
 
     return count($ids);
+  }
+
+
+  /** @param int[] $ids */
+  public function deleteByIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(NewsletterEntity::class, 'n')
+      ->where('n.id IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (NewsletterEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
   }
 
   /**

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -480,12 +480,17 @@ class NewslettersRepository extends Repository {
       }
 
       // Delete newsletter entities
-      $queryBuilder = $entityManager->createQueryBuilder();
-      $queryBuilder->delete(NewsletterEntity::class, 'n')
+      $this->entityManager->createQueryBuilder()
+        ->delete(NewsletterEntity::class, 'n')
         ->where('n.id IN (:ids)')
         ->setParameter('ids', $ids)
-        ->getQuery()->execute();
+        ->getQuery()
+        ->execute();
 
+      // delete was done via DQL, make sure the entities are also detached from the entity manager
+      $this->detachAll(function (NewsletterEntity $entity) use ($ids) {
+        return in_array($entity->getId(), $ids, true);
+      });
 
       $entityTypesToBeDetached = [
         StatisticsNewsletterEntity::class,

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -34,11 +34,8 @@ use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
  * @extends Repository<NewsletterEntity>
  */
 class NewslettersRepository extends Repository {
-  /** @var LoggerFactory */
-  private $loggerFactory;
-
-  /** @var WPFunctions */
-  private $wp;
+  private LoggerFactory $loggerFactory;
+  private WPFunctions $wp;
 
   public function __construct(
     EntityManager $entityManager,

--- a/mailpoet/lib/Newsletter/Options/NewsletterOptionsRepository.php
+++ b/mailpoet/lib/Newsletter/Options/NewsletterOptionsRepository.php
@@ -52,4 +52,20 @@ class NewsletterOptionsRepository extends Repository {
       ->setParameter('segmentIds', $segmentIds)
       ->getQuery()->getResult();
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(NewsletterOptionEntity::class, 'o')
+      ->where('o.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (NewsletterOptionEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Newsletter/Segment/NewsletterSegmentRepository.php
+++ b/mailpoet/lib/Newsletter/Segment/NewsletterSegmentRepository.php
@@ -65,4 +65,20 @@ class NewsletterSegmentRepository extends Repository {
     }
     return $nameMap;
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(NewsletterSegmentEntity::class, 's')
+      ->where('s.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (NewsletterSegmentEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -94,6 +94,11 @@ class ScheduledTaskSubscribersRepository extends Repository {
         ->setParameter('task', $task)
         ->getQuery()
         ->execute();
+
+      // update was done via DQL, make sure the entities are also refreshed in the entity manager
+      $this->refreshAll(function (ScheduledTaskSubscriberEntity $entity) use ($task, $subscriberIds) {
+        return $entity->getTask() === $task && in_array($entity->getSubscriberId(), $subscriberIds, true);
+      });
     }
 
     $this->checkCompleted($task);

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -118,6 +118,22 @@ class ScheduledTaskSubscribersRepository extends Repository {
     $stmt->executeQuery();
   }
 
+  /** @param int[] $ids */
+  public function deleteByTaskIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskSubscriberEntity::class, 'sts')
+      ->where('sts.task IN (:taskIds)')
+      ->setParameter('taskIds', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskSubscriberEntity $entity) use ($ids) {
+      $task = $entity->getTask();
+      return $task && in_array($task->getId(), $ids, true);
+    });
+  }
+
   public function deleteByScheduledTask(ScheduledTaskEntity $scheduledTask): void {
     $this->entityManager->createQueryBuilder()
       ->delete(ScheduledTaskSubscriberEntity::class, 'sts')

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -337,6 +337,21 @@ class ScheduledTasksRepository extends Repository {
     $this->flush();
   }
 
+  /** @param int[] $ids */
+  public function deleteByIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskEntity::class, 't')
+      ->where('t.id IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
+  }
+
   protected function findByTypeAndStatus($type, $status, $limit = null, $future = false) {
     $queryBuilder = $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -308,6 +308,11 @@ class ScheduledTasksRepository extends Repository {
       ->setParameter('ids', $ids, Connection::PARAM_INT_ARRAY)
       ->getQuery()
       ->execute();
+
+    // update was done via DQL, make sure the entities are also refreshed in the entity manager
+    $this->refreshAll(function (ScheduledTaskEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -238,4 +238,20 @@ class SendingQueuesRepository extends Repository {
     }
     $this->entityManager->flush();
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(SendingQueueEntity::class, 'q')
+      ->where('q.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (SendingQueueEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
+++ b/mailpoet/lib/NewsletterTemplates/NewsletterTemplatesRepository.php
@@ -93,6 +93,11 @@ class NewsletterTemplatesRepository extends Repository {
       ->setParameter('recentIds', array_column($recentIds, 'id'))
       ->getQuery()
       ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (NewsletterTemplateEntity $entity) use ($recentIds) {
+      return $entity->getCategories() === self::RECENTLY_SENT_CATEGORIES && !in_array($entity->getId(), $recentIds, true);
+    });
   }
 
   public function getRecentlySentCount(): int {

--- a/mailpoet/lib/Statistics/StatisticsClicksRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsClicksRepository.php
@@ -89,4 +89,20 @@ class StatisticsClicksRepository extends Repository {
       ->getQuery()
       ->getResult();
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(StatisticsClickEntity::class, 's')
+      ->where('s.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (StatisticsClickEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
@@ -40,4 +40,20 @@ class StatisticsNewslettersRepository extends Repository {
       $this->entityManager->flush();
     }
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(StatisticsNewsletterEntity::class, 's')
+      ->where('s.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (StatisticsNewsletterEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Statistics/StatisticsOpensRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsOpensRepository.php
@@ -90,4 +90,20 @@ class StatisticsOpensRepository extends Repository {
       ->orderBy('queue.newsletterRenderedSubject')
       ->setParameter('subscriber', $subscriber->getId());
   }
+
+  /** @param int[] $ids */
+  public function deleteByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(StatisticsOpenEntity::class, 's')
+      ->where('s.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (StatisticsOpenEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -117,8 +117,9 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
   public function removeNewsletterDataByNewsletterIds(array $ids): void {
     $this->entityManager->createQueryBuilder()
       ->update(StatisticsWooCommercePurchaseEntity::class, 'swp')
-      ->set('swp.newsletter', 0)
+      ->set('swp.newsletter', ':newsletter')
       ->where('swp.newsletter IN (:ids)')
+      ->setParameter('newsletter', null)
       ->setParameter('ids', $ids)
       ->getQuery()
       ->execute();

--- a/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsWooCommercePurchasesRepository.php
@@ -112,4 +112,21 @@ class StatisticsWooCommercePurchasesRepository extends Repository {
     }, $data);
     return $data;
   }
+
+  /** @param int[] $ids */
+  public function removeNewsletterDataByNewsletterIds(array $ids): void {
+    $this->entityManager->createQueryBuilder()
+      ->update(StatisticsWooCommercePurchaseEntity::class, 'swp')
+      ->set('swp.newsletter', 0)
+      ->where('swp.newsletter IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // update was done via DQL, make sure the entities are also refreshed in the entity manager
+    $this->refreshAll(function (StatisticsWooCommercePurchaseEntity $entity) use ($ids) {
+      $newsletter = $entity->getNewsletter();
+      return $newsletter && in_array($newsletter->getId(), $ids, true);
+    });
+  }
 }

--- a/mailpoet/lib/WooCommerce/Tracker.php
+++ b/mailpoet/lib/WooCommerce/Tracker.php
@@ -50,13 +50,13 @@ class Tracker {
   }
 
   /**
-   * @param array<int, array{revenue: float, campaign_id: string, campaign_type: string, orders_count: int}> $campaignsData
+   * @param array<int, array{revenue: float, campaign_id: string|null, campaign_type: string, orders_count: int}> $campaignsData
    * @return array<string, string|int|float>
    */
   private function formatCampaignsData(array $campaignsData): array {
     return array_reduce($campaignsData, function($result, array $campaign): array {
       $newsletter = $this->newslettersRepository->findOneById((int)$campaign['campaign_id']);
-      $keyPrefix = 'campaign_' . $campaign['campaign_id'];
+      $keyPrefix = 'campaign_' . ($campaign['campaign_id'] ?? 0);
       $result[$keyPrefix . '_revenue'] = $campaign['revenue'];
       $result[$keyPrefix . '_orders_count'] = $campaign['orders_count'];
       $result[$keyPrefix . '_type'] = $campaign['campaign_type'];

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -11,7 +11,6 @@ use MailPoet\Cron\DaemonHttpRunner;
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Cron\Workers\WorkersFactory;
-use MailPoet\Logging\LoggerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -82,7 +81,10 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
         }
       });
 
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunnerMock,
+      'workersFactory' => $this->createWorkersFactoryMock(),
+    ]);
     $daemonHttpRunner = $this->make(DaemonHttpRunner::class, [
       'pauseExecution' => null,
       'callSelf' => null,
@@ -208,7 +210,10 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $cronWorkerRunner = $this->make(CronWorkerRunner::class, [
       'run' => null,
     ]);
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunner, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunner,
+      'workersFactory' => $this->createWorkersFactoryMock(),
+    ]);
     $daemonHttpRunner->__construct($daemon, $this->cronHelper, SettingsController::getInstance(), $this->diContainer->get(WordPress::class));
     $daemonHttpRunner->run($data);
     $updatedDaemon = $this->settings->get(CronHelper::DAEMON_SETTING);
@@ -228,7 +233,10 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
           throw new \Exception();
         }
       });
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunnerMock,
+      'workersFactory' => $this->createWorkersFactoryMock(),
+    ]);
     $daemonHttpRunner = $this->make(DaemonHttpRunner::class, [
       'pauseExecution' => null,
       'callSelf' => null,
@@ -264,7 +272,10 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $cronWorkerRunnerMock = $this->make(CronWorkerRunner::class, [
       'run' => null,
     ]);
-    $daemon = new Daemon($this->cronHelper, $cronWorkerRunnerMock, $this->createWorkersFactoryMock(), $this->diContainer->get(LoggerFactory::class));
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunnerMock,
+      'workersFactory' => $this->createWorkersFactoryMock(),
+    ]);
     $daemonHttpRunner->__construct($daemon, $this->cronHelper, SettingsController::getInstance(), $this->diContainer->get(WordPress::class));
     $daemonHttpRunner->run($data);
     verify(ignore_user_abort())->equals(true);

--- a/mailpoet/tests/integration/Newsletter/NewsletterDeleteControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterDeleteControllerTest.php
@@ -1,0 +1,317 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter;
+
+use Codeception\Util\Fixtures;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\NewsletterOptionEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\NewsletterPostEntity;
+use MailPoet\Entities\NewsletterSegmentEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsNewsletterEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Entities\StatsNotificationEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\WpPostEntity;
+use MailPoet\Newsletter\NewsletterDeleteController;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
+use MailPoet\WP\Functions as WPFunctions;
+
+class NewsletterDeleteControllerTest extends \MailPoetTest {
+  private NewsletterDeleteController $controller;
+  private NewslettersRepository $repository;
+  private ScheduledTaskSubscribersRepository $taskSubscribersRepository;
+  private WPFunctions $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->controller = $this->diContainer->get(NewsletterDeleteController::class);
+    $this->repository = $this->diContainer->get(NewslettersRepository::class);
+    $this->taskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+  }
+
+  public function testItBulkDeleteNewslettersAndChildren() {
+    $standardNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
+    $standardQueue = $this->createQueueWithTaskAndSegmentAndSubscribers($standardNewsletter, null); // Null for scheduled task being processed
+    $notification = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    $notificationHistory = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SCHEDULED, $notification);
+    $notificationHistoryQueue = $this->createQueueWithTaskAndSegmentAndSubscribers($notificationHistory);
+
+    $standardSegment = $standardNewsletter->getNewsletterSegments()->first();
+    $this->assertInstanceOf(NewsletterSegmentEntity::class, $standardSegment);
+    $standardScheduledTaks = $standardQueue->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $standardScheduledTaks);
+    $standardScheduledTaskSubscriber = $this->taskSubscribersRepository->findOneBy(['task' => $standardScheduledTaks]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $standardScheduledTaskSubscriber);
+    $notificationHistoryScheduledTask = $notificationHistoryQueue->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $notificationHistoryScheduledTask);
+    $notificationHistorySegment = $notificationHistory->getNewsletterSegments()->first();
+    $this->assertInstanceOf(NewsletterSegmentEntity::class, $notificationHistorySegment);
+    $notificationHistoryScheduledTaskSubscriber = $this->taskSubscribersRepository->findOneBy(['task' => $notificationHistoryScheduledTask]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $notificationHistoryScheduledTaskSubscriber);
+    $standardStatsNotification = $this->createStatNotification($standardNewsletter);
+    $standardStatsNotificationScheduledTask = $standardStatsNotification->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $standardStatsNotificationScheduledTask);
+    $notificationHistoryStatsNotification = $this->createStatNotification($notificationHistory);
+    $notificationHistoryStatsNotificationScheduledTask = $notificationHistoryStatsNotification->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $notificationHistoryStatsNotificationScheduledTask);
+    $standardLink = $this->createNewsletterLink($standardNewsletter, $standardQueue);
+    $notificationHistoryLink = $this->createNewsletterLink($notificationHistory, $notificationHistoryQueue);
+    $optionField = (new NewsletterOptionField())->findOrCreate('name', NewsletterEntity::TYPE_NOTIFICATION);
+    $optionValue = $this->createNewsletterOption($notificationHistory, $optionField, 'value');
+    $newsletterPost = $this->createNewsletterPost($notification, 1);
+
+    $subscriber = $standardScheduledTaskSubscriber->getSubscriber();
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $statisticsNewsletter = $this->createNewsletterStatistics($standardNewsletter, $standardQueue, $subscriber);
+    $statisticsOpen = $this->createOpenStatistics($standardNewsletter, $standardQueue, $subscriber);
+    $statisticsClick = $this->createClickStatistics($standardNewsletter, $standardQueue, $subscriber, $standardLink);
+    $statisticsPurchase = $this->createPurchaseStatistics($standardNewsletter, $standardQueue, $statisticsClick, $subscriber);
+
+    // Trash
+    $this->repository->bulkTrash([(int)$standardNewsletter->getId(), (int)$notification->getId()]);
+    // Delete
+    $this->controller->bulkDelete([(int)$standardNewsletter->getId(), (int)$notification->getId()]);
+
+    // Clear entity manager to forget all entities
+    $this->entityManager->clear();
+
+    // Check they were all deleted
+    // Newsletters
+    verify($this->repository->findOneById($standardNewsletter->getId()))->null();
+    verify($this->repository->findOneById($notification->getId()))->null();
+    verify($this->repository->findOneById($notificationHistory->getId()))->null();
+
+    // Sending queues
+    verify($this->entityManager->find(SendingQueueEntity::class, $standardQueue->getId()))->null();
+    verify($this->entityManager->find(SendingQueueEntity::class, $notificationHistoryQueue->getId()))->null();
+
+    // Scheduled tasks subscribers
+    verify($this->taskSubscribersRepository->findOneBy(['task' => $standardScheduledTaks]))->null();
+    verify($this->taskSubscribersRepository->findOneBy(['task' => $notificationHistoryScheduledTask]))->null();
+
+    // Scheduled tasks
+    verify($this->entityManager->find(ScheduledTaskEntity::class, $standardScheduledTaks->getId()))->null();
+    verify($this->entityManager->find(ScheduledTaskEntity::class, $notificationHistoryScheduledTask->getId()))->null();
+
+    // Newsletter segments
+    verify($this->entityManager->find(NewsletterSegmentEntity::class, $standardSegment->getId()))->null();
+    verify($this->entityManager->find(NewsletterSegmentEntity::class, $notificationHistorySegment->getId()))->null();
+
+    // Newsletter stats notifications
+    verify($this->entityManager->find(StatsNotificationEntity::class, $standardStatsNotificationScheduledTask->getId()))->null();
+    verify($this->entityManager->find(StatsNotificationEntity::class, $notificationHistoryStatsNotification->getId()))->null();
+
+    // Newsletter stats notifications scheduled tasks
+    verify($this->entityManager->find(ScheduledTaskEntity::class, $standardStatsNotificationScheduledTask->getId()))->null();
+    verify($this->entityManager->find(ScheduledTaskEntity::class, $notificationHistoryStatsNotificationScheduledTask->getId()))->null();
+
+    // Newsletter links
+    verify($this->entityManager->find(NewsletterLinkEntity::class, $standardLink->getId()))->null();
+    verify($this->entityManager->find(NewsletterLinkEntity::class, $notificationHistoryLink->getId()))->null();
+
+    // Option fields values
+    verify($this->entityManager->find(NewsletterOptionEntity::class, $optionValue->getId()))->null();
+
+    // Newsletter post
+    verify($this->entityManager->find(NewsletterPostEntity::class, $newsletterPost->getId()))->null();
+
+    // Statistics data
+    verify($this->entityManager->find(StatisticsNewsletterEntity::class, $statisticsNewsletter->getId()))->null();
+    verify($this->entityManager->find(StatisticsOpenEntity::class, $statisticsOpen->getId()))->null();
+    verify($this->entityManager->find(StatisticsClickEntity::class, $statisticsClick->getId()))->null();
+    $statisticsPurchase = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase->getId());
+    $this->assertNotNull($statisticsPurchase);
+    verify($statisticsPurchase->getNewsletter())->null();
+  }
+
+  public function testItDeletesMultipleNewslettersWithPurchaseStatsAndKeepsStats() {
+    $standardNewsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
+    $statisticsPurchase1 = $this->createPurchaseStatsForNewsletter($standardNewsletter1);
+    $standardNewsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
+    $statisticsPurchase2 = $this->createPurchaseStatsForNewsletter($standardNewsletter2);
+
+    // Delete
+    $this->controller->bulkDelete([(int)$standardNewsletter1->getId(), (int)$standardNewsletter2->getId()]);
+
+    // Clear entity manager to forget all entities
+    $this->entityManager->clear();
+
+    // Check Newsletters were deleted
+    verify($this->repository->findOneById($standardNewsletter1->getId()))->null();
+    verify($this->repository->findOneById($standardNewsletter2->getId()))->null();
+
+    // Check purchase stats were not deleted
+    $statisticsPurchase1 = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase1->getId());
+    $statisticsPurchase2 = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase2->getId());
+    $this->assertNotNull($statisticsPurchase1);
+    verify($statisticsPurchase1->getNewsletter())->null();
+    $this->assertNotNull($statisticsPurchase2);
+    verify($statisticsPurchase2->getNewsletter())->null();
+  }
+
+  public function testItDeletesWpPostsBulkDelete() {
+    $newsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
+    $post1Id = $this->wp->wpInsertPost(['post_title' => 'Post 1']);
+    $newsletter1->setWpPost($this->entityManager->getReference(WpPostEntity::class, $post1Id));
+    $newsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_WELCOME, NewsletterEntity::STATUS_SENDING);
+    $post2Id = $this->wp->wpInsertPost(['post_title' => 'Post 2']);
+    $newsletter2->setWpPost($this->entityManager->getReference(WpPostEntity::class, $post2Id));
+    $newsletter3 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
+
+    $blogPost = $this->wp->wpInsertPost(['post_title' => 'Regular blog post']);
+
+    verify($this->wp->getPost($post1Id))->instanceOf(\WP_Post::class);
+    verify($this->wp->getPost($post2Id))->instanceOf(\WP_Post::class);
+
+    $this->entityManager->flush();
+    $this->entityManager->clear();
+
+    $this->controller->bulkDelete([(int)$newsletter1->getId(), (int)$newsletter2->getId(), (int)$newsletter3->getId()]);
+    verify($this->wp->getPost($post1Id))->null();
+    verify($this->wp->getPost($post2Id))->null();
+    verify($this->wp->getPost($blogPost))->instanceOf(\WP_Post::class);
+  }
+
+  private function createNewsletter(string $type, string $status = NewsletterEntity::STATUS_DRAFT, $parent = null): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType($type);
+    $newsletter->setSubject('My Standard Newsletter');
+    $newsletter->setBody(Fixtures::get('newsletter_body_template'));
+    $newsletter->setStatus($status);
+    $newsletter->setParent($parent);
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    return $newsletter;
+  }
+
+  private function createQueueWithTaskAndSegmentAndSubscribers(NewsletterEntity $newsletter, $status = ScheduledTaskEntity::STATUS_SCHEDULED): SendingQueueEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType(SendingQueue::TASK_TYPE);
+    $task->setStatus($status);
+    $this->entityManager->persist($task);
+
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $newsletter->getQueues()->add($queue);
+
+    $segment = new SegmentEntity("List for newsletter id {$newsletter->getId()}", SegmentEntity::TYPE_DEFAULT, 'Description');
+    $this->entityManager->persist($segment);
+
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail("sub{$newsletter->getId()}@mailpoet.com");
+    $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->entityManager->persist($subscriber);
+    $this->entityManager->flush();
+    $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $this->entityManager->persist($scheduledTaskSubscriber);
+
+    $newsletterSegment = new NewsletterSegmentEntity($newsletter, $segment);
+    $newsletter->getNewsletterSegments()->add($newsletterSegment);
+    $this->entityManager->persist($newsletterSegment);
+    $this->entityManager->flush();
+    return $queue;
+  }
+
+  private function createStatNotification(NewsletterEntity $newsletter): StatsNotificationEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType('stats_notification');
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->entityManager->persist($task);
+    $statsNotification = new StatsNotificationEntity($newsletter, $task);
+    $this->entityManager->persist($statsNotification);
+    $this->entityManager->flush();
+    return $statsNotification;
+  }
+
+  private function createNewsletterLink(NewsletterEntity $newsletter, SendingQueueEntity $queue): NewsletterLinkEntity {
+    $link = new NewsletterLinkEntity($newsletter, $queue, 'http://example.com', 'abcd');
+    $this->entityManager->persist($link);
+    $this->entityManager->flush();
+    return $link;
+  }
+
+  private function createNewsletterOption(NewsletterEntity $newsletter, NewsletterOptionFieldEntity $field, $value): NewsletterOptionEntity {
+    $option = new NewsletterOptionEntity($newsletter, $field);
+    $option->setValue($value);
+    $this->entityManager->persist($option);
+    $this->entityManager->flush();
+    return $option;
+  }
+
+  private function createNewsletterPost(NewsletterEntity $newsletter, int $postId): NewsletterPostEntity {
+    $post = new NewsletterPostEntity($newsletter, $postId);
+    $this->entityManager->persist($post);
+    $this->entityManager->flush();
+    return $post;
+  }
+
+  private function createNewsletterStatistics(NewsletterEntity $newsletter, SendingQueueEntity $queue, SubscriberEntity $subscriber): StatisticsNewsletterEntity {
+    $statisticsNewsletter = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
+    $this->entityManager->persist($statisticsNewsletter);
+    $this->entityManager->flush();
+    return $statisticsNewsletter;
+  }
+
+  private function createOpenStatistics(NewsletterEntity $newsletter, SendingQueueEntity $queue, SubscriberEntity $subscriber): StatisticsOpenEntity {
+    $statistics = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
+    $this->entityManager->persist($statistics);
+    $this->entityManager->flush();
+    return $statistics;
+  }
+
+  private function createClickStatistics(
+    NewsletterEntity $newsletter,
+    SendingQueueEntity $queue,
+    SubscriberEntity $subscriber,
+    NewsletterLinkEntity $link
+  ): StatisticsClickEntity {
+    $statistics = new StatisticsClickEntity($newsletter, $queue, $subscriber, $link, 1);
+    $this->entityManager->persist($statistics);
+    $this->entityManager->flush();
+    return $statistics;
+  }
+
+  private function createPurchaseStatistics(
+    NewsletterEntity $newsletter,
+    SendingQueueEntity $queue,
+    StatisticsClickEntity $click,
+    SubscriberEntity $subscriber
+  ): StatisticsWooCommercePurchaseEntity {
+    $statistics = new StatisticsWooCommercePurchaseEntity($newsletter, $queue, $click, 1, 'EUR', 100, 'completed');
+    $statistics->setSubscriber($subscriber);
+    $this->entityManager->persist($statistics);
+    $this->entityManager->flush();
+    return $statistics;
+  }
+
+  private function createPurchaseStatsForNewsletter(NewsletterEntity $newsletter): StatisticsWooCommercePurchaseEntity {
+    $queue = $this->createQueueWithTaskAndSegmentAndSubscribers($newsletter, NewsletterEntity::STATUS_SENT); // Null for scheduled task being processed
+    $segment = $newsletter->getNewsletterSegments()->first();
+    $this->assertInstanceOf(NewsletterSegmentEntity::class, $segment);
+    $scheduledTask = $queue->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $scheduledTaskSubscriber = $this->taskSubscribersRepository->findOneBy(['task' => $scheduledTask]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscriber);
+    $link = $this->createNewsletterLink($newsletter, $queue);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $link);
+    $subscriber = $scheduledTaskSubscriber->getSubscriber();
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $statisticsClick = $this->createClickStatistics($newsletter, $queue, $subscriber, $link);
+    $this->assertInstanceOf(StatisticsClickEntity::class, $statisticsClick);
+    return $this->createPurchaseStatistics($newsletter, $queue, $statisticsClick, $subscriber);
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -5,44 +5,23 @@ namespace MailPoet\Newsletter;
 use Codeception\Util\Fixtures;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\NewsletterLinkEntity;
-use MailPoet\Entities\NewsletterOptionEntity;
-use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Entities\StatisticsClickEntity;
-use MailPoet\Entities\StatisticsNewsletterEntity;
-use MailPoet\Entities\StatisticsOpenEntity;
-use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
-use MailPoet\Entities\StatsNotificationEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Entities\WpPostEntity;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
-use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
-use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class NewsletterRepositoryTest extends \MailPoetTest {
   /** @var NewslettersRepository */
   private $repository;
 
-  /** @var ScheduledTaskSubscribersRepository */
-  private $taskSubscribersRepository;
-
-  /** @var WPFunctions */
-  private $wp;
-
   public function _before() {
     parent::_before();
     $this->repository = $this->diContainer->get(NewslettersRepository::class);
-    $this->taskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
-    $this->wp = $this->diContainer->get(WPFunctions::class);
   }
 
   public function testItBulkTrashNewslettersAndChildren() {
@@ -125,149 +104,6 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->entityManager->refresh($scheduledTask);
     verify($scheduledTask->getDeletedAt())->null();
     verify($scheduledTask->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
-  }
-
-  public function testItBulkDeleteNewslettersAndChildren() {
-    $standardNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
-    $standardQueue = $this->createQueueWithTaskAndSegmentAndSubscribers($standardNewsletter, null); // Null for scheduled task being processed
-    $notification = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
-    $notificationHistory = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SCHEDULED, $notification);
-    $notificationHistoryQueue = $this->createQueueWithTaskAndSegmentAndSubscribers($notificationHistory);
-
-    $standardSegment = $standardNewsletter->getNewsletterSegments()->first();
-    $this->assertInstanceOf(NewsletterSegmentEntity::class, $standardSegment);
-    $standardScheduledTaks = $standardQueue->getTask();
-    $this->assertInstanceOf(ScheduledTaskEntity::class, $standardScheduledTaks);
-    $standardScheduledTaskSubscriber = $this->taskSubscribersRepository->findOneBy(['task' => $standardScheduledTaks]);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $standardScheduledTaskSubscriber);
-    $notificationHistoryScheduledTask = $notificationHistoryQueue->getTask();
-    $this->assertInstanceOf(ScheduledTaskEntity::class, $notificationHistoryScheduledTask);
-    $notificationHistorySegment = $notificationHistory->getNewsletterSegments()->first();
-    $this->assertInstanceOf(NewsletterSegmentEntity::class, $notificationHistorySegment);
-    $notificationHistoryScheduledTaskSubscriber = $this->taskSubscribersRepository->findOneBy(['task' => $notificationHistoryScheduledTask]);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $notificationHistoryScheduledTaskSubscriber);
-    $standardStatsNotification = $this->createStatNotification($standardNewsletter);
-    $standardStatsNotificationScheduledTask = $standardStatsNotification->getTask();
-    $this->assertInstanceOf(ScheduledTaskEntity::class, $standardStatsNotificationScheduledTask);
-    $notificationHistoryStatsNotification = $this->createStatNotification($notificationHistory);
-    $notificationHistoryStatsNotificationScheduledTask = $notificationHistoryStatsNotification->getTask();
-    $this->assertInstanceOf(ScheduledTaskEntity::class, $notificationHistoryStatsNotificationScheduledTask);
-    $standardLink = $this->createNewsletterLink($standardNewsletter, $standardQueue);
-    $notificationHistoryLink = $this->createNewsletterLink($notificationHistory, $notificationHistoryQueue);
-    $optionField = (new NewsletterOptionField())->findOrCreate('name', NewsletterEntity::TYPE_NOTIFICATION);
-    $optionValue = $this->createNewsletterOption($notificationHistory, $optionField, 'value');
-    $newsletterPost = $this->createNewsletterPost($notification, 1);
-
-    $subscriber = $standardScheduledTaskSubscriber->getSubscriber();
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    $statisticsNewsletter = $this->createNewsletterStatistics($standardNewsletter, $standardQueue, $subscriber);
-    $statisticsOpen = $this->createOpenStatistics($standardNewsletter, $standardQueue, $subscriber);
-    $statisticsClick = $this->createClickStatistics($standardNewsletter, $standardQueue, $subscriber, $standardLink);
-    $statisticsPurchase = $this->createPurchaseStatistics($standardNewsletter, $standardQueue, $statisticsClick, $subscriber);
-
-    // Trash
-    $this->repository->bulkTrash([$standardNewsletter->getId(), $notification->getId()]);
-    // Delete
-    $this->repository->bulkDelete([$standardNewsletter->getId(), $notification->getId()]);
-
-    // Clear entity manager to forget all entities
-    $this->entityManager->clear();
-
-    // Check they were all deleted
-    // Newsletters
-    verify($this->repository->findOneById($standardNewsletter->getId()))->null();
-    verify($this->repository->findOneById($notification->getId()))->null();
-    verify($this->repository->findOneById($notificationHistory->getId()))->null();
-
-    // Sending queues
-    verify($this->entityManager->find(SendingQueueEntity::class, $standardQueue->getId()))->null();
-    verify($this->entityManager->find(SendingQueueEntity::class, $notificationHistoryQueue->getId()))->null();
-
-    // Scheduled tasks subscribers
-    verify($this->taskSubscribersRepository->findOneBy(['task' => $standardScheduledTaks]))->null();
-    verify($this->taskSubscribersRepository->findOneBy(['task' => $notificationHistoryScheduledTask]))->null();
-
-    // Scheduled tasks
-    verify($this->entityManager->find(ScheduledTaskEntity::class, $standardScheduledTaks->getId()))->null();
-    verify($this->entityManager->find(ScheduledTaskEntity::class, $notificationHistoryScheduledTask->getId()))->null();
-
-    // Newsletter segments
-    verify($this->entityManager->find(NewsletterSegmentEntity::class, $standardSegment->getId()))->null();
-    verify($this->entityManager->find(NewsletterSegmentEntity::class, $notificationHistorySegment->getId()))->null();
-
-    // Newsletter stats notifications
-    verify($this->entityManager->find(StatsNotificationEntity::class, $standardStatsNotificationScheduledTask->getId()))->null();
-    verify($this->entityManager->find(StatsNotificationEntity::class, $notificationHistoryStatsNotification->getId()))->null();
-
-    // Newsletter stats notifications scheduled tasks
-    verify($this->entityManager->find(ScheduledTaskEntity::class, $standardStatsNotificationScheduledTask->getId()))->null();
-    verify($this->entityManager->find(ScheduledTaskEntity::class, $notificationHistoryStatsNotificationScheduledTask->getId()))->null();
-
-    // Newsletter links
-    verify($this->entityManager->find(NewsletterLinkEntity::class, $standardLink->getId()))->null();
-    verify($this->entityManager->find(NewsletterLinkEntity::class, $notificationHistoryLink->getId()))->null();
-
-    // Option fields values
-    verify($this->entityManager->find(NewsletterOptionEntity::class, $optionValue->getId()))->null();
-
-    // Newsletter post
-    verify($this->entityManager->find(NewsletterPostEntity::class, $newsletterPost->getId()))->null();
-
-    // Statistics data
-    verify($this->entityManager->find(StatisticsNewsletterEntity::class, $statisticsNewsletter->getId()))->null();
-    verify($this->entityManager->find(StatisticsOpenEntity::class, $statisticsOpen->getId()))->null();
-    verify($this->entityManager->find(StatisticsClickEntity::class, $statisticsClick->getId()))->null();
-    $statisticsPurchase = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase->getId());
-    $this->assertNotNull($statisticsPurchase);
-    verify($statisticsPurchase->getNewsletter())->null();
-  }
-
-  public function testItDeletesMultipleNewslettersWithPurchaseStatsAndKeepsStats() {
-    $standardNewsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
-    $statisticsPurchase1 = $this->createPurchaseStatsForNewsletter($standardNewsletter1);
-    $standardNewsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
-    $statisticsPurchase2 = $this->createPurchaseStatsForNewsletter($standardNewsletter2);
-
-    // Delete
-    $this->repository->bulkDelete([$standardNewsletter1->getId(), $standardNewsletter2->getId()]);
-
-    // Clear entity manager to forget all entities
-    $this->entityManager->clear();
-
-    // Check Newsletters were deleted
-    verify($this->repository->findOneById($standardNewsletter1->getId()))->null();
-    verify($this->repository->findOneById($standardNewsletter2->getId()))->null();
-
-    // Check purchase stats were not deleted
-    $statisticsPurchase1 = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase1->getId());
-    $statisticsPurchase2 = $this->entityManager->find(StatisticsWooCommercePurchaseEntity::class, $statisticsPurchase2->getId());
-    $this->assertNotNull($statisticsPurchase1);
-    verify($statisticsPurchase1->getNewsletter())->null();
-    $this->assertNotNull($statisticsPurchase2);
-    verify($statisticsPurchase2->getNewsletter())->null();
-  }
-
-  public function testItDeletesWpPostsBulkDelete() {
-    $newsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
-    $post1Id = $this->wp->wpInsertPost(['post_title' => 'Post 1']);
-    $newsletter1->setWpPost($this->entityManager->getReference(WpPostEntity::class, $post1Id));
-    $newsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_WELCOME, NewsletterEntity::STATUS_SENDING);
-    $post2Id = $this->wp->wpInsertPost(['post_title' => 'Post 2']);
-    $newsletter2->setWpPost($this->entityManager->getReference(WpPostEntity::class, $post2Id));
-    $newsletter3 = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENDING);
-
-    $blogPost = $this->wp->wpInsertPost(['post_title' => 'Regular blog post']);
-
-    verify($this->wp->getPost($post1Id))->instanceOf(\WP_Post::class);
-    verify($this->wp->getPost($post2Id))->instanceOf(\WP_Post::class);
-
-    $this->entityManager->flush();
-    $this->entityManager->clear();
-
-    $this->repository->bulkDelete([$newsletter1->getId(), $newsletter2->getId(), $newsletter3->getId()]);
-    verify($this->wp->getPost($post1Id))->null();
-    verify($this->wp->getPost($post2Id))->null();
-    verify($this->wp->getPost($blogPost))->instanceOf(\WP_Post::class);
   }
 
   public function testItGetsArchiveNewslettersForSegments() {
@@ -385,94 +221,5 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->entityManager->persist($newsletterSegment);
     $this->entityManager->flush();
     return $queue;
-  }
-
-  private function createStatNotification(NewsletterEntity $newsletter): StatsNotificationEntity {
-    $task = new ScheduledTaskEntity();
-    $task->setType('stats_notification');
-    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
-    $this->entityManager->persist($task);
-    $statsNotification = new StatsNotificationEntity($newsletter, $task);
-    $this->entityManager->persist($statsNotification);
-    $this->entityManager->flush();
-    return $statsNotification;
-  }
-
-  private function createNewsletterLink(NewsletterEntity $newsletter, SendingQueueEntity $queue): NewsletterLinkEntity {
-    $link = new NewsletterLinkEntity($newsletter, $queue, 'http://example.com', 'abcd');
-    $this->entityManager->persist($link);
-    $this->entityManager->flush();
-    return $link;
-  }
-
-  private function createNewsletterOption(NewsletterEntity $newsletter, NewsletterOptionFieldEntity $field, $value): NewsletterOptionEntity {
-    $option = new NewsletterOptionEntity($newsletter, $field);
-    $option->setValue($value);
-    $this->entityManager->persist($option);
-    $this->entityManager->flush();
-    return $option;
-  }
-
-  private function createNewsletterPost(NewsletterEntity $newsletter, int $postId): NewsletterPostEntity {
-    $post = new NewsletterPostEntity($newsletter, $postId);
-    $this->entityManager->persist($post);
-    $this->entityManager->flush();
-    return $post;
-  }
-
-  private function createNewsletterStatistics(NewsletterEntity $newsletter, SendingQueueEntity $queue, SubscriberEntity $subscriber): StatisticsNewsletterEntity {
-    $statisticsNewsletter = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
-    $this->entityManager->persist($statisticsNewsletter);
-    $this->entityManager->flush();
-    return $statisticsNewsletter;
-  }
-
-  private function createOpenStatistics(NewsletterEntity $newsletter, SendingQueueEntity $queue, SubscriberEntity $subscriber): StatisticsOpenEntity {
-    $statistics = new StatisticsOpenEntity($newsletter, $queue, $subscriber);
-    $this->entityManager->persist($statistics);
-    $this->entityManager->flush();
-    return $statistics;
-  }
-
-  private function createClickStatistics(
-    NewsletterEntity $newsletter,
-    SendingQueueEntity $queue,
-    SubscriberEntity $subscriber,
-    NewsletterLinkEntity $link
-  ): StatisticsClickEntity {
-    $statistics = new StatisticsClickEntity($newsletter, $queue, $subscriber, $link, 1);
-    $this->entityManager->persist($statistics);
-    $this->entityManager->flush();
-    return $statistics;
-  }
-
-  private function createPurchaseStatistics(
-    NewsletterEntity $newsletter,
-    SendingQueueEntity $queue,
-    StatisticsClickEntity $click,
-    SubscriberEntity $subscriber
-  ): StatisticsWooCommercePurchaseEntity {
-    $statistics = new StatisticsWooCommercePurchaseEntity($newsletter, $queue, $click, 1, 'EUR', 100, 'completed');
-    $statistics->setSubscriber($subscriber);
-    $this->entityManager->persist($statistics);
-    $this->entityManager->flush();
-    return $statistics;
-  }
-
-  private function createPurchaseStatsForNewsletter(NewsletterEntity $newsletter): StatisticsWooCommercePurchaseEntity {
-    $queue = $this->createQueueWithTaskAndSegmentAndSubscribers($newsletter, NewsletterEntity::STATUS_SENT); // Null for scheduled task being processed
-    $segment = $newsletter->getNewsletterSegments()->first();
-    $this->assertInstanceOf(NewsletterSegmentEntity::class, $segment);
-    $scheduledTask = $queue->getTask();
-    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
-    $scheduledTaskSubscriber = $this->taskSubscribersRepository->findOneBy(['task' => $scheduledTask]);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscriber);
-    $link = $this->createNewsletterLink($newsletter, $queue);
-    $this->assertInstanceOf(NewsletterLinkEntity::class, $link);
-    $subscriber = $scheduledTaskSubscriber->getSubscriber();
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
-    $statisticsClick = $this->createClickStatistics($newsletter, $queue, $subscriber, $link);
-    $this->assertInstanceOf(StatisticsClickEntity::class, $statisticsClick);
-    return $this->createPurchaseStatistics($newsletter, $queue, $statisticsClick, $subscriber);
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/TrackerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TrackerTest.php
@@ -8,7 +8,7 @@ use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Test\DataFactories\Newsletter;
@@ -200,8 +200,8 @@ class TrackerTest extends \MailPoetTest {
     $this->createRevenueRecord($newsletter2, $this->createOrderData(2, 'USD', 10));
     $this->createRevenueRecord($newsletter3, $this->createOrderData(3, 'USD', 10));
 
-    $newsletterRepository = $this->diContainer->get(NewslettersRepository::class);
-    $newsletterRepository->bulkDelete([$newsletter1->getId(), $newsletter2->getId()]);
+    $newsletterDeleteController = $this->diContainer->get(NewsletterDeleteController::class);
+    $newsletterDeleteController->bulkDelete([$newsletter1->getId(), $newsletter2->getId()]);
 
     $tracker = $this->diContainer->get(Tracker::class);
     $mailPoetData = $tracker->addTrackingData(['extensions' => []])['extensions']['mailpoet'];


### PR DESCRIPTION
## Description

This is a more proper fix and refactor of https://github.com/mailpoet/mailpoet/pull/5374, plus a few more improvements and entity manager clearing between runs.

See also: https://mailpoetdev.wordpress.com/2024/01/19/issue-with-stuck-post-notifications/

## Code review notes

_N/A_

## QA notes

Please, test that post notifications get scheduled and sent (and don't get stuck). Please, try a larger list, if possible.

It would also be good to smoke test other types of sending, and background jobs.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5845]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5845]: https://mailpoet.atlassian.net/browse/MAILPOET-5845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ