### PR TITLE
Make it obvious the list name can be visible by subscribers [MAILPOET-5841]

### DIFF
--- a/mailpoet/assets/js/src/segments/static/form.tsx
+++ b/mailpoet/assets/js/src/segments/static/form.tsx
@@ -10,8 +10,9 @@ import { TopBarWithBeamer } from '../../common/top-bar/top-bar';
 const fields = [
   {
     name: 'name',
-    label: MailPoet.I18n.t('name'),
+    label: MailPoet.I18n.t('segmentFormName'),
     type: 'text',
+    tip: MailPoet.I18n.t('segmentFormNameTip'),
   },
   {
     name: 'description',

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -33,7 +33,7 @@ class ManageListsCest {
     $i->click('New List');
     $i->click('[aria-label="Navigate to the lists page"]');
     $i->click('New List');
-    $i->fillField('Name', $newListTitle);
+    $i->fillField('Public list name', $newListTitle);
     $i->fillField('Description', $newListDesc);
     $i->click('Save');
     $i->waitForText('WordPress Users', 5, '[data-automation-id="listing_item_1"]');
@@ -62,7 +62,7 @@ class ManageListsCest {
     $i->clickItemRowActionByItemName($newListTitle, 'Edit');
     $i->waitForText($newListTitle);
     $i->clearFormField('#field_name');
-    $i->fillField('Name', $editedListTitle);
+    $i->fillField('Public list name', $editedListTitle);
     $i->fillField('Description', $editedListDesc);
     $i->click('Save');
     $i->waitForNoticeAndClose('List successfully updated!');

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -56,6 +56,8 @@
   'numberOfItemsMultiple': __('%1$d items'),
 
   'segmentDescriptionTip': __('This text box is for your own use and is never shown to your subscribers.'),
+  'segmentFormName': __('Public list name'),
+  'segmentFormNameTip': __('Subscribers may see this name when managing their subscriptions.'),
   'backToList': __('Back'),
 
   'showInManageSubscriptionPage': __('List visibility'),


### PR DESCRIPTION
## Description

It was not explicitly apparent that the (list) Name field was subscriber-facing. A first-time user of MailPoet may not realise this.  

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5841]
Fixes #5377

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5841]: https://mailpoet.atlassian.net/browse/MAILPOET-5841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ