### PR TITLE
Update k6 version and reduce nightly test cycle

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -63,8 +63,8 @@ let scenarios = {
       },
     },
     vus: 1,
-    iterations: 3,
-    maxDuration: '30m',
+    iterations: 1,
+    maxDuration: '15m',
     exec: 'nightly',
   },
 };

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.46.0';
+$version = 'v0.48.0';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Updated k6 version to its latest and reduced nightly testing cycle.
We have a different set of tests for the nightly testing and it seemed enough to run the test suite only once and not 3 times to get any different performance results, so let's save some virtual hours used from Grafana free plan and spend it somewhere else like new tests.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5849]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5849]: https://mailpoet.atlassian.net/browse/MAILPOET-5849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ