### PR TITLE
Increase limits for legacy emails [MAILPOET-5850]

### DIFF
--- a/mailpoet/assets/js/src/automation/listing/store/legacy-actions.tsx
+++ b/mailpoet/assets/js/src/automation/listing/store/legacy-actions.tsx
@@ -34,11 +34,13 @@ export function* loadLegacyAutomations() {
         endpoint: 'newsletters',
         method: 'listing',
         'data[params][type]': 'welcome',
+        'data[limit]': '400',
       }),
       legacyApiFetch({
         endpoint: 'newsletters',
         method: 'listing',
         'data[params][type]': 'automatic',
+        'data[limit]': '400',
       }),
     ]),
   );


### PR DESCRIPTION
## Description

This is a quick fix for ensuring users with a large number of legacy automatic emails are still able to see all of those emails. The listing endpoint defaults to returning 20.

## Code review notes

This is intended to be a quick fix, but I'm sure there's a better long term solution. I'm slightly worried about the API request taking a long time if someone actually has >= ~250~ 400 legacy emails, which is why I used that limit. On the flip side, some power users may have more than that, and this will be an incomplete solution.

Edit: an HE pointed out there's at least one user with 300 missing welcome emails, so I bumped the limit, but I suspect we'll want a more robust solution. Maybe we could detect the number of automatic emails a user has and if it's over a certain amount we could continue to render the legacy UI (until perhaps we convert them entirely into automations? Not sure if that's even part of the plan).

## QA notes

Please try to test with a very large number of legacy emails.

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5850

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
