### PR TITLE
Add autosaving to the email editor [MAILPOET-5742]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/autosave/autosave-monitor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/autosave/autosave-monitor.tsx
@@ -1,0 +1,39 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { storeName } from '../../store';
+
+/**
+ * This component is simplified version of the original one from @wordpress/editor package.
+ * The original component can be found here: https://github.com/WordPress/gutenberg/blob/46446b853d740c309c0675c7bf2ca4170a618c42/packages/editor/src/components/autosave-monitor/index.js
+ * The main reason for the own solution is that the original component needs to initialize the @wordpress/editor store.
+ * We could use the action `setEditedPost` from the editor package, but it is only in a newer version of the editor package.
+ */
+export function AutosaveMonitor() {
+  const { hasEdits, autosaveInterval } = useSelect(
+    (select) => ({
+      hasEdits: select(storeName).hasEdits(),
+      autosaveInterval: select(storeName).getAutosaveInterval(),
+    }),
+    [],
+  );
+
+  const { saveEditedEmail } = useDispatch(storeName);
+
+  useEffect(() => {
+    let autosaveTimer: NodeJS.Timeout | undefined;
+
+    if (hasEdits && autosaveInterval > 0) {
+      autosaveTimer = setTimeout(() => {
+        saveEditedEmail();
+      }, autosaveInterval * 1000);
+    }
+
+    return () => {
+      if (autosaveTimer) {
+        clearTimeout(autosaveTimer);
+      }
+    };
+  }, [hasEdits, autosaveInterval, saveEditedEmail]);
+
+  return null;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/autosave/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/autosave/index.ts
@@ -1,0 +1,1 @@
+export { AutosaveMonitor } from './autosave-monitor';

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -15,6 +15,7 @@ import {
   // @ts-ignore No types for this exist yet.
   __unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
+import { UnsavedChangesWarning } from '@wordpress/editor';
 import { uploadMedia } from '@wordpress/media-utils';
 import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
@@ -125,6 +126,7 @@ export function BlockEditor() {
       useSubRegistry={false}
     >
       <FullscreenMode isActive={isFullscreenActive} />
+      <UnsavedChangesWarning />
       <AutosaveMonitor />
       <Sidebar />
       <InterfaceSkeleton

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -26,6 +26,7 @@ import {
 
 import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import { storeName } from '../../store';
+import { AutosaveMonitor } from '../autosave';
 import { Sidebar } from '../sidebar/sidebar';
 import { Header } from '../header';
 import { ListviewSidebar } from '../listview-sidebar/listview-sidebar';
@@ -124,6 +125,7 @@ export function BlockEditor() {
       useSubRegistry={false}
     >
       <FullscreenMode isActive={isFullscreenActive} />
+      <AutosaveMonitor />
       <Sidebar />
       <InterfaceSkeleton
         className={className}

--- a/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
@@ -19,6 +19,7 @@ export function getInitialState(): State {
     editorSettings: getEditorSettings(),
     layoutStyles: getEmailLayoutStyles(),
     layout: getEditorLayout(),
+    autosaveInterval: 60,
     preview: {
       deviceType: 'Desktop',
       toEmail: window.MailPoetEmailEditor.current_wp_user_email,

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -111,3 +111,7 @@ export function getLayoutStyles(state: State): State['layoutStyles'] {
 export function getLayout(state: State): State['layout'] {
   return state.layout;
 }
+
+export function getAutosaveInterval(state: State): State['autosaveInterval'] {
+  return state.autosaveInterval;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -52,6 +52,7 @@ export type State = {
   editorSettings: EmailEditorSettings;
   layoutStyles: EmailLayoutStyles;
   layout: EmailEditorLayout;
+  autosaveInterval: number;
   preview: {
     deviceType: string;
     toEmail: string;


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

- The comment in the new component should describe the reasons for this solution.
- Because we work with our store only, the save button should be affected by autosaving, which is expected for now.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5742]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5742]: https://mailpoet.atlassian.net/browse/MAILPOET-5742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ