### PR TITLE
Hide advanced panel and WP version in the email editor [MAILPOET-5743]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -136,3 +136,7 @@
 .block-editor-block-inspector__advanced {
   display: none;
 }
+// Hide the footer that can overlay the part of the sidebar
+body.js.admin_page_mailpoet-email-editor #wpfooter {
+  display: none;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -131,3 +131,8 @@
     box-sizing: border-box;
   }
 }
+
+// Hide the advanced settings in the sidebar. This panel is not used in the email editor at this moment.
+.block-editor-block-inspector__advanced {
+  display: none;
+}


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5743]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5743]: https://mailpoet.atlassian.net/browse/MAILPOET-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ