### PR TITLE
Ensure invalid tasks don't prevent new post notifications [MAILPOET-5853]

### DIFF
--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -520,7 +520,7 @@ class NewslettersRepository extends Repository {
   /**
    * @return NewsletterEntity[]
    */
-  public function findSendingNotificationHistoryWithoutPausedTask(NewsletterEntity $newsletter): array {
+  public function findSendingNotificationHistoryWithoutPausedOrInvalidTask(NewsletterEntity $newsletter): array {
     return $this->entityManager->createQueryBuilder()
       ->select('n')
       ->from(NewsletterEntity::class, 'n')
@@ -530,11 +530,13 @@ class NewslettersRepository extends Repository {
       ->andWhere('n.type = :type')
       ->andWhere('n.status = :status')
       ->andWhere('n.deletedAt IS NULL')
-      ->andWhere('t.status != :taskStatus')
+      ->andWhere('t.status != :taskStatusPaused')
+      ->andWhere('t.status != :taskStatusInvalid')
       ->setParameter('parent', $newsletter)
       ->setParameter('type', NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
       ->setParameter('status', NewsletterEntity::STATUS_SENDING)
-      ->setParameter('taskStatus', ScheduledTaskEntity::STATUS_PAUSED)
+      ->setParameter('taskStatusPaused', ScheduledTaskEntity::STATUS_PAUSED)
+      ->setParameter('taskStatusInvalid', ScheduledTaskEntity::STATUS_INVALID)
       ->getQuery()->getResult();
   }
 

--- a/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/PostNotificationScheduler.php
@@ -111,7 +111,7 @@ class PostNotificationScheduler {
   }
 
   public function createPostNotificationSendingTask(NewsletterEntity $newsletter): ?ScheduledTaskEntity {
-    $notificationHistory = $this->newslettersRepository->findSendingNotificationHistoryWithoutPausedTask($newsletter);
+    $notificationHistory = $this->newslettersRepository->findSendingNotificationHistoryWithoutPausedOrInvalidTask($newsletter);
     if (count($notificationHistory) > 0) {
       return null;
     }


### PR DESCRIPTION
## Description

If a sending task associated with a post notification ever gets into an `invalid` status, it will prevent new post notifications from being scheduled if the associated newsletter is not marked as sent.

I'm not sure if this is a good approach or not, but I thought it would at least be worth considering.

## Code review notes

_N/A_

## QA notes

Make sure sending works (post notifications).

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
